### PR TITLE
resource/aws_elasticsearch_domain: Support three Availability Zone awareness

### DIFF
--- a/aws/resource_aws_elasticsearch_domain.go
+++ b/aws/resource_aws_elasticsearch_domain.go
@@ -191,14 +191,16 @@ func resourceAwsElasticSearchDomain() *schema.Resource {
 							Default:  "m3.medium.elasticsearch",
 						},
 						"zone_awareness_config": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
+							Type:             schema.TypeList,
+							Optional:         true,
+							MaxItems:         1,
+							DiffSuppressFunc: suppressMissingOptionalConfigurationBlock,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"availability_zone_count": {
 										Type:         schema.TypeInt,
-										Required:     true,
+										Optional:     true,
+										Default:      2,
 										ValidateFunc: validation.IntInSlice([]int{2, 3}),
 									},
 								},

--- a/aws/resource_aws_elasticsearch_domain.go
+++ b/aws/resource_aws_elasticsearch_domain.go
@@ -190,12 +190,22 @@ func resourceAwsElasticSearchDomain() *schema.Resource {
 							Optional: true,
 							Default:  "m3.medium.elasticsearch",
 						},
+						"zone_awareness_config": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"availability_zone_count": {
+										Type:         schema.TypeInt,
+										Required:     true,
+										ValidateFunc: validation.IntInSlice([]int{2, 3}),
+									},
+								},
+							},
+						},
 						"zone_awareness_enabled": {
 							Type:     schema.TypeBool,
-							Optional: true,
-						},
-						"zone_awareness_count": {
-							Type:     schema.TypeInt,
 							Optional: true,
 						},
 					},

--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -99,6 +99,7 @@ func TestAccAWSElasticSearchDomain_ClusterConfig_ZoneAwarenessConfig(t *testing.
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 			{

--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -77,9 +77,10 @@ func TestAccAWSElasticSearchDomain_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSElasticSearchDomain_ZoneAwareness(t *testing.T) {
-	var domain elasticsearch.ElasticsearchDomainStatus
-	ri := acctest.RandInt()
+func TestAccAWSElasticSearchDomain_ClusterConfig_ZoneAwarenessConfig(t *testing.T) {
+	var domain1, domain2, domain3, domain4 elasticsearch.ElasticsearchDomainStatus
+	rName := acctest.RandomWithPrefix("tf-acc-test")[:28]
+	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -87,43 +88,46 @@ func TestAccAWSElasticSearchDomain_ZoneAwareness(t *testing.T) {
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccESDomainConfig_ZoneAwareness(ri, 3, false),
+				Config: testAccESDomainConfig_ClusterConfig_ZoneAwarenessConfig_AvailabilityZoneCount(rName, 3),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckESDomainExists("aws_elasticsearch_domain.example", &domain),
-					resource.TestCheckResourceAttr("aws_elasticsearch_domain.example", "cluster_config.0.zone_awareness_enabled", "false"),
-					resource.TestCheckResourceAttr("aws_elasticsearch_domain.example", "cluster_config.0.zone_awareness_count", "3"),
+					testAccCheckESDomainExists(resourceName, &domain1),
+					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.zone_awareness_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.zone_awareness_config.0.availability_zone_count", "3"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.zone_awareness_enabled", "true"),
 				),
 			},
 			{
-				Config: testAccESDomainConfig_ZoneAwareness(ri, 3, true),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccESDomainConfig_ClusterConfig_ZoneAwarenessConfig_AvailabilityZoneCount(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckESDomainExists("aws_elasticsearch_domain.example", &domain),
-					resource.TestCheckResourceAttr("aws_elasticsearch_domain.example", "cluster_config.0.zone_awareness_enabled", "true"),
-					resource.TestCheckResourceAttr("aws_elasticsearch_domain.example", "cluster_config.0.zone_awareness_count", "3"),
+					testAccCheckESDomainExists(resourceName, &domain2),
+					testAccCheckAWSESDomainNotRecreated(&domain1, &domain2),
+					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.zone_awareness_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.zone_awareness_config.0.availability_zone_count", "2"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.zone_awareness_enabled", "true"),
 				),
 			},
 			{
-				Config: testAccESDomainConfig_ZoneAwareness(ri, 3, false),
+				Config: testAccESDomainConfig_ClusterConfig_ZoneAwarenessEnabled(rName, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckESDomainExists("aws_elasticsearch_domain.example", &domain),
-					resource.TestCheckResourceAttr("aws_elasticsearch_domain.example", "cluster_config.0.zone_awareness_enabled", "false"),
-					resource.TestCheckResourceAttr("aws_elasticsearch_domain.example", "cluster_config.0.zone_awareness_count", "3"),
+					testAccCheckESDomainExists(resourceName, &domain3),
+					testAccCheckAWSESDomainNotRecreated(&domain2, &domain3),
+					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.zone_awareness_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.zone_awareness_config.#", "0"),
 				),
 			},
 			{
-				Config: testAccESDomainConfig_ZoneAwareness(ri, 2, true),
+				Config: testAccESDomainConfig_ClusterConfig_ZoneAwarenessConfig_AvailabilityZoneCount(rName, 3),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckESDomainExists("aws_elasticsearch_domain.example", &domain),
-					resource.TestCheckResourceAttr("aws_elasticsearch_domain.example", "cluster_config.0.zone_awareness_enabled", "true"),
-					resource.TestCheckResourceAttr("aws_elasticsearch_domain.example", "cluster_config.0.zone_awareness_count", "2"),
-				),
-			},
-			{
-				Config: testAccESDomainConfig_ZoneAwareness(ri, 3, true),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckESDomainExists("aws_elasticsearch_domain.example", &domain),
-					resource.TestCheckResourceAttr("aws_elasticsearch_domain.example", "cluster_config.0.zone_awareness_enabled", "true"),
-					resource.TestCheckResourceAttr("aws_elasticsearch_domain.example", "cluster_config.0.zone_awareness_count", "3"),
+					testAccCheckESDomainExists(resourceName, &domain4),
+					testAccCheckAWSESDomainNotRecreated(&domain3, &domain4),
+					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.zone_awareness_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.zone_awareness_config.0.availability_zone_count", "3"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.zone_awareness_enabled", "true"),
 				),
 			},
 		},
@@ -802,24 +806,46 @@ resource "aws_elasticsearch_domain" "example" {
 `, randInt)
 }
 
-func testAccESDomainConfig_ZoneAwareness(randInt int, azcount int, enabled bool) string {
+func testAccESDomainConfig_ClusterConfig_ZoneAwarenessConfig_AvailabilityZoneCount(rName string, availabilityZoneCount int) string {
 	return fmt.Sprintf(`
-resource "aws_elasticsearch_domain" "example" {
-  domain_name = "tf-test-%d"
+resource "aws_elasticsearch_domain" "test" {
+  domain_name = %[1]q
+
+  cluster_config {
+    instance_type          = "t2.micro.elasticsearch"
+    instance_count         = 6
+    zone_awareness_enabled = true
+
+    zone_awareness_config {
+      availability_zone_count = %[2]d
+    }
+  }
 
   ebs_options {
     ebs_enabled = true
     volume_size = 10
   }
-  
+}
+`, rName, availabilityZoneCount)
+}
+
+func testAccESDomainConfig_ClusterConfig_ZoneAwarenessEnabled(rName string, zoneAwarenessEnabled bool) string {
+	return fmt.Sprintf(`
+resource "aws_elasticsearch_domain" "test" {
+  domain_name = %[1]q
+
   cluster_config {
-    instance_type = "t2.micro.elasticsearch"
-    instance_count = "6"
-    zone_awareness_enabled = %t
-    zone_awareness_count = "%d"
+    instance_type          = "t2.micro.elasticsearch"
+    instance_count         = 6
+    zone_awareness_enabled = %[2]t
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    volume_size = 10
   }
 }
-`, randInt, enabled, azcount)
+`, rName, zoneAwarenessEnabled)
 }
 
 func testAccESDomainConfig_WithDedicatedClusterMaster(randInt int, enabled bool) string {

--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -252,7 +252,7 @@ The following arguments are supported:
 
 **zone_awareness_config** supports the following attributes:
 
-* `availability_zone_count` - (Required) Number of Availability Zones for the domain to use when `zone_awareness_config` is enabled. Valid values: `2` or `3`.
+* `availability_zone_count` - (Optional) Number of Availability Zones for the domain to use with `zone_awareness_enabled`. Defaults to `2`. Valid values: `2` or `3`.
 
 **node_to_node_encryption** supports the following attributes:
 

--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -247,7 +247,12 @@ The following arguments are supported:
 * `dedicated_master_enabled` - (Optional) Indicates whether dedicated master nodes are enabled for the cluster.
 * `dedicated_master_type` - (Optional) Instance type of the dedicated master nodes in the cluster.
 * `dedicated_master_count` - (Optional) Number of dedicated master nodes in the cluster
-* `zone_awareness_enabled` - (Optional) Indicates whether zone awareness is enabled.
+* `zone_awareness_config` - (Optional) Configuration block containing zone awareness settings. Documented below.
+* `zone_awareness_enabled` - (Optional) Indicates whether zone awareness is enabled. To enable awareness with three Availability Zones, the `availability_zone_count` within the `zone_awareness_config` must be set to `3`.
+
+**zone_awareness_config** supports the following attributes:
+
+* `availability_zone_count` - (Required) Number of Availability Zones for the domain to use when `zone_awareness_config` is enabled. Valid values: `2` or `3`.
 
 **node_to_node_encryption** supports the following attributes:
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #7504 
Supersedes #8144

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_elasticsearch_domain: Add `cluster_config` configuration block `zone_awareness_config` configuration block (support three Availability Zone awareness)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSElasticSearchDomain_duplicate (597.97s)
--- PASS: TestAccAWSElasticSearchDomain_importBasic (725.23s)
--- PASS: TestAccAWSElasticSearchDomain_encrypt_at_rest_default_key (802.19s)
--- PASS: TestAccAWSElasticSearchDomain_tags (847.52s)
--- PASS: TestAccAWSElasticSearchDomain_basic (945.92s)
--- PASS: TestAccAWSElasticSearchDomain_v23 (1017.30s)
--- PASS: TestAccAWSElasticSearchDomain_vpc (1160.91s)
--- PASS: TestAccAWSElasticSearchDomain_policy (1210.63s)
--- PASS: TestAccAWSElasticSearchDomain_encrypt_at_rest_specify_key (1258.72s)
--- PASS: TestAccAWSElasticSearchDomain_NodeToNodeEncryption (1415.78s)
--- PASS: TestAccAWSElasticSearchDomain_complex (1476.53s)
--- PASS: TestAccAWSElasticSearchDomain_LogPublishingOptions (1695.50s)
--- PASS: TestAccAWSElasticSearchDomain_internetToVpcEndpoint (2051.69s)
--- PASS: TestAccAWSElasticSearchDomain_CognitoOptionsCreateAndRemove (2282.65s)
--- PASS: TestAccAWSElasticSearchDomain_update (2531.43s)
--- PASS: TestAccAWSElasticSearchDomain_CognitoOptionsUpdate (2880.18s)
--- PASS: TestAccAWSElasticSearchDomain_update_volume_type (3129.68s)
--- PASS: TestAccAWSElasticSearchDomain_vpc_update (3163.77s)
--- PASS: TestAccAWSElasticSearchDomain_withDedicatedMaster (3577.62s)
--- PASS: TestAccAWSElasticSearchDomain_update_version (3778.04s)
--- PASS: TestAccAWSElasticSearchDomain_ClusterConfig_ZoneAwarenessConfig (5371.73s)
```
