### PR TITLE
tests/resource/aws_rds_cluster_parameter_group: Add sweeper

### DIFF
--- a/aws/resource_aws_rds_cluster_parameter_group_test.go
+++ b/aws/resource_aws_rds_cluster_parameter_group_test.go
@@ -3,7 +3,9 @@ package aws
 import (
 	"errors"
 	"fmt"
+	"log"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,6 +16,72 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_rds_cluster_parameter_group", &resource.Sweeper{
+		Name: "aws_rds_cluster_parameter_group",
+		F:    testSweepRdsClusterParameterGroups,
+		Dependencies: []string{
+			"aws_rds_cluster",
+		},
+	})
+}
+
+func testSweepRdsClusterParameterGroups(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).rdsconn
+
+	input := &rds.DescribeDBClusterParameterGroupsInput{}
+
+	for {
+		output, err := conn.DescribeDBClusterParameterGroups(input)
+
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping RDS DB Cluster Parameter Group sweep for %s: %s", region, err)
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("error retrieving DB Cluster Parameter Groups: %s", err)
+		}
+
+		for _, dbcpg := range output.DBClusterParameterGroups {
+			if dbcpg == nil {
+				continue
+			}
+
+			input := &rds.DeleteDBClusterParameterGroupInput{
+				DBClusterParameterGroupName: dbcpg.DBClusterParameterGroupName,
+			}
+			name := aws.StringValue(dbcpg.DBClusterParameterGroupName)
+
+			if strings.HasPrefix(name, "default.") {
+				log.Printf("[INFO] Skipping DB Cluster Parameter Group: %s", name)
+				continue
+			}
+
+			log.Printf("[INFO] Deleting DB Cluster Parameter Group: %s", name)
+
+			_, err := conn.DeleteDBClusterParameterGroup(input)
+
+			if err != nil {
+				log.Printf("[ERROR] Failed to delete DB Cluster Parameter Group %s: %s", name, err)
+				continue
+			}
+		}
+
+		if aws.StringValue(output.Marker) == "" {
+			break
+		}
+
+		input.Marker = output.Marker
+	}
+
+	return nil
+}
 
 func TestAccAWSDBClusterParameterGroup_importBasic(t *testing.T) {
 	resourceName := "aws_rds_cluster_parameter_group.bar"


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from test sweeper in AWS Commercial:

```
$ go test ./aws -v -sweep=us-west-2,us-east-1 -sweep-run=aws_rds_cluster_parameter_group -timeout 10h
2019/07/08 21:59:17 [DEBUG] Running Sweepers for region (us-west-2):
2019/07/08 21:59:17 [DEBUG] Sweeper (aws_rds_cluster_parameter_group) has dependency (aws_rds_cluster), running..
2019/07/08 21:59:17 [DEBUG] Sweeper (aws_rds_cluster) has dependency (aws_db_instance), running..
2019/07/08 21:59:17 [INFO] Building AWS auth structure
2019/07/08 21:59:17 [INFO] Setting AWS metadata API timeout to 100ms
2019/07/08 21:59:18 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2019/07/08 21:59:18 [INFO] AWS Auth provider used: "SharedCredentialsProvider"
2019/07/08 21:59:18 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/07/08 21:59:18 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/07/08 21:59:19 [INFO] Building AWS auth structure
2019/07/08 21:59:19 [INFO] Setting AWS metadata API timeout to 100ms
2019/07/08 21:59:19 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2019/07/08 21:59:19 [INFO] AWS Auth provider used: "SharedCredentialsProvider"
2019/07/08 21:59:19 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/07/08 21:59:19 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/07/08 21:59:20 [INFO] Building AWS auth structure
2019/07/08 21:59:20 [INFO] Setting AWS metadata API timeout to 100ms
2019/07/08 21:59:20 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2019/07/08 21:59:20 [INFO] AWS Auth provider used: "SharedCredentialsProvider"
2019/07/08 21:59:20 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/07/08 21:59:20 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/07/08 21:59:21 [INFO] Deleting DB Cluster Parameter Group: cluster-parameter-group-test-terraform-1844594293549163779
2019/07/08 21:59:21 [INFO] Deleting DB Cluster Parameter Group: cluster-parameter-group-test-terraform-534038765522368457
2019/07/08 21:59:22 [INFO] Deleting DB Cluster Parameter Group: cluster-parameter-group-test-terraform-6898589886440596356
2019/07/08 21:59:22 [INFO] Deleting DB Cluster Parameter Group: cluster-parameter-group-test-tf-2020668958890966370
2019/07/08 21:59:23 [INFO] Skipping DB Cluster Parameter Group: default.aurora5.6
2019/07/08 21:59:23 [INFO] Skipping DB Cluster Parameter Group: default.aurora-mysql5.7
2019/07/08 21:59:23 [INFO] Skipping DB Cluster Parameter Group: default.aurora-postgresql9.6
2019/07/08 21:59:23 [INFO] Skipping DB Cluster Parameter Group: default.docdb3.6
2019/07/08 21:59:23 [INFO] Skipping DB Cluster Parameter Group: default.neptune1
2019/07/08 21:59:23 [INFO] Deleting DB Cluster Parameter Group: terraform-20190417124444975600000001
2019/07/08 21:59:24 [INFO] Deleting DB Cluster Parameter Group: terraform-20190603103458619400000001
2019/07/08 21:59:24 [INFO] Deleting DB Cluster Parameter Group: tf-aurora-prm-grp-257201181090950700
2019/07/08 21:59:25 [INFO] Deleting DB Cluster Parameter Group: tf-test-20190525103525958300000001
2019/07/08 21:59:25 Sweeper Tests ran:
	- aws_db_instance
	- aws_rds_cluster
	- aws_rds_cluster_parameter_group
2019/07/08 21:59:25 [DEBUG] Running Sweepers for region (us-east-1):
2019/07/08 21:59:25 [DEBUG] Sweeper (aws_rds_cluster_parameter_group) has dependency (aws_rds_cluster), running..
2019/07/08 21:59:25 [DEBUG] Sweeper (aws_rds_cluster) has dependency (aws_db_instance), running..
2019/07/08 21:59:25 [INFO] Building AWS auth structure
2019/07/08 21:59:25 [INFO] Setting AWS metadata API timeout to 100ms
2019/07/08 21:59:25 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2019/07/08 21:59:25 [INFO] AWS Auth provider used: "SharedCredentialsProvider"
2019/07/08 21:59:25 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/07/08 21:59:25 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/07/08 21:59:27 [INFO] Building AWS auth structure
2019/07/08 21:59:27 [INFO] Setting AWS metadata API timeout to 100ms
2019/07/08 21:59:27 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2019/07/08 21:59:27 [INFO] AWS Auth provider used: "SharedCredentialsProvider"
2019/07/08 21:59:27 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/07/08 21:59:27 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/07/08 21:59:27 [INFO] Building AWS auth structure
2019/07/08 21:59:27 [INFO] Setting AWS metadata API timeout to 100ms
2019/07/08 21:59:27 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2019/07/08 21:59:27 [INFO] AWS Auth provider used: "SharedCredentialsProvider"
2019/07/08 21:59:27 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/07/08 21:59:27 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/07/08 21:59:27 [INFO] Skipping DB Cluster Parameter Group: default.aurora5.6
2019/07/08 21:59:27 [INFO] Deleting DB Cluster Parameter Group: main-fc2
2019/07/08 21:59:28 Sweeper Tests ran:
	- aws_db_instance
	- aws_rds_cluster
	- aws_rds_cluster_parameter_group
ok  	github.com/terraform-providers/terraform-provider-aws/aws	12.596s

$ aws rds describe-db-cluster-parameter-groups | jq '[.DBClusterParameterGroups[] | select(.DBClusterParameterGroupName | contains("default.") | not)] | length'
0
```

Output from test sweeper in AWS GovCloud (US):

```
$ go test ./aws -v -sweep=us-gov-west-1 -sweep-run=aws_rds_cluster_parameter_group -timeout 10h
2019/07/08 21:59:52 [DEBUG] Running Sweepers for region (us-gov-west-1):
2019/07/08 21:59:52 [DEBUG] Sweeper (aws_rds_cluster_parameter_group) has dependency (aws_rds_cluster), running..
2019/07/08 21:59:52 [DEBUG] Sweeper (aws_rds_cluster) has dependency (aws_db_instance), running..
2019/07/08 21:59:52 [INFO] Building AWS auth structure
2019/07/08 21:59:52 [INFO] Setting AWS metadata API timeout to 100ms
2019/07/08 21:59:53 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2019/07/08 21:59:53 [INFO] AWS Auth provider used: "SharedCredentialsProvider"
2019/07/08 21:59:53 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/07/08 21:59:53 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/07/08 21:59:55 [INFO] Building AWS auth structure
2019/07/08 21:59:55 [INFO] Setting AWS metadata API timeout to 100ms
2019/07/08 21:59:55 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2019/07/08 21:59:55 [INFO] AWS Auth provider used: "SharedCredentialsProvider"
2019/07/08 21:59:55 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/07/08 21:59:56 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/07/08 21:59:57 [INFO] Deleting RDS DB Cluster: tf-acc-test-7573403505722178969
2019/07/08 21:59:57 [ERROR] Failed to delete RDS DB Cluster (tf-acc-test-7573403505722178969): InvalidParameterCombination: Cannot delete protected Cluster, please disable deletion protection and try again.
	status code: 400, request id: 7c8c5739-6d53-4301-8bd8-0efc07172f60
2019/07/08 21:59:57 [INFO] Building AWS auth structure
2019/07/08 21:59:57 [INFO] Setting AWS metadata API timeout to 100ms
2019/07/08 21:59:57 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2019/07/08 21:59:57 [INFO] AWS Auth provider used: "SharedCredentialsProvider"
2019/07/08 21:59:57 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/07/08 21:59:58 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/07/08 21:59:59 [INFO] Skipping DB Cluster Parameter Group: default.aurora-mysql5.7
2019/07/08 21:59:59 [INFO] Skipping DB Cluster Parameter Group: default.aurora-postgresql9.6
2019/07/08 21:59:59 [INFO] Skipping DB Cluster Parameter Group: default.aurora5.6
2019/07/08 21:59:59 Sweeper Tests ran:
	- aws_rds_cluster_parameter_group
	- aws_db_instance
	- aws_rds_cluster
ok  	github.com/terraform-providers/terraform-provider-aws/aws	7.899s

$ aws rds describe-db-cluster-parameter-groups | jq '[.DBClusterParameterGroups[] | select(.DBClusterParameterGroupName | contains("default.") | not)] | length'
0
```

