### PR TITLE
resource/aws_acmpca_certificate_authority: Support validation for ROOT certificate authority type and ensure type updates force recreation

### DIFF
--- a/aws/resource_aws_acmpca_certificate_authority.go
+++ b/aws/resource_aws_acmpca_certificate_authority.go
@@ -255,8 +255,10 @@ func resourceAwsAcmpcaCertificateAuthority() *schema.Resource {
 			"type": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 				Default:  acmpca.CertificateAuthorityTypeSubordinate,
 				ValidateFunc: validation.StringInSlice([]string{
+					acmpca.CertificateAuthorityTypeRoot,
 					acmpca.CertificateAuthorityTypeSubordinate,
 				}, false),
 			},

--- a/website/docs/r/acmpca_certificate_authority.html.markdown
+++ b/website/docs/r/acmpca_certificate_authority.html.markdown
@@ -95,7 +95,7 @@ The following arguments are supported:
 * `enabled` - (Optional) Whether the certificate authority is enabled or disabled. Defaults to `true`.
 * `revocation_configuration` - (Optional) Nested argument containing revocation configuration. Defined below.
 * `tags` - (Optional) Specifies a key-value map of user-defined tags that are attached to the certificate authority.
-* `type` - (Optional) The type of the certificate authority. Currently, this must be `SUBORDINATE`.
+* `type` - (Optional) The type of the certificate authority. Defaults to `SUBORDINATE`. Valid values: `ROOT` and `SUBORDINATE`.
 * `permanent_deletion_time_in_days` - (Optional) The number of days to make a CA restorable after it has been deleted, must be between 7 to 30 days, with default to 30 days.
 
 ### certificate_authority_configuration


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #9081

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_acmpca_certificate_authority: Support validation for `ROOT` certificate authority type
```

Output from acceptance testing:

```
--- PASS: TestAccAwsAcmpcaCertificateAuthority_Type_Root (17.66s)
```
