### PR TITLE
Add support for timeout_seconds in SSM MW

### DIFF
--- a/aws/resource_aws_ssm_maintenance_window_task.go
+++ b/aws/resource_aws_ssm_maintenance_window_task.go
@@ -265,14 +265,10 @@ func resourceAwsSsmMaintenanceWindowTaskCreate(d *schema.ResourceData, meta inte
 		}
 	}
 
-	log.Println("PARAMS", params)
-
 	resp, err := ssmconn.RegisterTaskWithMaintenanceWindow(params)
 	if err != nil {
 		return err
 	}
-
-	log.Println("RESP", resp)
 
 	d.SetId(*resp.WindowTaskId)
 

--- a/website/docs/r/ssm_maintenance_window_task.html.markdown
+++ b/website/docs/r/ssm_maintenance_window_task.html.markdown
@@ -30,6 +30,8 @@ resource "aws_ssm_maintenance_window_task" "task" {
   service_role_arn = "arn:aws:iam::187416307283:role/service-role/AWS_Events_Invoke_Run_Command_112316643"
   max_concurrency  = "2"
   max_errors       = "1"
+  
+  timeout_seconds = 60
 
   targets {
     key    = "InstanceIds"
@@ -65,6 +67,9 @@ The following arguments are supported:
 * `priority` - (Optional) The priority of the task in the Maintenance Window, the lower the number the higher the priority. Tasks in a Maintenance Window are scheduled in priority order with tasks that have the same priority scheduled in parallel.
 * `logging_info` - (Optional) A structure containing information about an Amazon S3 bucket to write instance-level logs to. Documented below.
 * `task_parameters` - (Optional) A structure containing information about parameters required by the particular `task_arn`. Documented below.
+
+`RUN_COMMAND` task type supports the following:
+* `timeout_seconds` - (Optional) Specify timeout on the task
 
 `logging_info` supports the following:
 

--- a/website/docs/r/ssm_maintenance_window_task.html.markdown
+++ b/website/docs/r/ssm_maintenance_window_task.html.markdown
@@ -69,6 +69,7 @@ The following arguments are supported:
 * `task_parameters` - (Optional) A structure containing information about parameters required by the particular `task_arn`. Documented below.
 
 `RUN_COMMAND` task type supports the following:
+
 * `timeout_seconds` - (Optional) Specify timeout on the task
 
 `logging_info` supports the following:


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #2876

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Added `timeout_seconds` to be used in `aws_ssm_maintenance_window_task` for `RUN_COMMAND` task type
Added functionality to use `TaskInvocationParameters` with Parameters and S3 Log bucket when `RUN_COMMAND` task type is used
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSSSMMaintenanceWindowTask'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSSSMMaintenanceWindowTask -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSSSMMaintenanceWindowTask_basic
=== PAUSE TestAccAWSSSMMaintenanceWindowTask_basic
=== RUN   TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource
=== PAUSE TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource
=== CONT  TestAccAWSSSMMaintenanceWindowTask_basic
=== CONT  TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource
--- PASS: TestAccAWSSSMMaintenanceWindowTask_basic (97.18s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource (111.73s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	111.782s

...
```
