### PR TITLE
docs/provider: Add missing step to release process for closing the milestone

### DIFF
--- a/.github/MAINTAINING.md
+++ b/.github/MAINTAINING.md
@@ -79,6 +79,7 @@ The fix for this has been merged and will release with version X.Y.Z of the Terr
 - Check the existing release milestone for open items and either work through them or move them to the next milestone
 - Run the HashiCorp (non-OSS) TeamCity release job with the `DEPLOYMENT_TARGET_VERSION` matching the expected release milestone and `DEPLOYMENT_NEXT_VERSION` matching the next release milestone
 - Wait for the TeamCity release job and TeamCity website deployment jobs to complete either by watching the build logs or Slack notifications
+- Close the release milestone
 - For each item noted in the `CHANGELOG.md` for the release just completed (or milestone as a whole), add a comment to the pull request and any linked closed issues noting that it has been released, e.g.
 
 ```markdown


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

On the tin. 😉 We will likely automate this one in our deployment process, but for now, noting the manual step.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing: N/A
