### PR TITLE
Add WAF IP set data source

### DIFF
--- a/aws/data_source_aws_waf_ipset.go
+++ b/aws/data_source_aws_waf_ipset.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/hashicorp/terraform/helper/schema"

--- a/aws/data_source_aws_waf_ipset.go
+++ b/aws/data_source_aws_waf_ipset.go
@@ -1,0 +1,58 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsWafIpSet() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAWSWafIpSetRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func dataSourceAWSWafIpSetRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafconn
+	name := d.Get("name").(string)
+
+	ipsets := make([]*waf.IPSetSummary, 0)
+	// ListIPSetsInput does not have a name parameter for filtering or a paginator
+	input := &waf.ListIPSetsInput{}
+	for {
+		output, err := conn.ListIPSets(input)
+		if err != nil {
+			return fmt.Errorf("Error reading WAF IP sets: %s", err)
+		}
+		for _, ipset := range output.IPSets {
+			if aws.StringValue(ipset.Name) == name {
+				ipsets = append(ipsets, ipset)
+			}
+		}
+
+		if output.NextMarker == nil {
+			break
+		}
+		input.NextMarker = output.NextMarker
+	}
+
+	if len(ipsets) == 0 {
+		return fmt.Errorf("WAF IP Set not found for name: %s", name)
+	}
+	if len(ipsets) > 1 {
+		return fmt.Errorf("Multiple WAF IP Sets found for name: %s", name)
+	}
+
+	ipset := ipsets[0]
+	d.SetId(aws.StringValue(ipset.IPSetId))
+
+	return nil
+}

--- a/aws/data_source_aws_waf_ipset_test.go
+++ b/aws/data_source_aws_waf_ipset_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccDataSourceAwsIPSet_Basic(t *testing.T) {
+func TestAccDataSourceAwsWafIPSet_Basic(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_waf_ipset.ipset"
 	datasourceName := "data.aws_waf_ipset.ipset"

--- a/aws/data_source_aws_waf_ipset_test.go
+++ b/aws/data_source_aws_waf_ipset_test.go
@@ -1,0 +1,51 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAwsIPSet_Basic(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_waf_ipset.ipset"
+	datasourceName := "data.aws_waf_ipset.ipset"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSourceAwsWafIPSet_NonExistent,
+				ExpectError: regexp.MustCompile(`WAF IP Set not found`),
+			},
+			{
+				Config: testAccDataSourceAwsWafIPSet_Name(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsWafIPSet_Name(name string) string {
+	return fmt.Sprintf(`
+resource "aws_waf_ipset" "ipset" {
+  name        = %[1]q
+}
+data "aws_waf_ipset" "ipset" {
+  name = "${aws_waf_ipset.ipset.name}"
+}
+`, name)
+}
+
+const testAccDataSourceAwsWafIPSet_NonExistent = `
+data "aws_waf_ipset" "ipset" {
+  name = "tf-acc-test-does-not-exist"
+}
+`

--- a/aws/data_source_aws_waf_ipset_test.go
+++ b/aws/data_source_aws_waf_ipset_test.go
@@ -2,10 +2,10 @@ package aws
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/acctest"
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 

--- a/aws/data_source_aws_waf_ipset_test.go
+++ b/aws/data_source_aws_waf_ipset_test.go
@@ -36,7 +36,7 @@ func TestAccDataSourceAwsWafIPSet_Basic(t *testing.T) {
 func testAccDataSourceAwsWafIPSet_Name(name string) string {
 	return fmt.Sprintf(`
 resource "aws_waf_ipset" "ipset" {
-  name        = %[1]q
+  name = %[1]q
 }
 data "aws_waf_ipset" "ipset" {
   name = "${aws_waf_ipset.ipset.name}"

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -273,6 +273,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_vpc_endpoint_service":                      dataSourceAwsVpcEndpointService(),
 			"aws_vpc_peering_connection":                    dataSourceAwsVpcPeeringConnection(),
 			"aws_vpn_gateway":                               dataSourceAwsVpnGateway(),
+			"aws_waf_ipset":                                 dataSourceAwsWafIpSet(),
 			"aws_waf_rule":                                  dataSourceAwsWafRule(),
 			"aws_waf_web_acl":                               dataSourceAwsWafWebAcl(),
 			"aws_wafregional_rule":                          dataSourceAwsWafRegionalRule(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -3094,6 +3094,12 @@
                                 <li>
                                     <a href="/docs/providers/aws/d/waf_web_acl.html">aws_waf_web_acl</a>
                                 </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/waf_ipset.html">aws_waf_ipset</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/waf_rule.html">aws_waf_rule</a>
+                                </li>
                             </ul>
                         </li>
                         <li>

--- a/website/docs/d/waf_ipset.html.markdown
+++ b/website/docs/d/waf_ipset.html.markdown
@@ -1,0 +1,30 @@
+---
+layout: "aws"
+page_title: "AWS: aws_waf_ipset"
+sidebar_current: "docs-aws-datasource-waf-ipset"
+description: |-
+  Retrieves an AWS WAF IP set id.
+---
+
+# Data Source: aws_waf_ipset
+
+`aws_waf_ipset` Retrieves a WAF IP Set Resource Id.
+
+## Example Usage
+
+```hcl
+data "aws_waf_ipset" "example" {
+  name = "tfWAFIPSet"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the WAF IP set.
+
+## Attributes Reference
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the WAF IP set.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #2654

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* **New Data Source** `aws_waf_ipset`

```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccDataSourceAwsWafIPSet"   
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccDataSourceAwsWafIPSet -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccDataSourceAwsWafIPSet_Basic
=== PAUSE TestAccDataSourceAwsWafIPSet_Basic
=== CONT  TestAccDataSourceAwsWafIPSet_Basic
--- PASS: TestAccDataSourceAwsWafIPSet_Basic (35.73s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       42.310s
```

Local docs screenshot:
![Screenshot 2019-07-24 at 16 46 55](https://user-images.githubusercontent.com/397565/61803574-b5034900-ae32-11e9-8ad2-2c77102af2cd.png)
