### PR TITLE
resource/aws_db_instance: Redact MasterUserPassword when displaying InvalidParameterValue error with CreateDBInstance

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -1185,6 +1185,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 		})
 		if err != nil {
 			if isAWSErr(err, "InvalidParameterValue", "") {
+				opts.MasterUserPassword = aws.String("********")
 				return fmt.Errorf("Error creating DB Instance: %s, %+v", err, opts)
 			}
 			return fmt.Errorf("Error creating DB Instance: %s", err)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_db_instance: Redact `MasterUserPassword` from user interface when displaying `InvalidParameterValue` error during resource creation
```

It was previously requested that the `aws_db_instance` Terraform resource show the given CreateDBInstance input configuration when receiving an `InvalidParameterValue` error. This would previously show the `MasterUserPassword` field of the input in the UI. The logic to show the input configuration has been present since [version 1.23.0 of the Terraform AWS Provider](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md#1230-june-14-2018).

Previously before code update:

```
--- FAIL: TestAccAWSDBInstance_Password (5.84s)
    testing.go:561: Step 0, expected error:

        errors during apply: Error creating DB Instance: InvalidParameterValue: The parameter MasterUserPassword is not a valid password because it is shorter than 8 characters.
        	status code: 400, request id: 795895e7-8110-4460-9bf7-5211729522d9, {
          AllocatedStorage: 5,
          AutoMinorVersionUpgrade: true,
          BackupRetentionPeriod: 0,
          CopyTagsToSnapshot: false,
          DBInstanceClass: "db.t2.micro",
          DBInstanceIdentifier: "tf-acc-test-796357036994784624",
          DBName: "",
          DeletionProtection: false,
          Engine: "mysql",
          EngineVersion: "",
          MasterUserPassword: "invalid",
          MasterUsername: "tfacctest",
          PubliclyAccessible: false,
          StorageEncrypted: false,
          Tags: []
        }

        To match:

        MasterUserPassword: "\*{8}",
```

Output from acceptance testing after code update:

```
--- PASS: TestAccAWSDBInstance_Password (401.36s)
```

