### PR TITLE
Added missing permission

### DIFF
--- a/website/docs/r/codepipeline.markdown
+++ b/website/docs/r/codepipeline.markdown
@@ -52,7 +52,8 @@ resource "aws_iam_role_policy" "codepipeline_policy" {
       "Action": [
         "s3:GetObject",
         "s3:GetObjectVersion",
-        "s3:GetBucketVersioning"
+        "s3:GetBucketVersioning",
+        "s3:PutObject"
       ],
       "Resource": [
         "${aws_s3_bucket.codepipeline_bucket.arn}",


### PR DESCRIPTION
As the source code artifacts should get stored in S3, we need the permission to do so.
For AWS docs, see:
https://docs.aws.amazon.com/de_de/AmazonS3/latest/dev/using-with-s3-actions.html

