### PR TITLE
resource/aws_rds_cluster: Properly update master_password during snapshot restore

### DIFF
--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -489,6 +489,11 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 			opts.KmsKeyId = aws.String(attr.(string))
 		}
 
+		if attr, ok := d.GetOk("master_password"); ok {
+			modifyDbClusterInput.MasterUserPassword = aws.String(attr.(string))
+			requiresModifyDbCluster = true
+		}
+
 		if attr, ok := d.GetOk("option_group_name"); ok {
 			opts.OptionGroupName = aws.String(attr.(string))
 		}

--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -89,7 +89,7 @@ The following arguments are supported:
 * `deletion_protection` - (Optional) If the DB instance should have deletion protection enabled. The database can't be deleted when this value is set to `true`. The default is `false`.
 * `master_password` - (Required unless a `snapshot_identifier` or `global_cluster_identifier` is provided) Password for the master DB user. Note that this may
     show up in logs, and it will be stored in the state file. Please refer to the [RDS Naming Constraints][5]
-* `master_username` - (Required unless a `snapshot_identifier` or `global_cluster_identifier` is provided) Username for the master DB user. Please refer to the [RDS Naming Constraints][5]
+* `master_username` - (Required unless a `snapshot_identifier` or `global_cluster_identifier` is provided) Username for the master DB user. Please refer to the [RDS Naming Constraints][5]. This argument does not support in-place updates and cannot be changed during a restore from snapshot.
 * `final_snapshot_identifier` - (Optional) The name of your final DB snapshot
     when this DB cluster is deleted. If omitted, no final snapshot will be
     made.


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9492

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_rds_cluster: Properly update `master_password` during snapshot restore
```

Since we cannot read the master password from the API during `Read`, it would silently be saved with the configuration value in the Terraform state and never trigger an update. This cannot be found via the acceptance testing framework without attempting to connect to the RDS Cluster (e.g. via the mysql provider), but relatedly added a test for master_username since that was also missing during snapshot restore, which highlighted a related missing test.

```
--- FAIL: TestAccAWSRDSCluster_SnapshotIdentifier_MasterUsername (377.68s)
    testing.go:568: Step 0 error: Check failed: Check 4/4 error: aws_rds_cluster.test: Attribute 'master_username' expected "username1", got "foo"
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_MasterPassword (378.00s)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_MasterPassword (364.62s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_MasterUsername (387.26s)
```
