### PR TITLE
Retries after timeouts for KMS keys and grants.

### DIFF
--- a/aws/resource_aws_kms_grant_test.go
+++ b/aws/resource_aws_kms_grant_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -169,18 +170,18 @@ resource "aws_kms_key" "tf-acc-test-key" {
 %s
 
 resource "aws_iam_role" "tf-acc-test-role" {
-  name               = "tf-acc-test-kms-grant-role-%s"
+  name               = "%s"
   path               = "/service-role/"
   assume_role_policy = "${data.aws_iam_policy_document.assumerole-policy-template.json}"
 }
 
-resource "aws_kms_grant" "%s" {
-	name = "%s"
+resource "aws_kms_grant" "%[4]s" {
+	name = "%[4]s"
 	key_id = "${aws_kms_key.tf-acc-test-key.key_id}"
 	grantee_principal = "${aws_iam_role.tf-acc-test-role.arn}"
-	operations = [ %s ]
+	operations = [ %[5]s ]
 }
-`, timestamp, staticAssumeRolePolicyString, rName, rName, rName, operations)
+`, timestamp, staticAssumeRolePolicyString, acctest.RandomWithPrefix("tf-acc-test-kms-grant-role"), rName, operations)
 }
 
 func testAccAWSKmsGrant_withConstraints(rName string, timestamp string, constraintName string, encryptionContext string) string {
@@ -193,23 +194,23 @@ resource "aws_kms_key" "tf-acc-test-key" {
 %s
 
 resource "aws_iam_role" "tf-acc-test-role" {
-  name               = "tf-acc-test-kms-grant-role-%s"
+  name               = "%s"
   path               = "/service-role/"
   assume_role_policy = "${data.aws_iam_policy_document.assumerole-policy-template.json}"
 }
 
-resource "aws_kms_grant" "%s" {
-	name = "%s"
+resource "aws_kms_grant" "%[4]s" {
+	name = "%[4]s"
 	key_id = "${aws_kms_key.tf-acc-test-key.key_id}"
 	grantee_principal = "${aws_iam_role.tf-acc-test-role.arn}"
 	operations = [ "RetireGrant", "DescribeKey" ]
 	constraints {
-		%s = {
-			%s
+		%[5]s = {
+			%[6]s
 		}
 	}
 }
-`, timestamp, staticAssumeRolePolicyString, rName, rName, rName, constraintName, encryptionContext)
+`, timestamp, staticAssumeRolePolicyString, acctest.RandomWithPrefix("tf-acc-test-kms-grant-role"), rName, constraintName, encryptionContext)
 }
 
 func testAccAWSKmsGrant_withRetiringPrincipal(rName string, timestamp string) string {
@@ -222,19 +223,19 @@ resource "aws_kms_key" "tf-acc-test-key" {
 %s
 
 resource "aws_iam_role" "tf-acc-test-role" {
-  name               = "tf-acc-test-kms-grant-role-%s"
+  name               = "%s"
   path               = "/service-role/"
   assume_role_policy = "${data.aws_iam_policy_document.assumerole-policy-template.json}"
 }
 
-resource "aws_kms_grant" "%s" {
-  name               = "%s"
+resource "aws_kms_grant" "%[4]s" {
+  name               = "%[4]s"
   key_id             = "${aws_kms_key.tf-acc-test-key.key_id}"
   grantee_principal  = "${aws_iam_role.tf-acc-test-role.arn}"
   operations         = ["ReEncryptTo", "CreateGrant"]
   retiring_principal = "${aws_iam_role.tf-acc-test-role.arn}"
 }
-`, timestamp, staticAssumeRolePolicyString, rName, rName, rName)
+`, timestamp, staticAssumeRolePolicyString, acctest.RandomWithPrefix("tf-acc-test-kms-grant-role"), rName)
 }
 
 func testAccAWSKmsGrant_bare(rName string, timestamp string) string {
@@ -247,7 +248,7 @@ resource "aws_kms_key" "tf-acc-test-key" {
 %s
 
 resource "aws_iam_role" "tf-acc-test-role" {
-  name               = "tf-acc-test-kms-grant-role-%s"
+  name               = "%s"
   path               = "/service-role/"
   assume_role_policy = "${data.aws_iam_policy_document.assumerole-policy-template.json}"
 }
@@ -257,7 +258,7 @@ resource "aws_kms_grant" "%s" {
   grantee_principal = "${aws_iam_role.tf-acc-test-role.arn}"
   operations        = ["ReEncryptTo", "CreateGrant"]
 }
-`, timestamp, staticAssumeRolePolicyString, rName, rName)
+`, timestamp, staticAssumeRolePolicyString, acctest.RandomWithPrefix("tf-acc-test-kms-grant-role"), rName)
 }
 
 const staticAssumeRolePolicyString = `
@@ -283,16 +284,16 @@ resource "aws_kms_key" "tf-acc-test-key" {
 %s
 
 resource "aws_iam_role" "tf-acc-test-role" {
-  name               = "tf-acc-test-kms-grant-role-%s"
+  name               = "%s"
   path               = "/service-role/"
   assume_role_policy = "${data.aws_iam_policy_document.assumerole-policy-template.json}"
 }
 
-resource "aws_kms_grant" "%s" {
-	name = "%s"
+resource "aws_kms_grant" "%[4]s" {
+	name = "%[4]s"
 	key_id = "${aws_kms_key.tf-acc-test-key.arn}"
 	grantee_principal = "${aws_iam_role.tf-acc-test-role.arn}"
-	operations = [ %s ]
+	operations = [ %[5]s ]
 }
-`, timestamp, staticAssumeRolePolicyString, rName, rName, rName, operations)
+`, timestamp, staticAssumeRolePolicyString, acctest.RandomWithPrefix("tf-acc-test-kms-grant-role"), rName, operations)
 }

--- a/aws/resource_aws_kms_key.go
+++ b/aws/resource_aws_kms_key.go
@@ -108,6 +108,9 @@ func resourceAwsKmsKeyCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 		return resource.NonRetryableError(err)
 	})
+	if isResourceTimeoutError(err) {
+		resp, err = conn.CreateKey(&req)
+	}
 	if err != nil {
 		return err
 	}
@@ -336,17 +339,7 @@ func updateKmsKeyRotationStatus(conn *kms.KMS, d *schema.ResourceData) error {
 
 	err := resource.Retry(10*time.Minute, func() *resource.RetryError {
 		var err error
-		if shouldEnableRotation {
-			log.Printf("[DEBUG] Enabling key rotation for KMS key %q", d.Id())
-			_, err = conn.EnableKeyRotation(&kms.EnableKeyRotationInput{
-				KeyId: aws.String(d.Id()),
-			})
-		} else {
-			log.Printf("[DEBUG] Disabling key rotation for KMS key %q", d.Id())
-			_, err = conn.DisableKeyRotation(&kms.DisableKeyRotationInput{
-				KeyId: aws.String(d.Id()),
-			})
-		}
+		err = handleKeyRotation(conn, shouldEnableRotation, aws.String(d.Id()))
 
 		if err != nil {
 			awsErr, ok := err.(awserr.Error)
@@ -362,6 +355,9 @@ func updateKmsKeyRotationStatus(conn *kms.KMS, d *schema.ResourceData) error {
 
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		err = handleKeyRotation(conn, shouldEnableRotation, aws.String(d.Id()))
+	}
 
 	if err != nil {
 		return fmt.Errorf("Failed to set key rotation for %q to %t: %q",
@@ -402,6 +398,22 @@ func updateKmsKeyRotationStatus(conn *kms.KMS, d *schema.ResourceData) error {
 	}
 
 	return nil
+}
+
+func handleKeyRotation(conn *kms.KMS, shouldEnableRotation bool, keyId *string) error {
+	var err error
+	if shouldEnableRotation {
+		log.Printf("[DEBUG] Enabling key rotation for KMS key %q", *keyId)
+		_, err = conn.EnableKeyRotation(&kms.EnableKeyRotationInput{
+			KeyId: keyId,
+		})
+	} else {
+		log.Printf("[DEBUG] Disabling key rotation for KMS key %q", *keyId)
+		_, err = conn.DisableKeyRotation(&kms.DisableKeyRotationInput{
+			KeyId: keyId,
+		})
+	}
+	return err
 }
 
 func resourceAwsKmsKeyExists(d *schema.ResourceData, meta interface{}) (bool, error) {

--- a/aws/resource_aws_kms_key.go
+++ b/aws/resource_aws_kms_key.go
@@ -338,8 +338,7 @@ func updateKmsKeyRotationStatus(conn *kms.KMS, d *schema.ResourceData) error {
 	shouldEnableRotation := d.Get("enable_key_rotation").(bool)
 
 	err := resource.Retry(10*time.Minute, func() *resource.RetryError {
-		var err error
-		err = handleKeyRotation(conn, shouldEnableRotation, aws.String(d.Id()))
+		err := handleKeyRotation(conn, shouldEnableRotation, aws.String(d.Id()))
 
 		if err != nil {
 			awsErr, ok := err.(awserr.Error)


### PR DESCRIPTION
Also updating the KMS grant tests to have randomized IAM role names.


<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* aws/kms_grant: Final retries after timeouts when creating, finding, and revoking grants
* aws/kms_key: Final retries after timeouts when creating keys and updating key rotation status
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSKmsGrant"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSKmsGrant -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSKmsGrant_Basic
=== PAUSE TestAccAWSKmsGrant_Basic
=== RUN   TestAccAWSKmsGrant_withConstraints
=== PAUSE TestAccAWSKmsGrant_withConstraints
=== RUN   TestAccAWSKmsGrant_withRetiringPrincipal
=== PAUSE TestAccAWSKmsGrant_withRetiringPrincipal
=== RUN   TestAccAWSKmsGrant_bare
=== PAUSE TestAccAWSKmsGrant_bare
=== RUN   TestAccAWSKmsGrant_ARN
=== PAUSE TestAccAWSKmsGrant_ARN
=== CONT  TestAccAWSKmsGrant_Basic
=== CONT  TestAccAWSKmsGrant_bare
=== CONT  TestAccAWSKmsGrant_withConstraints
=== CONT  TestAccAWSKmsGrant_ARN
=== CONT  TestAccAWSKmsGrant_withRetiringPrincipal
--- PASS: TestAccAWSKmsGrant_bare (74.60s)
--- PASS: TestAccAWSKmsGrant_Basic (74.78s)
--- PASS: TestAccAWSKmsGrant_ARN (74.94s)
--- PASS: TestAccAWSKmsGrant_withRetiringPrincipal (75.04s)
--- PASS: TestAccAWSKmsGrant_withConstraints (118.40s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       120.493s

make testacc TESTARGS="-run=TestAccAWSKmsKey"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSKmsKey -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSKmsKey_importBasic
=== PAUSE TestAccAWSKmsKey_importBasic
=== RUN   TestAccAWSKmsKey_basic
=== PAUSE TestAccAWSKmsKey_basic
=== RUN   TestAccAWSKmsKey_disappears
=== PAUSE TestAccAWSKmsKey_disappears
=== RUN   TestAccAWSKmsKey_policy
=== PAUSE TestAccAWSKmsKey_policy
=== RUN   TestAccAWSKmsKey_isEnabled
=== PAUSE TestAccAWSKmsKey_isEnabled
=== RUN   TestAccAWSKmsKey_tags
=== PAUSE TestAccAWSKmsKey_tags
=== CONT  TestAccAWSKmsKey_importBasic
=== CONT  TestAccAWSKmsKey_tags
=== CONT  TestAccAWSKmsKey_disappears
=== CONT  TestAccAWSKmsKey_policy
=== CONT  TestAccAWSKmsKey_isEnabled
=== CONT  TestAccAWSKmsKey_basic
--- PASS: TestAccAWSKmsKey_disappears (33.33s)
--- PASS: TestAccAWSKmsKey_policy (60.97s)
--- PASS: TestAccAWSKmsKey_tags (61.04s)
--- PASS: TestAccAWSKmsKey_importBasic (66.31s)
--- PASS: TestAccAWSKmsKey_basic (81.36s)
--- PASS: TestAccAWSKmsKey_isEnabled (292.76s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       293.826s
```