### PR TITLE
Acm cert transparency logging

### DIFF
--- a/aws/diff_suppress_funcs.go
+++ b/aws/diff_suppress_funcs.go
@@ -132,3 +132,14 @@ func suppressRoute53ZoneNameWithTrailingDot(k, old, new string, d *schema.Resour
 	}
 	return strings.TrimSuffix(old, ".") == strings.TrimSuffix(new, ".")
 }
+
+func suppressAcmMissingCertificateOptions(k, old, new string, d *schema.ResourceData) bool {
+	if _, ok := d.GetOk("private_key"); ok {
+		// ignore diffs for imported certs; they have a different logging preference
+		// default to requested certs which can't be changed by the ImportCertificate API
+		return true
+	} else {
+		// behave just like suppressMissingOptionalConfigurationBlock() for requested certs
+		return old == "1" && new == "0"
+	}
+}

--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -11,7 +11,13 @@ import (
 	"github.com/aws/aws-sdk-go/service/acm"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
+
+var validCTLoggingPreferences = []string{
+	acm.CertificateTransparencyLoggingPreferenceEnabled,
+	acm.CertificateTransparencyLoggingPreferenceDisabled,
+}
 
 func resourceAwsAcmCertificate() *schema.Resource {
 	return &schema.Resource{
@@ -22,7 +28,6 @@ func resourceAwsAcmCertificate() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
-
 		Schema: map[string]*schema.Schema{
 			"certificate_body": {
 				Type:      schema.TypeString,
@@ -108,6 +113,24 @@ func resourceAwsAcmCertificate() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"options": {
+				Type:             schema.TypeList,
+				Optional:         true,
+				MaxItems:         1,
+				DiffSuppressFunc: suppressAcmMissingCertificateOptions,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"certificate_transparency_logging_preference": {
+							Type:          schema.TypeString,
+							Optional:      true,
+							Default:       acm.CertificateTransparencyLoggingPreferenceEnabled,
+							ForceNew:      true,
+							ConflictsWith: []string{"private_key", "certificate_body", "certificate_chain"},
+							ValidateFunc:  validation.StringInSlice(validCTLoggingPreferences, false),
+						},
+					},
+				},
+			},
 			"tags": tagsSchema(),
 		},
 	}
@@ -164,6 +187,11 @@ func resourceAwsAcmCertificateCreateRequested(d *schema.ResourceData, meta inter
 			subjectAlternativeNames[i] = aws.String(strings.TrimSuffix(sanRaw.(string), "."))
 		}
 		params.SubjectAlternativeNames = subjectAlternativeNames
+	}
+
+	cert_options := expandAcmCertificateOptions(d.Get("options").([]interface{}))
+	if cert_options != nil {
+		params.SetOptions(cert_options)
 	}
 
 	log.Printf("[DEBUG] ACM Certificate Request: %#v", params)
@@ -228,6 +256,10 @@ func resourceAwsAcmCertificateRead(d *schema.ResourceData, meta interface{}) err
 		}
 
 		d.Set("validation_method", resourceAwsAcmCertificateGuessValidationMethod(domainValidationOptions, emailValidationOptions))
+
+		if err := d.Set("options", flattenAcmCertificateOptions(resp.Certificate.Options)); err != nil {
+			return resource.NonRetryableError(fmt.Errorf("error setting certificate options: %s", err))
+		}
 
 		params := &acm.ListTagsForCertificateInput{
 			CertificateArn: aws.String(d.Id()),
@@ -357,4 +389,28 @@ func resourceAwsAcmCertificateImport(conn *acm.ACM, d *schema.ResourceData, upda
 
 	log.Printf("[DEBUG] ACM Certificate Import: %#v", params)
 	return conn.ImportCertificate(params)
+}
+
+func expandAcmCertificateOptions(l []interface{}) *acm.CertificateOptions {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	options := &acm.CertificateOptions{}
+
+	if v, ok := m["certificate_transparency_logging_preference"]; ok {
+		options.CertificateTransparencyLoggingPreference = aws.String(v.(string))
+	}
+
+	return options
+}
+
+func flattenAcmCertificateOptions(co *acm.CertificateOptions) []interface{} {
+	m := map[string]interface{}{
+		"certificate_transparency_logging_preference": aws.StringValue(co.CertificateTransparencyLoggingPreference),
+	}
+
+	return []interface{}{m}
 }

--- a/website/docs/r/acm_certificate.html.markdown
+++ b/website/docs/r/acm_certificate.html.markdown
@@ -84,11 +84,18 @@ The following arguments are supported:
   * `domain_name` - (Required) A domain name for which the certificate should be issued
   * `subject_alternative_names` - (Optional) A list of domains that should be SANs in the issued certificate
   * `validation_method` - (Required) Which method to use for validation. `DNS` or `EMAIL` are valid, `NONE` can be used for certificates that were imported into ACM and then into Terraform.
+  * `options` - (Optional) Configuration block used to set certificate options. Detailed below.
 * Importing an existing certificate
   * `private_key` - (Required) The certificate's PEM-formatted private key
   * `certificate_body` - (Required) The certificate's PEM-formatted public key
   * `certificate_chain` - (Optional) The certificate's PEM-formatted chain
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+
+## options Configuration Block
+
+Supported nested arguments for the `options` configuration block:
+
+* `certificate_transparency_logging_preference` - (Optional) Specifies whether certificate details should be added to a certificate transparency log. Valid values are `ENABLED` or `DISABLED`. See https://docs.aws.amazon.com/acm/latest/userguide/acm-concepts.html#concept-transparency for more details.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #6789

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```
resource/aws_acm_certificate: Support `options` configuration block `certificate_transparency_logging_preference` argument [GH-6789]
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAcmCertificate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSAcmCertificate -timeout 120m
...
--- PASS: TestAccAWSAcmCertificateDataSource_noMatchReturnsError (21.76s)
--- PASS: TestAccAWSAcmCertificateValidation_timeout (31.86s)
--- PASS: TestAccAWSAcmCertificate_imported_IpAddress (32.80s)
--- PASS: TestAccAWSAcmCertificate_root_TrailingPeriod (36.65s)
--- PASS: TestAccAWSAcmCertificate_wildcard (36.98s)
--- PASS: TestAccAWSAcmCertificate_root (37.06s)
--- PASS: TestAccAWSAcmCertificate_dnsValidation (38.94s)
--- PASS: TestAccAWSAcmCertificate_disableCTLogging (34.14s)
--- PASS: TestAccAWSAcmCertificateDataSource_KeyTypes (36.32s)
--- PASS: TestAccAWSAcmCertificate_emailValidation (36.92s)
--- PASS: TestAccAWSAcmCertificate_wildcardAndRootSan (48.05s)
--- PASS: TestAccAWSAcmCertificate_imported_DomainName (56.33s)
--- PASS: TestAccAWSAcmCertificate_tags (97.05s)
...
```
Note that the other acceptance tests fail, but that looks to be because of the DNS config in my test account