### PR TITLE
resource/aws_vpn_connection: Implement sweeper and refactor StateChangeConf logic into functions

### DIFF
--- a/aws/resource_aws_ec2_transit_gateway_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_test.go
@@ -20,6 +20,7 @@ func init() {
 		Dependencies: []string{
 			"aws_dx_gateway_association",
 			"aws_ec2_transit_gateway_vpc_attachment",
+			"aws_vpn_connection",
 		},
 	})
 }


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
[05:32:45][Step 2/5] 2019/07/25 05:32:45 [ERR] error running (aws_ec2_transit_gateway): error deleting EC2 Transit Gateway (tgw-00aa5f7239c698b3e): IncorrectState: tgw-00aa5f7239c698b3e has non-deleted VPN Attachments: tgw-attach-03878e4de24295442.
```

Output from sweeper in AWS Commercial:

```
$ go test ./aws -v -sweep=us-east-1,us-west-2 -sweep-run=aws_ec2_transit_gateway -timeout 10h
...
2019/07/25 09:03:35 [INFO] Deleting EC2 VPN Connection: vpn-0ba5b3aa03c8898cd
...
2019/07/25 09:03:46 [INFO] Deleting EC2 Transit Gateway: tgw-00aa5f7239c698b3e
...
2019/07/25 09:05:39 Sweeper Tests ran:
  - aws_dx_gateway_association_proposal
  - aws_dx_gateway_association
  - aws_ec2_transit_gateway_vpc_attachment
  - aws_vpn_connection
  - aws_ec2_transit_gateway
...
2019/07/25 09:07:05 Sweeper Tests ran:
  - aws_vpn_connection
  - aws_ec2_transit_gateway
  - aws_dx_gateway_association_proposal
  - aws_dx_gateway_association
  - aws_ec2_transit_gateway_vpc_attachment
```

Output from sweeper in AWS GovCloud (US):

```
$ go test ./aws -v -sweep=us-gov-west-1 -sweep-run=aws_ec2_transit_gateway -timeout 10h
...
2019/07/25 09:03:44 Sweeper Tests ran:
  - aws_ec2_transit_gateway
  - aws_dx_gateway_association_proposal
  - aws_dx_gateway_association
  - aws_ec2_transit_gateway_vpc_attachment
  - aws_vpn_connection
```
