### PR TITLE
tests/resource/aws_ssm_maintenance_window_task: Switch to using window targets instead of instance targets

### DIFF
--- a/aws/resource_aws_ssm_maintenance_window_task_test.go
+++ b/aws/resource_aws_ssm_maintenance_window_task_test.go
@@ -321,10 +321,15 @@ resource "aws_ssm_maintenance_window" "test" {
   schedule = "cron(0 16 ? * TUE *)"
 }
 
-resource "aws_instance" "test" {
-  ami = "ami-4fccb37f"
+resource "aws_ssm_maintenance_window_target" "test" {
+  name          = %[1]q
+  resource_type = "INSTANCE"
+  window_id     = "${aws_ssm_maintenance_window.test.id}"
 
-  instance_type = "m1.small"
+  targets {
+    key    = "tag:Name"
+    values = ["tf-acc-test"]
+  }
 }
 
 resource "aws_iam_role" "test" {
@@ -376,8 +381,8 @@ resource "aws_ssm_maintenance_window_task" "target" {
   max_errors  = "1"
 
   targets {
-    key    = "InstanceIds"
-    values = ["${aws_instance.test.id}"]
+    key    = "WindowTargetIds"
+    values = ["${aws_ssm_maintenance_window_target.test.id}"]
   }
 
   task_parameters {
@@ -404,8 +409,8 @@ resource "aws_ssm_maintenance_window_task" "target" {
   max_errors  = %[7]d
 
   targets {
-    key    = "InstanceIds"
-    values = ["${aws_instance.test.id}"]
+    key    = "WindowTargetIds"
+    values = ["${aws_ssm_maintenance_window_target.test.id}"]
   }
 
   task_parameters {
@@ -467,8 +472,8 @@ resource "aws_ssm_maintenance_window_task" "target" {
   max_errors  = "1"
 
   targets {
-    key    = "InstanceIds"
-    values = ["${aws_instance.test.id}"]
+    key    = "WindowTargetIds"
+    values = ["${aws_ssm_maintenance_window_target.test.id}"]
   }
 
   task_parameters {
@@ -492,15 +497,15 @@ resource "aws_ssm_maintenance_window_task" "target" {
   max_concurrency = "2"
   max_errors = "1"
   targets {
-    key = "InstanceIds"
-    values = ["${aws_instance.test.id}"]
+    key    = "WindowTargetIds"
+    values = ["${aws_ssm_maintenance_window_target.test.id}"]
   }
   task_invocation_parameters {
     automation_parameters {
       document_version = "%[2]s"
       parameter {
         name = "InstanceId"
-        values = ["${aws_instance.test.id}"]
+        values = ["{{TARGET_ID}}"]
       }
       parameter {
         name = "NoReboot"
@@ -530,15 +535,15 @@ resource "aws_ssm_maintenance_window_task" "target" {
   max_concurrency = "2"
   max_errors = "1"
   targets {
-    key = "InstanceIds"
-    values = ["${aws_instance.test.id}"]
+    key    = "WindowTargetIds"
+    values = ["${aws_ssm_maintenance_window_target.test.id}"]
   }
   task_invocation_parameters {
     automation_parameters {
       document_version = "%[2]s"
       parameter {
         name = "InstanceId"
-        values = ["${aws_instance.test.id}"]
+        values = ["{{TARGET_ID}}"]
       }
       parameter {
         name = "NoReboot"
@@ -563,8 +568,8 @@ resource "aws_ssm_maintenance_window_task" "target" {
   max_concurrency = "2"
   max_errors = "1"
   targets {
-    key = "InstanceIds"
-    values = ["${aws_instance.test.id}"]
+    key    = "WindowTargetIds"
+    values = ["${aws_ssm_maintenance_window_target.test.id}"]
   }
   task_invocation_parameters {
     lambda_parameters {
@@ -607,8 +612,8 @@ resource "aws_ssm_maintenance_window_task" "target" {
   max_concurrency = "2"
   max_errors = "1"
   targets {
-    key = "InstanceIds"
-    values = ["${aws_instance.test.id}"]
+    key    = "WindowTargetIds"
+    values = ["${aws_ssm_maintenance_window_target.test.id}"]
   }
   task_invocation_parameters {
     run_command_parameters {
@@ -645,8 +650,8 @@ resource "aws_ssm_maintenance_window_task" "target" {
   max_concurrency = "2"
   max_errors = "1"
   targets {
-    key = "InstanceIds"
-    values = ["${aws_instance.test.id}"]
+    key    = "WindowTargetIds"
+    values = ["${aws_ssm_maintenance_window_target.test.id}"]
   }
   task_invocation_parameters {
     run_command_parameters {
@@ -682,8 +687,8 @@ resource "aws_ssm_maintenance_window_task" "target" {
   max_concurrency = "2"
   max_errors = "1"
   targets {
-    key = "InstanceIds"
-    values = ["${aws_instance.test.id}"]
+    key    = "WindowTargetIds"
+    values = ["${aws_ssm_maintenance_window_target.test.id}"]
   }
   task_invocation_parameters {
     step_functions_parameters {


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

The benefits here include executing faster, removing the EC2 dependency, and now works in AWS GovCloud (US).

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previous output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationStepFunctionParameters (126.33s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_basic (127.14s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource (157.65s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationRunCommandParameters (158.38s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationAutomationParameters (178.09s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationLambdaParameters (233.40s)
```

Previous output from acceptance testing in AWS GovCloud (US):

```
--- FAIL: TestAccAWSSSMMaintenanceWindowTask_basic (12.54s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error launching source instance: InvalidAMIID.NotFound: The image id '[ami-4fccb37f]' does not exist

--- FAIL: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationStepFunctionParameters (12.62s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error launching source instance: InvalidAMIID.NotFound: The image id '[ami-4fccb37f]' does not exist

--- FAIL: TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource (12.63s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error launching source instance: InvalidAMIID.NotFound: The image id '[ami-4fccb37f]' does not exist

--- FAIL: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationRunCommandParameters (12.64s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error launching source instance: InvalidAMIID.NotFound: The image id '[ami-4fccb37f]' does not exist

--- FAIL: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationAutomationParameters (12.71s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error launching source instance: InvalidAMIID.NotFound: The image id '[ami-4fccb37f]' does not exist

--- FAIL: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationLambdaParameters (26.90s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error launching source instance: InvalidAMIID.NotFound: The image id '[ami-4fccb37f]' does not exist
```

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationStepFunctionParameters (18.46s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource (28.33s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_basic (28.60s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationAutomationParameters (40.14s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationRunCommandParameters (41.51s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationLambdaParameters (41.72s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationStepFunctionParameters (24.90s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource (38.84s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_basic (39.69s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationLambdaParameters (39.93s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationAutomationParameters (49.56s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationRunCommandParameters (50.92s)
```
