### PR TITLE
Add WAF Regional IP set data source

### DIFF
--- a/aws/data_source_aws_wafregional_ipset.go
+++ b/aws/data_source_aws_wafregional_ipset.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/hashicorp/terraform/helper/schema"

--- a/aws/data_source_aws_wafregional_ipset.go
+++ b/aws/data_source_aws_wafregional_ipset.go
@@ -1,0 +1,58 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsWafRegionalIpSet() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAWSWafRegionalIpSetRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func dataSourceAWSWafRegionalIpSetRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafregionalconn
+	name := d.Get("name").(string)
+
+	ipsets := make([]*waf.IPSetSummary, 0)
+	// ListIPSetsInput does not have a name parameter for filtering or a paginator
+	input := &waf.ListIPSetsInput{}
+	for {
+		output, err := conn.ListIPSets(input)
+		if err != nil {
+			return fmt.Errorf("Error reading WAF Regional IP sets: %s", err)
+		}
+		for _, ipset := range output.IPSets {
+			if aws.StringValue(ipset.Name) == name {
+				ipsets = append(ipsets, ipset)
+			}
+		}
+
+		if output.NextMarker == nil {
+			break
+		}
+		input.NextMarker = output.NextMarker
+	}
+
+	if len(ipsets) == 0 {
+		return fmt.Errorf("WAF Regional IP Set not found for name: %s", name)
+	}
+	if len(ipsets) > 1 {
+		return fmt.Errorf("Multiple WAF Regional IP Sets found for name: %s", name)
+	}
+
+	ipset := ipsets[0]
+	d.SetId(aws.StringValue(ipset.IPSetId))
+
+	return nil
+}

--- a/aws/data_source_aws_wafregional_ipset_test.go
+++ b/aws/data_source_aws_wafregional_ipset_test.go
@@ -1,0 +1,51 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAwsWafRegionalIPSet_Basic(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_wafregional_ipset.ipset"
+	datasourceName := "data.aws_wafregional_ipset.ipset"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSourceAwsWafRegionalIPSet_NonExistent,
+				ExpectError: regexp.MustCompile(`WAF Regional IP Set not found`),
+			},
+			{
+				Config: testAccDataSourceAwsWafRegionalIPSet_Name(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsWafRegionalIPSet_Name(name string) string {
+	return fmt.Sprintf(`
+resource "aws_wafregional_ipset" "ipset" {
+  name        = %[1]q
+}
+data "aws_wafregional_ipset" "ipset" {
+  name = "${aws_wafregional_ipset.ipset.name}"
+}
+`, name)
+}
+
+const testAccDataSourceAwsWafRegionalIPSet_NonExistent = `
+data "aws_wafregional_ipset" "ipset" {
+  name = "tf-acc-test-does-not-exist"
+}
+`

--- a/aws/data_source_aws_wafregional_ipset_test.go
+++ b/aws/data_source_aws_wafregional_ipset_test.go
@@ -2,10 +2,10 @@ package aws
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/acctest"
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -275,6 +275,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_vpn_gateway":                               dataSourceAwsVpnGateway(),
 			"aws_waf_rule":                                  dataSourceAwsWafRule(),
 			"aws_waf_web_acl":                               dataSourceAwsWafWebAcl(),
+			"aws_wafregional_ipset":                         dataSourceAwsWafRegionalIpSet(),
 			"aws_wafregional_rule":                          dataSourceAwsWafRegionalRule(),
 			"aws_wafregional_web_acl":                       dataSourceAwsWafRegionalWebAcl(),
 			"aws_workspaces_bundle":                         dataSourceAwsWorkspaceBundle(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -3146,6 +3146,9 @@
                             <a href="#">Data Sources</a>
                             <ul class="nav nav-auto-expand">
                                 <li>
+                                    <a href="/docs/providers/aws/d/wafregional_ipset.html">aws_wafregional_ipset</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/aws/d/wafregional_rule.html">aws_wafregional_rule</a>
                                 </li>
                                 <li>

--- a/website/docs/d/wafregional_ipset.html.markdown
+++ b/website/docs/d/wafregional_ipset.html.markdown
@@ -1,0 +1,30 @@
+---
+layout: "aws"
+page_title: "AWS: aws_wafregional_ipset"
+sidebar_current: "docs-aws-datasource-wafregional-ipset"
+description: |-
+  Retrieves an AWS WAF Regional IP set id.
+---
+
+# Data Source: aws_wafregional_ipset
+
+`aws_wafregional_ipset` Retrieves a WAF Regional IP Set Resource Id.
+
+## Example Usage
+
+```hcl
+data "aws_wafregional_ipset" "example" {
+  name = "tfWAFRegionalIPSet"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the WAF Regional IP set.
+
+## Attributes Reference
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the WAF Regional IP set.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #2654

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* **New Data Source** `aws_wafregional_ipset`
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccDataSourceAwsWafRegionalIPSet"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccDataSourceAwsWafRegionalIPSet -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccDataSourceAwsWafRegionalIPSet_Basic
=== PAUSE TestAccDataSourceAwsWafRegionalIPSet_Basic
=== CONT  TestAccDataSourceAwsWafRegionalIPSet_Basic
--- PASS: TestAccDataSourceAwsWafRegionalIPSet_Basic (38.33s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       44.963s
```

Local screenshot of docs:
![Screenshot 2019-07-24 at 17 23 48](https://user-images.githubusercontent.com/397565/61807884-4a520d80-ae32-11e9-8842-f187e86bff51.png)
