### PR TITLE
Allow for creating a IoT Core certificate without CSR.

### DIFF
--- a/aws/resource_aws_iot_certificate_test.go
+++ b/aws/resource_aws_iot_certificate_test.go
@@ -11,17 +11,41 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSIoTCertificate_basic(t *testing.T) {
+func TestAccAWSIoTCertificate_csr(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSIoTCertificateDestroy_basic,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSIoTCertificate_basic,
+				Config: testAccAWSIoTCertificate_csr,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("aws_iot_certificate.foo_cert", "arn"),
 					resource.TestCheckResourceAttrSet("aws_iot_certificate.foo_cert", "csr"),
+					resource.TestCheckResourceAttrSet("aws_iot_certificate.foo_cert", "certificate_pem"),
+					resource.TestCheckNoResourceAttr("aws_iot_certificate.foo_cert", "public_key"),
+					resource.TestCheckNoResourceAttr("aws_iot_certificate.foo_cert", "private_key"),
+					resource.TestCheckResourceAttr("aws_iot_certificate.foo_cert", "active", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSIoTCertificate_keys_certificate(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSIoTCertificateDestroy_basic,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSIoTCertificate_keys_certificate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("aws_iot_certificate.foo_cert", "arn"),
+					resource.TestCheckNoResourceAttr("aws_iot_certificate.foo_cert", "csr"),
+					resource.TestCheckResourceAttrSet("aws_iot_certificate.foo_cert", "certificate_pem"),
+					resource.TestCheckResourceAttrSet("aws_iot_certificate.foo_cert", "public_key"),
+					resource.TestCheckResourceAttrSet("aws_iot_certificate.foo_cert", "private_key"),
 					resource.TestCheckResourceAttr("aws_iot_certificate.foo_cert", "active", "true"),
 				),
 			},
@@ -63,9 +87,15 @@ func testAccCheckAWSIoTCertificateDestroy_basic(s *terraform.State) error {
 	return nil
 }
 
-var testAccAWSIoTCertificate_basic = `
+var testAccAWSIoTCertificate_csr = `
 resource "aws_iot_certificate" "foo_cert" {
   csr = "${file("test-fixtures/iot-csr.pem")}"
+  active = true
+}
+`
+
+var testAccAWSIoTCertificate_keys_certificate = `
+resource "aws_iot_certificate" "foo_cert" {
   active = true
 }
 `

--- a/website/docs/r/iot_certificate.html.markdown
+++ b/website/docs/r/iot_certificate.html.markdown
@@ -11,10 +11,16 @@ description: |-
 Creates and manages an AWS IoT certificate.
 
 ## Example Usage
-
+### With CSR
 ```hcl
 resource "aws_iot_certificate" "cert" {
   csr    = "${file("/my/csr.pem")}"
+  active = true
+}
+```
+### Without CSR
+```hcl
+resource "aws_iot_certificate" "cert" {
   active = true
 }
 ```
@@ -22,10 +28,21 @@ resource "aws_iot_certificate" "cert" {
 ## Argument Reference
 
 * `active` - (Required)  Boolean flag to indicate if the certificate should be active
-* `csr` - (Required) The certificate signing request. Review the
-  [IoT API Reference Guide] (http://docs.aws.amazon.com/iot/latest/apireference/API_CreateCertificateFromCsr.html)
-  for more information on creating a certificate from a certificate signing request (CSR).
+* `csr` - (Optional) The certificate signing request. Review
+  [CreateCertificateFromCsr](https://docs.aws.amazon.com/iot/latest/apireference/API_CreateCertificateFromCsr.html)
+  for more information on generating a certificate from a certificate signing request (CSR).
+  If none is specified both the certificate and keys will be generated, review [CreateKeysAndCertificate](https://docs.aws.amazon.com/iot/latest/apireference/API_CreateKeysAndCertificate.html)
+  for more information on generating keys and a certificate.
 
+## Attributes Reference
+
+In addition to the arguments, the following attributes are exported:
+
+* `arn` - The ARN of the certificate.
+* `id` - The internal id assigned to this certificate by IoT Core.
+* `certificate_pem` - The certificate data, in PEM format.
+* `public_key` - When no CSR is provided, the public key.
+* `private_key` - When no CSR is provided, the private key.
 
 ## Attributes Reference
 

--- a/website/docs/r/iot_certificate.html.markdown
+++ b/website/docs/r/iot_certificate.html.markdown
@@ -38,12 +38,9 @@ resource "aws_iot_certificate" "cert" {
 
 In addition to the arguments, the following attributes are exported:
 
-* `arn` - The ARN of the certificate.
-* `id` - The internal id assigned to this certificate by IoT Core.
+* `id` - The internal ID assigned to this certificate.
+* `arn` - The ARN of the created certificate.
 * `certificate_pem` - The certificate data, in PEM format.
 * `public_key` - When no CSR is provided, the public key.
 * `private_key` - When no CSR is provided, the private key.
 
-## Attributes Reference
-
-* `arn` - The ARN of the created AWS IoT certificate


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Allow for creating a IoT Core certificate without CSR. Makes the CSR field optional and adds the CreateKeysAndCertificate API call.