### PR TITLE
tests/resource/aws_ec2_transit_gateway: Ensure sweeper has dependency on Direct Connect Gateway Associations

### DIFF
--- a/aws/resource_aws_dx_gateway_association_test.go
+++ b/aws/resource_aws_dx_gateway_association_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/directconnect"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -104,6 +105,77 @@ func testSweepDirectConnectGatewayAssociations(region string) error {
 		}
 
 		gatewayInput.NextToken = gatewayOutput.NextToken
+	}
+
+	// Handle cross-account EC2 Transit Gateway associations.
+	// Direct Connect does not provide an easy lookup method for
+	// these within the service itself so they can only be found
+	// via AssociatedGatewayId of the EC2 Transit Gateway since the
+	// DirectConnectGatewayId lives in the other account.
+	ec2conn := client.(*AWSClient).ec2conn
+
+	err = ec2conn.DescribeTransitGatewaysPages(&ec2.DescribeTransitGatewaysInput{}, func(page *ec2.DescribeTransitGatewaysOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, transitGateway := range page.TransitGateways {
+			if aws.StringValue(transitGateway.State) == ec2.TransitGatewayStateDeleted {
+				continue
+			}
+
+			associationInput := &directconnect.DescribeDirectConnectGatewayAssociationsInput{
+				AssociatedGatewayId: transitGateway.TransitGatewayId,
+			}
+			transitGatewayID := aws.StringValue(transitGateway.TransitGatewayId)
+
+			associationOutput, err := conn.DescribeDirectConnectGatewayAssociations(associationInput)
+
+			if err != nil {
+				log.Printf("[ERROR] error retrieving EC2 Transit Gateway (%s) Direct Connect Gateway Associations: %s", transitGatewayID, err)
+				continue
+			}
+
+			for _, association := range associationOutput.DirectConnectGatewayAssociations {
+				associationID := aws.StringValue(association.AssociationId)
+
+				if aws.StringValue(association.AssociationState) != directconnect.GatewayAssociationStateAssociated {
+					log.Printf("[INFO] Skipping EC2 Transit Gateway (%s) Direct Connect Gateway Association (%s) in non-available state: %s", transitGatewayID, associationID, aws.StringValue(association.AssociationState))
+					continue
+				}
+
+				input := &directconnect.DeleteDirectConnectGatewayAssociationInput{
+					AssociationId: association.AssociationId,
+				}
+
+				log.Printf("[INFO] Deleting EC2 Transit Gateway (%s) Direct Connect Gateway Association: %s", transitGatewayID, associationID)
+				_, err := conn.DeleteDirectConnectGatewayAssociation(input)
+
+				if isAWSErr(err, directconnect.ErrCodeClientException, "No association exists") {
+					continue
+				}
+
+				if err != nil {
+					log.Printf("[ERROR] error deleting EC2 Transit Gateway (%s) Direct Connect Gateway Association (%s): %s", transitGatewayID, associationID, err)
+					continue
+				}
+
+				if err := waitForDirectConnectGatewayAssociationDeletion(conn, associationID, 30*time.Minute); err != nil {
+					log.Printf("[ERROR] error waiting for EC2 Transit Gateway (%s) Direct Connect Gateway Association (%s) to be deleted: %s", transitGatewayID, associationID, err)
+				}
+			}
+		}
+
+		return !lastPage
+	})
+
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping EC2 Transit Gateway Direct Connect Gateway Association sweep for %s: %s", region, err)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error retrieving EC2 Transit Gateways: %s", err)
 	}
 
 	return nil

--- a/aws/resource_aws_ec2_transit_gateway_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -17,6 +18,7 @@ func init() {
 		Name: "aws_ec2_transit_gateway",
 		F:    testSweepEc2TransitGateways,
 		Dependencies: []string{
+			"aws_dx_gateway_association",
 			"aws_ec2_transit_gateway_vpc_attachment",
 		},
 	})
@@ -54,10 +56,34 @@ func testSweepEc2TransitGateways(region string) error {
 			}
 
 			log.Printf("[INFO] Deleting EC2 Transit Gateway: %s", id)
-			_, err := conn.DeleteTransitGateway(input)
+			err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+				_, err := conn.DeleteTransitGateway(input)
 
-			if isAWSErr(err, "InvalidTransitGatewayID.NotFound", "") {
-				continue
+				if isAWSErr(err, "IncorrectState", "has non-deleted Transit Gateway Attachments") {
+					return resource.RetryableError(err)
+				}
+
+				if isAWSErr(err, "IncorrectState", "has non-deleted DirectConnect Gateway Attachments") {
+					return resource.RetryableError(err)
+				}
+
+				if isAWSErr(err, "IncorrectState", "has non-deleted VPN Attachments") {
+					return resource.RetryableError(err)
+				}
+
+				if isAWSErr(err, "InvalidTransitGatewayID.NotFound", "") {
+					return nil
+				}
+
+				if err != nil {
+					return resource.NonRetryableError(err)
+				}
+
+				return nil
+			})
+
+			if isResourceTimeoutError(err) {
+				_, err = conn.DeleteTransitGateway(input)
 			}
 
 			if err != nil {


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

There is also eventual consistency with EC2 Transit Gateway disassociations, which was handled in the resource Delete function and needs to be handed with the sweeper.

Previously, the `aws_ec2_transit_gateway` sweper could fail with:

```
[04:29:17][Step 2/5] 2019/07/15 04:29:17 [ERR] error running (aws_ec2_transit_gateway): error deleting EC2 Transit Gateway (tgw-05cd4e77633d87984): IncorrectState: tgw-05cd4e77633d87984 has non-deleted DirectConnect Gateway Attachments: tgw-attach-00b9e5b1a496eb2f1.
```

Output from sweeper (before EC2 Transit Gateway retries added):

```
$ go test ./aws -v -sweep=us-west-2,us-east-1 -sweep-run=aws_ec2_transit_gateway -timeout 10h
2019/07/15 07:28:21 [DEBUG] Running Sweepers for region (us-west-2):
...
2019/07/15 07:28:26 [INFO] Deleting EC2 Transit Gateway (tgw-05cd4e77633d87984) Direct Connect Gateway Association: c4ec8e1a-2d7e-412d-b972-c5cb57616b40
2019/07/15 07:28:26 [DEBUG] Waiting for state to become: [disassociated deleted]
...
2019/07/15 07:39:19 [INFO] Deleting EC2 Transit Gateway: tgw-05cd4e77633d87984
2019/07/15 07:39:20 [ERR] error running (aws_ec2_transit_gateway): error deleting EC2 Transit Gateway (tgw-05cd4e77633d87984): IncorrectState: tgw-05cd4e77633d87984 has non-deleted DirectConnect Gateway Attachments: tgw-attach-00b9e5b1a496eb2f1.
```

Output from sweeper in AWS Commercial:

```
$ go test ./aws -v -sweep=us-west-2,us-east-1 -sweep-run=aws_ec2_transit_gateway -timeout 10h
2019/07/15 07:46:33 [DEBUG] Running Sweepers for region (us-west-2):
...
2019/07/15 07:46:47 [INFO] Deleting EC2 Transit Gateway: tgw-05cd4e77633d87984
...
2019/07/15 07:47:50 Sweeper Tests ran:
	- aws_dx_gateway_association_proposal
	- aws_dx_gateway_association
	- aws_ec2_transit_gateway_vpc_attachment
	- aws_ec2_transit_gateway
```

Output from sweeper in AWS GovCloud (US):

```
$ go test ./aws -v -sweep=us-gov-west-1 -sweep-run=aws_ec2_transit_gateway -timeout 10h
2019/07/15 07:46:33 [DEBUG] Running Sweepers for region (us-gov-west-1):
...
2019/07/15 07:46:44 Sweeper Tests ran:
	- aws_dx_gateway_association_proposal
	- aws_dx_gateway_association
	- aws_ec2_transit_gateway_vpc_attachment
	- aws_ec2_transit_gateway
```

