### PR TITLE
Aws vpc peering connections

### DIFF
--- a/aws/data_source_aws_vpc_peering_connections.go
+++ b/aws/data_source_aws_vpc_peering_connections.go
@@ -5,8 +5,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func dataSourceAwsVpcPeeringConnections() *schema.Resource {
@@ -32,7 +33,7 @@ func dataSourceAwsVpcPeeringConnectionsRead(d *schema.ResourceData, meta interfa
 	req := &ec2.DescribeVpcPeeringConnectionsInput{}
 
 	req.Filters = append(req.Filters, buildEC2TagFilterList(
-		tagsFromMap(d.Get("tags").(map[string]interface{})),
+		keyvaluetags.New(d.Get("tags").(map[string]interface{})).Ec2Tags(),
 	)...)
 	req.Filters = append(req.Filters, buildEC2CustomFilterList(
 		d.Get("filter").(*schema.Set),

--- a/aws/data_source_aws_vpc_peering_connections.go
+++ b/aws/data_source_aws_vpc_peering_connections.go
@@ -1,0 +1,79 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsVpcPeeringConnections() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsVpcPeeringConnectionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"filter": ec2CustomFiltersSchema(),
+			"tags":   tagsSchemaComputed(),
+		},
+	}
+}
+
+func dataSourceAwsVpcPeeringConnectionsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	log.Printf("[DEBUG] Reading VPC Peering Connections.")
+
+	req := &ec2.DescribeVpcPeeringConnectionsInput{}
+
+	if id, ok := d.GetOk("id"); ok {
+		req.VpcPeeringConnectionIds = aws.StringSlice([]string{id.(string)})
+	}
+
+	req.Filters = append(req.Filters, buildEC2TagFilterList(
+		tagsFromMap(d.Get("tags").(map[string]interface{})),
+	)...)
+	req.Filters = append(req.Filters, buildEC2CustomFilterList(
+		d.Get("filter").(*schema.Set),
+	)...)
+	if len(req.Filters) == 0 {
+		// Don't send an empty filters list; the EC2 API won't accept it.
+		req.Filters = nil
+	}
+
+	log.Printf("[DEBUG] Reading VPC Peering Connections: %s", req)
+	resp, err := conn.DescribeVpcPeeringConnections(req)
+	if err != nil {
+		return err
+	}
+	if resp == nil || len(resp.VpcPeeringConnections) == 0 {
+		return fmt.Errorf("no matching VPC peering connections found")
+	}
+
+	var ids []string
+	for _, pcx := range resp.VpcPeeringConnections {
+		ids = append(ids, aws.StringValue(pcx.VpcPeeringConnectionId))
+	}
+
+	if len(ids) < 1 {
+		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
+	}
+
+	log.Printf("[DEBUG] Found %d peering connections via given filter: %s", len(ids), req)
+
+	d.SetId(resource.UniqueId())
+	err = d.Set("ids", ids)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/aws/data_source_aws_vpc_peering_connections.go
+++ b/aws/data_source_aws_vpc_peering_connections.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 

--- a/aws/data_source_aws_vpc_peering_connections_test.go
+++ b/aws/data_source_aws_vpc_peering_connections_test.go
@@ -3,7 +3,7 @@ package aws
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDataSourceAwsVpcPeeringConnections_basic(t *testing.T) {

--- a/aws/data_source_aws_vpc_peering_connections_test.go
+++ b/aws/data_source_aws_vpc_peering_connections_test.go
@@ -3,7 +3,7 @@ package aws
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
 func TestAccDataSourceAwsVpcPeeringConnections_basic(t *testing.T) {

--- a/aws/data_source_aws_vpc_peering_connections_test.go
+++ b/aws/data_source_aws_vpc_peering_connections_test.go
@@ -1,0 +1,83 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAwsVpcPeeringConnections_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsVpcPeeringConnectionsConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_vpc_peering_connections.test_by_filters", "ids.#", "2"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+const testAccDataSourceAwsVpcPeeringConnectionsConfig = `
+resource "aws_vpc" "foo" {
+  cidr_block = "10.1.0.0/16"
+
+  tags {
+	  Name = "terraform-testacc-vpc-peering-connection-data-source-foo"
+	  Type = "primary"
+  }
+}
+
+resource "aws_vpc" "bar" {
+  cidr_block = "10.2.0.0/16"
+
+  tags {
+	  Name = "terraform-testacc-vpc-peering-connection-data-source-bar"
+	  Type = "secondary"
+  }
+}
+
+resource "aws_vpc" "baz" {
+  cidr_block = "10.3.0.0/16"
+
+  tags {
+	  Name = "terraform-testacc-vpc-peering-connection-data-source-baz"
+	  Type = "secondary"
+  }
+}
+
+resource "aws_vpc_peering_connection" "conn1" {
+	vpc_id = "${aws_vpc.foo.id}"
+	peer_vpc_id = "${aws_vpc.bar.id}"
+	auto_accept = true
+
+    tags {
+      Name = "terraform-testacc-vpc-peering-connection-data-source-foo-to-bar"
+      Environment = "test"
+    }
+}
+
+resource "aws_vpc_peering_connection" "conn2" {
+	vpc_id = "${aws_vpc.foo.id}"
+	peer_vpc_id = "${aws_vpc.baz.id}"
+	auto_accept = true
+
+    tags {
+      Name = "terraform-testacc-vpc-peering-connection-data-source-foo-to-baz"
+      Environment = "test"
+    }
+}
+
+data "aws_vpc_peering_connections" "test_by_filters" {
+  filter {
+    name = "requester-vpc-info.vpc-id"
+    values = ["${aws_vpc.foo.id}"]
+  }
+
+	depends_on = ["aws_vpc_peering_connection.conn1", "aws_vpc_peering_connection.conn2"]
+}
+`

--- a/aws/data_source_aws_vpc_peering_connections_test.go
+++ b/aws/data_source_aws_vpc_peering_connections_test.go
@@ -26,8 +26,8 @@ resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
   tags = {
-	  Name = "terraform-testacc-vpc-peering-connection-data-source-foo"
-	  Type = "primary"
+    Name = "terraform-testacc-vpc-peering-connection-data-source-foo"
+    Type = "primary"
   }
 }
 
@@ -35,8 +35,8 @@ resource "aws_vpc" "bar" {
   cidr_block = "10.2.0.0/16"
 
   tags = {
-	  Name = "terraform-testacc-vpc-peering-connection-data-source-bar"
-	  Type = "secondary"
+    Name = "terraform-testacc-vpc-peering-connection-data-source-bar"
+    Type = "secondary"
   }
 }
 
@@ -44,31 +44,31 @@ resource "aws_vpc" "baz" {
   cidr_block = "10.3.0.0/16"
 
   tags = {
-	  Name = "terraform-testacc-vpc-peering-connection-data-source-baz"
-	  Type = "secondary"
+    Name = "terraform-testacc-vpc-peering-connection-data-source-baz"
+    Type = "secondary"
   }
 }
 
 resource "aws_vpc_peering_connection" "conn1" {
-	vpc_id = aws_vpc.foo.id
-	peer_vpc_id = aws_vpc.bar.id
-	auto_accept = true
+  vpc_id = aws_vpc.foo.id
+  peer_vpc_id = aws_vpc.bar.id
+  auto_accept = true
 
-    tags = {
-      Name = "terraform-testacc-vpc-peering-connection-data-source-foo-to-bar"
-      Environment = "test"
-    }
+  tags = {
+    Name = "terraform-testacc-vpc-peering-connection-data-source-foo-to-bar"
+    Environment = "test"
+  }
 }
 
 resource "aws_vpc_peering_connection" "conn2" {
-	vpc_id = aws_vpc.foo.id
-	peer_vpc_id = aws_vpc.baz.id
-	auto_accept = true
+  vpc_id = aws_vpc.foo.id
+  peer_vpc_id = aws_vpc.baz.id
+  auto_accept = true
 
-    tags = {
-      Name = "terraform-testacc-vpc-peering-connection-data-source-foo-to-baz"
-      Environment = "test"
-    }
+  tags = {
+    Name = "terraform-testacc-vpc-peering-connection-data-source-foo-to-baz"
+    Environment = "test"
+  }
 }
 
 data "aws_vpc_peering_connections" "test_by_filters" {

--- a/aws/data_source_aws_vpc_peering_connections_test.go
+++ b/aws/data_source_aws_vpc_peering_connections_test.go
@@ -26,7 +26,7 @@ const testAccDataSourceAwsVpcPeeringConnectionsConfig = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
-  tags {
+  tags = {
 	  Name = "terraform-testacc-vpc-peering-connection-data-source-foo"
 	  Type = "primary"
   }
@@ -35,7 +35,7 @@ resource "aws_vpc" "foo" {
 resource "aws_vpc" "bar" {
   cidr_block = "10.2.0.0/16"
 
-  tags {
+  tags = {
 	  Name = "terraform-testacc-vpc-peering-connection-data-source-bar"
 	  Type = "secondary"
   }
@@ -44,7 +44,7 @@ resource "aws_vpc" "bar" {
 resource "aws_vpc" "baz" {
   cidr_block = "10.3.0.0/16"
 
-  tags {
+  tags = {
 	  Name = "terraform-testacc-vpc-peering-connection-data-source-baz"
 	  Type = "secondary"
   }
@@ -55,7 +55,7 @@ resource "aws_vpc_peering_connection" "conn1" {
 	peer_vpc_id = "${aws_vpc.bar.id}"
 	auto_accept = true
 
-    tags {
+    tags = {
       Name = "terraform-testacc-vpc-peering-connection-data-source-foo-to-bar"
       Environment = "test"
     }
@@ -66,7 +66,7 @@ resource "aws_vpc_peering_connection" "conn2" {
 	peer_vpc_id = "${aws_vpc.baz.id}"
 	auto_accept = true
 
-    tags {
+    tags = {
       Name = "terraform-testacc-vpc-peering-connection-data-source-foo-to-baz"
       Environment = "test"
     }

--- a/aws/data_source_aws_vpc_peering_connections_test.go
+++ b/aws/data_source_aws_vpc_peering_connections_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestAccDataSourceAwsVpcPeeringConnections_basic(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -16,7 +16,6 @@ func TestAccDataSourceAwsVpcPeeringConnections_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_vpc_peering_connections.test_by_filters", "ids.#", "2"),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -74,10 +73,8 @@ resource "aws_vpc_peering_connection" "conn2" {
 
 data "aws_vpc_peering_connections" "test_by_filters" {
   filter {
-    name = "requester-vpc-info.vpc-id"
-    values = [aws_vpc.foo.id]
+    name   = "vpc-peering-connection-id"
+    values = [aws_vpc_peering_connection.conn1.id, aws_vpc_peering_connection.conn2.id]
   }
-
-	depends_on = ["aws_vpc_peering_connection.conn1", "aws_vpc_peering_connection.conn2"]
 }
 `

--- a/aws/data_source_aws_vpc_peering_connections_test.go
+++ b/aws/data_source_aws_vpc_peering_connections_test.go
@@ -51,8 +51,8 @@ resource "aws_vpc" "baz" {
 }
 
 resource "aws_vpc_peering_connection" "conn1" {
-	vpc_id = "${aws_vpc.foo.id}"
-	peer_vpc_id = "${aws_vpc.bar.id}"
+	vpc_id = aws_vpc.foo.id
+	peer_vpc_id = aws_vpc.bar.id
 	auto_accept = true
 
     tags = {
@@ -62,8 +62,8 @@ resource "aws_vpc_peering_connection" "conn1" {
 }
 
 resource "aws_vpc_peering_connection" "conn2" {
-	vpc_id = "${aws_vpc.foo.id}"
-	peer_vpc_id = "${aws_vpc.baz.id}"
+	vpc_id = aws_vpc.foo.id
+	peer_vpc_id = aws_vpc.baz.id
 	auto_accept = true
 
     tags = {
@@ -75,7 +75,7 @@ resource "aws_vpc_peering_connection" "conn2" {
 data "aws_vpc_peering_connections" "test_by_filters" {
   filter {
     name = "requester-vpc-info.vpc-id"
-    values = ["${aws_vpc.foo.id}"]
+    values = [aws_vpc.foo.id]
   }
 
 	depends_on = ["aws_vpc_peering_connection.conn1", "aws_vpc_peering_connection.conn2"]

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -338,6 +338,7 @@ func Provider() *schema.Provider {
 			"aws_vpc_endpoint":                               dataSourceAwsVpcEndpoint(),
 			"aws_vpc_endpoint_service":                       dataSourceAwsVpcEndpointService(),
 			"aws_vpc_peering_connection":                     dataSourceAwsVpcPeeringConnection(),
+			"aws_vpc_peering_connections":                    dataSourceAwsVpcPeeringConnections(),
 			"aws_vpn_gateway":                                dataSourceAwsVpnGateway(),
 			"aws_waf_ipset":                                  dataSourceAwsWafIpSet(),
 			"aws_waf_rule":                                   dataSourceAwsWafRule(),
@@ -353,7 +354,6 @@ func Provider() *schema.Provider {
 			"aws_wafv2_web_acl":                              dataSourceAwsWafv2WebACL(),
 			"aws_workspaces_bundle":                          dataSourceAwsWorkspacesBundle(),
 			"aws_workspaces_directory":                       dataSourceAwsWorkspacesDirectory(),
-
 			// Adding the Aliases for the ALB -> LB Rename
 			"aws_lb":               dataSourceAwsLb(),
 			"aws_alb":              dataSourceAwsLb(),

--- a/website/docs/d/vpc_peering_connections.html.markdown
+++ b/website/docs/d/vpc_peering_connections.html.markdown
@@ -21,14 +21,14 @@ the data source, as noted in [issue 4149](https://github.com/hashicorp/terraform
 data "aws_vpc_peering_connections" "pcs" {
   filter {
     name   = "requester-vpc-info.vpc-id"
-    values = ["${aws_vpc.foo.id}"]
+    values = [aws_vpc.foo.id]
   }
 }
 
 # get the details of each resource
 data "aws_vpc_peering_connection" "pc" {
-  count = "${length(data.aws_vpc_peering_connections.pcs.ids)}"
-  id    = "${data.aws_vpc_peering_connections.pcs.ids[count.index]}"
+  count = length(data.aws_vpc_peering_connections.pcs.ids)
+  id    = data.aws_vpc_peering_connections.pcs.ids[count.index]
 }
 ```
 

--- a/website/docs/d/vpc_peering_connections.html.markdown
+++ b/website/docs/d/vpc_peering_connections.html.markdown
@@ -20,7 +20,7 @@ the data source, as noted in [issue 4149](https://github.com/hashicorp/terraform
 # Declare the data source
 data "aws_vpc_peering_connections" "pcs" {
   filter {
-    name = "requester-vpc-info.vpc-id"
+    name   = "requester-vpc-info.vpc-id"
     values = ["${aws_vpc.foo.id}"]
   }
 }
@@ -28,7 +28,7 @@ data "aws_vpc_peering_connections" "pcs" {
 # get the details of each resource
 data "aws_vpc_peering_connection" "pc" {
   count = "${length(data.aws_vpc_peering_connections.pcs.ids)}"
-  id = "${data.aws_vpc_peering_connections.pcs.ids[count.index]}"
+  id    = "${data.aws_vpc_peering_connections.pcs.ids[count.index]}"
 }
 ```
 

--- a/website/docs/d/vpc_peering_connections.html.markdown
+++ b/website/docs/d/vpc_peering_connections.html.markdown
@@ -1,0 +1,57 @@
+---
+layout: "aws"
+page_title: "AWS: aws_vpc_peering_connections"
+sidebar_current: "docs-aws-datasource-vpc-peering-connections"
+description: |-
+    Lists peering connections
+---
+
+# Data Source: aws_vpc_peering_connections
+
+Use this data source to get IDs of Amazon VPC peering connections
+To get more details on each connection, use the data resource [aws_vpc_peering_connection](/docs/providers/aws/d/vpc_peering_connection.html)
+
+Note: To use this data source in a count, the resources should exist before trying to access
+the data source, as noted in [issue 4149](https://github.com/hashicorp/terraform/issues/4149)
+
+## Example Usage
+
+```hcl
+# Declare the data source
+data "aws_vpc_peering_connections" "pcs" {
+  filter {
+    name = "requester-vpc-info.vpc-id"
+    values = ["${aws_vpc.foo.id}"]
+  }
+}
+
+# get the details of each resource
+data "aws_vpc_peering_connection" "pc" {
+  count = "${length(data.aws_vpc_peering_connections.pcs.ids)}"
+  id = "${data.aws_vpc_peering_connections.pcs.ids[count.index]}"
+}
+```
+
+## Argument Reference
+
+The arguments of this data source act as filters for querying the available VPC peering connections.
+
+* `filter` - (Optional) Custom filter block as described below.
+
+* `tags` - (Optional) A mapping of tags, each pair of which must exactly match
+  a pair on the desired VPC Peering Connection.
+
+More complex filters can be expressed using one or more `filter` sub-blocks,
+which take the following arguments:
+
+* `name` - (Required) The name of the field to filter by, as defined by
+  [the underlying AWS API](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeVpcPeeringConnections.html).
+
+* `values` - (Required) Set of values that are accepted for the given field.
+  A VPC Peering Connection will be selected if any one of the given values matches.
+
+## Attributes Reference
+
+All of the argument attributes except `filter` are also exported as result attributes.
+
+* `ids` - The IDs of the VPC Peering Connections.

--- a/website/docs/d/vpc_peering_connections.html.markdown
+++ b/website/docs/d/vpc_peering_connections.html.markdown
@@ -1,7 +1,7 @@
 ---
+subcategory: "VPC"
 layout: "aws"
 page_title: "AWS: aws_vpc_peering_connections"
-sidebar_current: "docs-aws-datasource-vpc-peering-connections"
 description: |-
     Lists peering connections
 ---


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #6350
Relates to #6351


This is built on top of #6351, but I resolved the merge conflict and cleaned it up a little bit. If you want to pull these changes into the exiting PR, that's fine with me. 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
- Add aws_vpc_peering_connections
list all peering connections using filters, returning ids.
Useful when trying to build route tables between vpcs with multiple
peering connections managed in different state files.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccDataSourceAwsVpcPeeringConnections_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccDataSourceAwsVpcPeeringConnections_basic -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccDataSourceAwsVpcPeeringConnections_basic
--- PASS: TestAccDataSourceAwsVpcPeeringConnections_basic (41.68s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       41.713s
```
