### PR TITLE
resource/aws_db_event_subscription: Handle SubscriptionNotFound errors during Read and Deletion

### DIFF
--- a/aws/resource_aws_db_event_subscription.go
+++ b/aws/resource_aws_db_event_subscription.go
@@ -155,6 +155,12 @@ func resourceAwsDbEventSubscriptionRead(d *schema.ResourceData, meta interface{}
 
 	sub, err := resourceAwsDbEventSubscriptionRetrieve(d.Id(), conn)
 
+	if isAWSErr(err, rds.ErrCodeSubscriptionNotFoundFault, "") {
+		log.Printf("[WARN] RDS Event Subscription (%s) not found - removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
 		return fmt.Errorf("error retrieving RDS Event Subscription (%s): %s", d.Id(), err)
 	}
@@ -385,6 +391,10 @@ func resourceAwsDbEventSubscriptionRefreshFunc(name string, conn *rds.RDS) resou
 
 	return func() (interface{}, string, error) {
 		sub, err := resourceAwsDbEventSubscriptionRetrieve(name, conn)
+
+		if isAWSErr(err, rds.ErrCodeSubscriptionNotFoundFault, "") {
+			return nil, "", nil
+		}
 
 		if err != nil {
 			return nil, "", err


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #9368

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_db_event_subscription: Handle `SubscriptionNotFound` errors during refresh and deletion
```

Previously (in us-gov-west-1 and us-east-1):

```
--- FAIL: TestAccAWSDBEventSubscription_basicUpdate (1228.44s)
    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: errors during apply: error waiting for RDS Event Subscription (tf-acc-test-rds-event-subs-2201031712637090321) deletion: SubscriptionNotFound: Event Subscription tf-acc-test-rds-event-subs-2201031712637090321 not found.
```

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSDBEventSubscription_withPrefix (535.76s)
--- PASS: TestAccAWSDBEventSubscription_importBasic (537.39s)
--- PASS: TestAccAWSDBEventSubscription_withSourceIds (539.77s)
--- PASS: TestAccAWSDBEventSubscription_disappears (543.52s)
--- PASS: TestAccAWSDBEventSubscription_categoryUpdate (944.42s)
--- PASS: TestAccAWSDBEventSubscription_basicUpdate (945.75s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAWSDBEventSubscription_withPrefix (622.68s)
--- PASS: TestAccAWSDBEventSubscription_importBasic (623.98s)
--- PASS: TestAccAWSDBEventSubscription_withSourceIds (628.56s)
--- PASS: TestAccAWSDBEventSubscription_disappears (631.20s)
--- PASS: TestAccAWSDBEventSubscription_basicUpdate (978.81s)
--- PASS: TestAccAWSDBEventSubscription_categoryUpdate (978.91s)
```

