### PR TITLE
Support creation of private ACM certificates

### DIFF
--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -243,6 +243,7 @@ func resourceAwsAcmCertificateRead(d *schema.ResourceData, meta interface{}) err
 		}
 
 		d.Set("validation_method", resourceAwsAcmCertificateGuessValidationMethod(domainValidationOptions, emailValidationOptions))
+		d.Set("certificate_authority_arn", resp.Certificate.CertificateAuthorityArn)
 
 		params := &acm.ListTagsForCertificateInput{
 			CertificateArn: aws.String(d.Id()),

--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -68,6 +68,12 @@ func resourceAwsAcmCertificate() *schema.Resource {
 					},
 				},
 			},
+			"certificate_authority_arn": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
+			},
 			"validation_method": {
 				Type:          schema.TypeString,
 				Optional:      true,
@@ -164,6 +170,10 @@ func resourceAwsAcmCertificateCreateRequested(d *schema.ResourceData, meta inter
 			subjectAlternativeNames[i] = aws.String(strings.TrimSuffix(sanRaw.(string), "."))
 		}
 		params.SubjectAlternativeNames = subjectAlternativeNames
+	}
+
+	if pca, ok := d.GetOk("certificate_authority_arn"); ok {
+		params.CertificateAuthorityArn = aws.String(pca.(string))
 	}
 
 	log.Printf("[DEBUG] ACM Certificate Request: %#v", params)

--- a/website/docs/r/acm_certificate.html.markdown
+++ b/website/docs/r/acm_certificate.html.markdown
@@ -80,10 +80,14 @@ resource "aws_acm_certificate" "cert" {
 
 The following arguments are supported:
 
-* Creating an amazon issued certificate
+* Creating an amazon issued public certificate
   * `domain_name` - (Required) A domain name for which the certificate should be issued
   * `subject_alternative_names` - (Optional) A list of domains that should be SANs in the issued certificate
   * `validation_method` - (Required) Which method to use for validation. `DNS` or `EMAIL` are valid, `NONE` can be used for certificates that were imported into ACM and then into Terraform.
+* Creating an amazon issued private certificate
+  * `domain_name` - (Required) A domain name for which the certificate should be issued
+  * `subject_alternative_names` - (Optional) A list of domains that should be SANs in the issued certificate
+  * `certificate_authority_arn` - (Required) The ARN of the private certificate authority (CA) that will be used to issue the certificate. If omitted, ACM will attempt to issue a public certificate (see above)
 * Importing an existing certificate
   * `private_key` - (Required) The certificate's PEM-formatted private key
   * `certificate_body` - (Required) The certificate's PEM-formatted public key


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #5550

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```resource/aws_acm_certificate: Support creation of private ACM certificates [GH-5550]```

Output from acceptance testing:

```
$ AWS_PROFILE=matt make testacc TEST=./aws TESTARGS='-run=TestAccAWSAcmCertificate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSAcmCertificate -timeout 120m
...
--- FAIL: TestAccAWSAcmCertificateDataSource_singleIssued (5.47s)
--- FAIL: TestAccAWSAcmCertificateValidation_validationRecordFqdnsWildcardAndRoot (5.73s)
--- FAIL: TestAccAWSAcmCertificateValidation_basic (5.74s)
--- FAIL: TestAccAWSAcmCertificateValidation_validationRecordFqdnsRoot (5.76s)
--- FAIL: TestAccAWSAcmCertificateValidation_validationRecordFqdnsWildcard (5.77s)
--- FAIL: TestAccAWSAcmCertificateValidation_validationRecordFqdnsRootAndWildcard (5.87s)
--- FAIL: TestAccAWSAcmCertificateValidation_validationRecordFqdnsSan (5.90s)
--- FAIL: TestAccAWSAcmCertificateDataSource_multipleIssued (3.80s)
--- PASS: TestAccAWSAcmCertificateDataSource_noMatchReturnsError (15.73s)
--- PASS: TestAccAWSAcmCertificate_root (19.32s)
--- PASS: TestAccAWSAcmCertificate_imported_IpAddress (19.62s)
--- PASS: TestAccAWSAcmCertificate_root_TrailingPeriod (19.77s)
--- FAIL: TestAccAWSAcmCertificate_san_TrailingPeriod (20.56s)
--- PASS: TestAccAWSAcmCertificateDataSource_KeyTypes (21.70s)
--- PASS: TestAccAWSAcmCertificate_wildcard (23.61s)
--- FAIL: TestAccAWSAcmCertificate_rootAndWildcardSan (18.66s)
--- FAIL: TestAccAWSAcmCertificate_san_single (19.18s)
--- FAIL: TestAccAWSAcmCertificate_san_multiple (19.17s)
--- PASS: TestAccAWSAcmCertificate_privateCert (27.78s)
--- PASS: TestAccAWSAcmCertificate_wildcardAndRootSan (28.11s)
--- FAIL: TestAccAWSAcmCertificateValidation_validationRecordFqdns (29.65s)
--- PASS: TestAccAWSAcmCertificate_emailValidation (29.89s)
--- PASS: TestAccAWSAcmCertificate_dnsValidation (30.21s)
--- PASS: TestAccAWSAcmCertificateValidation_timeout (31.48s)
--- PASS: TestAccAWSAcmCertificate_imported_DomainName (30.15s)
--- FAIL: TestAccAWSAcmCertificate_tags (48.38s)
...
```
The test failures are all around DNS validation/Route53 setup missing in my account by the looks of things.  I've confirmed they also fail for me on master, so this doesn't look to be a regression.