### PR TITLE
Add support import for aws_wafregional_ipset resource

### DIFF
--- a/aws/resource_aws_wafregional_ipset.go
+++ b/aws/resource_aws_wafregional_ipset.go
@@ -18,6 +18,9 @@ func resourceAwsWafRegionalIPSet() *schema.Resource {
 		Read:   resourceAwsWafRegionalIPSetRead,
 		Update: resourceAwsWafRegionalIPSetUpdate,
 		Delete: resourceAwsWafRegionalIPSetDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/aws/resource_aws_wafregional_ipset_test.go
+++ b/aws/resource_aws_wafregional_ipset_test.go
@@ -196,7 +196,7 @@ func TestAccAWSWafRegionalIPSet_IpSetDescriptors_1000UpdateLimit(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "aws_wafregional_ipset.ipset",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},

--- a/aws/resource_aws_wafregional_ipset_test.go
+++ b/aws/resource_aws_wafregional_ipset_test.go
@@ -41,6 +41,11 @@ func TestAccAWSWafRegionalIPSet_basic(t *testing.T) {
 						regexp.MustCompile(`^arn:[\w-]+:waf-regional:[^:]+:\d{12}:ipset/.+$`)),
 				),
 			},
+			{
+				ResourceName:      "aws_wafregional_ipset.ipset",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -99,6 +104,11 @@ func TestAccAWSWafRegionalIPSet_changeNameForceNew(t *testing.T) {
 						"aws_wafregional_ipset.ipset", "ip_set_descriptor.4037960608.value", "192.0.7.0/24"),
 				),
 			},
+			{
+				ResourceName:      "aws_wafregional_ipset.ipset",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -140,6 +150,11 @@ func TestAccAWSWafRegionalIPSet_changeDescriptors(t *testing.T) {
 						"aws_wafregional_ipset.ipset", "ip_set_descriptor.115741513.value", "192.0.8.0/24"),
 				),
 			},
+			{
+				ResourceName:      "aws_wafregional_ipset.ipset",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -180,6 +195,11 @@ func TestAccAWSWafRegionalIPSet_IpSetDescriptors_1000UpdateLimit(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptor.#", "2048"),
 				),
 			},
+			{
+				ResourceName:      "aws_wafregional_ipset.ipset",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -202,6 +222,11 @@ func TestAccAWSWafRegionalIPSet_noDescriptors(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_ipset.ipset", "ip_set_descriptor.#", "0"),
 				),
+			},
+			{
+				ResourceName:      "aws_wafregional_ipset.ipset",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/website/docs/r/wafregional_ipset.html.markdown
+++ b/website/docs/r/wafregional_ipset.html.markdown
@@ -53,3 +53,11 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the WAF IPSet.
 * `arn` - The ARN of the WAF IPSet.
+
+## Import
+
+WAF Regional IPSets can be imported using their ID, e.g.
+
+```
+$ terraform import aws_wafregional_ipset.example a1b2c3d4-d5f6-7777-8888-9999aaaabbbbcccc
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #9397

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_wafregional_ipset: Support resource import
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSWafRegionalIPSet'
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSWafRegionalIPSet -timeout 120m
=== RUN   TestAccAWSWafRegionalIPSet_basic
=== PAUSE TestAccAWSWafRegionalIPSet_basic
=== RUN   TestAccAWSWafRegionalIPSet_disappears
=== PAUSE TestAccAWSWafRegionalIPSet_disappears
=== RUN   TestAccAWSWafRegionalIPSet_changeNameForceNew
=== PAUSE TestAccAWSWafRegionalIPSet_changeNameForceNew
=== RUN   TestAccAWSWafRegionalIPSet_changeDescriptors
=== PAUSE TestAccAWSWafRegionalIPSet_changeDescriptors
=== RUN   TestAccAWSWafRegionalIPSet_IpSetDescriptors_1000UpdateLimit
=== PAUSE TestAccAWSWafRegionalIPSet_IpSetDescriptors_1000UpdateLimit
=== RUN   TestAccAWSWafRegionalIPSet_noDescriptors
=== PAUSE TestAccAWSWafRegionalIPSet_noDescriptors
=== CONT  TestAccAWSWafRegionalIPSet_basic
=== CONT  TestAccAWSWafRegionalIPSet_noDescriptors
=== CONT  TestAccAWSWafRegionalIPSet_IpSetDescriptors_1000UpdateLimit
=== CONT  TestAccAWSWafRegionalIPSet_changeDescriptors
=== CONT  TestAccAWSWafRegionalIPSet_changeNameForceNew
=== CONT  TestAccAWSWafRegionalIPSet_disappears
--- PASS: TestAccAWSWafRegionalIPSet_noDescriptors (24.72s)
--- PASS: TestAccAWSWafRegionalIPSet_disappears (26.56s)
--- PASS: TestAccAWSWafRegionalIPSet_basic (38.56s)
--- PASS: TestAccAWSWafRegionalIPSet_changeDescriptors (51.53s)
--- PASS: TestAccAWSWafRegionalIPSet_changeNameForceNew (56.63s)
--- PASS: TestAccAWSWafRegionalIPSet_IpSetDescriptors_1000UpdateLimit (86.18s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       86.236s
...
```
