### PR TITLE
provider: Replace other relevant time.Now() usage with resource.UniqueId() and document in Contributing Guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -384,6 +384,7 @@ The following resource checks need to be addressed before your contribution can 
   ```
 
 - [ ] __Uses resource.NotFoundError__: Custom errors for missing resources should use [`resource.NotFoundError`](https://godoc.org/github.com/hashicorp/terraform/helper/resource#NotFoundError).
+- [ ] __Uses resource.UniqueId()__: API fields for concurrency protection such as `CallerReference` and `IdempotencyToken` should use [`resource.UniqueId()`](https://godoc.org/github.com/hashicorp/terraform/helper/resource#UniqueId). The implementation includes a monotonic counter which is safer for concurrent operations than solutions such as `time.Now()`.
 - [ ] __Skips Exists Function__: Implementing a resource `Exists` function is extraneous as it often duplicates resource `Read` functionality. Ensure `d.SetId("")` is used to appropriately trigger resource recreation in the resource `Read` function.
 - [ ] __Skips id Attribute__: The `id` attribute is implicit for all Terraform resources and does not need to be defined in the schema.
 

--- a/aws/resource_aws_cloudfront_origin_access_identity.go
+++ b/aws/resource_aws_cloudfront_origin_access_identity.go
@@ -2,11 +2,11 @@ package aws
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -125,7 +125,7 @@ func expandOriginAccessIdentityConfig(d *schema.ResourceData) *cloudfront.Origin
 	}
 	// This sets CallerReference if it's still pending computation (ie: new resource)
 	if v, ok := d.GetOk("caller_reference"); !ok {
-		originAccessIdentityConfig.CallerReference = aws.String(time.Now().Format(time.RFC3339Nano))
+		originAccessIdentityConfig.CallerReference = aws.String(resource.UniqueId())
 	} else {
 		originAccessIdentityConfig.CallerReference = aws.String(v.(string))
 	}

--- a/aws/resource_aws_cloudfront_origin_access_identity_test.go
+++ b/aws/resource_aws_cloudfront_origin_access_identity_test.go
@@ -43,9 +43,7 @@ func TestAccAWSCloudFrontOriginAccessIdentity_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFrontOriginAccessIdentityExistence("aws_cloudfront_origin_access_identity.origin_access_identity"),
 					resource.TestCheckResourceAttr("aws_cloudfront_origin_access_identity.origin_access_identity", "comment", "some comment"),
-					resource.TestMatchResourceAttr("aws_cloudfront_origin_access_identity.origin_access_identity",
-						"caller_reference",
-						regexp.MustCompile("^20[0-9]{2}.*")),
+					resource.TestMatchResourceAttr("aws_cloudfront_origin_access_identity.origin_access_identity", "caller_reference", regexp.MustCompile(fmt.Sprintf("^%s", resource.UniqueIdPrefix))),
 					resource.TestMatchResourceAttr("aws_cloudfront_origin_access_identity.origin_access_identity",
 						"s3_canonical_user_id",
 						regexp.MustCompile("^[a-z0-9]+")),
@@ -71,9 +69,7 @@ func TestAccAWSCloudFrontOriginAccessIdentity_noComment(t *testing.T) {
 				Config: testAccAWSCloudFrontOriginAccessIdentityNoCommentConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFrontOriginAccessIdentityExistence("aws_cloudfront_origin_access_identity.origin_access_identity"),
-					resource.TestMatchResourceAttr("aws_cloudfront_origin_access_identity.origin_access_identity",
-						"caller_reference",
-						regexp.MustCompile("^20[0-9]{2}.*")),
+					resource.TestMatchResourceAttr("aws_cloudfront_origin_access_identity.origin_access_identity", "caller_reference", regexp.MustCompile(fmt.Sprintf("^%s", resource.UniqueIdPrefix))),
 					resource.TestMatchResourceAttr("aws_cloudfront_origin_access_identity.origin_access_identity",
 						"s3_canonical_user_id",
 						regexp.MustCompile("^[a-z0-9]+")),

--- a/aws/resource_aws_cloudfront_public_key.go
+++ b/aws/resource_aws_cloudfront_public_key.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
@@ -163,7 +162,7 @@ func expandPublicKeyConfig(d *schema.ResourceData) *cloudfront.PublicKeyConfig {
 	if v, ok := d.GetOk("caller_reference"); ok {
 		publicKeyConfig.CallerReference = aws.String(v.(string))
 	} else {
-		publicKeyConfig.CallerReference = aws.String(time.Now().Format(time.RFC3339Nano))
+		publicKeyConfig.CallerReference = aws.String(resource.UniqueId())
 	}
 
 	return publicKeyConfig

--- a/aws/resource_aws_cloudfront_public_key_test.go
+++ b/aws/resource_aws_cloudfront_public_key_test.go
@@ -25,9 +25,7 @@ func TestAccAWSCloudFrontPublicKey_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFrontPublicKeyExistence("aws_cloudfront_public_key.example"),
 					resource.TestCheckResourceAttr("aws_cloudfront_public_key.example", "comment", "test key"),
-					resource.TestMatchResourceAttr("aws_cloudfront_public_key.example",
-						"caller_reference",
-						regexp.MustCompile("^20[0-9]{2}.*")),
+					resource.TestMatchResourceAttr("aws_cloudfront_public_key.example", "caller_reference", regexp.MustCompile(fmt.Sprintf("^%s", resource.UniqueIdPrefix))),
 					resource.TestCheckResourceAttr("aws_cloudfront_public_key.example", "name", fmt.Sprintf("tf-acc-test-%d", rInt)),
 				),
 			},

--- a/aws/resource_aws_servicecatalog_portfolio.go
+++ b/aws/resource_aws_servicecatalog_portfolio.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/servicecatalog"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 )
@@ -61,12 +62,10 @@ func resourceAwsServiceCatalogPortfolio() *schema.Resource {
 func resourceAwsServiceCatalogPortfolioCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).scconn
 	input := servicecatalog.CreatePortfolioInput{
-		AcceptLanguage: aws.String("en"),
+		AcceptLanguage:   aws.String("en"),
+		DisplayName:      aws.String(d.Get("name").(string)),
+		IdempotencyToken: aws.String(resource.UniqueId()),
 	}
-	name := d.Get("name").(string)
-	input.DisplayName = &name
-	now := time.Now()
-	input.IdempotencyToken = aws.String(fmt.Sprintf("%d", now.UnixNano()))
 
 	if v, ok := d.GetOk("description"); ok {
 		input.Description = aws.String(v.(string))

--- a/aws/resource_aws_servicecatalog_portfolio_test.go
+++ b/aws/resource_aws_servicecatalog_portfolio_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 )
 
-func TestAccAWSServiceCatalogPortfolioBasic(t *testing.T) {
+func TestAccAWSServiceCatalogPortfolio_Basic(t *testing.T) {
 	name := acctest.RandString(5)
 	var dpo servicecatalog.DescribePortfolioOutput
 	resource.ParallelTest(t, resource.TestCase{
@@ -65,7 +65,7 @@ func TestAccAWSServiceCatalogPortfolioBasic(t *testing.T) {
 	})
 }
 
-func TestAccAWSServiceCatalogPortfolioDisappears(t *testing.T) {
+func TestAccAWSServiceCatalogPortfolio_Disappears(t *testing.T) {
 	name := acctest.RandString(5)
 	var dpo servicecatalog.DescribePortfolioOutput
 	resource.ParallelTest(t, resource.TestCase{
@@ -85,7 +85,7 @@ func TestAccAWSServiceCatalogPortfolioDisappears(t *testing.T) {
 	})
 }
 
-func TestAccAWSServiceCatalogPortfolioImport(t *testing.T) {
+func TestAccAWSServiceCatalogPortfolio_Import(t *testing.T) {
 	resourceName := "aws_servicecatalog_portfolio.test"
 
 	name := acctest.RandString(5)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Followup to https://github.com/terraform-providers/terraform-provider-aws/pull/9470

There was only a short list of similar fixes so went ahead and implemented them rather than creating a technical debt issue to followup on later.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
--- PASS: TestAccAWSCloudFrontPublicKey_namePrefix (10.06s)
--- PASS: TestAccAWSCloudFrontPublicKey_basic (10.11s)
--- PASS: TestAccAWSCloudFrontPublicKey_update (16.13s)

--- PASS: TestAccAWSCloudFrontOriginAccessIdentity_basic (9.81s)
--- PASS: TestAccAWSCloudFrontOriginAccessIdentity_noComment (10.25s)
--- PASS: TestAccAWSCloudFrontOriginAccessIdentity_importBasic (10.54s)

--- PASS: TestAccAWSServiceCatalogPortfolio_Disappears (10.62s)
--- PASS: TestAccAWSServiceCatalogPortfolio_Import (13.26s)
--- PASS: TestAccAWSServiceCatalogPortfolio_Basic (29.31s)
```
