### PR TITLE
EOL node engine 6.10 of lambda function

### DIFF
--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -279,7 +279,7 @@ func TestAccAWSLambdaFunction_updateRuntime(t *testing.T) {
 				Config: testAccAWSLambdaConfigBasicUpdateRuntime(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", "nodejs8.10"),
+					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", "nodejs10.x"),
 				),
 			},
 		},
@@ -1724,7 +1724,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs8.10"
+    runtime = "nodejs10.x"
 }
 `, funcName)
 }

--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -279,7 +279,7 @@ func TestAccAWSLambdaFunction_updateRuntime(t *testing.T) {
 				Config: testAccAWSLambdaConfigBasicUpdateRuntime(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", "nodejs6.10"),
+					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", "nodejs8.10"),
 				),
 			},
 		},
@@ -1724,7 +1724,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs6.10"
+    runtime = "nodejs8.10"
 }
 `, funcName)
 }

--- a/aws/resource_aws_lambda_layer_version_test.go
+++ b/aws/resource_aws_lambda_layer_version_test.go
@@ -345,7 +345,7 @@ resource "aws_lambda_layer_version" "lambda_layer_test" {
   filename   = "test-fixtures/lambdatest.zip"
   layer_name = "%s"
 
-  compatible_runtimes = ["nodejs8.10", "nodejs6.10"]
+  compatible_runtimes = ["nodejs8.10", "nodejs8.10"]
 }
 `, layerName)
 }

--- a/aws/resource_aws_lambda_layer_version_test.go
+++ b/aws/resource_aws_lambda_layer_version_test.go
@@ -345,7 +345,7 @@ resource "aws_lambda_layer_version" "lambda_layer_test" {
   filename   = "test-fixtures/lambdatest.zip"
   layer_name = "%s"
 
-  compatible_runtimes = ["nodejs8.10"]
+  compatible_runtimes = ["nodejs8.10", "nodejs10.x"]
 }
 `, layerName)
 }

--- a/aws/resource_aws_lambda_layer_version_test.go
+++ b/aws/resource_aws_lambda_layer_version_test.go
@@ -345,7 +345,7 @@ resource "aws_lambda_layer_version" "lambda_layer_test" {
   filename   = "test-fixtures/lambdatest.zip"
   layer_name = "%s"
 
-  compatible_runtimes = ["nodejs8.10", "nodejs8.10"]
+  compatible_runtimes = ["nodejs8.10"]
 }
 `, layerName)
 }

--- a/aws/resource_aws_pinpoint_app_test.go
+++ b/aws/resource_aws_pinpoint_app_test.go
@@ -193,7 +193,7 @@ resource "aws_lambda_function" "test" {
   function_name = "%s"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
   handler       = "lambdapinpoint.handler"
-  runtime       = "nodejs6.10"
+  runtime       = "nodejs8.10"
   publish       = true
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/lambda/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/lambda/api.go
@@ -9243,7 +9243,7 @@ const (
 	RuntimeNodejs43 = "nodejs4.3"
 
 	// RuntimeNodejs610 is a Runtime enum value
-	RuntimeNodejs610 = "nodejs6.10"
+	RuntimeNodejs610 = "nodejs8.10"
 
 	// RuntimeNodejs810 is a Runtime enum value
 	RuntimeNodejs810 = "nodejs8.10"

--- a/vendor/github.com/aws/aws-sdk-go/service/lambda/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/lambda/api.go
@@ -9243,7 +9243,7 @@ const (
 	RuntimeNodejs43 = "nodejs4.3"
 
 	// RuntimeNodejs610 is a Runtime enum value
-	RuntimeNodejs610 = "nodejs8.10"
+	RuntimeNodejs610 = "nodejs6.10"
 
 	// RuntimeNodejs810 is a Runtime enum value
 	RuntimeNodejs810 = "nodejs8.10"

--- a/website/docs/guides/serverless-with-aws-lambda-and-api-gateway.html.md
+++ b/website/docs/guides/serverless-with-aws-lambda-and-api-gateway.html.md
@@ -151,7 +151,7 @@ resource "aws_lambda_function" "example" {
   # is the name of the property under which the handler function was
   # exported in that file.
   handler = "main.handler"
-  runtime = "nodejs6.10"
+  runtime = "nodejs8.10"
 
   role = "${aws_iam_role.lambda_exec.arn}"
 }
@@ -227,7 +227,7 @@ aws_lambda_function.example: Creating...
   publish:          "" => "false"
   qualified_arn:    "" => "<computed>"
   role:             "" => "arn:aws:iam::123456:role/serverless_example_lambda"
-  runtime:          "" => "nodejs6.10"
+  runtime:          "" => "nodejs8.10"
   s3_bucket:        "" => "terraform-serverless-example"
   s3_key:           "" => "v1.0.0/example.zip"
   source_code_hash: "" => "<computed>"

--- a/website/docs/r/lambda_layer_version.html.markdown
+++ b/website/docs/r/lambda_layer_version.html.markdown
@@ -19,7 +19,7 @@ resource "aws_lambda_layer_version" "lambda_layer" {
   filename   = "lambda_layer_payload.zip"
   layer_name = "lambda_layer_name"
 
-  compatible_runtimes = ["nodejs8.10", "nodejs6.10"]
+  compatible_runtimes = ["nodejs8.10", "nodejs8.10"]
 }
 ```
 

--- a/website/docs/r/lambda_layer_version.html.markdown
+++ b/website/docs/r/lambda_layer_version.html.markdown
@@ -19,7 +19,7 @@ resource "aws_lambda_layer_version" "lambda_layer" {
   filename   = "lambda_layer_payload.zip"
   layer_name = "lambda_layer_name"
 
-  compatible_runtimes = ["nodejs8.10", "nodejs8.10"]
+  compatible_runtimes = ["nodejs8.10"]
 }
 ```
 

--- a/website/docs/r/lambda_permission.html.markdown
+++ b/website/docs/r/lambda_permission.html.markdown
@@ -35,7 +35,7 @@ resource "aws_lambda_function" "test_lambda" {
   function_name = "lambda_function_name"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
   handler       = "exports.handler"
-  runtime       = "nodejs6.10"
+  runtime       = "nodejs8.10"
 }
 
 resource "aws_iam_role" "iam_for_lambda" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes ~#0000~ Seems that the issue has not been reported

I faced the following error: (refer: https://www.terraform.io/docs/providers/aws/r/lambda_permission.html#example-usage)

```
   │ Error: Error creating Lambda function: InvalidParameterValueException: The runtime parameter of nodejs6.10 is no longer supported for creating or updating AWS Lambda functions. We re
       │ commend you use the new runtime (nodejs10.x) while creating or updating functions.
   │ /Users/take/go/src/github.com/hashicorp/terraform/states/statemgr/filesystem.go:349: [TRACE] statemgr.Filesystem: removing lock metadata file .terraform.tfstate.lock.info
   │     status code: 400, request id: 26c1b11c-e092-45d3-bb9f-18d685d26727
```

Unfortunately, nodejs6.10 was EOL on April 30, 2019
ref: https://aws.amazon.com/blogs/developer/node-js-6-is-approaching-end-of-life-upgrade-your-aws-lambda-functions-to-the-node-js-10-lts/

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

None of FEATURES, ENHANCEMENT and BUG FIX. This is just updating doc and test.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSLambdaFunction_updateRuntime'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSLambdaFunction_updateRuntime -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSLambdaFunction_updateRuntime
=== PAUSE TestAccAWSLambdaFunction_updateRuntime
=== CONT  TestAccAWSLambdaFunction_updateRuntime
--- PASS: TestAccAWSLambdaFunction_updateRuntime (87.40s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	87.465s
```
