### PR TITLE
data/aws_lambda_alias: new data source

### DIFF
--- a/aws/data_source_aws_lambda_alias.go
+++ b/aws/data_source_aws_lambda_alias.go
@@ -1,0 +1,75 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsLambdaAlias() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsLambdaAliasRead,
+
+		Schema: map[string]*schema.Schema{
+			"function_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"alias_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"invoke_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"function_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsLambdaAliasRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).lambdaconn
+
+	functionName := d.Get("function_name").(string)
+	aliasName := d.Get("alias_name").(string)
+
+	params := &lambda.GetAliasInput{
+		FunctionName: aws.String(functionName),
+		Name:         aws.String(aliasName),
+	}
+
+	aliasConfiguration, err := conn.GetAlias(params)
+	if err != nil {
+		return fmt.Errorf("Error getting Lambda alias: %s", err)
+	}
+
+	d.SetId(*aliasConfiguration.AliasArn)
+
+	d.Set("arn", aliasConfiguration.AliasArn)
+	d.Set("description", aliasConfiguration.Description)
+	d.Set("function_version", aliasConfiguration.FunctionVersion)
+
+	invokeArn := lambdaFunctionInvokeArn(*aliasConfiguration.AliasArn, meta)
+	d.Set("invoke_arn", invokeArn)
+
+	return nil
+}

--- a/aws/data_source_aws_lambda_alias_test.go
+++ b/aws/data_source_aws_lambda_alias_test.go
@@ -1,0 +1,59 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAWSLambdaAlias_basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rAlias := acctest.RandomWithPrefix("tf-acc-test")
+	rDescription := acctest.RandomWithPrefix("tf-acc-test")
+
+	dataSourceName := "data.aws_lambda_alias.test"
+	lambdaAliasResourceName := "aws_lambda_alias.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAWSLambdaAliasConfigBasic(rName, rAlias, rDescription),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", lambdaAliasResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "invoke_arn", lambdaAliasResourceName, "invoke_arn"),
+					resource.TestCheckResourceAttr(dataSourceName, "description", rDescription),
+					resource.TestCheckResourceAttr(dataSourceName, "function_version", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAWSLambdaAliasConfigBasic(rName, rAlias, rDescription string) string {
+	return fmt.Sprintf(`
+resource "aws_lambda_function" "test" {
+  filename         = "test-fixtures/lambdatest.zip"
+  function_name    = "%s"
+  handler          = "exports.example"
+  runtime          = "nodejs8.10"
+  source_code_hash = "${filebase64hash256("test-fixtures/lambdatest.zip")}"
+  publish          = "true"
+}
+
+resource "aws_lambda_alias" "test" {
+  name             = "%s"
+  description      = "%s"
+  function_name    = "${aws_lambda_function.test.function_name}"
+  function_version = "1"
+}
+
+data "aws_lambda_alias" "test" {
+  function_name = "${aws_lambda_function.test.function_name}"
+  alias         = "${aws_lambda_alias.test.arn}"
+}
+  `, rName, rAlias, rDescription)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -224,6 +224,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_kms_key":                                   dataSourceAwsKmsKey(),
 			"aws_kms_secret":                                dataSourceAwsKmsSecret(),
 			"aws_kms_secrets":                               dataSourceAwsKmsSecrets(),
+			"aws_lambda_alias":                              dataSourceAwsLambdaAlias(),
 			"aws_lambda_function":                           dataSourceAwsLambdaFunction(),
 			"aws_lambda_invocation":                         dataSourceAwsLambdaInvocation(),
 			"aws_lambda_layer_version":                      dataSourceAwsLambdaLayerVersion(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1853,6 +1853,10 @@
                             <a href="#">Data Sources</a>
                             <ul class="nav nav-auto-expand">
                                 <li>
+                                    <a href="/docs/providers/aws/d/lambda_alias.html">aws_lambda_alias</a>
+                                </li>
+
+                                <li>
                                     <a href="/docs/providers/aws/d/lambda_function.html">aws_lambda_function</a>
                                 </li>
                                 <li>

--- a/website/docs/d/lambda_alias.html.markdown
+++ b/website/docs/d/lambda_alias.html.markdown
@@ -1,0 +1,36 @@
+---
+layout: "aws"
+page_title: "AWS: aws_lambda_alias"
+sidebar_current: "docs-aws-datasource-lambda-alias"
+description: |-
+  Provides a Lambda Alias data source.
+---
+
+# aws_lambda_alias
+
+Provides information about a Lambda Alias.
+
+## Example Usage
+
+```hcl
+data "aws_lambda_alias" "production" {
+  function_name = "my-lambda-func"
+  alias_name    = "production"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `function_name` - (Required) Name of the aliased Lambda function.
+* `alias_name` - (Required) Name of the Lambda alias.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The Amazon Resource Name (ARN) identifying the Lambda function alias.
+* `description` - Description of alias.
+* `function_version` - Lambda function version which the alias uses.
+* `invoke_arn` - The ARN to be used for invoking Lambda Function from API Gateway - to be used in aws_api_gateway_integration's `uri`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes  #8938

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* New Data Source: * `aws_lambda_alias`
```

Output from acceptance testing:

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSLambdaAlias_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSLambdaAlias_basic -timeout 120m
=== RUN   TestAccAWSLambdaAlias_basic
=== PAUSE TestAccAWSLambdaAlias_basic
=== CONT  TestAccAWSLambdaAlias_basic
--- PASS: TestAccAWSLambdaAlias_basic (22.19s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	22.236s
```
