### PR TITLE
Fixed typo in configuration template

### DIFF
--- a/website/docs/r/codepipeline.markdown
+++ b/website/docs/r/codepipeline.markdown
@@ -138,7 +138,7 @@ resource "aws_codepipeline" "codepipeline" {
       input_artifacts = ["build_output"]
       version         = "1"
 
-      configuration {
+      configuration = {
         ActionMode     = "REPLACE_ON_FAILURE"
         Capabilities   = "CAPABILITY_AUTO_EXPAND,CAPABILITY_IAM"
         OutputFileName = "CreateStackOutput.json"


### PR DESCRIPTION
Stumbled upon it when I tried to use it, terraform verify raised an error.
I realized that there is a typo and fixed it.
