### PR TITLE
Add support import Autoscaling Lifecycle Hook

### DIFF
--- a/aws/resource_aws_autoscaling_lifecycle_hook.go
+++ b/aws/resource_aws_autoscaling_lifecycle_hook.go
@@ -20,6 +20,10 @@ func resourceAwsAutoscalingLifecycleHook() *schema.Resource {
 		Update: resourceAwsAutoscalingLifecycleHookPut,
 		Delete: resourceAwsAutoscalingLifecycleHookDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsAutoscalingLifecycleHookImport,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -191,4 +195,20 @@ func getAwsAutoscalingLifecycleHook(d *schema.ResourceData, meta interface{}) (*
 
 	// lifecycle hook not found
 	return nil, nil
+}
+
+func resourceAwsAutoscalingLifecycleHookImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	idParts := strings.SplitN(d.Id(), "/", 2)
+	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
+		return nil, fmt.Errorf("unexpected format (%q), expected <asg-name>/<lifecycle-hook-name>", d.Id())
+	}
+
+	asgName := idParts[0]
+	lifecycleHookName := idParts[1]
+
+	d.Set("name", lifecycleHookName)
+	d.Set("autoscaling_group_name", asgName)
+	d.SetId(lifecycleHookName)
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/aws/resource_aws_autoscaling_lifecycle_hook_test.go
+++ b/aws/resource_aws_autoscaling_lifecycle_hook_test.go
@@ -29,6 +29,12 @@ func TestAccAWSAutoscalingLifecycleHook_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_autoscaling_lifecycle_hook.foobar", "lifecycle_transition", "autoscaling:EC2_INSTANCE_LAUNCHING"),
 				),
 			},
+			{
+				ResourceName:      "aws_autoscaling_lifecycle_hook.foobar",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAutoscalingLifecycleHookImportStateIdFunc("aws_autoscaling_lifecycle_hook.foobar"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -105,6 +111,17 @@ func testAccCheckAWSAutoscalingLifecycleHookDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccAWSAutoscalingLifecycleHookImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["autoscaling_group_name"], rs.Primary.Attributes["name"]), nil
+	}
 }
 
 func testAccAWSAutoscalingLifecycleHookConfig(name string) string {

--- a/website/docs/r/autoscaling_lifecycle_hooks.html.markdown
+++ b/website/docs/r/autoscaling_lifecycle_hooks.html.markdown
@@ -68,3 +68,11 @@ The following arguments are supported:
 * `notification_metadata` - (Optional) Contains additional information that you want to include any time Auto Scaling sends a message to the notification target.
 * `notification_target_arn` - (Optional) The ARN of the notification target that Auto Scaling will use to notify you when an instance is in the transition state for the lifecycle hook. This ARN target can be either an SQS queue or an SNS topic.
 * `role_arn` - (Optional) The ARN of the IAM role that allows the Auto Scaling group to publish to the specified notification target.
+
+## Import
+
+AutoScaling Lifecycle Hook can be imported using the role autoscaling_group_name and name separated by `/`.
+
+```
+$ terraform import aws_aws_autoscaling_lifecycle_hook.test-lifecycle-hook asg-name/lifecycle-hook-name
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/9142

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_autoscaling_lifecycle_hook: Support resource import
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSAutoscalingLifecycleHook_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSAutoscalingLifecycleHook_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSAutoscalingLifecycleHook_basic
=== PAUSE TestAccAWSAutoscalingLifecycleHook_basic
=== CONT  TestAccAWSAutoscalingLifecycleHook_basic
--- PASS: TestAccAWSAutoscalingLifecycleHook_basic (164.47s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	164.539s
```

---

Basically, same with https://github.com/terraform-providers/terraform-provider-aws/commit/46f454975737ffc83b0bca206d8b48a61b2592b4 . Thank you for the implementation and great support me @kterada0509 🙏 