### PR TITLE
Add tags support for resource_aws_lightsail_instance

### DIFF
--- a/aws/resource_aws_lightsail_instance_test.go
+++ b/aws/resource_aws_lightsail_instance_test.go
@@ -32,6 +32,7 @@ func TestAccAWSLightsailInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aws_lightsail_instance.lightsail_instance_test", "blueprint_id"),
 					resource.TestCheckResourceAttrSet("aws_lightsail_instance.lightsail_instance_test", "bundle_id"),
 					resource.TestCheckResourceAttrSet("aws_lightsail_instance.lightsail_instance_test", "key_pair_name"),
+					resource.TestCheckResourceAttr("aws_lightsail_instance.lightsail_instance_test", "tags.%", "0"),
 				),
 			},
 		},
@@ -56,6 +57,42 @@ func TestAccAWSLightsailInstance_euRegion(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aws_lightsail_instance.lightsail_instance_test", "blueprint_id"),
 					resource.TestCheckResourceAttrSet("aws_lightsail_instance.lightsail_instance_test", "bundle_id"),
 					resource.TestCheckResourceAttrSet("aws_lightsail_instance.lightsail_instance_test", "key_pair_name"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSLightsailInstance_update(t *testing.T) {
+	var conf lightsail.Instance
+	lightsailName := fmt.Sprintf("tf-test-lightsail-%d", acctest.RandInt())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSLightsail(t) },
+		IDRefreshName: "aws_lightsail_instance.lightsail_instance_test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSLightsailInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLightsailInstanceConfig_update(lightsailName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLightsailInstanceExists("aws_lightsail_instance.lightsail_instance_test", &conf),
+					resource.TestCheckResourceAttrSet("aws_lightsail_instance.lightsail_instance_test", "availability_zone"),
+					resource.TestCheckResourceAttrSet("aws_lightsail_instance.lightsail_instance_test", "blueprint_id"),
+					resource.TestCheckResourceAttrSet("aws_lightsail_instance.lightsail_instance_test", "bundle_id"),
+					resource.TestCheckResourceAttrSet("aws_lightsail_instance.lightsail_instance_test", "key_pair_name"),
+					resource.TestCheckResourceAttr("aws_lightsail_instance.lightsail_instance_test", "tags.%", "1"),
+				),
+			},
+			{
+				Config: testAccAWSLightsailInstanceConfig_updated(lightsailName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLightsailInstanceExists("aws_lightsail_instance.lightsail_instance_test", &conf),
+					resource.TestCheckResourceAttrSet("aws_lightsail_instance.lightsail_instance_test", "availability_zone"),
+					resource.TestCheckResourceAttrSet("aws_lightsail_instance.lightsail_instance_test", "blueprint_id"),
+					resource.TestCheckResourceAttrSet("aws_lightsail_instance.lightsail_instance_test", "bundle_id"),
+					resource.TestCheckResourceAttrSet("aws_lightsail_instance.lightsail_instance_test", "key_pair_name"),
+					resource.TestCheckResourceAttr("aws_lightsail_instance.lightsail_instance_test", "tags.%", "2"),
 				),
 			},
 		},
@@ -187,6 +224,43 @@ resource "aws_lightsail_instance" "lightsail_instance_test" {
   availability_zone = "us-east-1b"
   blueprint_id      = "gitlab_8_12_6"
   bundle_id         = "nano_1_0"
+}
+`, lightsailName)
+}
+
+func testAccAWSLightsailInstanceConfig_update(lightsailName string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+resource "aws_lightsail_instance" "lightsail_instance_test" {
+  name              = "%s"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  blueprint_id      = "amazon_linux"
+  bundle_id         = "nano_1_0"
+  tags = {
+    Name = "tf-test"
+  }
+}
+`, lightsailName)
+}
+
+func testAccAWSLightsailInstanceConfig_updated(lightsailName string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+resource "aws_lightsail_instance" "lightsail_instance_test" {
+  name              = "%s"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  blueprint_id      = "amazon_linux"
+  bundle_id         = "nano_1_0"
+  tags = {
+    Name = "tf-test",
+    ExtraName = "tf-test"
+  }
 }
 `, lightsailName)
 }

--- a/aws/tagsLightsail.go
+++ b/aws/tagsLightsail.go
@@ -1,0 +1,97 @@
+package aws
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/lightsail"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// diffTags takes our tags locally and the ones remotely and returns
+// the set of tags that must be created, and the set of tags that must
+// be destroyed.
+func diffTagsLightsail(oldTags, newTags []*lightsail.Tag) ([]*lightsail.Tag, []*lightsail.Tag) {
+	// First, we're creating everything we have
+	create := make(map[string]interface{})
+	for _, t := range newTags {
+		create[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+	}
+
+	// Build the list of what to remove
+	var remove []*lightsail.Tag
+	for _, t := range oldTags {
+		old, ok := create[aws.StringValue(t.Key)]
+		if !ok || old != aws.StringValue(t.Value) {
+			// Delete it!
+			remove = append(remove, t)
+		} else if ok {
+			delete(create, aws.StringValue(t.Key))
+		}
+	}
+
+	return tagsFromMapLightsail(create), remove
+}
+
+// setTags is a helper to set the tags for a resource. It expects the
+// tags field to be named "tags"
+func setTagsLightsail(conn *lightsail.Lightsail, d *schema.ResourceData) error {
+	if d.HasChange("tags") {
+		oraw, nraw := d.GetChange("tags")
+		o := oraw.(map[string]interface{})
+		n := nraw.(map[string]interface{})
+		create, remove := diffTagsLightsail(tagsFromMapLightsail(o), tagsFromMapLightsail(n))
+
+		// Set tags
+		if len(remove) > 0 {
+			log.Printf("[DEBUG] Removing tags: %#v", remove)
+			k := make([]*string, len(remove))
+			for i, t := range remove {
+				k[i] = t.Key
+			}
+
+			_, err := conn.UntagResource(&lightsail.UntagResourceInput{
+				ResourceName: aws.String(d.Get("name").(string)),
+				TagKeys:      k,
+			})
+			if err != nil {
+				return err
+			}
+		}
+		if len(create) > 0 {
+			log.Printf("[DEBUG] Creating tags: %#v", create)
+			_, err := conn.TagResource(&lightsail.TagResourceInput{
+				ResourceName: aws.String(d.Get("name").(string)),
+				Tags:         create,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// tagsFromMap returns the tags for the given map of data.
+func tagsFromMapLightsail(m map[string]interface{}) []*lightsail.Tag {
+	result := make([]*lightsail.Tag, 0, len(m))
+	for k, v := range m {
+		result = append(result, &lightsail.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v.(string)),
+		})
+	}
+
+	return result
+}
+
+// tagsToMap turns the list of tags into a map.
+func tagsToMapLightsail(ts []*lightsail.Tag) map[string]string {
+	result := make(map[string]string)
+	for _, t := range ts {
+		result[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+	}
+
+	return result
+}

--- a/aws/tagsLightsail_test.go
+++ b/aws/tagsLightsail_test.go
@@ -1,0 +1,91 @@
+package aws
+
+import (
+	"reflect"
+	"testing"
+)
+
+// go test -v -run="TestDiffLightsailTags"
+func TestDiffLightsailTags(t *testing.T) {
+	cases := []struct {
+		Old, New       map[string]interface{}
+		Create, Remove map[string]string
+	}{
+		// Basic add/remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"bar": "baz",
+			},
+			Create: map[string]string{
+				"bar": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Modify
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "baz",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Overlap
+		{
+			Old: map[string]interface{}{
+				"foo":   "bar",
+				"hello": "world",
+			},
+			New: map[string]interface{}{
+				"foo":   "baz",
+				"hello": "world",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+				"bar": "baz",
+			},
+			New: map[string]interface{}{
+				"foo": "bar",
+			},
+			Create: map[string]string{},
+			Remove: map[string]string{
+				"bar": "baz",
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		c, r := diffTagsLightsail(tagsFromMapLightsail(tc.Old), tagsFromMapLightsail(tc.New))
+		cm := tagsToMapLightsail(c)
+		rm := tagsToMapLightsail(r)
+		if !reflect.DeepEqual(cm, tc.Create) {
+			t.Fatalf("%d: bad create: %#v", i, cm)
+		}
+		if !reflect.DeepEqual(rm, tc.Remove) {
+			t.Fatalf("%d: bad remove: %#v", i, rm)
+		}
+	}
+}

--- a/website/docs/r/lightsail_instance.html.markdown
+++ b/website/docs/r/lightsail_instance.html.markdown
@@ -24,6 +24,9 @@ resource "aws_lightsail_instance" "gitlab_test" {
   blueprint_id      = "string"
   bundle_id         = "string"
   key_pair_name     = "some_key_name"
+  tags = {
+    foo = "bar"
+  }
 }
 ```
 
@@ -40,6 +43,7 @@ instance (see list below)
 * `key_pair_name` - (Optional) The name of your key pair. Created in the
 Lightsail console (cannot use `aws_key_pair` at this time)
 * `user_data` - (Optional) launch script to configure server with additional user data
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Availability Zones
 Lightsail currently supports the following Availability Zones (e.g. `us-east-1a`):


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Add tags support for Lightsail instances.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_lightsail_instance.go:  Add `tags` argument
```

Output from acceptance testing:

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSLightsailInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSLightsailInstance_basic -timeout 120m
=== RUN   TestAccAWSLightsailInstance_basic
=== PAUSE TestAccAWSLightsailInstance_basic
=== CONT  TestAccAWSLightsailInstance_basic
--- PASS: TestAccAWSLightsailInstance_basic (85.64s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	85.671s

make testacc TEST=./aws TESTARGS='-run=TestDiffLightsailTags'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestDiffLightsailTags -timeout 120m
=== RUN   TestDiffLightsailTags
--- PASS: TestDiffLightsailTags (0.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	0.018s
...
```
