### PR TITLE
add workgroup support for Athena named query

### DIFF
--- a/aws/resource_aws_athena_named_query.go
+++ b/aws/resource_aws_athena_named_query.go
@@ -33,6 +33,7 @@ func resourceAwsAthenaNamedQuery() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Default:  "primary",
 			},
 			"database": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_athena_named_query.go
+++ b/aws/resource_aws_athena_named_query.go
@@ -29,6 +29,11 @@ func resourceAwsAthenaNamedQuery() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"workgroup": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"database": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -50,6 +55,9 @@ func resourceAwsAthenaNamedQueryCreate(d *schema.ResourceData, meta interface{})
 		Database:    aws.String(d.Get("database").(string)),
 		Name:        aws.String(d.Get("name").(string)),
 		QueryString: aws.String(d.Get("query").(string)),
+	}
+	if raw, ok := d.GetOk("workgroup"); ok {
+		input.WorkGroup = aws.String(raw.(string))
 	}
 	if raw, ok := d.GetOk("description"); ok {
 		input.Description = aws.String(raw.(string))
@@ -82,6 +90,7 @@ func resourceAwsAthenaNamedQueryRead(d *schema.ResourceData, meta interface{}) e
 
 	d.Set("name", resp.NamedQuery.Name)
 	d.Set("query", resp.NamedQuery.QueryString)
+	d.Set("workgroup", resp.NamedQuery.WorkGroup)
 	d.Set("database", resp.NamedQuery.Database)
 	d.Set("description", resp.NamedQuery.Description)
 	return nil

--- a/aws/resource_aws_athena_named_query_test.go
+++ b/aws/resource_aws_athena_named_query_test.go
@@ -36,7 +36,7 @@ func TestAccAWSAthenaNamedQuery_withWorkGroup(t *testing.T) {
 			{
 				Config: testAccAthenaNamedWorkGroupQueryConfig(acctest.RandInt(), acctest.RandString(5)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaNamedQueryExists("aws_athena_named_query.foo"),
+					testAccCheckAWSAthenaNamedQueryExists("aws_athena_named_query.bar"),
 				),
 			},
 		},

--- a/aws/resource_aws_athena_named_query_test.go
+++ b/aws/resource_aws_athena_named_query_test.go
@@ -27,6 +27,22 @@ func TestAccAWSAthenaNamedQuery_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSAthenaNamedQuery_withWorkGroup(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAthenaNamedQueryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAthenaNamedWorkGroupQueryConfig(acctest.RandInt(), acctest.RandString(5)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaNamedQueryExists("aws_athena_named_query.foo"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSAthenaNamedQuery_import(t *testing.T) {
 	resourceName := "aws_athena_named_query.foo"
 
@@ -110,4 +126,30 @@ resource "aws_athena_named_query" "foo" {
   description = "tf test"
 }
 `, rName, rInt, rName, rName)
+}
+
+func testAccAthenaNamedWorkGroupQueryConfig(rInt int, rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "hoge" {
+  bucket        = "tf-athena-db-%s-%d"
+  force_destroy = true
+}
+
+resource "aws_athena_workgroup" "test" {
+  name = "tf-athena-workgroup-%s-%d"
+}
+
+resource "aws_athena_database" "hoge" {
+  name   = "%s"
+  bucket = "${aws_s3_bucket.hoge.bucket}"
+}
+
+resource "aws_athena_named_query" "bar" {
+  name        = "tf-athena-named-query-%s"
+  workgroup   = "${aws_athena_workgroup.test.id}"
+  database    = "${aws_athena_database.hoge.name}"
+  query       = "SELECT * FROM ${aws_athena_database.hoge.name} limit 10;"
+  description = "tf test"
+}
+`, rName, rInt, rName, rInt, rName, rName)
 }

--- a/website/docs/r/athena_named_query.html.markdown
+++ b/website/docs/r/athena_named_query.html.markdown
@@ -53,7 +53,7 @@ resource "aws_athena_named_query" "foo" {
 The following arguments are supported:
 
 * `name` - (Required) The plain language name for the query. Maximum length of 128.
-* `workgroup` - (Optional) The workgroup to which the query belongs.
+* `workgroup` - (Optional) The workgroup to which the query belongs. Defaults to `primary`
 * `database` - (Required) The database to which the query belongs.
 * `query` - (Required) The text of the query itself. In other words, all query statements. Maximum length of 262144.
 * `description` - (Optional) A brief explanation of the query. Maximum length of 1024.

--- a/website/docs/r/athena_named_query.html.markdown
+++ b/website/docs/r/athena_named_query.html.markdown
@@ -17,15 +17,34 @@ resource "aws_s3_bucket" "hoge" {
   bucket = "tf-test"
 }
 
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+  description             = "Athena KMS Key"
+}
+
+resource "aws_athena_workgroup" "test" {
+  name = "example"
+
+  configuration {
+    result_configuration {
+      encryption_configuration {
+        encryption_option = "SSE_KMS"
+        kms_key_arn       = "${aws_kms_key.test.arn}"
+      }
+    }
+  }
+}
+
 resource "aws_athena_database" "hoge" {
   name   = "users"
   bucket = "${aws_s3_bucket.hoge.bucket}"
 }
 
 resource "aws_athena_named_query" "foo" {
-  name     = "bar"
-  database = "${aws_athena_database.hoge.name}"
-  query    = "SELECT * FROM ${aws_athena_database.hoge.name} limit 10;"
+  name      = "bar"
+  workgroup = "${aws_athena_workgroup.test.id}"
+  database  = "${aws_athena_database.hoge.name}"
+  query     = "SELECT * FROM ${aws_athena_database.hoge.name} limit 10;"
 }
 ```
 
@@ -34,6 +53,7 @@ resource "aws_athena_named_query" "foo" {
 The following arguments are supported:
 
 * `name` - (Required) The plain language name for the query. Maximum length of 128.
+* `workgroup` - (Optional) The workgroup to which the query belongs.
 * `database` - (Required) The database to which the query belongs.
 * `query` - (Required) The text of the query itself. In other words, all query statements. Maximum length of 262144.
 * `description` - (Optional) A brief explanation of the query. Maximum length of 1024.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8016

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Adds optional `workgroup` argument to athena_named_query resource.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAthenaNamedQuery'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSAthenaNamedQuery -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSAthenaNamedQuery_basic
=== PAUSE TestAccAWSAthenaNamedQuery_basic
=== RUN   TestAccAWSAthenaNamedQuery_withWorkGroup
=== PAUSE TestAccAWSAthenaNamedQuery_withWorkGroup
=== RUN   TestAccAWSAthenaNamedQuery_import
=== PAUSE TestAccAWSAthenaNamedQuery_import
=== CONT  TestAccAWSAthenaNamedQuery_basic
=== CONT  TestAccAWSAthenaNamedQuery_import
=== CONT  TestAccAWSAthenaNamedQuery_withWorkGroup
--- PASS: TestAccAWSAthenaNamedQuery_basic (81.90s)
--- PASS: TestAccAWSAthenaNamedQuery_withWorkGroup (82.52s)
--- PASS: TestAccAWSAthenaNamedQuery_import (85.07s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	85.186s
```
