### PR TITLE
Final retries for config timeouts

### DIFF
--- a/aws/resource_aws_config_delivery_channel.go
+++ b/aws/resource_aws_config_delivery_channel.go
@@ -99,13 +99,15 @@ func resourceAwsConfigDeliveryChannelPut(d *schema.ResourceData, meta interface{
 			return nil
 		}
 
-		awsErr, ok := err.(awserr.Error)
-		if ok && awsErr.Code() == "InsufficientDeliveryPolicyException" {
+		if isAWSErr(err, "InsufficientDeliveryPolicyException", "") {
 			return resource.RetryableError(err)
 		}
 
 		return resource.NonRetryableError(err)
 	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.PutDeliveryChannel(&input)
+	}
 	if err != nil {
 		return fmt.Errorf("Creating Delivery Channel failed: %s", err)
 	}
@@ -175,6 +177,9 @@ func resourceAwsConfigDeliveryChannelDelete(d *schema.ResourceData, meta interfa
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.DeleteDeliveryChannel(&input)
+	}
 	if err != nil {
 		return fmt.Errorf("Unable to delete delivery channel: %s", err)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Related #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES
* resource/aws_config_config_rule: Retries after timeouts when creating and deleting config rules
* resource/aws_config_delivery_channel: Retries after timeouts when creating and deleting config delivery channels
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSConfig/Config$" 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSConfig/Config -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSConfig
=== RUN   TestAccAWSConfig/Config
=== RUN   TestAccAWSConfig/Config/basic
=== RUN   TestAccAWSConfig/Config/ownerAws
=== RUN   TestAccAWSConfig/Config/customlambda
=== RUN   TestAccAWSConfig/Config/importAws
=== RUN   TestAccAWSConfig/Config/importLambda
=== RUN   TestAccAWSConfig/Config/scopeTagKey
=== RUN   TestAccAWSConfig/Config/scopeTagKeyEmpty
=== RUN   TestAccAWSConfig/Config/scopeTagValue
--- PASS: TestAccAWSConfig (1481.00s)
    --- PASS: TestAccAWSConfig/Config (963.09s)
        --- PASS: TestAccAWSConfig/Config/basic (103.54s)
        --- PASS: TestAccAWSConfig/Config/ownerAws (103.12s)
        --- PASS: TestAccAWSConfig/Config/customlambda (147.18s)
        --- PASS: TestAccAWSConfig/Config/importAws (104.68s)
        --- PASS: TestAccAWSConfig/Config/importLambda (141.80s)
        --- PASS: TestAccAWSConfig/Config/scopeTagKey (129.85s)
        --- PASS: TestAccAWSConfig/Config/scopeTagKeyEmpty (106.40s)
        --- PASS: TestAccAWSConfig/Config/scopeTagValue (126.52s)
    

make testacc TESTARGS="-run=TestAccAWSConfig/DeliveryChannel" 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSConfig/DeliveryChannel -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSConfigAggregateAuthorization_basic
=== PAUSE TestAccAWSConfigAggregateAuthorization_basic
=== RUN   TestAccAWSConfigConfigurationAggregator_account
=== PAUSE TestAccAWSConfigConfigurationAggregator_account
=== RUN   TestAccAWSConfigConfigurationAggregator_organization
=== PAUSE TestAccAWSConfigConfigurationAggregator_organization
=== RUN   TestAccAWSConfigConfigurationAggregator_switch
=== PAUSE TestAccAWSConfigConfigurationAggregator_switch
=== RUN   TestAccAWSConfig
=== RUN   TestAccAWSConfig/DeliveryChannel
=== RUN   TestAccAWSConfig/DeliveryChannel/allParams
=== RUN   TestAccAWSConfig/DeliveryChannel/importBasic
=== RUN   TestAccAWSConfig/DeliveryChannel/basic
--- PASS: TestAccAWSConfig (213.97s)
    --- PASS: TestAccAWSConfig/DeliveryChannel (213.97s)
        --- PASS: TestAccAWSConfig/DeliveryChannel/allParams (73.99s)
        --- PASS: TestAccAWSConfig/DeliveryChannel/importBasic (69.31s)
        --- PASS: TestAccAWSConfig/DeliveryChannel/basic (70.67s)
=== CONT  TestAccAWSConfigAggregateAuthorization_basic
=== CONT  TestAccAWSConfigConfigurationAggregator_organization
=== CONT  TestAccAWSConfigConfigurationAggregator_account
=== CONT  TestAccAWSConfigConfigurationAggregator_switch
--- SKIP: TestAccAWSConfigConfigurationAggregator_switch (2.64s)
    provider_test.go:247: skipping tests; this AWS account must not be an existing member of an AWS Organization
--- SKIP: TestAccAWSConfigConfigurationAggregator_organization (2.65s)
    provider_test.go:247: skipping tests; this AWS account must not be an existing member of an AWS Organization
--- PASS: TestAccAWSConfigAggregateAuthorization_basic (24.91s)
--- PASS: TestAccAWSConfigConfigurationAggregator_account (28.18s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       243.272s
```