### PR TITLE
New Resource: Support AWS AD service Log subscription

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -406,6 +406,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_devicefarm_project":                                  resourceAwsDevicefarmProject(),
 			"aws_directory_service_directory":                         resourceAwsDirectoryServiceDirectory(),
 			"aws_directory_service_conditional_forwarder":             resourceAwsDirectoryServiceConditionalForwarder(),
+			"aws_directory_service_log_subscription":                  resourceAwsDirectoryServiceLogSubscription(),
 			"aws_dlm_lifecycle_policy":                                resourceAwsDlmLifecyclePolicy(),
 			"aws_dms_certificate":                                     resourceAwsDmsCertificate(),
 			"aws_dms_endpoint":                                        resourceAwsDmsEndpoint(),

--- a/aws/resource_aws_directory_service_log_subscription.go
+++ b/aws/resource_aws_directory_service_log_subscription.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -12,7 +13,6 @@ func resourceAwsDirectoryServiceLogSubscription() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsDirectoryServiceLogSubscriptionCreate,
 		Read:   resourceAwsDirectoryServiceLogSubscriptionRead,
-		Update: nil,
 		Delete: resourceAwsDirectoryServiceLogSubscriptionDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -46,7 +46,7 @@ func resourceAwsDirectoryServiceLogSubscriptionCreate(d *schema.ResourceData, me
 
 	_, err := dsconn.CreateLogSubscription(&input)
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating Directory Service Log Subscription: %s", err)
 	}
 
 	d.SetId(directoryId.(string))
@@ -65,11 +65,12 @@ func resourceAwsDirectoryServiceLogSubscriptionRead(d *schema.ResourceData, meta
 
 	out, err := dsconn.ListLogSubscriptions(&input)
 	if err != nil {
-		return err
+		return fmt.Errorf("error listing Directory Service Log Subscription: %s", err)
 	}
 
 	if len(out.LogSubscriptions) == 0 {
 		log.Printf("[WARN] No log subscriptions for directory %s found", directoryId)
+		d.SetId("")
 		return nil
 	}
 
@@ -91,7 +92,7 @@ func resourceAwsDirectoryServiceLogSubscriptionDelete(d *schema.ResourceData, me
 
 	_, err := dsconn.DeleteLogSubscription(&input)
 	if err != nil {
-		return err
+		return fmt.Errorf("error deleting Directory Service Log Subscription: %s", err)
 	}
 
 	return nil

--- a/aws/resource_aws_directory_service_log_subscription.go
+++ b/aws/resource_aws_directory_service_log_subscription.go
@@ -1,0 +1,98 @@
+package aws
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/directoryservice"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsDirectoryServiceLogSubscription() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsDirectoryServiceLogSubscriptionCreate,
+		Read:   resourceAwsDirectoryServiceLogSubscriptionRead,
+		Update: nil,
+		Delete: resourceAwsDirectoryServiceLogSubscriptionDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"directory_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"log_group_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAwsDirectoryServiceLogSubscriptionCreate(d *schema.ResourceData, meta interface{}) error {
+	dsconn := meta.(*AWSClient).dsconn
+
+	directoryId := d.Get("directory_id")
+	logGroupName := d.Get("log_group_name")
+
+	input := directoryservice.CreateLogSubscriptionInput{
+		DirectoryId:  aws.String(directoryId.(string)),
+		LogGroupName: aws.String(logGroupName.(string)),
+	}
+
+	_, err := dsconn.CreateLogSubscription(&input)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(directoryId.(string))
+
+	return resourceAwsDirectoryServiceLogSubscriptionRead(d, meta)
+}
+
+func resourceAwsDirectoryServiceLogSubscriptionRead(d *schema.ResourceData, meta interface{}) error {
+	dsconn := meta.(*AWSClient).dsconn
+
+	directoryId := d.Id()
+
+	input := directoryservice.ListLogSubscriptionsInput{
+		DirectoryId: aws.String(directoryId),
+	}
+
+	out, err := dsconn.ListLogSubscriptions(&input)
+	if err != nil {
+		return err
+	}
+
+	if len(out.LogSubscriptions) == 0 {
+		log.Printf("[WARN] No log subscriptons for directory %s found", directoryId)
+		return nil
+	}
+
+	logSubscription := out.LogSubscriptions[0]
+	d.Set("directory_id", logSubscription.DirectoryId)
+	d.Set("log_group_name", logSubscription.LogGroupName)
+
+	return nil
+}
+
+func resourceAwsDirectoryServiceLogSubscriptionDelete(d *schema.ResourceData, meta interface{}) error {
+	dsconn := meta.(*AWSClient).dsconn
+
+	directoryId := d.Id()
+
+	input := directoryservice.DeleteLogSubscriptionInput{
+		DirectoryId: aws.String(directoryId),
+	}
+
+	_, err := dsconn.DeleteLogSubscription(&input)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/aws/resource_aws_directory_service_log_subscription.go
+++ b/aws/resource_aws_directory_service_log_subscription.go
@@ -69,7 +69,7 @@ func resourceAwsDirectoryServiceLogSubscriptionRead(d *schema.ResourceData, meta
 	}
 
 	if len(out.LogSubscriptions) == 0 {
-		log.Printf("[WARN] No log subscriptons for directory %s found", directoryId)
+		log.Printf("[WARN] No log subscriptions for directory %s found", directoryId)
 		return nil
 	}
 

--- a/aws/resource_aws_directory_service_log_subscription_test.go
+++ b/aws/resource_aws_directory_service_log_subscription_test.go
@@ -1,0 +1,188 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/directoryservice"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSDirectoryServiceLogSubscription_basic(t *testing.T) {
+	resourceName := "aws_directory_service_log_subscription.subscription"
+	logGroupName := "ad-service-log-subscription-test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSDirectoryService(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsDirectoryServiceLogSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			// test create
+			{
+				Config: testAccDirectoryServiceLogSubscriptionConfig(logGroupName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsDirectoryServiceLogSubscriptionExists(
+						resourceName,
+						logGroupName,
+					),
+				),
+			},
+			// test import
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAwsDirectoryServiceLogSubscriptionDestroy(s *terraform.State) error {
+	dsconn := testAccProvider.Meta().(*AWSClient).dsconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_directory_service_log_subscription" {
+			continue
+		}
+
+		res, err := dsconn.ListLogSubscriptions(&directoryservice.ListLogSubscriptionsInput{
+			DirectoryId: aws.String(rs.Primary.ID),
+		})
+
+		if isAWSErr(err, directoryservice.ErrCodeEntityDoesNotExistException, "") {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if len(res.LogSubscriptions) > 0 {
+			return fmt.Errorf("Expected AWS Directory Service Log Subscription to be gone, but was still found")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAwsDirectoryServiceLogSubscriptionExists(name string, logGroupName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		dsconn := testAccProvider.Meta().(*AWSClient).dsconn
+
+		res, err := dsconn.ListLogSubscriptions(&directoryservice.ListLogSubscriptionsInput{
+			DirectoryId: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if len(res.LogSubscriptions) == 0 {
+			return fmt.Errorf("No Log subscription found")
+		}
+
+		if *(res.LogSubscriptions[0].LogGroupName) != logGroupName {
+			return fmt.Errorf("Expected Log subscription not found")
+		}
+
+		return nil
+	}
+}
+
+func testAccDirectoryServiceLogSubscriptionConfig(logGroupName string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+resource "aws_directory_service_directory" "bar" {
+  name     = "corp.notexample.com"
+  password = "SuperSecretPassw0rd"
+  type     = "MicrosoftAD"
+  edition  = "Standard"
+
+  vpc_settings {
+    vpc_id     = "${aws_vpc.main.id}"
+    subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
+  }
+
+  tags = {
+    Name = "terraform-testacc-directory-service-conditional-forwarder"
+  }
+}
+
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "terraform-testacc-directory-service-conditional-forwarder"
+  }
+}
+
+resource "aws_subnet" "foo" {
+  vpc_id            = "${aws_vpc.main.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  cidr_block        = "10.0.1.0/24"
+
+  tags = {
+    Name = "terraform-testacc-directory-service-conditional-forwarder"
+  }
+}
+
+resource "aws_subnet" "bar" {
+  vpc_id            = "${aws_vpc.main.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[1]}"
+  cidr_block        = "10.0.2.0/24"
+
+  tags = {
+    Name = "terraform-testacc-directory-service-conditional-forwarder"
+  }
+}
+
+resource "aws_cloudwatch_log_group" "logs" {
+	name = "%s"
+	retention_in_days = 1
+}
+
+data "aws_iam_policy_document" "ad-log-policy" {
+	statement {
+	  actions = [
+		"logs:CreateLogStream",
+		"logs:PutLogEvents"
+	  ]
+  
+	  principals {
+		identifiers = ["ds.amazonaws.com"]
+		type = "Service"
+	  }
+  
+	  resources = ["${aws_cloudwatch_log_group.logs.arn}"]
+  
+	  effect = "Allow"
+	}
+  }
+  
+  resource "aws_cloudwatch_log_resource_policy" "ad-log-policy" {
+	policy_document = "${data.aws_iam_policy_document.ad-log-policy.json}"
+	policy_name = "ad-log-policy"
+  }
+
+resource "aws_directory_service_log_subscription" "subscription" {
+  directory_id = "${aws_directory_service_directory.bar.id}"
+  log_group_name = "${aws_cloudwatch_log_group.logs.name}
+
+}
+`, logGroupName)
+}

--- a/aws/resource_aws_directory_service_log_subscription_test.go
+++ b/aws/resource_aws_directory_service_log_subscription_test.go
@@ -152,37 +152,36 @@ resource "aws_subnet" "bar" {
 }
 
 resource "aws_cloudwatch_log_group" "logs" {
-	name = "%s"
-	retention_in_days = 1
+  name = "%s"
+  retention_in_days = 1
 }
 
 data "aws_iam_policy_document" "ad-log-policy" {
-	statement {
-	  actions = [
-		"logs:CreateLogStream",
-		"logs:PutLogEvents"
-	  ]
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
   
-	  principals {
-		identifiers = ["ds.amazonaws.com"]
-		type = "Service"
-	  }
+    principals {
+      identifiers = ["ds.amazonaws.com"]
+      type = "Service"
+    }
   
-	  resources = ["${aws_cloudwatch_log_group.logs.arn}"]
+    resources = ["${aws_cloudwatch_log_group.logs.arn}"]
   
-	  effect = "Allow"
-	}
+    effect = "Allow"
   }
+}
   
-  resource "aws_cloudwatch_log_resource_policy" "ad-log-policy" {
-	policy_document = "${data.aws_iam_policy_document.ad-log-policy.json}"
-	policy_name = "ad-log-policy"
-  }
+resource "aws_cloudwatch_log_resource_policy" "ad-log-policy" {
+  policy_document = "${data.aws_iam_policy_document.ad-log-policy.json}"
+  policy_name = "ad-log-policy"
+}
 
 resource "aws_directory_service_log_subscription" "subscription" {
   directory_id = "${aws_directory_service_directory.bar.id}"
-  log_group_name = "${aws_cloudwatch_log_group.logs.name}
-
+  log_group_name = "${aws_cloudwatch_log_group.logs.name}"
 }
 `, logGroupName)
 }

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1022,6 +1022,10 @@
                             <a href="/docs/providers/aws/r/directory_service_conditional_forwarder.html">aws_directory_service_conditional_forwarder</a>
                         </li>
 
+                        <li>
+                            <a href="/docs/providers/aws/r/directory_service_log_subscription.html">aws_directory_service_log_subscription</a>
+                        </li>
+
                     </ul>
                 </li>
 

--- a/website/docs/r/directory_service_log_subscription.html.markdown
+++ b/website/docs/r/directory_service_log_subscription.html.markdown
@@ -1,0 +1,58 @@
+---
+layout: "aws"
+page_title: "AWS: aws_directory_service_log_subscription"
+sidebar_current: "docs-aws-resource-directory-service-log-subscription"
+description: |-
+  Provides a Log subscription for AWS Directory Service that pushes logs to cloudwatch.
+---
+
+# Resource: aws_directory_service_log_subscription
+
+Provides a Log subscription for AWS Directory Service that pushes logs to cloudwatch.
+
+## Example Usage
+
+```hcl
+resource "aws_directory_service_log_subscription" "msad-cwl" {
+  directory_id = "d-1234567890"
+  log_group_name = "/aws/directoryservice/msad"
+}
+
+data "aws_iam_policy_document" "ad-log-policy" {
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+
+    principals {
+      identifiers = ["ds.amazonaws.com"]
+      type = "Service"
+    }
+
+    resources = ["/aws/directoryservice/msad"]
+
+    effect = "Allow"
+  }
+}
+
+resource "aws_cloudwatch_log_resource_policy" "ad-log-policy" {
+  policy_document = "${data.aws_iam_policy_document.ad-log-policy.json}"
+  policy_name = "ad-log-policy"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `directory_id` - (Required) The id of directory.
+* `log_group_name` - (Required) Name of the cloudwatch log group to which the logs should be published. The log group should be already created and the directory service principal should be provided with required permission to create stream and publish logs. Changing this value would delete the current subscription and create a new one. A directory can only have one log subscription at a time.
+
+## Import
+
+Conditional forwarders can be imported using the directory id and remote_domain_name, e.g.
+
+```
+$ terraform import aws_directory_service_log_subscription.msad d-1234567890
+```


### PR DESCRIPTION
Add capability to enable/configure the Cloudwatch Log to Directory Service (#9069)

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
resource/aws_directory_service_log_subscription: Adding support to enable/disable log subscription for Directory service
```

Output from acceptance testing:

```
make testacc TEST=./aws TESTARGS="-run=TestAccAWSDirectoryServiceLogSubscription_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSDirectoryServiceLogSubscription_ -timeout 120m
=== RUN   TestAccAWSDirectoryServiceLogSubscription_basic
=== PAUSE TestAccAWSDirectoryServiceLogSubscription_basic
=== CONT  TestAccAWSDirectoryServiceLogSubscription_basic
--- PASS: TestAccAWSDirectoryServiceLogSubscription_basic (1755.58s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1755.628s
...
```
