### PR TITLE
SourceArn should point to the sns topic publishing

### DIFF
--- a/website/docs/r/sqs_queue_policy.html.markdown
+++ b/website/docs/r/sqs_queue_policy.html.markdown
@@ -34,7 +34,7 @@ resource "aws_sqs_queue_policy" "test" {
       "Resource": "${aws_sqs_queue.q.arn}",
       "Condition": {
         "ArnEquals": {
-          "aws:SourceArn": "${aws_sns_topic.topic_name_here.arn}"
+          "aws:SourceArn": "${aws_sns_topic.example.arn}"
         }
       }
     }

--- a/website/docs/r/sqs_queue_policy.html.markdown
+++ b/website/docs/r/sqs_queue_policy.html.markdown
@@ -34,7 +34,7 @@ resource "aws_sqs_queue_policy" "test" {
       "Resource": "${aws_sqs_queue.q.arn}",
       "Condition": {
         "ArnEquals": {
-          "aws:SourceArn": "${aws_sqs_queue.q.arn}"
+          "aws:SourceArn": "${aws_sns_topic.topic_name_here.arn}"
         }
       }
     }


### PR DESCRIPTION
As shown by AWS docs here https://docs.aws.amazon.com/sns/latest/dg/AccessPolicyLanguage_UseCases_Sns.html
```
{   
		    "Version":"2012-10-17",
		    "Id":"MyQueuePolicy",
		    "Statement" :[
		        {
			        "Sid":"Allow-SNS-SendMessage",
			        "Effect":"Allow",           
			        "Principal" :"*",
			        "Action":["sqs:SendMessage"],
			        "Resource": "arn:aws:sqs:us-east-1:444455556666:MyQueue",
			        "Condition" :{
			            "ArnEquals" :{
				            "aws:SourceArn":"arn:aws:sns:us-east-1:444455556666:MyTopic"
		                 }
		            }
		        }
		    ]
		}
```

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
