### PR TITLE
r/aws_rds_cluster: Add TimeoutAction support

### DIFF
--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -188,6 +188,15 @@ func resourceAwsRDSCluster() *schema.Resource {
 							Default:      300,
 							ValidateFunc: validation.IntBetween(300, 86400),
 						},
+						"timeout_action": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "RollbackCapacityChange",
+							ValidateFunc: validation.StringInSlice([]string{
+								"ForceApplyCapacityChange",
+								"RollbackCapacityChange",
+							}, false),
+						},
 					},
 				},
 			},

--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -1038,7 +1038,7 @@ func TestAccAWSRDSCluster_ScalingConfiguration(t *testing.T) {
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSRDSClusterConfig_ScalingConfiguration(rName, false, 128, 4, 301),
+				Config: testAccAWSRDSClusterConfig_ScalingConfiguration(rName, false, 128, 4, 301, "RollbackCapacityChange"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterExists(resourceName, &dbCluster),
 					resource.TestCheckResourceAttr(resourceName, "scaling_configuration.#", "1"),
@@ -1046,10 +1046,11 @@ func TestAccAWSRDSCluster_ScalingConfiguration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "scaling_configuration.0.max_capacity", "128"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_configuration.0.min_capacity", "4"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_configuration.0.seconds_until_auto_pause", "301"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_configuration.0.timeout_action", "RollbackCapacityChange"),
 				),
 			},
 			{
-				Config: testAccAWSRDSClusterConfig_ScalingConfiguration(rName, true, 256, 8, 86400),
+				Config: testAccAWSRDSClusterConfig_ScalingConfiguration(rName, true, 256, 8, 86400, "ForceApplyCapacityChange"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterExists(resourceName, &dbCluster),
 					resource.TestCheckResourceAttr(resourceName, "scaling_configuration.#", "1"),
@@ -1057,6 +1058,7 @@ func TestAccAWSRDSCluster_ScalingConfiguration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "scaling_configuration.0.max_capacity", "256"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_configuration.0.min_capacity", "8"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_configuration.0.seconds_until_auto_pause", "86400"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_configuration.0.timeout_action", "ForceApplyCapacityChange"),
 				),
 			},
 			{
@@ -2534,7 +2536,7 @@ resource "aws_rds_cluster" "test" {
 `, rName, rName, globalClusterIdentifierResourceName)
 }
 
-func testAccAWSRDSClusterConfig_ScalingConfiguration(rName string, autoPause bool, maxCapacity, minCapacity, secondsUntilAutoPause int) string {
+func testAccAWSRDSClusterConfig_ScalingConfiguration(rName string, autoPause bool, maxCapacity, minCapacity, secondsUntilAutoPause int, timeoutAction string) string {
 	return fmt.Sprintf(`
 resource "aws_rds_cluster" "test" {
   cluster_identifier  = %q
@@ -2548,9 +2550,10 @@ resource "aws_rds_cluster" "test" {
     max_capacity             = %d
     min_capacity             = %d
     seconds_until_auto_pause = %d
+    timeout_action           = "%s"
   }
 }
-`, rName, autoPause, maxCapacity, minCapacity, secondsUntilAutoPause)
+`, rName, autoPause, maxCapacity, minCapacity, secondsUntilAutoPause, timeoutAction)
 }
 
 func testAccAWSRDSClusterConfig_SnapshotIdentifier(rName string) string {

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -4770,6 +4770,10 @@ func expandRdsScalingConfiguration(l []interface{}) *rds.ScalingConfiguration {
 		SecondsUntilAutoPause: aws.Int64(int64(m["seconds_until_auto_pause"].(int))),
 	}
 
+	if vTimeoutAction, ok := m["timeout_action"].(string); ok && vTimeoutAction != "" {
+		scalingConfiguration.TimeoutAction = aws.String(vTimeoutAction)
+	}
+
 	return scalingConfiguration
 }
 
@@ -4783,6 +4787,7 @@ func flattenRdsScalingConfigurationInfo(scalingConfigurationInfo *rds.ScalingCon
 		"max_capacity":             aws.Int64Value(scalingConfigurationInfo.MaxCapacity),
 		"min_capacity":             aws.Int64Value(scalingConfigurationInfo.MinCapacity),
 		"seconds_until_auto_pause": aws.Int64Value(scalingConfigurationInfo.SecondsUntilAutoPause),
+		"timeout_action":           aws.StringValue(scalingConfigurationInfo.TimeoutAction),
 	}
 
 	return []interface{}{m}

--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -169,6 +169,7 @@ resource "aws_rds_cluster" "example" {
     max_capacity             = 256
     min_capacity             = 2
     seconds_until_auto_pause = 300
+    timeout_action           = "ForceApplyCapacityChange"
   }
 }
 ```
@@ -177,6 +178,7 @@ resource "aws_rds_cluster" "example" {
 * `max_capacity` - (Optional) The maximum capacity. The maximum capacity must be greater than or equal to the minimum capacity. Valid capacity values are `1`, `2`, `4`, `8`, `16`, `32`, `64`, `128`, and `256`. Defaults to `16`.
 * `min_capacity` - (Optional) The minimum capacity. The minimum capacity must be lesser than or equal to the maximum capacity. Valid capacity values are `1`, `2`, `4`, `8`, `16`, `32`, `64`, `128`, and `256`. Defaults to `2`.
 * `seconds_until_auto_pause` - (Optional) The time, in seconds, before an Aurora DB cluster in serverless mode is paused. Valid values are `300` through `86400`. Defaults to `300`.
+* `timeout_action` - (Optional) The action to take when the timeout is reached. Valid values: `ForceApplyCapacityChange`, `RollbackCapacityChange`. Defaults to `RollbackCapacityChange`. See [documentation](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless.how-it-works.html#aurora-serverless.how-it-works.timeout-action).
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/8929

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
- resource/aws_rds_cluster: Support `scaling_configuration` configuration block `timeout_action` argument [GH-9374]
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSRDSCluster_ScalingConfiguration'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSRDSCluster_ScalingConfiguration -timeout 120m
=== RUN   TestAccAWSRDSCluster_ScalingConfiguration
=== PAUSE TestAccAWSRDSCluster_ScalingConfiguration
=== CONT  TestAccAWSRDSCluster_ScalingConfiguration
--- PASS: TestAccAWSRDSCluster_ScalingConfiguration (305.08s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	305.142s
```
