### PR TITLE
Fix typo in Elastic Transcoder documentation

### DIFF
--- a/website/docs/r/elastic_transcoder_pipeline.html.markdown
+++ b/website/docs/r/elastic_transcoder_pipeline.html.markdown
@@ -99,5 +99,5 @@ The `thumbnail_config_permissions` object supports the following:
 Elastic Transcoder pipelines can be imported using the `id`, e.g.
 
 ```
-$ terraform import aws_elastic_transcoder_pipeline.basic_pipeline 1407981661351-cttk8b
+$ terraform import aws_elastictranscoder_pipeline.basic_pipeline 1407981661351-cttk8b
 ```

--- a/website/docs/r/elastic_transcoder_preset.html.markdown
+++ b/website/docs/r/elastic_transcoder_preset.html.markdown
@@ -164,5 +164,5 @@ The `video_codec_options` map supports the following:
 Elastic Transcoder presets can be imported using the `id`, e.g.
 
 ```
-$ terraform import aws_elastic_transcoder_preset.basic_preset 1407981661351-cttk8b
+$ terraform import aws_elastictranscoder_preset.basic_preset 1407981661351-cttk8b
 ```


### PR DESCRIPTION
Small typo in the `terraform import` example for Elastic Transcoder Pipeline and Preset.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request