### PR TITLE
Fixes website_endpoint and website_domain attributes in Chinese regions

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -1595,7 +1595,7 @@ func WebsiteDomainUrl(region string) string {
 	if isOldRegion(region) {
 		return fmt.Sprintf("s3-website-%s.amazonaws.com", region)
 	}
-	if isInChina(region) {
+	if isChineseRegion(region) {
 		return fmt.Sprintf("s3-website.%s.amazonaws.com.cn", region)
 	}
 	return fmt.Sprintf("s3-website.%s.amazonaws.com", region)
@@ -1621,9 +1621,15 @@ func isOldRegion(region string) bool {
 	return false
 }
 
-func isInChina(region string) bool {
-	if region == "cn-northwest-1" {
-		return true
+func isChineseRegion(region string) bool {
+	chineseRegions := []string{
+		"cn-north-1",
+		"cn-northwest-1",
+	}
+	for _, r := range chineseRegions {
+		if region == r {
+			return true
+		}
 	}
 	return false
 }

--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -1589,10 +1589,14 @@ func WebsiteEndpoint(bucket string, region string) *S3Website {
 func WebsiteDomainUrl(region string) string {
 	region = normalizeRegion(region)
 
-	// New regions uses different syntax for website endpoints
-	// http://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteEndpoints.html
+	// Different regions have different syntax for website endpoints
+	// https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteEndpoints.html
+	// https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints
 	if isOldRegion(region) {
 		return fmt.Sprintf("s3-website-%s.amazonaws.com", region)
+	}
+	if isInChina(region) {
+		return fmt.Sprintf("s3-website.%s.amazonaws.com.cn", region)
 	}
 	return fmt.Sprintf("s3-website.%s.amazonaws.com", region)
 }
@@ -1613,6 +1617,13 @@ func isOldRegion(region string) bool {
 		if region == r {
 			return true
 		}
+	}
+	return false
+}
+
+func isInChina(region string) bool {
+	if region == "cn-northwest-1" {
+		return true
 	}
 	return false
 }

--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -1595,7 +1595,7 @@ func WebsiteDomainUrl(region string) string {
 	if isOldRegion(region) {
 		return fmt.Sprintf("s3-website-%s.amazonaws.com", region)
 	}
-	if isChineseRegion(region) {
+	if partition, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), region); ok && partition.ID() == endpoints.AwsCnPartitionID {
 		return fmt.Sprintf("s3-website.%s.amazonaws.com.cn", region)
 	}
 	return fmt.Sprintf("s3-website.%s.amazonaws.com", region)
@@ -1614,19 +1614,6 @@ func isOldRegion(region string) bool {
 		"us-west-2",
 	}
 	for _, r := range oldRegions {
-		if region == r {
-			return true
-		}
-	}
-	return false
-}
-
-func isChineseRegion(region string) bool {
-	chineseRegions := []string{
-		"cn-north-1",
-		"cn-northwest-1",
-	}
-	for _, r := range chineseRegions {
 		if region == r {
 			return true
 		}

--- a/aws/website_endpoint_url_test.go
+++ b/aws/website_endpoint_url_test.go
@@ -19,7 +19,7 @@ var websiteEndpoints = []struct {
 	{"ap-southeast-2", "bucket-name.s3-website-ap-southeast-2.amazonaws.com"},
 	{"ap-northeast-2", "bucket-name.s3-website.ap-northeast-2.amazonaws.com"},
 	{"sa-east-1", "bucket-name.s3-website-sa-east-1.amazonaws.com"},
-	{"cn-northwest-1","bucket-name.s3-website.cn-northwest-1.amazonaws.com.cn"},
+	{"cn-northwest-1", "bucket-name.s3-website.cn-northwest-1.amazonaws.com.cn"},
 	{"cn-north-1", "bucket-name.s3-website.cn-north-1.amazonaws.com.cn"},
 }
 

--- a/aws/website_endpoint_url_test.go
+++ b/aws/website_endpoint_url_test.go
@@ -19,6 +19,7 @@ var websiteEndpoints = []struct {
 	{"ap-southeast-2", "bucket-name.s3-website-ap-southeast-2.amazonaws.com"},
 	{"ap-northeast-2", "bucket-name.s3-website.ap-northeast-2.amazonaws.com"},
 	{"sa-east-1", "bucket-name.s3-website-sa-east-1.amazonaws.com"},
+	{"cn-northwest-1","bucket-name.s3-website.cn-northwest-1.amazonaws.com.cn"},
 }
 
 func TestWebsiteEndpointUrl(t *testing.T) {

--- a/aws/website_endpoint_url_test.go
+++ b/aws/website_endpoint_url_test.go
@@ -20,6 +20,7 @@ var websiteEndpoints = []struct {
 	{"ap-northeast-2", "bucket-name.s3-website.ap-northeast-2.amazonaws.com"},
 	{"sa-east-1", "bucket-name.s3-website-sa-east-1.amazonaws.com"},
 	{"cn-northwest-1","bucket-name.s3-website.cn-northwest-1.amazonaws.com.cn"},
+	{"cn-north-1", "bucket-name.s3-website.cn-north-1.amazonaws.com.cn"},
 }
 
 func TestWebsiteEndpointUrl(t *testing.T) {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #9378

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_s3_bucket: Fixes website_endpoint and website_domain attribute for Chinese regions 
```
