### PR TITLE
converting data.aws_subnet_ids.private.ids from string to list

### DIFF
--- a/website/docs/d/subnet_ids.html.markdown
+++ b/website/docs/d/subnet_ids.html.markdown
@@ -48,7 +48,7 @@ resource "aws_instance" "app" {
   count         = "3"
   ami           = "${var.ami}"
   instance_type = "t2.micro"
-  subnet_id     = "${element(data.aws_subnet_ids.private.ids, count.index)}"
+  subnet_id     = "${element(tolist(data.aws_subnet_ids.private.ids), count.index)}"
 }
 ```
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #22099
As aws_subnet_ids is retuning string(list), typecasting need to use aws_subnet_ids 
```release-note
Updating documentation for Data Source: aws_subnet_ids 
```
