### PR TITLE
resource/aws_cloudfront_distribution: Switch CallerReference from time.Now() to resource.UniqueId()

### DIFF
--- a/aws/cloudfront_distribution_configuration_structure.go
+++ b/aws/cloudfront_distribution_configuration_structure.go
@@ -11,12 +11,12 @@ import (
 	"bytes"
 	"fmt"
 	"strconv"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
 	"github.com/hashicorp/terraform/flatmap"
 	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -33,7 +33,7 @@ const cloudFrontRoute53ZoneID = "Z2FDTNDATAQYW2"
 func expandDistributionConfig(d *schema.ResourceData) *cloudfront.DistributionConfig {
 	distributionConfig := &cloudfront.DistributionConfig{
 		CacheBehaviors:       expandCacheBehaviors(d.Get("ordered_cache_behavior").([]interface{})),
-		CallerReference:      aws.String(time.Now().Format(time.RFC3339Nano)),
+		CallerReference:      aws.String(resource.UniqueId()),
 		Comment:              aws.String(d.Get("comment").(string)),
 		CustomErrorResponses: expandCustomErrorResponses(d.Get("custom_error_response").(*schema.Set)),
 		DefaultCacheBehavior: expandCloudFrontDefaultCacheBehavior(d.Get("default_cache_behavior").([]interface{})[0].(map[string]interface{})),


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #9434

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_cloudfront_distribution: Prevent `DistributionAlreadyExists` errors during concurrent distribution creation 
```

Output from acceptance testing:

```
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID (4.95s)
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName (5.08s)
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers (1567.50s)
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames (1569.28s)
--- PASS: TestAccAWSCloudFrontDistribution_disappears (1574.60s)
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Headers (1575.19s)
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Cookies_WhitelistedNames (3398.76s)
--- PASS: TestAccAWSCloudFrontDistribution_orderedCacheBehavior (3567.88s)
--- PASS: TestAccAWSCloudFrontDistribution_OriginGroups (3562.87s)
--- PASS: TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig (3570.24s)
--- PASS: TestAccAWSCloudFrontDistribution_RetainOnDelete (3571.87s)
--- PASS: TestAccAWSCloudFrontDistribution_noOptionalItemsConfig (3575.29s)
--- PASS: TestAccAWSCloudFrontDistribution_WaitForDeployment (3571.28s)
--- PASS: TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig (3577.28s)
--- PASS: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate (3581.27s)
--- PASS: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn (3584.68s)
--- PASS: TestAccAWSCloudFrontDistribution_customOrigin (4291.01s)
--- PASS: TestAccAWSCloudFrontDistribution_HTTP11Config (4294.31s)
--- PASS: TestAccAWSCloudFrontDistribution_S3Origin (4368.65s)
--- PASS: TestAccAWSCloudFrontDistribution_multiOrigin (4371.62s)
--- PASS: TestAccAWSCloudFrontDistribution_Enabled (4464.73s)
--- PASS: TestAccAWSCloudFrontDistribution_S3OriginWithTags (4466.44s)
```
