### PR TITLE
Update document about subnet ids' attributes reference

### DIFF
--- a/website/docs/d/subnet_ids.html.markdown
+++ b/website/docs/d/subnet_ids.html.markdown
@@ -81,4 +81,4 @@ data "aws_subnet_ids" "selected" {
 
 ## Attributes Reference
 
-* `ids` - A set of all the subnet ids found. This data source will fail if none are found.
+* `ids` - A set of all the subnet ids found. This data source will fail if none are found. A set is iterable but not indexable. For direct access to each `id` in `ids` by index, please consider [to_list](https://www.terraform.io/docs/configuration/functions/tolist.html)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fix #9420 

I believe that the returned ids are actually a set, not a list, which also means that data.aws_subnet_ids.private.ids[0], for example, wont work 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

