### PR TITLE
Add python_version for glue jobs

### DIFF
--- a/aws/resource_aws_glue_job.go
+++ b/aws/resource_aws_glue_job.go
@@ -47,6 +47,7 @@ func resourceAwsGlueJob() *schema.Resource {
 						"python_version": {
 							Type:         schema.TypeString,
 							Optional:     true,
+							Computed:     true,
 							ValidateFunc: validation.StringInSlice([]string{"2", "3"}, true),
 						},
 					},
@@ -336,7 +337,10 @@ func expandGlueJobCommand(l []interface{}) *glue.JobCommand {
 	jobCommand := &glue.JobCommand{
 		Name:           aws.String(m["name"].(string)),
 		ScriptLocation: aws.String(m["script_location"].(string)),
-		PythonVersion:  aws.String(m["python_version"].(string)),
+	}
+
+	if v, ok := m["python_version"].(string); ok && v != "" {
+		jobCommand.PythonVersion = aws.String(v)
 	}
 
 	return jobCommand

--- a/aws/resource_aws_glue_job.go
+++ b/aws/resource_aws_glue_job.go
@@ -45,8 +45,9 @@ func resourceAwsGlueJob() *schema.Resource {
 							Required: true,
 						},
 						"python_version": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice([]string{"2", "3"}, true),
 						},
 					},
 				},
@@ -369,6 +370,7 @@ func flattenGlueJobCommand(jobCommand *glue.JobCommand) []map[string]interface{}
 	m := map[string]interface{}{
 		"name":            aws.StringValue(jobCommand.Name),
 		"script_location": aws.StringValue(jobCommand.ScriptLocation),
+		"python_version":  aws.StringValue(jobCommand.PythonVersion),
 	}
 
 	return []map[string]interface{}{m}

--- a/aws/resource_aws_glue_job.go
+++ b/aws/resource_aws_glue_job.go
@@ -44,6 +44,10 @@ func resourceAwsGlueJob() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
+						"python_version": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -331,6 +335,7 @@ func expandGlueJobCommand(l []interface{}) *glue.JobCommand {
 	jobCommand := &glue.JobCommand{
 		Name:           aws.String(m["name"].(string)),
 		ScriptLocation: aws.String(m["script_location"].(string)),
+		PythonVersion:  aws.String(m["python_version"].(string)),
 	}
 
 	return jobCommand

--- a/aws/resource_aws_glue_job_test.go
+++ b/aws/resource_aws_glue_job_test.go
@@ -397,7 +397,6 @@ func TestAccAWSGlueJob_PythonShell(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "max_capacity", "0.0625"),
 					resource.TestCheckResourceAttr(resourceName, "command.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "command.0.script_location", "testscriptlocation"),
-					resource.TestCheckResourceAttr(resourceName, "command.0.python_version", "3"),
 					resource.TestCheckResourceAttr(resourceName, "command.0.name", "pythonshell"),
 				),
 			},
@@ -405,6 +404,31 @@ func TestAccAWSGlueJob_PythonShell(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSGlueJobConfig_PythonShellWithVersion(rName, "2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueJobExists(resourceName, &job),
+					resource.TestCheckResourceAttr(resourceName, "command.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "command.0.script_location", "testscriptlocation"),
+					resource.TestCheckResourceAttr(resourceName, "command.0.python_version", "2"),
+					resource.TestCheckResourceAttr(resourceName, "command.0.name", "pythonshell"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSGlueJobConfig_PythonShellWithVersion(rName, "3"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueJobExists(resourceName, &job),
+					resource.TestCheckResourceAttr(resourceName, "command.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "command.0.script_location", "testscriptlocation"),
+					resource.TestCheckResourceAttr(resourceName, "command.0.python_version", "3"),
+					resource.TestCheckResourceAttr(resourceName, "command.0.name", "pythonshell"),
+				),
 			},
 		},
 	})
@@ -730,12 +754,31 @@ resource "aws_glue_job" "test" {
   command {
     name            = "pythonshell"
     script_location = "testscriptlocation"
-    python_version =  "3"
   }
 
   depends_on = ["aws_iam_role_policy_attachment.test"]
 }
 `, testAccAWSGlueJobConfig_Base(rName), rName)
+}
+
+func testAccAWSGlueJobConfig_PythonShellWithVersion(rName string, pythonVersion string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "aws_glue_job" "test" {
+  name         = "%s"
+  role_arn     = "${aws_iam_role.test.arn}"
+  max_capacity = 0.0625
+
+  command {
+    name            = "pythonshell"
+    script_location = "testscriptlocation"
+		python_version  = "%s"
+  }
+
+  depends_on = ["aws_iam_role_policy_attachment.test"]
+}
+`, testAccAWSGlueJobConfig_Base(rName), rName, pythonVersion)
 }
 
 func testAccAWSGlueJobConfig_MaxCapacity(rName string, maxCapacity float64) string {

--- a/aws/resource_aws_glue_job_test.go
+++ b/aws/resource_aws_glue_job_test.go
@@ -730,7 +730,7 @@ resource "aws_glue_job" "test" {
   command {
     name            = "pythonshell"
     script_location = "testscriptlocation"
-    python_verison =  "3"
+    python_version =  "3"
   }
 
   depends_on = ["aws_iam_role_policy_attachment.test"]

--- a/aws/resource_aws_glue_job_test.go
+++ b/aws/resource_aws_glue_job_test.go
@@ -397,6 +397,7 @@ func TestAccAWSGlueJob_PythonShell(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "max_capacity", "0.0625"),
 					resource.TestCheckResourceAttr(resourceName, "command.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "command.0.script_location", "testscriptlocation"),
+					resource.TestCheckResourceAttr(resourceName, "command.0.python_version", "3"),
 					resource.TestCheckResourceAttr(resourceName, "command.0.name", "pythonshell"),
 				),
 			},
@@ -729,6 +730,7 @@ resource "aws_glue_job" "test" {
   command {
     name            = "pythonshell"
     script_location = "testscriptlocation"
+    python_verison =  "3"
   }
 
   depends_on = ["aws_iam_role_policy_attachment.test"]

--- a/website/docs/r/glue_job.html.markdown
+++ b/website/docs/r/glue_job.html.markdown
@@ -60,12 +60,13 @@ be removed in future releases, please use `max_capacity` instead.
 * `name` – (Required) The name you assign to this job. It must be unique in your account.
 * `role_arn` – (Required) The ARN of the IAM role associated with this job.
 * `timeout` – (Optional) The job timeout in minutes. The default is 2880 minutes (48 hours).
-* `security_configuration` - (Optional) The name of the Security Configuration to be associated with the job. 
+* `security_configuration` - (Optional) The name of the Security Configuration to be associated with the job.
 
 ### command Argument Reference
 
 * `name` - (Optional) The name of the job command. Defaults to `glueetl`
 * `script_location` - (Required) Specifies the S3 path to a script that executes a job.
+* `python_version` - (Optional) The Python version being used to execute a Python shell job. Allowed values are 2 or 3.
 
 ### execution_property Argument Reference
 


### PR DESCRIPTION
### Problem
Unable to specify the version of Python to use with pythonshell glue jobs despite supported in [API](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-setup.html)

### Solution
Add in ability to specify the python version with the JobCommand as mentioned in AWS [SDK](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Glue.html#createJob-property)

Signed-off-by: Mike Juarez <mikejuarez@gmail.com>

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Relates #9524 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Added ability to specify python version for pythonshell in glue jobs
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccXXX -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	0.045s [no tests to run]
```
