### PR TITLE
r/aws_security_group: Support ampersand in rule description

### DIFF
--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1830,7 +1830,7 @@ func validateSecurityGroupRuleDescription(v interface{}, k string) (ws []string,
 
 	// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpRange.html. Note that
 	// "" is an allowable description value.
-	pattern := `^[A-Za-z0-9 \.\_\-\:\/\(\)\#\,\@\[\]\+\=\;\{\}\!\$\*]*$`
+	pattern := `^[A-Za-z0-9 \.\_\-\:\/\(\)\#\,\@\[\]\+\=\&\;\{\}\!\$\*]*$`
 	if !regexp.MustCompile(pattern).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"%q doesn't comply with restrictions (%q): %q",

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2330,7 +2330,7 @@ func TestValidateSecurityGroupRuleDescription(t *testing.T) {
 		"testrule",
 		"testRule",
 		"testRule 123",
-		`testRule 123 ._-:/()#,@[]+=;{}!$*`,
+		`testRule 123 ._-:/()#,@[]+=&;{}!$*`,
 	}
 	for _, v := range validDescriptions {
 		_, errors := validateSecurityGroupRuleDescription(v, "description")
@@ -2342,6 +2342,7 @@ func TestValidateSecurityGroupRuleDescription(t *testing.T) {
 	invalidDescriptions := []string{
 		"`",
 		"%%",
+		`\`,
 	}
 	for _, v := range invalidDescriptions {
 		_, errors := validateSecurityGroupRuleDescription(v, "description")


### PR DESCRIPTION
The official API documentation is not accurate ([here](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpRange.html) and [here](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Ipv6Range.html)). User guides have their code on GitHub, but I wasn't able to find the API reference on GitHub. I'm sure some HashiCorp employees have better communications channels and can report this upstream.

If you try to use a character that is actually not allowed (e.g. `%`), then the error response will reveal the pattern that they are actually using, which is: `a-zA-Z0-9. _-:/()#,@[]+=&;{}!$*`.

Screenshot from console:

<img width="922" alt="Screen Shot 2019-07-27 at 12 24 04 PM" src="https://user-images.githubusercontent.com/1991151/61998816-82dc2c00-b06a-11e9-9345-da9903d22b6b.png">

Searching for `._-:/()#,@[]+=;{}!$*` on https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/ reveals two other locations where this regex is documented. Perhaps these two also support `&`? It is worth asking the AWS people.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/2278

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
- resource/aws_security_group: Support ampersand (`&`) in `description` field in `ingress` and `egress` rules.
- resource/aws_security_group_rule: Support ampersand (`&`) in `description` field.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestValidateSecurityGroupRuleDescription'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestValidateSecurityGroupRuleDescription -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestValidateSecurityGroupRuleDescription
--- PASS: TestValidateSecurityGroupRuleDescription (0.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	0.045s
```
