### PR TITLE
Final retry when creating SES domain identity verification

### DIFF
--- a/aws/resource_aws_ses_domain_identity_verification.go
+++ b/aws/resource_aws_ses_domain_identity_verification.go
@@ -73,8 +73,16 @@ func resourceAwsSesDomainIdentityVerificationCreate(d *schema.ResourceData, meta
 
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		var att *ses.IdentityVerificationAttributes
+		att, err = getAwsSesIdentityVerificationAttributes(conn, domainName)
+
+		if aws.StringValue(att.VerificationStatus) != ses.VerificationStatusSuccess {
+			return fmt.Errorf("Expected domain verification Success, but was in state %s", aws.StringValue(att.VerificationStatus))
+		}
+	}
 	if err != nil {
-		return err
+		return fmt.Errorf("Error creating SES domain identity verification: %s", err)
 	}
 
 	log.Printf("[INFO] Domain verification successful for %s", domainName)

--- a/aws/resource_aws_ses_domain_identity_verification.go
+++ b/aws/resource_aws_ses_domain_identity_verification.go
@@ -77,7 +77,7 @@ func resourceAwsSesDomainIdentityVerificationCreate(d *schema.ResourceData, meta
 		var att *ses.IdentityVerificationAttributes
 		att, err = getAwsSesIdentityVerificationAttributes(conn, domainName)
 
-		if aws.StringValue(att.VerificationStatus) != ses.VerificationStatusSuccess {
+		if att != nil && aws.StringValue(att.VerificationStatus) != ses.VerificationStatusSuccess {
 			return fmt.Errorf("Expected domain verification Success, but was in state %s", aws.StringValue(att.VerificationStatus))
 		}
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES
* aws/ses_domain_identity_verification: Retry after timeout when creating SES domain identity verification

```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAwsSesDomainIdentityVerification"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAwsSesDomainIdentityVerification -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAwsSesDomainIdentityVerification_basic
--- SKIP: TestAccAwsSesDomainIdentityVerification_basic (0.00s)
    resource_aws_ses_domain_identity_verification_test.go:20: Environment variable SES_DOMAIN_IDENTITY_ROOT_DOMAIN is not set. For DNS verification requests, this domain must be publicly accessible and configurable via Route53 during the testing. 
=== RUN   TestAccAwsSesDomainIdentityVerification_timeout
=== PAUSE TestAccAwsSesDomainIdentityVerification_timeout
=== RUN   TestAccAwsSesDomainIdentityVerification_nonexistent
=== PAUSE TestAccAwsSesDomainIdentityVerification_nonexistent
=== CONT  TestAccAwsSesDomainIdentityVerification_timeout
=== CONT  TestAccAwsSesDomainIdentityVerification_nonexistent
--- PASS: TestAccAwsSesDomainIdentityVerification_nonexistent (11.50s)
--- PASS: TestAccAwsSesDomainIdentityVerification_timeout (21.79s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       22.645s
```