### PR TITLE
Add support for lambda permission import

### DIFF
--- a/aws/resource_aws_lambda_permission_test.go
+++ b/aws/resource_aws_lambda_permission_test.go
@@ -169,7 +169,6 @@ func TestAccAWSLambdaPermission_basic(t *testing.T) {
 	rString := acctest.RandString(8)
 	funcName := fmt.Sprintf("tf_acc_lambda_perm_basic_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_perm_basic_%s", rString)
-	statementId := fmt.Sprintf("tf_acc_statement_lambda_perm_basic_%s", rString)
 	funcArnRe := regexp.MustCompile(":function:" + funcName + "$")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -192,7 +191,7 @@ func TestAccAWSLambdaPermission_basic(t *testing.T) {
 			{
 				ResourceName:      "aws_lambda_permission.allow_cloudwatch",
 				ImportState:       true,
-				ImportStateId:     fmt.Sprintf("%s/%s", funcName, statementId),
+				ImportStateIdFunc: testAccAWSCLambdaPermissionImportStateIdFunc("aws_lambda_permission.allow_cloudwatch"),
 				ImportStateVerify: true,
 			},
 		},
@@ -221,7 +220,6 @@ func TestAccAWSLambdaPermission_withRawFunctionName(t *testing.T) {
 	rString := acctest.RandString(8)
 	funcName := fmt.Sprintf("tf_acc_lambda_perm_w_raw_fname_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_perm_w_raw_fname_%s", rString)
-	statementId := fmt.Sprintf("tf_acc_statement_lambda_perm_basic_%s", rString)
 	funcArnRe := regexp.MustCompile(":function:" + funcName + "$")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -240,9 +238,9 @@ func TestAccAWSLambdaPermission_withRawFunctionName(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "aws_lambda_permission.allow_cloudwatch",
+				ResourceName:      "aws_lambda_permission.with_raw_func_name",
 				ImportState:       true,
-				ImportStateId:     fmt.Sprintf("%s/%s", funcName, statementId),
+				ImportStateIdFunc: testAccAWSCLambdaPermissionImportStateIdFunc("aws_lambda_permission.with_raw_func_name"),
 				ImportStateVerify: true,
 			},
 		},
@@ -252,10 +250,7 @@ func TestAccAWSLambdaPermission_withRawFunctionName(t *testing.T) {
 func TestAccAWSLambdaPermission_withStatementIdPrefix(t *testing.T) {
 	var statement LambdaPolicyStatement
 
-	rString := acctest.RandString(8)
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	funcName := fmt.Sprintf("tf_acc_lambda_perm_w_raw_fname_%s", rString)
-	statementId := fmt.Sprintf("tf_acc_statement_lambda_perm_basic_%s", rString)
 	endsWithFuncName := regexp.MustCompile(":function:lambda_function_name_perm$")
 	startsWithPrefix := regexp.MustCompile("^AllowExecutionWithStatementIdPrefix-")
 
@@ -275,10 +270,11 @@ func TestAccAWSLambdaPermission_withStatementIdPrefix(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "aws_lambda_permission.allow_cloudwatch",
-				ImportState:       true,
-				ImportStateId:     fmt.Sprintf("%s/%s", funcName, statementId),
-				ImportStateVerify: true,
+				ResourceName:            "aws_lambda_permission.with_statement_id_prefix",
+				ImportState:             true,
+				ImportStateIdFunc:       testAccAWSCLambdaPermissionImportStateIdFunc("aws_lambda_permission.with_statement_id_prefix"),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"statement_id_prefix"},
 			},
 		},
 	})
@@ -291,7 +287,6 @@ func TestAccAWSLambdaPermission_withQualifier(t *testing.T) {
 	aliasName := fmt.Sprintf("tf_acc_lambda_perm_alias_w_qualifier_%s", rString)
 	funcName := fmt.Sprintf("tf_acc_lambda_perm_w_qualifier_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_perm_w_qualifier_%s", rString)
-	statementId := fmt.Sprintf("tf_acc_statement_lambda_perm_basic_%s", rString)
 	funcArnRe := regexp.MustCompile(":function:" + funcName + "$")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -311,9 +306,9 @@ func TestAccAWSLambdaPermission_withQualifier(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "aws_lambda_permission.allow_cloudwatch",
+				ResourceName:      "aws_lambda_permission.with_qualifier",
 				ImportState:       true,
-				ImportStateId:     fmt.Sprintf("%s/%s", funcName, statementId),
+				ImportStateIdFunc: testAccAWSCLambdaPermissionImportStateIdFunc("aws_lambda_permission.with_qualifier"),
 				ImportStateVerify: true,
 			},
 		},
@@ -330,7 +325,6 @@ func TestAccAWSLambdaPermission_multiplePerms(t *testing.T) {
 	rString := acctest.RandString(8)
 	funcName := fmt.Sprintf("tf_acc_lambda_perm_multi_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_perm_multi_%s", rString)
-	statementId := fmt.Sprintf("tf_acc_statement_lambda_perm_basic_%s", rString)
 	funcArnRe := regexp.MustCompile(":function:" + funcName + "$")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -379,9 +373,15 @@ func TestAccAWSLambdaPermission_multiplePerms(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "aws_lambda_permission.allow_cloudwatch",
+				ResourceName:      "aws_lambda_permission.first",
 				ImportState:       true,
-				ImportStateId:     fmt.Sprintf("%s/%s", funcName, statementId),
+				ImportStateIdFunc: testAccAWSCLambdaPermissionImportStateIdFunc("aws_lambda_permission.first"),
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "aws_lambda_permission.sec0nd",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCLambdaPermissionImportStateIdFunc("aws_lambda_permission.sec0nd"),
 				ImportStateVerify: true,
 			},
 		},
@@ -395,7 +395,6 @@ func TestAccAWSLambdaPermission_withS3(t *testing.T) {
 	bucketName := fmt.Sprintf("tf-acc-bucket-lambda-perm-w-s3-%s", rString)
 	funcName := fmt.Sprintf("tf_acc_lambda_perm_w_s3_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_perm_w_s3_%s", rString)
-	statementId := fmt.Sprintf("tf_acc_statement_lambda_perm_basic_%s", rString)
 	funcArnRe := regexp.MustCompile(":function:" + funcName + "$")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -416,9 +415,9 @@ func TestAccAWSLambdaPermission_withS3(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "aws_lambda_permission.allow_cloudwatch",
+				ResourceName:      "aws_lambda_permission.with_s3",
 				ImportState:       true,
-				ImportStateId:     fmt.Sprintf("%s/%s", funcName, statementId),
+				ImportStateIdFunc: testAccAWSCLambdaPermissionImportStateIdFunc("aws_lambda_permission.with_s3"),
 				ImportStateVerify: true,
 			},
 		},
@@ -432,7 +431,6 @@ func TestAccAWSLambdaPermission_withSNS(t *testing.T) {
 	topicName := fmt.Sprintf("tf_acc_topic_lambda_perm_w_sns_%s", rString)
 	funcName := fmt.Sprintf("tf_acc_lambda_perm_w_sns_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_perm_w_sns_%s", rString)
-	statementId := fmt.Sprintf("tf_acc_statement_lambda_perm_basic_%s", rString)
 
 	funcArnRe := regexp.MustCompile(":function:" + funcName + "$")
 	topicArnRe := regexp.MustCompile(":" + topicName + "$")
@@ -454,9 +452,9 @@ func TestAccAWSLambdaPermission_withSNS(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "aws_lambda_permission.allow_cloudwatch",
+				ResourceName:      "aws_lambda_permission.with_sns",
 				ImportState:       true,
-				ImportStateId:     fmt.Sprintf("%s/%s", funcName, statementId),
+				ImportStateIdFunc: testAccAWSCLambdaPermissionImportStateIdFunc("aws_lambda_permission.with_sns"),
 				ImportStateVerify: true,
 			},
 		},
@@ -469,7 +467,6 @@ func TestAccAWSLambdaPermission_withIAMRole(t *testing.T) {
 	rString := acctest.RandString(8)
 	funcName := fmt.Sprintf("tf_acc_lambda_perm_w_iam_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_perm_w_iam_%s", rString)
-	statementId := fmt.Sprintf("tf_acc_statement_lambda_perm_basic_%s", rString)
 	funcArnRe := regexp.MustCompile(":function:" + funcName + "$")
 	roleArnRe := regexp.MustCompile("/" + roleName + "$")
 
@@ -489,9 +486,9 @@ func TestAccAWSLambdaPermission_withIAMRole(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "aws_lambda_permission.allow_cloudwatch",
+				ResourceName:      "aws_lambda_permission.iam_role",
 				ImportState:       true,
-				ImportStateId:     fmt.Sprintf("%s/%s", funcName, statementId),
+				ImportStateIdFunc: testAccAWSCLambdaPermissionImportStateIdFunc("aws_lambda_permission.iam_role"),
 				ImportStateVerify: true,
 			},
 		},
@@ -625,6 +622,20 @@ func lambdaPermissionExists(rs *terraform.ResourceState, conn *lambda.Lambda) (*
 	}
 
 	return findLambdaPolicyStatementById(&policy, rs.Primary.ID)
+}
+
+func testAccAWSCLambdaPermissionImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		if v, ok := rs.Primary.Attributes["qualifier"]; ok && v != "" {
+			return fmt.Sprintf("%s:%s/%s", rs.Primary.Attributes["function_name"], *aws.String(v), rs.Primary.Attributes["statement_id"]), nil
+		}
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["function_name"], rs.Primary.Attributes["statement_id"]), nil
+	}
 }
 
 func testAccAWSLambdaPermissionConfig(funcName, roleName string) string {

--- a/aws/resource_aws_lambda_permission_test.go
+++ b/aws/resource_aws_lambda_permission_test.go
@@ -252,6 +252,7 @@ func TestAccAWSLambdaPermission_withRawFunctionName(t *testing.T) {
 func TestAccAWSLambdaPermission_withStatementIdPrefix(t *testing.T) {
 	var statement LambdaPolicyStatement
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	funcName := fmt.Sprintf("tf_acc_lambda_perm_w_raw_fname_%s", rString)
 	statementId := fmt.Sprintf("tf_acc_statement_lambda_perm_basic_%s", rString)
 	endsWithFuncName := regexp.MustCompile(":function:lambda_function_name_perm$")
 	startsWithPrefix := regexp.MustCompile("^AllowExecutionWithStatementIdPrefix-")

--- a/aws/resource_aws_lambda_permission_test.go
+++ b/aws/resource_aws_lambda_permission_test.go
@@ -251,6 +251,8 @@ func TestAccAWSLambdaPermission_withRawFunctionName(t *testing.T) {
 
 func TestAccAWSLambdaPermission_withStatementIdPrefix(t *testing.T) {
 	var statement LambdaPolicyStatement
+
+	rString := acctest.RandString(8)
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	funcName := fmt.Sprintf("tf_acc_lambda_perm_w_raw_fname_%s", rString)
 	statementId := fmt.Sprintf("tf_acc_statement_lambda_perm_basic_%s", rString)

--- a/aws/resource_aws_lambda_permission_test.go
+++ b/aws/resource_aws_lambda_permission_test.go
@@ -221,6 +221,7 @@ func TestAccAWSLambdaPermission_withRawFunctionName(t *testing.T) {
 	rString := acctest.RandString(8)
 	funcName := fmt.Sprintf("tf_acc_lambda_perm_w_raw_fname_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_perm_w_raw_fname_%s", rString)
+	statementId := fmt.Sprintf("tf_acc_statement_lambda_perm_basic_%s", rString)
 	funcArnRe := regexp.MustCompile(":function:" + funcName + "$")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -251,6 +252,7 @@ func TestAccAWSLambdaPermission_withRawFunctionName(t *testing.T) {
 func TestAccAWSLambdaPermission_withStatementIdPrefix(t *testing.T) {
 	var statement LambdaPolicyStatement
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	statementId := fmt.Sprintf("tf_acc_statement_lambda_perm_basic_%s", rString)
 	endsWithFuncName := regexp.MustCompile(":function:lambda_function_name_perm$")
 	startsWithPrefix := regexp.MustCompile("^AllowExecutionWithStatementIdPrefix-")
 
@@ -286,6 +288,7 @@ func TestAccAWSLambdaPermission_withQualifier(t *testing.T) {
 	aliasName := fmt.Sprintf("tf_acc_lambda_perm_alias_w_qualifier_%s", rString)
 	funcName := fmt.Sprintf("tf_acc_lambda_perm_w_qualifier_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_perm_w_qualifier_%s", rString)
+	statementId := fmt.Sprintf("tf_acc_statement_lambda_perm_basic_%s", rString)
 	funcArnRe := regexp.MustCompile(":function:" + funcName + "$")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -324,6 +327,7 @@ func TestAccAWSLambdaPermission_multiplePerms(t *testing.T) {
 	rString := acctest.RandString(8)
 	funcName := fmt.Sprintf("tf_acc_lambda_perm_multi_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_perm_multi_%s", rString)
+	statementId := fmt.Sprintf("tf_acc_statement_lambda_perm_basic_%s", rString)
 	funcArnRe := regexp.MustCompile(":function:" + funcName + "$")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -388,6 +392,7 @@ func TestAccAWSLambdaPermission_withS3(t *testing.T) {
 	bucketName := fmt.Sprintf("tf-acc-bucket-lambda-perm-w-s3-%s", rString)
 	funcName := fmt.Sprintf("tf_acc_lambda_perm_w_s3_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_perm_w_s3_%s", rString)
+	statementId := fmt.Sprintf("tf_acc_statement_lambda_perm_basic_%s", rString)
 	funcArnRe := regexp.MustCompile(":function:" + funcName + "$")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -424,6 +429,7 @@ func TestAccAWSLambdaPermission_withSNS(t *testing.T) {
 	topicName := fmt.Sprintf("tf_acc_topic_lambda_perm_w_sns_%s", rString)
 	funcName := fmt.Sprintf("tf_acc_lambda_perm_w_sns_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_perm_w_sns_%s", rString)
+	statementId := fmt.Sprintf("tf_acc_statement_lambda_perm_basic_%s", rString)
 
 	funcArnRe := regexp.MustCompile(":function:" + funcName + "$")
 	topicArnRe := regexp.MustCompile(":" + topicName + "$")
@@ -460,6 +466,7 @@ func TestAccAWSLambdaPermission_withIAMRole(t *testing.T) {
 	rString := acctest.RandString(8)
 	funcName := fmt.Sprintf("tf_acc_lambda_perm_w_iam_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_perm_w_iam_%s", rString)
+	statementId := fmt.Sprintf("tf_acc_statement_lambda_perm_basic_%s", rString)
 	funcArnRe := regexp.MustCompile(":function:" + funcName + "$")
 	roleArnRe := regexp.MustCompile("/" + roleName + "$")
 

--- a/aws/resource_aws_lambda_permission_test.go
+++ b/aws/resource_aws_lambda_permission_test.go
@@ -238,6 +238,12 @@ func TestAccAWSLambdaPermission_withRawFunctionName(t *testing.T) {
 					resource.TestMatchResourceAttr("aws_lambda_permission.with_raw_func_name", "function_name", funcArnRe),
 				),
 			},
+			{
+				ResourceName:      "aws_lambda_permission.allow_cloudwatch",
+				ImportState:       true,
+				ImportStateId:     fmt.Sprintf("%s/%s", funcName, statementId),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -262,6 +268,12 @@ func TestAccAWSLambdaPermission_withStatementIdPrefix(t *testing.T) {
 					resource.TestMatchResourceAttr("aws_lambda_permission.with_statement_id_prefix", "statement_id", startsWithPrefix),
 					resource.TestMatchResourceAttr("aws_lambda_permission.with_statement_id_prefix", "function_name", endsWithFuncName),
 				),
+			},
+			{
+				ResourceName:      "aws_lambda_permission.allow_cloudwatch",
+				ImportState:       true,
+				ImportStateId:     fmt.Sprintf("%s/%s", funcName, statementId),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -291,6 +303,12 @@ func TestAccAWSLambdaPermission_withQualifier(t *testing.T) {
 					resource.TestMatchResourceAttr("aws_lambda_permission.with_qualifier", "function_name", funcArnRe),
 					resource.TestCheckResourceAttr("aws_lambda_permission.with_qualifier", "qualifier", aliasName),
 				),
+			},
+			{
+				ResourceName:      "aws_lambda_permission.allow_cloudwatch",
+				ImportState:       true,
+				ImportStateId:     fmt.Sprintf("%s/%s", funcName, statementId),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -353,6 +371,12 @@ func TestAccAWSLambdaPermission_multiplePerms(t *testing.T) {
 					resource.TestMatchResourceAttr("aws_lambda_permission.third", "function_name", funcArnRe),
 				),
 			},
+			{
+				ResourceName:      "aws_lambda_permission.allow_cloudwatch",
+				ImportState:       true,
+				ImportStateId:     fmt.Sprintf("%s/%s", funcName, statementId),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -382,6 +406,12 @@ func TestAccAWSLambdaPermission_withS3(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_lambda_permission.with_s3", "source_arn",
 						fmt.Sprintf("arn:aws:s3:::%s", bucketName)),
 				),
+			},
+			{
+				ResourceName:      "aws_lambda_permission.allow_cloudwatch",
+				ImportState:       true,
+				ImportStateId:     fmt.Sprintf("%s/%s", funcName, statementId),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -414,6 +444,12 @@ func TestAccAWSLambdaPermission_withSNS(t *testing.T) {
 					resource.TestMatchResourceAttr("aws_lambda_permission.with_sns", "source_arn", topicArnRe),
 				),
 			},
+			{
+				ResourceName:      "aws_lambda_permission.allow_cloudwatch",
+				ImportState:       true,
+				ImportStateId:     fmt.Sprintf("%s/%s", funcName, statementId),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -441,6 +477,12 @@ func TestAccAWSLambdaPermission_withIAMRole(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_lambda_permission.iam_role", "statement_id", "AllowExecutionFromIAMRole"),
 					resource.TestMatchResourceAttr("aws_lambda_permission.iam_role", "function_name", funcArnRe),
 				),
+			},
+			{
+				ResourceName:      "aws_lambda_permission.allow_cloudwatch",
+				ImportState:       true,
+				ImportStateId:     fmt.Sprintf("%s/%s", funcName, statementId),
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/aws/resource_aws_lambda_permission_test.go
+++ b/aws/resource_aws_lambda_permission_test.go
@@ -169,6 +169,7 @@ func TestAccAWSLambdaPermission_basic(t *testing.T) {
 	rString := acctest.RandString(8)
 	funcName := fmt.Sprintf("tf_acc_lambda_perm_basic_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_perm_basic_%s", rString)
+	statementId := fmt.Sprintf("tf_acc_statement_lambda_perm_basic_%s", rString)
 	funcArnRe := regexp.MustCompile(":function:" + funcName + "$")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -187,6 +188,12 @@ func TestAccAWSLambdaPermission_basic(t *testing.T) {
 					resource.TestMatchResourceAttr("aws_lambda_permission.allow_cloudwatch", "function_name", funcArnRe),
 					resource.TestCheckResourceAttr("aws_lambda_permission.allow_cloudwatch", "event_source_token", "test-event-source-token"),
 				),
+			},
+			{
+				ResourceName:      "aws_lambda_permission.allow_cloudwatch",
+				ImportState:       true,
+				ImportStateId:     fmt.Sprintf("%s/%s", funcName, statementId),
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/website/docs/r/lambda_permission.html.markdown
+++ b/website/docs/r/lambda_permission.html.markdown
@@ -154,7 +154,7 @@ resource "aws_lambda_permission" "lambda_permission" {
 
 ## Import
 
-Lambda Function Aliases can be imported using the function_name/statement_id, e.g.
+Lambda permission statements can be imported using the function_name/statement_id, e.g.
 
 ```
 $ terraform import aws_lambda_function_permission.test_lambda_permission my_test_lambda_function/AllowExecutionFromCloudWatch

--- a/website/docs/r/lambda_permission.html.markdown
+++ b/website/docs/r/lambda_permission.html.markdown
@@ -151,3 +151,11 @@ resource "aws_lambda_permission" "lambda_permission" {
  * `statement_id_prefix` - (Optional) A statement identifier prefix. Terraform will generate a unique suffix. Conflicts with `statement_id`.
 
 [1]: https://developer.amazon.com/docs/custom-skills/host-a-custom-skill-as-an-aws-lambda-function.html#use-aws-cli
+
+## Import
+
+Lambda Function Aliases can be imported using the function_name/statement_id, e.g.
+
+```
+$ terraform import aws_lambda_function_permission.test_lambda_permission my_test_lambda_function/AllowExecutionFromCloudWatch
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/9357

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_lambda_permission: Support resource import
```

Output from acceptance testing:

```
make testacc TESTARGS='-run=TestAccAWSCloudWatchEventTarget_basic' 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSCloudWatchEventTarget_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSCloudWatchEventTarget_basic
=== PAUSE TestAccAWSCloudWatchEventTarget_basic
=== CONT  TestAccAWSCloudWatchEventTarget_basic
--- PASS: TestAccAWSCloudWatchEventTarget_basic (58.64s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	58.721s
```
