### PR TITLE
resource/aws_ssm_maintenance_window_task: Prevent `task_parameters` ordering differences

### DIFF
--- a/aws/resource_aws_ssm_maintenance_window_task.go
+++ b/aws/resource_aws_ssm_maintenance_window_task.go
@@ -117,7 +117,7 @@ func resourceAwsSsmMaintenanceWindowTask() *schema.Resource {
 			},
 
 			"task_parameters": {
-				Type:          schema.TypeList,
+				Type:          schema.TypeSet,
 				Optional:      true,
 				ConflictsWith: []string{"task_invocation_parameters"},
 				Deprecated:    "use 'task_invocation_parameters' argument instead",
@@ -671,7 +671,7 @@ func resourceAwsSsmMaintenanceWindowTaskCreate(d *schema.ResourceData, meta inte
 	}
 
 	if v, ok := d.GetOk("task_parameters"); ok {
-		params.TaskParameters = expandAwsSsmTaskParameters(v.([]interface{}))
+		params.TaskParameters = expandAwsSsmTaskParameters(v.(*schema.Set).List())
 	}
 
 	if v, ok := d.GetOk("task_invocation_parameters"); ok {
@@ -773,7 +773,7 @@ func resourceAwsSsmMaintenanceWindowTaskUpdate(d *schema.ResourceData, meta inte
 	}
 
 	if v, ok := d.GetOk("task_parameters"); ok {
-		params.TaskParameters = expandAwsSsmTaskParameters(v.([]interface{}))
+		params.TaskParameters = expandAwsSsmTaskParameters(v.(*schema.Set).List())
 	}
 
 	if v, ok := d.GetOk("task_invocation_parameters"); ok {

--- a/aws/resource_aws_ssm_maintenance_window_task_test.go
+++ b/aws/resource_aws_ssm_maintenance_window_task_test.go
@@ -220,6 +220,32 @@ func TestAccAWSSSMMaintenanceWindowTask_TaskInvocationStepFunctionParameters(t *
 	})
 }
 
+func TestAccAWSSSMMaintenanceWindowTask_TaskParameters(t *testing.T) {
+	var task ssm.MaintenanceWindowTask
+	resourceName := "aws_ssm_maintenance_window_task.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMMaintenanceWindowTaskDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMMaintenanceWindowTaskConfigTaskParametersMultiple(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowTaskExists(resourceName, &task),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSSSMMaintenanceWindowTaskImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAwsSsmWindowsTaskNotRecreated(t *testing.T,
 	before, after *ssm.MaintenanceWindowTask) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -703,5 +729,91 @@ data "template_file" "input" {
 EOF
 }
 
+`, rName)
+}
+
+func testAccAWSSSMMaintenanceWindowTaskConfigTaskParametersMultiple(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_maintenance_window" "test" {
+  cutoff   = 1
+  duration = 3
+  name     = %[1]q
+  schedule = "cron(0 16 ? * TUE *)"
+}
+
+resource "aws_ssm_maintenance_window_target" "test" {
+  name          = %[1]q
+  resource_type = "INSTANCE"
+  window_id     = "${aws_ssm_maintenance_window.test.id}"
+
+  targets {
+    key    = "tag:Name"
+    values = ["tf-acc-test"]
+  }
+}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+  assume_role_policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "sts:AssumeRole",
+            "Principal": {
+                "Service": "events.amazonaws.com"
+            },
+            "Effect": "Allow",
+            "Sid": ""
+        }
+    ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy" "test" {
+  name = %[1]q
+  role = "${aws_iam_role.test.name}"
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Action": "ssm:*",
+    "Resource": "*"
+  }
+}
+POLICY
+}
+
+resource "aws_ssm_maintenance_window_task" "test" {
+  max_concurrency  = 1
+  max_errors       = 1
+  priority         = 1
+  service_role_arn = "${aws_iam_role.test.arn}"
+  task_arn         = "AWS-RunRemoteScript"
+  task_type        = "RUN_COMMAND"
+  window_id        = "${aws_ssm_maintenance_window.test.id}"
+
+  targets {
+    key    = "WindowTargetIds"
+    values = ["${aws_ssm_maintenance_window_target.test.id}"]
+  }
+
+  task_parameters {
+    name   = "sourceType"
+    values = ["s3"]
+  }
+
+  task_parameters {
+    name   = "sourceInfo"
+    values = ["https://s3.amazonaws.com/bucket"]
+  }
+
+  task_parameters {
+    name   = "commandLine"
+    values = ["date"]
+  }
+}
 `, rName)
 }


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #3218

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_ssm_maintenance_window_task: Prevent `task_parameters` ordering differences
```

Previously (before code update):

```
--- FAIL: TestAccAWSSSMMaintenanceWindowTask_TaskParameters (12.95s)
    testing.go:568: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        UPDATE: aws_ssm_maintenance_window_task.test
...
          task_parameters.#:            "3" => "3"
          task_parameters.0.name:       "commandLine" => "sourceType"
          task_parameters.0.values.#:   "1" => "1"
          task_parameters.0.values.0:   "date" => "s3"
          task_parameters.1.name:       "sourceInfo" => "sourceInfo"
          task_parameters.1.values.#:   "1" => "1"
          task_parameters.1.values.0:   "https://s3.amazonaws.com/bucket" => "https://s3.amazonaws.com/bucket"
          task_parameters.2.name:       "sourceType" => "commandLine"
          task_parameters.2.values.#:   "1" => "1"
          task_parameters.2.values.0:   "s3" => "date"
```

Output from acceptance testing:

```
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskParameters (18.13s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationStepFunctionParameters (126.33s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_basic (127.14s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource (157.65s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationRunCommandParameters (158.38s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationAutomationParameters (178.09s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationLambdaParameters (233.40s)
```