### PR TITLE
data-source/aws_route53_zone: add linked service attributes

### DIFF
--- a/aws/data_source_aws_route53_zone.go
+++ b/aws/data_source_aws_route53_zone.go
@@ -32,12 +32,10 @@ func dataSourceAwsRoute53Zone() *schema.Resource {
 			},
 			"comment": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"caller_reference": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"vpc_id": {
@@ -54,6 +52,14 @@ func dataSourceAwsRoute53Zone() *schema.Resource {
 			"name_servers": {
 				Type:     schema.TypeList,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"linked_service_principal": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"linked_service_description": {
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 		},
@@ -169,6 +175,10 @@ func dataSourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("private_zone", hostedZoneFound.Config.PrivateZone)
 	d.Set("caller_reference", hostedZoneFound.CallerReference)
 	d.Set("resource_record_set_count", hostedZoneFound.ResourceRecordSetCount)
+	if hostedZoneFound.LinkedService != nil {
+		d.Set("linked_service_principal", hostedZoneFound.LinkedService.ServicePrincipal)
+		d.Set("linked_service_description", hostedZoneFound.LinkedService.Description)
+	}
 
 	nameServers, err := hostedZoneNameServers(idHostedZone, conn)
 	if err != nil {

--- a/aws/data_source_aws_route53_zone_test.go
+++ b/aws/data_source_aws_route53_zone_test.go
@@ -2,19 +2,18 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccDataSourceAwsRoute53Zone(t *testing.T) {
 	rInt := acctest.RandInt()
 	publicResourceName := "aws_route53_zone.test"
-	publicDomain := fmt.Sprintf("terraformtestacchz-%d.com.", rInt)
 	privateResourceName := "aws_route53_zone.test_private"
-	privateDomain := fmt.Sprintf("test.acc-%d.", rInt)
+	serviceDiscoveryResourceName := "aws_service_discovery_private_dns_namespace.test_service_discovery"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -24,50 +23,24 @@ func TestAccDataSourceAwsRoute53Zone(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsRoute53ZoneConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceAwsRoute53ZoneCheck(
-						publicResourceName, "data.aws_route53_zone.by_zone_id", publicDomain),
-					testAccDataSourceAwsRoute53ZoneCheck(
-						publicResourceName, "data.aws_route53_zone.by_name", publicDomain),
-					testAccDataSourceAwsRoute53ZoneCheck(
-						privateResourceName, "data.aws_route53_zone.by_vpc", privateDomain),
-					testAccDataSourceAwsRoute53ZoneCheck(
-						privateResourceName, "data.aws_route53_zone.by_tag", privateDomain),
+					resource.TestCheckResourceAttrPair(publicResourceName, "id", "data.aws_route53_zone.by_zone_id", "id"),
+					resource.TestCheckResourceAttrPair(publicResourceName, "name", "data.aws_route53_zone.by_zone_id", "name"),
+					resource.TestCheckResourceAttrPair(publicResourceName, "name_servers", "data.aws_route53_zone.by_zone_id", "name_servers"),
+					resource.TestCheckResourceAttrPair(publicResourceName, "id", "data.aws_route53_zone.by_name", "id"),
+					resource.TestCheckResourceAttrPair(publicResourceName, "name", "data.aws_route53_zone.by_name", "name"),
+					resource.TestCheckResourceAttrPair(publicResourceName, "name_servers", "data.aws_route53_zone.by_name", "name_servers"),
+					resource.TestCheckResourceAttrPair(privateResourceName, "id", "data.aws_route53_zone.by_vpc", "id"),
+					resource.TestCheckResourceAttrPair(privateResourceName, "name", "data.aws_route53_zone.by_vpc", "name"),
+					resource.TestCheckResourceAttrPair(privateResourceName, "id", "data.aws_route53_zone.by_tag", "id"),
+					resource.TestCheckResourceAttrPair(privateResourceName, "name", "data.aws_route53_zone.by_tag", "name"),
+					resource.TestCheckResourceAttrPair(serviceDiscoveryResourceName, "hosted_zone", "data.aws_route53_zone.service_discovery_by_vpc", "id"),
+					resource.TestCheckResourceAttrPair(serviceDiscoveryResourceName, "name", "data.aws_route53_zone.service_discovery_by_vpc", "name"),
+					resource.TestCheckResourceAttr("data.aws_route53_zone.service_discovery_by_vpc", "linked_service_principal", "servicediscovery.amazonaws.com"),
+					resource.TestMatchResourceAttr("data.aws_route53_zone.service_discovery_by_vpc", "linked_service_description", regexp.MustCompile(`^arn:[^:]+:servicediscovery:[^:]+:[^:]+:namespace/ns-\w+$`)),
 				),
 			},
 		},
 	})
-}
-
-// rsName for the name of the created resource
-// dsName for the name of the created data source
-// zName for the name of the domain
-func testAccDataSourceAwsRoute53ZoneCheck(rsName, dsName, zName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[rsName]
-		if !ok {
-			return fmt.Errorf("root module has no resource called %s", rsName)
-		}
-
-		hostedZone, ok := s.RootModule().Resources[dsName]
-		if !ok {
-			return fmt.Errorf("can't find zone %q in state", dsName)
-		}
-
-		attr := rs.Primary.Attributes
-		if attr["id"] != hostedZone.Primary.Attributes["id"] {
-			return fmt.Errorf("Route53 Zone id is %s; want %s", attr["id"], hostedZone.Primary.Attributes["id"])
-		}
-
-		if attr["name"] != zName {
-			return fmt.Errorf("Route53 Zone name is %q; want %q", attr["name"], zName)
-		}
-
-		if attr["private_zone"] == "false" && len(attr["name_servers"]) == 0 {
-			return fmt.Errorf("Route53 Zone %s has no name_servers", zName)
-		}
-
-		return nil
-	}
 }
 
 func testAccDataSourceAwsRoute53ZoneConfig(rInt int) string {
@@ -85,14 +58,14 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_route53_zone" "test_private" {
-  name = "test.acc-%d."
+  name = "test.acc-%[1]d."
 
   vpc {
     vpc_id = "${aws_vpc.test.id}"
   }
 
   tags = {
-    Environment = "dev-%d"
+    Environment = "dev-%[1]d"
   }
 }
 
@@ -106,12 +79,12 @@ data "aws_route53_zone" "by_tag" {
   private_zone = true
 
   tags = {
-    Environment = "dev-%d"
+    Environment = "dev-%[1]d"
   }
 }
 
 resource "aws_route53_zone" "test" {
-  name = "terraformtestacchz-%d.com."
+  name = "terraformtestacchz-%[1]d.com."
 }
 
 data "aws_route53_zone" "by_zone_id" {
@@ -121,5 +94,15 @@ data "aws_route53_zone" "by_zone_id" {
 data "aws_route53_zone" "by_name" {
   name = "${data.aws_route53_zone.by_zone_id.name}"
 }
-`, rInt, rInt, rInt, rInt)
+
+resource "aws_service_discovery_private_dns_namespace" "test_service_discovery" {
+  name        = "test.acc-sd-%[1]d."
+  vpc         = "${aws_vpc.test.id}"
+}
+
+data "aws_route53_zone" "service_discovery_by_vpc" {
+  name   = "${aws_service_discovery_private_dns_namespace.test_service_discovery.name}"
+  vpc_id = "${aws_vpc.test.id}"
+}
+`, rInt)
 }

--- a/website/docs/d/route53_zone.html.markdown
+++ b/website/docs/d/route53_zone.html.markdown
@@ -57,4 +57,6 @@ The following attribute is additionally exported:
 * `caller_reference` - Caller Reference of the Hosted Zone.
 * `comment` - The comment field of the Hosted Zone.
 * `name_servers` - The list of DNS name servers for the Hosted Zone.
-* `resource_record_set_count` - the number of Record Set in the Hosted Zone
+* `resource_record_set_count` - The number of Record Set in the Hosted Zone.
+* `linked_service_principal` - The service that created the Hosted Zone (e.g. `servicediscovery.amazonaws.com`).
+* `linked_service_description` - The description provided by the service that created the Hosted Zone (e.g. `arn:aws:servicediscovery:us-east-1:1234567890:namespace/ns-xxxxxxxxxxxxxxxx`).


### PR DESCRIPTION
- updated test error strings to better reflect actual vs expected
- fixed `name_servers` check to test the data source, not the resource
- renamed the resource attributes variable and added a data source
  attributes varialbe to improve readability

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
data-source/aws_route53_zone: new attributes `linked_service_principal` and `linked_service_description`
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccDataSourceAwsRoute53Zone'
=== RUN   TestAccDataSourceAwsRoute53Zone
=== PAUSE TestAccDataSourceAwsRoute53Zone
=== CONT  TestAccDataSourceAwsRoute53Zone
--- PASS: TestAccDataSourceAwsRoute53Zone (128.46s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	128.504s
...
```
