### PR TITLE
tests/resource/aws_vpn_gateway: Remove tag filtering for sweeper

### DIFF
--- a/aws/resource_aws_vpn_gateway_test.go
+++ b/aws/resource_aws_vpn_gateway_test.go
@@ -31,17 +31,7 @@ func testSweepVPNGateways(region string) error {
 	}
 	conn := client.(*AWSClient).ec2conn
 
-	req := &ec2.DescribeVpnGatewaysInput{
-		Filters: []*ec2.Filter{
-			{
-				Name: aws.String("tag-value"),
-				Values: []*string{
-					aws.String("terraform-testacc-*"),
-					aws.String("tf-acc-test-*"),
-				},
-			},
-		},
-	}
+	req := &ec2.DescribeVpnGatewaysInput{}
 	resp, err := conn.DescribeVpnGateways(req)
 	if err != nil {
 		if testSweepSkipSweepError(err) {


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

This was an older style of sweeper logic. Since test resource implementations are community driven and tagging in inconsistent, we now just delete (almost) everything in the testing accounts.

Previously:

```
2019/07/25 09:37:09 [ERR] error running (aws_vpc): Error deleting VPC (vpc-0ba76b05c6b9217f3): DependencyViolation: The vpc 'vpc-0ba76b05c6b9217f3' has dependencies and cannot be deleted.
```

Output from sweeper:

```
$ go test ./aws -v -sweep=us-east-1,us-west-2 -sweep-run=aws_vpc -timeout 10h
...
2019/07/25 09:48:09 [DEBUG] Detaching VPN Gateway: {
  VpcId: "vpc-0ba76b05c6b9217f3",
  VpnGatewayId: "vgw-0fdfc1ff706b3c6b7"
}
2019/07/25 09:48:09 [DEBUG] Waiting for VPN Gateway (vgw-0fdfc1ff706b3c6b7) to detach from VPC (vpc-0ba76b05c6b9217f3)
2019/07/25 09:48:09 [DEBUG] Waiting for state to become: [detached]
2019/07/25 09:48:09 [DEBUG] Deleting VPN Gateway: {
  VpnGatewayId: "vgw-0fdfc1ff706b3c6b7"
}
...
2019/07/25 09:48:10 [DEBUG] Deleting VPC: {
  VpcId: "vpc-0ba76b05c6b9217f3"
}
2019/07/25 09:48:10 [DEBUG] Waiting for state to become: [success]
2019/07/25 09:48:10 [TRACE] Waiting 500ms before next try
2019/07/25 09:48:11 [TRACE] Waiting 1s before next try
2019/07/25 09:48:12 [TRACE] Waiting 2s before next try
2019/07/25 09:48:14 [TRACE] Waiting 4s before next try
2019/07/25 09:48:18 [TRACE] Waiting 8s before next try
2019/07/25 09:48:26 Sweeper Tests ran:
  - aws_api_gateway_vpc_link
  - aws_route53_resolver_endpoint
  - aws_security_group
  - aws_vpc_endpoint_service
  - aws_batch_compute_environment
  - aws_lambda_function
  - aws_eks_cluster
  - aws_elasticache_replication_group
  - aws_nat_gateway
  - aws_vpc
  - aws_beanstalk_environment
  - aws_db_instance
  - aws_ec2_transit_gateway_vpc_attachment
  - aws_vpn_gateway
  - aws_batch_job_queue
  - aws_emr_cluster
  - aws_instance
  - aws_msk_cluster
  - aws_dx_gateway_association
  - aws_autoscaling_group
  - aws_elasticsearch_domain
  - aws_elb
  - aws_dx_gateway_association_proposal
  - aws_network_interface
  - aws_redshift_cluster
  - aws_spot_fleet_request
  - aws_network_acl
  - aws_mq_broker
  - aws_route_table
  - aws_vpc_endpoint
  - aws_vpc_peering_connection
  - aws_lb
  - aws_ec2_client_vpn_endpoint
  - aws_elasticache_cluster
  - aws_subnet
  - aws_internet_gateway
  - aws_vpc_dhcp_options
  - aws_db_subnet_group
  - aws_directory_service_directory
```