### PR TITLE
Send all attributes when updating a cognito_identity_pool resource

### DIFF
--- a/aws/resource_aws_cognito_identity_pool.go
+++ b/aws/resource_aws_cognito_identity_pool.go
@@ -198,24 +198,24 @@ func resourceAwsCognitoIdentityPoolUpdate(d *schema.ResourceData, meta interface
 		IdentityPoolName:               aws.String(d.Get("identity_pool_name").(string)),
 	}
 
-	if d.HasChange("developer_provider_name") {
-		params.DeveloperProviderName = aws.String(d.Get("developer_provider_name").(string))
+	if v, ok := d.GetOk("developer_provider_name"); ok {
+		params.DeveloperProviderName = aws.String(v.(string))
 	}
 
-	if d.HasChange("cognito_identity_providers") {
-		params.CognitoIdentityProviders = expandCognitoIdentityProviders(d.Get("cognito_identity_providers").(*schema.Set))
+	if v, ok := d.GetOk("cognito_identity_providers"); ok {
+		params.CognitoIdentityProviders = expandCognitoIdentityProviders(v.(*schema.Set))
 	}
 
-	if d.HasChange("supported_login_providers") {
-		params.SupportedLoginProviders = expandCognitoSupportedLoginProviders(d.Get("supported_login_providers").(map[string]interface{}))
+	if v, ok := d.GetOk("supported_login_providers"); ok {
+		params.SupportedLoginProviders = expandCognitoSupportedLoginProviders(v.(map[string]interface{}))
 	}
 
-	if d.HasChange("openid_connect_provider_arns") {
-		params.OpenIdConnectProviderARNs = expandStringList(d.Get("openid_connect_provider_arns").([]interface{}))
+	if v, ok := d.GetOk("openid_connect_provider_arns"); ok {
+		params.OpenIdConnectProviderARNs = expandStringList(v.([]interface{}))
 	}
 
-	if d.HasChange("saml_provider_arns") {
-		params.SamlProviderARNs = expandStringList(d.Get("saml_provider_arns").([]interface{}))
+	if v, ok := d.GetOk("saml_provider_arns"); ok {
+		params.SamlProviderARNs = expandStringList(v.([]interface{}))
 	}
 
 	_, err := conn.UpdateIdentityPool(params)

--- a/aws/resource_aws_cognito_identity_pool_test.go
+++ b/aws/resource_aws_cognito_identity_pool_test.go
@@ -215,6 +215,44 @@ func TestAccAWSCognitoIdentityPool_cognitoIdentityProviders(t *testing.T) {
 	})
 }
 
+func TestAccAWSCognitoIdentityPool_addingNewProviderKeepsOldProvider(t *testing.T) {
+	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentity(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoIdentityPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoIdentityPoolConfig_cognitoIdentityProviders(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoIdentityPoolExists("aws_cognito_identity_pool.main"),
+					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
+					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "cognito_identity_providers.#", "2"),
+				),
+			},
+			{
+				Config: testAccAWSCognitoIdentityPoolConfig_cognitoIdentityProvidersAndOpenidConnectProviderArns(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoIdentityPoolExists("aws_cognito_identity_pool.main"),
+					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
+					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "cognito_identity_providers.#", "2"),
+					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "openid_connect_provider_arns.#", "1"),
+				),
+			},
+			{
+				Config: testAccAWSCognitoIdentityPoolConfig_basic(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoIdentityPoolExists("aws_cognito_identity_pool.main"),
+					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
+					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "cognito_identity_providers.#", "0"),
+					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "openid_connect_provider_arns.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSCognitoIdentityPoolExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -405,6 +443,29 @@ resource "aws_cognito_identity_pool" "main" {
     provider_name           = "cognito-idp.us-east-1.amazonaws.com/us-east-1_Zr231apJu"
     server_side_token_check = false
   }
+}
+`, name)
+}
+
+func testAccAWSCognitoIdentityPoolConfig_cognitoIdentityProvidersAndOpenidConnectProviderArns(name string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_identity_pool" "main" {
+  identity_pool_name               = "identity pool %s"
+  allow_unauthenticated_identities = false
+
+  cognito_identity_providers {
+    client_id               = "7lhlkkfbfb4q5kpp90urffao"
+    provider_name           = "cognito-idp.us-east-1.amazonaws.com/us-east-1_Ab129faBb"
+    server_side_token_check = false
+  }
+
+  cognito_identity_providers {
+    client_id               = "7lhlkkfbfb4q5kpp90urffao"
+    provider_name           = "cognito-idp.us-east-1.amazonaws.com/us-east-1_Zr231apJu"
+    server_side_token_check = false
+  }
+
+  openid_connect_provider_arns = ["arn:aws:iam::123456789012:oidc-provider/server.example.com"]
 }
 `, name)
 }


### PR DESCRIPTION
The UpdateIdentityPool API expects all attributes to be present.  It
treats missing attributes as a request to remove those attributes from
the identity pool.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #9394 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

Newly added test fails on master:
```
miles@mbudnek-desktop:~/git/terraform-provider-aws$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCognitoIdentityPool_addingNewProviderKeepsOldProvider'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSCognitoIdentityPool_addingNewProviderKeepsOldProvider -timeout 120m
=== RUN   TestAccAWSCognitoIdentityPool_addingNewProviderKeepsOldProvider
--- FAIL: TestAccAWSCognitoIdentityPool_addingNewProviderKeepsOldProvider (24.35s)
    testing.go:568: Step 1 error: After applying this step and refreshing, the plan was not empty:

        DIFF:

        UPDATE: aws_cognito_identity_pool.main
          allow_unauthenticated_identities:                     "false" => "false"
          arn:                                                  "arn:aws:cognito-identity:us-west-2:116127484844:identitypool/us-west-2:5cec08a9-f0a5-4ebd-ab14-74cbca7082b2" => "arn:aws:cognito-identity:us-west-2:116127484844:identitypool/us-west-2:5cec08a9-f0a5-4ebd-ab14-74cbca7082b2"
          cognito_identity_providers.#:                         "0" => "2"
          cognito_identity_providers.0.client_id:               "" => "7lhlkkfbfb4q5kpp90urffao"
          cognito_identity_providers.0.provider_name:           "" => "cognito-idp.us-east-1.amazonaws.com/us-east-1_Ab129faBb"
          cognito_identity_providers.0.server_side_token_check: "" => "false"
          cognito_identity_providers.1.client_id:               "" => "7lhlkkfbfb4q5kpp90urffao"
          cognito_identity_providers.1.provider_name:           "" => "cognito-idp.us-east-1.amazonaws.com/us-east-1_Zr231apJu"
          cognito_identity_providers.1.server_side_token_check: "" => "false"
          developer_provider_name:                              "" => ""
          id:                                                   "us-west-2:5cec08a9-f0a5-4ebd-ab14-74cbca7082b2" => "us-west-2:5cec08a9-f0a5-4ebd-ab14-74cbca7082b2"
          identity_pool_name:                                   "identity pool qxit7yoirk" => "identity pool qxit7yoirk"
          openid_connect_provider_arns.#:                       "1" => "1"
          openid_connect_provider_arns.0:                       "arn:aws:iam::123456789012:oidc-provider/server.example.com" => "arn:aws:iam::123456789012:oidc-provider/server.example.com"
          saml_provider_arns.#:                                 "0" => "0"



        STATE:

        aws_cognito_identity_pool.main:
          ID = us-west-2:5cec08a9-f0a5-4ebd-ab14-74cbca7082b2
          provider = provider.aws
          allow_unauthenticated_identities = false
          arn = arn:aws:cognito-identity:us-west-2:116127484844:identitypool/us-west-2:5cec08a9-f0a5-4ebd-ab14-74cbca7082b2
          developer_provider_name =
          identity_pool_name = identity pool qxit7yoirk
          openid_connect_provider_arns.# = 1
          openid_connect_provider_arns.0 = arn:aws:iam::123456789012:oidc-provider/server.example.com
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	24.394s
make: *** [GNUmakefile:20: testacc] Error 1
```

Passes on this branch:
```
miles@mbudnek-desktop:~/git/terraform-provider-aws$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCognitoIdentityPool_addingNewProviderKeepsOldProvider'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSCognitoIdentityPool_addingNewProviderKeepsOldProvider -timeout 120m
=== RUN   TestAccAWSCognitoIdentityPool_addingNewProviderKeepsOldProvider
--- PASS: TestAccAWSCognitoIdentityPool_addingNewProviderKeepsOldProvider (34.57s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	34.609s
```

One existing Cognito Identity Pool related test fails on both master and this branch:
```
miles@mbudnek-desktop:~/git/terraform-provider-aws$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCognitoIdentityPool_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSCognitoIdentityPool_ -timeout 120m
=== RUN   TestAccAWSCognitoIdentityPool_importBasic
=== PAUSE TestAccAWSCognitoIdentityPool_importBasic
=== RUN   TestAccAWSCognitoIdentityPool_basic
=== PAUSE TestAccAWSCognitoIdentityPool_basic
=== RUN   TestAccAWSCognitoIdentityPool_supportedLoginProviders
=== PAUSE TestAccAWSCognitoIdentityPool_supportedLoginProviders
=== RUN   TestAccAWSCognitoIdentityPool_openidConnectProviderArns
=== PAUSE TestAccAWSCognitoIdentityPool_openidConnectProviderArns
=== RUN   TestAccAWSCognitoIdentityPool_samlProviderArns
=== PAUSE TestAccAWSCognitoIdentityPool_samlProviderArns
=== RUN   TestAccAWSCognitoIdentityPool_cognitoIdentityProviders
=== PAUSE TestAccAWSCognitoIdentityPool_cognitoIdentityProviders
=== RUN   TestAccAWSCognitoIdentityPool_addingNewProviderKeepsOldProvider
--- PASS: TestAccAWSCognitoIdentityPool_addingNewProviderKeepsOldProvider (36.44s)
=== CONT  TestAccAWSCognitoIdentityPool_importBasic
=== CONT  TestAccAWSCognitoIdentityPool_cognitoIdentityProviders
=== CONT  TestAccAWSCognitoIdentityPool_supportedLoginProviders
=== CONT  TestAccAWSCognitoIdentityPool_samlProviderArns
=== CONT  TestAccAWSCognitoIdentityPool_openidConnectProviderArns
=== CONT  TestAccAWSCognitoIdentityPool_basic
--- PASS: TestAccAWSCognitoIdentityPool_importBasic (14.84s)
--- FAIL: TestAccAWSCognitoIdentityPool_openidConnectProviderArns (19.88s)
    testing.go:568: Step 1 error: After applying this step, the plan was not empty:

        DIFF:

        UPDATE: aws_cognito_identity_pool.main
          allow_unauthenticated_identities: "false" => "false"
          arn:                              "arn:aws:cognito-identity:us-west-2:116127484844:identitypool/us-west-2:333f51cd-86bc-46bb-ae3a-30932fe5f5f6" => "arn:aws:cognito-identity:us-west-2:116127484844:identitypool/us-west-2:333f51cd-86bc-46bb-ae3a-30932fe5f5f6"
          cognito_identity_providers.#:     "0" => "0"
          developer_provider_name:          "" => ""
          id:                               "us-west-2:333f51cd-86bc-46bb-ae3a-30932fe5f5f6" => "us-west-2:333f51cd-86bc-46bb-ae3a-30932fe5f5f6"
          identity_pool_name:               "identity pool a9stdtokkw" => "identity pool a9stdtokkw"
          openid_connect_provider_arns.#:   "2" => "2"
          openid_connect_provider_arns.0:   "arn:aws:iam::123456789012:oidc-provider/bar.example.com" => "arn:aws:iam::123456789012:oidc-provider/foo.example.com"
          openid_connect_provider_arns.1:   "arn:aws:iam::123456789012:oidc-provider/foo.example.com" => "arn:aws:iam::123456789012:oidc-provider/bar.example.com"
          saml_provider_arns.#:             "0" => "0"



        STATE:

        aws_cognito_identity_pool.main:
          ID = us-west-2:333f51cd-86bc-46bb-ae3a-30932fe5f5f6
          provider = provider.aws
          allow_unauthenticated_identities = false
          arn = arn:aws:cognito-identity:us-west-2:116127484844:identitypool/us-west-2:333f51cd-86bc-46bb-ae3a-30932fe5f5f6
          developer_provider_name =
          identity_pool_name = identity pool a9stdtokkw
          openid_connect_provider_arns.# = 2
          openid_connect_provider_arns.0 = arn:aws:iam::123456789012:oidc-provider/bar.example.com
          openid_connect_provider_arns.1 = arn:aws:iam::123456789012:oidc-provider/foo.example.com
--- PASS: TestAccAWSCognitoIdentityPool_basic (23.63s)
--- PASS: TestAccAWSCognitoIdentityPool_supportedLoginProviders (33.19s)
--- PASS: TestAccAWSCognitoIdentityPool_cognitoIdentityProviders (33.36s)
--- PASS: TestAccAWSCognitoIdentityPool_samlProviderArns (33.40s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	69.892s
make: *** [GNUmakefile:20: testacc] Error 1
```
It looks like it's just shuffling the order of some attributes between runs.  Maybe related to #5704, but I didn't investigate all that much.
