### PR TITLE
Make hsm csr availability condition clear

### DIFF
--- a/website/docs/r/cloudhsm_v2_cluster.html.markdown
+++ b/website/docs/r/cloudhsm_v2_cluster.html.markdown
@@ -17,7 +17,7 @@ CloudHSM API Reference][2].
 ~> **NOTE:** CloudHSM can take up to several minutes to be set up.
 Practically no single attribute can be updated except TAGS.
 If you need to delete a cluster, you have to remove its HSM modules first.
-To initialize cluster you have to sign CSR and upload it.
+To initialize cluster, you have to add an hsm instance to the cluster then sign CSR and upload it.
 
 ## Example Usage
 
@@ -78,7 +78,7 @@ The following attributes are exported:
 * `security_group_id` - The ID of the security group associated with the CloudHSM cluster.
 * `cluster_certificates` - The list of cluster certificates.
   * `cluster_certificates.0.cluster_certificate` - The cluster certificate issued (signed) by the issuing certificate authority (CA) of the cluster's owner.
-  * `cluster_certificates.0.cluster_csr` - The certificate signing request (CSR). Available only in UNINITIALIZED state.
+  * `cluster_certificates.0.cluster_csr` - The certificate signing request (CSR). Available only in UNINITIALIZED state after an hsm instance is added to the cluster.
   * `cluster_certificates.0.aws_hardware_certificate` - The HSM hardware certificate issued (signed) by AWS CloudHSM.
   * `cluster_certificates.0.hsm_certificate` - The HSM certificate issued (signed) by the HSM hardware.
   * `cluster_certificates.0.manufacturer_hardware_certificate` - The HSM hardware certificate issued (signed) by the hardware manufacturer.


### PR DESCRIPTION
The hsm cluster csr is only available after the 1st hsm instance is added.
See : https://docs.aws.amazon.com/cloudhsm/latest/userguide/initialize-cluster.html
Confirmed by running this on an uninitialized cluster with no hsm instance which returns blank : aws cloudhsmv2 describe-clusters --filters clusterIds=<cluster-id> --output text --query 'Clusters[].Certificates.ClusterCsr' --region ap-southeast-2

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Doco change
```

Output from acceptance testing:

```
Doco change
...
```
