### PR TITLE
tests/resource/aws_elb: Switch test configurations to data sources to be region agnostic

### DIFF
--- a/aws/resource_aws_elb_test.go
+++ b/aws/resource_aws_elb_test.go
@@ -6,7 +6,6 @@ import (
 	"math/rand"
 	"reflect"
 	"regexp"
-	"sort"
 	"testing"
 	"time"
 
@@ -104,14 +103,7 @@ func TestAccAWSELB_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_elb.bar", "availability_zones.#", "3"),
 					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "availability_zones.2487133097", "us-west-2a"),
-					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "availability_zones.221770259", "us-west-2b"),
-					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "availability_zones.2050015877", "us-west-2c"),
-					resource.TestCheckResourceAttr(
 						"aws_elb.bar", "subnets.#", "3"),
-					// NOTE: Subnet IDs are different across AWS accounts and cannot be checked.
 					resource.TestCheckResourceAttr(
 						"aws_elb.bar", "listener.206423021.instance_port", "8000"),
 					resource.TestCheckResourceAttr(
@@ -343,12 +335,6 @@ func TestAccAWSELB_availabilityZones(t *testing.T) {
 					testAccCheckAWSELBExists("aws_elb.bar", &conf),
 					resource.TestCheckResourceAttr(
 						"aws_elb.bar", "availability_zones.#", "3"),
-					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "availability_zones.2487133097", "us-west-2a"),
-					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "availability_zones.221770259", "us-west-2b"),
-					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "availability_zones.2050015877", "us-west-2c"),
 				),
 			},
 
@@ -358,10 +344,6 @@ func TestAccAWSELB_availabilityZones(t *testing.T) {
 					testAccCheckAWSELBExists("aws_elb.bar", &conf),
 					resource.TestCheckResourceAttr(
 						"aws_elb.bar", "availability_zones.#", "2"),
-					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "availability_zones.2487133097", "us-west-2a"),
-					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "availability_zones.221770259", "us-west-2b"),
 				),
 			},
 		},
@@ -1086,16 +1068,6 @@ func testAccCheckAWSELBDisappears(loadBalancer *elb.LoadBalancerDescription) res
 
 func testAccCheckAWSELBAttributes(conf *elb.LoadBalancerDescription) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		zones := []string{"us-west-2a", "us-west-2b", "us-west-2c"}
-		azs := make([]string, 0, len(conf.AvailabilityZones))
-		for _, x := range conf.AvailabilityZones {
-			azs = append(azs, *x)
-		}
-		sort.StringSlice(azs).Sort()
-		if !reflect.DeepEqual(azs, zones) {
-			return fmt.Errorf("bad availability_zones")
-		}
-
 		l := elb.Listener{
 			InstancePort:     aws.Int64(int64(8000)),
 			InstanceProtocol: aws.String("HTTP"),
@@ -1120,16 +1092,6 @@ func testAccCheckAWSELBAttributes(conf *elb.LoadBalancerDescription) resource.Te
 
 func testAccCheckAWSELBAttributesHealthCheck(conf *elb.LoadBalancerDescription) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		zones := []string{"us-west-2a", "us-west-2b", "us-west-2c"}
-		azs := make([]string, 0, len(conf.AvailabilityZones))
-		for _, x := range conf.AvailabilityZones {
-			azs = append(azs, *x)
-		}
-		sort.StringSlice(azs).Sort()
-		if !reflect.DeepEqual(azs, zones) {
-			return fmt.Errorf("bad availability_zones")
-		}
-
 		check := &elb.HealthCheck{
 			Timeout:            aws.Int64(int64(30)),
 			UnhealthyThreshold: aws.Int64(int64(5)),
@@ -1195,15 +1157,18 @@ func testAccCheckAWSELBExists(n string, res *elb.LoadBalancerDescription) resour
 }
 
 const testAccAWSELBConfig = `
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_elb" "bar" {
-  availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
   listener {
     instance_port = 8000
     instance_protocol = "http"
     lb_port = 80
-    // Protocol should be case insensitive
-    lb_protocol = "HttP"
+    lb_protocol = "http"
   }
 
 	tags = {
@@ -1215,9 +1180,13 @@ resource "aws_elb" "bar" {
 `
 
 const testAccAWSELBFullRangeOfCharacters = `
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_elb" "foo" {
   name = "%s"
-  availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
   listener {
     instance_port = 8000
@@ -1229,8 +1198,12 @@ resource "aws_elb" "foo" {
 `
 
 const testAccAWSELBAccessLogs = `
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_elb" "foo" {
-  availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
   listener {
     instance_port = 8000
@@ -1243,9 +1216,14 @@ resource "aws_elb" "foo" {
 
 func testAccAWSELBAccessLogsOn(r string) string {
 	return fmt.Sprintf(`
-# an S3 bucket configured for Access logs
-# The 797873946194 is the AWS ID for us-west-2, so this test
-# must be ran in us-west-2
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+data "aws_elb_service_account" "current" {}
+
+data "aws_partition" "current" {}
+
 resource "aws_s3_bucket" "acceslogs_bucket" {
   bucket        = "%s"
   acl           = "private"
@@ -1259,9 +1237,9 @@ resource "aws_s3_bucket" "acceslogs_bucket" {
       "Action": "s3:PutObject",
       "Effect": "Allow",
       "Principal": {
-        "AWS": "arn:aws:iam::797873946194:root"
+        "AWS": "${data.aws_elb_service_account.current.arn}"
       },
-      "Resource": "arn:aws:s3:::%s/*",
+      "Resource": "arn:${data.aws_partition.current.partition}:s3:::%s/*",
       "Sid": "Stmt1446575236270"
     }
   ],
@@ -1271,7 +1249,7 @@ EOF
 }
 
 resource "aws_elb" "foo" {
-  availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
   listener {
     instance_port     = 8000
@@ -1290,9 +1268,14 @@ resource "aws_elb" "foo" {
 
 func testAccAWSELBAccessLogsDisabled(r string) string {
 	return fmt.Sprintf(`
-# an S3 bucket configured for Access logs
-# The 797873946194 is the AWS ID for us-west-2, so this test
-# must be ran in us-west-2
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+data "aws_elb_service_account" "current" {}
+
+data "aws_partition" "current" {}
+
 resource "aws_s3_bucket" "acceslogs_bucket" {
   bucket        = "%s"
   acl           = "private"
@@ -1306,9 +1289,9 @@ resource "aws_s3_bucket" "acceslogs_bucket" {
       "Action": "s3:PutObject",
       "Effect": "Allow",
       "Principal": {
-        "AWS": "arn:aws:iam::797873946194:root"
+        "AWS": "${data.aws_elb_service_account.current.arn}"
       },
-      "Resource": "arn:aws:s3:::%s/*",
+      "Resource": "arn:${data.aws_partition.current.partition}:s3:::%s/*",
       "Sid": "Stmt1446575236270"
     }
   ],
@@ -1318,7 +1301,7 @@ EOF
 }
 
 resource "aws_elb" "foo" {
-  availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
   listener {
     instance_port     = 8000
@@ -1337,9 +1320,13 @@ resource "aws_elb" "foo" {
 }
 
 const testAccAWSELB_namePrefix = `
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_elb" "test" {
   name_prefix = "test-"
-  availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
   listener {
     instance_port = 8000
@@ -1351,8 +1338,12 @@ resource "aws_elb" "test" {
 `
 
 const testAccAWSELBGeneratedName = `
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_elb" "foo" {
-  availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
   listener {
     instance_port = 8000
@@ -1364,9 +1355,13 @@ resource "aws_elb" "foo" {
 `
 
 const testAccAWSELB_zeroValueName = `
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_elb" "foo" {
   name               = ""
-  availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
   listener {
     instance_port = 8000
@@ -1383,8 +1378,12 @@ output "lb_name" {
 `
 
 const testAccAWSELBConfig_AvailabilityZonesUpdate = `
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_elb" "bar" {
-  availability_zones = ["us-west-2a", "us-west-2b"]
+  availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}"]
 
   listener {
     instance_port = 8000
@@ -1396,8 +1395,12 @@ resource "aws_elb" "bar" {
 `
 
 const testAccAWSELBConfig_TagUpdate = `
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_elb" "bar" {
-  availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
   listener {
     instance_port = 8000
@@ -1416,8 +1419,27 @@ resource "aws_elb" "bar" {
 `
 
 const testAccAWSELBConfigNewInstance = `
+data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn-ami-minimal-hvm-*"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_elb" "bar" {
-  availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
   listener {
     instance_port = 8000
@@ -1430,15 +1452,18 @@ resource "aws_elb" "bar" {
 }
 
 resource "aws_instance" "foo" {
-	# us-west-2
-	ami = "ami-043a5034"
-	instance_type = "t1.micro"
+  ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type = "t3.micro"
 }
 `
 
 const testAccAWSELBConfigHealthCheck = `
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_elb" "bar" {
-  availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
   listener {
     instance_port = 8000
@@ -1458,8 +1483,12 @@ resource "aws_elb" "bar" {
 `
 
 const testAccAWSELBConfigHealthCheck_update = `
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_elb" "bar" {
-  availability_zones = ["us-west-2a"]
+  availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
 
   listener {
     instance_port = 8000
@@ -1479,8 +1508,12 @@ resource "aws_elb" "bar" {
 `
 
 const testAccAWSELBConfigListener_update = `
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_elb" "bar" {
-  availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
   listener {
     instance_port = 8080
@@ -1492,8 +1525,12 @@ resource "aws_elb" "bar" {
 `
 
 const testAccAWSELBConfigListener_multipleListeners = `
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_elb" "bar" {
-  availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
   listener {
     instance_port = 8000
@@ -1512,8 +1549,12 @@ resource "aws_elb" "bar" {
 `
 
 const testAccAWSELBConfigIdleTimeout = `
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_elb" "bar" {
-	availability_zones = ["us-west-2a"]
+	availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
 
 	listener {
 		instance_port = 8000
@@ -1527,8 +1568,12 @@ resource "aws_elb" "bar" {
 `
 
 const testAccAWSELBConfigIdleTimeout_update = `
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_elb" "bar" {
-	availability_zones = ["us-west-2a"]
+	availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
 
 	listener {
 		instance_port = 8000
@@ -1542,8 +1587,12 @@ resource "aws_elb" "bar" {
 `
 
 const testAccAWSELBConfigConnectionDraining = `
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_elb" "bar" {
-	availability_zones = ["us-west-2a"]
+	availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
 
 	listener {
 		instance_port = 8000
@@ -1558,8 +1607,12 @@ resource "aws_elb" "bar" {
 `
 
 const testAccAWSELBConfigConnectionDraining_update_timeout = `
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_elb" "bar" {
-	availability_zones = ["us-west-2a"]
+	availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
 
 	listener {
 		instance_port = 8000
@@ -1574,8 +1627,12 @@ resource "aws_elb" "bar" {
 `
 
 const testAccAWSELBConfigConnectionDraining_update_disable = `
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_elb" "bar" {
-	availability_zones = ["us-west-2a"]
+	availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
 
 	listener {
 		instance_port = 8000
@@ -1589,8 +1646,12 @@ resource "aws_elb" "bar" {
 `
 
 const testAccAWSELBConfigSecurityGroups = `
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_elb" "bar" {
-  availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
   listener {
     instance_port = 8000
@@ -1678,6 +1739,10 @@ resource "aws_elb" "bar" {
 }
 
 const testAccAWSELBConfig_subnets = `
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_vpc" "azelb" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
@@ -1691,7 +1756,7 @@ resource "aws_subnet" "public_a_one" {
   vpc_id = "${aws_vpc.azelb.id}"
 
   cidr_block        = "10.1.1.0/24"
-  availability_zone = "us-west-2a"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
   tags = {
     Name = "tf-acc-elb-subnets-a-one"
   }
@@ -1701,7 +1766,7 @@ resource "aws_subnet" "public_b_one" {
   vpc_id = "${aws_vpc.azelb.id}"
 
   cidr_block        = "10.1.7.0/24"
-  availability_zone = "us-west-2b"
+  availability_zone = "${data.aws_availability_zones.available.names[1]}"
   tags = {
     Name = "tf-acc-elb-subnets-b-one"
   }
@@ -1711,7 +1776,7 @@ resource "aws_subnet" "public_a_two" {
   vpc_id = "${aws_vpc.azelb.id}"
 
   cidr_block        = "10.1.2.0/24"
-  availability_zone = "us-west-2a"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
   tags = {
     Name = "tf-acc-elb-subnets-a-two"
   }
@@ -1745,6 +1810,10 @@ resource "aws_internet_gateway" "gw" {
 `
 
 const testAccAWSELBConfig_subnet_swap = `
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_vpc" "azelb" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
@@ -1758,7 +1827,7 @@ resource "aws_subnet" "public_a_one" {
   vpc_id = "${aws_vpc.azelb.id}"
 
   cidr_block        = "10.1.1.0/24"
-  availability_zone = "us-west-2a"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
   tags = {
     Name = "tf-acc-elb-subnet-swap-a-one"
   }
@@ -1768,7 +1837,7 @@ resource "aws_subnet" "public_b_one" {
   vpc_id = "${aws_vpc.azelb.id}"
 
   cidr_block        = "10.1.7.0/24"
-  availability_zone = "us-west-2b"
+  availability_zone = "${data.aws_availability_zones.available.names[1]}"
   tags = {
     Name = "tf-acc-elb-subnet-swap-b-one"
   }
@@ -1778,7 +1847,7 @@ resource "aws_subnet" "public_a_two" {
   vpc_id = "${aws_vpc.azelb.id}"
 
   cidr_block        = "10.1.2.0/24"
-  availability_zone = "us-west-2a"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
   tags = {
     Name = "tf-acc-elb-subnet-swap-a-two"
   }


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

While this gets the acceptance testing working in GovCloud (US), it does now also highlight a bug similar to https://github.com/terraform-providers/terraform-provider-aws/issues/9304

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSELB_disappears (68.68s)
--- PASS: TestAccAWSELB_ConnectionDraining (76.74s)
--- PASS: TestAccAWSELB_namePrefix (93.59s)
--- PASS: TestAccAWSELB_AccessLogs_enabled (103.17s)
--- PASS: TestAccAWSELB_generatedName (106.01s)
--- PASS: TestAccAWSELB_fullCharacterRange (106.48s)
--- PASS: TestAccAWSELB_importBasic (112.57s)
--- PASS: TestAccAWSELB_generatesNameForZeroValue (122.21s)
--- PASS: TestAccAWSELB_basic (130.19s)
--- PASS: TestAccAWSELB_HealthCheck (133.04s)
--- PASS: TestAccAWSELB_Listener_SSLCertificateID_IAMServerCertificate (136.34s)
--- PASS: TestAccAWSELB_SecurityGroups (142.99s)
--- FAIL: TestAccAWSELB_listener (148.51s)
    testing.go:568: Step 4 error: errors during plan:

        Error: insufficient items for attribute "listener"; must have at least 1

    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: errors during refresh: insufficient items for attribute "listener"; must have at least 1

        State: <nil>
--- PASS: TestAccAWSELB_AccessLogs_disabled (154.64s)
--- PASS: TestAccAWSELB_tags (155.92s)
--- PASS: TestAccAWSELB_Timeout (168.71s)
--- PASS: TestAccAWSELB_availabilityZones (210.40s)
--- PASS: TestAccAWSELB_swap_subnets (228.13s)
--- PASS: TestAccAWSELB_InstanceAttaching (527.69s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAWSELB_availabilityZones (88.33s)
--- PASS: TestAccAWSELB_tags (113.93s)
--- PASS: TestAccAWSELB_Timeout (115.69s)
--- PASS: TestAccAWSELB_importBasic (123.79s)
--- PASS: TestAccAWSELB_swap_subnets (124.01s)
--- PASS: TestAccAWSELB_Listener_SSLCertificateID_IAMServerCertificate (147.94s)
--- PASS: TestAccAWSELB_HealthCheck (149.88s)
--- PASS: TestAccAWSELB_SecurityGroups (154.84s)
--- PASS: TestAccAWSELB_disappears (200.13s)
--- PASS: TestAccAWSELB_namePrefix (200.70s)
--- PASS: TestAccAWSELB_fullCharacterRange (213.47s)
--- PASS: TestAccAWSELB_generatesNameForZeroValue (214.22s)
--- PASS: TestAccAWSELB_generatedName (229.05s)
--- PASS: TestAccAWSELB_ConnectionDraining (230.66s)
--- PASS: TestAccAWSELB_basic (240.03s)
--- FAIL: TestAccAWSELB_listener (268.22s)
    testing.go:568: Step 4 error: errors during plan:

        Error: insufficient items for attribute "listener"; must have at least 1

    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: errors during refresh: insufficient items for attribute "listener"; must have at least 1

        State: <nil>
--- PASS: TestAccAWSELB_AccessLogs_enabled (275.48s)
--- PASS: TestAccAWSELB_AccessLogs_disabled (298.22s)
--- PASS: TestAccAWSELB_InstanceAttaching (306.86s)
```