### PR TITLE
tests/resource/aws_egress_only_internet_gateway: Implement sweeper

### DIFF
--- a/aws/resource_aws_vpc_test.go
+++ b/aws/resource_aws_vpc_test.go
@@ -19,6 +19,7 @@ func init() {
 	resource.AddTestSweepers("aws_vpc", &resource.Sweeper{
 		Name: "aws_vpc",
 		Dependencies: []string{
+			"aws_egress_only_internet_gateway",
 			"aws_internet_gateway",
 			"aws_nat_gateway",
 			"aws_network_acl",


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
[14:26:27][Step 2/5] 2019/07/24 14:26:27 [ERR] error running (aws_vpc): Error deleting VPC (vpc-0b76960aca642fd69): DependencyViolation: The vpc 'vpc-0b76960aca642fd69' has dependencies and cannot be deleted.
```

Output from sweeper:

```
$ go test ./aws -v -sweep=us-east-1 -sweep-run=aws_vpc -timeout 10h
2019/07/24 11:15:49 [DEBUG] Running Sweepers for region (us-east-1):
...

...
2019/07/24 11:16:21 [DEBUG] Deleting VPC: {
  VpcId: "vpc-0b76960aca642fd69"
}
2019/07/24 11:16:21 [DEBUG] Waiting for state to become: [success]
2019/07/24 11:16:21 [DEBUG] Deleting VPC: {
  VpcId: "vpc-029813c56490ac204"
}
...
```