### PR TITLE
Final retries for timeouts on SFN objects

### DIFF
--- a/aws/resource_aws_sfn_state_machine.go
+++ b/aws/resource_aws_sfn_state_machine.go
@@ -87,6 +87,9 @@ func resourceAwsSfnStateMachineCreate(d *schema.ResourceData, meta interface{}) 
 
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		activity, err = conn.CreateStateMachine(params)
+	}
 
 	if err != nil {
 		return fmt.Errorf("Error creating Step Function State Machine: %s", err)
@@ -202,7 +205,6 @@ func resourceAwsSfnStateMachineUpdate(d *schema.ResourceData, meta interface{}) 
 			}
 		}
 	}
-
 	return resourceAwsSfnStateMachineRead(d, meta)
 }
 
@@ -210,10 +212,11 @@ func resourceAwsSfnStateMachineDelete(d *schema.ResourceData, meta interface{}) 
 	conn := meta.(*AWSClient).sfnconn
 	log.Printf("[DEBUG] Deleting Step Function State Machine: %s", d.Id())
 
-	return resource.Retry(5*time.Minute, func() *resource.RetryError {
-		_, err := conn.DeleteStateMachine(&sfn.DeleteStateMachineInput{
-			StateMachineArn: aws.String(d.Id()),
-		})
+	input := &sfn.DeleteStateMachineInput{
+		StateMachineArn: aws.String(d.Id()),
+	}
+	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
+		_, err := conn.DeleteStateMachine(input)
 
 		if err == nil {
 			return nil
@@ -221,4 +224,11 @@ func resourceAwsSfnStateMachineDelete(d *schema.ResourceData, meta interface{}) 
 
 		return resource.NonRetryableError(err)
 	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.DeleteStateMachine(input)
+	}
+	if err != nil {
+		return fmt.Errorf("Error deleting SFN state machine: %s", err)
+	}
+	return nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES
* resource/aws_sfn_activity: Retry after timeout deleting SFN activity
* resource/aws_sfn_state_machine: Retry after timeouts deleting and creating SFN state machines

```

Output from acceptance testing:

```
NOTE: Failure is long-standing due to eventual consistency of the DescribeStateMachine API call.


$ make testacc TESTARGS="-run=TestAccAWSSfnActivity"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSSfnActivity -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSSfnActivity_importBasic
=== PAUSE TestAccAWSSfnActivity_importBasic
=== RUN   TestAccAWSSfnActivity_basic
=== PAUSE TestAccAWSSfnActivity_basic
=== RUN   TestAccAWSSfnActivity_Tags
=== PAUSE TestAccAWSSfnActivity_Tags
=== CONT  TestAccAWSSfnActivity_importBasic
=== CONT  TestAccAWSSfnActivity_Tags
=== CONT  TestAccAWSSfnActivity_basic
--- PASS: TestAccAWSSfnActivity_basic (26.60s)
--- PASS: TestAccAWSSfnActivity_importBasic (30.09s)
--- PASS: TestAccAWSSfnActivity_Tags (68.38s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       69.481s

make testacc TESTARGS="-run=TestAccAWSSfnStateMachine"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSSfnStateMachine -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSSfnStateMachine_createUpdate
=== PAUSE TestAccAWSSfnStateMachine_createUpdate
=== RUN   TestAccAWSSfnStateMachine_Tags
=== PAUSE TestAccAWSSfnStateMachine_Tags
=== CONT  TestAccAWSSfnStateMachine_createUpdate
=== CONT  TestAccAWSSfnStateMachine_Tags
--- FAIL: TestAccAWSSfnStateMachine_createUpdate (66.91s)
    testing.go:568: Step 1 error: Check failed: Check 5/6 error: aws_sfn_state_machine.foo: Attribute 'definition' didn't match ".*\\\"MaxAttempts\\\": 10.*", got "{\n  \"Comment\": \"A Hello World example of the Amazon States Language using an AWS Lambda Function\",\n  \"StartAt\": \"HelloWorld\",\n  \"States\": {\n    \"HelloWorld\": {\n      \"Type\": \"Task\",\n      \"Resource\": \"arn:aws:lambda:us-west-2:187416307283:function:sfn-u0z61cbfcq\",\n      \"Retry\": [\n        {\n          \"ErrorEquals\": [\"States.ALL\"],\n          \"IntervalSeconds\": 5,\n          \"MaxAttempts\": 5,\n          \"BackoffRate\": 8.0\n        }\n      ],\n      \"End\": true\n    }\n  }\n}\n"
--- PASS: TestAccAWSSfnStateMachine_Tags (101.58s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-aws/aws       103.434s
make: *** [testacc] Error 1
```