### PR TITLE
Ignore an empty iam_instance_profile name or ARN in aws_launch_template

### DIFF
--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -1335,6 +1335,10 @@ func readIamInstanceProfileFromConfig(iip map[string]interface{}) *ec2.LaunchTem
 		iamInstanceProfile.Name = aws.String(v)
 	}
 
+	if iamInstanceProfile.Arn == nil && iamInstanceProfile.Name == nil {
+		return nil
+	}
+
 	return iamInstanceProfile
 }
 

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -512,6 +512,20 @@ func TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock(t *test
 				),
 				ExpectNonEmptyPlan: true,
 			},
+			{
+				Config: testAccAWSLaunchTemplateConfigIamInstanceProfileEmptyArn(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template1),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccAWSLaunchTemplateConfigIamInstanceProfileEmptyName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template1),
+				),
+				ExpectNonEmptyPlan: true,
+			},
 		},
 	})
 }
@@ -987,6 +1001,30 @@ resource "aws_launch_template" "test" {
   name = %q
 
   iam_instance_profile {}
+}
+`, rName)
+}
+
+func testAccAWSLaunchTemplateConfigIamInstanceProfileEmptyArn(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_launch_template" "test" {
+  name = %q
+
+  iam_instance_profile {
+	  name = ""
+  }
+}
+`, rName)
+}
+
+func testAccAWSLaunchTemplateConfigIamInstanceProfileEmptyName(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_launch_template" "test" {
+  name = %q
+
+  iam_instance_profile {
+	  name = ""
+  }
 }
 `, rName)
 }


### PR DESCRIPTION
…om aws_launch_template resource

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #9308

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$  make testacc TEST=./aws TESTARGS='-run=TestAccAWSLaunchTemplate_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSLaunchTemplate_ -timeout 120m
=== RUN   TestAccAWSLaunchTemplate_importBasic
=== PAUSE TestAccAWSLaunchTemplate_importBasic
=== RUN   TestAccAWSLaunchTemplate_importData
=== PAUSE TestAccAWSLaunchTemplate_importData
=== RUN   TestAccAWSLaunchTemplate_basic
=== PAUSE TestAccAWSLaunchTemplate_basic
=== RUN   TestAccAWSLaunchTemplate_disappears
=== PAUSE TestAccAWSLaunchTemplate_disappears
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
=== PAUSE TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
=== PAUSE TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
=== RUN   TestAccAWSLaunchTemplate_EbsOptimized
=== PAUSE TestAccAWSLaunchTemplate_EbsOptimized
=== RUN   TestAccAWSLaunchTemplate_ElasticInferenceAccelerator
=== PAUSE TestAccAWSLaunchTemplate_ElasticInferenceAccelerator
=== RUN   TestAccAWSLaunchTemplate_data
=== PAUSE TestAccAWSLaunchTemplate_data
=== RUN   TestAccAWSLaunchTemplate_description
=== PAUSE TestAccAWSLaunchTemplate_description
=== RUN   TestAccAWSLaunchTemplate_update
=== PAUSE TestAccAWSLaunchTemplate_update
=== RUN   TestAccAWSLaunchTemplate_tags
=== PAUSE TestAccAWSLaunchTemplate_tags
=== RUN   TestAccAWSLaunchTemplate_capacityReservation_preference
=== PAUSE TestAccAWSLaunchTemplate_capacityReservation_preference
=== RUN   TestAccAWSLaunchTemplate_capacityReservation_target
=== PAUSE TestAccAWSLaunchTemplate_capacityReservation_target
=== RUN   TestAccAWSLaunchTemplate_creditSpecification_nonBurstable
=== PAUSE TestAccAWSLaunchTemplate_creditSpecification_nonBurstable
=== RUN   TestAccAWSLaunchTemplate_creditSpecification_t2
=== PAUSE TestAccAWSLaunchTemplate_creditSpecification_t2
=== RUN   TestAccAWSLaunchTemplate_creditSpecification_t3
=== PAUSE TestAccAWSLaunchTemplate_creditSpecification_t3
=== RUN   TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock
=== PAUSE TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock
=== RUN   TestAccAWSLaunchTemplate_networkInterface
=== PAUSE TestAccAWSLaunchTemplate_networkInterface
=== RUN   TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses
=== PAUSE TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses
=== RUN   TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount
=== PAUSE TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount
=== RUN   TestAccAWSLaunchTemplate_instanceMarketOptions
=== PAUSE TestAccAWSLaunchTemplate_instanceMarketOptions
=== RUN   TestAccAWSLaunchTemplate_licenseSpecification
=== PAUSE TestAccAWSLaunchTemplate_licenseSpecification
=== CONT  TestAccAWSLaunchTemplate_importBasic
=== CONT  TestAccAWSLaunchTemplate_capacityReservation_preference
=== CONT  TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock
=== CONT  TestAccAWSLaunchTemplate_creditSpecification_t3
=== CONT  TestAccAWSLaunchTemplate_creditSpecification_t2
=== CONT  TestAccAWSLaunchTemplate_creditSpecification_nonBurstable
=== CONT  TestAccAWSLaunchTemplate_capacityReservation_target
=== CONT  TestAccAWSLaunchTemplate_EbsOptimized
=== CONT  TestAccAWSLaunchTemplate_tags
=== CONT  TestAccAWSLaunchTemplate_update
=== CONT  TestAccAWSLaunchTemplate_description
=== CONT  TestAccAWSLaunchTemplate_data
=== CONT  TestAccAWSLaunchTemplate_ElasticInferenceAccelerator
=== CONT  TestAccAWSLaunchTemplate_disappears
=== CONT  TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
=== CONT  TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
=== CONT  TestAccAWSLaunchTemplate_instanceMarketOptions
=== CONT  TestAccAWSLaunchTemplate_licenseSpecification
=== CONT  TestAccAWSLaunchTemplate_basic
=== CONT  TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount
--- PASS: TestAccAWSLaunchTemplate_disappears (33.09s)
=== CONT  TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses
--- PASS: TestAccAWSLaunchTemplate_data (37.29s)
=== CONT  TestAccAWSLaunchTemplate_importData
--- PASS: TestAccAWSLaunchTemplate_basic (38.09s)
=== CONT  TestAccAWSLaunchTemplate_networkInterface
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount (38.10s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t2 (38.22s)
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_preference (38.22s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t3 (38.30s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_nonBurstable (38.32s)
--- PASS: TestAccAWSLaunchTemplate_licenseSpecification (40.25s)
--- PASS: TestAccAWSLaunchTemplate_importBasic (42.02s)
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_target (46.77s)
--- PASS: TestAccAWSLaunchTemplate_description (56.66s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses (25.68s)
--- PASS: TestAccAWSLaunchTemplate_tags (59.33s)
--- PASS: TestAccAWSLaunchTemplate_ElasticInferenceAccelerator (60.38s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS (61.84s)
--- PASS: TestAccAWSLaunchTemplate_importData (28.08s)
--- PASS: TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock (75.55s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface (49.65s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination (91.03s)
--- PASS: TestAccAWSLaunchTemplate_update (95.71s)
--- PASS: TestAccAWSLaunchTemplate_instanceMarketOptions (102.12s)
--- PASS: TestAccAWSLaunchTemplate_EbsOptimized (118.12s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	118.259s
```
