### PR TITLE
docs : fix spelling in aws_glue_catalog_table docs

### DIFF
--- a/website/docs/r/glue_catalog_table.html.markdown
+++ b/website/docs/r/glue_catalog_table.html.markdown
@@ -124,7 +124,7 @@ The following arguments are supported:
 * `parameters` - (Optional) A map of initialization parameters for the SerDe, in key-value form.
 * `serialization_library` - (Optional) Usually the class that implements the SerDe. An example is: org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe.
 
-##### sort_column
+##### sort_columns
 
 * `column` - (Required) The name of the column.
 * `sort_order` - (Required) Indicates that the column is sorted in ascending order (== 1), or in descending order (==0).


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->


#### BUG FIXES:
*    resource/aws_glue_catalog_table: Fix spelling `sort_column` -> `sort_columns` (#9450)

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
