### PR TITLE
Add support for cloudwatch event target import

### DIFF
--- a/aws/resource_aws_cloudwatch_event_target_test.go
+++ b/aws/resource_aws_cloudwatch_event_target_test.go
@@ -123,6 +123,12 @@ func TestAccAWSCloudWatchEventTarget_basic(t *testing.T) {
 						regexp.MustCompile(fmt.Sprintf(":%s$", snsTopicName2))),
 				),
 			},
+			{
+				ResourceName:      "aws_cloudwatch_event_target.moobar",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCloudWatchEventTargetImportStateIdFunc("aws_cloudwatch_event_target.moobar"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -330,6 +336,17 @@ func testAccCheckAWSCloudWatchEventTargetDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccAWSCloudWatchEventTargetImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["rule"], rs.Primary.Attributes["target_id"]), nil
+	}
 }
 
 func testAccAWSCloudWatchEventTargetConfig(ruleName, snsTopicName, targetID string) string {

--- a/aws/resource_aws_cloudwatch_event_target_test.go
+++ b/aws/resource_aws_cloudwatch_event_target_test.go
@@ -153,6 +153,12 @@ func TestAccAWSCloudWatchEventTarget_missingTargetId(t *testing.T) {
 						regexp.MustCompile(fmt.Sprintf(":%s$", snsTopicName))),
 				),
 			},
+			{
+				ResourceName:      "aws_cloudwatch_event_target.moobar",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCloudWatchEventTargetImportStateIdFunc("aws_cloudwatch_event_target.moobar"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -181,6 +187,12 @@ func TestAccAWSCloudWatchEventTarget_full(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_cloudwatch_event_target.foobar", "input_path", ""),
 				),
 			},
+			{
+				ResourceName:      "aws_cloudwatch_event_target.foobar",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCloudWatchEventTargetImportStateIdFunc("aws_cloudwatch_event_target.foobar"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -199,6 +211,12 @@ func TestAccAWSCloudWatchEventTarget_ssmDocument(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudWatchEventTargetExists("aws_cloudwatch_event_target.test", &target),
 				),
+			},
+			{
+				ResourceName:      "aws_cloudwatch_event_target.test",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCloudWatchEventTargetImportStateIdFunc("aws_cloudwatch_event_target.test"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -219,6 +237,12 @@ func TestAccAWSCloudWatchEventTarget_ecs(t *testing.T) {
 					testAccCheckCloudWatchEventTargetExists("aws_cloudwatch_event_target.test", &target),
 				),
 			},
+			{
+				ResourceName:      "aws_cloudwatch_event_target.test",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCloudWatchEventTargetImportStateIdFunc("aws_cloudwatch_event_target.test"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -237,6 +261,12 @@ func TestAccAWSCloudWatchEventTarget_batch(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudWatchEventTargetExists("aws_cloudwatch_event_target.test", &target),
 				),
+			},
+			{
+				ResourceName:      "aws_cloudwatch_event_target.test",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCloudWatchEventTargetImportStateIdFunc("aws_cloudwatch_event_target.test"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -257,6 +287,12 @@ func TestAccAWSCloudWatchEventTarget_kinesis(t *testing.T) {
 					testAccCheckCloudWatchEventTargetExists("aws_cloudwatch_event_target.test", &target),
 				),
 			},
+			{
+				ResourceName:      "aws_cloudwatch_event_target.test",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCloudWatchEventTargetImportStateIdFunc("aws_cloudwatch_event_target.test"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -276,6 +312,12 @@ func TestAccAWSCloudWatchEventTarget_sqs(t *testing.T) {
 					testAccCheckCloudWatchEventTargetExists("aws_cloudwatch_event_target.test", &target),
 				),
 			},
+			{
+				ResourceName:      "aws_cloudwatch_event_target.test",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCloudWatchEventTargetImportStateIdFunc("aws_cloudwatch_event_target.test"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -294,6 +336,12 @@ func TestAccAWSCloudWatchEventTarget_input_transformer(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudWatchEventTargetExists("aws_cloudwatch_event_target.test", &target),
 				),
+			},
+			{
+				ResourceName:      "aws_cloudwatch_event_target.test",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCloudWatchEventTargetImportStateIdFunc("aws_cloudwatch_event_target.test"),
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -302,3 +302,11 @@ For more information, see [Task Networking](https://docs.aws.amazon.com/AmazonEC
 
 * `input_paths` - (Optional) Key value pairs specified in the form of JSONPath (for example, time = $.time)
 * `input_template` - (Required) Structure containing the template body.
+
+## Import
+
+Cloud Watch Event Target can be imported using the role event_rule and target_id separated by `/`.
+
+ ```
+$ terraform import aws_cloudwatch_event_target.test-event-target rule-name/target-id
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/9264

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_cloudwatch_event_target: Support resource import
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSCloudWatchEventTarget_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSCloudWatchEventTarget_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSCloudWatchEventTarget_basic
=== PAUSE TestAccAWSCloudWatchEventTarget_basic
=== CONT  TestAccAWSCloudWatchEventTarget_basic
--- PASS: TestAccAWSCloudWatchEventTarget_basic (59.97s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	60.034s
```
