### PR TITLE
resource/aws_ssm_document: Ensure content attribute is refreshed and support resource import

### DIFF
--- a/aws/resource_aws_ssm_document.go
+++ b/aws/resource_aws_ssm_document.go
@@ -24,6 +24,9 @@ func resourceAwsSsmDocument() *schema.Resource {
 		Read:   resourceAwsSsmDocumentRead,
 		Update: resourceAwsSsmDocumentUpdate,
 		Delete: resourceAwsSsmDocumentDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"arn": {
@@ -202,7 +205,7 @@ func resourceAwsSsmDocumentRead(d *schema.ResourceData, meta interface{}) error 
 	log.Printf("[DEBUG] Reading SSM Document: %s", d.Id())
 
 	describeDocumentInput := &ssm.DescribeDocumentInput{
-		Name: aws.String(d.Get("name").(string)),
+		Name: aws.String(d.Id()),
 	}
 
 	describeDocumentOutput, err := ssmconn.DescribeDocument(describeDocumentInput)
@@ -244,12 +247,8 @@ func resourceAwsSsmDocumentRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("default_version", doc.DefaultVersion)
 	d.Set("description", doc.Description)
 	d.Set("schema_version", doc.SchemaVersion)
-
-	if _, ok := d.GetOk("document_type"); ok {
-		d.Set("document_type", doc.DocumentType)
-	}
-
 	d.Set("document_format", doc.DocumentFormat)
+	d.Set("document_type", doc.DocumentType)
 	d.Set("document_version", doc.DocumentVersion)
 	d.Set("hash", doc.Hash)
 	d.Set("hash_type", doc.HashType)

--- a/aws/resource_aws_ssm_document.go
+++ b/aws/resource_aws_ssm_document.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"strconv"
 	"strings"
 	"time"
 
@@ -17,7 +16,6 @@ import (
 )
 
 const (
-	MINIMUM_VERSIONED_SCHEMA             = 2.0
 	SSM_DOCUMENT_PERMISSIONS_BATCH_LIMIT = 20
 )
 
@@ -317,15 +315,6 @@ func resourceAwsSsmDocumentUpdate(d *schema.ResourceData, meta interface{}) erro
 
 	if !d.HasChange("content") {
 		return nil
-	}
-
-	if schemaVersion, ok := d.GetOk("schemaVersion"); ok {
-		schemaNumber, _ := strconv.ParseFloat(schemaVersion.(string), 64)
-
-		if schemaNumber < MINIMUM_VERSIONED_SCHEMA {
-			log.Printf("[DEBUG] Skipping document update because document version is not 2.0 %q", d.Id())
-			return nil
-		}
 	}
 
 	if err := updateAwsSSMDocument(d, meta); err != nil {

--- a/aws/resource_aws_ssm_document_test.go
+++ b/aws/resource_aws_ssm_document_test.go
@@ -32,6 +32,11 @@ func TestAccAWSSSMDocument_basic(t *testing.T) {
 						"aws_ssm_document.foo", "tags.Name", "My Document"),
 				),
 			},
+			{
+				ResourceName:      "aws_ssm_document.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -54,6 +59,11 @@ func TestAccAWSSSMDocument_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_ssm_document.foo", "default_version", "1"),
 				),
+			},
+			{
+				ResourceName:      "aws_ssm_document.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSSSMDocument20UpdatedConfig(name),
@@ -86,6 +96,11 @@ func TestAccAWSSSMDocument_permission_public(t *testing.T) {
 						"aws_ssm_document.foo", "permissions.account_ids", "all"),
 				),
 			},
+			{
+				ResourceName:      "aws_ssm_document.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -106,6 +121,11 @@ func TestAccAWSSSMDocument_permission_private(t *testing.T) {
 						"aws_ssm_document.foo", "permissions.type", "Share"),
 				),
 			},
+			{
+				ResourceName:      "aws_ssm_document.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -125,6 +145,11 @@ func TestAccAWSSSMDocument_permission_batching(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_ssm_document.foo", "permissions.type", "Share"),
 				),
+			},
+			{
+				ResourceName:      "aws_ssm_document.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -148,6 +173,11 @@ func TestAccAWSSSMDocument_permission_change(t *testing.T) {
 						"aws_ssm_document.foo", "permissions.type", "Share"),
 					resource.TestCheckResourceAttr("aws_ssm_document.foo", "permissions.account_ids", idsInitial),
 				),
+			},
+			{
+				ResourceName:      "aws_ssm_document.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSSSMDocumentPrivatePermissionConfig(name, idsRemove),
@@ -196,6 +226,11 @@ func TestAccAWSSSMDocument_params(t *testing.T) {
 						"aws_ssm_document.foo", "parameter.2.type", "String"),
 				),
 			},
+			{
+				ResourceName:      "aws_ssm_document.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -214,6 +249,11 @@ func TestAccAWSSSMDocument_automation(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_ssm_document.foo", "document_type", "Automation"),
 				),
+			},
+			{
+				ResourceName:      "aws_ssm_document.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -234,6 +274,11 @@ func TestAccAWSSSMDocument_SchemaVersion_1(t *testing.T) {
 					testAccCheckAWSSSMDocumentExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "schema_version", "1.0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSSSMDocumentConfigSchemaVersion1Update(rName),
@@ -260,6 +305,11 @@ func TestAccAWSSSMDocument_session(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_ssm_document.foo", "document_type", "Session"),
 				),
+			},
+			{
+				ResourceName:      "aws_ssm_document.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -303,6 +353,11 @@ mainSteps:
 				),
 			},
 			{
+				ResourceName:      "aws_ssm_document.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAWSSSMDocumentConfig_DocumentFormat_YAML(name, content2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMDocumentExists("aws_ssm_document.foo"),
@@ -330,6 +385,11 @@ func TestAccAWSSSMDocument_Tags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSSSMDocumentConfig_Tags_Multiple(rName, "key1", "value1updated", "key2", "value2"),

--- a/aws/resource_aws_ssm_document_test.go
+++ b/aws/resource_aws_ssm_document_test.go
@@ -219,6 +219,33 @@ func TestAccAWSSSMDocument_automation(t *testing.T) {
 	})
 }
 
+func TestAccAWSSSMDocument_SchemaVersion_1(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ssm_document.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMDocumentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMDocumentConfigSchemaVersion1(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMDocumentExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "schema_version", "1.0"),
+				),
+			},
+			{
+				Config: testAccAWSSSMDocumentConfigSchemaVersion1Update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMDocumentExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "schema_version", "1.0"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSSSMDocument_session(t *testing.T) {
 	name := acctest.RandString(10)
 	resource.ParallelTest(t, resource.TestCase{
@@ -717,6 +744,54 @@ resource "aws_ssm_document" "foo" {
 DOC
 }
 `, rName, content)
+}
+
+func testAccAWSSSMDocumentConfigSchemaVersion1(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_document" "test" {
+  name          = %[1]q
+  document_type = "Session"
+
+  content = <<DOC
+{
+    "schemaVersion": "1.0",
+    "description": "Document to hold regional settings for Session Manager",
+    "sessionType": "Standard_Stream",
+    "inputs": {
+        "s3BucketName": "test",
+        "s3KeyPrefix": "test",
+        "s3EncryptionEnabled": true,
+        "cloudWatchLogGroupName": "/logs/sessions",
+        "cloudWatchEncryptionEnabled": false
+    }
+}
+DOC
+}
+`, rName)
+}
+
+func testAccAWSSSMDocumentConfigSchemaVersion1Update(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_document" "test" {
+  name          = %[1]q
+  document_type = "Session"
+
+  content = <<DOC
+{
+    "schemaVersion": "1.0",
+    "description": "Document to hold regional settings for Session Manager",
+    "sessionType": "Standard_Stream",
+    "inputs": {
+        "s3BucketName": "test",
+        "s3KeyPrefix": "test",
+        "s3EncryptionEnabled": true,
+        "cloudWatchLogGroupName": "/logs/sessions-updated",
+        "cloudWatchEncryptionEnabled": false
+    }
+}
+DOC
+}
+`, rName)
 }
 
 func testAccAWSSSMDocumentConfig_Tags_Single(rName, key1, value1 string) string {

--- a/website/docs/r/ssm_document.html.markdown
+++ b/website/docs/r/ssm_document.html.markdown
@@ -82,3 +82,11 @@ The permissions mapping supports the following:
 
 * `type` - The permission type for the document. The permission type can be `Share`.
 * `account_ids` - The AWS user accounts that should have access to the document. The account IDs can either be a group of account IDs or `All`.
+
+## Import
+
+SSM Documents can be imported using the name, e.g.
+
+```
+$ terraform import aws_ssm_document.example example
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #7516

Sorry for the dual bug and enhancement pull request, but import support is generally the easiest way to verify all attributes are properly being refreshed during the resource `Read` function.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
ENHANCEMENTS:

* resource/aws_ssm_document: Support resource import

BUG FIXES:

* resource/aws_ssm_document: Ensure `content` attribute is always refreshed
```

Output from acceptance testing:

```
--- PASS: TestAccAWSSSMDocument_session (20.77s)
--- PASS: TestAccAWSSSMDocument_permission_public (20.81s)
--- PASS: TestAccAWSSSMDocument_params (27.54s)
--- PASS: TestAccAWSSSMDocument_permission_batching (35.68s)
--- PASS: TestAccAWSSSMDocument_basic (35.72s)
--- PASS: TestAccAWSSSMDocument_permission_private (38.92s)
--- PASS: TestAccAWSSSMDocument_update (48.37s)
--- PASS: TestAccAWSSSMDocument_SchemaVersion_1 (48.81s)
--- PASS: TestAccAWSSSMDocument_Tags (52.70s)
--- PASS: TestAccAWSSSMDocument_automation (53.60s)
--- PASS: TestAccAWSSSMDocument_permission_change (59.26s)
--- PASS: TestAccAWSSSMDocument_DocumentFormat_YAML (60.57s)
PASS
```
