### PR TITLE
Add support aws_datapipeline_pipeline resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -387,6 +387,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_codepipeline_webhook":                                resourceAwsCodePipelineWebhook(),
 			"aws_cur_report_definition":                               resourceAwsCurReportDefinition(),
 			"aws_customer_gateway":                                    resourceAwsCustomerGateway(),
+			"aws_datapipeline_pipeline":                               resourceAwsDataPipelinePipeline(),
 			"aws_datasync_agent":                                      resourceAwsDataSyncAgent(),
 			"aws_datasync_location_efs":                               resourceAwsDataSyncLocationEfs(),
 			"aws_datasync_location_nfs":                               resourceAwsDataSyncLocationNfs(),

--- a/aws/resource_aws_datapipeline_pipeline.go
+++ b/aws/resource_aws_datapipeline_pipeline.go
@@ -1,0 +1,163 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/datapipeline"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsDataPipelinePipeline() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsDataPipelinePipelineCreate,
+		Read:   resourceAwsDataPipelinePipelineRead,
+		Update: resourceAwsDataPipelinePipelineUpdate,
+		Delete: resourceAwsDataPipelinePipelineDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsDataPipelinePipelineCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).datapipelineconn
+
+	uniqueID := resource.UniqueId()
+
+	input := datapipeline.CreatePipelineInput{
+		Name:     aws.String(d.Get("name").(string)),
+		UniqueId: aws.String(uniqueID),
+		Tags:     tagsFromMapDataPipeline(d.Get("tags").(map[string]interface{})),
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		input.Description = aws.String(v.(string))
+	}
+
+	resp, err := conn.CreatePipeline(&input)
+
+	if err != nil {
+		return fmt.Errorf("Error creating datapipeline: %s", err)
+	}
+
+	d.SetId(aws.StringValue(resp.PipelineId))
+
+	return resourceAwsDataPipelinePipelineRead(d, meta)
+}
+
+func resourceAwsDataPipelinePipelineRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).datapipelineconn
+
+	v, err := resourceAwsDataPipelinePipelineRetrieve(d.Id(), conn)
+	if isAWSErr(err, datapipeline.ErrCodePipelineNotFoundException, "") || isAWSErr(err, datapipeline.ErrCodePipelineDeletedException, "") || v == nil {
+		log.Printf("[WARN] DataPipeline (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error describing DataPipeline (%s): %s", d.Id(), err)
+	}
+
+	d.Set("name", v.Name)
+	d.Set("description", v.Description)
+	if err := d.Set("tags", tagsToMapDataPipeline(v.Tags)); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+	return nil
+}
+
+func resourceAwsDataPipelinePipelineUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).datapipelineconn
+
+	if err := setTagsDataPipeline(conn, d); err != nil {
+		if isAWSErr(err, datapipeline.ErrCodePipelineNotFoundException, "") || isAWSErr(err, datapipeline.ErrCodePipelineDeletedException, "") {
+			log.Printf("[WARN] DataPipeline (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error updating tags: %s", err)
+	}
+
+	return resourceAwsDataPipelinePipelineRead(d, meta)
+}
+
+func resourceAwsDataPipelinePipelineDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).datapipelineconn
+
+	opts := datapipeline.DeletePipelineInput{
+		PipelineId: aws.String(d.Id()),
+	}
+
+	_, err := conn.DeletePipeline(&opts)
+	if isAWSErr(err, datapipeline.ErrCodePipelineNotFoundException, "") || isAWSErr(err, datapipeline.ErrCodePipelineDeletedException, "") {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error deleting Data Pipeline %s: %s", d.Id(), err.Error())
+	}
+
+	return waitForDataPipelineDeletion(conn, d.Id())
+}
+
+func resourceAwsDataPipelinePipelineRetrieve(id string, conn *datapipeline.DataPipeline) (*datapipeline.PipelineDescription, error) {
+	opts := datapipeline.DescribePipelinesInput{
+		PipelineIds: []*string{aws.String(id)},
+	}
+
+	resp, err := conn.DescribePipelines(&opts)
+	if err != nil {
+		return nil, err
+	}
+
+	var pipeline *datapipeline.PipelineDescription
+
+	for _, p := range resp.PipelineDescriptionList {
+		if p == nil {
+			continue
+		}
+
+		if aws.StringValue(p.PipelineId) == id {
+			pipeline = p
+			break
+		}
+	}
+
+	return pipeline, nil
+}
+
+func waitForDataPipelineDeletion(conn *datapipeline.DataPipeline, pipelineID string) error {
+	params := &datapipeline.DescribePipelinesInput{
+		PipelineIds: []*string{aws.String(pipelineID)},
+	}
+	return resource.Retry(10*time.Minute, func() *resource.RetryError {
+		_, err := conn.DescribePipelines(params)
+		if isAWSErr(err, datapipeline.ErrCodePipelineNotFoundException, "") || isAWSErr(err, datapipeline.ErrCodePipelineDeletedException, "") {
+			return nil
+		}
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return resource.RetryableError(fmt.Errorf("DataPipeline (%s) still exists", pipelineID))
+	})
+}

--- a/aws/resource_aws_datapipeline_pipeline_test.go
+++ b/aws/resource_aws_datapipeline_pipeline_test.go
@@ -1,0 +1,260 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/datapipeline"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSDataPipelinePipeline_basic(t *testing.T) {
+	var conf1, conf2 datapipeline.PipelineDescription
+	rName1 := fmt.Sprintf("tf-datapipeline-%s", acctest.RandString(5))
+	rName2 := fmt.Sprintf("tf-datapipeline-%s", acctest.RandString(5))
+	resourceName := "aws_datapipeline_pipeline.default"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDataPipelinePipelineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDataPipelinePipelineConfig(rName1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataPipelinePipelineExists(resourceName, &conf1),
+					resource.TestCheckResourceAttr(resourceName, "name", rName1),
+				),
+			},
+			{
+				Config: testAccAWSDataPipelinePipelineConfig(rName2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataPipelinePipelineExists(resourceName, &conf2),
+					testAccCheckAWSDataPipelinePipelineNotEqual(&conf1, &conf2),
+					resource.TestCheckResourceAttr(resourceName, "name", rName2),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSDataPipelinePipeline_description(t *testing.T) {
+	var conf1, conf2 datapipeline.PipelineDescription
+	rName := fmt.Sprintf("tf-datapipeline-%s", acctest.RandString(5))
+	resourceName := "aws_datapipeline_pipeline.default"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDataPipelinePipelineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDataPipelinePipelineConfigWithDescription(rName, "test description"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataPipelinePipelineExists(resourceName, &conf1),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
+				),
+			},
+			{
+				Config: testAccAWSDataPipelinePipelineConfigWithDescription(rName, "update description"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataPipelinePipelineExists(resourceName, &conf2),
+					testAccCheckAWSDataPipelinePipelineNotEqual(&conf1, &conf2),
+					resource.TestCheckResourceAttr(resourceName, "description", "update description"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSDataPipelinePipeline_disappears(t *testing.T) {
+	var conf datapipeline.PipelineDescription
+	rName := fmt.Sprintf("tf-datapipeline-%s", acctest.RandString(5))
+	resourceName := "aws_datapipeline_pipeline.default"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDataPipelinePipelineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDataPipelinePipelineConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataPipelinePipelineExists(resourceName, &conf),
+					testAccCheckAWSDataPipelinePipelineDisappears(&conf),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSDataPipelinePipeline_tags(t *testing.T) {
+	var conf datapipeline.PipelineDescription
+	rName := fmt.Sprintf("tf-datapipeline-%s", acctest.RandString(5))
+	resourceName := "aws_datapipeline_pipeline.default"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDataPipelinePipelineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDataPipelinePipelineConfigWithTags(rName, "foo", "bar", "fizz", "buzz"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataPipelinePipelineExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(
+						resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(
+						resourceName, "tags.fizz", "buzz"),
+				),
+			},
+			{
+				Config: testAccAWSDataPipelinePipelineConfigWithTags(rName, "foo", "bar2", "fizz2", "buzz2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataPipelinePipelineExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(
+						resourceName, "tags.foo", "bar2"),
+					resource.TestCheckResourceAttr(
+						resourceName, "tags.fizz2", "buzz2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSDataPipelinePipelineConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataPipelinePipelineExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSDataPipelinePipelineDisappears(conf *datapipeline.PipelineDescription) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).datapipelineconn
+		params := &datapipeline.DeletePipelineInput{
+			PipelineId: conf.PipelineId,
+		}
+
+		_, err := conn.DeletePipeline(params)
+		if err != nil {
+			return err
+		}
+		return waitForDataPipelineDeletion(conn, *conf.PipelineId)
+	}
+}
+
+func testAccCheckAWSDataPipelinePipelineDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).datapipelineconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_datapipeline_pipeline" {
+			continue
+		}
+		// Try to find the Pipeline
+		pipelineDescription, err := resourceAwsDataPipelinePipelineRetrieve(rs.Primary.ID, conn)
+		if isAWSErr(err, datapipeline.ErrCodePipelineNotFoundException, "") {
+			continue
+		} else if isAWSErr(err, datapipeline.ErrCodePipelineDeletedException, "") {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+		if pipelineDescription != nil {
+			return fmt.Errorf("Pipeline still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAWSDataPipelinePipelineExists(n string, v *datapipeline.PipelineDescription) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No DataPipeline ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).datapipelineconn
+
+		pipelineDescription, err := resourceAwsDataPipelinePipelineRetrieve(rs.Primary.ID, conn)
+
+		if err != nil {
+			return err
+		}
+		if pipelineDescription == nil {
+			return fmt.Errorf("DataPipeline not found")
+		}
+
+		*v = *pipelineDescription
+		return nil
+	}
+}
+
+func testAccCheckAWSDataPipelinePipelineNotEqual(pipeline1, pipeline2 *datapipeline.PipelineDescription) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if aws.StringValue(pipeline1.PipelineId) == aws.StringValue(pipeline2.PipelineId) {
+			return fmt.Errorf("Pipeline IDs are equal")
+		}
+
+		return nil
+	}
+}
+
+func testAccAWSDataPipelinePipelineConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_datapipeline_pipeline" "default" {
+	name      = "%[1]s"
+}`, rName)
+
+}
+
+func testAccAWSDataPipelinePipelineConfigWithDescription(rName, description string) string {
+	return fmt.Sprintf(`
+resource "aws_datapipeline_pipeline" "default" {
+	name      	= "%[1]s"
+	description = %[2]q
+}`, rName, description)
+
+}
+
+func testAccAWSDataPipelinePipelineConfigWithTags(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_datapipeline_pipeline" "default" {
+	name      = "%[1]s"
+
+	tags = {
+		%[2]s = %[3]q
+		%[4]s = %[5]q
+	}
+}`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+
+}

--- a/aws/tagsDataPipeline.go
+++ b/aws/tagsDataPipeline.go
@@ -1,0 +1,111 @@
+package aws
+
+import (
+	"log"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/datapipeline"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// setTags is a helper to set the tags for a resource. It expects the
+// tags field to be named "tags"
+func setTagsDataPipeline(conn *datapipeline.DataPipeline, d *schema.ResourceData) error {
+	if d.HasChange("tags") {
+		oraw, nraw := d.GetChange("tags")
+		o := oraw.(map[string]interface{})
+		n := nraw.(map[string]interface{})
+		create, remove := diffTagsDataPipeline(tagsFromMapDataPipeline(o), tagsFromMapDataPipeline(n))
+		// Set tags
+		if len(remove) > 0 {
+			log.Printf("[DEBUG] Removing tags: %#v", remove)
+			k := make([]*string, len(remove))
+			for i, t := range remove {
+				k[i] = t.Key
+			}
+			_, err := conn.RemoveTags(&datapipeline.RemoveTagsInput{
+				PipelineId: aws.String(d.Id()),
+				TagKeys:    k,
+			})
+			if err != nil {
+				return err
+			}
+		}
+		if len(create) > 0 {
+			log.Printf("[DEBUG] Creating tags: %#v", create)
+			_, err := conn.AddTags(&datapipeline.AddTagsInput{
+				PipelineId: aws.String(d.Id()),
+				Tags:       create,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// diffTags takes our tags locally and the ones remotely and returns
+// the set of tags that must be created, and the set of tags that must
+// be destroyed.
+func diffTagsDataPipeline(oldTags, newTags []*datapipeline.Tag) ([]*datapipeline.Tag, []*datapipeline.Tag) {
+	// First, we're creating everything we have
+	create := make(map[string]interface{})
+	for _, t := range newTags {
+		create[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+	}
+	// Build the list of what to remove
+	var remove []*datapipeline.Tag
+	for _, t := range oldTags {
+		old, ok := create[aws.StringValue(t.Key)]
+		if !ok || old != aws.StringValue(t.Value) {
+			// Delete it!
+			remove = append(remove, t)
+		} else if ok {
+			// already present so remove from new
+			delete(create, aws.StringValue(t.Key))
+		}
+	}
+	return tagsFromMapDataPipeline(create), remove
+}
+
+// tagsFromMap returns the tags for the given map of data.
+func tagsFromMapDataPipeline(m map[string]interface{}) []*datapipeline.Tag {
+	var result []*datapipeline.Tag
+	for k, v := range m {
+		t := &datapipeline.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v.(string)),
+		}
+		if !tagIgnoredDataPipeline(t) {
+			result = append(result, t)
+		}
+	}
+	return result
+}
+
+// tagsToMap turns the list of tags into a map.
+func tagsToMapDataPipeline(ts []*datapipeline.Tag) map[string]string {
+	result := make(map[string]string)
+	for _, t := range ts {
+		if !tagIgnoredDataPipeline(t) {
+			result[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+		}
+	}
+	return result
+}
+
+// compare a tag against a list of strings and checks if it should
+// be ignored or not
+func tagIgnoredDataPipeline(t *datapipeline.Tag) bool {
+	filter := []string{"^aws:"}
+	for _, v := range filter {
+		log.Printf("[DEBUG] Matching %v with %v\n", v, aws.StringValue(t.Key))
+		if r, _ := regexp.MatchString(v, aws.StringValue(t.Key)); r {
+			log.Printf("[DEBUG] Found AWS specific tag %s (val: %s), ignoring.\n", aws.StringValue(t.Key), aws.StringValue(t.Value))
+			return true
+		}
+	}
+	return false
+}

--- a/aws/tagsDataPipeline_test.go
+++ b/aws/tagsDataPipeline_test.go
@@ -1,0 +1,108 @@
+package aws
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/datapipeline"
+)
+
+func TestDiffTagsDataPipeline(t *testing.T) {
+	cases := []struct {
+		Old, New       map[string]interface{}
+		Create, Remove map[string]string
+	}{
+		// Basic add/remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"bar": "baz",
+			},
+			Create: map[string]string{
+				"bar": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Modify
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "baz",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Overlap
+		{
+			Old: map[string]interface{}{
+				"foo":   "bar",
+				"hello": "world",
+			},
+			New: map[string]interface{}{
+				"foo":   "baz",
+				"hello": "world",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+				"bar": "baz",
+			},
+			New: map[string]interface{}{
+				"foo": "bar",
+			},
+			Create: map[string]string{},
+			Remove: map[string]string{
+				"bar": "baz",
+			},
+		},
+	}
+	for i, tc := range cases {
+		c, r := diffTagsDataPipeline(tagsFromMapDataPipeline(tc.Old), tagsFromMapDataPipeline(tc.New))
+		cm := tagsToMapDataPipeline(c)
+		rm := tagsToMapDataPipeline(r)
+		if !reflect.DeepEqual(cm, tc.Create) {
+			t.Fatalf("%d: bad create: %#v", i, cm)
+		}
+		if !reflect.DeepEqual(rm, tc.Remove) {
+			t.Fatalf("%d: bad remove: %#v", i, rm)
+		}
+	}
+}
+func TestIgnoringTagsDataPipeline(t *testing.T) {
+	var ignoredTags []*datapipeline.Tag
+	ignoredTags = append(ignoredTags, &datapipeline.Tag{
+		Key:   aws.String("aws:cloudformation:logical-id"),
+		Value: aws.String("foo"),
+	})
+	ignoredTags = append(ignoredTags, &datapipeline.Tag{
+		Key:   aws.String("aws:foo:bar"),
+		Value: aws.String("baz"),
+	})
+	for _, tag := range ignoredTags {
+		if !tagIgnoredDataPipeline(tag) {
+			t.Fatalf("Tag %v with value %v not ignored, but should be!", *tag.Key, *tag.Value)
+		}
+	}
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -978,6 +978,17 @@
                 </li>
 
                 <li>
+                    <a href="#">DataPipeline Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/datapipeline_pipeline.html">aws_datapipeline_pipeline</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+                <li>
                     <a href="#">DataSync Resources</a>
                     <ul class="nav">
 

--- a/website/docs/r/datapipeline_pipeline.html.markdown
+++ b/website/docs/r/datapipeline_pipeline.html.markdown
@@ -1,0 +1,41 @@
+---
+layout: "aws"
+page_title: "AWS: aws_datapipeline_pipeline"
+sidebar_current: "docs-aws-resource-datapipeline-pipeline"
+description: |-
+  Provides a AWS DataPipeline Pipeline.
+---
+
+# Resource: aws_datapipeline_pipeline
+
+Provides a Data Pipeline resource.
+
+## Example Usage
+
+```hcl
+resource "aws_datapipeline_pipeline" "default" {
+	name      	= "tf-pipeline-default"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of Pipeline.
+* `description` - (Optional) The description of Pipeline.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The identifier of the client certificate.
+
+## Import
+
+`aws_datapipeline_pipeline` can be imported by using the id (Pipeline ID), e.g.
+
+```
+$ terraform import aws_datapipeline_pipeline.default df-1234567890
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference #1538 #6972 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Features:
- resource/aws_datapipeline_pipeline: Add support aws_datapipeline_pipeline resource
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDataPipeline_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSDataPipeline_ -timeout 120m
=== RUN   TestAccAWSDataPipeline_basic
=== PAUSE TestAccAWSDataPipeline_basic
=== RUN   TestAccAWSDataPipeline_description
=== PAUSE TestAccAWSDataPipeline_description
=== RUN   TestAccAWSDataPipeline_disappears
=== PAUSE TestAccAWSDataPipeline_disappears
=== RUN   TestAccAWSDataPipeline_tags
=== PAUSE TestAccAWSDataPipeline_tags
=== CONT  TestAccAWSDataPipeline_basic
=== CONT  TestAccAWSDataPipeline_tags
=== CONT  TestAccAWSDataPipeline_disappears
=== CONT  TestAccAWSDataPipeline_description
--- PASS: TestAccAWSDataPipeline_disappears (20.50s)
--- PASS: TestAccAWSDataPipeline_description (43.87s)
--- PASS: TestAccAWSDataPipeline_basic (44.59s)
--- PASS: TestAccAWSDataPipeline_tags (59.74s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	59.843s
```
