### PR TITLE
feature(config): manage AWS Config Remediation Configuration

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -375,6 +375,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_config_delivery_channel":                             resourceAwsConfigDeliveryChannel(),
 			"aws_config_organization_custom_rule":                     resourceAwsConfigOrganizationCustomRule(),
 			"aws_config_organization_managed_rule":                    resourceAwsConfigOrganizationManagedRule(),
+			"aws_config_remediation_configuration":                    resourceAwsConfigRemediationConfiguration(),
 			"aws_cognito_identity_pool":                               resourceAwsCognitoIdentityPool(),
 			"aws_cognito_identity_pool_roles_attachment":              resourceAwsCognitoIdentityPoolRolesAttachment(),
 			"aws_cognito_identity_provider":                           resourceAwsCognitoIdentityProvider(),

--- a/aws/resource_aws_config_remediation_configuration.go
+++ b/aws/resource_aws_config_remediation_configuration.go
@@ -1,0 +1,219 @@
+package aws
+
+import (
+	//"bytes"
+	"fmt"
+	"log"
+	"time"
+
+	//"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/configservice"
+)
+
+func resourceAwsConfigRemediationConfiguration() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsConfigRemediationConfigurationPut,
+		Read:   resourceAwsConfigRemediationConfigurationRead,
+		Update: resourceAwsConfigRemediationConfigurationPut,
+		Delete: resourceAwsConfigRemediationConfigurationDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"config_rule_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(0, 64),
+			},
+			"resource_type": {
+				Type:     schema.TypeString,
+				Computed: false,
+			},
+			"target_id": {
+				Type:     schema.TypeString,
+				Computed: false,
+			},
+			"target_type": {
+				Type:     schema.TypeString,
+				Computed: false,
+			},
+			"target_version": {
+				Type:     schema.TypeString,
+				Computed: false,
+			},
+			"parameters": {
+				Type:     schema.TypeSet,
+				MaxItems: 25,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"resource_value": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(0, 256),
+						},
+						"static_value": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:     schema.TypeString,
+										Computed: false,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Computed: false,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsConfigRemediationConfigurationPut(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).configconn
+
+	name := d.Get("config_rule_name").(string)
+	remediationConfigurationInput := configservice.RemediationConfiguration{
+		ConfigRuleName: aws.String(name),
+	}
+
+	if v, ok := d.GetOk("parameters"); ok {
+		remediationConfigurationInput.Parameters = expandConfigRemediationConfigurationParameters(v.(*schema.Set))
+	}
+
+	if v, ok := d.GetOk("resource_type"); ok && v.(string) != "" {
+		remediationConfigurationInput.ResourceType = aws.String(v.(string))
+	}
+	if v, ok := d.GetOk("target_id"); ok && v.(string) != "" {
+		remediationConfigurationInput.TargetId = aws.String(v.(string))
+	}
+	if v, ok := d.GetOk("target_type"); ok && v.(string) != "" {
+		remediationConfigurationInput.TargetType = aws.String(v.(string))
+	}
+	if v, ok := d.GetOk("target_version"); ok && v.(string) != "" {
+		remediationConfigurationInput.TargetVersion = aws.String(v.(string))
+	}
+
+	remediationConfigurations := make([]*configservice.RemediationConfiguration, 1)
+	remediationConfigurations = append(remediationConfigurations, &remediationConfigurationInput)
+
+	input := configservice.PutRemediationConfigurationsInput{
+		RemediationConfigurations: remediationConfigurations,
+	}
+	log.Printf("[DEBUG] Creating AWSConfig remediation configuration: %s", input)
+	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+		_, err := conn.PutRemediationConfigurations(&input)
+		if err != nil {
+			if awsErr, ok := err.(awserr.Error); ok {
+				if awsErr.Code() == "InsufficientPermissionsException" {
+					// IAM is eventually consistent
+					return resource.RetryableError(err)
+				}
+			}
+
+			return resource.NonRetryableError(fmt.Errorf("Failed to create AWSConfig remediation configuration: %s", err))
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	d.SetId(name)
+
+	log.Printf("[DEBUG] AWSConfig config remediation configuration for rule %q created", name)
+
+	return resourceAwsConfigRemediationConfigurationRead(d, meta)
+}
+
+func resourceAwsConfigRemediationConfigurationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).configconn
+	out, err := conn.DescribeRemediationConfigurations(&configservice.DescribeRemediationConfigurationsInput{
+		ConfigRuleNames: []*string{aws.String(d.Id())},
+	})
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NoSuchConfigRuleException" {
+			log.Printf("[WARN] Config Rule %q is gone (NoSuchConfigRuleException)", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	numberOfRemediationConfigurations := len(out.RemediationConfigurations)
+	if numberOfRemediationConfigurations < 1 {
+		log.Printf("[WARN] No Remediation Configuration for Config Rule %q (no remediation configuration found)", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	log.Printf("[DEBUG] AWS Config remediation configurations received: %s", out)
+
+	remediationConfigurations := out.RemediationConfigurations
+	d.Set("remediationConfigurations", flattenRemediationConfigurations(remediationConfigurations))
+
+	return nil
+}
+
+func resourceAwsConfigRemediationConfigurationDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).configconn
+
+	name := d.Get("config_rule_name").(string)
+
+	deleteRemediationConfigurationInput := configservice.DeleteRemediationConfigurationInput{
+		ConfigRuleName: aws.String(name),
+	}
+
+	if v, ok := d.GetOk("resource_type"); ok && v.(string) != "" {
+		deleteRemediationConfigurationInput.ResourceType = aws.String(v.(string))
+	}
+
+	log.Printf("[DEBUG] Deleting AWS Config remediation configurations for rule %q", name)
+	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+		_, err := conn.DeleteRemediationConfiguration(&deleteRemediationConfigurationInput)
+		if err != nil {
+			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "ResourceInUseException" {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("Deleting Remediation Configurations failed: %s", err)
+	}
+
+	log.Printf("[DEBUG] AWS Config remediation configurations for rule %q deleted", name)
+
+	return nil
+}
+
+/*func configRuleSourceDetailsHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	if v, ok := m["message_type"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+	}
+	if v, ok := m["event_source"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+	}
+	if v, ok := m["maximum_execution_frequency"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+	}
+	return hashcode.String(buf.String())
+}*/

--- a/aws/resource_aws_config_remediation_configuration.go
+++ b/aws/resource_aws_config_remediation_configuration.go
@@ -1,12 +1,10 @@
 package aws
 
 import (
-	//"bytes"
 	"fmt"
 	"log"
 	"time"
 
-	//"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
@@ -35,19 +33,19 @@ func resourceAwsConfigRemediationConfiguration() *schema.Resource {
 			},
 			"resource_type": {
 				Type:     schema.TypeString,
-				Computed: false,
+				Optional: true,
 			},
 			"target_id": {
 				Type:     schema.TypeString,
-				Computed: false,
+				Required: true,
 			},
 			"target_type": {
 				Type:     schema.TypeString,
-				Computed: false,
+				Required: true,
 			},
 			"target_version": {
 				Type:     schema.TypeString,
-				Computed: false,
+				Optional: true,
 			},
 			"parameters": {
 				Type:     schema.TypeSet,
@@ -67,11 +65,11 @@ func resourceAwsConfigRemediationConfiguration() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"key": {
 										Type:     schema.TypeString,
-										Computed: false,
+										Required: true,
 									},
 									"value": {
 										Type:     schema.TypeString,
-										Computed: false,
+										Required: true,
 									},
 								},
 							},

--- a/aws/resource_aws_config_remediation_configuration_test.go
+++ b/aws/resource_aws_config_remediation_configuration_test.go
@@ -117,28 +117,23 @@ resource "aws_config_remediation_configuration" "foo" {
 	target_type = "AWS-PublishSNSNotification"
 	target_version = "1"
 
-	parameters = [
-		{
-			resource_value = "Message"
-		},
-		{
-			static_value = {
-				key = "TopicArn"
-				value = "${aws_sns_topic.foo.arn}"
-			}
-		},
-		{
-			static_value = {
-				key = "AutomationAssumeRole"
-				value = "${aws_iam_role.aar.arn}"
-			}
+	parameter {
+		resource_value = "Message"
+	}
+	
+	parameter {
+		static_value {
+			key   = "TopicArn"
+			value = "${aws_sns_topic.foo.arn}"
 		}
-	]
-
-	depends_on = [
-		"aws_config_config_rule.foo",
-		"aws_sns_topic.foo"
-	]
+	}
+	
+	parameter {
+		static_value {
+			key   = "AutomationAssumeRole"
+			value = "${aws_iam_role.aar.arn}"
+		}
+	}
 }
 
 resource "aws_sns_topic" "foo" {

--- a/aws/resource_aws_config_remediation_configuration_test.go
+++ b/aws/resource_aws_config_remediation_configuration_test.go
@@ -26,7 +26,6 @@ func testAccConfigRemediationConfiguration_basic(t *testing.T) {
 				Config: testAccConfigRemediationConfigurationConfig_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigRemediationConfigurationExists("aws_config_remediation_configuration.foo", &rc),
-					testAccCheckConfigRemediationConfigurationName("aws_config_remediation_configuration.foo", expectedName, &rc),
 					resource.TestCheckResourceAttr("aws_config_remediation_configuration.foo", "config_rule_name", expectedName),
 					resource.TestCheckResourceAttr("aws_config_remediation_configuration.foo", "target_id", "SSM_DOCUMENT"),
 					resource.TestCheckResourceAttr("aws_config_remediation_configuration.foo", "target_type", "AWS-PublishSNSNotification"),
@@ -40,19 +39,6 @@ func testAccConfigRemediationConfiguration_basic(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccCheckConfigRemediationConfigurationName(n, desired string, obj *configservice.RemediationConfiguration) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-		if rs.Primary.Attributes["cnofig_rule_name"] != *obj.ConfigRuleName {
-			return fmt.Errorf("Expected name: %q, given: %q", desired, *obj.ConfigRuleName)
-		}
-		return nil
-	}
 }
 
 func testAccCheckConfigRemediationConfigurationExists(n string, obj *configservice.RemediationConfiguration) resource.TestCheckFunc {
@@ -131,7 +117,7 @@ resource "aws_config_remediation_configuration" "foo" {
 	parameter {
 		static_value {
 			key   = "AutomationAssumeRole"
-			value = "${aws_iam_role.aar.arn}"
+			value = "${aws_iam_role.r.arn}"
 		}
 	}
 }

--- a/aws/resource_aws_config_remediation_configuration_test.go
+++ b/aws/resource_aws_config_remediation_configuration_test.go
@@ -1,0 +1,324 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/configservice"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func testAccConfigRemediationConfiguration_basic(t *testing.T) {
+	var rc configservice.RemediationConfiguration
+	rInt := acctest.RandInt()
+	expectedName := fmt.Sprintf("tf-acc-test-%d", rInt)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckConfigRemediationConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigRemediationConfigurationConfig_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigRemediationConfigurationExists("aws_config_remediation_configuration.foo", &rc),
+					testAccCheckConfigRemediationConfigurationName("aws_config_remediation_configuration.foo", expectedName, &rc),
+					resource.TestCheckResourceAttr("aws_config_remediation_configuration.foo", "config_rule_name", expectedName),
+					resource.TestCheckResourceAttr("aws_config_remediation_configuration.foo", "target_id", "SSM_DOCUMENT"),
+					resource.TestCheckResourceAttr("aws_config_remediation_configuration.foo", "target_type", "AWS-PublishSNSNotification"),
+					resource.TestCheckResourceAttr("aws_config_remediation_configuration.foo", "parameters.0.resource_value", "Message"),
+				),
+			},
+		},
+	})
+}
+
+func testAccConfigRemediationConfiguration_importAws(t *testing.T) {
+	resourceName := "aws_config_remediation_configuration.foo"
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckConfigRemediationConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigRemediationConfigurationConfig_ownerAws(rInt),
+			},
+
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckConfigRemediationConfigurationName(n, desired string, obj *configservice.RemediationConfiguration) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		if rs.Primary.Attributes["cnofig_rule_name"] != *obj.ConfigRuleName {
+			return fmt.Errorf("Expected name: %q, given: %q", desired, *obj.ConfigRuleName)
+		}
+		return nil
+	}
+}
+
+func testAccCheckConfigRemediationConfigurationExists(n string, obj *configservice.RemediationConfiguration) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not Found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No config rule ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).configconn
+		out, err := conn.DescribeRemediationConfigurations(&configservice.DescribeRemediationConfigurationsInput{
+			ConfigRuleNames: []*string{aws.String(rs.Primary.Attributes["name"])},
+		})
+		if err != nil {
+			return fmt.Errorf("Failed to describe config rule: %s", err)
+		}
+		if len(out.RemediationConfigurations) < 1 {
+			return fmt.Errorf("No config rule found when describing %q", rs.Primary.Attributes["name"])
+		}
+
+		rc := out.RemediationConfigurations[0]
+		*obj = *rc
+
+		return nil
+	}
+}
+
+func testAccCheckConfigRemediationConfigurationDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).configconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_config_remediation_configuration" {
+			continue
+		}
+
+		resp, err := conn.DescribeRemediationConfigurations(&configservice.DescribeRemediationConfigurationsInput{
+			ConfigRuleNames: []*string{aws.String(rs.Primary.Attributes["name"])},
+		})
+
+		if err == nil {
+			if len(resp.RemediationConfigurations) != 0 &&
+				*resp.RemediationConfigurations[0].ConfigRuleName == rs.Primary.Attributes["name"] {
+				return fmt.Errorf("remediation configuration(s) still exist for rule: %s", rs.Primary.Attributes["name"])
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccConfigRemediationConfigurationConfig_basic(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_config_remediation_configuration" "foo" {
+	config_rule_name = "${aws_config_config_rule.foo.name}"
+
+	resource_type = ""
+	target_id = "SSM_DOCUMENT"
+	target_type = "AWS-PublishSNSNotification"
+	target_version = "1"
+
+	parameters = [
+		{
+			resource_value = "Message"
+		},
+		{
+			static_value = {
+				key = "TopicArn"
+				value = "${aws_sns_topic.foo.arn}"
+			}
+		},
+		{
+			static_value = {
+				key = "AutomationAssumeRole"
+				value = "${aws_iam_role.aar.arn}"
+			}
+		}
+	]
+
+	depends_on = [
+		"aws_config_config_rule.foo",
+		"aws_sns_topic.foo"
+	]
+}
+
+resource "aws_sns_topic" "foo" {
+  name = "sns_topic_name"
+}
+
+resource "aws_config_config_rule" "foo" {
+  name = "tf-acc-test-%d"
+
+  source {
+    owner             = "AWS"
+    source_identifier = "S3_BUCKET_VERSIONING_ENABLED"
+  }
+
+  depends_on = ["aws_config_configuration_recorder.foo"]
+}
+
+resource "aws_config_configuration_recorder" "foo" {
+  name     = "tf-acc-test-%d"
+  role_arn = "${aws_iam_role.r.arn}"
+}
+
+resource "aws_iam_role" "r" {
+  name = "tf-acc-test-awsconfig-%d"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "config.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "p" {
+  name = "tf-acc-test-awsconfig-%d"
+  role = "${aws_iam_role.r.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+        "Action": "config:Put*",
+        "Effect": "Allow",
+        "Resource": "*"
+
+    }
+  ]
+}
+EOF
+}
+`, randInt, randInt, randInt, randInt)
+}
+
+func testAccConfigRemediationConfigurationConfig_ownerAws(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_config_remediation_configuration" "foo" {
+	config_rule_name = "${aws_config_config_rule.foo.name}"
+
+	resource_type = ""
+	target_id = "SSM_DOCUMENT"
+	target_type = "AWS-PublishSNSNotification"
+	target_version = "1"
+
+	parameters = [
+		{
+			resource_value = "Message"
+		},
+		{
+			static_value = {
+				key = "TopicArn"
+				value = "${aws_sns_topic.foo.arn}"
+			}
+		},
+		{
+			static_value = {
+				key = "AutomationAssumeRole"
+				value = "${aws_iam_role.aar.arn}"
+			}
+		}
+	]
+
+	depends_on = [
+		"aws_config_config_rule.foo",
+		"aws_sns_topic.foo"
+	]
+}
+
+resource "aws_sns_topic" "foo" {
+	name = "sns_topic_name"
+}
+
+resource "aws_config_config_rule" "foo" {
+  name        = "tf-acc-test-%d"
+  description = "Terraform Acceptance tests"
+
+  source {
+    owner             = "AWS"
+    source_identifier = "REQUIRED_TAGS"
+  }
+
+  scope {
+    compliance_resource_id    = "blablah"
+    compliance_resource_types = ["AWS::EC2::Instance"]
+  }
+
+  input_parameters = <<PARAMS
+{"tag1Key":"CostCenter", "tag2Key":"Owner"}
+PARAMS
+
+  depends_on = ["aws_config_configuration_recorder.foo"]
+}
+
+resource "aws_config_configuration_recorder" "foo" {
+  name     = "tf-acc-test-%d"
+  role_arn = "${aws_iam_role.r.arn}"
+}
+
+resource "aws_iam_role" "r" {
+  name = "tf-acc-test-awsconfig-%d"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "config.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "p" {
+  name = "tf-acc-test-awsconfig-%d"
+  role = "${aws_iam_role.r.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+        "Action": "config:Put*",
+        "Effect": "Allow",
+        "Resource": "*"
+
+    }
+  ]
+}
+EOF
+}
+`, randInt, randInt, randInt, randInt)
+}

--- a/aws/resource_aws_config_test.go
+++ b/aws/resource_aws_config_test.go
@@ -61,6 +61,10 @@ func TestAccAWSConfig(t *testing.T) {
 			"TagKeyScope":               testAccConfigOrganizationManagedRule_TagKeyScope,
 			"TagValueScope":             testAccConfigOrganizationManagedRule_TagValueScope,
 		},
+		"RemediationConfiguration": {
+			"basic":     testAccConfigRemediationConfiguration_basic,
+			"importAws": testAccConfigRemediationConfiguration_importAws,
+		},
 	}
 
 	for group, m := range testCases {

--- a/aws/resource_aws_config_test.go
+++ b/aws/resource_aws_config_test.go
@@ -62,8 +62,7 @@ func TestAccAWSConfig(t *testing.T) {
 			"TagValueScope":             testAccConfigOrganizationManagedRule_TagValueScope,
 		},
 		"RemediationConfiguration": {
-			"basic":     testAccConfigRemediationConfiguration_basic,
-			"importAws": testAccConfigRemediationConfiguration_importAws,
+			"basic": testAccConfigRemediationConfiguration_basic,
 		},
 	}
 

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -2254,38 +2254,6 @@ func expandConfigRuleSource(configured []interface{}) *configservice.Source {
 	return &source
 }
 
-func expandConfigRemediationConfigurationParameters(configured *schema.Set) map[string]*configservice.RemediationParameterValue {
-	var staticValues []*string
-	results := make(map[string]*configservice.RemediationParameterValue)
-
-	emptyString := ""
-
-	for _, item := range configured.List() {
-		detail := item.(map[string]interface{})
-		rpv := configservice.RemediationParameterValue{}
-
-		if resourceValue, ok := detail["resource_value"].(string); ok {
-			rv := configservice.ResourceValue{
-				Value: &emptyString,
-			}
-			rpv.ResourceValue = &rv
-			results[resourceValue] = &rpv
-		}
-		if staticValue, ok := detail["static_value"].(map[string]string); ok {
-			value := staticValue["value"]
-			staticValues = make([]*string, 0)
-			staticValues = append(staticValues, &value)
-			sv := configservice.StaticValue{
-				Values: staticValues,
-			}
-			rpv.StaticValue = &sv
-			results[staticValue["key"]] = &rpv
-		}
-	}
-
-	return results
-}
-
 func expandConfigRuleSourceDetails(configured *schema.Set) []*configservice.SourceDetail {
 	var results []*configservice.SourceDetail
 
@@ -2396,30 +2364,6 @@ func flattenApiGatewayUsageApiStages(s []*apigateway.ApiStage) []map[string]inte
 
 	if len(stages) > 0 {
 		return stages
-	}
-
-	return nil
-}
-
-func flattenRemediationConfigurations(c []*configservice.RemediationConfiguration) []map[string]interface{} {
-	configurations := make([]map[string]interface{}, 0)
-
-	for _, bd := range c {
-		if bd.ConfigRuleName != nil && bd.Parameters != nil {
-			configuration := make(map[string]interface{})
-			configuration["config_rule_name"] = *bd.ConfigRuleName
-			configuration["parameters"] = flattenRemediationConfigurationParameters(bd.Parameters)
-			configuration["resource_type"] = *bd.ResourceType
-			configuration["target_id"] = *bd.TargetId
-			configuration["target_type"] = *bd.TargetType
-			configuration["target_version"] = *bd.TargetVersion
-
-			configurations = append(configurations, configuration)
-		}
-	}
-
-	if len(configurations) > 0 {
-		return configurations
 	}
 
 	return nil

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -2256,8 +2256,7 @@ func expandConfigRuleSource(configured []interface{}) *configservice.Source {
 
 func expandConfigRemediationConfigurationParameters(configured *schema.Set) map[string]*configservice.RemediationParameterValue {
 	var staticValues []*string
-	var results map[string]*configservice.RemediationParameterValue
-	results = make(map[string]*configservice.RemediationParameterValue)
+	results := make(map[string]*configservice.RemediationParameterValue)
 
 	emptyString := ""
 

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -2254,6 +2254,39 @@ func expandConfigRuleSource(configured []interface{}) *configservice.Source {
 	return &source
 }
 
+func expandConfigRemediationConfigurationParameters(configured *schema.Set) map[string]*configservice.RemediationParameterValue {
+	var staticValues []*string
+	var results map[string]*configservice.RemediationParameterValue
+	results = make(map[string]*configservice.RemediationParameterValue)
+
+	emptyString := ""
+
+	for _, item := range configured.List() {
+		detail := item.(map[string]interface{})
+		rpv := configservice.RemediationParameterValue{}
+
+		if resourceValue, ok := detail["resource_value"].(string); ok {
+			rv := configservice.ResourceValue{
+				Value: &emptyString,
+			}
+			rpv.ResourceValue = &rv
+			results[resourceValue] = &rpv
+		}
+		if staticValue, ok := detail["static_value"].(map[string]string); ok {
+			value := staticValue["value"]
+			staticValues = make([]*string, 0)
+			staticValues = append(staticValues, &value)
+			sv := configservice.StaticValue{
+				Values: staticValues,
+			}
+			rpv.StaticValue = &sv
+			results[staticValue["key"]] = &rpv
+		}
+	}
+
+	return results
+}
+
 func expandConfigRuleSourceDetails(configured *schema.Set) []*configservice.SourceDetail {
 	var results []*configservice.SourceDetail
 
@@ -2367,6 +2400,52 @@ func flattenApiGatewayUsageApiStages(s []*apigateway.ApiStage) []map[string]inte
 	}
 
 	return nil
+}
+
+func flattenRemediationConfigurations(c []*configservice.RemediationConfiguration) []map[string]interface{} {
+	configurations := make([]map[string]interface{}, 0)
+
+	for _, bd := range c {
+		if bd.ConfigRuleName != nil && bd.Parameters != nil {
+			configuration := make(map[string]interface{})
+			configuration["config_rule_name"] = *bd.ConfigRuleName
+			configuration["parameters"] = flattenRemediationConfigurationParameters(bd.Parameters)
+			configuration["resource_type"] = *bd.ResourceType
+			configuration["target_id"] = *bd.TargetId
+			configuration["target_type"] = *bd.TargetType
+			configuration["target_version"] = *bd.TargetVersion
+
+			configurations = append(configurations, configuration)
+		}
+	}
+
+	if len(configurations) > 0 {
+		return configurations
+	}
+
+	return nil
+}
+
+func flattenRemediationConfigurationParameters(parameters map[string]*configservice.RemediationParameterValue) []interface{} {
+	var items []interface{}
+
+	for key, value := range parameters {
+		item := make(map[string]interface{})
+
+		if value.ResourceValue != nil {
+			item["resource_value"] = key
+		}
+		if value.StaticValue != nil {
+			trueValue := value.StaticValue.Values[0]
+			subItem := make(map[string]*string)
+			subItem[key] = trueValue
+			item["static_value"] = subItem
+		}
+
+		items = append(items, item)
+	}
+
+	return items
 }
 
 func flattenApiGatewayUsagePlanThrottling(s *apigateway.ThrottleSettings) []map[string]interface{} {

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -699,6 +699,9 @@
                                 <li>
                                     <a href="/docs/providers/aws/r/config_organization_managed_rule.html">aws_config_organization_managed_rule</a>
                                 </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/config_remediation_configuration.html">aws_config_remediation_configuration</a>
+                                </li>
                             </ul>
                         </li>
                     </ul>

--- a/website/docs/r/config_remediation_configuration.html.markdown
+++ b/website/docs/r/config_remediation_configuration.html.markdown
@@ -1,0 +1,138 @@
+---
+layout: "aws"
+page_title: "AWS: aws_config_remediation_configuration"
+sidebar_current: "docs-aws-resource-config-remediation-configuration"
+description: |-
+  Provides an AWS Config Remediation Configuration.
+---
+
+# Resource: aws_config_remediation_configuration
+
+Provides an AWS Config Remediation Configuration.
+
+~> **Note:** Config Remediation Configuration requires an existing [Config Rule](/docs/providers/aws/r/config_config_rule.html) to be present. Use of `depends_on` is recommended (as shown below) to avoid race conditions.
+
+## Example Usage
+
+AWS managed rules can be used by setting the source owner to `AWS` and the source identifier to the name of the managed rule. More information about AWS managed rules can be found in the [AWS Config Developer Guide](https://docs.aws.amazon.com/config/latest/developerguide/evaluate-config_use-managed-rules.html).
+
+```hcl
+resource "aws_config_config_rule" "r" {
+  name = "example"
+
+  source {
+    owner             = "AWS"
+    source_identifier = "S3_BUCKET_VERSIONING_ENABLED"
+  }
+
+  depends_on = ["aws_config_configuration_recorder.foo"]
+}
+
+resource "aws_config_configuration_recorder" "foo" {
+  name     = "example"
+  role_arn = "${aws_iam_role.r.arn}"
+}
+
+resource "aws_iam_role" "r" {
+  name = "my-awsconfig-role"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "config.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy" "p" {
+  name = "my-awsconfig-policy"
+  role = "${aws_iam_role.r.id}"
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+  	{
+  		"Action": "config:Put*",
+  		"Effect": "Allow",
+  		"Resource": "*"
+
+  	}
+  ]
+}
+POLICY
+}
+
+resource "aws_sns_topic" "crc_topic" {
+  name = "sns_topic_name"
+}
+
+resource "aws_config_remediation_configuration" "crc" {
+  config_rule_name = "example"
+
+  resource_type = ""
+	target_id = "SSM_DOCUMENT"
+	target_type = "AWS-PublishSNSNotification"
+	target_version = "1"
+
+	parameter {
+		resource_value = "Message"
+	}
+	
+	parameter {
+		static_value {
+			key   = "TopicArn"
+			value = "${aws_sns_topic.crc_topic.arn}"
+		}
+	}
+	
+	parameter {
+		static_value {
+			key   = "AutomationAssumeRole"
+			value = "${aws_iam_role.r.arn}"
+		}
+	}
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `config_rule_name` - (Required) The name of the AWS Config rule
+* `resource_type` - (Optional) The type of a resource
+* `target_id` - (Required) Target ID is the name of the public document
+* `target_type` - (Required) The type of the target. Target executes remediation. For example, SSM document
+* `target_version` - (Required) Version of the target. For example, version of the SSM document
+
+### `parameters`
+
+The value is either a dynamic (resource) value or a static value.
+You must select either a dynamic value or a static value. 
+
+* `resource_value` - (Optional) The value is dynamic and changes at run-time.
+* `static_value` - (Optional) The value is static and does not change at run-time.
+
+#### `static_value`
+
+The value is static and does not change at run-time.
+
+* `key` - (Required) The key of the parameter.
+* `value` - (Required) The value of the parameter.
+
+## Import
+
+Remediation Configurations can be imported using the name config_rule_name, e.g.
+
+```
+$ terraform import aws_config_remediation_configuration.foo example
+```


### PR DESCRIPTION
Answering https://github.com/terraform-providers/terraform-provider-aws/issues/7972
This is my 1st go development ever, so please feel free to tell me if I
did something in a bad way, which is most probable :)

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #7972

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add support for AWS Config Remediation Configuration objects
```

Output from acceptance testing: (ran on a docker container with image `golang:1.12.9-buster` )

```
root@b12d15607224:/src# make testacc TESTARGS='-run=TestAccXXX'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccXXX -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       0.046s [no tests to run]
...
```
