### PR TITLE
Add support for aws_datapipeline_definition resource

### DIFF
--- a/aws/datapipeline_helpers.go
+++ b/aws/datapipeline_helpers.go
@@ -1,0 +1,365 @@
+package aws
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/datapipeline"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func expandDataPipelineParameterObject(rawParameterObject map[string]interface{}) (*datapipeline.ParameterObject, error) {
+	parameterObject := &datapipeline.ParameterObject{}
+	parameterAttributeList := []*datapipeline.ParameterAttribute{}
+
+	if val, ok := rawParameterObject["id"].(string); ok && val != "" {
+		parameterObject.Id = aws.String(val)
+	}
+
+	if val, ok := rawParameterObject["description"].(string); ok && val != "" {
+		p := &datapipeline.ParameterAttribute{
+			Key:         aws.String("description"),
+			StringValue: aws.String(val),
+		}
+		parameterAttributeList = append(parameterAttributeList, p)
+	}
+
+	if val, ok := rawParameterObject["type"].(string); ok && val != "" {
+		p := &datapipeline.ParameterAttribute{
+			Key:         aws.String("type"),
+			StringValue: aws.String(val),
+		}
+		parameterAttributeList = append(parameterAttributeList, p)
+	}
+
+	if val, ok := rawParameterObject["optional"].(bool); ok {
+		p := &datapipeline.ParameterAttribute{
+			Key:         aws.String("optional"),
+			StringValue: aws.String(strconv.FormatBool(val)),
+		}
+		parameterAttributeList = append(parameterAttributeList, p)
+	}
+
+	if val, ok := rawParameterObject["allowed_values"].([]string); ok && len(val) != 0 {
+		for _, v := range val {
+			p := &datapipeline.ParameterAttribute{
+				Key:         aws.String("allowedValues"),
+				StringValue: aws.String(v),
+			}
+			parameterAttributeList = append(parameterAttributeList, p)
+		}
+	}
+
+	if val, ok := rawParameterObject["default"].(string); ok && val != "" {
+		p := &datapipeline.ParameterAttribute{
+			Key:         aws.String("default"),
+			StringValue: aws.String(val),
+		}
+		parameterAttributeList = append(parameterAttributeList, p)
+	}
+
+	if val, ok := rawParameterObject["is_array"].(bool); ok {
+		p := &datapipeline.ParameterAttribute{
+			Key:         aws.String("isArray"),
+			StringValue: aws.String(strconv.FormatBool(val)),
+		}
+		parameterAttributeList = append(parameterAttributeList, p)
+	}
+
+	parameterObject.Attributes = parameterAttributeList
+
+	if err := parameterObject.Validate(); err != nil {
+		return nil, fmt.Errorf("Error validate parameter object: %s", err)
+	}
+
+	return parameterObject, nil
+}
+
+func expandDataPipelineParameterValue(rawParameterValue map[string]interface{}) (*datapipeline.ParameterValue, error) {
+	parameterValue := &datapipeline.ParameterValue{}
+
+	if val, ok := rawParameterValue["id"].(string); ok && val != "" {
+		parameterValue.Id = aws.String(val)
+	}
+
+	if val, ok := rawParameterValue["string_value"].(string); ok && val != "" {
+		parameterValue.StringValue = aws.String(val)
+	}
+
+	if err := parameterValue.Validate(); err != nil {
+		return nil, fmt.Errorf("Error validate parameter value: %s", err)
+	}
+
+	return parameterValue, nil
+}
+
+func expandDataPipelineDefaultPipelineObject(l []interface{}) (*datapipeline.PipelineObject, error) {
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	pipelineObject := &datapipeline.PipelineObject{
+		Id:   aws.String("Default"),
+		Name: aws.String("Default"),
+	}
+	fieldList := []*datapipeline.Field{}
+
+	typeField := &datapipeline.Field{
+		Key:         aws.String("type"),
+		StringValue: aws.String("Default"),
+	}
+	fieldList = append(fieldList, typeField)
+
+	if val, ok := m["schedule_type"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("scheduleType"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := m["failure_and_rerun_mode"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("failureAndRerunMode"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := m["pipeline_log_uri"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("pipelineLogUri"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := m["role"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("role"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := m["resource_role"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("resourceRole"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := m["schedule"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:      aws.String("schedule"),
+			RefValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	pipelineObject.Fields = fieldList
+
+	err := pipelineObject.Validate()
+	if err != nil {
+		return nil, fmt.Errorf("Error validate default pipeline object: %s", err)
+	}
+
+	return pipelineObject, nil
+}
+
+func expandDataPipelinePipelineObject(pipelineObjectType string, rawPipelineObject map[string]interface{}) (*datapipeline.PipelineObject, error) {
+	pipelineObject := &datapipeline.PipelineObject{
+		Id:   aws.String(rawPipelineObject["id"].(string)),
+		Name: aws.String(rawPipelineObject["name"].(string)),
+	}
+	fieldList := []*datapipeline.Field{}
+
+	typeField := &datapipeline.Field{
+		Key:         aws.String("type"),
+		StringValue: aws.String(pipelineObjectType),
+	}
+	fieldList = append(fieldList, typeField)
+
+	if v, ok := rawPipelineObject["period"]; ok && v.(string) != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("period"),
+			StringValue: aws.String(v.(string)),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if v, ok := rawPipelineObject["start_at"]; ok && v.(string) != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("startAt"),
+			StringValue: aws.String(v.(string)),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if v, ok := rawPipelineObject["start_date_time"]; ok && v.(string) != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("startDateTime"),
+			StringValue: aws.String(v.(string)),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if v, ok := rawPipelineObject["end_date_time"]; ok && v.(string) != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("endDateTime"),
+			StringValue: aws.String(v.(string)),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if v, ok := rawPipelineObject["occurrences"]; ok && v.(int) != 0 {
+		f := &datapipeline.Field{
+			Key:         aws.String("occurrences"),
+			StringValue: aws.String(strconv.Itoa(v.(int))),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if v, ok := rawPipelineObject["parent"]; ok && v.(string) != "" {
+		f := &datapipeline.Field{
+			Key:      aws.String("parent"),
+			RefValue: aws.String(v.(string)),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	pipelineObject.Fields = fieldList
+
+	err := pipelineObject.Validate()
+	if err != nil {
+		return nil, fmt.Errorf("Error validate pipeline object: %s", err)
+	}
+	return pipelineObject, nil
+}
+
+func flattenDataPipelineParameterValues(objects []*datapipeline.ParameterValue) []map[string]interface{} {
+	parameterValues := make([]map[string]interface{}, 0, len(objects))
+
+	for _, object := range objects {
+		obj := make(map[string]interface{})
+		obj["id"] = aws.StringValue(object.Id)
+		obj["string_value"] = aws.StringValue(object.StringValue)
+
+		parameterValues = append(parameterValues, obj)
+	}
+	return parameterValues
+}
+
+func flattenDataPipelinePipelineObjects(d *schema.ResourceData, pipelineObjects []*datapipeline.PipelineObject) error {
+	var schedules []map[string]interface{}
+
+	for _, pipelineObject := range pipelineObjects {
+		for _, field := range pipelineObject.Fields {
+			if aws.StringValue(field.Key) == "type" {
+				switch aws.StringValue(field.StringValue) {
+				case "Default":
+					if err := d.Set("default", flattenDataPipelineDefaultPipelineObject(pipelineObject)); err != nil {
+						return fmt.Errorf("Error setting default object: %s", err)
+					}
+				case "Schedule":
+					scheduleObject, err := flattenDataPipelinePipelineObject(pipelineObject)
+					if err != nil {
+						return fmt.Errorf("Error setting schedule object: %s", err)
+					}
+					schedules = append(schedules, scheduleObject)
+				}
+			}
+		}
+	}
+
+	if err := d.Set("schedule", schedules); err != nil {
+		return fmt.Errorf("Error setting default object: %s", err)
+	}
+
+	return nil
+}
+
+func flattenDataPipelineParameterObjects(objects []*datapipeline.ParameterObject) []map[string]interface{} {
+	parameterObjects := make([]map[string]interface{}, 0, len(objects))
+	for _, object := range objects {
+		obj := make(map[string]interface{})
+
+		obj["id"] = aws.StringValue(object.Id)
+		for _, attribute := range object.Attributes {
+			switch aws.StringValue(attribute.Key) {
+			case "type":
+				obj["type"] = aws.StringValue(attribute.StringValue)
+			case "description":
+				obj["description"] = aws.StringValue(attribute.StringValue)
+			case "optional":
+				b, _ := strconv.ParseBool(aws.StringValue(attribute.StringValue))
+				obj["optional"] = b
+			case "allowedValues":
+				obj["allowed_values"] = aws.StringValue(attribute.StringValue)
+			case "default":
+				obj["default"] = aws.StringValue(attribute.StringValue)
+			case "isArray":
+				b, _ := strconv.ParseBool(aws.StringValue(attribute.StringValue))
+				obj["is_array"] = b
+			}
+		}
+		parameterObjects = append(parameterObjects, obj)
+	}
+
+	return parameterObjects
+}
+
+func flattenDataPipelineDefaultPipelineObject(object *datapipeline.PipelineObject) []map[string]interface{} {
+	pipelineObject := make(map[string]interface{})
+	for _, field := range object.Fields {
+		switch aws.StringValue(field.Key) {
+		case "scheduleType":
+			pipelineObject["schedule_type"] = aws.StringValue(field.StringValue)
+		case "failureAndRerunMode":
+			pipelineObject["failure_and_rerun_mode"] = aws.StringValue(field.StringValue)
+		case "pipelineLogUri":
+			pipelineObject["pipeline_log_uri"] = aws.StringValue(field.StringValue)
+		case "role":
+			pipelineObject["role"] = aws.StringValue(field.StringValue)
+		case "resourceRole":
+			pipelineObject["resource_role"] = aws.StringValue(field.StringValue)
+		case "schedule":
+			pipelineObject["schedule"] = aws.StringValue(field.RefValue)
+		}
+	}
+
+	return []map[string]interface{}{pipelineObject}
+}
+
+func flattenDataPipelinePipelineObject(object *datapipeline.PipelineObject) (map[string]interface{}, error) {
+	pipelineObject := make(map[string]interface{})
+
+	pipelineObject["id"] = aws.StringValue(object.Id)
+	pipelineObject["name"] = aws.StringValue(object.Name)
+
+	for _, field := range object.Fields {
+		switch aws.StringValue(field.Key) {
+		case "period":
+			pipelineObject["period"] = aws.StringValue(field.StringValue)
+		case "startAt":
+			pipelineObject["start_at"] = aws.StringValue(field.StringValue)
+		case "startDateTime":
+			pipelineObject["start_date_time"] = aws.StringValue(field.StringValue)
+		case "endDateTime":
+			pipelineObject["end_date_time"] = aws.StringValue(field.StringValue)
+		case "occurrences":
+			val, err := strconv.Atoi(aws.StringValue(field.StringValue))
+			if err != nil {
+				return nil, err
+			}
+			pipelineObject["occurrences"] = val
+		}
+	}
+
+	return pipelineObject, nil
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -387,6 +387,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_codepipeline_webhook":                                resourceAwsCodePipelineWebhook(),
 			"aws_cur_report_definition":                               resourceAwsCurReportDefinition(),
 			"aws_customer_gateway":                                    resourceAwsCustomerGateway(),
+			"aws_datapipeline_definition":                             resourceAwsDataPipelineDefinition(),
 			"aws_datapipeline_pipeline":                               resourceAwsDataPipelinePipeline(),
 			"aws_datasync_agent":                                      resourceAwsDataSyncAgent(),
 			"aws_datasync_location_efs":                               resourceAwsDataSyncLocationEfs(),

--- a/aws/resource_aws_datapipeline_definition.go
+++ b/aws/resource_aws_datapipeline_definition.go
@@ -1,0 +1,334 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/datapipeline"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+var dataPipelineScheduleTypeList = []string{
+	"cron",
+	"ondemand",
+	"timeseries",
+}
+
+var dataPipelineFailureAndRerunModeList = []string{
+	"cascade",
+	"none",
+}
+
+var dataPipelineParameterObjectTypeList = []string{
+	"String",
+	"Integer",
+	"Double",
+	"AWS::S3::ObjectKey",
+}
+
+var dataPipelineParameterObjectStartAtList = []string{
+	"FIRST_ACTIVATION_DATE_TIME",
+}
+
+func resourceAwsDataPipelineDefinition() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsDataPipelineDefinitionPut,
+		Read:   resourceAwsDataPipelineDefinitionRead,
+		Update: resourceAwsDataPipelineDefinitionPut,
+		Delete: schema.Noop,
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsDataPipelineDefinitionImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"pipeline_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"default": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"resource_role": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateArn,
+						},
+
+						"role": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateArn,
+						},
+
+						"schedule_type": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(dataPipelineScheduleTypeList, false),
+						},
+
+						"failure_and_rerun_mode": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(dataPipelineFailureAndRerunModeList, false),
+							Default:      "none",
+						},
+
+						"pipeline_log_uri": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"schedule": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+
+			"schedule": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"period": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"start_at": {
+							Type:          schema.TypeString,
+							Optional:      true,
+							ConflictsWith: []string{"schedule.start_date_time"},
+							ValidateFunc:  validation.StringInSlice(dataPipelineParameterObjectStartAtList, false),
+						},
+
+						"start_date_time": {
+							Type:          schema.TypeString,
+							Optional:      true,
+							ConflictsWith: []string{"schedule.start_at"},
+						},
+
+						"end_date_time": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"occurrences": {
+							Type:          schema.TypeInt,
+							Optional:      true,
+							ConflictsWith: []string{"schedule.end_date_time"},
+						},
+
+						"parent": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+
+			"parameter_object": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "String",
+							ValidateFunc: validation.StringInSlice(dataPipelineParameterObjectTypeList, false),
+						},
+						"optional": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+						"allowed_values": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"default": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"is_array": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+					},
+				},
+			},
+
+			"parameter_value": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"string_value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsDataPipelineDefinitionPut(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).datapipelineconn
+
+	pipelineID := d.Get("pipeline_id").(string)
+	input := &datapipeline.PutPipelineDefinitionInput{
+		PipelineId: aws.String(pipelineID),
+	}
+
+	pipelineObjectsConfigs := []*datapipeline.PipelineObject{}
+
+	if v, ok := d.GetOk("default"); ok {
+		pipelineObject, err := expandDataPipelineDefaultPipelineObject(v.([]interface{}))
+		if err != nil {
+			return err
+		}
+		pipelineObjectsConfigs = append(pipelineObjectsConfigs, pipelineObject)
+	}
+
+	if v, ok := d.GetOk("schedule"); ok {
+		for _, s := range v.([]interface{}) {
+			pipelineObject, err := expandDataPipelinePipelineObject("Schedule", s.(map[string]interface{}))
+			if err != nil {
+				return err
+			}
+			pipelineObjectsConfigs = append(pipelineObjectsConfigs, pipelineObject)
+		}
+	}
+
+	if len(pipelineObjectsConfigs) > 0 {
+		input.PipelineObjects = pipelineObjectsConfigs
+	}
+
+	parameterObjectsConfigs := []*datapipeline.ParameterObject{}
+	if v, ok := d.GetOk("parameter_object"); ok {
+		for _, p := range v.([]interface{}) {
+			parameterObject, err := expandDataPipelineParameterObject(p.(map[string]interface{}))
+			if err != nil {
+				return err
+			}
+			parameterObjectsConfigs = append(parameterObjectsConfigs, parameterObject)
+		}
+	}
+
+	if len(parameterObjectsConfigs) > 0 {
+		input.ParameterObjects = parameterObjectsConfigs
+	}
+
+	parameterValuesConfigs := []*datapipeline.ParameterValue{}
+	if v, ok := d.GetOk("parameter_value"); ok {
+		for _, p := range v.([]interface{}) {
+			parameterValue, err := expandDataPipelineParameterValue(p.(map[string]interface{}))
+			if err != nil {
+				return err
+			}
+			parameterValuesConfigs = append(parameterValuesConfigs, parameterValue)
+		}
+	}
+
+	if len(parameterValuesConfigs) > 0 {
+		input.ParameterValues = parameterValuesConfigs
+	}
+
+	_, err := conn.PutPipelineDefinition(input)
+	if isAWSErr(err, datapipeline.ErrCodePipelineNotFoundException, "") || isAWSErr(err, datapipeline.ErrCodePipelineDeletedException, "") {
+		log.Printf("[WARN] DataPipeline (%s) not found, removing from state", pipelineID)
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error putting DataPipeline (%s) Definition: %s", pipelineID, err)
+	}
+
+	d.SetId(pipelineID)
+	return resourceAwsDataPipelineDefinitionRead(d, meta)
+}
+
+func resourceAwsDataPipelineDefinitionRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).datapipelineconn
+
+	v, err := resourceAwsDataPipelineDefinitionRetrieve(d.Id(), conn)
+	if isAWSErr(err, datapipeline.ErrCodePipelineNotFoundException, "") || isAWSErr(err, datapipeline.ErrCodePipelineDeletedException, "") {
+		log.Printf("[WARN] DataPipeline (%s) Definition not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error getting DataPipeline (%s) Definition: %s", d.Id(), err)
+	}
+
+	// Parameter Objects
+	if err := d.Set("parameter_object", flattenDataPipelineParameterObjects(v.ParameterObjects)); err != nil {
+		return fmt.Errorf("error setting DataPipeline (%s) parameter objects: %s", d.Id(), err)
+	}
+
+	// Parameter Values
+	if err := d.Set("parameter_value", flattenDataPipelineParameterValues(v.ParameterValues)); err != nil {
+		return fmt.Errorf("error setting DataPipeline (%s) parameter values: %s", d.Id(), err)
+	}
+
+	if err := flattenDataPipelinePipelineObjects(d, v.PipelineObjects); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceAwsDataPipelineDefinitionImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	d.Set("pipeline_id", d.Id())
+	return []*schema.ResourceData{d}, nil
+}
+
+func resourceAwsDataPipelineDefinitionRetrieve(id string, conn *datapipeline.DataPipeline) (*datapipeline.GetPipelineDefinitionOutput, error) {
+	opts := datapipeline.GetPipelineDefinitionInput{
+		PipelineId: aws.String(id),
+	}
+	log.Printf("[DEBUG] Data Pipeline describe configuration: %#v", opts)
+
+	resp, err := conn.GetPipelineDefinition(&opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}

--- a/aws/resource_aws_datapipeline_definition_test.go
+++ b/aws/resource_aws_datapipeline_definition_test.go
@@ -1,0 +1,508 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/datapipeline"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSDataPipelineDefinition_basic(t *testing.T) {
+	var conf datapipeline.GetPipelineDefinitionOutput
+	rName := fmt.Sprintf("tf-datapipeline-%s", acctest.RandString(5))
+	bucketName := fmt.Sprintf("tf-test-pipeline-log-bucket-%s", acctest.RandString(5))
+	resourceName := "aws_datapipeline_definition.default"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSDataPipeline(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDataPipelineDefinitionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDataPipelineDefinitionConfig(rName, "cron"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataPipelineDefinitionExists(resourceName, &conf),
+					resource.TestCheckResourceAttrPair(
+						"aws_datapipeline_pipeline.default", "id",
+						resourceName, "pipeline_id"),
+					resource.TestCheckResourceAttr(resourceName, "default.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default.0.schedule_type", "cron"),
+					resource.TestCheckResourceAttr(resourceName, "default.0.failure_and_rerun_mode", "none"),
+					resource.TestCheckResourceAttrPair(
+						"aws_iam_role.role", "arn",
+						resourceName, "default.0.role"),
+					resource.TestCheckResourceAttrPair(
+						"aws_iam_instance_profile.resource_role", "arn",
+						resourceName, "default.0.resource_role"),
+				),
+			},
+			{
+				Config: testAccAWSDataPipelineDefinitionConfig(rName, "ondemand"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataPipelineDefinitionExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "default.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default.0.schedule_type", "ondemand"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSDataPipelineDefinitionConfigDefaultUpdate(rName, "ondemand", bucketName, "cascade"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataPipelineDefinitionExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "default.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default.0.failure_and_rerun_mode", "cascade"),
+					resource.TestCheckResourceAttr(resourceName, "default.0.pipeline_log_uri", fmt.Sprintf("s3://%s/log_prefix", bucketName)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSDataPipelineDefinition_schedule(t *testing.T) {
+	var conf datapipeline.GetPipelineDefinitionOutput
+	rName := fmt.Sprintf("tf-datapipeline-%s", acctest.RandString(5))
+	resourceName := "aws_datapipeline_definition.default"
+	nowTime := time.Now()
+	startDateTime1 := nowTime.Format("2006-01-02T15:04:05")
+	startDateTime2 := nowTime.AddDate(0, 0, -1).Format("2006-01-02T15:04:05")
+	endDateTime1 := nowTime.AddDate(0, 1, 0).Format("2006-01-02T15:04:05")
+	endDateTime2 := nowTime.AddDate(1, 0, 0).Format("2006-01-02T15:04:05")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSDataPipeline(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDataPipelineDefinitionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDataPipelineDefinitionConfig(rName, "cron"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataPipelineDefinitionExists(resourceName, &conf),
+				),
+			},
+			{
+				Config: testAccAWSDataPipelineDefinitionConfigWithSchedule(rName, "DefaultSchedule", "1 hours", startDateTime1, endDateTime1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataPipelineDefinitionExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "schedule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "schedule.0.id", "DefaultSchedule"),
+					resource.TestCheckResourceAttr(resourceName, "schedule.0.name", "DefaultSchedule"),
+					resource.TestCheckResourceAttr(resourceName, "schedule.0.period", "1 hours"),
+					resource.TestCheckResourceAttr(resourceName, "schedule.0.start_date_time", startDateTime1),
+					resource.TestCheckResourceAttr(resourceName, "schedule.0.end_date_time", endDateTime1),
+				),
+			},
+			{
+				Config: testAccAWSDataPipelineDefinitionConfigWithSchedule(rName, "DefaultSchedule1", "1 Day", startDateTime2, endDateTime2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataPipelineDefinitionExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "schedule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "schedule.0.id", "DefaultSchedule1"),
+					resource.TestCheckResourceAttr(resourceName, "schedule.0.name", "DefaultSchedule1"),
+					resource.TestCheckResourceAttr(resourceName, "schedule.0.start_date_time", startDateTime2),
+					resource.TestCheckResourceAttr(resourceName, "schedule.0.end_date_time", endDateTime2),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSDataPipelineDefinitionConfigWithScheduleUpdate(rName, "DefaultSchedule1", "1 Day", "FIRST_ACTIVATION_DATE_TIME", 10),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataPipelineDefinitionExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "schedule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "schedule.0.start_at", "FIRST_ACTIVATION_DATE_TIME"),
+					resource.TestCheckResourceAttr(resourceName, "schedule.0.occurrences", "10"),
+				),
+			},
+			{
+				Config: testAccAWSDataPipelineDefinitionConfig(rName, "cron"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataPipelineDefinitionExists(resourceName, &conf),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDataPipelineDefinition_parameters(t *testing.T) {
+	var conf datapipeline.GetPipelineDefinitionOutput
+	rName := fmt.Sprintf("tf-datapipeline-%s", acctest.RandString(5))
+	resourceName := "aws_datapipeline_definition.default"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSDataPipeline(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDataPipelineDefinitionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDataPipelineDefinitionConfigWithParameter(rName, "myDDBTableName", "test-table"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataPipelineDefinitionExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "parameter_object.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_object.0.id", "myDDBTableName"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_object.0.type", "String"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_object.0.optional", "false"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_value.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_value.0.id", "myDDBTableName"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_value.0.string_value", "test-table"),
+				),
+			},
+			{
+				Config: testAccAWSDataPipelineDefinitionConfigWithParameterUpdate(rName, "myDDBTableName", "test-table2", "myItemList", "item"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataPipelineDefinitionExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "parameter_object.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_object.0.id", "myDDBTableName"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_object.0.default", rName),
+					resource.TestCheckResourceAttr(resourceName, "parameter_object.0.optional", "true"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_object.1.id", "myItemList"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_object.1.is_array", "true"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_object.1.description", "Array value myItemList"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_value.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_value.0.id", "myDDBTableName"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_value.0.string_value", "test-table2"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_value.1.id", "myItemList"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_value.1.string_value", "item-1"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_value.2.id", "myItemList"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_value.2.string_value", "item-2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSDataPipelineDefinitionConfigWithParameter(rName, "myDDBTableName", "test-table"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataPipelineDefinitionExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "parameter_object.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_object.0.id", "myDDBTableName"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_object.0.type", "String"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_object.0.optional", "false"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_value.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_value.0.id", "myDDBTableName"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_value.0.string_value", "test-table"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDataPipelineDefinition_disappears(t *testing.T) {
+	var description datapipeline.PipelineDescription
+	var definition datapipeline.GetPipelineDefinitionOutput
+	rName := fmt.Sprintf("tf-datapipeline-%s", acctest.RandString(5))
+	resourceName := "aws_datapipeline_definition.default"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSDataPipeline(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDataPipelineDefinitionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDataPipelineDefinitionConfig(rName, "ondemand"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataPipelinePipelineExists("aws_datapipeline_pipeline.default", &description),
+					testAccCheckAWSDataPipelineDefinitionExists(resourceName, &definition),
+					testAccCheckAWSDataPipelinePipelineDisappears(&description),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSDataPipelineDefinitionDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).datapipelineconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_datapipeline_definition" {
+			continue
+		}
+		// Try to find the Pipeline
+		pipelineDefinition, err := resourceAwsDataPipelineDefinitionRetrieve(rs.Primary.ID, conn)
+		if isAWSErr(err, datapipeline.ErrCodePipelineNotFoundException, "") {
+			continue
+		} else if isAWSErr(err, datapipeline.ErrCodePipelineDeletedException, "") {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+		if pipelineDefinition != nil {
+			return fmt.Errorf("Pipeline Definition still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAWSDataPipelineDefinitionExists(n string, v *datapipeline.GetPipelineDefinitionOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No DataPipeline ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).datapipelineconn
+
+		pipelineDefinition, err := resourceAwsDataPipelineDefinitionRetrieve(rs.Primary.ID, conn)
+
+		if err != nil {
+			return err
+		}
+		if pipelineDefinition == nil {
+			return fmt.Errorf("DataPipeline Definition not found")
+		}
+
+		*v = *pipelineDefinition
+		return nil
+	}
+}
+
+func testAccAWSDataPipelineDefinitionConfigCommon(rName string) string {
+	return fmt.Sprintf(testAccAWSDataPipelinePipelineConfig(rName)+`
+resource "aws_iam_role" "role" {
+  name = "tf-test-datapipeline-role-%[1]s"
+      
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "elasticmapreduce.amazonaws.com",
+          "datapipeline.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+data "aws_iam_policy" "role" {
+  arn = "arn:aws:iam::aws:policy/service-role/AWSDataPipelineRole"
+}
+
+resource "aws_iam_role_policy_attachment" "role" {
+  role       = "${aws_iam_role.role.name}"
+  policy_arn = "${data.aws_iam_policy.role.arn}"
+}
+
+resource "aws_iam_role" "resource_role" {
+  name = "tf-test-datapipeline-resource-role-%[1]s"
+      
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "ec2.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+data "aws_iam_policy" "resource_role" {
+  arn = "arn:aws:iam::aws:policy/service-role/AWSDataPipelineRole"
+}
+
+resource "aws_iam_role_policy_attachment" "resource_role" {
+  role       = "${aws_iam_role.resource_role.name}"
+  policy_arn = "${data.aws_iam_policy.resource_role.arn}"
+}
+
+resource "aws_iam_instance_profile" "resource_role" {
+  name = "tf-test-datapipeline-resource-role-profile-%[1]s"
+  role = "${aws_iam_role.resource_role.name}"
+}
+
+`, rName)
+}
+
+func testAccAWSDataPipelineDefinitionConfig(rName, scheduleType string) string {
+	return fmt.Sprintf(testAccAWSDataPipelineDefinitionConfigCommon(rName)+`
+
+resource "aws_datapipeline_definition" "default" {
+  pipeline_id = "${aws_datapipeline_pipeline.default.id}"
+
+  default {
+	schedule_type = %[2]q
+	role          = "${aws_iam_role.role.arn}"
+	resource_role = "${aws_iam_instance_profile.resource_role.arn}"
+  }
+}`, rName, scheduleType)
+
+}
+
+func testAccAWSDataPipelineDefinitionConfigDefaultUpdate(rName, scheduleType, bucketName, failureAndRerunMode string) string {
+	return fmt.Sprintf(testAccAWSDataPipelineDefinitionConfigCommon(rName)+`
+resource "aws_s3_bucket" "log_bucket" {
+  bucket = %[3]q
+  acl    = "log-delivery-write"
+		
+  force_destroy = true
+}
+
+
+resource "aws_datapipeline_definition" "default" {
+  pipeline_id = "${aws_datapipeline_pipeline.default.id}"
+
+  default {
+	schedule_type          = %[2]q
+	role                   = "${aws_iam_role.role.arn}"
+	resource_role          = "${aws_iam_instance_profile.resource_role.arn}"
+	pipeline_log_uri       = "s3://${aws_s3_bucket.log_bucket.id}/log_prefix"
+	failure_and_rerun_mode = %[4]q
+  }
+}`, rName, scheduleType, bucketName, failureAndRerunMode)
+
+}
+
+func testAccAWSDataPipelineDefinitionConfigWithSchedule(rName, scheduleID, period, startDateTime, endDateTime string) string {
+	return fmt.Sprintf(testAccAWSDataPipelineDefinitionConfigCommon(rName)+`
+resource "aws_datapipeline_definition" "default" {
+  pipeline_id = "${aws_datapipeline_pipeline.default.id}"
+
+  default {
+	schedule_type          = "cron"
+	role                   = "${aws_iam_role.role.arn}"
+	resource_role          = "${aws_iam_instance_profile.resource_role.arn}"
+
+	schedule			   = %[1]q
+  }
+
+  schedule {
+	  id              = %[1]q
+	  name            = %[1]q
+	  period          = %[2]q
+	  start_date_time = %[3]q
+	  end_date_time   = %[4]q
+  }
+}`, scheduleID, period, startDateTime, endDateTime)
+
+}
+
+func testAccAWSDataPipelineDefinitionConfigWithScheduleUpdate(rName, scheduleID, period, startAt string, occurrences int) string {
+	return fmt.Sprintf(testAccAWSDataPipelineDefinitionConfigCommon(rName)+`
+resource "aws_datapipeline_definition" "default" {
+  pipeline_id = "${aws_datapipeline_pipeline.default.id}"
+
+  default {
+	schedule_type          = "cron"
+	role                   = "${aws_iam_role.role.arn}"
+	resource_role          = "${aws_iam_instance_profile.resource_role.arn}"
+
+	schedule			   = %[1]q
+  }
+
+  schedule {
+	  id           = %[1]q
+	  name         = %[1]q
+	  period       = %[2]q
+	  start_at     = %[3]q
+	  occurrences  = %[4]d
+  }
+}`, scheduleID, period, startAt, occurrences)
+
+}
+
+func testAccAWSDataPipelineDefinitionConfigWithParameter(rName, parameterObjectID, parameterObjectValue string) string {
+	return fmt.Sprintf(testAccAWSDataPipelineDefinitionConfigCommon(rName)+`
+
+resource "aws_datapipeline_definition" "default" {
+  pipeline_id = "${aws_datapipeline_pipeline.default.id}"
+
+  default {
+	schedule_type = "cron"
+	role          = "${aws_iam_role.role.arn}"
+	resource_role = "${aws_iam_instance_profile.resource_role.arn}"
+  }
+
+  parameter_object {
+	id = %[2]q
+  }
+
+  parameter_value {
+	id = %[2]q
+	string_value = %[3]q
+  }
+}`, rName, parameterObjectID, parameterObjectValue)
+
+}
+
+func testAccAWSDataPipelineDefinitionConfigWithParameterUpdate(rName, parameterObjectID1, parameterObjectValue1, parameterObjectID2, parameterObjectValue2 string) string {
+	return fmt.Sprintf(testAccAWSDataPipelineDefinitionConfigCommon(rName)+`
+
+resource "aws_datapipeline_definition" "default" {
+  pipeline_id = "${aws_datapipeline_pipeline.default.id}"
+
+  default {
+	schedule_type = "cron"
+	role          = "${aws_iam_role.role.arn}"
+	resource_role = "${aws_iam_instance_profile.resource_role.arn}"
+  }
+
+  parameter_object {
+	id       = %[2]q
+	optional = true
+	default  = %[1]q
+  }
+
+  parameter_value {
+	id = %[2]q
+	string_value = %[3]q
+  }
+
+  parameter_object {
+	id          = %[4]q
+	description = "Array value %[4]s"
+	is_array    = true
+  }
+
+  parameter_value {
+	id           = %[4]q
+	string_value = "%[5]s-1"
+  }
+
+  parameter_value {
+	id           = %[4]q
+	string_value = "%[5]s-2"
+  }
+
+}`, rName, parameterObjectID1, parameterObjectValue1, parameterObjectID2, parameterObjectValue2)
+
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -980,6 +980,9 @@
                 <li>
                     <a href="#">DataPipeline Resources</a>
                     <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/datapipeline_definition.html">aws_datapipeline_definition</a>
+                        </li>
 
                         <li>
                             <a href="/docs/providers/aws/r/datapipeline_pipeline.html">aws_datapipeline_pipeline</a>

--- a/website/docs/r/datapipeline_definition.html.markdown
+++ b/website/docs/r/datapipeline_definition.html.markdown
@@ -1,0 +1,152 @@
+---
+layout: "aws"
+page_title: "AWS: aws_datapipeline_definition"
+sidebar_current: "docs-aws-resource-datapipeline-definition"
+description: |-
+  Provides a AWS DataPipeline Definition.
+---
+
+# Resource: aws_datapipeline_definition
+
+Provides a Data Pipeline Definition resource.
+
+## Example Usage
+
+```hcl
+resource "aws_iam_role" "role" {
+  name = "tf-test-datapipeline-role-%[1]s"
+      
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "elasticmapreduce.amazonaws.com",
+          "datapipeline.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+data "aws_iam_policy" "role" {
+  arn = "arn:aws:iam::aws:policy/service-role/AWSDataPipelineRole"
+}
+
+resource "aws_iam_role_policy_attachment" "role" {
+  role       = "${aws_iam_role.role.name}"
+  policy_arn = "${data.aws_iam_policy.role.arn}"
+}
+
+resource "aws_iam_role" "resource_role" {
+  name = "tf-test-datapipeline-resource-role-%[1]s"
+      
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "ec2.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+data "aws_iam_policy" "resource_role" {
+  arn = "arn:aws:iam::aws:policy/service-role/AWSDataPipelineRole"
+}
+
+resource "aws_iam_role_policy_attachment" "resource_role" {
+  role       = "${aws_iam_role.resource_role.name}"
+  policy_arn = "${data.aws_iam_policy.resource_role.arn}"
+}
+
+resource "aws_iam_instance_profile" "resource_role" {
+  name = "tf-test-datapipeline-resource-role-profile-%[1]s"
+  role = "${aws_iam_role.resource_role.name}"
+}
+
+resource "aws_datapipeline_pipeline" "default" {
+	name      	= "tf-pipeline-default"
+}
+
+resource "aws_datapipeline_definition" "default" {
+  pipeline_id = "${aws_datapipeline_pipeline.default.id}"
+
+  default {
+	schedule_type = "ondemand"
+	role          = "${aws_iam_role.role.arn}"
+	resource_role = "${aws_iam_instance_profile.resource_role.arn}"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `pipeline_id` - (Required) The id of Pipeline.
+* `default` - (Required) The default configuration to assign to the resource. Documented below.
+* `schedule` - (Optional) A list of schedule configuration to assign to the resource. Defines the timing of a scheduled event, such as when an activity runs. Documented below.
+* `parameter_object` - (Optional) A list of parameter object configuration to assign to the resource. Documented below.
+* `parameter_value` - (Optional) A list of parameter value configuration to assign to the resource. Documented below.
+
+The `default` configuration supports the following:
+
+* `resource_role` - (Required) The arn of iam instance profile attached to resources.
+* `role` - (Required) The arn of iam role, execute pipeline.
+* `schedule_type` - (Required) The parameters for the RUN_COMMAND task execution. Valid values are `cron`, `ondemand` and `none`. Default to `none`.
+* `failure_and_rerun_mode` - (Optional) The date and time to start the scheduled runs. Valid values are `cascade` and `timeseries`.
+* `pipeline_log_uri` - (Optional) The s3 bucket uri for default to output logs. Example: `s3://<bucket-name>/<prefix>`.
+* `schedule` - (Optional) The id of schedule pipeline object.
+
+The `schedule` configuration supports the following:
+For more information, see the [Schedule - AWS Data Pipeline](https://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-object-schedule.html).
+
+* `id` - (Required) The ID of schedule pipeline object.
+* `name` - (Required) The Name of schedule pipeline object.
+* `period` - (Required) How often the pipeline should run. The format is "N [minutes|hours|days|weeks|months]", where N is a number followed by one of the time specifiers.
+* `start_at` - (Optional) The date and time at which to start the scheduled pipeline runs. Valid value is `FIRST_ACTIVATION_DATE_TIME`, which is deprecated in favor of creating an on-demand pipeline. Conflicts with `start_date_time`.
+* `start_date_time` - (Optional) The date and time to start the scheduled runs. Conflicts with `start_at`.
+* `end_date_time` - (Optional) The date and time to end the scheduled runs. Must be a date and time later than the value of startDateTime or startAt. The default behavior is to schedule runs until the pipeline is shut down. Conflicts with `occurrences`.
+* `occurrences` - (Optional) The number of times to execute the pipeline after it's activated. Conflicts with `end_date_time`.
+* `parent` - (Optional) Parent of the current object from which slots will be inherited.
+
+The `parameter_object` configuration supports the following:
+For more information, see the [ParameterObject - AWS Data Pipeline](https://docs.aws.amazon.com/ja_jp/datapipeline/latest/APIReference/API_ParameterObject.html).
+
+* `id` - (Required) The ID of the parameter object.
+* `description` - (Optional) The parameters for the RUN_COMMAND task execution. Documented below.
+
+`parameter_value` supports the following:
+For more information, see the [ParameterValue - AWS Data Pipeline](https://docs.aws.amazon.com/ja_jp/datapipeline/latest/APIReference/API_ParameterValue.html).
+
+* `id` - (Required) The ID of the parameter value.
+* `string_value` - (Required) The field value, expressed as a String.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The identifier of the pipeline.
+
+## Import
+
+`aws_datapipeline_definition` can be imported by using the id (Pipeline ID), e.g.
+
+```
+$ terraform import aws_datapipeline_definition.default df-1234567890
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference #1538 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Features:
- resource/aws_datapipeline_definition: Add support aws_datapipeline_definition resource
```

Output from acceptance testing:

```
ture/add-support-aws_datapipeline_definition-resource *)$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDataPipelineDefinition_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSDataPipelineDefinition_ -timeout 120m
=== RUN   TestAccAWSDataPipelineDefinition_basic
=== PAUSE TestAccAWSDataPipelineDefinition_basic
=== RUN   TestAccAWSDataPipelineDefinition_schedule
=== PAUSE TestAccAWSDataPipelineDefinition_schedule
=== RUN   TestAccAWSDataPipelineDefinition_parameters
=== PAUSE TestAccAWSDataPipelineDefinition_parameters
=== RUN   TestAccAWSDataPipelineDefinition_disappears
=== PAUSE TestAccAWSDataPipelineDefinition_disappears
=== CONT  TestAccAWSDataPipelineDefinition_basic
=== CONT  TestAccAWSDataPipelineDefinition_disappears
=== CONT  TestAccAWSDataPipelineDefinition_parameters
=== CONT  TestAccAWSDataPipelineDefinition_schedule
--- PASS: TestAccAWSDataPipelineDefinition_disappears (48.83s)
--- PASS: TestAccAWSDataPipelineDefinition_parameters (87.87s)
--- PASS: TestAccAWSDataPipelineDefinition_basic (105.36s)
--- PASS: TestAccAWSDataPipelineDefinition_schedule (126.45s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	126.543s
```
