### PR TITLE
tests/resource/aws_eip: Implement sweeper

### DIFF
--- a/aws/resource_aws_eip_test.go
+++ b/aws/resource_aws_eip_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"strings"
 	"testing"
@@ -13,6 +14,76 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+// Implement a test sweeper for EIPs.
+// This will currently skip EIPs with associations,
+// although we depend on aws_vpc to potentially have
+// the majority of those associations removed.
+func init() {
+	resource.AddTestSweepers("aws_eip", &resource.Sweeper{
+		Name: "aws_eip",
+		Dependencies: []string{
+			"aws_vpc",
+		},
+		F: testSweepEc2Eips,
+	})
+}
+
+func testSweepEc2Eips(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).ec2conn
+
+	// There is currently no paginator or Marker/NextToken
+	input := &ec2.DescribeAddressesInput{}
+
+	output, err := conn.DescribeAddresses(input)
+
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping EC2 EIP sweep for %s: %s", region, err)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error describing EC2 EIPs: %s", err)
+	}
+
+	if output == nil || len(output.Addresses) == 0 {
+		log.Print("[DEBUG] No EC2 EIPs to sweep")
+		return nil
+	}
+
+	for _, address := range output.Addresses {
+		publicIP := aws.StringValue(address.PublicIp)
+
+		if address.AssociationId != nil {
+			log.Printf("[INFO] Skipping EC2 EIP (%s) with association: %s", publicIP, aws.StringValue(address.AssociationId))
+			continue
+		}
+
+		input := &ec2.ReleaseAddressInput{}
+
+		// The EC2 API is particular that you only specify one or the other
+		// InvalidParameterCombination: You may specify public IP or allocation id, but not both in the same call
+		if address.AllocationId != nil {
+			input.AllocationId = address.AllocationId
+		} else {
+			input.PublicIp = address.PublicIp
+		}
+
+		log.Printf("[INFO] Releasing EC2 EIP: %s", publicIP)
+
+		_, err := conn.ReleaseAddress(input)
+
+		if err != nil {
+			return fmt.Errorf("error releasing EC2 EIP (%s): %s", publicIP, err)
+		}
+	}
+
+	return nil
+}
 
 func TestAccAWSEIP_importEc2Classic(t *testing.T) {
 	oldvar := os.Getenv("AWS_DEFAULT_REGION")


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
--- FAIL: TestAccAWSEIP_basic (3.40s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error creating EIP: AddressLimitExceeded: The maximum number of addresses has been reached.

$ aws ec2 describe-addresses | jq '.Addresses | length'
12
```

Output from sweeper:

```
$ go test ./aws -v -sweep=us-west-2,us-east-1 -sweep-run=aws_eip -timeout 10h
2019/07/12 11:19:39 [DEBUG] Running Sweepers for region (us-west-2):
...
2019/07/12 11:22:11 [INFO] Releasing EC2 EIP: 34.208.158.17
2019/07/12 11:22:11 [INFO] Releasing EC2 EIP: 34.212.143.58
2019/07/12 11:22:12 [INFO] Releasing EC2 EIP: 35.162.26.198
2019/07/12 11:22:13 [INFO] Releasing EC2 EIP: 50.112.70.32
2019/07/12 11:22:13 [INFO] Releasing EC2 EIP: 52.11.97.102
2019/07/12 11:22:14 [INFO] Releasing EC2 EIP: 52.27.133.157
2019/07/12 11:22:14 [INFO] Releasing EC2 EIP: 52.32.47.10
2019/07/12 11:22:15 [INFO] Releasing EC2 EIP: 52.33.200.11
2019/07/12 11:22:15 [INFO] Releasing EC2 EIP: 52.35.152.141
2019/07/12 11:22:16 [INFO] Releasing EC2 EIP: 52.37.153.78
2019/07/12 11:22:16 [INFO] Releasing EC2 EIP: 52.39.3.122
2019/07/12 11:22:17 [INFO] Releasing EC2 EIP: 54.218.52.146
2019/07/12 11:22:18 Sweeper Tests ran:
  - aws_route_table
  - aws_eip
  - aws_batch_compute_environment
  - aws_db_instance
  - aws_elb
  - aws_instance
  - aws_vpc
  - aws_ec2_client_vpn_endpoint
  - aws_elasticache_replication_group
  - aws_lambda_function
  - aws_mq_broker
  - aws_ec2_transit_gateway_vpc_attachment
  - aws_route53_resolver_endpoint
  - aws_eks_cluster
  - aws_elasticache_cluster
  - aws_emr_cluster
  - aws_network_interface
  - aws_api_gateway_vpc_link
  - aws_security_group
  - aws_dx_gateway_association
  - aws_internet_gateway
  - aws_dx_gateway_association_proposal
  - aws_batch_job_queue
  - aws_beanstalk_environment
  - aws_vpc_endpoint
  - aws_msk_cluster
  - aws_spot_fleet_request
  - aws_vpn_gateway
  - aws_autoscaling_group
  - aws_db_subnet_group
  - aws_directory_service_directory
  - aws_vpc_endpoint_service
  - aws_nat_gateway
  - aws_network_acl
  - aws_elasticsearch_domain
  - aws_lb
  - aws_redshift_cluster
  - aws_subnet
2019/07/12 11:22:18 [DEBUG] Running Sweepers for region (us-east-1):
2019/07/12 11:22:39 [INFO] Releasing EC2 EIP: 54.225.196.195
2019/07/12 11:22:39 [INFO] Releasing EC2 EIP: 54.243.49.93
2019/07/12 11:22:39 [INFO] Releasing EC2 EIP: 3.212.164.38
2019/07/12 11:22:39 Sweeper Tests ran:
  - aws_autoscaling_group
  - aws_db_instance
  - aws_vpn_gateway
  - aws_db_subnet_group
  - aws_spot_fleet_request
  - aws_subnet
  - aws_nat_gateway
  - aws_elasticache_cluster
  - aws_vpc_endpoint
  - aws_lb
  - aws_redshift_cluster
  - aws_elb
  - aws_lambda_function
  - aws_network_acl
  - aws_vpc
  - aws_security_group
  - aws_dx_gateway_association
  - aws_eip
  - aws_directory_service_directory
  - aws_elasticache_replication_group
  - aws_mq_broker
  - aws_route_table
  - aws_instance
  - aws_network_interface
  - aws_route53_resolver_endpoint
  - aws_batch_compute_environment
  - aws_ec2_client_vpn_endpoint
  - aws_api_gateway_vpc_link
  - aws_msk_cluster
  - aws_vpc_endpoint_service
  - aws_internet_gateway
  - aws_dx_gateway_association_proposal
  - aws_beanstalk_environment
  - aws_ec2_transit_gateway_vpc_attachment
  - aws_eks_cluster
  - aws_elasticsearch_domain
  - aws_batch_job_queue
  - aws_emr_cluster

$ aws ec2 describe-addresses | jq '.Addresses | length'
0
```
