### PR TITLE
resource/aws_backup_selection: IAM retries, test fix, documentation updates to remove wildcard usage

### DIFF
--- a/aws/resource_aws_backup_selection_test.go
+++ b/aws/resource_aws_backup_selection_test.go
@@ -304,6 +304,17 @@ resource "aws_backup_selection" "test" {
 
 func testAccBackupSelectionConfigWithResources(rInt int) string {
 	return testAccBackupSelectionConfigBase(rInt) + fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+resource "aws_ebs_volume" "test" {
+  count = 2
+
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  size              = 1
+}
+
 resource "aws_backup_selection" "test" {
   plan_id      = "${aws_backup_plan.test.id}"
 
@@ -317,8 +328,8 @@ resource "aws_backup_selection" "test" {
   }
 
   resources = [
-    "arn:${data.aws_partition.current.partition}:elasticfilesystem:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:file-system/",
-    "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/"
+    "${aws_ebs_volume.test.0.arn}",
+    "${aws_ebs_volume.test.1.arn}",
   ]
 }
 `, rInt)

--- a/website/docs/r/backup_selection.html.markdown
+++ b/website/docs/r/backup_selection.html.markdown
@@ -12,21 +12,71 @@ Manages selection conditions for AWS Backup plan resources.
 
 ## Example Usage
 
+### IAM Role
+
+-> For more information about creating and managing IAM Roles for backups and restores, see the [AWS Backup Developer Guide](https://docs.aws.amazon.com/aws-backup/latest/devguide/iam-service-roles.html).
+
+The below example creates an IAM role with the default managed IAM Policy for allowing AWS Backup to create backups.
+
+```hcl
+resource "aws_iam_role" "example" {
+  name               = "example"
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": ["sts:AssumeRole"],
+      "Effect": "allow",
+      "Principal": {
+        "Service": ["backup.amazonaws.com"]
+      }
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "example" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
+  role       = "${aws_iam_role.example.name}"
+}
+
+resource "aws_backup_selection" "example" {
+  # ... other configuration ...
+
+  iam_role_arn = "${aws_iam_role.example.arn}"
+}
+```
+
+### Selecting Backups By Tag
+
 ```hcl
 resource "aws_backup_selection" "example" {
-  plan_id = "${aws_backup_plan.example.id}"
-
+  iam_role_arn = "${aws_iam_role.example.arn}"
   name         = "tf_example_backup_selection"
-  iam_role_arn = "arn:aws:iam::123456789012:role/service-role/AWSBackupDefaultServiceRole"
+  plan_id      = "${aws_backup_plan.example.id}"
 
   selection_tag {
     type  = "STRINGEQUALS"
     key   = "foo"
     value = "bar"
   }
+}
+```
+
+### Selecting Backups By Resource
+
+```hcl
+resource "aws_backup_selection" "example" {
+  iam_role_arn = "${aws_iam_role.example.arn}"
+  name         = "tf_example_backup_selection"
+  plan_id      = "${aws_backup_plan.example.id}"
 
   resources = [
-    "arn:aws:ec2:us-east-1:123456789012:volume/",
+    "${aws_db_instance.example.arn}",
+    "${aws_ebs_volume.example.arn}",
+    "${aws_efs_file_system.example.arn}",
   ]
 }
 ```


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #9269
Closes #9297

Each commit has notes about the changes.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_backup_selection: Retry creation for IAM eventual consistency error
```

Output from acceptance testing:

Output from acceptance testing (failure present on master):

```
--- PASS: TestAccAwsBackupSelection_disappears (17.20s)
--- PASS: TestAccAwsBackupSelection_basic (18.44s)
--- PASS: TestAccAwsBackupSelection_withTags (18.47s)
--- PASS: TestAccAwsBackupSelection_updateTag (28.73s)
--- PASS: TestAccAwsBackupSelection_withResources (29.35s)
```
