### PR TITLE
resource/aws_autoscaling_group: Fix issue preventing the removal of `load_balancers` when switching to `target_group_arns`

### DIFF
--- a/aws/resource_aws_autoscaling_group.go
+++ b/aws/resource_aws_autoscaling_group.go
@@ -258,7 +258,6 @@ func resourceAwsAutoscalingGroup() *schema.Resource {
 			"load_balancers": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
@@ -330,7 +329,6 @@ func resourceAwsAutoscalingGroup() *schema.Resource {
 			"target_group_arns": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},

--- a/aws/resource_aws_autoscaling_group_test.go
+++ b/aws/resource_aws_autoscaling_group_test.go
@@ -459,6 +459,84 @@ func TestAccAWSAutoScalingGroup_WithLoadBalancer(t *testing.T) {
 	})
 }
 
+func TestAccAWSAutoScalingGroup_WithLoadBalancer_ToTargetGroup(t *testing.T) {
+	var group autoscaling.Group
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAutoScalingGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAutoScalingGroupConfigWithLoadBalancer,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAutoScalingGroupExists("aws_autoscaling_group.bar", &group),
+					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "load_balancers.#", "1"),
+					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "target_group_arns.#", "0"),
+				),
+			},
+			{
+				ResourceName:      "aws_autoscaling_group.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_delete",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
+					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
+				},
+			},
+			{
+				Config: testAccAWSAutoScalingGroupConfigWithTargetGroup,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAutoScalingGroupExists("aws_autoscaling_group.bar", &group),
+					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "target_group_arns.#", "1"),
+					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "load_balancers.#", "0"),
+				),
+			},
+			{
+				ResourceName:      "aws_autoscaling_group.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_delete",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
+					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
+				},
+			},
+			{
+				Config: testAccAWSAutoScalingGroupConfigWithLoadBalancer,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAutoScalingGroupExists("aws_autoscaling_group.bar", &group),
+					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "load_balancers.#", "1"),
+					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "target_group_arns.#", "0"),
+				),
+			},
+			{
+				ResourceName:      "aws_autoscaling_group.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_delete",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
+					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
+				},
+			},
+		},
+	})
+}
+
 func TestAccAWSAutoScalingGroup_withPlacementGroup(t *testing.T) {
 	var group autoscaling.Group
 
@@ -2064,6 +2142,105 @@ resource "aws_autoscaling_group" "bar" {
 
   launch_configuration = "${aws_launch_configuration.foobar.name}"
   load_balancers = ["${aws_elb.bar.name}"]
+}
+`
+
+const testAccAWSAutoScalingGroupConfigWithTargetGroup = `
+resource "aws_vpc" "foo" {
+  cidr_block = "10.1.0.0/16"
+  tags = {
+    Name = "terraform-testacc-autoscaling-group-with-lb"
+  }
+}
+
+resource "aws_internet_gateway" "gw" {
+  vpc_id = "${aws_vpc.foo.id}"
+}
+
+resource "aws_subnet" "foo" {
+	cidr_block = "10.1.1.0/24"
+	vpc_id = "${aws_vpc.foo.id}"
+	tags = {
+		Name = "tf-acc-autoscaling-group-with-load-balancer"
+	}
+}
+
+resource "aws_security_group" "foo" {
+  vpc_id="${aws_vpc.foo.id}"
+
+  ingress {
+    protocol = "-1"
+    from_port = 0
+    to_port = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    protocol = "-1"
+    from_port = 0
+    to_port = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_lb_target_group" "foo" {
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = "${aws_vpc.foo.id}"
+}
+
+resource "aws_elb" "bar" {
+  subnets = ["${aws_subnet.foo.id}"]
+	security_groups = ["${aws_security_group.foo.id}"]
+
+  listener {
+    instance_port = 80
+    instance_protocol = "http"
+    lb_port = 80
+    lb_protocol = "http"
+  }
+
+  health_check {
+    healthy_threshold = 2
+    unhealthy_threshold = 2
+    target = "HTTP:80/"
+    interval = 5
+    timeout = 2
+  }
+
+	depends_on = ["aws_internet_gateway.gw"]
+}
+
+// need an AMI that listens on :80 at boot, this is:
+data "aws_ami" "test_ami" {
+  most_recent = true
+
+  owners     = ["979382823631"]
+
+  filter {
+    name   = "name"
+    values = ["bitnami-nginxstack-*-linux-debian-9-x86_64-hvm-ebs"]
+  }
+}
+
+resource "aws_launch_configuration" "foobar" {
+  image_id = "${data.aws_ami.test_ami.id}"
+  instance_type = "t2.micro"
+	security_groups = ["${aws_security_group.foo.id}"]
+}
+
+resource "aws_autoscaling_group" "bar" {
+  availability_zones = ["${aws_subnet.foo.availability_zone}"]
+  vpc_zone_identifier = ["${aws_subnet.foo.id}"]
+  max_size = 2
+  min_size = 2
+  health_check_grace_period = 300
+  health_check_type = "ELB"
+  wait_for_elb_capacity = 2
+  force_delete = true
+
+  launch_configuration = "${aws_launch_configuration.foobar.name}"
+	target_group_arns = ["${aws_lb_target_group.foo.arn}"]
 }
 `
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


Closes: #5197

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_autoscaling_group: Fix issue preventing the removal of `load_balancers` when switching to `target_group_arns`

```

Upon configuring an ASG with load_balancers, it was found that swapping the load_balancers argument with a list of target_group_arns would result in no diff for the load_balancers despite them being removed.This issue being the computed property on `load_balancers`, which refreshes the configuration at plan time resulting in `load_balancers` being added back to the configuration as they are still part of the referenced infrastructure. This change removes the `Computed` property on both `load_balancers` and `target_group_arns` to ensure Terraform always honors the arguments within a provided configuration.

Output from acceptance testing:
```
$ make testacc TESTARGS='-run=TestAccAWSAutoScalingGroup_WithLoadBalancer'
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer (390.68s)
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer_ToTargetGroup (468.74s)
```