### PR TITLE
New Resource: aws_athena_workgroup

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -330,6 +330,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_appsync_resolver":                                    resourceAwsAppsyncResolver(),
 			"aws_athena_database":                                     resourceAwsAthenaDatabase(),
 			"aws_athena_named_query":                                  resourceAwsAthenaNamedQuery(),
+			"aws_athena_workgroup":                                    resourceAwsAthenaWorkgroup(),
 			"aws_autoscaling_attachment":                              resourceAwsAutoscalingAttachment(),
 			"aws_autoscaling_group":                                   resourceAwsAutoscalingGroup(),
 			"aws_autoscaling_lifecycle_hook":                          resourceAwsAutoscalingLifecycleHook(),

--- a/aws/resource_aws_athena_workgroup.go
+++ b/aws/resource_aws_athena_workgroup.go
@@ -147,7 +147,7 @@ func resourceAwsAthenaWorkgroupCreate(d *schema.ResourceData, meta interface{}) 
 	_, err := conn.CreateWorkGroup(input)
 
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating Athena WorkGroup: %s", err)
 	}
 
 	d.SetId(name)
@@ -171,7 +171,7 @@ func resourceAwsAthenaWorkgroupRead(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if err != nil {
-		return err
+		return fmt.Errorf("error reading Athena WorkGroup (%s): %s", d.Id(), err)
 	}
 
 	d.Set("name", *resp.WorkGroup.Name)
@@ -246,7 +246,11 @@ func resourceAwsAthenaWorkgroupDelete(d *schema.ResourceData, meta interface{}) 
 
 	_, err := conn.DeleteWorkGroup(input)
 
-	return err
+	if err != nil {
+		return fmt.Errorf("error deleting Athena WorkGroup (%s): %s", d.Id(), err)
+	}
+
+	return nil
 }
 
 func resourceAwsAthenaWorkgroupUpdate(d *schema.ResourceData, meta interface{}) error {
@@ -350,7 +354,7 @@ func resourceAwsAthenaWorkgroupUpdate(d *schema.ResourceData, meta interface{}) 
 		_, err := conn.UpdateWorkGroup(input)
 
 		if err != nil {
-			return fmt.Errorf("Error updating Athena WorkGroup (%s): %s", d.Id(), err)
+			return fmt.Errorf("error updating Athena WorkGroup (%s): %s", d.Id(), err)
 		}
 	}
 

--- a/aws/resource_aws_athena_workgroup.go
+++ b/aws/resource_aws_athena_workgroup.go
@@ -1,0 +1,339 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/athena"
+	"github.com/hashicorp/terraform/helper/validation"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsAthenaWorkgroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsAthenaWorkgroupCreate,
+		Read:   resourceAwsAthenaWorkgroupRead,
+		Update: resourceAwsAthenaWorkgroupUpdate,
+		Delete: resourceAwsAthenaWorkgroupDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"bytes_scanned_cutoff_per_query": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntAtLeast(10485760),
+			},
+			"enforce_workgroup_configuration": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"publish_cloudwatch_metrics_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"output_location": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"encryption_option": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					athena.EncryptionOptionCseKms,
+					athena.EncryptionOptionSseKms,
+					athena.EncryptionOptionSseS3,
+				}, false),
+			},
+			"kms_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsAthenaWorkgroupCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).athenaconn
+
+	name := d.Get("name").(string)
+
+	input := &athena.CreateWorkGroupInput{
+		Name: aws.String(name),
+	}
+
+	basicConfig := false
+	resultConfig := false
+	encryptConfig := false
+
+	if v, ok := d.GetOk("description"); ok {
+		input.Description = aws.String(v.(string))
+	}
+
+	inputConfiguration := &athena.WorkGroupConfiguration{}
+
+	if v, ok := d.GetOk("bytes_scanned_cutoff_per_query"); ok {
+		basicConfig = true
+		inputConfiguration.BytesScannedCutoffPerQuery = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("enforce_workgroup_configuration"); ok {
+		basicConfig = true
+		inputConfiguration.EnforceWorkGroupConfiguration = aws.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("publish_cloudwatch_metrics_enabled"); ok {
+		basicConfig = true
+		inputConfiguration.PublishCloudWatchMetricsEnabled = aws.Bool(v.(bool))
+	}
+
+	resultConfiguration := &athena.ResultConfiguration{}
+
+	if v, ok := d.GetOk("output_location"); ok {
+		resultConfig = true
+		resultConfiguration.OutputLocation = aws.String(v.(string))
+	}
+
+	encryptionConfiguration := &athena.EncryptionConfiguration{}
+
+	if v, ok := d.GetOk("encryption_option"); ok {
+		resultConfig = true
+		encryptConfig = true
+		encryptionConfiguration.EncryptionOption = aws.String(v.(string))
+
+		if v.(string) == athena.EncryptionOptionCseKms || v.(string) == athena.EncryptionOptionSseKms {
+			if vkms, ok := d.GetOk("kms_key"); ok {
+				encryptionConfiguration.KmsKey = aws.String(vkms.(string))
+			} else {
+				return fmt.Errorf("KMS Key required but not provided for encryption_option: %s", v.(string))
+			}
+		}
+	}
+
+	if basicConfig {
+		input.Configuration = inputConfiguration
+	}
+
+	if resultConfig {
+		input.Configuration.ResultConfiguration = resultConfiguration
+
+		if encryptConfig {
+			input.Configuration.ResultConfiguration.EncryptionConfiguration = encryptionConfiguration
+		}
+	}
+
+	_, err := conn.CreateWorkGroup(input)
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId(name)
+
+	return resourceAwsAthenaWorkgroupRead(d, meta)
+}
+
+func resourceAwsAthenaWorkgroupRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).athenaconn
+
+	input := &athena.GetWorkGroupInput{
+		WorkGroup: aws.String(d.Id()),
+	}
+
+	resp, err := conn.GetWorkGroup(input)
+
+	if err != nil {
+		if isAWSErr(err, athena.ErrCodeInvalidRequestException, d.Id()) {
+			log.Printf("[WARN] Athena WorkGroup (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	d.Set("name", *resp.WorkGroup.Name)
+
+	if resp.WorkGroup.Description != nil {
+		d.Set("description", *resp.WorkGroup.Description)
+	}
+
+	client := meta.(*AWSClient)
+
+	arn := arn.ARN{
+		Partition: client.partition,
+		Region:    client.region,
+		Service:   "athena",
+		AccountID: client.accountid,
+		Resource:  fmt.Sprintf("workgroup/%s", d.Id()),
+	}
+
+	d.Set("arn", arn.String())
+
+	if resp.WorkGroup.Configuration != nil {
+		if resp.WorkGroup.Configuration.BytesScannedCutoffPerQuery != nil {
+			d.Set("bytes_scanned_cutoff_per_query", *resp.WorkGroup.Configuration.BytesScannedCutoffPerQuery)
+		}
+
+		if resp.WorkGroup.Configuration.EnforceWorkGroupConfiguration != nil {
+			d.Set("enforce_workgroup_configuration", *resp.WorkGroup.Configuration.EnforceWorkGroupConfiguration)
+		}
+
+		if resp.WorkGroup.Configuration.PublishCloudWatchMetricsEnabled != nil {
+			d.Set("publish_cloudwatch_metrics_enabled", *resp.WorkGroup.Configuration.PublishCloudWatchMetricsEnabled)
+		}
+
+		if resp.WorkGroup.Configuration.ResultConfiguration != nil {
+			if resp.WorkGroup.Configuration.ResultConfiguration.OutputLocation != nil {
+				d.Set("output_location", *resp.WorkGroup.Configuration.ResultConfiguration.OutputLocation)
+			}
+
+			if resp.WorkGroup.Configuration.ResultConfiguration.EncryptionConfiguration != nil {
+				if resp.WorkGroup.Configuration.ResultConfiguration.EncryptionConfiguration.EncryptionOption != nil {
+					d.Set("encryption_option", *resp.WorkGroup.Configuration.ResultConfiguration.EncryptionConfiguration.EncryptionOption)
+				}
+
+				if resp.WorkGroup.Configuration.ResultConfiguration.EncryptionConfiguration.KmsKey != nil {
+					d.Set("kms_key", *resp.WorkGroup.Configuration.ResultConfiguration.EncryptionConfiguration.KmsKey)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func resourceAwsAthenaWorkgroupDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).athenaconn
+
+	input := &athena.DeleteWorkGroupInput{
+		WorkGroup: aws.String(d.Id()),
+	}
+
+	_, err := conn.DeleteWorkGroup(input)
+
+	return err
+}
+
+func resourceAwsAthenaWorkgroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).athenaconn
+
+	workGroupUpdate := false
+	resultConfigUpdate := false
+	configUpdate := false
+	encryptionUpdate := false
+	removeEncryption := false
+
+	input := &athena.UpdateWorkGroupInput{
+		WorkGroup: aws.String(d.Get("name").(string)),
+	}
+
+	if d.HasChange("description") {
+		workGroupUpdate = true
+		input.Description = aws.String(d.Get("description").(string))
+	}
+
+	inputConfigurationUpdates := &athena.WorkGroupConfigurationUpdates{}
+
+	if d.HasChange("bytes_scanned_cutoff_per_query") {
+		workGroupUpdate = true
+		configUpdate = true
+
+		if v, ok := d.GetOk("bytes_scanned_cutoff_per_query"); ok {
+			inputConfigurationUpdates.BytesScannedCutoffPerQuery = aws.Int64(int64(v.(int)))
+		} else {
+			inputConfigurationUpdates.RemoveBytesScannedCutoffPerQuery = aws.Bool(true)
+		}
+	}
+
+	if d.HasChange("enforce_workgroup_configuration") {
+		workGroupUpdate = true
+		configUpdate = true
+
+		v := d.Get("enforce_workgroup_configuration")
+		inputConfigurationUpdates.EnforceWorkGroupConfiguration = aws.Bool(v.(bool))
+	}
+
+	if d.HasChange("publish_cloudwatch_metrics_enabled") {
+		workGroupUpdate = true
+		configUpdate = true
+
+		v := d.Get("publish_cloudwatch_metrics_enabled")
+		inputConfigurationUpdates.PublishCloudWatchMetricsEnabled = aws.Bool(v.(bool))
+	}
+
+	resultConfigurationUpdates := &athena.ResultConfigurationUpdates{}
+
+	if d.HasChange("output_location") {
+		workGroupUpdate = true
+		configUpdate = true
+		resultConfigUpdate = true
+
+		if v, ok := d.GetOk("output_location"); ok {
+			resultConfigurationUpdates.OutputLocation = aws.String(v.(string))
+		} else {
+			resultConfigurationUpdates.RemoveOutputLocation = aws.Bool(true)
+		}
+	}
+
+	encryptionConfiguration := &athena.EncryptionConfiguration{}
+
+	if d.HasChange("encryption_option") {
+		workGroupUpdate = true
+		configUpdate = true
+		resultConfigUpdate = true
+		encryptionUpdate = true
+
+		if v, ok := d.GetOk("encryption_option"); ok {
+			encryptionConfiguration.EncryptionOption = aws.String(v.(string))
+
+			if v.(string) == athena.EncryptionOptionCseKms || v.(string) == athena.EncryptionOptionSseKms {
+				if vkms, ok := d.GetOk("kms_key"); ok {
+					encryptionConfiguration.KmsKey = aws.String(vkms.(string))
+				} else {
+					return fmt.Errorf("KMS Key required but not provided for encryption_option: %s", v.(string))
+				}
+			}
+		} else {
+			removeEncryption = true
+			resultConfigurationUpdates.RemoveEncryptionConfiguration = aws.Bool(true)
+		}
+	}
+
+	if workGroupUpdate {
+		if configUpdate {
+			input.ConfigurationUpdates = inputConfigurationUpdates
+		}
+
+		if resultConfigUpdate {
+			input.ConfigurationUpdates.ResultConfigurationUpdates = resultConfigurationUpdates
+
+			if encryptionUpdate && !removeEncryption {
+				input.ConfigurationUpdates.ResultConfigurationUpdates.EncryptionConfiguration = encryptionConfiguration
+			}
+		}
+
+		_, err := conn.UpdateWorkGroup(input)
+
+		if err != nil {
+			return fmt.Errorf("Error updating Athena WorkGroup (%s): %s", d.Id(), err)
+		}
+	}
+
+	return resourceAwsAthenaWorkgroupRead(d, meta)
+}

--- a/aws/resource_aws_athena_workgroup.go
+++ b/aws/resource_aws_athena_workgroup.go
@@ -174,50 +174,29 @@ func resourceAwsAthenaWorkgroupRead(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("error reading Athena WorkGroup (%s): %s", d.Id(), err)
 	}
 
-	d.Set("name", *resp.WorkGroup.Name)
-
-	if resp.WorkGroup.Description != nil {
-		d.Set("description", *resp.WorkGroup.Description)
-	}
-
-	client := meta.(*AWSClient)
-
 	arn := arn.ARN{
-		Partition: client.partition,
-		Region:    client.region,
+		Partition: meta.(*AWSClient).partition,
+		Region:    meta.(*AWSClient).region,
 		Service:   "athena",
-		AccountID: client.accountid,
+		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("workgroup/%s", d.Id()),
 	}
 
 	d.Set("arn", arn.String())
+	d.Set("description", resp.WorkGroup.Description)
+	d.Set("name", resp.WorkGroup.Name)
 
 	if resp.WorkGroup.Configuration != nil {
-		if resp.WorkGroup.Configuration.BytesScannedCutoffPerQuery != nil {
-			d.Set("bytes_scanned_cutoff_per_query", *resp.WorkGroup.Configuration.BytesScannedCutoffPerQuery)
-		}
-
-		if resp.WorkGroup.Configuration.EnforceWorkGroupConfiguration != nil {
-			d.Set("enforce_workgroup_configuration", *resp.WorkGroup.Configuration.EnforceWorkGroupConfiguration)
-		}
-
-		if resp.WorkGroup.Configuration.PublishCloudWatchMetricsEnabled != nil {
-			d.Set("publish_cloudwatch_metrics_enabled", *resp.WorkGroup.Configuration.PublishCloudWatchMetricsEnabled)
-		}
+		d.Set("bytes_scanned_cutoff_per_query", resp.WorkGroup.Configuration.BytesScannedCutoffPerQuery)
+		d.Set("enforce_workgroup_configuration", resp.WorkGroup.Configuration.EnforceWorkGroupConfiguration)
+		d.Set("publish_cloudwatch_metrics_enabled", resp.WorkGroup.Configuration.PublishCloudWatchMetricsEnabled)
 
 		if resp.WorkGroup.Configuration.ResultConfiguration != nil {
-			if resp.WorkGroup.Configuration.ResultConfiguration.OutputLocation != nil {
-				d.Set("output_location", *resp.WorkGroup.Configuration.ResultConfiguration.OutputLocation)
-			}
+			d.Set("output_location", resp.WorkGroup.Configuration.ResultConfiguration.OutputLocation)
 
 			if resp.WorkGroup.Configuration.ResultConfiguration.EncryptionConfiguration != nil {
-				if resp.WorkGroup.Configuration.ResultConfiguration.EncryptionConfiguration.EncryptionOption != nil {
-					d.Set("encryption_option", *resp.WorkGroup.Configuration.ResultConfiguration.EncryptionConfiguration.EncryptionOption)
-				}
-
-				if resp.WorkGroup.Configuration.ResultConfiguration.EncryptionConfiguration.KmsKey != nil {
-					d.Set("kms_key", *resp.WorkGroup.Configuration.ResultConfiguration.EncryptionConfiguration.KmsKey)
-				}
+				d.Set("encryption_option", resp.WorkGroup.Configuration.ResultConfiguration.EncryptionConfiguration.EncryptionOption)
+				d.Set("kms_key", resp.WorkGroup.Configuration.ResultConfiguration.EncryptionConfiguration.KmsKey)
 			}
 		}
 	}

--- a/aws/resource_aws_athena_workgroup.go
+++ b/aws/resource_aws_athena_workgroup.go
@@ -18,6 +18,9 @@ func resourceAwsAthenaWorkgroup() *schema.Resource {
 		Read:   resourceAwsAthenaWorkgroupRead,
 		Update: resourceAwsAthenaWorkgroupUpdate,
 		Delete: resourceAwsAthenaWorkgroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/aws/resource_aws_athena_workgroup.go
+++ b/aws/resource_aws_athena_workgroup.go
@@ -164,12 +164,13 @@ func resourceAwsAthenaWorkgroupRead(d *schema.ResourceData, meta interface{}) er
 
 	resp, err := conn.GetWorkGroup(input)
 
+	if isAWSErr(err, athena.ErrCodeInvalidRequestException, "is not found") {
+		log.Printf("[WARN] Athena WorkGroup (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
-		if isAWSErr(err, athena.ErrCodeInvalidRequestException, d.Id()) {
-			log.Printf("[WARN] Athena WorkGroup (%s) not found, removing from state", d.Id())
-			d.SetId("")
-			return nil
-		}
 		return err
 	}
 
@@ -223,7 +224,7 @@ func resourceAwsAthenaWorkgroupRead(d *schema.ResourceData, meta interface{}) er
 
 	err = saveTagsAthena(conn, d, d.Get("arn").(string))
 
-	if isAWSErr(err, athena.ErrCodeInvalidRequestException, d.Id()) {
+	if isAWSErr(err, athena.ErrCodeInvalidRequestException, "is not found") {
 		log.Printf("[WARN] Athena WorkGroup (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/aws/resource_aws_athena_workgroup_test.go
+++ b/aws/resource_aws_athena_workgroup_test.go
@@ -26,6 +26,12 @@ func TestAccAWSAthenaWorkGroup_basic(t *testing.T) {
 				Config: testAccAthenaWorkGroupConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup1),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "athena", fmt.Sprintf("workgroup/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.enforce_workgroup_configuration", "true"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.publish_cloudwatch_metrics_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "state", athena.WorkGroupStateEnabled),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
@@ -61,6 +67,220 @@ func TestAccAWSAthenaWorkGroup_disappears(t *testing.T) {
 	})
 }
 
+func TestAccAWSAthenaWorkGroup_Configuration_BytesScannedCutoffPerQuery(t *testing.T) {
+	var workgroup1, workgroup2 athena.WorkGroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_athena_workgroup.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAthenaWorkGroupConfigConfigurationBytesScannedCutoffPerQuery(rName, 12582912),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup1),
+					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.bytes_scanned_cutoff_per_query", "12582912"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAthenaWorkGroupConfigConfigurationBytesScannedCutoffPerQuery(rName, 10485760),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup2),
+					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.bytes_scanned_cutoff_per_query", "10485760"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAthenaWorkGroup_Configuration_EnforceWorkgroupConfiguration(t *testing.T) {
+	var workgroup1, workgroup2 athena.WorkGroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_athena_workgroup.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAthenaWorkGroupConfigConfigurationEnforceWorkgroupConfiguration(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup1),
+					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.enforce_workgroup_configuration", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAthenaWorkGroupConfigConfigurationEnforceWorkgroupConfiguration(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup2),
+					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.enforce_workgroup_configuration", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAthenaWorkGroup_Configuration_PublishCloudWatchMetricsEnabled(t *testing.T) {
+	var workgroup1, workgroup2 athena.WorkGroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_athena_workgroup.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAthenaWorkGroupConfigConfigurationPublishCloudWatchMetricsEnabled(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup1),
+					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.publish_cloudwatch_metrics_enabled", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAthenaWorkGroupConfigConfigurationPublishCloudWatchMetricsEnabled(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup2),
+					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.publish_cloudwatch_metrics_enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_EncryptionConfiguration_SseS3(t *testing.T) {
+	var workgroup1 athena.WorkGroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_athena_workgroup.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAthenaWorkGroupConfigConfigurationResultConfigurationEncryptionConfigurationEncryptionOptionSseS3(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup1),
+					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.result_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.result_configuration.0.encryption_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.result_configuration.0.encryption_configuration.0.encryption_option", athena.EncryptionOptionSseS3),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_EncryptionConfiguration_Kms(t *testing.T) {
+	var workgroup1, workgroup2 athena.WorkGroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_athena_workgroup.test"
+	rEncryption := athena.EncryptionOptionSseKms
+	rEncryption2 := athena.EncryptionOptionCseKms
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAthenaWorkGroupConfigConfigurationResultConfigurationEncryptionConfigurationEncryptionOptionWithKms(rName, rEncryption),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup1),
+					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.result_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.result_configuration.0.encryption_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.result_configuration.0.encryption_configuration.0.encryption_option", rEncryption),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAthenaWorkGroupConfigConfigurationResultConfigurationEncryptionConfigurationEncryptionOptionWithKms(rName, rEncryption2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup2),
+					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.result_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.result_configuration.0.encryption_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.result_configuration.0.encryption_configuration.0.encryption_option", rEncryption2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_OutputLocation(t *testing.T) {
+	var workgroup1, workgroup2 athena.WorkGroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_athena_workgroup.test"
+	rOutputLocation1 := fmt.Sprintf("%s-1", rName)
+	rOutputLocation2 := fmt.Sprintf("%s-2", rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAthenaWorkGroupConfigConfigurationResultConfigurationOutputLocation(rName, rOutputLocation1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup1),
+					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.result_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.result_configuration.0.output_location", "s3://"+rOutputLocation1+"/test/output"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAthenaWorkGroupConfigConfigurationResultConfigurationOutputLocation(rName, rOutputLocation2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup2),
+					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.result_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.result_configuration.0.output_location", "s3://"+rOutputLocation2+"/test/output"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSAthenaWorkGroup_Description(t *testing.T) {
 	var workgroup1, workgroup2 athena.WorkGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -90,208 +310,6 @@ func TestAccAWSAthenaWorkGroup_Description(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup2),
 					resource.TestCheckResourceAttr(resourceName, "description", rDescriptionUpdate),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSAthenaWorkGroup_BytesScannedCutoffPerQuery(t *testing.T) {
-	var workgroup1, workgroup2 athena.WorkGroup
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_athena_workgroup.test"
-	rBytesScannedCutoffPerQuery := "10485760"
-	rBytesScannedCutoffPerQueryUpdate := "12582912"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAthenaWorkGroupConfigBytesScannedCutoffPerQuery(rName, rBytesScannedCutoffPerQuery),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup1),
-					resource.TestCheckResourceAttr(resourceName, "bytes_scanned_cutoff_per_query", rBytesScannedCutoffPerQuery),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccAthenaWorkGroupConfigBytesScannedCutoffPerQuery(rName, rBytesScannedCutoffPerQueryUpdate),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup2),
-					resource.TestCheckResourceAttr(resourceName, "bytes_scanned_cutoff_per_query", rBytesScannedCutoffPerQueryUpdate),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSAthenaWorkGroup_EnforceWorkgroupConfiguration(t *testing.T) {
-	var workgroup1, workgroup2 athena.WorkGroup
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_athena_workgroup.test"
-	rEnforce := "true"
-	rEnforceUpdate := "false"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAthenaWorkGroupConfigEnforceWorkgroupConfiguration(rName, rEnforce),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup1),
-					resource.TestCheckResourceAttr(resourceName, "enforce_workgroup_configuration", rEnforce),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccAthenaWorkGroupConfigEnforceWorkgroupConfiguration(rName, rEnforceUpdate),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup2),
-					resource.TestCheckResourceAttr(resourceName, "enforce_workgroup_configuration", rEnforceUpdate),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSAthenaWorkGroup_PublishCloudWatchMetricsEnabled(t *testing.T) {
-	var workgroup1, workgroup2 athena.WorkGroup
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_athena_workgroup.test"
-	rEnabled := "true"
-	rEnabledUpdate := "false"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAthenaWorkGroupConfigPublishCloudWatchMetricsEnabled(rName, rEnabled),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup1),
-					resource.TestCheckResourceAttr(resourceName, "publish_cloudwatch_metrics_enabled", rEnabled),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccAthenaWorkGroupConfigPublishCloudWatchMetricsEnabled(rName, rEnabledUpdate),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup2),
-					resource.TestCheckResourceAttr(resourceName, "publish_cloudwatch_metrics_enabled", rEnabledUpdate),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSAthenaWorkGroup_OutputLocation(t *testing.T) {
-	var workgroup1, workgroup2 athena.WorkGroup
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_athena_workgroup.test"
-	rOutputLocation1 := fmt.Sprintf("%s-1", rName)
-	rOutputLocation2 := fmt.Sprintf("%s-2", rName)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAthenaWorkGroupConfigOutputLocation(rName, rOutputLocation1),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup1),
-					resource.TestCheckResourceAttr(resourceName, "output_location", "s3://"+rOutputLocation1+"/test/output"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccAthenaWorkGroupConfigOutputLocation(rName, rOutputLocation2),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup2),
-					resource.TestCheckResourceAttr(resourceName, "output_location", "s3://"+rOutputLocation2+"/test/output"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSAthenaWorkGroup_SseS3Encryption(t *testing.T) {
-	var workgroup1 athena.WorkGroup
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_athena_workgroup.test"
-	rEncryption := athena.EncryptionOptionSseS3
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAthenaWorkGroupConfigEncryptionS3(rName, rEncryption),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup1),
-					resource.TestCheckResourceAttr(resourceName, "encryption_option", rEncryption),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSAthenaWorkGroup_KmsEncryption(t *testing.T) {
-	var workgroup1, workgroup2 athena.WorkGroup
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_athena_workgroup.test"
-	rEncryption := athena.EncryptionOptionSseKms
-	rEncryption2 := athena.EncryptionOptionCseKms
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAthenaWorkGroupConfigEncryptionKms(rName, rEncryption),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup1),
-					resource.TestCheckResourceAttr(resourceName, "encryption_option", rEncryption),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccAthenaWorkGroupConfigEncryptionKms(rName, rEncryption2),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup2),
-					resource.TestCheckResourceAttr(resourceName, "encryption_option", rEncryption2),
 				),
 			},
 		},
@@ -457,43 +475,52 @@ resource "aws_athena_workgroup" "test" {
 `, rName)
 }
 
-func testAccAthenaWorkGroupConfigDescription(rName string, rDescription string) string {
+func testAccAthenaWorkGroupConfigDescription(rName string, description string) string {
 	return fmt.Sprintf(`
 resource "aws_athena_workgroup" "test" {
   description = %[2]q
   name        = %[1]q
 }
-`, rName, rDescription)
+`, rName, description)
 }
 
-func testAccAthenaWorkGroupConfigBytesScannedCutoffPerQuery(rName string, rBytesScannedCutoffPerQuery string) string {
+func testAccAthenaWorkGroupConfigConfigurationBytesScannedCutoffPerQuery(rName string, bytesScannedCutoffPerQuery int) string {
 	return fmt.Sprintf(`
 resource "aws_athena_workgroup" "test" {
-  bytes_scanned_cutoff_per_query = %[2]s
-  name                           = %[1]q
+  name = %[1]q
+
+  configuration {
+    bytes_scanned_cutoff_per_query = %[2]d
+  }
 }
-`, rName, rBytesScannedCutoffPerQuery)
+`, rName, bytesScannedCutoffPerQuery)
 }
 
-func testAccAthenaWorkGroupConfigEnforceWorkgroupConfiguration(rName string, rEnforce string) string {
+func testAccAthenaWorkGroupConfigConfigurationEnforceWorkgroupConfiguration(rName string, enforceWorkgroupConfiguration bool) string {
 	return fmt.Sprintf(`
 resource "aws_athena_workgroup" "test" {
-  enforce_workgroup_configuration = %[2]s
-  name                            = %[1]q
+  name = %[1]q
+
+  configuration {
+    enforce_workgroup_configuration = %[2]t
+  }
 }
-`, rName, rEnforce)
+`, rName, enforceWorkgroupConfiguration)
 }
 
-func testAccAthenaWorkGroupConfigPublishCloudWatchMetricsEnabled(rName string, rEnable string) string {
+func testAccAthenaWorkGroupConfigConfigurationPublishCloudWatchMetricsEnabled(rName string, publishCloudwatchMetricsEnabled bool) string {
 	return fmt.Sprintf(`
 resource "aws_athena_workgroup" "test" {
-  name                               = %[1]q
-  publish_cloudwatch_metrics_enabled = %[2]s
+  name = %[1]q
+
+  configuration {
+    publish_cloudwatch_metrics_enabled = %[2]t
+  }
 }
-`, rName, rEnable)
+`, rName, publishCloudwatchMetricsEnabled)
 }
 
-func testAccAthenaWorkGroupConfigOutputLocation(rName string, rOutputLocation string) string {
+func testAccAthenaWorkGroupConfigConfigurationResultConfigurationOutputLocation(rName string, bucketName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test"{
   bucket        = %[2]q
@@ -501,22 +528,34 @@ resource "aws_s3_bucket" "test"{
 }
 
 resource "aws_athena_workgroup" "test" {
-  name            = %[1]q
-  output_location = "s3://${aws_s3_bucket.test.bucket}/test/output"
+  name = %[1]q
+
+  configuration {
+    result_configuration {
+      output_location = "s3://${aws_s3_bucket.test.bucket}/test/output"
+    }
+  }
 }
-`, rName, rOutputLocation)
+`, rName, bucketName)
 }
 
-func testAccAthenaWorkGroupConfigEncryptionS3(rName string, rEncryption string) string {
+func testAccAthenaWorkGroupConfigConfigurationResultConfigurationEncryptionConfigurationEncryptionOptionSseS3(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_athena_workgroup" "test" {
-  encryption_option = %[2]q
-  name              = %[1]q
+  name = %[1]q
+
+  configuration {
+    result_configuration {
+      encryption_configuration {
+        encryption_option = "SSE_S3"
+      }
+    }
+  }
 }
-`, rName, rEncryption)
+`, rName)
 }
 
-func testAccAthenaWorkGroupConfigEncryptionKms(rName string, rEncryption string) string {
+func testAccAthenaWorkGroupConfigConfigurationResultConfigurationEncryptionConfigurationEncryptionOptionWithKms(rName, encryptionOption string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
@@ -524,11 +563,18 @@ resource "aws_kms_key" "test" {
 }
 
 resource "aws_athena_workgroup" "test" {
-  encryption_option = %[2]q
-  kms_key           = "${aws_kms_key.test.arn}"
-  name              = %[1]q
+  name = %[1]q
+
+  configuration {
+    result_configuration {
+      encryption_configuration {
+        encryption_option = %[2]q
+        kms_key_arn       = "${aws_kms_key.test.arn}"
+      }
+    }
+  }
 }
-`, rName, rEncryption)
+`, rName, encryptionOption)
 }
 
 func testAccAthenaWorkGroupConfigState(rName, state string) string {

--- a/aws/resource_aws_athena_workgroup_test.go
+++ b/aws/resource_aws_athena_workgroup_test.go
@@ -29,6 +29,11 @@ func TestAccAWSAthenaWorkGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -75,6 +80,11 @@ func TestAccAWSAthenaWorkGroup_Description(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAthenaWorkGroupConfigDescription(rName, rDescriptionUpdate),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup2),
@@ -103,6 +113,11 @@ func TestAccAWSAthenaWorkGroup_BytesScannedCutoffPerQuery(t *testing.T) {
 					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup1),
 					resource.TestCheckResourceAttr(resourceName, "bytes_scanned_cutoff_per_query", rBytesScannedCutoffPerQuery),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAthenaWorkGroupConfigBytesScannedCutoffPerQuery(rName, rBytesScannedCutoffPerQueryUpdate),
@@ -135,6 +150,11 @@ func TestAccAWSAthenaWorkGroup_EnforceWorkgroupConfiguration(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAthenaWorkGroupConfigEnforceWorkgroupConfiguration(rName, rEnforceUpdate),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup2),
@@ -163,6 +183,11 @@ func TestAccAWSAthenaWorkGroup_PublishCloudWatchMetricsEnabled(t *testing.T) {
 					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup1),
 					resource.TestCheckResourceAttr(resourceName, "publish_cloudwatch_metrics_enabled", rEnabled),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAthenaWorkGroupConfigPublishCloudWatchMetricsEnabled(rName, rEnabledUpdate),
@@ -195,6 +220,11 @@ func TestAccAWSAthenaWorkGroup_OutputLocation(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAthenaWorkGroupConfigOutputLocation(rName, rOutputLocation2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup2),
@@ -223,6 +253,11 @@ func TestAccAWSAthenaWorkGroup_SseS3Encryption(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "encryption_option", rEncryption),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -245,6 +280,11 @@ func TestAccAWSAthenaWorkGroup_KmsEncryption(t *testing.T) {
 					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup1),
 					resource.TestCheckResourceAttr(resourceName, "encryption_option", rEncryption),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAthenaWorkGroupConfigEncryptionKms(rName, rEncryption2),
@@ -274,6 +314,11 @@ func TestAccAWSAthenaWorkGroup_Tags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAthenaWorkGroupConfigTags2(rName, "key1", "value1updated", "key2", "value2"),

--- a/aws/resource_aws_athena_workgroup_test.go
+++ b/aws/resource_aws_athena_workgroup_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccAWSAthenaWorkGroup_basic(t *testing.T) {
+	var workgroup1 athena.WorkGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_athena_workgroup.test"
 
@@ -24,7 +25,7 @@ func TestAccAWSAthenaWorkGroup_basic(t *testing.T) {
 			{
 				Config: testAccAthenaWorkGroupConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists(resourceName),
+					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup1),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
@@ -32,7 +33,30 @@ func TestAccAWSAthenaWorkGroup_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSAthenaWorkGroup_disappears(t *testing.T) {
+	var workgroup1 athena.WorkGroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_athena_workgroup.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAthenaWorkGroupConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup1),
+					testAccCheckAWSAthenaWorkGroupDisappears(&workgroup1),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSAthenaWorkGroup_Description(t *testing.T) {
+	var workgroup1, workgroup2 athena.WorkGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_athena_workgroup.test"
 	rDescription := acctest.RandString(20)
@@ -46,14 +70,14 @@ func TestAccAWSAthenaWorkGroup_Description(t *testing.T) {
 			{
 				Config: testAccAthenaWorkGroupConfigDescription(rName, rDescription),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists(resourceName),
+					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup1),
 					resource.TestCheckResourceAttr(resourceName, "description", rDescription),
 				),
 			},
 			{
 				Config: testAccAthenaWorkGroupConfigDescription(rName, rDescriptionUpdate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists(resourceName),
+					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup2),
 					resource.TestCheckResourceAttr(resourceName, "description", rDescriptionUpdate),
 				),
 			},
@@ -62,6 +86,7 @@ func TestAccAWSAthenaWorkGroup_Description(t *testing.T) {
 }
 
 func TestAccAWSAthenaWorkGroup_BytesScannedCutoffPerQuery(t *testing.T) {
+	var workgroup1, workgroup2 athena.WorkGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_athena_workgroup.test"
 	rBytesScannedCutoffPerQuery := "10485760"
@@ -75,14 +100,14 @@ func TestAccAWSAthenaWorkGroup_BytesScannedCutoffPerQuery(t *testing.T) {
 			{
 				Config: testAccAthenaWorkGroupConfigBytesScannedCutoffPerQuery(rName, rBytesScannedCutoffPerQuery),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists(resourceName),
+					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup1),
 					resource.TestCheckResourceAttr(resourceName, "bytes_scanned_cutoff_per_query", rBytesScannedCutoffPerQuery),
 				),
 			},
 			{
 				Config: testAccAthenaWorkGroupConfigBytesScannedCutoffPerQuery(rName, rBytesScannedCutoffPerQueryUpdate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists(resourceName),
+					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup2),
 					resource.TestCheckResourceAttr(resourceName, "bytes_scanned_cutoff_per_query", rBytesScannedCutoffPerQueryUpdate),
 				),
 			},
@@ -91,6 +116,7 @@ func TestAccAWSAthenaWorkGroup_BytesScannedCutoffPerQuery(t *testing.T) {
 }
 
 func TestAccAWSAthenaWorkGroup_EnforceWorkgroupConfiguration(t *testing.T) {
+	var workgroup1, workgroup2 athena.WorkGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_athena_workgroup.test"
 	rEnforce := "true"
@@ -104,14 +130,14 @@ func TestAccAWSAthenaWorkGroup_EnforceWorkgroupConfiguration(t *testing.T) {
 			{
 				Config: testAccAthenaWorkGroupConfigEnforceWorkgroupConfiguration(rName, rEnforce),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists(resourceName),
+					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup1),
 					resource.TestCheckResourceAttr(resourceName, "enforce_workgroup_configuration", rEnforce),
 				),
 			},
 			{
 				Config: testAccAthenaWorkGroupConfigEnforceWorkgroupConfiguration(rName, rEnforceUpdate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists(resourceName),
+					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup2),
 					resource.TestCheckResourceAttr(resourceName, "enforce_workgroup_configuration", rEnforceUpdate),
 				),
 			},
@@ -120,6 +146,7 @@ func TestAccAWSAthenaWorkGroup_EnforceWorkgroupConfiguration(t *testing.T) {
 }
 
 func TestAccAWSAthenaWorkGroup_PublishCloudWatchMetricsEnabled(t *testing.T) {
+	var workgroup1, workgroup2 athena.WorkGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_athena_workgroup.test"
 	rEnabled := "true"
@@ -133,14 +160,14 @@ func TestAccAWSAthenaWorkGroup_PublishCloudWatchMetricsEnabled(t *testing.T) {
 			{
 				Config: testAccAthenaWorkGroupConfigPublishCloudWatchMetricsEnabled(rName, rEnabled),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists(resourceName),
+					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup1),
 					resource.TestCheckResourceAttr(resourceName, "publish_cloudwatch_metrics_enabled", rEnabled),
 				),
 			},
 			{
 				Config: testAccAthenaWorkGroupConfigPublishCloudWatchMetricsEnabled(rName, rEnabledUpdate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists(resourceName),
+					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup2),
 					resource.TestCheckResourceAttr(resourceName, "publish_cloudwatch_metrics_enabled", rEnabledUpdate),
 				),
 			},
@@ -149,6 +176,7 @@ func TestAccAWSAthenaWorkGroup_PublishCloudWatchMetricsEnabled(t *testing.T) {
 }
 
 func TestAccAWSAthenaWorkGroup_OutputLocation(t *testing.T) {
+	var workgroup1, workgroup2 athena.WorkGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_athena_workgroup.test"
 	rOutputLocation1 := fmt.Sprintf("%s-1", rName)
@@ -162,14 +190,14 @@ func TestAccAWSAthenaWorkGroup_OutputLocation(t *testing.T) {
 			{
 				Config: testAccAthenaWorkGroupConfigOutputLocation(rName, rOutputLocation1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists(resourceName),
+					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup1),
 					resource.TestCheckResourceAttr(resourceName, "output_location", "s3://"+rOutputLocation1+"/test/output"),
 				),
 			},
 			{
 				Config: testAccAthenaWorkGroupConfigOutputLocation(rName, rOutputLocation2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists(resourceName),
+					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup2),
 					resource.TestCheckResourceAttr(resourceName, "output_location", "s3://"+rOutputLocation2+"/test/output"),
 				),
 			},
@@ -178,6 +206,7 @@ func TestAccAWSAthenaWorkGroup_OutputLocation(t *testing.T) {
 }
 
 func TestAccAWSAthenaWorkGroup_SseS3Encryption(t *testing.T) {
+	var workgroup1 athena.WorkGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_athena_workgroup.test"
 	rEncryption := athena.EncryptionOptionSseS3
@@ -190,7 +219,7 @@ func TestAccAWSAthenaWorkGroup_SseS3Encryption(t *testing.T) {
 			{
 				Config: testAccAthenaWorkGroupConfigEncryptionS3(rName, rEncryption),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists(resourceName),
+					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup1),
 					resource.TestCheckResourceAttr(resourceName, "encryption_option", rEncryption),
 				),
 			},
@@ -199,6 +228,7 @@ func TestAccAWSAthenaWorkGroup_SseS3Encryption(t *testing.T) {
 }
 
 func TestAccAWSAthenaWorkGroup_KmsEncryption(t *testing.T) {
+	var workgroup1, workgroup2 athena.WorkGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_athena_workgroup.test"
 	rEncryption := athena.EncryptionOptionSseKms
@@ -212,14 +242,14 @@ func TestAccAWSAthenaWorkGroup_KmsEncryption(t *testing.T) {
 			{
 				Config: testAccAthenaWorkGroupConfigEncryptionKms(rName, rEncryption),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists(resourceName),
+					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup1),
 					resource.TestCheckResourceAttr(resourceName, "encryption_option", rEncryption),
 				),
 			},
 			{
 				Config: testAccAthenaWorkGroupConfigEncryptionKms(rName, rEncryption2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists(resourceName),
+					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup2),
 					resource.TestCheckResourceAttr(resourceName, "encryption_option", rEncryption2),
 				),
 			},
@@ -228,6 +258,7 @@ func TestAccAWSAthenaWorkGroup_KmsEncryption(t *testing.T) {
 }
 
 func TestAccAWSAthenaWorkGroup_Tags(t *testing.T) {
+	var workgroup1, workgroup2, workgroup3 athena.WorkGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_athena_workgroup.test"
 
@@ -239,7 +270,7 @@ func TestAccAWSAthenaWorkGroup_Tags(t *testing.T) {
 			{
 				Config: testAccAthenaWorkGroupConfigTags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists(resourceName),
+					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup1),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
@@ -247,7 +278,7 @@ func TestAccAWSAthenaWorkGroup_Tags(t *testing.T) {
 			{
 				Config: testAccAthenaWorkGroupConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists(resourceName),
+					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup2),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
@@ -256,7 +287,7 @@ func TestAccAWSAthenaWorkGroup_Tags(t *testing.T) {
 			{
 				Config: testAccAthenaWorkGroupConfigTags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists(resourceName),
+					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup3),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
@@ -277,12 +308,15 @@ func testAccCheckAWSAthenaWorkGroupDestroy(s *terraform.State) error {
 		}
 
 		resp, err := conn.GetWorkGroup(input)
+
+		if isAWSErr(err, athena.ErrCodeInvalidRequestException, "is not found") {
+			continue
+		}
+
 		if err != nil {
-			if isAWSErr(err, athena.ErrCodeInvalidRequestException, rs.Primary.ID) {
-				return nil
-			}
 			return err
 		}
+
 		if resp.WorkGroup != nil {
 			return fmt.Errorf("Athena WorkGroup (%s) found", rs.Primary.ID)
 		}
@@ -290,7 +324,7 @@ func testAccCheckAWSAthenaWorkGroupDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAWSAthenaWorkGroupExists(name string) resource.TestCheckFunc {
+func testAccCheckAWSAthenaWorkGroupExists(name string, workgroup *athena.WorkGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -303,7 +337,28 @@ func testAccCheckAWSAthenaWorkGroupExists(name string) resource.TestCheckFunc {
 			WorkGroup: aws.String(rs.Primary.ID),
 		}
 
-		_, err := conn.GetWorkGroup(input)
+		output, err := conn.GetWorkGroup(input)
+
+		if err != nil {
+			return err
+		}
+
+		*workgroup = *output.WorkGroup
+
+		return nil
+	}
+}
+
+func testAccCheckAWSAthenaWorkGroupDisappears(workgroup *athena.WorkGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).athenaconn
+
+		input := &athena.DeleteWorkGroupInput{
+			WorkGroup: workgroup.Name,
+		}
+
+		_, err := conn.DeleteWorkGroup(input)
+
 		return err
 	}
 }

--- a/aws/resource_aws_athena_workgroup_test.go
+++ b/aws/resource_aws_athena_workgroup_test.go
@@ -28,27 +28,7 @@ func TestAccAWSAthenaWorkGroup_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSAthenaWorkGroup_withDescription(t *testing.T) {
-	rName := acctest.RandString(5)
-	rDescription := acctest.RandString(20)
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAthenaWorkGroupConfigDescription(rName, rDescription),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.desc"),
-					resource.TestCheckResourceAttr(
-						"aws_athena_workgroup.desc", "description", rDescription),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSAthenaWorkGroup_withDescriptionUpdate(t *testing.T) {
+func TestAccAWSAthenaWorkGroup_Description(t *testing.T) {
 	rName := acctest.RandString(5)
 	rDescription := acctest.RandString(20)
 	rDescriptionUpdate := acctest.RandString(20)
@@ -78,27 +58,7 @@ func TestAccAWSAthenaWorkGroup_withDescriptionUpdate(t *testing.T) {
 	})
 }
 
-func TestAccAWSAthenaWorkGroup_withBytesScannedCutoffPerQuery(t *testing.T) {
-	rName := acctest.RandString(5)
-	rBytesScannedCutoffPerQuery := "10485760"
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAthenaWorkGroupConfigBytesScannedCutoffPerQuery(rName, rBytesScannedCutoffPerQuery),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.bytes"),
-					resource.TestCheckResourceAttr(
-						"aws_athena_workgroup.bytes", "bytes_scanned_cutoff_per_query", rBytesScannedCutoffPerQuery),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSAthenaWorkGroup_withBytesScannedCutoffPerQueryUpdate(t *testing.T) {
+func TestAccAWSAthenaWorkGroup_BytesScannedCutoffPerQuery(t *testing.T) {
 	rName := acctest.RandString(5)
 	rBytesScannedCutoffPerQuery := "10485760"
 	rBytesScannedCutoffPerQueryUpdate := "12582912"
@@ -127,27 +87,7 @@ func TestAccAWSAthenaWorkGroup_withBytesScannedCutoffPerQueryUpdate(t *testing.T
 	})
 }
 
-func TestAccAWSAthenaWorkGroup_withEnforceWorkgroupConfiguration(t *testing.T) {
-	rName := acctest.RandString(5)
-	rEnforce := "true"
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAthenaWorkGroupConfigEnforceWorkgroupConfiguration(rName, rEnforce),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.enforce"),
-					resource.TestCheckResourceAttr(
-						"aws_athena_workgroup.enforce", "enforce_workgroup_configuration", rEnforce),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSAthenaWorkGroup_withEnforceWorkgroupConfigurationUpdate(t *testing.T) {
+func TestAccAWSAthenaWorkGroup_EnforceWorkgroupConfiguration(t *testing.T) {
 	rName := acctest.RandString(5)
 	rEnforce := "true"
 	rEnforceUpdate := "false"
@@ -176,27 +116,7 @@ func TestAccAWSAthenaWorkGroup_withEnforceWorkgroupConfigurationUpdate(t *testin
 	})
 }
 
-func TestAccAWSAthenaWorkGroup_withPublishCloudWatchMetricsEnabled(t *testing.T) {
-	rName := acctest.RandString(5)
-	rEnabled := "true"
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAthenaWorkGroupConfigPublishCloudWatchMetricsEnabled(rName, rEnabled),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.enable"),
-					resource.TestCheckResourceAttr(
-						"aws_athena_workgroup.enable", "publish_cloudwatch_metrics_enabled", rEnabled),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSAthenaWorkGroup_withPublishCloudWatchMetricsEnabledUpdate(t *testing.T) {
+func TestAccAWSAthenaWorkGroup_PublishCloudWatchMetricsEnabled(t *testing.T) {
 	rName := acctest.RandString(5)
 	rEnabled := "true"
 	rEnabledUpdate := "false"
@@ -225,27 +145,7 @@ func TestAccAWSAthenaWorkGroup_withPublishCloudWatchMetricsEnabledUpdate(t *test
 	})
 }
 
-func TestAccAWSAthenaWorkGroup_withOutputLocation(t *testing.T) {
-	rName := acctest.RandString(5)
-	rOutputLocation := acctest.RandString(10)
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAthenaWorkGroupConfigOutputLocation(rName, rOutputLocation),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.output"),
-					resource.TestCheckResourceAttr(
-						"aws_athena_workgroup.output", "output_location", "s3://"+rOutputLocation+"/test/output"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSAthenaWorkGroup_withOutputLocationUpdate(t *testing.T) {
+func TestAccAWSAthenaWorkGroup_OutputLocation(t *testing.T) {
 	rName := acctest.RandString(5)
 	rOutputLocation1 := acctest.RandString(10)
 	rOutputLocation2 := acctest.RandString(10)
@@ -274,7 +174,7 @@ func TestAccAWSAthenaWorkGroup_withOutputLocationUpdate(t *testing.T) {
 	})
 }
 
-func TestAccAWSAthenaWorkGroup_withSseS3Encryption(t *testing.T) {
+func TestAccAWSAthenaWorkGroup_SseS3Encryption(t *testing.T) {
 	rName := acctest.RandString(5)
 	rEncryption := athena.EncryptionOptionSseS3
 	resource.ParallelTest(t, resource.TestCase{
@@ -294,27 +194,7 @@ func TestAccAWSAthenaWorkGroup_withSseS3Encryption(t *testing.T) {
 	})
 }
 
-func TestAccAWSAthenaWorkGroup_withKmsEncryption(t *testing.T) {
-	rName := acctest.RandString(5)
-	rEncryption := athena.EncryptionOptionSseKms
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAthenaWorkGroupConfigEncryptionKms(rName, rEncryption),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.encryptionkms"),
-					resource.TestCheckResourceAttr(
-						"aws_athena_workgroup.encryptionkms", "encryption_option", rEncryption),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSAthenaWorkGroup_withKmsEncryptionUpdate(t *testing.T) {
+func TestAccAWSAthenaWorkGroup_KmsEncryption(t *testing.T) {
 	rName := acctest.RandString(5)
 	rEncryption := athena.EncryptionOptionSseKms
 	rEncryption2 := athena.EncryptionOptionCseKms

--- a/aws/resource_aws_athena_workgroup_test.go
+++ b/aws/resource_aws_athena_workgroup_test.go
@@ -1,0 +1,485 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/athena"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSAthenaWorkGroup_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAthenaWorkGroupConfig(acctest.RandString(5)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.foo"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAthenaWorkGroup_withDescription(t *testing.T) {
+	rName := acctest.RandString(5)
+	rDescription := acctest.RandString(20)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAthenaWorkGroupConfigDescription(rName, rDescription),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.desc"),
+					resource.TestCheckResourceAttr(
+						"aws_athena_workgroup.desc", "description", rDescription),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAthenaWorkGroup_withDescriptionUpdate(t *testing.T) {
+	rName := acctest.RandString(5)
+	rDescription := acctest.RandString(20)
+	rDescriptionUpdate := acctest.RandString(20)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAthenaWorkGroupConfigDescription(rName, rDescription),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.desc"),
+					resource.TestCheckResourceAttr(
+						"aws_athena_workgroup.desc", "description", rDescription),
+				),
+			},
+			{
+				Config: testAccAthenaWorkGroupConfigDescription(rName, rDescriptionUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.desc"),
+					resource.TestCheckResourceAttr(
+						"aws_athena_workgroup.desc", "description", rDescriptionUpdate),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAthenaWorkGroup_withBytesScannedCutoffPerQuery(t *testing.T) {
+	rName := acctest.RandString(5)
+	rBytesScannedCutoffPerQuery := "10485760"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAthenaWorkGroupConfigBytesScannedCutoffPerQuery(rName, rBytesScannedCutoffPerQuery),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.bytes"),
+					resource.TestCheckResourceAttr(
+						"aws_athena_workgroup.bytes", "bytes_scanned_cutoff_per_query", rBytesScannedCutoffPerQuery),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAthenaWorkGroup_withBytesScannedCutoffPerQueryUpdate(t *testing.T) {
+	rName := acctest.RandString(5)
+	rBytesScannedCutoffPerQuery := "10485760"
+	rBytesScannedCutoffPerQueryUpdate := "12582912"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAthenaWorkGroupConfigBytesScannedCutoffPerQuery(rName, rBytesScannedCutoffPerQuery),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.bytes"),
+					resource.TestCheckResourceAttr(
+						"aws_athena_workgroup.bytes", "bytes_scanned_cutoff_per_query", rBytesScannedCutoffPerQuery),
+				),
+			},
+			{
+				Config: testAccAthenaWorkGroupConfigBytesScannedCutoffPerQuery(rName, rBytesScannedCutoffPerQueryUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.bytes"),
+					resource.TestCheckResourceAttr(
+						"aws_athena_workgroup.bytes", "bytes_scanned_cutoff_per_query", rBytesScannedCutoffPerQueryUpdate),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAthenaWorkGroup_withEnforceWorkgroupConfiguration(t *testing.T) {
+	rName := acctest.RandString(5)
+	rEnforce := "true"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAthenaWorkGroupConfigEnforceWorkgroupConfiguration(rName, rEnforce),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.enforce"),
+					resource.TestCheckResourceAttr(
+						"aws_athena_workgroup.enforce", "enforce_workgroup_configuration", rEnforce),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAthenaWorkGroup_withEnforceWorkgroupConfigurationUpdate(t *testing.T) {
+	rName := acctest.RandString(5)
+	rEnforce := "true"
+	rEnforceUpdate := "false"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAthenaWorkGroupConfigEnforceWorkgroupConfiguration(rName, rEnforce),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.enforce"),
+					resource.TestCheckResourceAttr(
+						"aws_athena_workgroup.enforce", "enforce_workgroup_configuration", rEnforce),
+				),
+			},
+			{
+				Config: testAccAthenaWorkGroupConfigEnforceWorkgroupConfiguration(rName, rEnforceUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.enforce"),
+					resource.TestCheckResourceAttr(
+						"aws_athena_workgroup.enforce", "enforce_workgroup_configuration", rEnforceUpdate),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAthenaWorkGroup_withPublishCloudWatchMetricsEnabled(t *testing.T) {
+	rName := acctest.RandString(5)
+	rEnabled := "true"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAthenaWorkGroupConfigPublishCloudWatchMetricsEnabled(rName, rEnabled),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.enable"),
+					resource.TestCheckResourceAttr(
+						"aws_athena_workgroup.enable", "publish_cloudwatch_metrics_enabled", rEnabled),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAthenaWorkGroup_withPublishCloudWatchMetricsEnabledUpdate(t *testing.T) {
+	rName := acctest.RandString(5)
+	rEnabled := "true"
+	rEnabledUpdate := "false"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAthenaWorkGroupConfigPublishCloudWatchMetricsEnabled(rName, rEnabled),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.enable"),
+					resource.TestCheckResourceAttr(
+						"aws_athena_workgroup.enable", "publish_cloudwatch_metrics_enabled", rEnabled),
+				),
+			},
+			{
+				Config: testAccAthenaWorkGroupConfigPublishCloudWatchMetricsEnabled(rName, rEnabledUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.enable"),
+					resource.TestCheckResourceAttr(
+						"aws_athena_workgroup.enable", "publish_cloudwatch_metrics_enabled", rEnabledUpdate),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAthenaWorkGroup_withOutputLocation(t *testing.T) {
+	rName := acctest.RandString(5)
+	rOutputLocation := acctest.RandString(10)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAthenaWorkGroupConfigOutputLocation(rName, rOutputLocation),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.output"),
+					resource.TestCheckResourceAttr(
+						"aws_athena_workgroup.output", "output_location", "s3://"+rOutputLocation+"/test/output"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAthenaWorkGroup_withOutputLocationUpdate(t *testing.T) {
+	rName := acctest.RandString(5)
+	rOutputLocation1 := acctest.RandString(10)
+	rOutputLocation2 := acctest.RandString(10)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAthenaWorkGroupConfigOutputLocation(rName, rOutputLocation1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.output"),
+					resource.TestCheckResourceAttr(
+						"aws_athena_workgroup.output", "output_location", "s3://"+rOutputLocation1+"/test/output"),
+				),
+			},
+			{
+				Config: testAccAthenaWorkGroupConfigOutputLocation(rName, rOutputLocation2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.output"),
+					resource.TestCheckResourceAttr(
+						"aws_athena_workgroup.output", "output_location", "s3://"+rOutputLocation2+"/test/output"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAthenaWorkGroup_withSseS3Encryption(t *testing.T) {
+	rName := acctest.RandString(5)
+	rEncryption := athena.EncryptionOptionSseS3
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAthenaWorkGroupConfigEncryptionS3(rName, rEncryption),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.encryption"),
+					resource.TestCheckResourceAttr(
+						"aws_athena_workgroup.encryption", "encryption_option", rEncryption),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAthenaWorkGroup_withKmsEncryption(t *testing.T) {
+	rName := acctest.RandString(5)
+	rEncryption := athena.EncryptionOptionSseKms
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAthenaWorkGroupConfigEncryptionKms(rName, rEncryption),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.encryptionkms"),
+					resource.TestCheckResourceAttr(
+						"aws_athena_workgroup.encryptionkms", "encryption_option", rEncryption),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAthenaWorkGroup_withKmsEncryptionUpdate(t *testing.T) {
+	rName := acctest.RandString(5)
+	rEncryption := athena.EncryptionOptionSseKms
+	rEncryption2 := athena.EncryptionOptionCseKms
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAthenaWorkGroupConfigEncryptionKms(rName, rEncryption),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.encryptionkms"),
+					resource.TestCheckResourceAttr(
+						"aws_athena_workgroup.encryptionkms", "encryption_option", rEncryption),
+				),
+			},
+			{
+				Config: testAccAthenaWorkGroupConfigEncryptionKms(rName, rEncryption2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.encryptionkms"),
+					resource.TestCheckResourceAttr(
+						"aws_athena_workgroup.encryptionkms", "encryption_option", rEncryption2),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSAthenaWorkGroupDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).athenaconn
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_athena_workgroup" {
+			continue
+		}
+
+		input := &athena.GetWorkGroupInput{
+			WorkGroup: aws.String(rs.Primary.ID),
+		}
+
+		resp, err := conn.GetWorkGroup(input)
+		if err != nil {
+			if isAWSErr(err, athena.ErrCodeInvalidRequestException, rs.Primary.ID) {
+				return nil
+			}
+			return err
+		}
+		if resp.WorkGroup != nil {
+			return fmt.Errorf("Athena WorkGroup (%s) found", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testAccCheckAWSAthenaWorkGroupExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).athenaconn
+
+		input := &athena.GetWorkGroupInput{
+			WorkGroup: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.GetWorkGroup(input)
+		return err
+	}
+}
+
+func testAccAthenaWorkGroupConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_athena_workgroup" "foo" {
+  name = "tf-athena-workgroup-%s"
+}
+		`, rName)
+}
+
+func testAccAthenaWorkGroupConfigDescription(rName string, rDescription string) string {
+	return fmt.Sprintf(`
+	resource "aws_athena_workgroup" "desc" {
+		name = "tf-athena-workgroup-%s"
+		description = "%s"
+	}
+	`, rName, rDescription)
+}
+
+func testAccAthenaWorkGroupConfigBytesScannedCutoffPerQuery(rName string, rBytesScannedCutoffPerQuery string) string {
+	return fmt.Sprintf(`
+	resource "aws_athena_workgroup" "bytes" {
+		name = "tf-athena-workgroup-%s"
+		bytes_scanned_cutoff_per_query = %s
+	}
+	`, rName, rBytesScannedCutoffPerQuery)
+}
+
+func testAccAthenaWorkGroupConfigEnforceWorkgroupConfiguration(rName string, rEnforce string) string {
+	return fmt.Sprintf(`
+	resource "aws_athena_workgroup" "enforce" {
+		name = "tf-athena-workgroup-%s"
+		enforce_workgroup_configuration = %s
+	}
+	`, rName, rEnforce)
+}
+
+func testAccAthenaWorkGroupConfigPublishCloudWatchMetricsEnabled(rName string, rEnable string) string {
+	return fmt.Sprintf(`
+	resource "aws_athena_workgroup" "enable" {
+		name = "tf-athena-workgroup-%s"
+		publish_cloudwatch_metrics_enabled = %s
+	}
+	`, rName, rEnable)
+}
+
+func testAccAthenaWorkGroupConfigOutputLocation(rName string, rOutputLocation string) string {
+	return fmt.Sprintf(`
+	resource "aws_s3_bucket" "output-bucket"{
+		bucket = "%s"
+		force_destroy = true
+	}
+
+	resource "aws_athena_workgroup" "output" {
+		name = "tf-athena-workgroup-%s"
+		output_location = "s3://${aws_s3_bucket.output-bucket.bucket}/test/output"
+	}
+	`, rOutputLocation, rName)
+}
+
+func testAccAthenaWorkGroupConfigEncryptionS3(rName string, rEncryption string) string {
+	return fmt.Sprintf(`
+	resource "aws_athena_workgroup" "encryption" {
+		name = "tf-athena-workgroup-%s"
+		encryption_option = "%s"
+	}
+	`, rName, rEncryption)
+}
+
+func testAccAthenaWorkGroupConfigEncryptionKms(rName string, rEncryption string) string {
+	return fmt.Sprintf(`
+	resource "aws_kms_key" "kmstest" {
+		description = "EncryptionKmsTest"
+		policy = <<POLICY
+	{
+		"Version": "2012-10-17",
+		"Id": "kms-tf-1",
+		"Statement": [
+			{
+				"Sid": "Enable IAM User Permissions",
+				"Effect": "Allow",
+				"Principal": {
+					"AWS": "*"
+				},
+				"Action": "kms:*",
+				"Resource": "*"
+			}
+		]
+	}
+	POLICY
+	}
+
+	resource "aws_athena_workgroup" "encryptionkms" {
+		name = "tf-athena-workgroup-%s"
+		encryption_option = "%s"
+		kms_key = "${aws_kms_key.kmstest.arn}"
+	}
+	`, rName, rEncryption)
+}

--- a/aws/resource_aws_athena_workgroup_test.go
+++ b/aws/resource_aws_athena_workgroup_test.go
@@ -13,15 +13,18 @@ import (
 )
 
 func TestAccAWSAthenaWorkGroup_basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_athena_workgroup.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAthenaWorkGroupConfig(acctest.RandString(5)),
+				Config: testAccAthenaWorkGroupConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.foo"),
+					testAccCheckAWSAthenaWorkGroupExists(resourceName),
 				),
 			},
 		},
@@ -29,7 +32,8 @@ func TestAccAWSAthenaWorkGroup_basic(t *testing.T) {
 }
 
 func TestAccAWSAthenaWorkGroup_Description(t *testing.T) {
-	rName := acctest.RandString(5)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_athena_workgroup.test"
 	rDescription := acctest.RandString(20)
 	rDescriptionUpdate := acctest.RandString(20)
 
@@ -41,17 +45,15 @@ func TestAccAWSAthenaWorkGroup_Description(t *testing.T) {
 			{
 				Config: testAccAthenaWorkGroupConfigDescription(rName, rDescription),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.desc"),
-					resource.TestCheckResourceAttr(
-						"aws_athena_workgroup.desc", "description", rDescription),
+					testAccCheckAWSAthenaWorkGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", rDescription),
 				),
 			},
 			{
 				Config: testAccAthenaWorkGroupConfigDescription(rName, rDescriptionUpdate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.desc"),
-					resource.TestCheckResourceAttr(
-						"aws_athena_workgroup.desc", "description", rDescriptionUpdate),
+					testAccCheckAWSAthenaWorkGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", rDescriptionUpdate),
 				),
 			},
 		},
@@ -59,9 +61,11 @@ func TestAccAWSAthenaWorkGroup_Description(t *testing.T) {
 }
 
 func TestAccAWSAthenaWorkGroup_BytesScannedCutoffPerQuery(t *testing.T) {
-	rName := acctest.RandString(5)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_athena_workgroup.test"
 	rBytesScannedCutoffPerQuery := "10485760"
 	rBytesScannedCutoffPerQueryUpdate := "12582912"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -70,17 +74,15 @@ func TestAccAWSAthenaWorkGroup_BytesScannedCutoffPerQuery(t *testing.T) {
 			{
 				Config: testAccAthenaWorkGroupConfigBytesScannedCutoffPerQuery(rName, rBytesScannedCutoffPerQuery),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.bytes"),
-					resource.TestCheckResourceAttr(
-						"aws_athena_workgroup.bytes", "bytes_scanned_cutoff_per_query", rBytesScannedCutoffPerQuery),
+					testAccCheckAWSAthenaWorkGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "bytes_scanned_cutoff_per_query", rBytesScannedCutoffPerQuery),
 				),
 			},
 			{
 				Config: testAccAthenaWorkGroupConfigBytesScannedCutoffPerQuery(rName, rBytesScannedCutoffPerQueryUpdate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.bytes"),
-					resource.TestCheckResourceAttr(
-						"aws_athena_workgroup.bytes", "bytes_scanned_cutoff_per_query", rBytesScannedCutoffPerQueryUpdate),
+					testAccCheckAWSAthenaWorkGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "bytes_scanned_cutoff_per_query", rBytesScannedCutoffPerQueryUpdate),
 				),
 			},
 		},
@@ -88,9 +90,11 @@ func TestAccAWSAthenaWorkGroup_BytesScannedCutoffPerQuery(t *testing.T) {
 }
 
 func TestAccAWSAthenaWorkGroup_EnforceWorkgroupConfiguration(t *testing.T) {
-	rName := acctest.RandString(5)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_athena_workgroup.test"
 	rEnforce := "true"
 	rEnforceUpdate := "false"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -99,17 +103,15 @@ func TestAccAWSAthenaWorkGroup_EnforceWorkgroupConfiguration(t *testing.T) {
 			{
 				Config: testAccAthenaWorkGroupConfigEnforceWorkgroupConfiguration(rName, rEnforce),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.enforce"),
-					resource.TestCheckResourceAttr(
-						"aws_athena_workgroup.enforce", "enforce_workgroup_configuration", rEnforce),
+					testAccCheckAWSAthenaWorkGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "enforce_workgroup_configuration", rEnforce),
 				),
 			},
 			{
 				Config: testAccAthenaWorkGroupConfigEnforceWorkgroupConfiguration(rName, rEnforceUpdate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.enforce"),
-					resource.TestCheckResourceAttr(
-						"aws_athena_workgroup.enforce", "enforce_workgroup_configuration", rEnforceUpdate),
+					testAccCheckAWSAthenaWorkGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "enforce_workgroup_configuration", rEnforceUpdate),
 				),
 			},
 		},
@@ -117,9 +119,11 @@ func TestAccAWSAthenaWorkGroup_EnforceWorkgroupConfiguration(t *testing.T) {
 }
 
 func TestAccAWSAthenaWorkGroup_PublishCloudWatchMetricsEnabled(t *testing.T) {
-	rName := acctest.RandString(5)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_athena_workgroup.test"
 	rEnabled := "true"
 	rEnabledUpdate := "false"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -128,17 +132,15 @@ func TestAccAWSAthenaWorkGroup_PublishCloudWatchMetricsEnabled(t *testing.T) {
 			{
 				Config: testAccAthenaWorkGroupConfigPublishCloudWatchMetricsEnabled(rName, rEnabled),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.enable"),
-					resource.TestCheckResourceAttr(
-						"aws_athena_workgroup.enable", "publish_cloudwatch_metrics_enabled", rEnabled),
+					testAccCheckAWSAthenaWorkGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "publish_cloudwatch_metrics_enabled", rEnabled),
 				),
 			},
 			{
 				Config: testAccAthenaWorkGroupConfigPublishCloudWatchMetricsEnabled(rName, rEnabledUpdate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.enable"),
-					resource.TestCheckResourceAttr(
-						"aws_athena_workgroup.enable", "publish_cloudwatch_metrics_enabled", rEnabledUpdate),
+					testAccCheckAWSAthenaWorkGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "publish_cloudwatch_metrics_enabled", rEnabledUpdate),
 				),
 			},
 		},
@@ -146,9 +148,11 @@ func TestAccAWSAthenaWorkGroup_PublishCloudWatchMetricsEnabled(t *testing.T) {
 }
 
 func TestAccAWSAthenaWorkGroup_OutputLocation(t *testing.T) {
-	rName := acctest.RandString(5)
-	rOutputLocation1 := acctest.RandString(10)
-	rOutputLocation2 := acctest.RandString(10)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_athena_workgroup.test"
+	rOutputLocation1 := fmt.Sprintf("%s-1", rName)
+	rOutputLocation2 := fmt.Sprintf("%s-2", rName)
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -157,17 +161,15 @@ func TestAccAWSAthenaWorkGroup_OutputLocation(t *testing.T) {
 			{
 				Config: testAccAthenaWorkGroupConfigOutputLocation(rName, rOutputLocation1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.output"),
-					resource.TestCheckResourceAttr(
-						"aws_athena_workgroup.output", "output_location", "s3://"+rOutputLocation1+"/test/output"),
+					testAccCheckAWSAthenaWorkGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "output_location", "s3://"+rOutputLocation1+"/test/output"),
 				),
 			},
 			{
 				Config: testAccAthenaWorkGroupConfigOutputLocation(rName, rOutputLocation2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.output"),
-					resource.TestCheckResourceAttr(
-						"aws_athena_workgroup.output", "output_location", "s3://"+rOutputLocation2+"/test/output"),
+					testAccCheckAWSAthenaWorkGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "output_location", "s3://"+rOutputLocation2+"/test/output"),
 				),
 			},
 		},
@@ -175,8 +177,10 @@ func TestAccAWSAthenaWorkGroup_OutputLocation(t *testing.T) {
 }
 
 func TestAccAWSAthenaWorkGroup_SseS3Encryption(t *testing.T) {
-	rName := acctest.RandString(5)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_athena_workgroup.test"
 	rEncryption := athena.EncryptionOptionSseS3
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -185,9 +189,8 @@ func TestAccAWSAthenaWorkGroup_SseS3Encryption(t *testing.T) {
 			{
 				Config: testAccAthenaWorkGroupConfigEncryptionS3(rName, rEncryption),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.encryption"),
-					resource.TestCheckResourceAttr(
-						"aws_athena_workgroup.encryption", "encryption_option", rEncryption),
+					testAccCheckAWSAthenaWorkGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "encryption_option", rEncryption),
 				),
 			},
 		},
@@ -195,9 +198,11 @@ func TestAccAWSAthenaWorkGroup_SseS3Encryption(t *testing.T) {
 }
 
 func TestAccAWSAthenaWorkGroup_KmsEncryption(t *testing.T) {
-	rName := acctest.RandString(5)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_athena_workgroup.test"
 	rEncryption := athena.EncryptionOptionSseKms
 	rEncryption2 := athena.EncryptionOptionCseKms
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -206,17 +211,15 @@ func TestAccAWSAthenaWorkGroup_KmsEncryption(t *testing.T) {
 			{
 				Config: testAccAthenaWorkGroupConfigEncryptionKms(rName, rEncryption),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.encryptionkms"),
-					resource.TestCheckResourceAttr(
-						"aws_athena_workgroup.encryptionkms", "encryption_option", rEncryption),
+					testAccCheckAWSAthenaWorkGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "encryption_option", rEncryption),
 				),
 			},
 			{
 				Config: testAccAthenaWorkGroupConfigEncryptionKms(rName, rEncryption2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaWorkGroupExists("aws_athena_workgroup.encryptionkms"),
-					resource.TestCheckResourceAttr(
-						"aws_athena_workgroup.encryptionkms", "encryption_option", rEncryption2),
+					testAccCheckAWSAthenaWorkGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "encryption_option", rEncryption2),
 				),
 			},
 		},
@@ -268,98 +271,82 @@ func testAccCheckAWSAthenaWorkGroupExists(name string) resource.TestCheckFunc {
 
 func testAccAthenaWorkGroupConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_athena_workgroup" "foo" {
-  name = "tf-athena-workgroup-%s"
+resource "aws_athena_workgroup" "test" {
+  name = %[1]q
 }
-		`, rName)
+`, rName)
 }
 
 func testAccAthenaWorkGroupConfigDescription(rName string, rDescription string) string {
 	return fmt.Sprintf(`
-	resource "aws_athena_workgroup" "desc" {
-		name = "tf-athena-workgroup-%s"
-		description = "%s"
-	}
-	`, rName, rDescription)
+resource "aws_athena_workgroup" "test" {
+  description = %[2]q
+  name        = %[1]q
+}
+`, rName, rDescription)
 }
 
 func testAccAthenaWorkGroupConfigBytesScannedCutoffPerQuery(rName string, rBytesScannedCutoffPerQuery string) string {
 	return fmt.Sprintf(`
-	resource "aws_athena_workgroup" "bytes" {
-		name = "tf-athena-workgroup-%s"
-		bytes_scanned_cutoff_per_query = %s
-	}
-	`, rName, rBytesScannedCutoffPerQuery)
+resource "aws_athena_workgroup" "test" {
+  bytes_scanned_cutoff_per_query = %[2]s
+  name                           = %[1]q
+}
+`, rName, rBytesScannedCutoffPerQuery)
 }
 
 func testAccAthenaWorkGroupConfigEnforceWorkgroupConfiguration(rName string, rEnforce string) string {
 	return fmt.Sprintf(`
-	resource "aws_athena_workgroup" "enforce" {
-		name = "tf-athena-workgroup-%s"
-		enforce_workgroup_configuration = %s
-	}
-	`, rName, rEnforce)
+resource "aws_athena_workgroup" "test" {
+  enforce_workgroup_configuration = %[2]s
+  name                            = %[1]q
+}
+`, rName, rEnforce)
 }
 
 func testAccAthenaWorkGroupConfigPublishCloudWatchMetricsEnabled(rName string, rEnable string) string {
 	return fmt.Sprintf(`
-	resource "aws_athena_workgroup" "enable" {
-		name = "tf-athena-workgroup-%s"
-		publish_cloudwatch_metrics_enabled = %s
-	}
-	`, rName, rEnable)
+resource "aws_athena_workgroup" "test" {
+  name                               = %[1]q
+  publish_cloudwatch_metrics_enabled = %[2]s
+}
+`, rName, rEnable)
 }
 
 func testAccAthenaWorkGroupConfigOutputLocation(rName string, rOutputLocation string) string {
 	return fmt.Sprintf(`
-	resource "aws_s3_bucket" "output-bucket"{
-		bucket = "%s"
-		force_destroy = true
-	}
+resource "aws_s3_bucket" "test"{
+  bucket        = %[2]q
+  force_destroy = true
+}
 
-	resource "aws_athena_workgroup" "output" {
-		name = "tf-athena-workgroup-%s"
-		output_location = "s3://${aws_s3_bucket.output-bucket.bucket}/test/output"
-	}
-	`, rOutputLocation, rName)
+resource "aws_athena_workgroup" "test" {
+  name            = %[1]q
+  output_location = "s3://${aws_s3_bucket.test.bucket}/test/output"
+}
+`, rName, rOutputLocation)
 }
 
 func testAccAthenaWorkGroupConfigEncryptionS3(rName string, rEncryption string) string {
 	return fmt.Sprintf(`
-	resource "aws_athena_workgroup" "encryption" {
-		name = "tf-athena-workgroup-%s"
-		encryption_option = "%s"
-	}
-	`, rName, rEncryption)
+resource "aws_athena_workgroup" "test" {
+  encryption_option = %[2]q
+  name              = %[1]q
+}
+`, rName, rEncryption)
 }
 
 func testAccAthenaWorkGroupConfigEncryptionKms(rName string, rEncryption string) string {
 	return fmt.Sprintf(`
-	resource "aws_kms_key" "kmstest" {
-		description = "EncryptionKmsTest"
-		policy = <<POLICY
-	{
-		"Version": "2012-10-17",
-		"Id": "kms-tf-1",
-		"Statement": [
-			{
-				"Sid": "Enable IAM User Permissions",
-				"Effect": "Allow",
-				"Principal": {
-					"AWS": "*"
-				},
-				"Action": "kms:*",
-				"Resource": "*"
-			}
-		]
-	}
-	POLICY
-	}
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+  description             = "Terraform Acceptance Testing"
+}
 
-	resource "aws_athena_workgroup" "encryptionkms" {
-		name = "tf-athena-workgroup-%s"
-		encryption_option = "%s"
-		kms_key = "${aws_kms_key.kmstest.arn}"
-	}
-	`, rName, rEncryption)
+resource "aws_athena_workgroup" "test" {
+  encryption_option = %[2]q
+  kms_key           = "${aws_kms_key.test.arn}"
+  name              = %[1]q
+}
+`, rName, rEncryption)
 }

--- a/aws/tagsAthena.go
+++ b/aws/tagsAthena.go
@@ -1,0 +1,134 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/athena"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// setTags is a helper to set the tags for a resource. It expects the
+// tags field to be named "tags"
+func setTagsAthena(conn *athena.Athena, d *schema.ResourceData, arn string) error {
+	if d.HasChange("tags") {
+		oraw, nraw := d.GetChange("tags")
+		o := oraw.(map[string]interface{})
+		n := nraw.(map[string]interface{})
+		create, remove := diffTagsAthena(tagsFromMapAthena(o), tagsFromMapAthena(n))
+
+		// Set tags
+		if len(remove) > 0 {
+			log.Printf("[DEBUG] Removing tags: %#v", remove)
+			k := make([]*string, len(remove))
+			for i, t := range remove {
+				k[i] = t.Key
+			}
+
+			_, err := conn.UntagResource(&athena.UntagResourceInput{
+				ResourceARN: aws.String(arn),
+				TagKeys:     k,
+			})
+			if err != nil {
+				return err
+			}
+		}
+		if len(create) > 0 {
+			log.Printf("[DEBUG] Creating tags: %#v", create)
+			_, err := conn.TagResource(&athena.TagResourceInput{
+				ResourceARN: aws.String(arn),
+				Tags:        create,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// diffTags takes our tags locally and the ones remotely and returns
+// the set of tags that must be created, and the set of tags that must
+// be destroyed.
+func diffTagsAthena(oldTags, newTags []*athena.Tag) ([]*athena.Tag, []*athena.Tag) {
+	// First, we're creating everything we have
+	create := make(map[string]interface{})
+	for _, t := range newTags {
+		create[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+	}
+
+	// Build the list of what to remove
+	var remove []*athena.Tag
+	for _, t := range oldTags {
+		old, ok := create[aws.StringValue(t.Key)]
+		if !ok || old != aws.StringValue(t.Value) {
+			// Delete it!
+			remove = append(remove, t)
+		}
+	}
+
+	return tagsFromMapAthena(create), remove
+}
+
+// tagsFromMap returns the tags for the given map of data.
+func tagsFromMapAthena(m map[string]interface{}) []*athena.Tag {
+	result := make([]*athena.Tag, 0, len(m))
+	for k, v := range m {
+		t := &athena.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v.(string)),
+		}
+		if !tagIgnoredAthena(t) {
+			result = append(result, t)
+		}
+	}
+
+	return result
+}
+
+// tagsToMap turns the list of tags into a map.
+func tagsToMapAthena(ts []*athena.Tag) map[string]string {
+	result := make(map[string]string)
+	for _, t := range ts {
+		if !tagIgnoredAthena(t) {
+			result[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+		}
+	}
+
+	return result
+}
+
+func saveTagsAthena(conn *athena.Athena, d *schema.ResourceData, arn string) error {
+	resp, err := conn.ListTagsForResource(&athena.ListTagsForResourceInput{
+		ResourceARN: aws.String(arn),
+	})
+
+	if err != nil {
+		return fmt.Errorf("Error retreiving tags for ARN: %s", arn)
+	}
+
+	var tagList []*athena.Tag
+	if len(resp.Tags) > 0 {
+		tagList = resp.Tags
+	}
+
+	return d.Set("tags", tagsToMapAthena(tagList))
+}
+
+// compare a tag against a list of strings and checks if it should
+// be ignored or not
+func tagIgnoredAthena(t *athena.Tag) bool {
+	filter := []string{"^aws:"}
+	for _, v := range filter {
+		log.Printf("[DEBUG] Matching %v with %v\n", v, aws.StringValue(t.Key))
+		r, _ := regexp.MatchString(v, aws.StringValue(t.Key))
+		if r {
+			log.Printf("[DEBUG] Found AWS specific tag %s (val: %s), ignoring.\n", aws.StringValue(t.Key), aws.StringValue(t.Value))
+			return true
+		}
+	}
+	return false
+}

--- a/aws/tagsAthena_test.go
+++ b/aws/tagsAthena_test.go
@@ -1,0 +1,79 @@
+package aws
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/athena"
+)
+
+// go test -v -run="TestDiffAthenaTags"
+func TestDiffAthenaTags(t *testing.T) {
+	cases := []struct {
+		Old, New       map[string]interface{}
+		Create, Remove map[string]string
+	}{
+		// Basic add/remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"bar": "baz",
+			},
+			Create: map[string]string{
+				"bar": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Modify
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "baz",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		c, r := diffTagsAthena(tagsFromMapAthena(tc.Old), tagsFromMapAthena(tc.New))
+		cm := tagsToMapAthena(c)
+		rm := tagsToMapAthena(r)
+		if !reflect.DeepEqual(cm, tc.Create) {
+			t.Fatalf("%d: bad create: %#v", i, cm)
+		}
+		if !reflect.DeepEqual(rm, tc.Remove) {
+			t.Fatalf("%d: bad remove: %#v", i, rm)
+		}
+	}
+}
+
+// go test -v -run="TestIgnoringTagsAthena"
+func TestIgnoringTagsAthena(t *testing.T) {
+	var ignoredTags []*athena.Tag
+	ignoredTags = append(ignoredTags, &athena.Tag{
+		Key:   aws.String("aws:cloudformation:logical-id"),
+		Value: aws.String("foo"),
+	})
+	ignoredTags = append(ignoredTags, &athena.Tag{
+		Key:   aws.String("aws:foo:bar"),
+		Value: aws.String("baz"),
+	})
+	for _, tag := range ignoredTags {
+		if !tagIgnoredAthena(tag) {
+			t.Fatalf("Tag %v with value %v not ignored, but should be!", *tag.Key, *tag.Value)
+		}
+	}
+}

--- a/aws/tagsAthena_test.go
+++ b/aws/tagsAthena_test.go
@@ -11,23 +11,23 @@ import (
 // go test -v -run="TestDiffAthenaTags"
 func TestDiffAthenaTags(t *testing.T) {
 	cases := []struct {
-		Old, New       map[string]interface{}
-		Create, Remove map[string]string
+		Old, New map[string]interface{}
+		Create   map[string]string
+		Remove   []string
 	}{
-		// Basic add/remove
+		// Add
 		{
 			Old: map[string]interface{}{
 				"foo": "bar",
 			},
 			New: map[string]interface{}{
+				"foo": "bar",
 				"bar": "baz",
 			},
 			Create: map[string]string{
 				"bar": "baz",
 			},
-			Remove: map[string]string{
-				"foo": "bar",
-			},
+			Remove: []string{},
 		},
 
 		// Modify
@@ -41,8 +41,41 @@ func TestDiffAthenaTags(t *testing.T) {
 			Create: map[string]string{
 				"foo": "baz",
 			},
-			Remove: map[string]string{
+			Remove: []string{
+				"foo",
+			},
+		},
+
+		// Overlap
+		{
+			Old: map[string]interface{}{
+				"foo":   "bar",
+				"hello": "world",
+			},
+			New: map[string]interface{}{
+				"foo":   "baz",
+				"hello": "world",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: []string{
+				"foo",
+			},
+		},
+
+		// Remove
+		{
+			Old: map[string]interface{}{
 				"foo": "bar",
+				"bar": "baz",
+			},
+			New: map[string]interface{}{
+				"foo": "bar",
+			},
+			Create: map[string]string{},
+			Remove: []string{
+				"bar",
 			},
 		},
 	}
@@ -50,12 +83,15 @@ func TestDiffAthenaTags(t *testing.T) {
 	for i, tc := range cases {
 		c, r := diffTagsAthena(tagsFromMapAthena(tc.Old), tagsFromMapAthena(tc.New))
 		cm := tagsToMapAthena(c)
-		rm := tagsToMapAthena(r)
+		rl := []string{}
+		for _, tagName := range r {
+			rl = append(rl, *tagName)
+		}
 		if !reflect.DeepEqual(cm, tc.Create) {
 			t.Fatalf("%d: bad create: %#v", i, cm)
 		}
-		if !reflect.DeepEqual(rm, tc.Remove) {
-			t.Fatalf("%d: bad remove: %#v", i, rm)
+		if !reflect.DeepEqual(rl, tc.Remove) {
+			t.Fatalf("%d: bad remove: %#v", i, rl)
 		}
 	}
 }

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -619,6 +619,9 @@
                         <li>
                           <a href="/docs/providers/aws/r/athena_named_query.html">aws_athena_named_query</a>
                         </li>
+                        <li>
+                          <a href="/docs/providers/aws/r/athena_workgroup.html">aws_athena_workgroup</a>
+                        </li>
                     </ul>
                 </li>
 

--- a/website/docs/r/athena_workgroup.html.markdown
+++ b/website/docs/r/athena_workgroup.html.markdown
@@ -1,0 +1,80 @@
+---
+layout: "aws"
+page_title: "AWS: aws_athena_workgroup"
+sidebar_current: "docs-aws-resource-athena-workgroup"
+description: |-
+  Manages an Athena Workgroup.
+---
+
+# Resource: aws_athena_workgroup
+
+Provides an Athena Workgroup.
+
+## Example Usage
+
+```hcl
+resource "aws_athena_workgroup" "example" {
+  name = "example"
+
+  configuration {
+    enforce_workgroup_configuration    = true
+    publish_cloudwatch_metrics_enabled = true
+
+    result_configuration {
+      output_location = "s3://{aws_s3_bucket.example.bucket}/output/"
+
+      encryption_configuration {
+        encryption_option = "SSE-KMS"
+        kms_key_arn       = "${aws_kms_key.example.arn}"
+      }
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the workgroup.
+* `configuration` - (Optional) Configuration block with various settings for the workgroup. Documented below.
+* `description` - (Optional) Description of the workgroup.
+* `state` - (Optional) State of the workgroup. Valid values are `DISABLED` or `ENABLED`. Defaults to `ENABLED`.
+* `tags` - (Optional) Key-value mapping of resource tags for the workgroup.
+
+### configuration Argument Reference
+
+The `configuration` configuration block supports the following arguments:
+
+* `bytes_scanned_cutoff_per_query` - (Optional) Integer for the upper data usage limit (cutoff) for the amount of bytes a single query in a workgroup is allowed to scan. Must be at least `10485760`.
+* `enforce_workgroup_configuration` - (Optional) Boolean whether the settings for the workgroup override client-side settings. For more information, see [Workgroup Settings Override Client-Side Settings](https://docs.aws.amazon.com/athena/latest/ug/workgroups-settings-override.html).
+* `publish_cloudwatch_metrics_enabled` - (Optional) Boolean whether Amazon CloudWatch metrics are enabled for the workgroup.
+* `result_configuration` - (Optional) Configuration block with result settings. Documented below.
+
+#### result_configuration Argument Reference
+
+The `result_configuration` configuration block within the `configuration` supports the following arguments:
+
+* `encryption_configuration` - (Optional) Configuration block with encryption settings. Documented below.
+* `output_location` - (Optional) The location in Amazon S3 where your query results are stored, such as `s3://path/to/query/bucket/`. For more information, see [Queries and Query Result Files](https://docs.aws.amazon.com/athena/latest/ug/querying.html).
+
+##### encryption_configuration Argument Reference
+
+The `encryption_configuration` configuration block within the `result_configuration` of the `configuration` supports the following arguments:
+
+* `encryption_option` - (Required) Indicates whether Amazon S3 server-side encryption with Amazon S3-managed keys (SSE-S3), server-side encryption with KMS-managed keys (SSE-KMS), or client-side encryption with KMS-managed keys (CSE-KMS) is used. If a query runs in a workgroup and the workgroup overrides client-side settings, then the workgroup's setting for encryption is used. It specifies whether query results must be encrypted, for all queries that run in this workgroup.
+* `kms_key_arn` - (Optional) For SSE-KMS and CSE-KMS, this is the KMS key Amazon Resource Name (ARN).
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The workgroup name
+
+## Import
+
+Athena Workgroups can be imported using their name, e.g.
+
+```
+$ terraform import aws_athena_workgroup.example example
+```

--- a/website/docs/r/athena_workgroup.html.markdown
+++ b/website/docs/r/athena_workgroup.html.markdown
@@ -24,7 +24,7 @@ resource "aws_athena_workgroup" "example" {
       output_location = "s3://{aws_s3_bucket.example.bucket}/output/"
 
       encryption_configuration {
-        encryption_option = "SSE-KMS"
+        encryption_option = "SSE_KMS"
         kms_key_arn       = "${aws_kms_key.example.arn}"
       }
     }
@@ -47,8 +47,8 @@ The following arguments are supported:
 The `configuration` configuration block supports the following arguments:
 
 * `bytes_scanned_cutoff_per_query` - (Optional) Integer for the upper data usage limit (cutoff) for the amount of bytes a single query in a workgroup is allowed to scan. Must be at least `10485760`.
-* `enforce_workgroup_configuration` - (Optional) Boolean whether the settings for the workgroup override client-side settings. For more information, see [Workgroup Settings Override Client-Side Settings](https://docs.aws.amazon.com/athena/latest/ug/workgroups-settings-override.html).
-* `publish_cloudwatch_metrics_enabled` - (Optional) Boolean whether Amazon CloudWatch metrics are enabled for the workgroup.
+* `enforce_workgroup_configuration` - (Optional) Boolean whether the settings for the workgroup override client-side settings. For more information, see [Workgroup Settings Override Client-Side Settings](https://docs.aws.amazon.com/athena/latest/ug/workgroups-settings-override.html). Defaults to `true`.
+* `publish_cloudwatch_metrics_enabled` - (Optional) Boolean whether Amazon CloudWatch metrics are enabled for the workgroup. Defaults to `true`.
 * `result_configuration` - (Optional) Configuration block with result settings. Documented below.
 
 #### result_configuration Argument Reference

--- a/website/docs/r/athena_workgroup.html.markdown
+++ b/website/docs/r/athena_workgroup.html.markdown
@@ -69,6 +69,7 @@ The `encryption_configuration` configuration block within the `result_configurat
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - Amazon Resource Name (ARN) of the workgroup
 * `id` - The workgroup name
 
 ## Import


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Includes and supersedes #7995
Includes and supersedes #8136
Closes #7650 
Closes #7667

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* **New Resource:** `aws_athena_workgroup`
```

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSAthenaWorkGroup_disappears (9.08s)
--- PASS: TestAccAWSAthenaWorkGroup_basic (15.76s)
--- PASS: TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_EncryptionConfiguration_SseS3 (25.96s)
--- PASS: TestAccAWSAthenaWorkGroup_Configuration_EnforceWorkgroupConfiguration (27.10s)
--- PASS: TestAccAWSAthenaWorkGroup_Tags (31.92s)
--- PASS: TestAccAWSAthenaWorkGroup_State (36.06s)
--- PASS: TestAccAWSAthenaWorkGroup_Description (36.53s)
--- PASS: TestAccAWSAthenaWorkGroup_Configuration_BytesScannedCutoffPerQuery (37.99s)
--- PASS: TestAccAWSAthenaWorkGroup_Configuration_PublishCloudWatchMetricsEnabled (41.14s)
--- PASS: TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_OutputLocation (54.00s)
--- PASS: TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_EncryptionConfiguration_Kms (57.21s)
PASS
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAWSAthenaWorkGroup_disappears (13.12s)
--- PASS: TestAccAWSAthenaWorkGroup_basic (19.15s)
--- PASS: TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_EncryptionConfiguration_SseS3 (21.32s)
--- PASS: TestAccAWSAthenaWorkGroup_Configuration_PublishCloudWatchMetricsEnabled (28.45s)
--- PASS: TestAccAWSAthenaWorkGroup_Configuration_EnforceWorkgroupConfiguration (33.33s)
--- PASS: TestAccAWSAthenaWorkGroup_Description (33.73s)
--- PASS: TestAccAWSAthenaWorkGroup_Configuration_BytesScannedCutoffPerQuery (36.62s)
--- PASS: TestAccAWSAthenaWorkGroup_Tags (39.83s)
--- PASS: TestAccAWSAthenaWorkGroup_State (45.99s)
--- PASS: TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_EncryptionConfiguration_Kms (63.29s)
--- PASS: TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_OutputLocation (64.17s)
PASS
```

