### PR TITLE
Fix name updates on cognito_user_pool_client resource

### DIFF
--- a/aws/resource_aws_cognito_user_pool_client.go
+++ b/aws/resource_aws_cognito_user_pool_client.go
@@ -269,6 +269,10 @@ func resourceAwsCognitoUserPoolClientUpdate(d *schema.ResourceData, meta interfa
 		UserPoolId: aws.String(d.Get("user_pool_id").(string)),
 	}
 
+	if v, ok := d.GetOk("name"); ok {
+		params.ClientName = aws.String(v.(string))
+	}
+
 	if v, ok := d.GetOk("explicit_auth_flows"); ok {
 		params.ExplicitAuthFlows = expandStringList(v.(*schema.Set).List())
 	}

--- a/aws/resource_aws_cognito_user_pool_client_test.go
+++ b/aws/resource_aws_cognito_user_pool_client_test.go
@@ -114,6 +114,33 @@ func TestAccAWSCognitoUserPoolClient_RefreshTokenValidity(t *testing.T) {
 	})
 }
 
+func TestAccAWSCognitoUserPoolClient_ClientName(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rName2 := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoUserPoolClientDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoUserPoolClientConfig_ClientName(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoUserPoolClientExists("aws_cognito_user_pool_client.client"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "name", rName),
+				),
+			},
+			{
+				Config: testAccAWSCognitoUserPoolClientConfig_ClientName(rName2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoUserPoolClientExists("aws_cognito_user_pool_client.client"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "name", rName2),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSCognitoUserPoolClient_allFields(t *testing.T) {
 	userPoolName := fmt.Sprintf("tf-acc-cognito-user-pool-%s", acctest.RandString(7))
 	clientName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
@@ -285,6 +312,19 @@ resource "aws_cognito_user_pool_client" "client" {
   user_pool_id           = "${aws_cognito_user_pool.pool.id}"
 }
 `, rName, rName, refreshTokenValidity)
+}
+
+func testAccAWSCognitoUserPoolClientConfig_ClientName(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "pool" {
+  name = "%s"
+}
+
+resource "aws_cognito_user_pool_client" "client" {
+  name                   = "%s"
+  user_pool_id           = "${aws_cognito_user_pool.pool.id}"
+}
+`, rName, rName)
 }
 
 func testAccAWSCognitoUserPoolClientConfig_allFields(userPoolName, clientName string, refreshTokenValidity int) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #7525

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:

* resource/aws_cognito_user_pool_client: Properly update name value
```


Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSCognitoUserPoolClient_ClientName'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSCognitoUserPoolClient_ClientName -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSCognitoUserPoolClient_ClientName
=== PAUSE TestAccAWSCognitoUserPoolClient_ClientName
=== CONT  TestAccAWSCognitoUserPoolClient_ClientName
--- PASS: TestAccAWSCognitoUserPoolClient_ClientName (47.14s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	47.232s
...
```
