### PR TITLE
Glue Crawler: Add catalog target config

### DIFF
--- a/aws/resource_aws_glue_crawler.go
+++ b/aws/resource_aws_glue_crawler.go
@@ -159,6 +159,24 @@ func resourceAwsGlueCrawler() *schema.Resource {
 					},
 				},
 			},
+			"catalog_target": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MinItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"database_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"tables": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
 			"configuration": {
 				Type:             schema.TypeString,
 				Optional:         true,
@@ -325,14 +343,16 @@ func expandGlueCrawlerTargets(d *schema.ResourceData) (*glue.CrawlerTargets, err
 	dynamodbTargets, dynamodbTargetsOk := d.GetOk("dynamodb_target")
 	jdbcTargets, jdbcTargetsOk := d.GetOk("jdbc_target")
 	s3Targets, s3TargetsOk := d.GetOk("s3_target")
-	if !dynamodbTargetsOk && !jdbcTargetsOk && !s3TargetsOk {
-		return nil, fmt.Errorf("One of the following configurations is required: dynamodb_target, jdbc_target, s3_target")
+	catalogTargets, catalogTargetsOk := d.GetOk("catalog_target")
+	if !dynamodbTargetsOk && !jdbcTargetsOk && !s3TargetsOk && !catalogTargetsOk {
+		return nil, fmt.Errorf("One of the following configurations is required: dynamodb_target, jdbc_target, s3_target, catalog_target")
 	}
 
 	log.Print("[DEBUG] Creating crawler target")
 	crawlerTargets.DynamoDBTargets = expandGlueDynamoDBTargets(dynamodbTargets.([]interface{}))
 	crawlerTargets.JdbcTargets = expandGlueJdbcTargets(jdbcTargets.([]interface{}))
 	crawlerTargets.S3Targets = expandGlueS3Targets(s3Targets.([]interface{}))
+	crawlerTargets.CatalogTargets = expandGlueCatalogTargets(catalogTargets.([]interface{}))
 
 	return crawlerTargets, nil
 }
@@ -404,6 +424,28 @@ func expandGlueJdbcTarget(cfg map[string]interface{}) *glue.JdbcTarget {
 	if exclusions, ok := cfg["exclusions"]; ok {
 		target.Exclusions = expandStringList(exclusions.([]interface{}))
 	}
+	return target
+}
+
+func expandGlueCatalogTargets(targets []interface{}) []*glue.CatalogTarget {
+	if len(targets) < 1 {
+		return []*glue.CatalogTarget{}
+	}
+
+	perms := make([]*glue.CatalogTarget, len(targets))
+	for i, rawCfg := range targets {
+		cfg := rawCfg.(map[string]interface{})
+		perms[i] = expandGlueCatalogTarget(cfg)
+	}
+	return perms
+}
+
+func expandGlueCatalogTarget(cfg map[string]interface{}) *glue.CatalogTarget {
+	target := &glue.CatalogTarget{
+		DatabaseName: aws.String(cfg["database_name"].(string)),
+		Tables:       expandStringList(cfg["tables"].([]interface{})),
+	}
+
 	return target
 }
 

--- a/aws/resource_aws_glue_crawler.go
+++ b/aws/resource_aws_glue_crawler.go
@@ -551,6 +551,10 @@ func resourceAwsGlueCrawlerRead(d *schema.ResourceData, meta interface{}) error 
 		if err := d.Set("s3_target", flattenGlueS3Targets(crawlerOutput.Crawler.Targets.S3Targets)); err != nil {
 			return fmt.Errorf("error setting s3_target: %s", err)
 		}
+
+		if err := d.Set("catalog_target", flattenGlueCatalogTargets(crawlerOutput.Crawler.Targets.CatalogTargets)); err != nil {
+			return fmt.Errorf("error setting catalog_target: %s", err)
+		}
 	}
 
 	return nil
@@ -563,6 +567,19 @@ func flattenGlueS3Targets(s3Targets []*glue.S3Target) []map[string]interface{} {
 		attrs := make(map[string]interface{})
 		attrs["exclusions"] = flattenStringList(s3Target.Exclusions)
 		attrs["path"] = aws.StringValue(s3Target.Path)
+
+		result = append(result, attrs)
+	}
+	return result
+}
+
+func flattenGlueCatalogTargets(CatalogTargets []*glue.CatalogTarget) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0)
+
+	for _, catalogTarget := range CatalogTargets {
+		attrs := make(map[string]interface{})
+		attrs["tables"] = flattenStringList(catalogTarget.Tables)
+		attrs["database_name"] = aws.StringValue(catalogTarget.DatabaseName)
 
 		result = append(result, attrs)
 	}

--- a/aws/resource_aws_glue_crawler_test.go
+++ b/aws/resource_aws_glue_crawler_test.go
@@ -445,6 +445,76 @@ func TestAccAWSGlueCrawler_S3Target_Multiple(t *testing.T) {
 	})
 }
 
+func TestAccAWSGlueCrawler_CatalogTarget(t *testing.T) {
+	var crawler glue.Crawler
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_glue_crawler.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueCrawlerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlueCrawlerConfig_CatalogTarget(rName, []string{"table_1"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "classifiers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "database_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb_target.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "jdbc_target.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "s3_target.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "role", rName),
+					resource.TestCheckResourceAttr(resourceName, "catalog_target.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "catalog_target.0.database_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "catalog_target.0.tables.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "catalog_target.0.tables.0", "table_1"),
+					resource.TestCheckResourceAttr(resourceName, "schedule", ""),
+					resource.TestCheckResourceAttr(resourceName, "schema_change_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "schema_change_policy.0.delete_behavior", "LOG"),
+					resource.TestCheckResourceAttr(resourceName, "schema_change_policy.0.update_behavior", "UPDATE_IN_DATABASE"),
+					resource.TestCheckResourceAttr(resourceName, "table_prefix", ""),
+					resource.TestCheckResourceAttr(resourceName, "configuration", "{\"Version\":1.0,\"Grouping\":{\"TableGroupingPolicy\":\"CombineCompatibleSchemas\"}}"),
+				),
+			},
+			{
+				Config: testAccGlueCrawlerConfig_CatalogTarget(rName, []string{"table_1", "table_2"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "classifiers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "database_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb_target.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "jdbc_target.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "s3_target.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "role", rName),
+					resource.TestCheckResourceAttr(resourceName, "catalog_target.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "catalog_target.0.database_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "catalog_target.0.tables.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "catalog_target.0.tables.0", "table_1"),
+					resource.TestCheckResourceAttr(resourceName, "catalog_target.0.tables.1", "table_2"),
+					resource.TestCheckResourceAttr(resourceName, "schedule", ""),
+					resource.TestCheckResourceAttr(resourceName, "schema_change_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "schema_change_policy.0.delete_behavior", "LOG"),
+					resource.TestCheckResourceAttr(resourceName, "schema_change_policy.0.update_behavior", "UPDATE_IN_DATABASE"),
+					resource.TestCheckResourceAttr(resourceName, "table_prefix", ""),
+					resource.TestCheckResourceAttr(resourceName, "configuration", "{\"Version\":1.0,\"Grouping\":{\"TableGroupingPolicy\":\"CombineCompatibleSchemas\"}}"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSGlueCrawler_recreates(t *testing.T) {
 	var crawler glue.Crawler
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -893,26 +963,26 @@ data "aws_partition" "current" {}
 
 resource "aws_iam_role" "test" {
   name = %q
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "glue.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
+  assume_role_policy = "${data.aws_iam_policy_document.assume.json}"
 }
-EOF
+
+data "aws_iam_policy_document" "assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["glue.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy" "AWSGlueServiceRole" {
+  arn = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
 }
 
 resource "aws_iam_role_policy_attachment" "test-AWSGlueServiceRole" {
-  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSGlueServiceRole"
+  policy_arn = "${data.aws_iam_policy.AWSGlueServiceRole.arn}"
   role       = "${aws_iam_role.test.name}"
 }
 `, rName)
@@ -1389,6 +1459,78 @@ resource "aws_glue_crawler" "test" {
   }
 }
 `, rName, rName, path1, path2)
+}
+
+func testAccGlueCrawlerConfig_CatalogTarget_TableResources(tables []string) string {
+	var config string
+	for _, table := range tables {
+		config += fmt.Sprintf(`
+      resource "aws_glue_catalog_table" %q {
+        database_name = "${aws_glue_catalog_database.test.name}"
+        name          = %q
+        table_type    = "EXTERNAL_TABLE"
+
+        storage_descriptor {
+          location      = "s3://${aws_s3_bucket.default.bucket}"
+        }
+      }
+    `, table, table)
+	}
+
+	return config
+}
+
+func testAccGlueCrawlerConfig_CatalogTarget_TableList(tables []string) string {
+	var list string
+	for _, table := range tables {
+		list += fmt.Sprintf(`"${aws_glue_catalog_table.%s.name}",`, table)
+	}
+
+	return list
+}
+
+func testAccGlueCrawlerConfig_CatalogTarget(rName string, tables []string) string {
+	tableResources := testAccGlueCrawlerConfig_CatalogTarget_TableResources(tables)
+	catalogTableList := testAccGlueCrawlerConfig_CatalogTarget_TableList(tables)
+
+	return testAccGlueCrawlerConfig_Base(rName) + fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %q
+}
+
+resource "aws_s3_bucket" "default" {
+  bucket = %q
+  force_destroy = true
+}
+
+%s
+
+resource "aws_glue_crawler" "test" {
+  depends_on = ["aws_iam_role_policy_attachment.test-AWSGlueServiceRole"]
+
+  database_name = "${aws_glue_catalog_database.test.name}"
+  name          = %q
+  role          = "${aws_iam_role.test.name}"
+
+  schema_change_policy {
+    delete_behavior = "LOG"
+  }
+  
+  catalog_target {
+    database_name = "${aws_glue_catalog_database.test.name}"
+    tables = [%s]
+  }
+
+  configuration = <<EOF
+{
+  "Version":1.0,
+  "Grouping": {
+    "TableGroupingPolicy": "CombineCompatibleSchemas"
+  }
+}
+EOF
+}
+`, rName, rName, tableResources, rName, catalogTableList)
 }
 
 func testAccGlueCrawlerConfig_Schedule(rName, schedule string) string {

--- a/aws/resource_aws_glue_crawler_test.go
+++ b/aws/resource_aws_glue_crawler_test.go
@@ -456,7 +456,7 @@ func TestAccAWSGlueCrawler_CatalogTarget(t *testing.T) {
 		CheckDestroy: testAccCheckAWSGlueCrawlerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGlueCrawlerConfig_CatalogTarget(rName, []string{"table_1"}),
+				Config: testAccGlueCrawlerConfig_CatalogTarget(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
 					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
@@ -471,7 +471,7 @@ func TestAccAWSGlueCrawler_CatalogTarget(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "catalog_target.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "catalog_target.0.database_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "catalog_target.0.tables.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "catalog_target.0.tables.0", "table_1"),
+					resource.TestCheckResourceAttr(resourceName, "catalog_target.0.tables.0", fmt.Sprintf("%s_table_0", rName)),
 					resource.TestCheckResourceAttr(resourceName, "schedule", ""),
 					resource.TestCheckResourceAttr(resourceName, "schema_change_policy.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "schema_change_policy.0.delete_behavior", "LOG"),
@@ -481,7 +481,7 @@ func TestAccAWSGlueCrawler_CatalogTarget(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccGlueCrawlerConfig_CatalogTarget(rName, []string{"table_1", "table_2"}),
+				Config: testAccGlueCrawlerConfig_CatalogTarget(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
 					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
@@ -496,8 +496,8 @@ func TestAccAWSGlueCrawler_CatalogTarget(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "catalog_target.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "catalog_target.0.database_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "catalog_target.0.tables.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "catalog_target.0.tables.0", "table_1"),
-					resource.TestCheckResourceAttr(resourceName, "catalog_target.0.tables.1", "table_2"),
+					resource.TestCheckResourceAttr(resourceName, "catalog_target.0.tables.0", fmt.Sprintf("%s_table_0", rName)),
+					resource.TestCheckResourceAttr(resourceName, "catalog_target.0.tables.1", fmt.Sprintf("%s_table_1", rName)),
 					resource.TestCheckResourceAttr(resourceName, "schedule", ""),
 					resource.TestCheckResourceAttr(resourceName, "schema_change_policy.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "schema_change_policy.0.delete_behavior", "LOG"),
@@ -526,14 +526,14 @@ func TestAccAWSGlueCrawler_CatalogTarget_Multiple(t *testing.T) {
 		CheckDestroy: testAccCheckAWSGlueCrawlerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGlueCrawlerConfig_CatalogTarget(rName, []string{"table_1"}),
+				Config: testAccGlueCrawlerConfig_CatalogTarget(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
 					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "catalog_target.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "catalog_target.0.database_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "catalog_target.0.tables.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "catalog_target.0.tables.0", "table_1"),
+					resource.TestCheckResourceAttr(resourceName, "catalog_target.0.tables.0", fmt.Sprintf("%s_table_0", rName)),
 				),
 			},
 			{
@@ -542,23 +542,23 @@ func TestAccAWSGlueCrawler_CatalogTarget_Multiple(t *testing.T) {
 					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
 					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "catalog_target.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "catalog_target.0.database_name", fmt.Sprintf("%s_test_1", rName)),
+					resource.TestCheckResourceAttr(resourceName, "catalog_target.0.database_name", fmt.Sprintf("%s_database_0", rName)),
+					resource.TestCheckResourceAttr(resourceName, "catalog_target.1.database_name", fmt.Sprintf("%s_database_1", rName)),
 					resource.TestCheckResourceAttr(resourceName, "catalog_target.0.tables.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "catalog_target.0.tables.0", "table_1"),
-					resource.TestCheckResourceAttr(resourceName, "catalog_target.1.database_name", fmt.Sprintf("%s_test_2", rName)),
+					resource.TestCheckResourceAttr(resourceName, "catalog_target.0.tables.0", fmt.Sprintf("%s_table_0", rName)),
 					resource.TestCheckResourceAttr(resourceName, "catalog_target.1.tables.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "catalog_target.1.tables.0", "table_2"),
+					resource.TestCheckResourceAttr(resourceName, "catalog_target.1.tables.0", fmt.Sprintf("%s_table_1", rName)),
 				),
 			},
 			{
-				Config: testAccGlueCrawlerConfig_CatalogTarget(rName, []string{"table_1"}),
+				Config: testAccGlueCrawlerConfig_CatalogTarget(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
 					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "catalog_target.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "catalog_target.0.database_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "catalog_target.0.tables.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "catalog_target.0.tables.0", "table_1"),
+					resource.TestCheckResourceAttr(resourceName, "catalog_target.0.tables.0", fmt.Sprintf("%s_table_0", rName)),
 				),
 			},
 			{
@@ -1516,55 +1516,34 @@ resource "aws_glue_crawler" "test" {
 `, rName, rName, path1, path2)
 }
 
-func testAccGlueCrawlerConfig_CatalogTarget_TableResources(tables []string) string {
-	var config string
-	for _, table := range tables {
-		config += fmt.Sprintf(`
-      resource "aws_glue_catalog_table" %q {
-        database_name = "${aws_glue_catalog_database.test.name}"
-        name          = %q
-        table_type    = "EXTERNAL_TABLE"
-
-        storage_descriptor {
-          location      = "s3://${aws_s3_bucket.default.bucket}"
-        }
-      }
-    `, table, table)
-	}
-
-	return config
-}
-
-func testAccGlueCrawlerConfig_CatalogTarget_TableList(tables []string) string {
-	var list string
-	for _, table := range tables {
-		list += fmt.Sprintf(`"${aws_glue_catalog_table.%s.name}",`, table)
-	}
-
-	return list
-}
-
-func testAccGlueCrawlerConfig_CatalogTarget(rName string, tables []string) string {
-	tableResources := testAccGlueCrawlerConfig_CatalogTarget_TableResources(tables)
-	catalogTableList := testAccGlueCrawlerConfig_CatalogTarget_TableList(tables)
-
+func testAccGlueCrawlerConfig_CatalogTarget(rName string, tableCount int) string {
 	return testAccGlueCrawlerConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
-  name = %q
+  name = %[1]q
 }
 
 resource "aws_s3_bucket" "default" {
-  bucket = %q
+  bucket = %[1]q
   force_destroy = true
 }
 
-%s
+resource "aws_glue_catalog_table" "test" {
+	count = %[2]d
+
+	database_name = "${aws_glue_catalog_database.test.name}"
+	name          = "%[1]s_table_${count.index}"
+	table_type    = "EXTERNAL_TABLE"
+
+	storage_descriptor {
+		location      = "s3://${aws_s3_bucket.default.bucket}"
+	}
+}
 
 resource "aws_glue_crawler" "test" {
   depends_on = ["aws_iam_role_policy_attachment.test-AWSGlueServiceRole"]
 
   database_name = "${aws_glue_catalog_database.test.name}"
-  name          = %q
+  name          = %[1]q
   role          = "${aws_iam_role.test.name}"
 
   schema_change_policy {
@@ -1573,7 +1552,7 @@ resource "aws_glue_crawler" "test" {
 
   catalog_target {
     database_name = "${aws_glue_catalog_database.test.name}"
-    tables = [%s]
+    tables = flatten(["${aws_glue_catalog_table.test[*].name}"])
   }
 
   configuration = <<EOF
@@ -1585,32 +1564,20 @@ resource "aws_glue_crawler" "test" {
 }
 EOF
 }
-`, rName, rName, tableResources, rName, catalogTableList)
+`, rName, tableCount)
 }
 
 func testAccGlueCrawlerConfig_CatalogTarget_Multiple(rName string) string {
 	return testAccGlueCrawlerConfig_Base(rName) + fmt.Sprintf(`
-resource "aws_glue_catalog_database" "test_1" {
-  name = "%[1]q_test_1"
+resource "aws_glue_catalog_database" "test" {
+	count = 2
+  name = "%[1]s_database_${count.index}"
 }
 
-resource "aws_glue_catalog_database" "test_2" {
-  name = "%[1]q_test_2"
-}
-
-resource "aws_glue_catalog_table" "test_1" {
-  database_name = "${aws_glue_catalog_database.test_1.name}"
-  name          = "table_1"
-  table_type    = "EXTERNAL_TABLE"
-
-  storage_descriptor {
-    location      = "s3://${aws_s3_bucket.default.bucket}"
-  }
-}
-
-resource "aws_glue_catalog_table" "test_2" {
-  database_name = "${aws_glue_catalog_database.test_2.name}"
-  name          = "table_2"
+resource "aws_glue_catalog_table" "test" {
+	count = 2
+  database_name = "${aws_glue_catalog_database.test[count.index].name}"
+  name          = "%[1]s_table_${count.index}"
   table_type    = "EXTERNAL_TABLE"
 
   storage_descriptor {
@@ -1626,7 +1593,7 @@ resource "aws_s3_bucket" "default" {
 resource "aws_glue_crawler" "test" {
   depends_on = ["aws_iam_role_policy_attachment.test-AWSGlueServiceRole"]
 
-  database_name = "${aws_glue_catalog_database.test_1.name}"
+  database_name = "${aws_glue_catalog_database.test[0].name}"
   name          = %[1]q
   role          = "${aws_iam_role.test.name}"
 
@@ -1635,13 +1602,13 @@ resource "aws_glue_crawler" "test" {
   }
 
   catalog_target {
-    database_name = "${aws_glue_catalog_database.test_1.name}"
-    tables = ["${aws_glue_catalog_table.test_1.name}"]
+    database_name = "${aws_glue_catalog_database.test[0].name}"
+    tables = ["${aws_glue_catalog_table.test[0].name}"]
   }
 
   catalog_target {
-    database_name = "${aws_glue_catalog_database.test_2.name}"
-    tables = ["${aws_glue_catalog_table.test_2.name}"]
+    database_name = "${aws_glue_catalog_database.test[1].name}"
+    tables = ["${aws_glue_catalog_table.test[1].name}"]
   }
 
   configuration = <<EOF

--- a/aws/resource_aws_glue_crawler_test.go
+++ b/aws/resource_aws_glue_crawler_test.go
@@ -1033,7 +1033,7 @@ data "aws_iam_policy_document" "assume" {
 }
 
 data "aws_iam_policy" "AWSGlueServiceRole" {
-  arn = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
+  arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSGlueServiceRole"
 }
 
 resource "aws_iam_role_policy_attachment" "test-AWSGlueServiceRole" {
@@ -1570,7 +1570,7 @@ resource "aws_glue_crawler" "test" {
   schema_change_policy {
     delete_behavior = "LOG"
   }
-  
+
   catalog_target {
     database_name = "${aws_glue_catalog_database.test.name}"
     tables = [%s]
@@ -1633,7 +1633,7 @@ resource "aws_glue_crawler" "test" {
   schema_change_policy {
     delete_behavior = "LOG"
   }
-  
+
   catalog_target {
     database_name = "${aws_glue_catalog_database.test_1.name}"
     tables = ["${aws_glue_catalog_table.test_1.name}"]

--- a/aws/resource_aws_glue_crawler_test.go
+++ b/aws/resource_aws_glue_crawler_test.go
@@ -1591,11 +1591,11 @@ EOF
 func testAccGlueCrawlerConfig_CatalogTarget_Multiple(rName string) string {
 	return testAccGlueCrawlerConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test_1" {
-  name = "%s_test_1"
+  name = "%[1]q_test_1"
 }
 
 resource "aws_glue_catalog_database" "test_2" {
-  name = "%s_test_2"
+  name = "%[1]q_test_2"
 }
 
 resource "aws_glue_catalog_table" "test_1" {
@@ -1619,7 +1619,7 @@ resource "aws_glue_catalog_table" "test_2" {
 }
 
 resource "aws_s3_bucket" "default" {
-  bucket = %q
+  bucket = %[1]q
   force_destroy = true
 }
 
@@ -1627,7 +1627,7 @@ resource "aws_glue_crawler" "test" {
   depends_on = ["aws_iam_role_policy_attachment.test-AWSGlueServiceRole"]
 
   database_name = "${aws_glue_catalog_database.test_1.name}"
-  name          = %q
+  name          = %[1]q
   role          = "${aws_iam_role.test.name}"
 
   schema_change_policy {
@@ -1653,7 +1653,7 @@ resource "aws_glue_crawler" "test" {
 }
 EOF
 }
-`, rName, rName, rName, rName)
+`, rName)
 }
 
 func testAccGlueCrawlerConfig_Schedule(rName, schedule string) string {

--- a/website/docs/r/glue_crawler.html.markdown
+++ b/website/docs/r/glue_crawler.html.markdown
@@ -55,9 +55,38 @@ resource "aws_glue_crawler" "example" {
 }
 ```
 
+
+### Catalog Target
+
+```hcl
+resource "aws_glue_crawler" "example" {
+  database_name = "${aws_glue_catalog_database.example.name}"
+  name          = "example"
+  role          = "${aws_iam_role.example.arn}"
+
+  catalog_target {
+    database_name = "${aws_glue_catalog_database.example.name}"
+    tables = ["${aws_glue_catalog_table.example.name}"]
+  }
+
+  schema_change_policy {
+    delete_behavior = "LOG"
+  }
+
+  configuration = <<EOF
+{
+  "Version":1.0,
+  "Grouping": {
+    "TableGroupingPolicy": "CombineCompatibleSchemas"
+  }
+}
+EOF
+}
+```
+
 ## Argument Reference
 
-~> **NOTE:** At least one `jdbc_target` or `s3_target` must be specified.
+~> **NOTE:** Must specify at least one of `dynamodb_target`, `jdbc_target`, `s3_target` or `catalog_target`.
 
 The following arguments are supported:
 
@@ -89,6 +118,16 @@ The following arguments are supported:
 
 * `path` - (Required) The path to the Amazon S3 target.
 * `exclusions` - (Optional) A list of glob patterns used to exclude from the crawl.
+
+### catalog_target Argument Reference
+
+* `database_name` - (Required) The name of the Glue database to be synchronized.
+* `tables` - (Required) A list of catalog tables to be synchronized.
+
+~> **Note:** `deletion_behavior` of catalog target doesn't support `DEPRECATE_IN_DATABASE`.
+
+-> **Note:** `configuration` for catalog target crawlers will have `{ ... "Grouping": { "TableGroupingPolicy": "CombineCompatibleSchemas"} }` by default.
+
 
 ### schema_change_policy Argument Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8631

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_glue_crawler: Add `catalog_target` attribute
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSGlueCrawler_CatalogTarget'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSGlueCrawler_CatalogTarget -timeout 120m
=== RUN   TestAccAWSGlueCrawler_CatalogTarget
=== PAUSE TestAccAWSGlueCrawler_CatalogTarget
=== RUN   TestAccAWSGlueCrawler_CatalogTarget_Multiple
=== PAUSE TestAccAWSGlueCrawler_CatalogTarget_Multiple
=== CONT  TestAccAWSGlueCrawler_CatalogTarget
=== CONT  TestAccAWSGlueCrawler_CatalogTarget_Multiple
--- PASS: TestAccAWSGlueCrawler_CatalogTarget (126.62s)
--- PASS: TestAccAWSGlueCrawler_CatalogTarget_Multiple (174.49s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	174.556s
```
