### PR TITLE
docs/provider: Split sidebar Data Sources section into relevant service categories

### DIFF
--- a/website/aws.erb
+++ b/website/aws.erb
@@ -36,50 +36,10 @@
                 </li>
 
                 <li>
-                <a href="#">Data Sources</a>
+                <a href="#">Provider Data Sources</a>
                     <ul class="nav">
-
-                        <li>
-                            <a href="/docs/providers/aws/d/acm_certificate.html">aws_acm_certificate</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/acmpca_certificate_authority.html">aws_acmpca_certificate_authority</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/lb.html">aws_alb</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/lb_listener.html">aws_alb_listener</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/lb_target_group.html">aws_alb_target_group</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/ami.html">aws_ami</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/ami_ids.html">aws_ami_ids</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/api_gateway_api_key.html">aws_api_gateway_api_key</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/api_gateway_resource.html">aws_api_gateway_resource</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/api_gateway_rest_api.html">aws_api_gateway_rest_api</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/api_gateway_vpc_link.html">aws_api_gateway_vpc_link</a>
-                        </li>
                         <li>
                             <a href="/docs/providers/aws/d/arn.html">aws_arn</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/autoscaling_group.html">aws_autoscaling_group</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/autoscaling_groups.html">aws_autoscaling_groups</a>
                         </li>
                         <li>
                             <a href="/docs/providers/aws/d/availability_zone.html">aws_availability_zone</a>
@@ -88,414 +48,59 @@
                             <a href="/docs/providers/aws/d/availability_zones.html">aws_availability_zones</a>
                         </li>
                         <li>
-                          <a href="/docs/providers/aws/d/batch_compute_environment.html">aws_batch_compute_environment</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/batch_job_queue.html">aws_batch_job_queue</a>
-                        </li>
-                        <li>
                             <a href="/docs/providers/aws/d/billing_service_account.html">aws_billing_service_account</a>
                         </li>
                         <li>
                           <a href="/docs/providers/aws/d/caller_identity.html">aws_caller_identity</a>
                         </li>
                         <li>
-                            <a href="/docs/providers/aws/d/canonical_user_id.html">aws_canonical_user_id</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/cloudformation_export.html">aws_cloudformation_export</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/cloudformation_stack.html">aws_cloudformation_stack</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/cloudhsm_v2_cluster.html">aws_cloudhsm_v2_cluster</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/cloudtrail_service_account.html">aws_cloudtrail_service_account</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/cloudwatch_log_group.html">aws_cloudwatch_log_group</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/codecommit_repository.html">aws_codecommit_repository</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/cognito_user_pools.html">aws_cognito_user_pools</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/cur_report_definition.html">aws_cur_report_definition</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/customer_gateway.html">aws_customer_gateway</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/db_cluster_snapshot.html">aws_db_cluster_snapshot</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/db_event_categories.html">aws_db_event_categories</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/db_instance.html">aws_db_instance</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/db_snapshot.html">aws_db_snapshot</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/dx_gateway.html">aws_dx_gateway</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/dynamodb_table.html">aws_dynamodb_table</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/ebs_default_kms_key.html">aws_ebs_default_kms_key</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/ebs_encryption_by_default.html">aws_ebs_encryption_by_default</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/ebs_snapshot.html">aws_ebs_snapshot</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/ebs_snapshot_ids.html">aws_ebs_snapshot_ids</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/ebs_volume.html">aws_ebs_volume</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/ec2_transit_gateway.html">aws_ec2_transit_gateway</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/ec2_transit_gateway_dx_gateway_attachment.html">aws_ec2_transit_gateway_dx_gateway_attachment</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/ec2_transit_gateway_route_table.html">aws_ec2_transit_gateway_route_table</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/ec2_transit_gateway_vpc_attachment.html">aws_ec2_transit_gateway_vpc_attachment</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/ec2_transit_gateway_vpn_attachment.html">aws_ec2_transit_gateway_vpn_attachment</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/ecr_image.html">aws_ecr_image</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/ecr_repository.html">aws_ecr_repository</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/ecs_cluster.html">aws_ecs_cluster</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/ecs_container_definition.html">aws_ecs_container_definition</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/ecs_service.html">aws_ecs_service</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/ecs_task_definition.html">aws_ecs_task_definition</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/efs_file_system.html">aws_efs_file_system</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/efs_mount_target.html">aws_efs_mount_target</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/eip.html">aws_eip</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/eks_cluster.html">aws_eks_cluster</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/eks_cluster_auth.html">aws_eks_cluster_auth</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/elastic_beanstalk_application.html">aws_elastic_beanstalk_application</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/elastic_beanstalk_hosted_zone.html">aws_elastic_beanstalk_hosted_zone</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/elastic_beanstalk_solution_stack.html">aws_elastic_beanstalk_solution_stack</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/elasticache_cluster.html">aws_elasticache_cluster</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/elasticache_replication_group.html">aws_elasticache_replication_group</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/elb.html">aws_elb</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/elb_hosted_zone_id.html">aws_elb_hosted_zone_id</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/elb_service_account.html">aws_elb_service_account</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/glue_script.html">aws_glue_script</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/iam_account_alias.html">aws_iam_account_alias</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/iam_group.html">aws_iam_group</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/iam_instance_profile.html">aws_iam_instance_profile</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/iam_policy.html">aws_iam_policy</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/iam_policy_document.html">aws_iam_policy_document</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/iam_role.html">aws_iam_role</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/iam_server_certificate.html">aws_iam_server_certificate</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/iam_user.html">aws_iam_user</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/inspector_rules_packages.html">aws_inspector_rules_packages</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/instance.html">aws_instance</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/instances.html">aws_instances</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/internet_gateway.html">aws_internet_gateway</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/iot_endpoint.html">aws_iot_endpoint</a>
-                        </li>
-                        <li>
                             <a href="/docs/providers/aws/d/ip_ranges.html">aws_ip_ranges</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/kinesis_stream.html">aws_kinesis_stream</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/kms_alias.html">aws_kms_alias</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/kms_ciphertext.html">aws_kms_ciphertext</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/kms_key.html">aws_kms_key</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/kms_secrets.html">aws_kms_secrets</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/lambda_function.html">aws_lambda_function</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/lambda_invocation.html">aws_lambda_invocation</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/lambda_layer_version.html">aws_lambda_layer_version</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/launch_configuration.html">aws_launch_configuration</a>
-                        </li>
-
-
-                        <li>
-                            <a href="/docs/providers/aws/d/launch_template.html">aws_launch_template</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/d/lb.html">aws_lb</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/lb_listener.html">aws_lb_listener</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/lb_target_group.html">aws_lb_target_group</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/mq_broker.html">aws_mq_broker</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/msk_cluster.html">aws_msk_cluster</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/msk_configuration.html">aws_msk_configuration</a>
-                        </li>
-                        <li>
-                           <a href="/docs/providers/aws/d/nat_gateway.html">aws_nat_gateway</a>
-                        </li>
-                        <li>
-                           <a href="/docs/providers/aws/d/network_acls.html">aws_network_acls</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/network_interface.html">aws_network_interface</a>
-                        </li>
-                         <li>
-                            <a href="/docs/providers/aws/d/network_interfaces.html">aws_network_interfaces</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/organizations_organization.html">aws_organizations_organization</a>
                         </li>
                         <li>
                             <a href="/docs/providers/aws/d/partition.html">aws_partition</a>
                         </li>
                         <li>
-                            <a href="/docs/providers/aws/d/prefix_list.html">aws_prefix_list</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/pricing_product.html">aws_pricing_product</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/rds_cluster.html">aws_rds_cluster</a>
-                        </li>
-                        <li>
-                        <a href="/docs/providers/aws/d/ram_resource_share.html">aws_ram_resource_share</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/redshift_cluster.html">aws_redshift_cluster</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/redshift_service_account.html">aws_redshift_service_account</a>
-                        </li>
-                        <li>
                             <a href="/docs/providers/aws/d/region.html">aws_region</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/route.html">aws_route</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/route53_delegation_set.html">aws_route53_delegation_set</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/route53_zone.html">aws_route53_zone</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/route_table.html">aws_route_table</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/route_tables.html">aws_route_tables</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/s3_bucket.html">aws_s3_bucket</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/s3_bucket_object.html">aws_s3_bucket_object</a>
-                        </li>
-                        <li>
-                         <a href="/docs/providers/aws/d/secretsmanager_secret.html">aws_secretsmanager_secret</a>
-                        </li>
-                        <li>
-                         <a href="/docs/providers/aws/d/secretsmanager_secret_version.html">aws_secretsmanager_secret_version</a>
-                        </li>
-                        <li>
-                         <a href="/docs/providers/aws/d/security_group.html">aws_security_group</a>
-                        </li>
-                        <li>
-                         <a href="/docs/providers/aws/d/security_groups.html">aws_security_groups</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/servicequotas_service.html">aws_servicequotas_service</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/d/servicequotas_service_quota.html">aws_servicequotas_service_quota</a>
-                        </li>
-                        <li>
-                         <a href="/docs/providers/aws/d/sns_topic.html">aws_sns_topic</a>
-                        </li>
-                        <li>
-                         <a href="/docs/providers/aws/d/sqs_queue.html">aws_sqs_queue</a>
-                        </li>
-
-                        <li>
-                         <a href="/docs/providers/aws/d/ssm_document.html">aws_ssm_document</a>
-                        </li>
-                        <li>
-                         <a href="/docs/providers/aws/d/ssm_parameter.html">aws_ssm_parameter</a>
-                        </li>
-                        <li>
-                         <a href="/docs/providers/aws/d/storagegateway_local_disk.html">aws_storagegateway_local_disk</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/subnet.html">aws_subnet</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/subnet_ids.html">aws_subnet_ids</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/transfer_server.html">aws_transfer_server</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/vpc.html">aws_vpc</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/vpc_dhcp_options.html">aws_vpc_dhcp_options</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/vpc_endpoint.html">aws_vpc_endpoint</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/vpc_endpoint_service.html">aws_vpc_endpoint_service</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/vpc_peering_connection.html">aws_vpc_peering_connection</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/vpcs.html">aws_vpcs</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/vpn_gateway.html">aws_vpn_gateway</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/waf_rule.html">aws_vpn_gateway</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/waf_web_acl.html">aws_waf_web_acl</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/wafregional_rule.html">aws_wafregional_rule</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/wafregional_web_acl.html">aws_wafregional_web_acl</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/d/workspaces_bundle.html">aws_workspaces_bundle</a>
                         </li>
                     </ul>
                 </li>
 
                 <li>
-                  <a href="#">ACM Resources</a>
-                  <ul class="nav">
+                  <a href="#">ACM</a>
+                  <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/acm_certificate.html">aws_acm_certificate</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
                     <li>
                       <a href="/docs/providers/aws/r/acm_certificate.html">aws_acm_certificate</a>
                     </li>
                     <li>
                       <a href="/docs/providers/aws/r/acm_certificate_validation.html">aws_acm_certificate_validation</a>
                     </li>
-                  </ul>
+                  </ul></li></ul>
                 </li>
 
                 <li>
-                  <a href="#">ACM PCA Resources</a>
-                  <ul class="nav">
+                  <a href="#">ACM PCA</a>
+                  <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/acmpca_certificate_authority.html">aws_acmpca_certificate_authority</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
                     <li>
                       <a href="/docs/providers/aws/r/acmpca_certificate_authority.html">aws_acmpca_certificate_authority</a>
                     </li>
-                  </ul>
+                  </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">API Gateway Resources</a>
-                    <ul class="nav">
+                    <a href="#">API Gateway</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/api_gateway_api_key.html">aws_api_gateway_api_key</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/api_gateway_resource.html">aws_api_gateway_resource</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/api_gateway_rest_api.html">aws_api_gateway_rest_api</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/api_gateway_vpc_link.html">aws_api_gateway_vpc_link</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/r/api_gateway_account.html">aws_api_gateway_account</a>
                         </li>
@@ -565,12 +170,12 @@
                         <li>
                             <a href="/docs/providers/aws/r/api_gateway_vpc_link.html">aws_api_gateway_vpc_link</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Application Autoscaling Resources</a>
-                    <ul class="nav">
+                    <a href="#">Application Autoscaling</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
                       <li>
                         <a href="/docs/providers/aws/r/appautoscaling_policy.html">aws_appautoscaling_policy</a>
                       </li>
@@ -580,12 +185,12 @@
                       <li>
                         <a href="/docs/providers/aws/r/appautoscaling_target.html">aws_appautoscaling_target</a>
                       </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">AppMesh Resources</a>
-                    <ul class="nav">
+                    <a href="#">AppMesh</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/r/appmesh_mesh.html">aws_appmesh_mesh</a>
                         </li>
@@ -601,12 +206,12 @@
                         <li>
                             <a href="/docs/providers/aws/r/appmesh_virtual_service.html">aws_appmesh_virtual_service</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">AppSync Resources</a>
-                    <ul class="nav">
+                    <a href="#">AppSync</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/r/appsync_datasource.html">aws_appsync_datasource</a>
                         </li>
@@ -622,12 +227,12 @@
                         <li>
                             <a href="/docs/providers/aws/r/appsync_resolver.html">aws_appsync_resolver</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Athena Resources</a>
-                    <ul class="nav">
+                    <a href="#">Athena</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/r/athena_database.html">aws_athena_database</a>
                         </li>
@@ -637,12 +242,18 @@
                         <li>
                           <a href="/docs/providers/aws/r/athena_workgroup.html">aws_athena_workgroup</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Autoscaling Resources</a>
-                    <ul class="nav">
+                    <a href="#">Autoscaling</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/autoscaling_group.html">aws_autoscaling_group</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/autoscaling_groups.html">aws_autoscaling_groups</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/launch_configuration.html">aws_launch_configuration</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
                         <li>
                           <a href="/docs/providers/aws/r/autoscaling_attachment.html">aws_autoscaling_attachment</a>
                         </li>
@@ -666,12 +277,12 @@
                         <li>
                           <a href="/docs/providers/aws/r/autoscaling_schedule.html">aws_autoscaling_schedule</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Backup Resources</a>
-                    <ul class="nav">
+                    <a href="#">Backup</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/r/backup_plan.html">aws_backup_plan</a>
                         </li>
@@ -681,12 +292,16 @@
                         <li>
                             <a href="/docs/providers/aws/r/backup_vault.html">aws_backup_vault</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Batch Resources</a>
-                    <ul class="nav">
+                    <a href="#">Batch</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                          <a href="/docs/providers/aws/d/batch_compute_environment.html">aws_batch_compute_environment</a>
+                        </li><li>
+                          <a href="/docs/providers/aws/d/batch_job_queue.html">aws_batch_job_queue</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/r/batch_compute_environment.html">aws_batch_compute_environment</a>
                         </li>
@@ -696,30 +311,34 @@
                         <li>
                             <a href="/docs/providers/aws/r/batch_job_queue.html">aws_batch_job_queue</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Budgets Resources</a>
-                    <ul class="nav">
+                    <a href="#">Budgets</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/r/budgets_budget.html">aws_budgets_budget</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Cloud9 Resources</a>
-                    <ul class="nav">
+                    <a href="#">Cloud9</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/r/cloud9_environment_ec2.html">aws_cloud9_environment_ec2</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">CloudFormation Resources</a>
-                    <ul class="nav">
+                    <a href="#">CloudFormation</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/cloudformation_export.html">aws_cloudformation_export</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/cloudformation_stack.html">aws_cloudformation_stack</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/r/cloudformation_stack.html">aws_cloudformation_stack</a>
                         </li>
@@ -729,12 +348,12 @@
                         <li>
                             <a href="/docs/providers/aws/r/cloudformation_stack_set_instance.html">aws_cloudformation_stack_set_instance</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">CloudFront Resources</a>
-                    <ul class="nav">
+                    <a href="#">CloudFront</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/r/cloudfront_distribution.html">aws_cloudfront_distribution</a>
                         </li>
@@ -744,33 +363,39 @@
                         <li>
                             <a href="/docs/providers/aws/r/cloudfront_public_key.html">aws_cloudfront_public_key</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">CloudHSM v2 Resources</a>
-                    <ul class="nav">
+                    <a href="#">CloudHSM v2</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/cloudhsm_v2_cluster.html">aws_cloudhsm_v2_cluster</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/r/cloudhsm_v2_cluster.html">aws_cloudhsm_v2_cluster</a>
                         </li>
                         <li>
                             <a href="/docs/providers/aws/r/cloudhsm_v2_hsm.html">aws_cloudhsm_v2_hsm</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">CloudTrail Resources</a>
-                    <ul class="nav">
+                    <a href="#">CloudTrail</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/cloudtrail_service_account.html">aws_cloudtrail_service_account</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/r/cloudtrail.html">aws_cloudtrail</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">CloudWatch Resources</a>
-                    <ul class="nav">
+                    <a href="#">CloudWatch</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/cloudwatch_log_group.html">aws_cloudwatch_log_group</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/r/cloudwatch_dashboard.html">aws_cloudwatch_dashboard</a>
                         </li>
@@ -819,13 +444,13 @@
                             <a href="/docs/providers/aws/r/cloudwatch_metric_alarm.html">aws_cloudwatch_metric_alarm</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
 
                 <li>
-                    <a href="#">CodeBuild Resources</a>
-                    <ul class="nav">
+                    <a href="#">CodeBuild</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/codebuild_project.html">aws_codebuild_project</a>
@@ -835,13 +460,15 @@
                             <a href="/docs/providers/aws/r/codebuild_webhook.html">aws_codebuild_webhook</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
 
                 <li>
-                    <a href="#">CodeCommit Resources</a>
-                    <ul class="nav">
+                    <a href="#">CodeCommit</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/codecommit_repository.html">aws_codecommit_repository</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/codecommit_repository.html">aws_codecommit_repository</a>
@@ -850,12 +477,12 @@
                         <li>
                             <a href="/docs/providers/aws/r/codecommit_trigger.html">aws_codecommit_trigger</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">CodeDeploy Resources</a>
-                    <ul class="nav">
+                    <a href="#">CodeDeploy</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/codedeploy_app.html">aws_codedeploy_app</a>
@@ -869,12 +496,12 @@
                             <a href="/docs/providers/aws/r/codedeploy_deployment_group.html">aws_codedeploy_deployment_group</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">CodePipeline Resources</a>
-                    <ul class="nav">
+                    <a href="#">CodePipeline</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/codepipeline.html">aws_codepipeline</a>
@@ -885,12 +512,14 @@
                             <a href="/docs/providers/aws/r/codepipeline_webhook.html">aws_codepipeline_webhook</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Cognito Resources</a>
-                    <ul class="nav">
+                    <a href="#">Cognito</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/cognito_user_pools.html">aws_cognito_user_pools</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/r/cognito_identity_pool.html">aws_cognito_identity_pool</a>
                         </li>
@@ -915,12 +544,12 @@
                         <li>
                             <a href="/docs/providers/aws/r/cognito_user_pool_domain.html">aws_cognito_user_pool_domain</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Config Resources</a>
-                    <ul class="nav">
+                    <a href="#">Config</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/r/config_aggregate_authorization.html">aws_config_aggregate_authorization</a>
                         </li>
@@ -945,32 +574,34 @@
                             <a href="/docs/providers/aws/r/config_delivery_channel.html">aws_config_delivery_channel</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Cost and Usage Report Resources</a>
-                    <ul class="nav">
+                    <a href="#">Cost and Usage Report</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/cur_report_definition.html">aws_cur_report_definition</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/cur_report_definition.html">aws_cur_report_definition</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Data Lifecycle Manager (DLM) Resources</a>
-                    <ul class="nav">
+                    <a href="#">Data Lifecycle Manager (DLM)</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/r/dlm_lifecycle_policy.html">aws_dlm_lifecycle_policy</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Database Migration Service (DMS) Resources</a>
-                    <ul class="nav">
+                    <a href="#">Database Migration Service (DMS)</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/dms_certificate.html">aws_dms_certificate</a>
@@ -992,23 +623,23 @@
                             <a href="/docs/providers/aws/r/dms_replication_task.html">aws_dms_replication_task</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">DataPipeline Resources</a>
-                    <ul class="nav">
+                    <a href="#">DataPipeline</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/datapipeline_pipeline.html">aws_datapipeline_pipeline</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">DataSync Resources</a>
-                    <ul class="nav">
+                    <a href="#">DataSync</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/datasync_agent.html">aws_datasync_agent</a>
@@ -1030,21 +661,21 @@
                             <a href="/docs/providers/aws/r/datasync_task.html">aws_datasync_task</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Device Farm Resources</a>
-                    <ul class="nav">
+                    <a href="#">Device Farm</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/r/devicefarm_project.html">aws_devicefarm_project</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Directory Service Resources</a>
-                    <ul class="nav">
+                    <a href="#">Directory Service</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/directory_service_directory.html">aws_directory_service_directory</a>
@@ -1058,12 +689,14 @@
                             <a href="/docs/providers/aws/r/directory_service_log_subscription.html">aws_directory_service_log_subscription</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Direct Connect Resources</a>
-                    <ul class="nav">
+                    <a href="#">Direct Connect</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                          <a href="/docs/providers/aws/d/dx_gateway.html">aws_dx_gateway</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/r/dx_bgp_peer.html">aws_dx_bgp_peer</a>
                         </li>
@@ -1103,12 +736,14 @@
                         <li>
                             <a href="/docs/providers/aws/r/dx_public_virtual_interface.html">aws_dx_public_virtual_interface</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">DynamoDB Resources</a>
-                    <ul class="nav">
+                    <a href="#">DynamoDB</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                          <a href="/docs/providers/aws/d/dynamodb_table.html">aws_dynamodb_table</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/dynamodb_global_table.html">aws_dynamodb_global_table</a>
@@ -1122,13 +757,13 @@
                             <a href="/docs/providers/aws/r/dynamodb_table_item.html">aws_dynamodb_table_item</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
 
                 <li>
-                    <a href="#">DynamoDB Accelerator (DAX) Resources</a>
-                    <ul class="nav">
+                    <a href="#">DynamoDB Accelerator (DAX)</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/dax_cluster.html">aws_dax_cluster</a>
@@ -1142,12 +777,12 @@
                             <a href="/docs/providers/aws/r/dax_subnet_group.html">aws_dax_subnet_group</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">DocumentDB Resources</a>
-                    <ul class="nav">
+                    <a href="#">DocumentDB</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/docdb_cluster.html">aws_docdb_cluster</a>
@@ -1169,12 +804,44 @@
                             <a href="/docs/providers/aws/r/docdb_subnet_group.html">aws_docdb_subnet_group</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">EC2 Resources</a>
-                    <ul class="nav">
+                    <a href="#">EC2</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/ami.html">aws_ami</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/ami_ids.html">aws_ami_ids</a>
+                        </li><li>
+                          <a href="/docs/providers/aws/d/ebs_default_kms_key.html">aws_ebs_default_kms_key</a>
+                        </li><li>
+                          <a href="/docs/providers/aws/d/ebs_encryption_by_default.html">aws_ebs_encryption_by_default</a>
+                        </li><li>
+                          <a href="/docs/providers/aws/d/ebs_snapshot.html">aws_ebs_snapshot</a>
+                        </li><li>
+                          <a href="/docs/providers/aws/d/ebs_snapshot_ids.html">aws_ebs_snapshot_ids</a>
+                        </li><li>
+                          <a href="/docs/providers/aws/d/ebs_volume.html">aws_ebs_volume</a>
+                        </li><li>
+                          <a href="/docs/providers/aws/d/ec2_transit_gateway.html">aws_ec2_transit_gateway</a>
+                        </li><li>
+                          <a href="/docs/providers/aws/d/ec2_transit_gateway_dx_gateway_attachment.html">aws_ec2_transit_gateway_dx_gateway_attachment</a>
+                        </li><li>
+                          <a href="/docs/providers/aws/d/ec2_transit_gateway_route_table.html">aws_ec2_transit_gateway_route_table</a>
+                        </li><li>
+                          <a href="/docs/providers/aws/d/ec2_transit_gateway_vpc_attachment.html">aws_ec2_transit_gateway_vpc_attachment</a>
+                        </li><li>
+                          <a href="/docs/providers/aws/d/ec2_transit_gateway_vpn_attachment.html">aws_ec2_transit_gateway_vpn_attachment</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/eip.html">aws_eip</a>
+                        </li><li>
+                          <a href="/docs/providers/aws/d/instance.html">aws_instance</a>
+                        </li><li>
+                          <a href="/docs/providers/aws/d/instances.html">aws_instances</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/launch_template.html">aws_launch_template</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/ami.html">aws_ami</a>
@@ -1303,12 +970,16 @@
                         <li>
                             <a href="/docs/providers/aws/r/volume_attachment.html">aws_volume_attachment</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">ECR Resources</a>
-                    <ul class="nav">
+                    <a href="#">ECR</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                          <a href="/docs/providers/aws/d/ecr_image.html">aws_ecr_image</a>
+                        </li><li>
+                          <a href="/docs/providers/aws/d/ecr_repository.html">aws_ecr_repository</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/ecr_lifecycle_policy.html">aws_ecr_lifecycle_policy</a>
@@ -1322,13 +993,21 @@
                             <a href="/docs/providers/aws/r/ecr_repository_policy.html">aws_ecr_repository_policy</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
 
                 <li>
-                    <a href="#">ECS Resources</a>
-                    <ul class="nav">
+                    <a href="#">ECS</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                          <a href="/docs/providers/aws/d/ecs_cluster.html">aws_ecs_cluster</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/ecs_container_definition.html">aws_ecs_container_definition</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/ecs_service.html">aws_ecs_service</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/ecs_task_definition.html">aws_ecs_task_definition</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/ecs_cluster.html">aws_ecs_cluster</a>
@@ -1342,12 +1021,16 @@
                             <a href="/docs/providers/aws/r/ecs_task_definition.html">aws_ecs_task_definition</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">EFS Resources</a>
-                    <ul class="nav">
+                    <a href="#">EFS</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/efs_file_system.html">aws_efs_file_system</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/efs_mount_target.html">aws_efs_mount_target</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/efs_file_system.html">aws_efs_file_system</a>
@@ -1357,25 +1040,33 @@
                             <a href="/docs/providers/aws/r/efs_mount_target.html">aws_efs_mount_target</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
 
                 <li>
-                    <a href="#">EKS Resources</a>
-                    <ul class="nav">
+                    <a href="#">EKS</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/eks_cluster.html">aws_eks_cluster</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/eks_cluster_auth.html">aws_eks_cluster_auth</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/eks_cluster.html">aws_eks_cluster</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
 
                 <li>
-                    <a href="#">ElastiCache Resources</a>
-                    <ul class="nav">
+                    <a href="#">ElastiCache</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/elasticache_cluster.html">aws_elasticache_cluster</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/elasticache_replication_group.html">aws_elasticache_replication_group</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/elasticache_cluster.html">aws_elasticache_cluster</a>
@@ -1397,13 +1088,19 @@
                             <a href="/docs/providers/aws/r/elasticache_subnet_group.html">aws_elasticache_subnet_group</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
 
                 <li>
-                    <a href="#">Elastic Beanstalk Resources</a>
-                    <ul class="nav">
+                    <a href="#">Elastic Beanstalk</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/elastic_beanstalk_application.html">aws_elastic_beanstalk_application</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/elastic_beanstalk_hosted_zone.html">aws_elastic_beanstalk_hosted_zone</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/elastic_beanstalk_solution_stack.html">aws_elastic_beanstalk_solution_stack</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/r/elastic_beanstalk_application.html">aws_elastic_beanstalk_application</a>
                         </li>
@@ -1417,12 +1114,18 @@
                         <li>
                             <a href="/docs/providers/aws/r/elastic_beanstalk_environment.html">aws_elastic_beanstalk_environment</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Elastic Load Balancing (ELB Classic) Resources</a>
-                    <ul class="nav">
+                    <a href="#">Elastic Load Balancing (ELB Classic)</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/elb.html">aws_elb</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/elb_hosted_zone_id.html">aws_elb_hosted_zone_id</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/elb_service_account.html">aws_elb_service_account</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/r/app_cookie_stickiness_policy.html">aws_app_cookie_stickiness_policy</a>
                         </li>
@@ -1458,12 +1161,24 @@
                         <li>
                             <a href="/docs/providers/aws/r/proxy_protocol_policy.html">aws_proxy_protocol_policy</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Elastic Load Balancing v2 (ALB/NLB) Resources</a>
-                    <ul class="nav">
+                    <a href="#">Elastic Load Balancing v2 (ALB/NLB)</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/lb.html">aws_alb</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/lb_listener.html">aws_alb_listener</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/lb_target_group.html">aws_alb_target_group</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/lb.html">aws_lb</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/lb_listener.html">aws_lb_listener</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/lb_target_group.html">aws_lb_target_group</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/r/lb.html">aws_lb</a>
                         </li>
@@ -1487,12 +1202,12 @@
                         <li>
                           <a href="/docs/providers/aws/r/lb_target_group_attachment.html">aws_lb_target_group_attachment</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Elastic Map Reduce (EMR) Resources</a>
-                    <ul class="nav">
+                    <a href="#">Elastic Map Reduce (EMR)</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/r/emr_cluster.html">aws_emr_cluster</a>
                         </li>
@@ -1504,12 +1219,12 @@
                         <li>
                             <a href="/docs/providers/aws/r/emr_security_configuration.html">aws_emr_security_configuration</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">ElasticSearch Resources</a>
-                    <ul class="nav">
+                    <a href="#">ElasticSearch</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/elasticsearch_domain.html">aws_elasticsearch_domain</a>
@@ -1519,12 +1234,12 @@
                             <a href="/docs/providers/aws/r/elasticsearch_domain_policy.html">aws_elasticsearch_domain_policy</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Elastic Transcoder Resources</a>
-                    <ul class="nav">
+                    <a href="#">Elastic Transcoder</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/elastic_transcoder_pipeline.html">aws_elastictranscoder_pipeline</a>
@@ -1534,12 +1249,12 @@
                             <a href="/docs/providers/aws/r/elastic_transcoder_preset.html">aws_elastictranscoder_preset</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Gamelift Resources</a>
-                    <ul class="nav">
+                    <a href="#">Gamelift</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/r/gamelift_alias.html">aws_gamelift_alias</a>
                         </li>
@@ -1552,43 +1267,45 @@
                         <li>
                             <a href="/docs/providers/aws/r/gamelift_game_session_queue.html">aws_gamelift_game_session_queue</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                  </li>
 
                 <li>
-                    <a href="#">Glacier Resources</a>
-                    <ul class="nav">
+                    <a href="#">Glacier</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/r/glacier_vault.html">aws_glacier_vault</a>
                         </li>
                         <li>
                             <a href="/docs/providers/aws/r/glacier_vault_lock.html">aws_glacier_vault_lock</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                  </li>
 
                 <li>
-                    <a href="#">Global Accelerator Resources</a>
-                    <ul class="nav">
+                    <a href="#">Global Accelerator</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/r/globalaccelerator_accelerator.html">aws_globalaccelerator_accelerator</a>
                         </li>
-                    </ul>
-                    <ul class="nav">
+                    </ul></li></ul>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/r/globalaccelerator_endpoint_group.html">aws_globalaccelerator_endpoint_group</a>
                         </li>
-                    </ul>
-                    <ul class="nav">
+                    </ul></li></ul>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/r/globalaccelerator_listener.html">aws_globalaccelerator_listener</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                  </li>
 
                  <li>
-                    <a href="#">Glue Resources</a>
-                    <ul class="nav">
+                    <a href="#">Glue</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/glue_script.html">aws_glue_script</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/r/glue_catalog_database.html">aws_glue_catalog_database</a>
                         </li>
@@ -1613,12 +1330,12 @@
                         <li>
                             <a href="/docs/providers/aws/r/glue_trigger.html">aws_glue_trigger</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                  </li>
 
                 <li>
-                    <a href="#">GuardDuty Resources</a>
-                    <ul class="nav">
+                    <a href="#">GuardDuty</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/r/guardduty_detector.html">aws_guardduty_detector</a>
                         </li>
@@ -1638,12 +1355,28 @@
                         <li>
                             <a href="/docs/providers/aws/r/guardduty_threatintelset.html">aws_guardduty_threatintelset</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                  </li>
 
                 <li>
-                    <a href="#">IAM Resources</a>
-                    <ul class="nav">
+                    <a href="#">IAM</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/iam_account_alias.html">aws_iam_account_alias</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/iam_group.html">aws_iam_group</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/iam_instance_profile.html">aws_iam_instance_profile</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/iam_policy.html">aws_iam_policy</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/iam_policy_document.html">aws_iam_policy_document</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/iam_role.html">aws_iam_role</a>
+                        </li><li>
+                          <a href="/docs/providers/aws/d/iam_server_certificate.html">aws_iam_server_certificate</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/iam_user.html">aws_iam_user</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/iam_access_key.html">aws_iam_access_key</a>
@@ -1737,12 +1470,14 @@
                           <a href="/docs/providers/aws/r/iam_user_ssh_key.html">aws_iam_user_ssh_key</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">IoT Resources</a>
-                    <ul class="nav">
+                    <a href="#">IoT</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                          <a href="/docs/providers/aws/d/iot_endpoint.html">aws_iot_endpoint</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
 
                     <li>
                       <a href="/docs/providers/aws/r/iot_certificate.html">aws_iot_certificate</a>
@@ -1774,12 +1509,14 @@
                     <li>
                         <a href="/docs/providers/aws/r/iot_role_alias.html">aws_iot_role_alias</a>
                     </li>
-                  </ul>
+                  </ul></li></ul>
                 </li>
 
                 <li>
-                  <a href="#">Inspector Resources</a>
-                  <ul class="nav">
+                  <a href="#">Inspector</a>
+                  <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                          <a href="/docs/providers/aws/d/inspector_rules_packages.html">aws_inspector_rules_packages</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
 
                     <li>
                       <a href="/docs/providers/aws/r/inspector_assessment_target.html">aws_inspector_assessment_target</a>
@@ -1793,13 +1530,15 @@
                       <a href="/docs/providers/aws/r/inspector_resource_group.html">aws_inspector_resource_group</a>
                     </li>
 
-                  </ul>
+                  </ul></li></ul>
                 </li>
 
 
                 <li>
-                    <a href="#">Kinesis Resources</a>
-                    <ul class="nav">
+                    <a href="#">Kinesis</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/kinesis_stream.html">aws_kinesis_stream</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/kinesis_analytics_application.html">aws_kinesis_analytics_application</a>
@@ -1809,23 +1548,31 @@
                             <a href="/docs/providers/aws/r/kinesis_stream.html">aws_kinesis_stream</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
               <li>
-                <a href="#">Kinesis Firehose Resources</a>
-                <ul class="nav">
+                <a href="#">Kinesis Firehose</a>
+                <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
 
                   <li>
                     <a href="/docs/providers/aws/r/kinesis_firehose_delivery_stream.html">aws_kinesis_firehose_delivery_stream</a>
                   </li>
 
-                </ul>
+                </ul></li></ul>
               </li>
 
               <li>
-                <a href="#">KMS Resources</a>
-                <ul class="nav">
+                <a href="#">KMS</a>
+                <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/kms_alias.html">aws_kms_alias</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/kms_ciphertext.html">aws_kms_ciphertext</a>
+                        </li><li>
+                          <a href="/docs/providers/aws/d/kms_key.html">aws_kms_key</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/kms_secrets.html">aws_kms_secrets</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
 
                   <li>
                     <a href="/docs/providers/aws/r/kms_alias.html">aws_kms_alias</a>
@@ -1847,12 +1594,18 @@
                     <a href="/docs/providers/aws/r/kms_key.html">aws_kms_key</a>
                   </li>
 
-                </ul>
+                </ul></li></ul>
               </li>
 
               <li>
-                  <a href="#">Lambda Resources</a>
-                  <ul class="nav">
+                  <a href="#">Lambda</a>
+                  <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/lambda_function.html">aws_lambda_function</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/lambda_invocation.html">aws_lambda_invocation</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/lambda_layer_version.html">aws_lambda_layer_version</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
                       <li>
                           <a href="/docs/providers/aws/r/lambda_alias.html">aws_lambda_alias</a>
                       </li>
@@ -1868,12 +1621,12 @@
                       <li>
                           <a href="/docs/providers/aws/r/lambda_permission.html">aws_lambda_permission</a>
                       </li>
-                  </ul>
+                  </ul></li></ul>
               </li>
 
                 <li>
-                    <a href="#">License Manager Resources</a>
-                    <ul class="nav">
+                    <a href="#">License Manager</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/licensemanager_association.html">aws_licensemanager_association</a>
@@ -1883,12 +1636,12 @@
                             <a href="/docs/providers/aws/r/licensemanager_license_configuration.html">aws_licensemanager_license_configuration</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Lightsail Resources</a>
-                    <ul class="nav">
+                    <a href="#">Lightsail</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                           <a href="/docs/providers/aws/r/lightsail_domain.html">aws_lightsail_domain</a>
@@ -1910,12 +1663,12 @@
                             <a href="/docs/providers/aws/r/lightsail_static_ip_attachment.html">aws_lightsail_static_ip_attachment</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Macie Resources</a>
-                    <ul class="nav">
+                    <a href="#">Macie</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/macie_member_account_association.html">aws_macie_member_account_association</a>
@@ -1925,12 +1678,14 @@
                             <a href="/docs/providers/aws/r/macie_s3_bucket_association.html">aws_macie_s3_bucket_association</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">MQ Resources</a>
-                    <ul class="nav">
+                    <a href="#">MQ</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/mq_broker.html">aws_mq_broker</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
                         <li>
                           <a href="/docs/providers/aws/r/mq_broker.html">aws_mq_broker</a>
                         </li>
@@ -1938,23 +1693,23 @@
                             <a href="/docs/providers/aws/r/mq_configuration.html">aws_mq_configuration</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">MediaPackage Resources</a>
-                    <ul class="nav">
+                    <a href="#">MediaPackage</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                           <a href="/docs/providers/aws/r/media_package_channel.html">aws_media_package_channel</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">MediaStore Resources</a>
-                    <ul class="nav">
+                    <a href="#">MediaStore</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                           <a href="/docs/providers/aws/r/media_store_container.html">aws_media_store_container</a>
@@ -1963,12 +1718,16 @@
                           <a href="/docs/providers/aws/r/media_store_container_policy.html">aws_media_store_container_policy</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Managed Streaming for Kafka (MSK) Resources</a>
-                    <ul class="nav">
+                    <a href="#">Managed Streaming for Kafka (MSK)</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/msk_cluster.html">aws_msk_cluster</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/msk_configuration.html">aws_msk_configuration</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/msk_cluster.html">aws_msk_cluster</a>
@@ -1977,12 +1736,12 @@
                         <li>
                             <a href="/docs/providers/aws/r/msk_configuration.html">aws_msk_configuration</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Neptune Resources</a>
-                    <ul class="nav">
+                    <a href="#">Neptune</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/neptune_parameter_group.html">aws_neptune_parameter_group</a>
@@ -2012,12 +1771,12 @@
                             <a href="/docs/providers/aws/r/neptune_event_subscription.html">aws_neptune_event_subscription</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">OpsWorks Resources</a>
-                    <ul class="nav">
+                    <a href="#">OpsWorks</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/opsworks_application.html">aws_opsworks_application</a>
@@ -2083,12 +1842,14 @@
                             <a href="/docs/providers/aws/r/opsworks_user_profile.html">aws_opsworks_user_profile</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Organizations Resources</a>
-                    <ul class="nav">
+                    <a href="#">Organizations</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/organizations_organization.html">aws_organizations_organization</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/organizations_account.html">aws_organizations_account</a>
@@ -2105,12 +1866,12 @@
                         <li>
                             <a href="/docs/providers/aws/r/organizations_policy_attachment.html">aws_organizations_policy_attachment</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Pinpoint Resources</a>
-                    <ul class="nav">
+                    <a href="#">Pinpoint</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/pinpoint_app.html">aws_pinpoint_app</a>
@@ -2145,21 +1906,32 @@
                         <li>
                             <a href="/docs/providers/aws/r/pinpoint_sms_channel.html">aws_pinpoint_sms_channel</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">QuickSight Resources</a>
-                    <ul class="nav">
+                    <a href="#">Pricing</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/d/pricing_product.html">aws_pricing_product</a>
+                        </li>
+                    </ul></li></ul>
+                </li>
+
+                <li>
+                    <a href="#">QuickSight</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
                         <li>
                         <a href="/docs/providers/aws/r/quicksight_group.html">aws_quicksight_group</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">RAM Resources</a>
-                    <ul class="nav">
+                    <a href="#">RAM</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                        <a href="/docs/providers/aws/d/ram_resource_share.html">aws_ram_resource_share</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
                         <li>
                         <a href="/docs/providers/aws/r/ram_principal_association.html">aws_ram_principal_association</a>
                         </li>
@@ -2169,12 +1941,22 @@
                         <li>
                         <a href="/docs/providers/aws/r/ram_resource_share.html">aws_ram_resource_share</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">RDS Resources</a>
-                    <ul class="nav">
+                    <a href="#">RDS</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                          <a href="/docs/providers/aws/d/db_cluster_snapshot.html">aws_db_cluster_snapshot</a>
+                        </li><li>
+                          <a href="/docs/providers/aws/d/db_event_categories.html">aws_db_event_categories</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/db_instance.html">aws_db_instance</a>
+                        </li><li>
+                          <a href="/docs/providers/aws/d/db_snapshot.html">aws_db_snapshot</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/rds_cluster.html">aws_rds_cluster</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                           <a href="/docs/providers/aws/r/db_cluster_snapshot.html">aws_db_cluster_snapshot</a>
@@ -2231,12 +2013,16 @@
                         <li>
                             <a href="/docs/providers/aws/r/rds_global_cluster.html">aws_rds_global_cluster</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
               <li>
-                <a href="#">Redshift Resources</a>
-                <ul class="nav">
+                <a href="#">Redshift</a>
+                <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/redshift_cluster.html">aws_redshift_cluster</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/redshift_service_account.html">aws_redshift_service_account</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
 
                   <li>
                     <a href="/docs/providers/aws/r/redshift_cluster.html">aws_redshift_cluster</a>
@@ -2262,22 +2048,26 @@
                     <a href="/docs/providers/aws/r/redshift_subnet_group.html">aws_redshift_subnet_group</a>
                   </li>
 
-                </ul>
+                </ul></li></ul>
               </li>
 
 
               <li>
-                <a href="#">Resource Groups Resources</a>
-                <ul class="nav">
+                <a href="#">Resource Groups</a>
+                <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
                   <li>
                     <a href="/docs/providers/aws/r/resourcegroups_group.html">aws_resourcegroups_group</a>
                   </li>
-                </ul>
+                </ul></li></ul>
               </li>
 
                 <li>
-                    <a href="#">Route53 Resources</a>
-                    <ul class="nav">
+                    <a href="#">Route53</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                          <a href="/docs/providers/aws/d/route53_delegation_set.html">aws_route53_delegation_set</a>
+                        </li><li>
+                          <a href="/docs/providers/aws/d/route53_zone.html">aws_route53_zone</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/route53_delegation_set.html">aws_route53_delegation_set</a>
@@ -2303,13 +2093,13 @@
                             <a href="/docs/providers/aws/r/route53_zone_association.html">aws_route53_zone_association</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
 
                 <li>
-                    <a href="#">Route53 Resolver Resources</a>
-                    <ul class="nav">
+                    <a href="#">Route53 Resolver</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/route53_resolver_endpoint.html">aws_route53_resolver_endpoint</a>
@@ -2323,13 +2113,19 @@
                             <a href="/docs/providers/aws/r/route53_resolver_rule_association.html">aws_route53_resolver_rule_association</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
 
                 <li>
-                    <a href="#">S3 Resources</a>
-                    <ul class="nav">
+                    <a href="#">S3</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/canonical_user_id.html">aws_canonical_user_id</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/s3_bucket.html">aws_s3_bucket</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/s3_bucket_object.html">aws_s3_bucket_object</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/s3_account_public_access_block.html">aws_s3_account_public_access_block</a>
@@ -2362,12 +2158,12 @@
                         <li>
                             <a href="/docs/providers/aws/r/s3_bucket_public_access_block.html">aws_s3_bucket_public_access_block</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Sagemaker Resources</a>
-                    <ul class="nav">
+                    <a href="#">Sagemaker</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                           <a href="/docs/providers/aws/r/sagemaker_endpoint.html">aws_sagemaker_endpoint</a>
@@ -2389,12 +2185,16 @@
                           <a href="/docs/providers/aws/r/sagemaker_notebook_instance_lifecycle_configuration.html">aws_sagemaker_notebook_instance_lifecycle_configuration</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Secrets Manager Resources</a>
-                    <ul class="nav">
+                    <a href="#">Secrets Manager</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                         <a href="/docs/providers/aws/d/secretsmanager_secret.html">aws_secretsmanager_secret</a>
+                        </li><li>
+                         <a href="/docs/providers/aws/d/secretsmanager_secret_version.html">aws_secretsmanager_secret_version</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/secretsmanager_secret.html">aws_secretsmanager_secret</a>
@@ -2404,12 +2204,12 @@
                             <a href="/docs/providers/aws/r/secretsmanager_secret_version.html">aws_secretsmanager_secret_version</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Security Hub Resources</a>
-                    <ul class="nav">
+                    <a href="#">Security Hub</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/securityhub_account.html">aws_securityhub_account</a>
@@ -2423,12 +2223,12 @@
                             <a href="/docs/providers/aws/r/securityhub_standards_subscription.html">aws_securityhub_standards_subscription</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">SES Resources</a>
-                    <ul class="nav">
+                    <a href="#">SES</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/ses_active_receipt_rule_set.html">aws_ses_active_receipt_rule_set</a>
@@ -2486,23 +2286,23 @@
                             <a href="/docs/providers/aws/r/ses_template.html">aws_ses_template</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Service Catalog Resources</a>
-                    <ul class="nav">
+                    <a href="#">Service Catalog</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/servicecatalog_portfolio.html">aws_servicecatalog_portfolio</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Service Discovery Resources</a>
-                    <ul class="nav">
+                    <a href="#">Service Discovery</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/service_discovery_http_namespace.html">aws_service_discovery_http_namespace</a>
@@ -2520,46 +2320,52 @@
                             <a href="/docs/providers/aws/r/service_discovery_service.html">aws_service_discovery_service</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Service Quotas Resources</a>
-                    <ul class="nav">
+                    <a href="#">Service Quotas</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                          <a href="/docs/providers/aws/d/servicequotas_service.html">aws_servicequotas_service</a>
+                        </li><li>
+                          <a href="/docs/providers/aws/d/servicequotas_service_quota.html">aws_servicequotas_service_quota</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/servicequotas_service_quota.html">aws_servicequotas_service_quota</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Shield Resources</a>
-                    <ul class="nav">
+                    <a href="#">Shield</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/shield_protection.html">aws_shield_protection</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">SimpleDB Resources</a>
-                    <ul class="nav">
+                    <a href="#">SimpleDB</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/simpledb_domain.html">aws_simpledb_domain</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
 
                 <li>
-                    <a href="#">SNS Resources</a>
-                    <ul class="nav">
+                    <a href="#">SNS</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                         <a href="/docs/providers/aws/d/sns_topic.html">aws_sns_topic</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/sns_platform_application.html">aws_sns_platform_application</a>
@@ -2581,12 +2387,14 @@
                             <a href="/docs/providers/aws/r/sns_topic_subscription.html">aws_sns_topic_subscription</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">SQS Resources</a>
-                    <ul class="nav">
+                    <a href="#">SQS</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                         <a href="/docs/providers/aws/d/sqs_queue.html">aws_sqs_queue</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/sqs_queue.html">aws_sqs_queue</a>
@@ -2596,12 +2404,16 @@
                             <a href="/docs/providers/aws/r/sqs_queue_policy.html">aws_sqs_queue_policy</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">SSM Resources</a>
-                    <ul class="nav">
+                    <a href="#">SSM</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                         <a href="/docs/providers/aws/d/ssm_document.html">aws_ssm_document</a>
+                        </li><li>
+                         <a href="/docs/providers/aws/d/ssm_parameter.html">aws_ssm_parameter</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/ssm_activation.html">aws_ssm_activation</a>
@@ -2642,12 +2454,12 @@
                             <a href="/docs/providers/aws/r/ssm_resource_data_sync.html">aws_ssm_resource_data_sync</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Step Function (SFN) Resources</a>
-                    <ul class="nav">
+                    <a href="#">Step Function (SFN)</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/sfn_activity.html">aws_sfn_activity</a>
@@ -2657,12 +2469,14 @@
                             <a href="/docs/providers/aws/r/sfn_state_machine.html">aws_sfn_state_machine</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Storage Gateway Resources</a>
-                    <ul class="nav">
+                    <a href="#">Storage Gateway</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                         <a href="/docs/providers/aws/d/storagegateway_local_disk.html">aws_storagegateway_local_disk</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/storagegateway_cache.html">aws_storagegateway_cache</a>
@@ -2692,23 +2506,25 @@
                             <a href="/docs/providers/aws/r/storagegateway_working_storage.html">aws_storagegateway_working_storage</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">SWF Resources</a>
-                    <ul class="nav">
+                    <a href="#">SWF</a>
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/swf_domain.html">aws_swf_domain</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">Transfer Resources</a>
-                    <ul class="nav">
+                    <a href="#">Transfer</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/transfer_server.html">aws_transfer_server</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/transfer_server.html">aws_transfer_server</a>
@@ -2721,12 +2537,56 @@
                         <li>
                             <a href="/docs/providers/aws/r/transfer_user.html">aws_transfer_user</a>
                         </li>
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
                 <li>
-                    <a href="#">VPC Resources</a>
-                    <ul class="nav">
+                    <a href="#">VPC</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/customer_gateway.html">aws_customer_gateway</a>
+                        </li><li>
+                          <a href="/docs/providers/aws/d/internet_gateway.html">aws_internet_gateway</a>
+                        </li><li>
+                           <a href="/docs/providers/aws/d/nat_gateway.html">aws_nat_gateway</a>
+                        </li><li>
+                           <a href="/docs/providers/aws/d/network_acls.html">aws_network_acls</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/network_interface.html">aws_network_interface</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/network_interfaces.html">aws_network_interfaces</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/prefix_list.html">aws_prefix_list</a>
+                        </li><li>
+                          <a href="/docs/providers/aws/d/route.html">aws_route</a>
+                        </li><li>
+                          <a href="/docs/providers/aws/d/route_table.html">aws_route_table</a>
+                        </li><li>
+                          <a href="/docs/providers/aws/d/route_tables.html">aws_route_tables</a>
+                        </li><li>
+                         <a href="/docs/providers/aws/d/security_group.html">aws_security_group</a>
+                        </li><li>
+                         <a href="/docs/providers/aws/d/security_groups.html">aws_security_groups</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/subnet.html">aws_subnet</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/subnet_ids.html">aws_subnet_ids</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/vpc.html">aws_vpc</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/vpc_dhcp_options.html">aws_vpc_dhcp_options</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/vpc_endpoint.html">aws_vpc_endpoint</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/vpc_endpoint_service.html">aws_vpc_endpoint_service</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/vpc_peering_connection.html">aws_vpc_peering_connection</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/vpcs.html">aws_vpcs</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/vpn_gateway.html">aws_vpn_gateway</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/waf_rule.html">aws_vpn_gateway</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/customer_gateway.html">aws_customer_gateway</a>
@@ -2890,12 +2750,14 @@
                             <a href="/docs/providers/aws/r/vpn_gateway_route_propagation.html">aws_vpn_gateway_route_propagation</a>
                         </li>
 
-                    </ul>
+                    </ul></li></ul>
                 </li>
 
-<li>
-                <a href="#">WAF Resources</a>
-                <ul class="nav">
+              <li>
+                <a href="#">WAF</a>
+                <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/waf_web_acl.html">aws_waf_web_acl</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
 
                   <li>
                     <a href="/docs/providers/aws/r/waf_byte_match_set.html">aws_waf_byte_match_set</a>
@@ -2945,12 +2807,16 @@
                     <a href="/docs/providers/aws/r/waf_xss_match_set.html">aws_waf_xss_match_set</a>
                   </li>
 
-                </ul>
+                </ul></li></ul>
               </li>
 
               <li>
-                <a href="#">WAF Regional Resources</a>
-                <ul class="nav">
+                <a href="#">WAF Regional</a>
+                <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                            <a href="/docs/providers/aws/d/wafregional_rule.html">aws_wafregional_rule</a>
+                        </li><li>
+                            <a href="/docs/providers/aws/d/wafregional_web_acl.html">aws_wafregional_web_acl</a>
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
 
                   <li>
                     <a href="/docs/providers/aws/r/wafregional_byte_match_set.html">aws_wafregional_byte_match_set</a>
@@ -3004,28 +2870,37 @@
                     <a href="/docs/providers/aws/r/wafregional_xss_match_set.html">aws_wafregional_xss_match_set</a>
                   </li>
 
-                </ul>
+                </ul></li></ul>
               </li>
 
               <li>
-                <a href="#">WorkLink Resources</a>
-                <ul class="nav">
+                <a href="#">WorkLink</a>
+                <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
                     <li>
                         <a href="/docs/providers/aws/r/worklink_fleet.html">aws_worklink_fleet</a>
                     </li>
                     <li>
                         <a href="/docs/providers/aws/r/worklink_website_certificate_authority_association.html">aws_worklink_website_certificate_authority_association</a>
                     </li>
-                </ul>
+                </ul></li></ul>
               </li>
 
+                <li>
+                    <a href="#">WorkSpaces</a>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/d/workspaces_bundle.html">aws_workspaces_bundle</a>
+                        </li>
+                    </ul></li></ul>
+                </li>
+
               <li>
-                <a href="#">XRay Resources</a>
-                <ul class="nav">
+                <a href="#">XRay</a>
+                <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
                     <li>
                         <a href="/docs/providers/aws/r/xray_sampling_rule.html">aws_xray_sampling_rule</a>
                     </li>
-                </ul>
+                </ul></li></ul>
               </li>
 
             </ul>

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -67,9 +67,9 @@
 
                 <li>
                   <a href="#">ACM</a>
-                  <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                  <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/acm_certificate.html">aws_acm_certificate</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                     <li>
                       <a href="/docs/providers/aws/r/acm_certificate.html">aws_acm_certificate</a>
                     </li>
@@ -81,9 +81,9 @@
 
                 <li>
                   <a href="#">ACM PCA</a>
-                  <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                  <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/acmpca_certificate_authority.html">aws_acmpca_certificate_authority</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                     <li>
                       <a href="/docs/providers/aws/r/acmpca_certificate_authority.html">aws_acmpca_certificate_authority</a>
                     </li>
@@ -92,7 +92,7 @@
 
                 <li>
                     <a href="#">API Gateway</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/api_gateway_api_key.html">aws_api_gateway_api_key</a>
                         </li><li>
                             <a href="/docs/providers/aws/d/api_gateway_resource.html">aws_api_gateway_resource</a>
@@ -100,7 +100,7 @@
                             <a href="/docs/providers/aws/d/api_gateway_rest_api.html">aws_api_gateway_rest_api</a>
                         </li><li>
                             <a href="/docs/providers/aws/d/api_gateway_vpc_link.html">aws_api_gateway_vpc_link</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                             <a href="/docs/providers/aws/r/api_gateway_account.html">aws_api_gateway_account</a>
                         </li>
@@ -175,7 +175,7 @@
 
                 <li>
                     <a href="#">Application Autoscaling</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                       <li>
                         <a href="/docs/providers/aws/r/appautoscaling_policy.html">aws_appautoscaling_policy</a>
                       </li>
@@ -190,7 +190,7 @@
 
                 <li>
                     <a href="#">AppMesh</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                             <a href="/docs/providers/aws/r/appmesh_mesh.html">aws_appmesh_mesh</a>
                         </li>
@@ -211,7 +211,7 @@
 
                 <li>
                     <a href="#">AppSync</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                             <a href="/docs/providers/aws/r/appsync_datasource.html">aws_appsync_datasource</a>
                         </li>
@@ -232,7 +232,7 @@
 
                 <li>
                     <a href="#">Athena</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                             <a href="/docs/providers/aws/r/athena_database.html">aws_athena_database</a>
                         </li>
@@ -247,13 +247,13 @@
 
                 <li>
                     <a href="#">Autoscaling</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/autoscaling_group.html">aws_autoscaling_group</a>
                         </li><li>
                             <a href="/docs/providers/aws/d/autoscaling_groups.html">aws_autoscaling_groups</a>
                         </li><li>
                             <a href="/docs/providers/aws/d/launch_configuration.html">aws_launch_configuration</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                           <a href="/docs/providers/aws/r/autoscaling_attachment.html">aws_autoscaling_attachment</a>
                         </li>
@@ -282,7 +282,7 @@
 
                 <li>
                     <a href="#">Backup</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                             <a href="/docs/providers/aws/r/backup_plan.html">aws_backup_plan</a>
                         </li>
@@ -297,11 +297,11 @@
 
                 <li>
                     <a href="#">Batch</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                           <a href="/docs/providers/aws/d/batch_compute_environment.html">aws_batch_compute_environment</a>
                         </li><li>
                           <a href="/docs/providers/aws/d/batch_job_queue.html">aws_batch_job_queue</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                             <a href="/docs/providers/aws/r/batch_compute_environment.html">aws_batch_compute_environment</a>
                         </li>
@@ -316,7 +316,7 @@
 
                 <li>
                     <a href="#">Budgets</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                             <a href="/docs/providers/aws/r/budgets_budget.html">aws_budgets_budget</a>
                         </li>
@@ -325,7 +325,7 @@
 
                 <li>
                     <a href="#">Cloud9</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                             <a href="/docs/providers/aws/r/cloud9_environment_ec2.html">aws_cloud9_environment_ec2</a>
                         </li>
@@ -334,11 +334,11 @@
 
                 <li>
                     <a href="#">CloudFormation</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/cloudformation_export.html">aws_cloudformation_export</a>
                         </li><li>
                             <a href="/docs/providers/aws/d/cloudformation_stack.html">aws_cloudformation_stack</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                             <a href="/docs/providers/aws/r/cloudformation_stack.html">aws_cloudformation_stack</a>
                         </li>
@@ -353,7 +353,7 @@
 
                 <li>
                     <a href="#">CloudFront</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                             <a href="/docs/providers/aws/r/cloudfront_distribution.html">aws_cloudfront_distribution</a>
                         </li>
@@ -368,9 +368,9 @@
 
                 <li>
                     <a href="#">CloudHSM v2</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/cloudhsm_v2_cluster.html">aws_cloudhsm_v2_cluster</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                             <a href="/docs/providers/aws/r/cloudhsm_v2_cluster.html">aws_cloudhsm_v2_cluster</a>
                         </li>
@@ -382,9 +382,9 @@
 
                 <li>
                     <a href="#">CloudTrail</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/cloudtrail_service_account.html">aws_cloudtrail_service_account</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                             <a href="/docs/providers/aws/r/cloudtrail.html">aws_cloudtrail</a>
                         </li>
@@ -393,9 +393,9 @@
 
                 <li>
                     <a href="#">CloudWatch</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/cloudwatch_log_group.html">aws_cloudwatch_log_group</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                             <a href="/docs/providers/aws/r/cloudwatch_dashboard.html">aws_cloudwatch_dashboard</a>
                         </li>
@@ -450,7 +450,7 @@
 
                 <li>
                     <a href="#">CodeBuild</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/codebuild_project.html">aws_codebuild_project</a>
@@ -466,9 +466,9 @@
 
                 <li>
                     <a href="#">CodeCommit</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/codecommit_repository.html">aws_codecommit_repository</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/codecommit_repository.html">aws_codecommit_repository</a>
@@ -482,7 +482,7 @@
 
                 <li>
                     <a href="#">CodeDeploy</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/codedeploy_app.html">aws_codedeploy_app</a>
@@ -501,7 +501,7 @@
 
                 <li>
                     <a href="#">CodePipeline</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/codepipeline.html">aws_codepipeline</a>
@@ -517,9 +517,9 @@
 
                 <li>
                     <a href="#">Cognito</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/cognito_user_pools.html">aws_cognito_user_pools</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                             <a href="/docs/providers/aws/r/cognito_identity_pool.html">aws_cognito_identity_pool</a>
                         </li>
@@ -549,7 +549,7 @@
 
                 <li>
                     <a href="#">Config</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                             <a href="/docs/providers/aws/r/config_aggregate_authorization.html">aws_config_aggregate_authorization</a>
                         </li>
@@ -579,9 +579,9 @@
 
                 <li>
                     <a href="#">Cost and Usage Report</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/cur_report_definition.html">aws_cur_report_definition</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/cur_report_definition.html">aws_cur_report_definition</a>
@@ -592,7 +592,7 @@
 
                 <li>
                     <a href="#">Data Lifecycle Manager (DLM)</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                             <a href="/docs/providers/aws/r/dlm_lifecycle_policy.html">aws_dlm_lifecycle_policy</a>
                         </li>
@@ -601,7 +601,7 @@
 
                 <li>
                     <a href="#">Database Migration Service (DMS)</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/dms_certificate.html">aws_dms_certificate</a>
@@ -628,7 +628,7 @@
 
                 <li>
                     <a href="#">DataPipeline</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/datapipeline_pipeline.html">aws_datapipeline_pipeline</a>
@@ -639,7 +639,7 @@
 
                 <li>
                     <a href="#">DataSync</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/datasync_agent.html">aws_datasync_agent</a>
@@ -666,7 +666,7 @@
 
                 <li>
                     <a href="#">Device Farm</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                             <a href="/docs/providers/aws/r/devicefarm_project.html">aws_devicefarm_project</a>
                         </li>
@@ -675,7 +675,7 @@
 
                 <li>
                     <a href="#">Directory Service</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/directory_service_directory.html">aws_directory_service_directory</a>
@@ -694,9 +694,9 @@
 
                 <li>
                     <a href="#">Direct Connect</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                           <a href="/docs/providers/aws/d/dx_gateway.html">aws_dx_gateway</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                             <a href="/docs/providers/aws/r/dx_bgp_peer.html">aws_dx_bgp_peer</a>
                         </li>
@@ -741,9 +741,9 @@
 
                 <li>
                     <a href="#">DynamoDB</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                           <a href="/docs/providers/aws/d/dynamodb_table.html">aws_dynamodb_table</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/dynamodb_global_table.html">aws_dynamodb_global_table</a>
@@ -763,7 +763,7 @@
 
                 <li>
                     <a href="#">DynamoDB Accelerator (DAX)</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/dax_cluster.html">aws_dax_cluster</a>
@@ -782,7 +782,7 @@
 
                 <li>
                     <a href="#">DocumentDB</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/docdb_cluster.html">aws_docdb_cluster</a>
@@ -809,7 +809,7 @@
 
                 <li>
                     <a href="#">EC2</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/ami.html">aws_ami</a>
                         </li><li>
                             <a href="/docs/providers/aws/d/ami_ids.html">aws_ami_ids</a>
@@ -841,7 +841,7 @@
                           <a href="/docs/providers/aws/d/instances.html">aws_instances</a>
                         </li><li>
                             <a href="/docs/providers/aws/d/launch_template.html">aws_launch_template</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/ami.html">aws_ami</a>
@@ -975,11 +975,11 @@
 
                 <li>
                     <a href="#">ECR</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                           <a href="/docs/providers/aws/d/ecr_image.html">aws_ecr_image</a>
                         </li><li>
                           <a href="/docs/providers/aws/d/ecr_repository.html">aws_ecr_repository</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/ecr_lifecycle_policy.html">aws_ecr_lifecycle_policy</a>
@@ -999,7 +999,7 @@
 
                 <li>
                     <a href="#">ECS</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                           <a href="/docs/providers/aws/d/ecs_cluster.html">aws_ecs_cluster</a>
                         </li><li>
                             <a href="/docs/providers/aws/d/ecs_container_definition.html">aws_ecs_container_definition</a>
@@ -1007,7 +1007,7 @@
                             <a href="/docs/providers/aws/d/ecs_service.html">aws_ecs_service</a>
                         </li><li>
                             <a href="/docs/providers/aws/d/ecs_task_definition.html">aws_ecs_task_definition</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/ecs_cluster.html">aws_ecs_cluster</a>
@@ -1026,11 +1026,11 @@
 
                 <li>
                     <a href="#">EFS</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/efs_file_system.html">aws_efs_file_system</a>
                         </li><li>
                             <a href="/docs/providers/aws/d/efs_mount_target.html">aws_efs_mount_target</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/efs_file_system.html">aws_efs_file_system</a>
@@ -1046,11 +1046,11 @@
 
                 <li>
                     <a href="#">EKS</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/eks_cluster.html">aws_eks_cluster</a>
                         </li><li>
                             <a href="/docs/providers/aws/d/eks_cluster_auth.html">aws_eks_cluster_auth</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/eks_cluster.html">aws_eks_cluster</a>
@@ -1062,11 +1062,11 @@
 
                 <li>
                     <a href="#">ElastiCache</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/elasticache_cluster.html">aws_elasticache_cluster</a>
                         </li><li>
                             <a href="/docs/providers/aws/d/elasticache_replication_group.html">aws_elasticache_replication_group</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/elasticache_cluster.html">aws_elasticache_cluster</a>
@@ -1094,13 +1094,13 @@
 
                 <li>
                     <a href="#">Elastic Beanstalk</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/elastic_beanstalk_application.html">aws_elastic_beanstalk_application</a>
                         </li><li>
                             <a href="/docs/providers/aws/d/elastic_beanstalk_hosted_zone.html">aws_elastic_beanstalk_hosted_zone</a>
                         </li><li>
                             <a href="/docs/providers/aws/d/elastic_beanstalk_solution_stack.html">aws_elastic_beanstalk_solution_stack</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                             <a href="/docs/providers/aws/r/elastic_beanstalk_application.html">aws_elastic_beanstalk_application</a>
                         </li>
@@ -1119,13 +1119,13 @@
 
                 <li>
                     <a href="#">Elastic Load Balancing (ELB Classic)</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/elb.html">aws_elb</a>
                         </li><li>
                             <a href="/docs/providers/aws/d/elb_hosted_zone_id.html">aws_elb_hosted_zone_id</a>
                         </li><li>
                             <a href="/docs/providers/aws/d/elb_service_account.html">aws_elb_service_account</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                             <a href="/docs/providers/aws/r/app_cookie_stickiness_policy.html">aws_app_cookie_stickiness_policy</a>
                         </li>
@@ -1166,7 +1166,7 @@
 
                 <li>
                     <a href="#">Elastic Load Balancing v2 (ALB/NLB)</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/lb.html">aws_alb</a>
                         </li><li>
                             <a href="/docs/providers/aws/d/lb_listener.html">aws_alb_listener</a>
@@ -1178,7 +1178,7 @@
                             <a href="/docs/providers/aws/d/lb_listener.html">aws_lb_listener</a>
                         </li><li>
                             <a href="/docs/providers/aws/d/lb_target_group.html">aws_lb_target_group</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                             <a href="/docs/providers/aws/r/lb.html">aws_lb</a>
                         </li>
@@ -1207,7 +1207,7 @@
 
                 <li>
                     <a href="#">Elastic Map Reduce (EMR)</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                             <a href="/docs/providers/aws/r/emr_cluster.html">aws_emr_cluster</a>
                         </li>
@@ -1224,7 +1224,7 @@
 
                 <li>
                     <a href="#">ElasticSearch</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/elasticsearch_domain.html">aws_elasticsearch_domain</a>
@@ -1239,7 +1239,7 @@
 
                 <li>
                     <a href="#">Elastic Transcoder</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/elastic_transcoder_pipeline.html">aws_elastictranscoder_pipeline</a>
@@ -1254,7 +1254,7 @@
 
                 <li>
                     <a href="#">Gamelift</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                             <a href="/docs/providers/aws/r/gamelift_alias.html">aws_gamelift_alias</a>
                         </li>
@@ -1272,7 +1272,7 @@
 
                 <li>
                     <a href="#">Glacier</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                             <a href="/docs/providers/aws/r/glacier_vault.html">aws_glacier_vault</a>
                         </li>
@@ -1284,17 +1284,17 @@
 
                 <li>
                     <a href="#">Global Accelerator</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                             <a href="/docs/providers/aws/r/globalaccelerator_accelerator.html">aws_globalaccelerator_accelerator</a>
                         </li>
                     </ul></li></ul>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                             <a href="/docs/providers/aws/r/globalaccelerator_endpoint_group.html">aws_globalaccelerator_endpoint_group</a>
                         </li>
                     </ul></li></ul>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                             <a href="/docs/providers/aws/r/globalaccelerator_listener.html">aws_globalaccelerator_listener</a>
                         </li>
@@ -1303,9 +1303,9 @@
 
                  <li>
                     <a href="#">Glue</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/glue_script.html">aws_glue_script</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                             <a href="/docs/providers/aws/r/glue_catalog_database.html">aws_glue_catalog_database</a>
                         </li>
@@ -1335,7 +1335,7 @@
 
                 <li>
                     <a href="#">GuardDuty</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                             <a href="/docs/providers/aws/r/guardduty_detector.html">aws_guardduty_detector</a>
                         </li>
@@ -1360,7 +1360,7 @@
 
                 <li>
                     <a href="#">IAM</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/iam_account_alias.html">aws_iam_account_alias</a>
                         </li><li>
                             <a href="/docs/providers/aws/d/iam_group.html">aws_iam_group</a>
@@ -1376,7 +1376,7 @@
                           <a href="/docs/providers/aws/d/iam_server_certificate.html">aws_iam_server_certificate</a>
                         </li><li>
                             <a href="/docs/providers/aws/d/iam_user.html">aws_iam_user</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/iam_access_key.html">aws_iam_access_key</a>
@@ -1475,9 +1475,9 @@
 
                 <li>
                     <a href="#">IoT</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                           <a href="/docs/providers/aws/d/iot_endpoint.html">aws_iot_endpoint</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                     <li>
                       <a href="/docs/providers/aws/r/iot_certificate.html">aws_iot_certificate</a>
@@ -1514,9 +1514,9 @@
 
                 <li>
                   <a href="#">Inspector</a>
-                  <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                  <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                           <a href="/docs/providers/aws/d/inspector_rules_packages.html">aws_inspector_rules_packages</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                     <li>
                       <a href="/docs/providers/aws/r/inspector_assessment_target.html">aws_inspector_assessment_target</a>
@@ -1536,9 +1536,9 @@
 
                 <li>
                     <a href="#">Kinesis</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/kinesis_stream.html">aws_kinesis_stream</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/kinesis_analytics_application.html">aws_kinesis_analytics_application</a>
@@ -1553,7 +1553,7 @@
 
               <li>
                 <a href="#">Kinesis Firehose</a>
-                <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                   <li>
                     <a href="/docs/providers/aws/r/kinesis_firehose_delivery_stream.html">aws_kinesis_firehose_delivery_stream</a>
@@ -1564,7 +1564,7 @@
 
               <li>
                 <a href="#">KMS</a>
-                <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/kms_alias.html">aws_kms_alias</a>
                         </li><li>
                             <a href="/docs/providers/aws/d/kms_ciphertext.html">aws_kms_ciphertext</a>
@@ -1572,7 +1572,7 @@
                           <a href="/docs/providers/aws/d/kms_key.html">aws_kms_key</a>
                         </li><li>
                             <a href="/docs/providers/aws/d/kms_secrets.html">aws_kms_secrets</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                   <li>
                     <a href="/docs/providers/aws/r/kms_alias.html">aws_kms_alias</a>
@@ -1599,13 +1599,13 @@
 
               <li>
                   <a href="#">Lambda</a>
-                  <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                  <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/lambda_function.html">aws_lambda_function</a>
                         </li><li>
                             <a href="/docs/providers/aws/d/lambda_invocation.html">aws_lambda_invocation</a>
                         </li><li>
                             <a href="/docs/providers/aws/d/lambda_layer_version.html">aws_lambda_layer_version</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                       <li>
                           <a href="/docs/providers/aws/r/lambda_alias.html">aws_lambda_alias</a>
                       </li>
@@ -1626,7 +1626,7 @@
 
                 <li>
                     <a href="#">License Manager</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/licensemanager_association.html">aws_licensemanager_association</a>
@@ -1641,7 +1641,7 @@
 
                 <li>
                     <a href="#">Lightsail</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                           <a href="/docs/providers/aws/r/lightsail_domain.html">aws_lightsail_domain</a>
@@ -1668,7 +1668,7 @@
 
                 <li>
                     <a href="#">Macie</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/macie_member_account_association.html">aws_macie_member_account_association</a>
@@ -1683,9 +1683,9 @@
 
                 <li>
                     <a href="#">MQ</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/mq_broker.html">aws_mq_broker</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                           <a href="/docs/providers/aws/r/mq_broker.html">aws_mq_broker</a>
                         </li>
@@ -1698,7 +1698,7 @@
 
                 <li>
                     <a href="#">MediaPackage</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                           <a href="/docs/providers/aws/r/media_package_channel.html">aws_media_package_channel</a>
@@ -1709,7 +1709,7 @@
 
                 <li>
                     <a href="#">MediaStore</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                           <a href="/docs/providers/aws/r/media_store_container.html">aws_media_store_container</a>
@@ -1723,11 +1723,11 @@
 
                 <li>
                     <a href="#">Managed Streaming for Kafka (MSK)</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/msk_cluster.html">aws_msk_cluster</a>
                         </li><li>
                             <a href="/docs/providers/aws/d/msk_configuration.html">aws_msk_configuration</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/msk_cluster.html">aws_msk_cluster</a>
@@ -1741,7 +1741,7 @@
 
                 <li>
                     <a href="#">Neptune</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/neptune_parameter_group.html">aws_neptune_parameter_group</a>
@@ -1776,7 +1776,7 @@
 
                 <li>
                     <a href="#">OpsWorks</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/opsworks_application.html">aws_opsworks_application</a>
@@ -1847,9 +1847,9 @@
 
                 <li>
                     <a href="#">Organizations</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/organizations_organization.html">aws_organizations_organization</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/organizations_account.html">aws_organizations_account</a>
@@ -1871,7 +1871,7 @@
 
                 <li>
                     <a href="#">Pinpoint</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/pinpoint_app.html">aws_pinpoint_app</a>
@@ -1911,7 +1911,7 @@
 
                 <li>
                     <a href="#">Pricing</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand">
                         <li>
                             <a href="/docs/providers/aws/d/pricing_product.html">aws_pricing_product</a>
                         </li>
@@ -1920,7 +1920,7 @@
 
                 <li>
                     <a href="#">QuickSight</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                         <a href="/docs/providers/aws/r/quicksight_group.html">aws_quicksight_group</a>
                         </li>
@@ -1929,9 +1929,9 @@
 
                 <li>
                     <a href="#">RAM</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                         <a href="/docs/providers/aws/d/ram_resource_share.html">aws_ram_resource_share</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                         <li>
                         <a href="/docs/providers/aws/r/ram_principal_association.html">aws_ram_principal_association</a>
                         </li>
@@ -1946,7 +1946,7 @@
 
                 <li>
                     <a href="#">RDS</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                           <a href="/docs/providers/aws/d/db_cluster_snapshot.html">aws_db_cluster_snapshot</a>
                         </li><li>
                           <a href="/docs/providers/aws/d/db_event_categories.html">aws_db_event_categories</a>
@@ -1956,7 +1956,7 @@
                           <a href="/docs/providers/aws/d/db_snapshot.html">aws_db_snapshot</a>
                         </li><li>
                             <a href="/docs/providers/aws/d/rds_cluster.html">aws_rds_cluster</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                           <a href="/docs/providers/aws/r/db_cluster_snapshot.html">aws_db_cluster_snapshot</a>
@@ -2018,11 +2018,11 @@
 
               <li>
                 <a href="#">Redshift</a>
-                <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/redshift_cluster.html">aws_redshift_cluster</a>
                         </li><li>
                             <a href="/docs/providers/aws/d/redshift_service_account.html">aws_redshift_service_account</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                   <li>
                     <a href="/docs/providers/aws/r/redshift_cluster.html">aws_redshift_cluster</a>
@@ -2054,7 +2054,7 @@
 
               <li>
                 <a href="#">Resource Groups</a>
-                <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                   <li>
                     <a href="/docs/providers/aws/r/resourcegroups_group.html">aws_resourcegroups_group</a>
                   </li>
@@ -2063,11 +2063,11 @@
 
                 <li>
                     <a href="#">Route53</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                           <a href="/docs/providers/aws/d/route53_delegation_set.html">aws_route53_delegation_set</a>
                         </li><li>
                           <a href="/docs/providers/aws/d/route53_zone.html">aws_route53_zone</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/route53_delegation_set.html">aws_route53_delegation_set</a>
@@ -2099,7 +2099,7 @@
 
                 <li>
                     <a href="#">Route53 Resolver</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/route53_resolver_endpoint.html">aws_route53_resolver_endpoint</a>
@@ -2119,13 +2119,13 @@
 
                 <li>
                     <a href="#">S3</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/canonical_user_id.html">aws_canonical_user_id</a>
                         </li><li>
                             <a href="/docs/providers/aws/d/s3_bucket.html">aws_s3_bucket</a>
                         </li><li>
                             <a href="/docs/providers/aws/d/s3_bucket_object.html">aws_s3_bucket_object</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/s3_account_public_access_block.html">aws_s3_account_public_access_block</a>
@@ -2163,7 +2163,7 @@
 
                 <li>
                     <a href="#">Sagemaker</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                           <a href="/docs/providers/aws/r/sagemaker_endpoint.html">aws_sagemaker_endpoint</a>
@@ -2190,11 +2190,11 @@
 
                 <li>
                     <a href="#">Secrets Manager</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                          <a href="/docs/providers/aws/d/secretsmanager_secret.html">aws_secretsmanager_secret</a>
                         </li><li>
                          <a href="/docs/providers/aws/d/secretsmanager_secret_version.html">aws_secretsmanager_secret_version</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/secretsmanager_secret.html">aws_secretsmanager_secret</a>
@@ -2209,7 +2209,7 @@
 
                 <li>
                     <a href="#">Security Hub</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/securityhub_account.html">aws_securityhub_account</a>
@@ -2228,7 +2228,7 @@
 
                 <li>
                     <a href="#">SES</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/ses_active_receipt_rule_set.html">aws_ses_active_receipt_rule_set</a>
@@ -2291,7 +2291,7 @@
 
                 <li>
                     <a href="#">Service Catalog</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/servicecatalog_portfolio.html">aws_servicecatalog_portfolio</a>
@@ -2302,7 +2302,7 @@
 
                 <li>
                     <a href="#">Service Discovery</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/service_discovery_http_namespace.html">aws_service_discovery_http_namespace</a>
@@ -2325,11 +2325,11 @@
 
                 <li>
                     <a href="#">Service Quotas</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                           <a href="/docs/providers/aws/d/servicequotas_service.html">aws_servicequotas_service</a>
                         </li><li>
                           <a href="/docs/providers/aws/d/servicequotas_service_quota.html">aws_servicequotas_service_quota</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/servicequotas_service_quota.html">aws_servicequotas_service_quota</a>
@@ -2340,7 +2340,7 @@
 
                 <li>
                     <a href="#">Shield</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/shield_protection.html">aws_shield_protection</a>
@@ -2351,7 +2351,7 @@
 
                 <li>
                     <a href="#">SimpleDB</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/simpledb_domain.html">aws_simpledb_domain</a>
@@ -2363,9 +2363,9 @@
 
                 <li>
                     <a href="#">SNS</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                          <a href="/docs/providers/aws/d/sns_topic.html">aws_sns_topic</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/sns_platform_application.html">aws_sns_platform_application</a>
@@ -2392,9 +2392,9 @@
 
                 <li>
                     <a href="#">SQS</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                          <a href="/docs/providers/aws/d/sqs_queue.html">aws_sqs_queue</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/sqs_queue.html">aws_sqs_queue</a>
@@ -2409,11 +2409,11 @@
 
                 <li>
                     <a href="#">SSM</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                          <a href="/docs/providers/aws/d/ssm_document.html">aws_ssm_document</a>
                         </li><li>
                          <a href="/docs/providers/aws/d/ssm_parameter.html">aws_ssm_parameter</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/ssm_activation.html">aws_ssm_activation</a>
@@ -2459,7 +2459,7 @@
 
                 <li>
                     <a href="#">Step Function (SFN)</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/sfn_activity.html">aws_sfn_activity</a>
@@ -2474,9 +2474,9 @@
 
                 <li>
                     <a href="#">Storage Gateway</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                          <a href="/docs/providers/aws/d/storagegateway_local_disk.html">aws_storagegateway_local_disk</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/storagegateway_cache.html">aws_storagegateway_cache</a>
@@ -2511,7 +2511,7 @@
 
                 <li>
                     <a href="#">SWF</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/swf_domain.html">aws_swf_domain</a>
@@ -2522,9 +2522,9 @@
 
                 <li>
                     <a href="#">Transfer</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/transfer_server.html">aws_transfer_server</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/transfer_server.html">aws_transfer_server</a>
@@ -2542,7 +2542,7 @@
 
                 <li>
                     <a href="#">VPC</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/customer_gateway.html">aws_customer_gateway</a>
                         </li><li>
                           <a href="/docs/providers/aws/d/internet_gateway.html">aws_internet_gateway</a>
@@ -2586,7 +2586,7 @@
                             <a href="/docs/providers/aws/d/vpn_gateway.html">aws_vpn_gateway</a>
                         </li><li>
                             <a href="/docs/providers/aws/d/waf_rule.html">aws_vpn_gateway</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                         <li>
                             <a href="/docs/providers/aws/r/customer_gateway.html">aws_customer_gateway</a>
@@ -2755,9 +2755,9 @@
 
               <li>
                 <a href="#">WAF</a>
-                <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/waf_web_acl.html">aws_waf_web_acl</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                   <li>
                     <a href="/docs/providers/aws/r/waf_byte_match_set.html">aws_waf_byte_match_set</a>
@@ -2812,11 +2812,11 @@
 
               <li>
                 <a href="#">WAF Regional</a>
-                <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav"><li>
+                <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
                             <a href="/docs/providers/aws/d/wafregional_rule.html">aws_wafregional_rule</a>
                         </li><li>
                             <a href="/docs/providers/aws/d/wafregional_web_acl.html">aws_wafregional_web_acl</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav">
+                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
 
                   <li>
                     <a href="/docs/providers/aws/r/wafregional_byte_match_set.html">aws_wafregional_byte_match_set</a>
@@ -2875,7 +2875,7 @@
 
               <li>
                 <a href="#">WorkLink</a>
-                <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                     <li>
                         <a href="/docs/providers/aws/r/worklink_fleet.html">aws_worklink_fleet</a>
                     </li>
@@ -2887,7 +2887,7 @@
 
                 <li>
                     <a href="#">WorkSpaces</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav">
+                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand">
                         <li>
                             <a href="/docs/providers/aws/d/workspaces_bundle.html">aws_workspaces_bundle</a>
                         </li>
@@ -2896,7 +2896,7 @@
 
               <li>
                 <a href="#">XRay</a>
-                <ul class="nav"><li><a href="#">Resources</a><ul class="nav">
+                <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
                     <li>
                         <a href="/docs/providers/aws/r/xray_sampling_rule.html">aws_xray_sampling_rule</a>
                     </li>

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -2,41 +2,32 @@
     <% content_for :sidebar do %>
         <div class="docs-sidebar hidden-print affix-top" role="complementary">
             <a href="#" class="subnav-toggle">(Expand/collapse all)</a>
-
             <ul class="nav docs-sidenav">
                 <li>
                     <a href="/docs/providers/index.html">All Providers</a>
                 </li>
-
                 <li>
                     <a href="/docs/providers/aws/index.html">AWS Provider</a>
                 </li>
-
                 <li>
-                <a href="#">Guides</a>
+                    <a href="#">Guides</a>
                     <ul class="nav nav-visible">
-
                         <li>
                             <a href="/docs/providers/aws/guides/version-2-upgrade.html">AWS Provider Version 2 Upgrade</a>
                         </li>
-
                         <li>
                             <a href="/docs/providers/aws/guides/version-3-upgrade.html">AWS Provider Version 3 Upgrade</a>
                         </li>
-
                         <li>
                             <a href="/docs/providers/aws/guides/custom-service-endpoints.html">Custom Service Endpoints</a>
                         </li>
-
                         <li>
                             <a href="https://learn.hashicorp.com/terraform/?track=aws#aws">AWS Provider Track on HashiCorp Learn</a>
                         </li>
-
                     </ul>
                 </li>
-
                 <li>
-                <a href="#">Provider Data Sources</a>
+                    <a href="#">Provider Data Sources</a>
                     <ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/d/arn.html">aws_arn</a>
@@ -51,7 +42,7 @@
                             <a href="/docs/providers/aws/d/billing_service_account.html">aws_billing_service_account</a>
                         </li>
                         <li>
-                          <a href="/docs/providers/aws/d/caller_identity.html">aws_caller_identity</a>
+                            <a href="/docs/providers/aws/d/caller_identity.html">aws_caller_identity</a>
                         </li>
                         <li>
                             <a href="/docs/providers/aws/d/ip_ranges.html">aws_ip_ranges</a>
@@ -64,2848 +55,3194 @@
                         </li>
                     </ul>
                 </li>
-
                 <li>
-                  <a href="#">ACM</a>
-                  <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/acm_certificate.html">aws_acm_certificate</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-                    <li>
-                      <a href="/docs/providers/aws/r/acm_certificate.html">aws_acm_certificate</a>
-                    </li>
-                    <li>
-                      <a href="/docs/providers/aws/r/acm_certificate_validation.html">aws_acm_certificate_validation</a>
-                    </li>
-                  </ul></li></ul>
+                    <a href="#">ACM</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/acm_certificate.html">aws_acm_certificate</a>
+                                </li>
+                            </ul>
+                        </li>
+                        <li>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/acm_certificate.html">aws_acm_certificate</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/acm_certificate_validation.html">aws_acm_certificate_validation</a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
                 </li>
-
                 <li>
-                  <a href="#">ACM PCA</a>
-                  <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/acmpca_certificate_authority.html">aws_acmpca_certificate_authority</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-                    <li>
-                      <a href="/docs/providers/aws/r/acmpca_certificate_authority.html">aws_acmpca_certificate_authority</a>
-                    </li>
-                  </ul></li></ul>
+                    <a href="#">ACM PCA</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/acmpca_certificate_authority.html">aws_acmpca_certificate_authority</a>
+                                </li>
+                            </ul>
+                        </li>
+                        <li>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/acmpca_certificate_authority.html">aws_acmpca_certificate_authority</a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">API Gateway</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/api_gateway_api_key.html">aws_api_gateway_api_key</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/api_gateway_resource.html">aws_api_gateway_resource</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/api_gateway_rest_api.html">aws_api_gateway_rest_api</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/api_gateway_vpc_link.html">aws_api_gateway_vpc_link</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/api_gateway_account.html">aws_api_gateway_account</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/api_gateway_api_key.html">aws_api_gateway_api_key</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/api_gateway_resource.html">aws_api_gateway_resource</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/api_gateway_rest_api.html">aws_api_gateway_rest_api</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/api_gateway_vpc_link.html">aws_api_gateway_vpc_link</a>
+                                </li>
+                            </ul>
                         </li>
                         <li>
-                            <a href="/docs/providers/aws/r/api_gateway_api_key.html">aws_api_gateway_api_key</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/api_gateway_account.html">aws_api_gateway_account</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/api_gateway_api_key.html">aws_api_gateway_api_key</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/api_gateway_authorizer.html">aws_api_gateway_authorizer</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/api_gateway_base_path_mapping.html">aws_api_gateway_base_path_mapping</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/api_gateway_client_certificate.html">aws_api_gateway_client_certificate</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/api_gateway_deployment.html">aws_api_gateway_deployment</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/api_gateway_documentation_part.html">aws_api_gateway_documentation_part</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/api_gateway_documentation_version.html">aws_api_gateway_documentation_version</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/api_gateway_domain_name.html">aws_api_gateway_domain_name</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/api_gateway_gateway_response.html">aws_api_gateway_gateway_response</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/api_gateway_integration.html">aws_api_gateway_integration</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/api_gateway_integration_response.html">aws_api_gateway_integration_response</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/api_gateway_method.html">aws_api_gateway_method</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/api_gateway_method_response.html">aws_api_gateway_method_response</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/api_gateway_method_settings.html">aws_api_gateway_method_settings</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/api_gateway_model.html">aws_api_gateway_model</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/api_gateway_request_validator.html">aws_api_gateway_request_validator</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/api_gateway_resource.html">aws_api_gateway_resource</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/api_gateway_rest_api.html">aws_api_gateway_rest_api</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/api_gateway_stage.html">aws_api_gateway_stage</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/api_gateway_usage_plan.html">aws_api_gateway_usage_plan</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/api_gateway_usage_plan_key.html">aws_api_gateway_usage_plan_key</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/api_gateway_vpc_link.html">aws_api_gateway_vpc_link</a>
+                                </li>
+                            </ul>
                         </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/api_gateway_authorizer.html">aws_api_gateway_authorizer</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/api_gateway_base_path_mapping.html">aws_api_gateway_base_path_mapping</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/api_gateway_client_certificate.html">aws_api_gateway_client_certificate</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/api_gateway_deployment.html">aws_api_gateway_deployment</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/api_gateway_documentation_part.html">aws_api_gateway_documentation_part</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/api_gateway_documentation_version.html">aws_api_gateway_documentation_version</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/api_gateway_domain_name.html">aws_api_gateway_domain_name</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/api_gateway_gateway_response.html">aws_api_gateway_gateway_response</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/api_gateway_integration.html">aws_api_gateway_integration</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/api_gateway_integration_response.html">aws_api_gateway_integration_response</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/api_gateway_method.html">aws_api_gateway_method</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/api_gateway_method_response.html">aws_api_gateway_method_response</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/api_gateway_method_settings.html">aws_api_gateway_method_settings</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/api_gateway_model.html">aws_api_gateway_model</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/api_gateway_request_validator.html">aws_api_gateway_request_validator</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/api_gateway_resource.html">aws_api_gateway_resource</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/api_gateway_rest_api.html">aws_api_gateway_rest_api</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/api_gateway_stage.html">aws_api_gateway_stage</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/api_gateway_usage_plan.html">aws_api_gateway_usage_plan</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/api_gateway_usage_plan_key.html">aws_api_gateway_usage_plan_key</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/api_gateway_vpc_link.html">aws_api_gateway_vpc_link</a>
-                        </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Application Autoscaling</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-                      <li>
-                        <a href="/docs/providers/aws/r/appautoscaling_policy.html">aws_appautoscaling_policy</a>
-                      </li>
-                      <li>
-                        <a href="/docs/providers/aws/r/appautoscaling_scheduled_action.html">aws_appautoscaling_scheduled_action</a>
-                      </li>
-                      <li>
-                        <a href="/docs/providers/aws/r/appautoscaling_target.html">aws_appautoscaling_target</a>
-                      </li>
-                    </ul></li></ul>
+                    <ul class="nav">
+                        <li>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/appautoscaling_policy.html">aws_appautoscaling_policy</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/appautoscaling_scheduled_action.html">aws_appautoscaling_scheduled_action</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/appautoscaling_target.html">aws_appautoscaling_target</a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">AppMesh</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/appmesh_mesh.html">aws_appmesh_mesh</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/appmesh_mesh.html">aws_appmesh_mesh</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/appmesh_route.html">aws_appmesh_route</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/appmesh_virtual_node.html">aws_appmesh_virtual_node</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/appmesh_virtual_router.html">aws_appmesh_virtual_router</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/appmesh_virtual_service.html">aws_appmesh_virtual_service</a>
+                                </li>
+                            </ul>
                         </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/appmesh_route.html">aws_appmesh_route</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/appmesh_virtual_node.html">aws_appmesh_virtual_node</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/appmesh_virtual_router.html">aws_appmesh_virtual_router</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/appmesh_virtual_service.html">aws_appmesh_virtual_service</a>
-                        </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">AppSync</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/appsync_datasource.html">aws_appsync_datasource</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/appsync_datasource.html">aws_appsync_datasource</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/appsync_function.html">aws_appsync_function</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/appsync_graphql_api.html">aws_appsync_graphql_api</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/appsync_api_key.html">aws_appsync_api_key</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/appsync_resolver.html">aws_appsync_resolver</a>
+                                </li>
+                            </ul>
                         </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/appsync_function.html">aws_appsync_function</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/appsync_graphql_api.html">aws_appsync_graphql_api</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/appsync_api_key.html">aws_appsync_api_key</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/appsync_resolver.html">aws_appsync_resolver</a>
-                        </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Athena</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/athena_database.html">aws_athena_database</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/athena_database.html">aws_athena_database</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/athena_named_query.html">aws_athena_named_query</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/athena_workgroup.html">aws_athena_workgroup</a>
+                                </li>
+                            </ul>
                         </li>
-                        <li>
-                          <a href="/docs/providers/aws/r/athena_named_query.html">aws_athena_named_query</a>
-                        </li>
-                        <li>
-                          <a href="/docs/providers/aws/r/athena_workgroup.html">aws_athena_workgroup</a>
-                        </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Autoscaling</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/autoscaling_group.html">aws_autoscaling_group</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/autoscaling_groups.html">aws_autoscaling_groups</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/launch_configuration.html">aws_launch_configuration</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                          <a href="/docs/providers/aws/r/autoscaling_attachment.html">aws_autoscaling_attachment</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/autoscaling_group.html">aws_autoscaling_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/autoscaling_groups.html">aws_autoscaling_groups</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/launch_configuration.html">aws_launch_configuration</a>
+                                </li>
+                            </ul>
                         </li>
-
                         <li>
-                            <a href="/docs/providers/aws/r/autoscaling_group.html">aws_autoscaling_group</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/autoscaling_attachment.html">aws_autoscaling_attachment</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/autoscaling_group.html">aws_autoscaling_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/autoscaling_lifecycle_hooks.html">aws_autoscaling_lifecycle_hook</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/autoscaling_notification.html">aws_autoscaling_notification</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/autoscaling_policy.html">aws_autoscaling_policy</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/autoscaling_schedule.html">aws_autoscaling_schedule</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/autoscaling_lifecycle_hooks.html">aws_autoscaling_lifecycle_hook</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/autoscaling_notification.html">aws_autoscaling_notification</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/autoscaling_policy.html">aws_autoscaling_policy</a>
-                        </li>
-
-                        <li>
-                          <a href="/docs/providers/aws/r/autoscaling_schedule.html">aws_autoscaling_schedule</a>
-                        </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Backup</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/backup_plan.html">aws_backup_plan</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/backup_plan.html">aws_backup_plan</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/backup_selection.html">aws_backup_selection</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/backup_vault.html">aws_backup_vault</a>
+                                </li>
+                            </ul>
                         </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/backup_selection.html">aws_backup_selection</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/backup_vault.html">aws_backup_vault</a>
-                        </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Batch</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                          <a href="/docs/providers/aws/d/batch_compute_environment.html">aws_batch_compute_environment</a>
-                        </li><li>
-                          <a href="/docs/providers/aws/d/batch_job_queue.html">aws_batch_job_queue</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/batch_compute_environment.html">aws_batch_compute_environment</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/batch_compute_environment.html">aws_batch_compute_environment</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/batch_job_queue.html">aws_batch_job_queue</a>
+                                </li>
+                            </ul>
                         </li>
                         <li>
-                            <a href="/docs/providers/aws/r/batch_job_definition.html">aws_batch_job_definition</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/batch_compute_environment.html">aws_batch_compute_environment</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/batch_job_definition.html">aws_batch_job_definition</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/batch_job_queue.html">aws_batch_job_queue</a>
+                                </li>
+                            </ul>
                         </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/batch_job_queue.html">aws_batch_job_queue</a>
-                        </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Budgets</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/budgets_budget.html">aws_budgets_budget</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/budgets_budget.html">aws_budgets_budget</a>
+                                </li>
+                            </ul>
                         </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Cloud9</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/cloud9_environment_ec2.html">aws_cloud9_environment_ec2</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/cloud9_environment_ec2.html">aws_cloud9_environment_ec2</a>
+                                </li>
+                            </ul>
                         </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">CloudFormation</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/cloudformation_export.html">aws_cloudformation_export</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/cloudformation_stack.html">aws_cloudformation_stack</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/cloudformation_stack.html">aws_cloudformation_stack</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/cloudformation_export.html">aws_cloudformation_export</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/cloudformation_stack.html">aws_cloudformation_stack</a>
+                                </li>
+                            </ul>
                         </li>
                         <li>
-                            <a href="/docs/providers/aws/r/cloudformation_stack_set.html">aws_cloudformation_stack_set</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/cloudformation_stack.html">aws_cloudformation_stack</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/cloudformation_stack_set.html">aws_cloudformation_stack_set</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/cloudformation_stack_set_instance.html">aws_cloudformation_stack_set_instance</a>
+                                </li>
+                            </ul>
                         </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/cloudformation_stack_set_instance.html">aws_cloudformation_stack_set_instance</a>
-                        </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">CloudFront</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/cloudfront_distribution.html">aws_cloudfront_distribution</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/cloudfront_distribution.html">aws_cloudfront_distribution</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/cloudfront_origin_access_identity.html">aws_cloudfront_origin_access_identity</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/cloudfront_public_key.html">aws_cloudfront_public_key</a>
+                                </li>
+                            </ul>
                         </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/cloudfront_origin_access_identity.html">aws_cloudfront_origin_access_identity</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/cloudfront_public_key.html">aws_cloudfront_public_key</a>
-                        </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">CloudHSM v2</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/cloudhsm_v2_cluster.html">aws_cloudhsm_v2_cluster</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/cloudhsm_v2_cluster.html">aws_cloudhsm_v2_cluster</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/cloudhsm_v2_cluster.html">aws_cloudhsm_v2_cluster</a>
+                                </li>
+                            </ul>
                         </li>
                         <li>
-                            <a href="/docs/providers/aws/r/cloudhsm_v2_hsm.html">aws_cloudhsm_v2_hsm</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/cloudhsm_v2_cluster.html">aws_cloudhsm_v2_cluster</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/cloudhsm_v2_hsm.html">aws_cloudhsm_v2_hsm</a>
+                                </li>
+                            </ul>
                         </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">CloudTrail</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/cloudtrail_service_account.html">aws_cloudtrail_service_account</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/cloudtrail.html">aws_cloudtrail</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/cloudtrail_service_account.html">aws_cloudtrail_service_account</a>
+                                </li>
+                            </ul>
                         </li>
-                    </ul></li></ul>
+                        <li>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/cloudtrail.html">aws_cloudtrail</a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">CloudWatch</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/cloudwatch_log_group.html">aws_cloudwatch_log_group</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/cloudwatch_dashboard.html">aws_cloudwatch_dashboard</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/cloudwatch_log_group.html">aws_cloudwatch_log_group</a>
+                                </li>
+                            </ul>
                         </li>
-
                         <li>
-                            <a href="/docs/providers/aws/r/cloudwatch_event_permission.html">aws_cloudwatch_event_permission</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/cloudwatch_dashboard.html">aws_cloudwatch_dashboard</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/cloudwatch_event_permission.html">aws_cloudwatch_event_permission</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/cloudwatch_event_rule.html">aws_cloudwatch_event_rule</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/cloudwatch_event_target.html">aws_cloudwatch_event_target</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/cloudwatch_log_destination.html">aws_cloudwatch_log_destination</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/cloudwatch_log_destination_policy.html">aws_cloudwatch_log_destination_policy</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/cloudwatch_log_group.html">aws_cloudwatch_log_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/cloudwatch_log_metric_filter.html">aws_cloudwatch_log_metric_filter</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/cloudwatch_log_resource_policy.html">aws_cloudwatch_log_resource_policy</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/cloudwatch_log_stream.html">aws_cloudwatch_log_stream</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/cloudwatch_log_subscription_filter.html">aws_cloudwatch_log_subscription_filter</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/cloudwatch_metric_alarm.html">aws_cloudwatch_metric_alarm</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/cloudwatch_event_rule.html">aws_cloudwatch_event_rule</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/cloudwatch_event_target.html">aws_cloudwatch_event_target</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/cloudwatch_log_destination.html">aws_cloudwatch_log_destination</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/cloudwatch_log_destination_policy.html">aws_cloudwatch_log_destination_policy</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/cloudwatch_log_group.html">aws_cloudwatch_log_group</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/cloudwatch_log_metric_filter.html">aws_cloudwatch_log_metric_filter</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/cloudwatch_log_resource_policy.html">aws_cloudwatch_log_resource_policy</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/cloudwatch_log_stream.html">aws_cloudwatch_log_stream</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/cloudwatch_log_subscription_filter.html">aws_cloudwatch_log_subscription_filter</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/cloudwatch_metric_alarm.html">aws_cloudwatch_metric_alarm</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
-
                 <li>
                     <a href="#">CodeBuild</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/codebuild_project.html">aws_codebuild_project</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/codebuild_project.html">aws_codebuild_project</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/codebuild_webhook.html">aws_codebuild_webhook</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/codebuild_webhook.html">aws_codebuild_webhook</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
-
                 <li>
                     <a href="#">CodeCommit</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/codecommit_repository.html">aws_codecommit_repository</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/codecommit_repository.html">aws_codecommit_repository</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/codecommit_repository.html">aws_codecommit_repository</a>
+                                </li>
+                            </ul>
                         </li>
-
                         <li>
-                            <a href="/docs/providers/aws/r/codecommit_trigger.html">aws_codecommit_trigger</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/codecommit_repository.html">aws_codecommit_repository</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/codecommit_trigger.html">aws_codecommit_trigger</a>
+                                </li>
+                            </ul>
                         </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">CodeDeploy</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/codedeploy_app.html">aws_codedeploy_app</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/codedeploy_app.html">aws_codedeploy_app</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/codedeploy_deployment_config.html">aws_codedeploy_deployment_config</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/codedeploy_deployment_group.html">aws_codedeploy_deployment_group</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/codedeploy_deployment_config.html">aws_codedeploy_deployment_config</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/codedeploy_deployment_group.html">aws_codedeploy_deployment_group</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">CodePipeline</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/codepipeline.html">aws_codepipeline</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/codepipeline.html">aws_codepipeline</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/codepipeline_webhook.html">aws_codepipeline_webhook</a>
+                                </li>
+                            </ul>
                         </li>
-
-
-                        <li>
-                            <a href="/docs/providers/aws/r/codepipeline_webhook.html">aws_codepipeline_webhook</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Cognito</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/cognito_user_pools.html">aws_cognito_user_pools</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/cognito_identity_pool.html">aws_cognito_identity_pool</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/cognito_user_pools.html">aws_cognito_user_pools</a>
+                                </li>
+                            </ul>
                         </li>
                         <li>
-                            <a href="/docs/providers/aws/r/cognito_identity_pool_roles_attachment.html">aws_cognito_identity_pool_roles_attachment</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/cognito_identity_pool.html">aws_cognito_identity_pool</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/cognito_identity_pool_roles_attachment.html">aws_cognito_identity_pool_roles_attachment</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/cognito_identity_provider.html">aws_cognito_identity_provider</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/cognito_resource_server.html">aws_cognito_resource_server</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/cognito_user_group.html">aws_cognito_user_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/cognito_user_pool.html">aws_cognito_user_pool</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/cognito_user_pool_client.html">aws_cognito_user_pool_client</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/cognito_user_pool_domain.html">aws_cognito_user_pool_domain</a>
+                                </li>
+                            </ul>
                         </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/cognito_identity_provider.html">aws_cognito_identity_provider</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/cognito_resource_server.html">aws_cognito_resource_server</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/cognito_user_group.html">aws_cognito_user_group</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/cognito_user_pool.html">aws_cognito_user_pool</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/cognito_user_pool_client.html">aws_cognito_user_pool_client</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/cognito_user_pool_domain.html">aws_cognito_user_pool_domain</a>
-                        </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Config</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/config_aggregate_authorization.html">aws_config_aggregate_authorization</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/config_aggregate_authorization.html">aws_config_aggregate_authorization</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/config_configuration_aggregator.html">aws_config_configuration_aggregator</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/config_config_rule.html">aws_config_config_rule</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/config_configuration_recorder.html">aws_config_configuration_recorder</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/config_configuration_recorder_status.html">aws_config_configuration_recorder_status</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/config_delivery_channel.html">aws_config_delivery_channel</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/config_configuration_aggregator.html">aws_config_configuration_aggregator</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/config_config_rule.html">aws_config_config_rule</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/config_configuration_recorder.html">aws_config_configuration_recorder</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/config_configuration_recorder_status.html">aws_config_configuration_recorder_status</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/config_delivery_channel.html">aws_config_delivery_channel</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Cost and Usage Report</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/cur_report_definition.html">aws_cur_report_definition</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/cur_report_definition.html">aws_cur_report_definition</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/cur_report_definition.html">aws_cur_report_definition</a>
+                                </li>
+                            </ul>
                         </li>
-
-                    </ul></li></ul>
+                        <li>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/cur_report_definition.html">aws_cur_report_definition</a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Data Lifecycle Manager (DLM)</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/dlm_lifecycle_policy.html">aws_dlm_lifecycle_policy</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/dlm_lifecycle_policy.html">aws_dlm_lifecycle_policy</a>
+                                </li>
+                            </ul>
                         </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Database Migration Service (DMS)</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/dms_certificate.html">aws_dms_certificate</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/dms_certificate.html">aws_dms_certificate</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/dms_endpoint.html">aws_dms_endpoint</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/dms_replication_instance.html">aws_dms_replication_instance</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/dms_replication_subnet_group.html">aws_dms_replication_subnet_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/dms_replication_task.html">aws_dms_replication_task</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/dms_endpoint.html">aws_dms_endpoint</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/dms_replication_instance.html">aws_dms_replication_instance</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/dms_replication_subnet_group.html">aws_dms_replication_subnet_group</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/dms_replication_task.html">aws_dms_replication_task</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">DataPipeline</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/datapipeline_pipeline.html">aws_datapipeline_pipeline</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/datapipeline_pipeline.html">aws_datapipeline_pipeline</a>
+                                </li>
+                            </ul>
                         </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">DataSync</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/datasync_agent.html">aws_datasync_agent</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/datasync_agent.html">aws_datasync_agent</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/datasync_location_efs.html">aws_datasync_location_efs</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/datasync_location_nfs.html">aws_datasync_location_nfs</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/datasync_location_s3.html">aws_datasync_location_s3</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/datasync_task.html">aws_datasync_task</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/datasync_location_efs.html">aws_datasync_location_efs</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/datasync_location_nfs.html">aws_datasync_location_nfs</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/datasync_location_s3.html">aws_datasync_location_s3</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/datasync_task.html">aws_datasync_task</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Device Farm</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/devicefarm_project.html">aws_devicefarm_project</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/devicefarm_project.html">aws_devicefarm_project</a>
+                                </li>
+                            </ul>
                         </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Directory Service</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/directory_service_directory.html">aws_directory_service_directory</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/directory_service_directory.html">aws_directory_service_directory</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/directory_service_conditional_forwarder.html">aws_directory_service_conditional_forwarder</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/directory_service_log_subscription.html">aws_directory_service_log_subscription</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/directory_service_conditional_forwarder.html">aws_directory_service_conditional_forwarder</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/directory_service_log_subscription.html">aws_directory_service_log_subscription</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Direct Connect</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                          <a href="/docs/providers/aws/d/dx_gateway.html">aws_dx_gateway</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/dx_bgp_peer.html">aws_dx_bgp_peer</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/dx_gateway.html">aws_dx_gateway</a>
+                                </li>
+                            </ul>
                         </li>
                         <li>
-                            <a href="/docs/providers/aws/r/dx_connection.html">aws_dx_connection</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/dx_bgp_peer.html">aws_dx_bgp_peer</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/dx_connection.html">aws_dx_connection</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/dx_connection_association.html">aws_dx_connection_association</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/dx_gateway.html">aws_dx_gateway</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/dx_gateway_association.html">aws_dx_gateway_association</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/dx_gateway_association_proposal.html">aws_dx_gateway_association_proposal</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/dx_hosted_private_virtual_interface.html">aws_dx_hosted_private_virtual_interface</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/dx_hosted_private_virtual_interface_accepter.html">aws_dx_hosted_private_virtual_interface_accepter</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/dx_hosted_public_virtual_interface.html">aws_dx_hosted_public_virtual_interface</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/dx_hosted_public_virtual_interface_accepter.html">aws_dx_hosted_public_virtual_interface_accepter</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/dx_lag.html">aws_dx_lag</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/dx_private_virtual_interface.html">aws_dx_private_virtual_interface</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/dx_public_virtual_interface.html">aws_dx_public_virtual_interface</a>
+                                </li>
+                            </ul>
                         </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/dx_connection_association.html">aws_dx_connection_association</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/dx_gateway.html">aws_dx_gateway</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/dx_gateway_association.html">aws_dx_gateway_association</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/dx_gateway_association_proposal.html">aws_dx_gateway_association_proposal</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/dx_hosted_private_virtual_interface.html">aws_dx_hosted_private_virtual_interface</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/dx_hosted_private_virtual_interface_accepter.html">aws_dx_hosted_private_virtual_interface_accepter</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/dx_hosted_public_virtual_interface.html">aws_dx_hosted_public_virtual_interface</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/dx_hosted_public_virtual_interface_accepter.html">aws_dx_hosted_public_virtual_interface_accepter</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/dx_lag.html">aws_dx_lag</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/dx_private_virtual_interface.html">aws_dx_private_virtual_interface</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/dx_public_virtual_interface.html">aws_dx_public_virtual_interface</a>
-                        </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">DynamoDB</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                          <a href="/docs/providers/aws/d/dynamodb_table.html">aws_dynamodb_table</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/dynamodb_global_table.html">aws_dynamodb_global_table</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/dynamodb_table.html">aws_dynamodb_table</a>
+                                </li>
+                            </ul>
                         </li>
-
                         <li>
-                            <a href="/docs/providers/aws/r/dynamodb_table.html">aws_dynamodb_table</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/dynamodb_global_table.html">aws_dynamodb_global_table</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/dynamodb_table.html">aws_dynamodb_table</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/dynamodb_table_item.html">aws_dynamodb_table_item</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/dynamodb_table_item.html">aws_dynamodb_table_item</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
-
                 <li>
                     <a href="#">DynamoDB Accelerator (DAX)</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/dax_cluster.html">aws_dax_cluster</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/dax_cluster.html">aws_dax_cluster</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/dax_parameter_group.html">aws_dax_parameter_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/dax_subnet_group.html">aws_dax_subnet_group</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/dax_parameter_group.html">aws_dax_parameter_group</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/dax_subnet_group.html">aws_dax_subnet_group</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">DocumentDB</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/docdb_cluster.html">aws_docdb_cluster</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/docdb_cluster.html">aws_docdb_cluster</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/docdb_cluster_instance.html">aws_docdb_cluster_instance</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/docdb_cluster_parameter_group.html">aws_docdb_cluster_parameter_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/docdb_cluster_snapshot.html">aws_docdb_cluster_snapshot</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/docdb_subnet_group.html">aws_docdb_subnet_group</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/docdb_cluster_instance.html">aws_docdb_cluster_instance</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/docdb_cluster_parameter_group.html">aws_docdb_cluster_parameter_group</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/docdb_cluster_snapshot.html">aws_docdb_cluster_snapshot</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/docdb_subnet_group.html">aws_docdb_subnet_group</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">EC2</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/ami.html">aws_ami</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/ami_ids.html">aws_ami_ids</a>
-                        </li><li>
-                          <a href="/docs/providers/aws/d/ebs_default_kms_key.html">aws_ebs_default_kms_key</a>
-                        </li><li>
-                          <a href="/docs/providers/aws/d/ebs_encryption_by_default.html">aws_ebs_encryption_by_default</a>
-                        </li><li>
-                          <a href="/docs/providers/aws/d/ebs_snapshot.html">aws_ebs_snapshot</a>
-                        </li><li>
-                          <a href="/docs/providers/aws/d/ebs_snapshot_ids.html">aws_ebs_snapshot_ids</a>
-                        </li><li>
-                          <a href="/docs/providers/aws/d/ebs_volume.html">aws_ebs_volume</a>
-                        </li><li>
-                          <a href="/docs/providers/aws/d/ec2_transit_gateway.html">aws_ec2_transit_gateway</a>
-                        </li><li>
-                          <a href="/docs/providers/aws/d/ec2_transit_gateway_dx_gateway_attachment.html">aws_ec2_transit_gateway_dx_gateway_attachment</a>
-                        </li><li>
-                          <a href="/docs/providers/aws/d/ec2_transit_gateway_route_table.html">aws_ec2_transit_gateway_route_table</a>
-                        </li><li>
-                          <a href="/docs/providers/aws/d/ec2_transit_gateway_vpc_attachment.html">aws_ec2_transit_gateway_vpc_attachment</a>
-                        </li><li>
-                          <a href="/docs/providers/aws/d/ec2_transit_gateway_vpn_attachment.html">aws_ec2_transit_gateway_vpn_attachment</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/eip.html">aws_eip</a>
-                        </li><li>
-                          <a href="/docs/providers/aws/d/instance.html">aws_instance</a>
-                        </li><li>
-                          <a href="/docs/providers/aws/d/instances.html">aws_instances</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/launch_template.html">aws_launch_template</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/ami.html">aws_ami</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/ami.html">aws_ami</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/ami_ids.html">aws_ami_ids</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/ebs_default_kms_key.html">aws_ebs_default_kms_key</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/ebs_encryption_by_default.html">aws_ebs_encryption_by_default</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/ebs_snapshot.html">aws_ebs_snapshot</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/ebs_snapshot_ids.html">aws_ebs_snapshot_ids</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/ebs_volume.html">aws_ebs_volume</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/ec2_transit_gateway.html">aws_ec2_transit_gateway</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/ec2_transit_gateway_dx_gateway_attachment.html">aws_ec2_transit_gateway_dx_gateway_attachment</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/ec2_transit_gateway_route_table.html">aws_ec2_transit_gateway_route_table</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/ec2_transit_gateway_vpc_attachment.html">aws_ec2_transit_gateway_vpc_attachment</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/ec2_transit_gateway_vpn_attachment.html">aws_ec2_transit_gateway_vpn_attachment</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/eip.html">aws_eip</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/instance.html">aws_instance</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/instances.html">aws_instances</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/launch_template.html">aws_launch_template</a>
+                                </li>
+                            </ul>
                         </li>
-
                         <li>
-                            <a href="/docs/providers/aws/r/ami_copy.html">aws_ami_copy</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/ami.html">aws_ami</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ami_copy.html">aws_ami_copy</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ami_from_instance.html">aws_ami_from_instance</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ami_launch_permission.html">aws_ami_launch_permission</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ebs_default_kms_key.html">aws_ebs_default_kms_key</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ebs_encryption_by_default.html">aws_ebs_encryption_by_default</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ebs_snapshot.html">aws_ebs_snapshot</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ebs_snapshot_copy.html">aws_ebs_snapshot_copy</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ebs_volume.html">aws_ebs_volume</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ec2_capacity_reservation.html">aws_ec2_capacity_reservation</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ec2_client_vpn_endpoint.html">aws_ec2_client_vpn_endpoint</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ec2_client_vpn_network_association.html">aws_ec2_client_vpn_network_association</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ec2_fleet.html">aws_ec2_fleet</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ec2_transit_gateway.html">aws_ec2_transit_gateway</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ec2_transit_gateway_route.html">aws_ec2_transit_gateway_route</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ec2_transit_gateway_route_table.html">aws_ec2_transit_gateway_route_table</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ec2_transit_gateway_route_table_association.html">aws_ec2_transit_gateway_route_table_association</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ec2_transit_gateway_route_table_propagation.html">aws_ec2_transit_gateway_route_table_propagation</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ec2_transit_gateway_vpc_attachment.html">aws_ec2_transit_gateway_vpc_attachment</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ec2_transit_gateway_vpc_attachment_accepter.html">aws_ec2_transit_gateway_vpc_attachment_accepter</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/eip.html">aws_eip</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/eip_association.html">aws_eip_association</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/instance.html">aws_instance</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/key_pair.html">aws_key_pair</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/launch_configuration.html">aws_launch_configuration</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/launch_template.html">aws_launch_template</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/placement_group.html">aws_placement_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/snapshot_create_volume_permission.html">aws_snapshot_create_volume_permission</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/spot_datafeed_subscription.html">aws_spot_datafeed_subscription</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/spot_fleet_request.html">aws_spot_fleet_request</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/spot_instance_request.html">aws_spot_instance_request</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/volume_attachment.html">aws_volume_attachment</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ami_from_instance.html">aws_ami_from_instance</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ami_launch_permission.html">aws_ami_launch_permission</a>
-                        </li>
-
-                        <li>
-                          <a href="/docs/providers/aws/r/ebs_default_kms_key.html">aws_ebs_default_kms_key</a>
-                        </li>
-
-                        <li>
-                          <a href="/docs/providers/aws/r/ebs_encryption_by_default.html">aws_ebs_encryption_by_default</a>
-                        </li>
-
-                        <li>
-                          <a href="/docs/providers/aws/r/ebs_snapshot.html">aws_ebs_snapshot</a>
-                        </li>
-
-                        <li>
-                          <a href="/docs/providers/aws/r/ebs_snapshot_copy.html">aws_ebs_snapshot_copy</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ebs_volume.html">aws_ebs_volume</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ec2_capacity_reservation.html">aws_ec2_capacity_reservation</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ec2_client_vpn_endpoint.html">aws_ec2_client_vpn_endpoint</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ec2_client_vpn_network_association.html">aws_ec2_client_vpn_network_association</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ec2_fleet.html">aws_ec2_fleet</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ec2_transit_gateway.html">aws_ec2_transit_gateway</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ec2_transit_gateway_route.html">aws_ec2_transit_gateway_route</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ec2_transit_gateway_route_table.html">aws_ec2_transit_gateway_route_table</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ec2_transit_gateway_route_table_association.html">aws_ec2_transit_gateway_route_table_association</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ec2_transit_gateway_route_table_propagation.html">aws_ec2_transit_gateway_route_table_propagation</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ec2_transit_gateway_vpc_attachment.html">aws_ec2_transit_gateway_vpc_attachment</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ec2_transit_gateway_vpc_attachment_accepter.html">aws_ec2_transit_gateway_vpc_attachment_accepter</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/eip.html">aws_eip</a>
-                        </li>
-
-                        <li>
-                          <a href="/docs/providers/aws/r/eip_association.html">aws_eip_association</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/instance.html">aws_instance</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/key_pair.html">aws_key_pair</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/launch_configuration.html">aws_launch_configuration</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/launch_template.html">aws_launch_template</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/placement_group.html">aws_placement_group</a>
-                        </li>
-
-                        <li>
-                          <a href="/docs/providers/aws/r/snapshot_create_volume_permission.html">aws_snapshot_create_volume_permission</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/spot_datafeed_subscription.html">aws_spot_datafeed_subscription</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/spot_fleet_request.html">aws_spot_fleet_request</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/spot_instance_request.html">aws_spot_instance_request</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/volume_attachment.html">aws_volume_attachment</a>
-                        </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">ECR</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                          <a href="/docs/providers/aws/d/ecr_image.html">aws_ecr_image</a>
-                        </li><li>
-                          <a href="/docs/providers/aws/d/ecr_repository.html">aws_ecr_repository</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/ecr_lifecycle_policy.html">aws_ecr_lifecycle_policy</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/ecr_image.html">aws_ecr_image</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/ecr_repository.html">aws_ecr_repository</a>
+                                </li>
+                            </ul>
                         </li>
-
                         <li>
-                            <a href="/docs/providers/aws/r/ecr_repository.html">aws_ecr_repository</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/ecr_lifecycle_policy.html">aws_ecr_lifecycle_policy</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ecr_repository.html">aws_ecr_repository</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ecr_repository_policy.html">aws_ecr_repository_policy</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ecr_repository_policy.html">aws_ecr_repository_policy</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
-
                 <li>
                     <a href="#">ECS</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                          <a href="/docs/providers/aws/d/ecs_cluster.html">aws_ecs_cluster</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/ecs_container_definition.html">aws_ecs_container_definition</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/ecs_service.html">aws_ecs_service</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/ecs_task_definition.html">aws_ecs_task_definition</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/ecs_cluster.html">aws_ecs_cluster</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/ecs_cluster.html">aws_ecs_cluster</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/ecs_container_definition.html">aws_ecs_container_definition</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/ecs_service.html">aws_ecs_service</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/ecs_task_definition.html">aws_ecs_task_definition</a>
+                                </li>
+                            </ul>
                         </li>
-
                         <li>
-                            <a href="/docs/providers/aws/r/ecs_service.html">aws_ecs_service</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/ecs_cluster.html">aws_ecs_cluster</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ecs_service.html">aws_ecs_service</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ecs_task_definition.html">aws_ecs_task_definition</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ecs_task_definition.html">aws_ecs_task_definition</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">EFS</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/efs_file_system.html">aws_efs_file_system</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/efs_mount_target.html">aws_efs_mount_target</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/efs_file_system.html">aws_efs_file_system</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/efs_file_system.html">aws_efs_file_system</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/efs_mount_target.html">aws_efs_mount_target</a>
+                                </li>
+                            </ul>
                         </li>
-
                         <li>
-                            <a href="/docs/providers/aws/r/efs_mount_target.html">aws_efs_mount_target</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/efs_file_system.html">aws_efs_file_system</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/efs_mount_target.html">aws_efs_mount_target</a>
+                                </li>
+                            </ul>
                         </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
-
                 <li>
                     <a href="#">EKS</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/eks_cluster.html">aws_eks_cluster</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/eks_cluster_auth.html">aws_eks_cluster_auth</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/eks_cluster.html">aws_eks_cluster</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/eks_cluster.html">aws_eks_cluster</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/eks_cluster_auth.html">aws_eks_cluster_auth</a>
+                                </li>
+                            </ul>
                         </li>
-
-                    </ul></li></ul>
+                        <li>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/eks_cluster.html">aws_eks_cluster</a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
                 </li>
-
-
                 <li>
                     <a href="#">ElastiCache</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/elasticache_cluster.html">aws_elasticache_cluster</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/elasticache_replication_group.html">aws_elasticache_replication_group</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/elasticache_cluster.html">aws_elasticache_cluster</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/elasticache_cluster.html">aws_elasticache_cluster</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/elasticache_replication_group.html">aws_elasticache_replication_group</a>
+                                </li>
+                            </ul>
                         </li>
-
                         <li>
-                            <a href="/docs/providers/aws/r/elasticache_parameter_group.html">aws_elasticache_parameter_group</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/elasticache_cluster.html">aws_elasticache_cluster</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/elasticache_parameter_group.html">aws_elasticache_parameter_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/elasticache_replication_group.html">aws_elasticache_replication_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/elasticache_security_group.html">aws_elasticache_security_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/elasticache_subnet_group.html">aws_elasticache_subnet_group</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/elasticache_replication_group.html">aws_elasticache_replication_group</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/elasticache_security_group.html">aws_elasticache_security_group</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/elasticache_subnet_group.html">aws_elasticache_subnet_group</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
-
                 <li>
                     <a href="#">Elastic Beanstalk</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/elastic_beanstalk_application.html">aws_elastic_beanstalk_application</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/elastic_beanstalk_hosted_zone.html">aws_elastic_beanstalk_hosted_zone</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/elastic_beanstalk_solution_stack.html">aws_elastic_beanstalk_solution_stack</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/elastic_beanstalk_application.html">aws_elastic_beanstalk_application</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/elastic_beanstalk_application.html">aws_elastic_beanstalk_application</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/elastic_beanstalk_hosted_zone.html">aws_elastic_beanstalk_hosted_zone</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/elastic_beanstalk_solution_stack.html">aws_elastic_beanstalk_solution_stack</a>
+                                </li>
+                            </ul>
                         </li>
                         <li>
-                            <a href="/docs/providers/aws/r/elastic_beanstalk_application_version.html">aws_elastic_beanstalk_application_version</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/elastic_beanstalk_application.html">aws_elastic_beanstalk_application</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/elastic_beanstalk_application_version.html">aws_elastic_beanstalk_application_version</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/elastic_beanstalk_configuration_template.html">aws_elastic_beanstalk_configuration_template</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/elastic_beanstalk_environment.html">aws_elastic_beanstalk_environment</a>
+                                </li>
+                            </ul>
                         </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/elastic_beanstalk_configuration_template.html">aws_elastic_beanstalk_configuration_template</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/elastic_beanstalk_environment.html">aws_elastic_beanstalk_environment</a>
-                        </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Elastic Load Balancing (ELB Classic)</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/elb.html">aws_elb</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/elb_hosted_zone_id.html">aws_elb_hosted_zone_id</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/elb_service_account.html">aws_elb_service_account</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/app_cookie_stickiness_policy.html">aws_app_cookie_stickiness_policy</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/elb.html">aws_elb</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/elb_hosted_zone_id.html">aws_elb_hosted_zone_id</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/elb_service_account.html">aws_elb_service_account</a>
+                                </li>
+                            </ul>
                         </li>
-
                         <li>
-                            <a href="/docs/providers/aws/r/elb.html">aws_elb</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/app_cookie_stickiness_policy.html">aws_app_cookie_stickiness_policy</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/elb.html">aws_elb</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/elb_attachment.html">aws_elb_attachment</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/lb_cookie_stickiness_policy.html">aws_lb_cookie_stickiness_policy</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/lb_ssl_negotiation_policy.html">aws_lb_ssl_negotiation_policy</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/load_balancer_backend_server_policy.html">aws_load_balancer_backend_server_policy</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/load_balancer_listener_policy.html">aws_load_balancer_listener_policy</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/load_balancer_policy.html">aws_load_balancer_policy</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/proxy_protocol_policy.html">aws_proxy_protocol_policy</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/elb_attachment.html">aws_elb_attachment</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/lb_cookie_stickiness_policy.html">aws_lb_cookie_stickiness_policy</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/lb_ssl_negotiation_policy.html">aws_lb_ssl_negotiation_policy</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/load_balancer_backend_server_policy.html">aws_load_balancer_backend_server_policy</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/load_balancer_listener_policy.html">aws_load_balancer_listener_policy</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/load_balancer_policy.html">aws_load_balancer_policy</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/proxy_protocol_policy.html">aws_proxy_protocol_policy</a>
-                        </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Elastic Load Balancing v2 (ALB/NLB)</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/lb.html">aws_alb</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/lb_listener.html">aws_alb_listener</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/lb_target_group.html">aws_alb_target_group</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/lb.html">aws_lb</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/lb_listener.html">aws_lb_listener</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/lb_target_group.html">aws_lb_target_group</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/lb.html">aws_lb</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/lb.html">aws_alb</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/lb_listener.html">aws_alb_listener</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/lb_target_group.html">aws_alb_target_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/lb.html">aws_lb</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/lb_listener.html">aws_lb_listener</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/lb_target_group.html">aws_lb_target_group</a>
+                                </li>
+                            </ul>
                         </li>
-
                         <li>
-                            <a href="/docs/providers/aws/r/lb_listener.html">aws_lb_listener</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/lb.html">aws_lb</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/lb_listener.html">aws_lb_listener</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/lb_listener_certificate.html">aws_lb_listener_certificate</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/lb_listener_rule.html">aws_lb_listener_rule</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/lb_target_group.html">aws_lb_target_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/lb_target_group_attachment.html">aws_lb_target_group_attachment</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                          <a href="/docs/providers/aws/r/lb_listener_certificate.html">aws_lb_listener_certificate</a>
-                        </li>
-
-                        <li>
-                          <a href="/docs/providers/aws/r/lb_listener_rule.html">aws_lb_listener_rule</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/lb_target_group.html">aws_lb_target_group</a>
-                        </li>
-
-                        <li>
-                          <a href="/docs/providers/aws/r/lb_target_group_attachment.html">aws_lb_target_group_attachment</a>
-                        </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Elastic Map Reduce (EMR)</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/emr_cluster.html">aws_emr_cluster</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/emr_cluster.html">aws_emr_cluster</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/emr_instance_group.html">aws_emr_instance_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/emr_security_configuration.html">aws_emr_security_configuration</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/emr_instance_group.html">aws_emr_instance_group</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/emr_security_configuration.html">aws_emr_security_configuration</a>
-                        </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">ElasticSearch</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/elasticsearch_domain.html">aws_elasticsearch_domain</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/elasticsearch_domain.html">aws_elasticsearch_domain</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/elasticsearch_domain_policy.html">aws_elasticsearch_domain_policy</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/elasticsearch_domain_policy.html">aws_elasticsearch_domain_policy</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Elastic Transcoder</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/elastic_transcoder_pipeline.html">aws_elastictranscoder_pipeline</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/elastic_transcoder_pipeline.html">aws_elastictranscoder_pipeline</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/elastic_transcoder_preset.html">aws_elastictranscoder_preset</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/elastic_transcoder_preset.html">aws_elastictranscoder_preset</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Gamelift</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/gamelift_alias.html">aws_gamelift_alias</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/gamelift_alias.html">aws_gamelift_alias</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/gamelift_build.html">aws_gamelift_build</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/gamelift_fleet.html">aws_gamelift_fleet</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/gamelift_game_session_queue.html">aws_gamelift_game_session_queue</a>
+                                </li>
+                            </ul>
                         </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/gamelift_build.html">aws_gamelift_build</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/gamelift_fleet.html">aws_gamelift_fleet</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/gamelift_game_session_queue.html">aws_gamelift_game_session_queue</a>
-                        </li>
-                    </ul></li></ul>
-                 </li>
-
+                    </ul>
+                </li>
                 <li>
                     <a href="#">Glacier</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/glacier_vault.html">aws_glacier_vault</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/glacier_vault.html">aws_glacier_vault</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/glacier_vault_lock.html">aws_glacier_vault_lock</a>
+                                </li>
+                            </ul>
                         </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/glacier_vault_lock.html">aws_glacier_vault_lock</a>
-                        </li>
-                    </ul></li></ul>
-                 </li>
-
+                    </ul>
+                </li>
                 <li>
                     <a href="#">Global Accelerator</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/globalaccelerator_accelerator.html">aws_globalaccelerator_accelerator</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/globalaccelerator_accelerator.html">aws_globalaccelerator_accelerator</a>
+                                </li>
+                            </ul>
                         </li>
-                    </ul></li></ul>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    </ul>
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/globalaccelerator_endpoint_group.html">aws_globalaccelerator_endpoint_group</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/globalaccelerator_endpoint_group.html">aws_globalaccelerator_endpoint_group</a>
+                                </li>
+                            </ul>
                         </li>
-                    </ul></li></ul>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    </ul>
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/globalaccelerator_listener.html">aws_globalaccelerator_listener</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/globalaccelerator_listener.html">aws_globalaccelerator_listener</a>
+                                </li>
+                            </ul>
                         </li>
-                    </ul></li></ul>
-                 </li>
-
-                 <li>
+                    </ul>
+                </li>
+                <li>
                     <a href="#">Glue</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/glue_script.html">aws_glue_script</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/glue_catalog_database.html">aws_glue_catalog_database</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/glue_script.html">aws_glue_script</a>
+                                </li>
+                            </ul>
                         </li>
                         <li>
-                            <a href="/docs/providers/aws/r/glue_catalog_table.html">aws_glue_catalog_table</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/glue_catalog_database.html">aws_glue_catalog_database</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/glue_catalog_table.html">aws_glue_catalog_table</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/glue_classifier.html">aws_glue_classifier</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/glue_connection.html">aws_glue_connection</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/glue_crawler.html">aws_glue_crawler</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/glue_job.html">aws_glue_job</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/glue_security_configuration.html">aws_glue_security_configuration</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/glue_trigger.html">aws_glue_trigger</a>
+                                </li>
+                            </ul>
                         </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/glue_classifier.html">aws_glue_classifier</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/glue_connection.html">aws_glue_connection</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/glue_crawler.html">aws_glue_crawler</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/glue_job.html">aws_glue_job</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/glue_security_configuration.html">aws_glue_security_configuration</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/glue_trigger.html">aws_glue_trigger</a>
-                        </li>
-                    </ul></li></ul>
-                 </li>
-
+                    </ul>
+                </li>
                 <li>
                     <a href="#">GuardDuty</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/guardduty_detector.html">aws_guardduty_detector</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/guardduty_detector.html">aws_guardduty_detector</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/guardduty_invite_accepter.html">aws_guardduty_invite_accepter</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/guardduty_ipset.html">aws_guardduty_ipset</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/guardduty_member.html">aws_guardduty_member</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/guardduty_threatintelset.html">aws_guardduty_threatintelset</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/guardduty_invite_accepter.html">aws_guardduty_invite_accepter</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/guardduty_ipset.html">aws_guardduty_ipset</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/guardduty_member.html">aws_guardduty_member</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/guardduty_threatintelset.html">aws_guardduty_threatintelset</a>
-                        </li>
-                    </ul></li></ul>
-                 </li>
-
+                    </ul>
+                </li>
                 <li>
                     <a href="#">IAM</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/iam_account_alias.html">aws_iam_account_alias</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/iam_group.html">aws_iam_group</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/iam_instance_profile.html">aws_iam_instance_profile</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/iam_policy.html">aws_iam_policy</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/iam_policy_document.html">aws_iam_policy_document</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/iam_role.html">aws_iam_role</a>
-                        </li><li>
-                          <a href="/docs/providers/aws/d/iam_server_certificate.html">aws_iam_server_certificate</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/iam_user.html">aws_iam_user</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/iam_access_key.html">aws_iam_access_key</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/iam_account_alias.html">aws_iam_account_alias</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/iam_group.html">aws_iam_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/iam_instance_profile.html">aws_iam_instance_profile</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/iam_policy.html">aws_iam_policy</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/iam_policy_document.html">aws_iam_policy_document</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/iam_role.html">aws_iam_role</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/iam_server_certificate.html">aws_iam_server_certificate</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/iam_user.html">aws_iam_user</a>
+                                </li>
+                            </ul>
                         </li>
-
                         <li>
-                            <a href="/docs/providers/aws/r/iam_account_alias.html">aws_iam_account_alias</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/iam_access_key.html">aws_iam_access_key</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/iam_account_alias.html">aws_iam_account_alias</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/iam_account_password_policy.html">aws_iam_account_password_policy</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/iam_group.html">aws_iam_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/iam_group_membership.html">aws_iam_group_membership</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/iam_group_policy.html">aws_iam_group_policy</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/iam_group_policy_attachment.html">aws_iam_group_policy_attachment</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/iam_instance_profile.html">aws_iam_instance_profile</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/iam_openid_connect_provider.html">aws_iam_openid_connect_provider</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/iam_policy.html">aws_iam_policy</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/iam_policy_attachment.html">aws_iam_policy_attachment</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/iam_role.html">aws_iam_role</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/iam_role_policy.html">aws_iam_role_policy</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/iam_role_policy_attachment.html">aws_iam_role_policy_attachment</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/iam_saml_provider.html">aws_iam_saml_provider</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/iam_server_certificate.html">aws_iam_server_certificate</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/iam_service_linked_role.html">aws_iam_service_linked_role</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/iam_user.html">aws_iam_user</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/iam_user_group_membership.html">aws_iam_user_group_membership</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/iam_user_login_profile.html">aws_iam_user_login_profile</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/iam_user_policy.html">aws_iam_user_policy</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/iam_user_policy_attachment.html">aws_iam_user_policy_attachment</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/iam_user_ssh_key.html">aws_iam_user_ssh_key</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/iam_account_password_policy.html">aws_iam_account_password_policy</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/iam_group.html">aws_iam_group</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/iam_group_membership.html">aws_iam_group_membership</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/iam_group_policy.html">aws_iam_group_policy</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/iam_group_policy_attachment.html">aws_iam_group_policy_attachment</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/iam_instance_profile.html">aws_iam_instance_profile</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/iam_openid_connect_provider.html">aws_iam_openid_connect_provider</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/iam_policy.html">aws_iam_policy</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/iam_policy_attachment.html">aws_iam_policy_attachment</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/iam_role.html">aws_iam_role</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/iam_role_policy.html">aws_iam_role_policy</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/iam_role_policy_attachment.html">aws_iam_role_policy_attachment</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/iam_saml_provider.html">aws_iam_saml_provider</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/iam_server_certificate.html">aws_iam_server_certificate</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/iam_service_linked_role.html">aws_iam_service_linked_role</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/iam_user.html">aws_iam_user</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/iam_user_group_membership.html">aws_iam_user_group_membership</a>
-                        </li>
-
-                        <li>
-                          <a href="/docs/providers/aws/r/iam_user_login_profile.html">aws_iam_user_login_profile</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/iam_user_policy.html">aws_iam_user_policy</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/iam_user_policy_attachment.html">aws_iam_user_policy_attachment</a>
-                        </li>
-
-                        <li>
-                          <a href="/docs/providers/aws/r/iam_user_ssh_key.html">aws_iam_user_ssh_key</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">IoT</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                          <a href="/docs/providers/aws/d/iot_endpoint.html">aws_iot_endpoint</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
-                    <li>
-                      <a href="/docs/providers/aws/r/iot_certificate.html">aws_iot_certificate</a>
-                    </li>
-
-                    <li>
-                      <a href="/docs/providers/aws/r/iot_policy.html">aws_iot_policy</a>
-                    </li>
-
-                    <li>
-                      <a href="/docs/providers/aws/r/iot_policy_attachment.html">aws_iot_policy_attachment</a>
-                    </li>
-
-                    <li>
-                        <a href="/docs/providers/aws/r/iot_topic_rule.html">aws_iot_topic_rule</a>
-                    </li>
-                    <li>
-                        <a href="/docs/providers/aws/r/iot_thing.html">aws_iot_thing</a>
-                    </li>
-
-                    <li>
-                        <a href="/docs/providers/aws/r/iot_thing_principal_attachment.html">aws_iot_thing_principal_attachment</a>
-                    </li>
-
-                    <li>
-                        <a href="/docs/providers/aws/r/iot_thing_type.html">aws_iot_thing_type</a>
-                    </li>
-
-                    <li>
-                        <a href="/docs/providers/aws/r/iot_role_alias.html">aws_iot_role_alias</a>
-                    </li>
-                  </ul></li></ul>
+                    <ul class="nav">
+                        <li>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/iot_endpoint.html">aws_iot_endpoint</a>
+                                </li>
+                            </ul>
+                        </li>
+                        <li>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/iot_certificate.html">aws_iot_certificate</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/iot_policy.html">aws_iot_policy</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/iot_policy_attachment.html">aws_iot_policy_attachment</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/iot_topic_rule.html">aws_iot_topic_rule</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/iot_thing.html">aws_iot_thing</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/iot_thing_principal_attachment.html">aws_iot_thing_principal_attachment</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/iot_thing_type.html">aws_iot_thing_type</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/iot_role_alias.html">aws_iot_role_alias</a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
                 </li>
-
                 <li>
-                  <a href="#">Inspector</a>
-                  <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                          <a href="/docs/providers/aws/d/inspector_rules_packages.html">aws_inspector_rules_packages</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
-                    <li>
-                      <a href="/docs/providers/aws/r/inspector_assessment_target.html">aws_inspector_assessment_target</a>
-                    </li>
-
-                    <li>
-                      <a href="/docs/providers/aws/r/inspector_assessment_template.html">aws_inspector_assessment_template</a>
-                    </li>
-
-                    <li>
-                      <a href="/docs/providers/aws/r/inspector_resource_group.html">aws_inspector_resource_group</a>
-                    </li>
-
-                  </ul></li></ul>
+                    <a href="#">Inspector</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/inspector_rules_packages.html">aws_inspector_rules_packages</a>
+                                </li>
+                            </ul>
+                        </li>
+                        <li>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/inspector_assessment_target.html">aws_inspector_assessment_target</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/inspector_assessment_template.html">aws_inspector_assessment_template</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/inspector_resource_group.html">aws_inspector_resource_group</a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
                 </li>
-
-
                 <li>
                     <a href="#">Kinesis</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/kinesis_stream.html">aws_kinesis_stream</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/kinesis_analytics_application.html">aws_kinesis_analytics_application</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/kinesis_stream.html">aws_kinesis_stream</a>
+                                </li>
+                            </ul>
                         </li>
-
                         <li>
-                            <a href="/docs/providers/aws/r/kinesis_stream.html">aws_kinesis_stream</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/kinesis_analytics_application.html">aws_kinesis_analytics_application</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/kinesis_stream.html">aws_kinesis_stream</a>
+                                </li>
+                            </ul>
                         </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
-              <li>
-                <a href="#">Kinesis Firehose</a>
-                <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
-                  <li>
-                    <a href="/docs/providers/aws/r/kinesis_firehose_delivery_stream.html">aws_kinesis_firehose_delivery_stream</a>
-                  </li>
-
-                </ul></li></ul>
-              </li>
-
-              <li>
-                <a href="#">KMS</a>
-                <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/kms_alias.html">aws_kms_alias</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/kms_ciphertext.html">aws_kms_ciphertext</a>
-                        </li><li>
-                          <a href="/docs/providers/aws/d/kms_key.html">aws_kms_key</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/kms_secrets.html">aws_kms_secrets</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
-                  <li>
-                    <a href="/docs/providers/aws/r/kms_alias.html">aws_kms_alias</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/kms_external_key.html">aws_kms_external_key</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/kms_grant.html">aws_kms_grant</a>
-                  </li>
-
-                  <li>
-                      <a href="/docs/providers/aws/r/kms_ciphertext.html">aws_kms_ciphertext</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/kms_key.html">aws_kms_key</a>
-                  </li>
-
-                </ul></li></ul>
-              </li>
-
-              <li>
-                  <a href="#">Lambda</a>
-                  <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/lambda_function.html">aws_lambda_function</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/lambda_invocation.html">aws_lambda_invocation</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/lambda_layer_version.html">aws_lambda_layer_version</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-                      <li>
-                          <a href="/docs/providers/aws/r/lambda_alias.html">aws_lambda_alias</a>
-                      </li>
-                      <li>
-                          <a href="/docs/providers/aws/r/lambda_event_source_mapping.html">aws_lambda_event_source_mapping</a>
-                      </li>
-                      <li>
-                          <a href="/docs/providers/aws/r/lambda_function.html">aws_lambda_function</a>
-                      </li>
-                      <li>
-                          <a href="/docs/providers/aws/r/lambda_layer_version.html">aws_lambda_layer_version</a>
-                      </li>
-                      <li>
-                          <a href="/docs/providers/aws/r/lambda_permission.html">aws_lambda_permission</a>
-                      </li>
-                  </ul></li></ul>
-              </li>
-
+                <li>
+                    <a href="#">Kinesis Firehose</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/kinesis_firehose_delivery_stream.html">aws_kinesis_firehose_delivery_stream</a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </li>
+                <li>
+                    <a href="#">KMS</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/kms_alias.html">aws_kms_alias</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/kms_ciphertext.html">aws_kms_ciphertext</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/kms_key.html">aws_kms_key</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/kms_secrets.html">aws_kms_secrets</a>
+                                </li>
+                            </ul>
+                        </li>
+                        <li>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/kms_alias.html">aws_kms_alias</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/kms_external_key.html">aws_kms_external_key</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/kms_grant.html">aws_kms_grant</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/kms_ciphertext.html">aws_kms_ciphertext</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/kms_key.html">aws_kms_key</a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </li>
+                <li>
+                    <a href="#">Lambda</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/lambda_function.html">aws_lambda_function</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/lambda_invocation.html">aws_lambda_invocation</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/lambda_layer_version.html">aws_lambda_layer_version</a>
+                                </li>
+                            </ul>
+                        </li>
+                        <li>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/lambda_alias.html">aws_lambda_alias</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/lambda_event_source_mapping.html">aws_lambda_event_source_mapping</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/lambda_function.html">aws_lambda_function</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/lambda_layer_version.html">aws_lambda_layer_version</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/lambda_permission.html">aws_lambda_permission</a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </li>
                 <li>
                     <a href="#">License Manager</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/licensemanager_association.html">aws_licensemanager_association</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/licensemanager_association.html">aws_licensemanager_association</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/licensemanager_license_configuration.html">aws_licensemanager_license_configuration</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/licensemanager_license_configuration.html">aws_licensemanager_license_configuration</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Lightsail</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                          <a href="/docs/providers/aws/r/lightsail_domain.html">aws_lightsail_domain</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/lightsail_domain.html">aws_lightsail_domain</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/lightsail_instance.html">aws_lightsail_instance</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/lightsail_key_pair.html">aws_lightsail_key_pair</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/lightsail_static_ip.html">aws_lightsail_static_ip</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/lightsail_static_ip_attachment.html">aws_lightsail_static_ip_attachment</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/lightsail_instance.html">aws_lightsail_instance</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/lightsail_key_pair.html">aws_lightsail_key_pair</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/lightsail_static_ip.html">aws_lightsail_static_ip</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/lightsail_static_ip_attachment.html">aws_lightsail_static_ip_attachment</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Macie</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/macie_member_account_association.html">aws_macie_member_account_association</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/macie_member_account_association.html">aws_macie_member_account_association</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/macie_s3_bucket_association.html">aws_macie_s3_bucket_association</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/macie_s3_bucket_association.html">aws_macie_s3_bucket_association</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">MQ</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/mq_broker.html">aws_mq_broker</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                          <a href="/docs/providers/aws/r/mq_broker.html">aws_mq_broker</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/mq_broker.html">aws_mq_broker</a>
+                                </li>
+                            </ul>
                         </li>
                         <li>
-                            <a href="/docs/providers/aws/r/mq_configuration.html">aws_mq_configuration</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/mq_broker.html">aws_mq_broker</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/mq_configuration.html">aws_mq_configuration</a>
+                                </li>
+                            </ul>
                         </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">MediaPackage</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                          <a href="/docs/providers/aws/r/media_package_channel.html">aws_media_package_channel</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/media_package_channel.html">aws_media_package_channel</a>
+                                </li>
+                            </ul>
                         </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">MediaStore</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                          <a href="/docs/providers/aws/r/media_store_container.html">aws_media_store_container</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/media_store_container.html">aws_media_store_container</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/media_store_container_policy.html">aws_media_store_container_policy</a>
+                                </li>
+                            </ul>
                         </li>
-                        <li>
-                          <a href="/docs/providers/aws/r/media_store_container_policy.html">aws_media_store_container_policy</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Managed Streaming for Kafka (MSK)</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/msk_cluster.html">aws_msk_cluster</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/msk_configuration.html">aws_msk_configuration</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/msk_cluster.html">aws_msk_cluster</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/msk_cluster.html">aws_msk_cluster</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/msk_configuration.html">aws_msk_configuration</a>
+                                </li>
+                            </ul>
                         </li>
-
                         <li>
-                            <a href="/docs/providers/aws/r/msk_configuration.html">aws_msk_configuration</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/msk_cluster.html">aws_msk_cluster</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/msk_configuration.html">aws_msk_configuration</a>
+                                </li>
+                            </ul>
                         </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Neptune</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/neptune_parameter_group.html">aws_neptune_parameter_group</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/neptune_parameter_group.html">aws_neptune_parameter_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/neptune_subnet_group.html">aws_neptune_subnet_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/neptune_cluster_parameter_group.html">aws_neptune_cluster_parameter_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/neptune_cluster.html">aws_neptune_cluster</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/neptune_cluster_instance.html">aws_neptune_cluster_instance</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/neptune_cluster_snapshot.html">aws_neptune_cluster_snapshot</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/neptune_event_subscription.html">aws_neptune_event_subscription</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/neptune_subnet_group.html">aws_neptune_subnet_group</a>
-                        </li>
-
-                         <li>
-                            <a href="/docs/providers/aws/r/neptune_cluster_parameter_group.html">aws_neptune_cluster_parameter_group</a>
-                        </li>
-
-                         <li>
-                            <a href="/docs/providers/aws/r/neptune_cluster.html">aws_neptune_cluster</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/neptune_cluster_instance.html">aws_neptune_cluster_instance</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/neptune_cluster_snapshot.html">aws_neptune_cluster_snapshot</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/neptune_event_subscription.html">aws_neptune_event_subscription</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">OpsWorks</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/opsworks_application.html">aws_opsworks_application</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/opsworks_application.html">aws_opsworks_application</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/opsworks_custom_layer.html">aws_opsworks_custom_layer</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/opsworks_ganglia_layer.html">aws_opsworks_ganglia_layer</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/opsworks_haproxy_layer.html">aws_opsworks_haproxy_layer</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/opsworks_instance.html">aws_opsworks_instance</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/opsworks_java_app_layer.html">aws_opsworks_java_app_layer</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/opsworks_memcached_layer.html">aws_opsworks_memcached_layer</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/opsworks_mysql_layer.html">aws_opsworks_mysql_layer</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/opsworks_nodejs_app_layer.html">aws_opsworks_nodejs_app_layer</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/opsworks_permission.html">aws_opsworks_permission</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/opsworks_php_app_layer.html">aws_opsworks_php_app_layer</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/opsworks_rails_app_layer.html">aws_opsworks_rails_app_layer</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/opsworks_rds_db_instance.html">aws_opsworks_rds_db_instance</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/opsworks_stack.html">aws_opsworks_stack</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/opsworks_static_web_layer.html">aws_opsworks_static_web_layer</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/opsworks_user_profile.html">aws_opsworks_user_profile</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/opsworks_custom_layer.html">aws_opsworks_custom_layer</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/opsworks_ganglia_layer.html">aws_opsworks_ganglia_layer</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/opsworks_haproxy_layer.html">aws_opsworks_haproxy_layer</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/opsworks_instance.html">aws_opsworks_instance</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/opsworks_java_app_layer.html">aws_opsworks_java_app_layer</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/opsworks_memcached_layer.html">aws_opsworks_memcached_layer</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/opsworks_mysql_layer.html">aws_opsworks_mysql_layer</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/opsworks_nodejs_app_layer.html">aws_opsworks_nodejs_app_layer</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/opsworks_permission.html">aws_opsworks_permission</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/opsworks_php_app_layer.html">aws_opsworks_php_app_layer</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/opsworks_rails_app_layer.html">aws_opsworks_rails_app_layer</a>
-                        </li>
-
-                        <li>
-                          <a href="/docs/providers/aws/r/opsworks_rds_db_instance.html">aws_opsworks_rds_db_instance</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/opsworks_stack.html">aws_opsworks_stack</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/opsworks_static_web_layer.html">aws_opsworks_static_web_layer</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/opsworks_user_profile.html">aws_opsworks_user_profile</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Organizations</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/organizations_organization.html">aws_organizations_organization</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/organizations_account.html">aws_organizations_account</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/organizations_organization.html">aws_organizations_organization</a>
+                                </li>
+                            </ul>
                         </li>
                         <li>
-                            <a href="/docs/providers/aws/r/organizations_organization.html">aws_organizations_organization</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/organizations_account.html">aws_organizations_account</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/organizations_organization.html">aws_organizations_organization</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/organizations_organizational_unit.html">aws_organizations_organizational_unit</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/organizations_policy.html">aws_organizations_policy</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/organizations_policy_attachment.html">aws_organizations_policy_attachment</a>
+                                </li>
+                            </ul>
                         </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/organizations_organizational_unit.html">aws_organizations_organizational_unit</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/organizations_policy.html">aws_organizations_policy</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/organizations_policy_attachment.html">aws_organizations_policy_attachment</a>
-                        </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Pinpoint</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/pinpoint_app.html">aws_pinpoint_app</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/pinpoint_app.html">aws_pinpoint_app</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/pinpoint_adm_channel.html">aws_pinpoint_adm_channel</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/pinpoint_apns_channel.html">aws_pinpoint_apns_channel</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/pinpoint_apns_sandbox_channel.html">aws_pinpoint_apns_sandbox_channel</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/pinpoint_apns_voip_channel.html">aws_pinpoint_apns_voip_channel</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/pinpoint_apns_voip_sandbox_channel.html">aws_pinpoint_apns_voip_sandbox_channel</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/pinpoint_baidu_channel.html">aws_pinpoint_baidu_channel</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/pinpoint_email_channel.html">aws_pinpoint_email_channel</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/pinpoint_event_stream.html">aws_pinpoint_event_stream</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/pinpoint_gcm_channel.html">aws_pinpoint_gcm_channel</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/pinpoint_sms_channel.html">aws_pinpoint_sms_channel</a>
+                                </li>
+                            </ul>
                         </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/pinpoint_adm_channel.html">aws_pinpoint_adm_channel</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/pinpoint_apns_channel.html">aws_pinpoint_apns_channel</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/pinpoint_apns_sandbox_channel.html">aws_pinpoint_apns_sandbox_channel</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/pinpoint_apns_voip_channel.html">aws_pinpoint_apns_voip_channel</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/pinpoint_apns_voip_sandbox_channel.html">aws_pinpoint_apns_voip_sandbox_channel</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/pinpoint_baidu_channel.html">aws_pinpoint_baidu_channel</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/pinpoint_email_channel.html">aws_pinpoint_email_channel</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/pinpoint_event_stream.html">aws_pinpoint_event_stream</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/pinpoint_gcm_channel.html">aws_pinpoint_gcm_channel</a>
-                        </li>
-                        <li>
-                            <a href="/docs/providers/aws/r/pinpoint_sms_channel.html">aws_pinpoint_sms_channel</a>
-                        </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Pricing</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/d/pricing_product.html">aws_pricing_product</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/pricing_product.html">aws_pricing_product</a>
+                                </li>
+                            </ul>
                         </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">QuickSight</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                        <a href="/docs/providers/aws/r/quicksight_group.html">aws_quicksight_group</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/quicksight_group.html">aws_quicksight_group</a>
+                                </li>
+                            </ul>
                         </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">RAM</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                        <a href="/docs/providers/aws/d/ram_resource_share.html">aws_ram_resource_share</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                        <a href="/docs/providers/aws/r/ram_principal_association.html">aws_ram_principal_association</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/ram_resource_share.html">aws_ram_resource_share</a>
+                                </li>
+                            </ul>
                         </li>
                         <li>
-                        <a href="/docs/providers/aws/r/ram_resource_association.html">aws_ram_resource_association</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/ram_principal_association.html">aws_ram_principal_association</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ram_resource_association.html">aws_ram_resource_association</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ram_resource_share.html">aws_ram_resource_share</a>
+                                </li>
+                            </ul>
                         </li>
-                        <li>
-                        <a href="/docs/providers/aws/r/ram_resource_share.html">aws_ram_resource_share</a>
-                        </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">RDS</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                          <a href="/docs/providers/aws/d/db_cluster_snapshot.html">aws_db_cluster_snapshot</a>
-                        </li><li>
-                          <a href="/docs/providers/aws/d/db_event_categories.html">aws_db_event_categories</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/db_instance.html">aws_db_instance</a>
-                        </li><li>
-                          <a href="/docs/providers/aws/d/db_snapshot.html">aws_db_snapshot</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/rds_cluster.html">aws_rds_cluster</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                          <a href="/docs/providers/aws/r/db_cluster_snapshot.html">aws_db_cluster_snapshot</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/db_cluster_snapshot.html">aws_db_cluster_snapshot</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/db_event_categories.html">aws_db_event_categories</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/db_instance.html">aws_db_instance</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/db_snapshot.html">aws_db_snapshot</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/rds_cluster.html">aws_rds_cluster</a>
+                                </li>
+                            </ul>
                         </li>
-
                         <li>
-                            <a href="/docs/providers/aws/r/db_event_subscription.html">aws_db_event_subscription</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/db_cluster_snapshot.html">aws_db_cluster_snapshot</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/db_event_subscription.html">aws_db_event_subscription</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/db_instance.html">aws_db_instance</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/db_instance_role_association.html">aws_db_instance_role_association</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/db_option_group.html">aws_db_option_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/db_parameter_group.html">aws_db_parameter_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/db_security_group.html">aws_db_security_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/db_snapshot.html">aws_db_snapshot</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/db_subnet_group.html">aws_db_subnet_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/rds_cluster.html">aws_rds_cluster</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/rds_cluster_endpoint.html">aws_rds_cluster_endpoint</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/rds_cluster_instance.html">aws_rds_cluster_instance</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/rds_cluster_parameter_group.html">aws_rds_cluster_parameter_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/rds_global_cluster.html">aws_rds_global_cluster</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/db_instance.html">aws_db_instance</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/db_instance_role_association.html">aws_db_instance_role_association</a>
-                        </li>
-
-                        <li>
-                          <a href="/docs/providers/aws/r/db_option_group.html">aws_db_option_group</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/db_parameter_group.html">aws_db_parameter_group</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/db_security_group.html">aws_db_security_group</a>
-                        </li>
-
-                        <li>
-                          <a href="/docs/providers/aws/r/db_snapshot.html">aws_db_snapshot</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/db_subnet_group.html">aws_db_subnet_group</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/rds_cluster.html">aws_rds_cluster</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/rds_cluster_endpoint.html">aws_rds_cluster_endpoint</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/rds_cluster_instance.html">aws_rds_cluster_instance</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/rds_cluster_parameter_group.html">aws_rds_cluster_parameter_group</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/rds_global_cluster.html">aws_rds_global_cluster</a>
-                        </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
-              <li>
-                <a href="#">Redshift</a>
-                <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/redshift_cluster.html">aws_redshift_cluster</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/redshift_service_account.html">aws_redshift_service_account</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
-                  <li>
-                    <a href="/docs/providers/aws/r/redshift_cluster.html">aws_redshift_cluster</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/redshift_event_subscription.html">aws_redshift_event_subscription</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/redshift_parameter_group.html">aws_redshift_parameter_group</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/redshift_security_group.html">aws_redshift_security_group</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/redshift_snapshot_copy_grant.html">aws_redshift_snapshot_copy_grant</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/redshift_subnet_group.html">aws_redshift_subnet_group</a>
-                  </li>
-
-                </ul></li></ul>
-              </li>
-
-
-              <li>
-                <a href="#">Resource Groups</a>
-                <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-                  <li>
-                    <a href="/docs/providers/aws/r/resourcegroups_group.html">aws_resourcegroups_group</a>
-                  </li>
-                </ul></li></ul>
-              </li>
-
+                <li>
+                    <a href="#">Redshift</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/redshift_cluster.html">aws_redshift_cluster</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/redshift_service_account.html">aws_redshift_service_account</a>
+                                </li>
+                            </ul>
+                        </li>
+                        <li>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/redshift_cluster.html">aws_redshift_cluster</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/redshift_event_subscription.html">aws_redshift_event_subscription</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/redshift_parameter_group.html">aws_redshift_parameter_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/redshift_security_group.html">aws_redshift_security_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/redshift_snapshot_copy_grant.html">aws_redshift_snapshot_copy_grant</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/redshift_subnet_group.html">aws_redshift_subnet_group</a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </li>
+                <li>
+                    <a href="#">Resource Groups</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/resourcegroups_group.html">aws_resourcegroups_group</a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </li>
                 <li>
                     <a href="#">Route53</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                          <a href="/docs/providers/aws/d/route53_delegation_set.html">aws_route53_delegation_set</a>
-                        </li><li>
-                          <a href="/docs/providers/aws/d/route53_zone.html">aws_route53_zone</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/route53_delegation_set.html">aws_route53_delegation_set</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/route53_delegation_set.html">aws_route53_delegation_set</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/route53_zone.html">aws_route53_zone</a>
+                                </li>
+                            </ul>
                         </li>
-
                         <li>
-                            <a href="/docs/providers/aws/r/route53_health_check.html">aws_route53_health_check</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/route53_delegation_set.html">aws_route53_delegation_set</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/route53_health_check.html">aws_route53_health_check</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/route53_query_log.html">aws_route53_query_log</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/route53_record.html">aws_route53_record</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/route53_zone.html">aws_route53_zone</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/route53_zone_association.html">aws_route53_zone_association</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/route53_query_log.html">aws_route53_query_log</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/route53_record.html">aws_route53_record</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/route53_zone.html">aws_route53_zone</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/route53_zone_association.html">aws_route53_zone_association</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
-
                 <li>
                     <a href="#">Route53 Resolver</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/route53_resolver_endpoint.html">aws_route53_resolver_endpoint</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/route53_resolver_endpoint.html">aws_route53_resolver_endpoint</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/route53_resolver_rule.html">aws_route53_resolver_rule</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/route53_resolver_rule_association.html">aws_route53_resolver_rule_association</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/route53_resolver_rule.html">aws_route53_resolver_rule</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/route53_resolver_rule_association.html">aws_route53_resolver_rule_association</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
-
                 <li>
                     <a href="#">S3</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/canonical_user_id.html">aws_canonical_user_id</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/s3_bucket.html">aws_s3_bucket</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/s3_bucket_object.html">aws_s3_bucket_object</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/s3_account_public_access_block.html">aws_s3_account_public_access_block</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/canonical_user_id.html">aws_canonical_user_id</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/s3_bucket.html">aws_s3_bucket</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/s3_bucket_object.html">aws_s3_bucket_object</a>
+                                </li>
+                            </ul>
                         </li>
-
                         <li>
-                            <a href="/docs/providers/aws/r/s3_bucket.html">aws_s3_bucket</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/s3_account_public_access_block.html">aws_s3_account_public_access_block</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/s3_bucket.html">aws_s3_bucket</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/s3_bucket_inventory.html">aws_s3_bucket_inventory</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/s3_bucket_metric.html">aws_s3_bucket_metric</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/s3_bucket_notification.html">aws_s3_bucket_notification</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/s3_bucket_object.html">aws_s3_bucket_object</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/s3_bucket_policy.html">aws_s3_bucket_policy</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/s3_bucket_public_access_block.html">aws_s3_bucket_public_access_block</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/s3_bucket_inventory.html">aws_s3_bucket_inventory</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/s3_bucket_metric.html">aws_s3_bucket_metric</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/s3_bucket_notification.html">aws_s3_bucket_notification</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/s3_bucket_object.html">aws_s3_bucket_object</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/s3_bucket_policy.html">aws_s3_bucket_policy</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/s3_bucket_public_access_block.html">aws_s3_bucket_public_access_block</a>
-                        </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Sagemaker</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                          <a href="/docs/providers/aws/r/sagemaker_endpoint.html">aws_sagemaker_endpoint</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/sagemaker_endpoint.html">aws_sagemaker_endpoint</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/sagemaker_endpoint_configuration.html">aws_sagemaker_endpoint_configuration</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/sagemaker_model.html">aws_sagemaker_model</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/sagemaker_notebook_instance.html">aws_sagemaker_notebook_instance</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/sagemaker_notebook_instance_lifecycle_configuration.html">aws_sagemaker_notebook_instance_lifecycle_configuration</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                          <a href="/docs/providers/aws/r/sagemaker_endpoint_configuration.html">aws_sagemaker_endpoint_configuration</a>
-                        </li>
-
-                        <li>
-                          <a href="/docs/providers/aws/r/sagemaker_model.html">aws_sagemaker_model</a>
-                        </li>
-
-                        <li>
-                         <a href="/docs/providers/aws/r/sagemaker_notebook_instance.html">aws_sagemaker_notebook_instance</a>
-                        </li>
-
-                        <li>
-                          <a href="/docs/providers/aws/r/sagemaker_notebook_instance_lifecycle_configuration.html">aws_sagemaker_notebook_instance_lifecycle_configuration</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Secrets Manager</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                         <a href="/docs/providers/aws/d/secretsmanager_secret.html">aws_secretsmanager_secret</a>
-                        </li><li>
-                         <a href="/docs/providers/aws/d/secretsmanager_secret_version.html">aws_secretsmanager_secret_version</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/secretsmanager_secret.html">aws_secretsmanager_secret</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/secretsmanager_secret.html">aws_secretsmanager_secret</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/secretsmanager_secret_version.html">aws_secretsmanager_secret_version</a>
+                                </li>
+                            </ul>
                         </li>
-
                         <li>
-                            <a href="/docs/providers/aws/r/secretsmanager_secret_version.html">aws_secretsmanager_secret_version</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/secretsmanager_secret.html">aws_secretsmanager_secret</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/secretsmanager_secret_version.html">aws_secretsmanager_secret_version</a>
+                                </li>
+                            </ul>
                         </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Security Hub</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/securityhub_account.html">aws_securityhub_account</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/securityhub_account.html">aws_securityhub_account</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/securityhub_product_subscription.html">aws_securityhub_product_subscription</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/securityhub_standards_subscription.html">aws_securityhub_standards_subscription</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/securityhub_product_subscription.html">aws_securityhub_product_subscription</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/securityhub_standards_subscription.html">aws_securityhub_standards_subscription</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">SES</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/ses_active_receipt_rule_set.html">aws_ses_active_receipt_rule_set</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/ses_active_receipt_rule_set.html">aws_ses_active_receipt_rule_set</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ses_domain_identity.html">aws_ses_domain_identity</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ses_domain_identity_verification.html">aws_ses_domain_identity_verification</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ses_domain_dkim.html">aws_ses_domain_dkim</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ses_domain_mail_from.html">aws_ses_domain_mail_from</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ses_email_identity.html">aws_ses_email_identity</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ses_receipt_filter.html">aws_ses_receipt_filter</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ses_receipt_rule.html">aws_ses_receipt_rule</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ses_receipt_rule_set.html">aws_ses_receipt_rule_set</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ses_configuration_set.html">aws_ses_configuration_set</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ses_event_destination.html">aws_ses_event_destination</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ses_identity_notification_topic.html">aws_ses_identity_notification_topic</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ses_identity_policy.html">aws_ses_identity_policy</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ses_template.html">aws_ses_template</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ses_domain_identity.html">aws_ses_domain_identity</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ses_domain_identity_verification.html">aws_ses_domain_identity_verification</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ses_domain_dkim.html">aws_ses_domain_dkim</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ses_domain_mail_from.html">aws_ses_domain_mail_from</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ses_email_identity.html">aws_ses_email_identity</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ses_receipt_filter.html">aws_ses_receipt_filter</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ses_receipt_rule.html">aws_ses_receipt_rule</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ses_receipt_rule_set.html">aws_ses_receipt_rule_set</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ses_configuration_set.html">aws_ses_configuration_set</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ses_event_destination.html">aws_ses_event_destination</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ses_identity_notification_topic.html">aws_ses_identity_notification_topic</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ses_identity_policy.html">aws_ses_identity_policy</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ses_template.html">aws_ses_template</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Service Catalog</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/servicecatalog_portfolio.html">aws_servicecatalog_portfolio</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/servicecatalog_portfolio.html">aws_servicecatalog_portfolio</a>
+                                </li>
+                            </ul>
                         </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Service Discovery</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/service_discovery_http_namespace.html">aws_service_discovery_http_namespace</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/service_discovery_http_namespace.html">aws_service_discovery_http_namespace</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/service_discovery_private_dns_namespace.html">aws_service_discovery_private_dns_namespace</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/service_discovery_public_dns_namespace.html">aws_service_discovery_public_dns_namespace</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/service_discovery_service.html">aws_service_discovery_service</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/service_discovery_private_dns_namespace.html">aws_service_discovery_private_dns_namespace</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/service_discovery_public_dns_namespace.html">aws_service_discovery_public_dns_namespace</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/service_discovery_service.html">aws_service_discovery_service</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Service Quotas</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                          <a href="/docs/providers/aws/d/servicequotas_service.html">aws_servicequotas_service</a>
-                        </li><li>
-                          <a href="/docs/providers/aws/d/servicequotas_service_quota.html">aws_servicequotas_service_quota</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/servicequotas_service_quota.html">aws_servicequotas_service_quota</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/servicequotas_service.html">aws_servicequotas_service</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/servicequotas_service_quota.html">aws_servicequotas_service_quota</a>
+                                </li>
+                            </ul>
                         </li>
-
-                    </ul></li></ul>
+                        <li>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/servicequotas_service_quota.html">aws_servicequotas_service_quota</a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Shield</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/shield_protection.html">aws_shield_protection</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/shield_protection.html">aws_shield_protection</a>
+                                </li>
+                            </ul>
                         </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">SimpleDB</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/simpledb_domain.html">aws_simpledb_domain</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/simpledb_domain.html">aws_simpledb_domain</a>
+                                </li>
+                            </ul>
                         </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
-
                 <li>
                     <a href="#">SNS</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                         <a href="/docs/providers/aws/d/sns_topic.html">aws_sns_topic</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/sns_platform_application.html">aws_sns_platform_application</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/sns_topic.html">aws_sns_topic</a>
+                                </li>
+                            </ul>
                         </li>
-
                         <li>
-                            <a href="/docs/providers/aws/r/sns_sms_preferences.html">aws_sns_sms_preferences</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/sns_platform_application.html">aws_sns_platform_application</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/sns_sms_preferences.html">aws_sns_sms_preferences</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/sns_topic.html">aws_sns_topic</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/sns_topic_policy.html">aws_sns_topic_policy</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/sns_topic_subscription.html">aws_sns_topic_subscription</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/sns_topic.html">aws_sns_topic</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/sns_topic_policy.html">aws_sns_topic_policy</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/sns_topic_subscription.html">aws_sns_topic_subscription</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">SQS</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                         <a href="/docs/providers/aws/d/sqs_queue.html">aws_sqs_queue</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/sqs_queue.html">aws_sqs_queue</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/sqs_queue.html">aws_sqs_queue</a>
+                                </li>
+                            </ul>
                         </li>
-
                         <li>
-                            <a href="/docs/providers/aws/r/sqs_queue_policy.html">aws_sqs_queue_policy</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/sqs_queue.html">aws_sqs_queue</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/sqs_queue_policy.html">aws_sqs_queue_policy</a>
+                                </li>
+                            </ul>
                         </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">SSM</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                         <a href="/docs/providers/aws/d/ssm_document.html">aws_ssm_document</a>
-                        </li><li>
-                         <a href="/docs/providers/aws/d/ssm_parameter.html">aws_ssm_parameter</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/ssm_activation.html">aws_ssm_activation</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ssm_association.html">aws_ssm_association</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ssm_document.html">aws_ssm_document</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ssm_maintenance_window.html">aws_ssm_maintenance_window</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ssm_maintenance_window_target.html">aws_ssm_maintenance_window_target</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ssm_maintenance_window_task.html">aws_ssm_maintenance_window_task</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ssm_patch_baseline.html">aws_ssm_patch_baseline</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ssm_patch_group.html">aws_ssm_patch_group</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/ssm_document.html">aws_ssm_document</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/ssm_parameter.html">aws_ssm_parameter</a>
+                                </li>
+                            </ul>
                         </li>
                         <li>
-                            <a href="/docs/providers/aws/r/ssm_parameter.html">aws_ssm_parameter</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/ssm_activation.html">aws_ssm_activation</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ssm_association.html">aws_ssm_association</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ssm_document.html">aws_ssm_document</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ssm_maintenance_window.html">aws_ssm_maintenance_window</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ssm_maintenance_window_target.html">aws_ssm_maintenance_window_target</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ssm_maintenance_window_task.html">aws_ssm_maintenance_window_task</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ssm_patch_baseline.html">aws_ssm_patch_baseline</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ssm_patch_group.html">aws_ssm_patch_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ssm_parameter.html">aws_ssm_parameter</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/ssm_resource_data_sync.html">aws_ssm_resource_data_sync</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/ssm_resource_data_sync.html">aws_ssm_resource_data_sync</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Step Function (SFN)</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/sfn_activity.html">aws_sfn_activity</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/sfn_activity.html">aws_sfn_activity</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/sfn_state_machine.html">aws_sfn_state_machine</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/sfn_state_machine.html">aws_sfn_state_machine</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Storage Gateway</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                         <a href="/docs/providers/aws/d/storagegateway_local_disk.html">aws_storagegateway_local_disk</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/storagegateway_cache.html">aws_storagegateway_cache</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/storagegateway_local_disk.html">aws_storagegateway_local_disk</a>
+                                </li>
+                            </ul>
                         </li>
-
                         <li>
-                            <a href="/docs/providers/aws/r/storagegateway_cached_iscsi_volume.html">aws_storagegateway_cached_iscsi_volume</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/storagegateway_cache.html">aws_storagegateway_cache</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/storagegateway_cached_iscsi_volume.html">aws_storagegateway_cached_iscsi_volume</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/storagegateway_gateway.html">aws_storagegateway_gateway</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/storagegateway_nfs_file_share.html">aws_storagegateway_nfs_file_share</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/storagegateway_smb_file_share.html">aws_storagegateway_smb_file_share</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/storagegateway_upload_buffer.html">aws_storagegateway_upload_buffer</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/storagegateway_working_storage.html">aws_storagegateway_working_storage</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/storagegateway_gateway.html">aws_storagegateway_gateway</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/storagegateway_nfs_file_share.html">aws_storagegateway_nfs_file_share</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/storagegateway_smb_file_share.html">aws_storagegateway_smb_file_share</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/storagegateway_upload_buffer.html">aws_storagegateway_upload_buffer</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/storagegateway_working_storage.html">aws_storagegateway_working_storage</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">SWF</a>
-                    <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/swf_domain.html">aws_swf_domain</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/swf_domain.html">aws_swf_domain</a>
+                                </li>
+                            </ul>
                         </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">Transfer</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/transfer_server.html">aws_transfer_server</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/transfer_server.html">aws_transfer_server</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/transfer_server.html">aws_transfer_server</a>
+                                </li>
+                            </ul>
                         </li>
-
                         <li>
-                            <a href="/docs/providers/aws/r/transfer_ssh_key.html">aws_transfer_ssh_key</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/transfer_server.html">aws_transfer_server</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/transfer_ssh_key.html">aws_transfer_ssh_key</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/transfer_user.html">aws_transfer_user</a>
+                                </li>
+                            </ul>
                         </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/transfer_user.html">aws_transfer_user</a>
-                        </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
                 <li>
                     <a href="#">VPC</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/customer_gateway.html">aws_customer_gateway</a>
-                        </li><li>
-                          <a href="/docs/providers/aws/d/internet_gateway.html">aws_internet_gateway</a>
-                        </li><li>
-                           <a href="/docs/providers/aws/d/nat_gateway.html">aws_nat_gateway</a>
-                        </li><li>
-                           <a href="/docs/providers/aws/d/network_acls.html">aws_network_acls</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/network_interface.html">aws_network_interface</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/network_interfaces.html">aws_network_interfaces</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/prefix_list.html">aws_prefix_list</a>
-                        </li><li>
-                          <a href="/docs/providers/aws/d/route.html">aws_route</a>
-                        </li><li>
-                          <a href="/docs/providers/aws/d/route_table.html">aws_route_table</a>
-                        </li><li>
-                          <a href="/docs/providers/aws/d/route_tables.html">aws_route_tables</a>
-                        </li><li>
-                         <a href="/docs/providers/aws/d/security_group.html">aws_security_group</a>
-                        </li><li>
-                         <a href="/docs/providers/aws/d/security_groups.html">aws_security_groups</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/subnet.html">aws_subnet</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/subnet_ids.html">aws_subnet_ids</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/vpc.html">aws_vpc</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/vpc_dhcp_options.html">aws_vpc_dhcp_options</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/vpc_endpoint.html">aws_vpc_endpoint</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/vpc_endpoint_service.html">aws_vpc_endpoint_service</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/vpc_peering_connection.html">aws_vpc_peering_connection</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/vpcs.html">aws_vpcs</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/vpn_gateway.html">aws_vpn_gateway</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/waf_rule.html">aws_vpn_gateway</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/customer_gateway.html">aws_customer_gateway</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/default_network_acl.html">aws_default_network_acl</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/default_route_table.html">aws_default_route_table</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/default_security_group.html">aws_default_security_group</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/default_subnet.html">aws_default_subnet</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/default_vpc.html">aws_default_vpc</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/default_vpc_dhcp_options.html">aws_default_vpc_dhcp_options</a>
-                        </li>
-
-                        <li>
-                          <a href="/docs/providers/aws/r/egress_only_internet_gateway.html">aws_egress_only_internet_gateway</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/flow_log.html">aws_flow_log</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/internet_gateway.html">aws_internet_gateway</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/main_route_table_assoc.html">aws_main_route_table_association</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/nat_gateway.html">aws_nat_gateway</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/network_acl.html">aws_network_acl</a>
-                        </li>
-
-                        <li>
-                          <a href="/docs/providers/aws/r/network_acl_rule.html">aws_network_acl_rule</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/network_interface.html">aws_network_interface</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/customer_gateway.html">aws_customer_gateway</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/internet_gateway.html">aws_internet_gateway</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/nat_gateway.html">aws_nat_gateway</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/network_acls.html">aws_network_acls</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/network_interface.html">aws_network_interface</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/network_interfaces.html">aws_network_interfaces</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/prefix_list.html">aws_prefix_list</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/route.html">aws_route</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/route_table.html">aws_route_table</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/route_tables.html">aws_route_tables</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/security_group.html">aws_security_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/security_groups.html">aws_security_groups</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/subnet.html">aws_subnet</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/subnet_ids.html">aws_subnet_ids</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/vpc.html">aws_vpc</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/vpc_dhcp_options.html">aws_vpc_dhcp_options</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/vpc_endpoint.html">aws_vpc_endpoint</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/vpc_endpoint_service.html">aws_vpc_endpoint_service</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/vpc_peering_connection.html">aws_vpc_peering_connection</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/vpcs.html">aws_vpcs</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/vpn_gateway.html">aws_vpn_gateway</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/waf_rule.html">aws_vpn_gateway</a>
+                                </li>
+                            </ul>
                         </li>
                         <li>
-                            <a href="/docs/providers/aws/r/network_interface_attachment.html">aws_network_interface_attachment</a>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/customer_gateway.html">aws_customer_gateway</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/default_network_acl.html">aws_default_network_acl</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/default_route_table.html">aws_default_route_table</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/default_security_group.html">aws_default_security_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/default_subnet.html">aws_default_subnet</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/default_vpc.html">aws_default_vpc</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/default_vpc_dhcp_options.html">aws_default_vpc_dhcp_options</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/egress_only_internet_gateway.html">aws_egress_only_internet_gateway</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/flow_log.html">aws_flow_log</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/internet_gateway.html">aws_internet_gateway</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/main_route_table_assoc.html">aws_main_route_table_association</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/nat_gateway.html">aws_nat_gateway</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/network_acl.html">aws_network_acl</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/network_acl_rule.html">aws_network_acl_rule</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/network_interface.html">aws_network_interface</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/network_interface_attachment.html">aws_network_interface_attachment</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/route.html">aws_route</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/route_table.html">aws_route_table</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/route_table_association.html">aws_route_table_association</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/security_group.html">aws_security_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/network_interface_sg_attachment.html">aws_network_interface_sg_attachment</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/security_group_rule.html">aws_security_group_rule</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/subnet.html">aws_subnet</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/vpc.html">aws_vpc</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/vpc_dhcp_options.html">aws_vpc_dhcp_options</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/vpc_dhcp_options_association.html">aws_vpc_dhcp_options_association</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/vpc_endpoint.html">aws_vpc_endpoint</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/vpc_endpoint_connection_notification.html">aws_vpc_endpoint_connection_notification</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/vpc_endpoint_route_table_association.html">aws_vpc_endpoint_route_table_association</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/vpc_endpoint_service.html">aws_vpc_endpoint_service</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/vpc_endpoint_service_allowed_principal.html">aws_vpc_endpoint_service_allowed_principal</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/vpc_endpoint_subnet_association.html">aws_vpc_endpoint_subnet_association</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/vpc_ipv4_cidr_block_association.html">aws_vpc_ipv4_cidr_block_association</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/vpc_peering.html">aws_vpc_peering_connection</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/vpc_peering_accepter.html">aws_vpc_peering_connection_accepter</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/vpc_peering_options.html">aws_vpc_peering_connection_options</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/vpn_connection.html">aws_vpn_connection</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/vpn_connection_route.html">aws_vpn_connection_route</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/vpn_gateway.html">aws_vpn_gateway</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/vpn_gateway_attachment.html">aws_vpn_gateway_attachment</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/vpn_gateway_route_propagation.html">aws_vpn_gateway_route_propagation</a>
+                                </li>
+                            </ul>
                         </li>
-                        <li>
-                          <a href="/docs/providers/aws/r/route.html">aws_route</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/route_table.html">aws_route_table</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/route_table_association.html">aws_route_table_association</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/security_group.html">aws_security_group</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/network_interface_sg_attachment.html">aws_network_interface_sg_attachment</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/security_group_rule.html">aws_security_group_rule</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/subnet.html">aws_subnet</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/vpc.html">aws_vpc</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/vpc_dhcp_options.html">aws_vpc_dhcp_options</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/vpc_dhcp_options_association.html">aws_vpc_dhcp_options_association</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/vpc_endpoint.html">aws_vpc_endpoint</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/vpc_endpoint_connection_notification.html">aws_vpc_endpoint_connection_notification</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/vpc_endpoint_route_table_association.html">aws_vpc_endpoint_route_table_association</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/vpc_endpoint_service.html">aws_vpc_endpoint_service</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/vpc_endpoint_service_allowed_principal.html">aws_vpc_endpoint_service_allowed_principal</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/vpc_endpoint_subnet_association.html">aws_vpc_endpoint_subnet_association</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/vpc_ipv4_cidr_block_association.html">aws_vpc_ipv4_cidr_block_association</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/vpc_peering.html">aws_vpc_peering_connection</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/vpc_peering_accepter.html">aws_vpc_peering_connection_accepter</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/vpc_peering_options.html">aws_vpc_peering_connection_options</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/vpn_connection.html">aws_vpn_connection</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/vpn_connection_route.html">aws_vpn_connection_route</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/vpn_gateway.html">aws_vpn_gateway</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/vpn_gateway_attachment.html">aws_vpn_gateway_attachment</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/vpn_gateway_route_propagation.html">aws_vpn_gateway_route_propagation</a>
-                        </li>
-
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
-              <li>
-                <a href="#">WAF</a>
-                <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/waf_web_acl.html">aws_waf_web_acl</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
-                  <li>
-                    <a href="/docs/providers/aws/r/waf_byte_match_set.html">aws_waf_byte_match_set</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/waf_geo_match_set.html">aws_waf_geo_match_set</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/waf_ipset.html">aws_waf_ipset</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/waf_rate_based_rule.html">aws_waf_rate_based_rule</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/waf_regex_match_set.html">aws_waf_regex_match_set</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/waf_regex_pattern_set.html">aws_waf_regex_pattern_set</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/waf_rule.html">aws_waf_rule</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/waf_rule_group.html">aws_waf_rule_group</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/waf_size_constraint_set.html">aws_waf_size_constraint_set</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/waf_sql_injection_match_set.html">aws_waf_sql_injection_match_set</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/waf_web_acl.html">aws_waf_web_acl</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/waf_xss_match_set.html">aws_waf_xss_match_set</a>
-                  </li>
-
-                </ul></li></ul>
-              </li>
-
-              <li>
-                <a href="#">WAF Regional</a>
-                <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand"><li>
-                            <a href="/docs/providers/aws/d/wafregional_rule.html">aws_wafregional_rule</a>
-                        </li><li>
-                            <a href="/docs/providers/aws/d/wafregional_web_acl.html">aws_wafregional_web_acl</a>
-                        </li></ul></li><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-
-                  <li>
-                    <a href="/docs/providers/aws/r/wafregional_byte_match_set.html">aws_wafregional_byte_match_set</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/wafregional_geo_match_set.html">aws_wafregional_geo_match_set</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/wafregional_ipset.html">aws_wafregional_ipset</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/wafregional_rate_based_rule.html">aws_wafregional_rate_based_rule</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/wafregional_regex_match_set.html">aws_wafregional_regex_match_set</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/wafregional_regex_pattern_set.html">aws_wafregional_regex_pattern_set</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/wafregional_rule.html">aws_wafregional_rule</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/wafregional_rule_group.html">aws_wafregional_rule_group</a>
-                  </li>
-
-                   <li>
-                    <a href="/docs/providers/aws/r/wafregional_size_constraint_set.html">aws_wafregional_size_constraint_set</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/wafregional_sql_injection_match_set.html">aws_wafregional_sql_injection_match_set</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/wafregional_web_acl.html">aws_wafregional_web_acl</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/wafregional_web_acl_association.html">aws_wafregional_web_acl_association</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/wafregional_xss_match_set.html">aws_wafregional_xss_match_set</a>
-                  </li>
-
-                </ul></li></ul>
-              </li>
-
-              <li>
-                <a href="#">WorkLink</a>
-                <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-                    <li>
-                        <a href="/docs/providers/aws/r/worklink_fleet.html">aws_worklink_fleet</a>
-                    </li>
-                    <li>
-                        <a href="/docs/providers/aws/r/worklink_website_certificate_authority_association.html">aws_worklink_website_certificate_authority_association</a>
-                    </li>
-                </ul></li></ul>
-              </li>
-
+                <li>
+                    <a href="#">WAF</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/waf_web_acl.html">aws_waf_web_acl</a>
+                                </li>
+                            </ul>
+                        </li>
+                        <li>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/waf_byte_match_set.html">aws_waf_byte_match_set</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/waf_geo_match_set.html">aws_waf_geo_match_set</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/waf_ipset.html">aws_waf_ipset</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/waf_rate_based_rule.html">aws_waf_rate_based_rule</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/waf_regex_match_set.html">aws_waf_regex_match_set</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/waf_regex_pattern_set.html">aws_waf_regex_pattern_set</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/waf_rule.html">aws_waf_rule</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/waf_rule_group.html">aws_waf_rule_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/waf_size_constraint_set.html">aws_waf_size_constraint_set</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/waf_sql_injection_match_set.html">aws_waf_sql_injection_match_set</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/waf_web_acl.html">aws_waf_web_acl</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/waf_xss_match_set.html">aws_waf_xss_match_set</a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </li>
+                <li>
+                    <a href="#">WAF Regional</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/wafregional_rule.html">aws_wafregional_rule</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/wafregional_web_acl.html">aws_wafregional_web_acl</a>
+                                </li>
+                            </ul>
+                        </li>
+                        <li>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/wafregional_byte_match_set.html">aws_wafregional_byte_match_set</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/wafregional_geo_match_set.html">aws_wafregional_geo_match_set</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/wafregional_ipset.html">aws_wafregional_ipset</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/wafregional_rate_based_rule.html">aws_wafregional_rate_based_rule</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/wafregional_regex_match_set.html">aws_wafregional_regex_match_set</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/wafregional_regex_pattern_set.html">aws_wafregional_regex_pattern_set</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/wafregional_rule.html">aws_wafregional_rule</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/wafregional_rule_group.html">aws_wafregional_rule_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/wafregional_size_constraint_set.html">aws_wafregional_size_constraint_set</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/wafregional_sql_injection_match_set.html">aws_wafregional_sql_injection_match_set</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/wafregional_web_acl.html">aws_wafregional_web_acl</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/wafregional_web_acl_association.html">aws_wafregional_web_acl_association</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/wafregional_xss_match_set.html">aws_wafregional_xss_match_set</a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </li>
+                <li>
+                    <a href="#">WorkLink</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/worklink_fleet.html">aws_worklink_fleet</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/worklink_website_certificate_authority_association.html">aws_worklink_website_certificate_authority_association</a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </li>
                 <li>
                     <a href="#">WorkSpaces</a>
-                    <ul class="nav"><li><a href="#">Data Sources</a><ul class="nav nav-auto-expand">
+                    <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/d/workspaces_bundle.html">aws_workspaces_bundle</a>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/workspaces_bundle.html">aws_workspaces_bundle</a>
+                                </li>
+                            </ul>
                         </li>
-                    </ul></li></ul>
+                    </ul>
                 </li>
-
-              <li>
-                <a href="#">XRay</a>
-                <ul class="nav"><li><a href="#">Resources</a><ul class="nav nav-auto-expand">
-                    <li>
-                        <a href="/docs/providers/aws/r/xray_sampling_rule.html">aws_xray_sampling_rule</a>
-                    </li>
-                </ul></li></ul>
-              </li>
-
+                <li>
+                    <a href="#">XRay</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/xray_sampling_rule.html">aws_xray_sampling_rule</a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </li>
             </ul>
         </div>
     <% end %>
-
     <%= yield %>
 <% end %>


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #8225

The large `Data Source` listing can be a hassle to determine which data sources are relevant for the AWS service you are working with. A jarring example is the `aws_canonical_user_id` data source, which is for S3. This change moves data sources under their relevant service names by introducing an additional navigation under each service for data sources and resources, which can also be augmented with other sections for each service such as guides and/or examples.

The list item migrations were performed with a `goquery` script that was provided a mapping of prefixes to category names.

To play with this using the local documentation server, you can use `make website`.

Example screenshot with a few sections opened for illustrative purposes:

<img width="312" alt="Screen Shot 2019-07-22 at 1 32 22 PM" src="https://user-images.githubusercontent.com/189114/61652417-e1c62d80-ac85-11e9-8b19-eb4e9f9f8f3e.png">


Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing: N/A