### PR TITLE
Allow S3 objects to use etag and SSE-S3 encryption

### DIFF
--- a/aws/resource_aws_s3_bucket_object.go
+++ b/aws/resource_aws_s3_bucket_object.go
@@ -139,7 +139,7 @@ func resourceAwsS3BucketObject() *schema.Resource {
 				// See http://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html
 				Optional:      true,
 				Computed:      true,
-				ConflictsWith: []string{"kms_key_id", "server_side_encryption"},
+				ConflictsWith: []string{"kms_key_id"},
 			},
 
 			"version_id": {


### PR DESCRIPTION
# Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Fixes #5033

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
BUG FIXES
* resource/aws_s3_bucket_object: Allow using SSE-S3 encryption with etags
```

Output from acceptance testing:

```
$make testacc TESTARGS="-run=TestAccAWSS3BucketObject_etagEncryption"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3BucketObject_etagEncryption -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSS3BucketObject_etagEncryption
=== PAUSE TestAccAWSS3BucketObject_etagEncryption
=== CONT  TestAccAWSS3BucketObject_etagEncryption
--- PASS: TestAccAWSS3BucketObject_etagEncryption (37.25s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	37.296s
...
```
