### PR TITLE
Update security_group.html.markdown

### DIFF
--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -33,7 +33,7 @@ resource "aws_security_group" "allow_tls" {
     # TLS (change to whatever ports you need)
     from_port   = 443
     to_port     = 443
-    protocol    = "-1"
+    protocol    = "tcp"
     # Please restrict your ingress to only necessary IPs and ports.
     # Opening to 0.0.0.0/0 can lead to security vulnerabilities.
     cidr_blocks = # add a CIDR block here


### PR DESCRIPTION
Proposed update to the docs:
Change protocol from "-1" to "tcp" 

Reason:
The example ingress settings are invalid because `from_port` and `to_port` must be 0 if all protocols are accepted.