### PR TITLE
resource/aws_ssm_document: Removing the code that adds Null parameters

### DIFF
--- a/aws/resource_aws_ssm_document.go
+++ b/aws/resource_aws_ssm_document.go
@@ -278,10 +278,6 @@ func resourceAwsSsmDocumentRead(d *schema.ResourceData, meta interface{}) error 
 		params = append(params, param)
 	}
 
-	if len(params) == 0 {
-		params = make([]map[string]interface{}, 1)
-	}
-
 	if err := d.Set("parameter", params); err != nil {
 		return err
 	}


### PR DESCRIPTION
I actually added this code back in 2016 and there is zero reason for
it. It should have skipped over if there were no parameters present

```
▶ acctests aws TestAccAWSSSMDocument_
=== RUN   TestAccAWSSSMDocument_basic
=== PAUSE TestAccAWSSSMDocument_basic
=== RUN   TestAccAWSSSMDocument_update
=== PAUSE TestAccAWSSSMDocument_update
=== RUN   TestAccAWSSSMDocument_permission_public
=== PAUSE TestAccAWSSSMDocument_permission_public
=== RUN   TestAccAWSSSMDocument_permission_private
=== PAUSE TestAccAWSSSMDocument_permission_private
=== RUN   TestAccAWSSSMDocument_permission_batching
=== PAUSE TestAccAWSSSMDocument_permission_batching
=== RUN   TestAccAWSSSMDocument_permission_change
=== PAUSE TestAccAWSSSMDocument_permission_change
=== RUN   TestAccAWSSSMDocument_params
=== PAUSE TestAccAWSSSMDocument_params
=== RUN   TestAccAWSSSMDocument_automation
=== PAUSE TestAccAWSSSMDocument_automation
=== RUN   TestAccAWSSSMDocument_session
=== PAUSE TestAccAWSSSMDocument_session
=== RUN   TestAccAWSSSMDocument_DocumentFormat_YAML
=== PAUSE TestAccAWSSSMDocument_DocumentFormat_YAML
=== RUN   TestAccAWSSSMDocument_Tags
=== PAUSE TestAccAWSSSMDocument_Tags
=== CONT  TestAccAWSSSMDocument_basic
=== CONT  TestAccAWSSSMDocument_params
=== CONT  TestAccAWSSSMDocument_permission_change
=== CONT  TestAccAWSSSMDocument_Tags
=== CONT  TestAccAWSSSMDocument_DocumentFormat_YAML
=== CONT  TestAccAWSSSMDocument_permission_public
=== CONT  TestAccAWSSSMDocument_permission_private
=== CONT  TestAccAWSSSMDocument_update
=== CONT  TestAccAWSSSMDocument_permission_batching
=== CONT  TestAccAWSSSMDocument_automation
=== CONT  TestAccAWSSSMDocument_session
--- PASS: TestAccAWSSSMDocument_session (30.23s)
--- PASS: TestAccAWSSSMDocument_params (30.26s)
--- PASS: TestAccAWSSSMDocument_basic (32.52s)
--- PASS: TestAccAWSSSMDocument_permission_private (34.13s)
--- PASS: TestAccAWSSSMDocument_permission_public (34.36s)
--- PASS: TestAccAWSSSMDocument_automation (44.68s)
--- PASS: TestAccAWSSSMDocument_permission_batching (49.03s)
--- PASS: TestAccAWSSSMDocument_DocumentFormat_YAML (52.10s)
--- PASS: TestAccAWSSSMDocument_update (54.77s)
--- PASS: TestAccAWSSSMDocument_Tags (70.72s)
--- PASS: TestAccAWSSSMDocument_permission_change (71.78s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	71.833s
```


<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```