### PR TITLE
Enable container_insights for ecs_cluster

### DIFF
--- a/aws/resource_aws_ecs_cluster.go
+++ b/aws/resource_aws_ecs_cluster.go
@@ -59,11 +59,12 @@ func resourceAwsEcsClusterCreate(d *schema.ResourceData, meta interface{}) error
 	conn := meta.(*AWSClient).ecsconn
 
 	clusterName := d.Get("name").(string)
-	log.Printf("[DEBUG] Creating ECS cluster %s", clusterName)
+	containerInsights := d.Get("container_insights").(bool)
+	log.Printf("[DEBUG] Creating ECS cluster %s container_insights %t", clusterName, containerInsights)
 
 	settings := &ecs.ClusterSetting{
 		Name:  aws.String("containerInsights"),
-		Value: aws.String("enabled"),
+		Value: aws.String(clusterSettingValue(containerInsights)),
 	}
 	clusterSetting := make([]*ecs.ClusterSetting, 0, 1)
 	clusterSetting = append(clusterSetting, settings)
@@ -260,4 +261,12 @@ func resourceAwsEcsClusterDelete(d *schema.ResourceData, meta interface{}) error
 
 	log.Printf("[DEBUG] ECS cluster %q deleted", d.Id())
 	return nil
+}
+
+func clusterSettingValue(b bool) string {
+	if b {
+		return "enabled"
+	} else {
+		return "disabled"
+	}
 }

--- a/aws/resource_aws_ecs_cluster.go
+++ b/aws/resource_aws_ecs_cluster.go
@@ -61,8 +61,16 @@ func resourceAwsEcsClusterCreate(d *schema.ResourceData, meta interface{}) error
 	clusterName := d.Get("name").(string)
 	log.Printf("[DEBUG] Creating ECS cluster %s", clusterName)
 
+	settings := &ecs.ClusterSetting{
+		Name:  aws.String("containerInsights"),
+		Value: aws.String("enabled"),
+	}
+	clusterSetting := make([]*ecs.ClusterSetting, 0, 1)
+	clusterSetting = append(clusterSetting, settings)
+
 	out, err := conn.CreateCluster(&ecs.CreateClusterInput{
 		ClusterName: aws.String(clusterName),
+		Settings:    clusterSetting,
 		Tags:        tagsFromMapECS(d.Get("tags").(map[string]interface{})),
 	})
 	if err != nil {

--- a/aws/resource_aws_ecs_cluster.go
+++ b/aws/resource_aws_ecs_cluster.go
@@ -33,6 +33,7 @@ func resourceAwsEcsCluster() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: true,
+				Default:  false,
 			},
 			"tags": tagsSchema(),
 			"arn": {

--- a/aws/resource_aws_ecs_cluster.go
+++ b/aws/resource_aws_ecs_cluster.go
@@ -144,8 +144,11 @@ func resourceAwsEcsClusterRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
+	settings := *(cluster.Settings)
+	container_insights := settings[0]["Value"].(bool)
 	d.Set("arn", cluster.ClusterArn)
 	d.Set("name", cluster.ClusterName)
+	d.Set("container_insights", container_insights)
 
 	if err := d.Set("tags", tagsToMapECS(cluster.Tags)); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)

--- a/aws/resource_aws_ecs_cluster.go
+++ b/aws/resource_aws_ecs_cluster.go
@@ -29,6 +29,11 @@ func resourceAwsEcsCluster() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"container_insights": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
 			"tags": tagsSchema(),
 			"arn": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_ecs_cluster_test.go
+++ b/aws/resource_aws_ecs_cluster_test.go
@@ -65,6 +65,7 @@ func TestAccAWSEcsCluster_basic(t *testing.T) {
 	var cluster1 ecs.Cluster
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ecs_cluster.test"
+	countainerInsights := true
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -72,7 +73,7 @@ func TestAccAWSEcsCluster_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSEcsClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEcsClusterConfig(rName),
+				Config: testAccAWSEcsClusterConfig(rName, countainerInsights),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsClusterExists(resourceName, &cluster1),
 					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "ecs", fmt.Sprintf("cluster/%s", rName)),
@@ -94,6 +95,7 @@ func TestAccAWSEcsCluster_disappears(t *testing.T) {
 	var cluster1 ecs.Cluster
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ecs_cluster.test"
+	countainerInsights := true
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -101,7 +103,7 @@ func TestAccAWSEcsCluster_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAWSEcsClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEcsClusterConfig(rName),
+				Config: testAccAWSEcsClusterConfig(rName, countainerInsights),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsClusterExists(resourceName, &cluster1),
 					testAccCheckAWSEcsClusterDisappears(&cluster1),
@@ -230,12 +232,13 @@ func testAccCheckAWSEcsClusterDisappears(cluster *ecs.Cluster) resource.TestChec
 	}
 }
 
-func testAccAWSEcsClusterConfig(rName string) string {
+func testAccAWSEcsClusterConfig(rName string, containerInsights bool) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "test" {
   name = %q
+	container_insights = %t
 }
-`, rName)
+`, rName, containerInsights)
 }
 
 func testAccAWSEcsClusterConfigTags1(rName, tag1Key, tag1Value string) string {

--- a/website/docs/r/ecs_cluster.html.markdown
+++ b/website/docs/r/ecs_cluster.html.markdown
@@ -15,6 +15,7 @@ Provides an ECS cluster.
 ```hcl
 resource "aws_ecs_cluster" "foo" {
   name = "white-hart"
+	container_insights: true
 }
 ```
 
@@ -24,6 +25,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the cluster (up to 255 letters, numbers, hyphens, and underscores)
 * `tags` - (Optional) Key-value mapping of resource tags
+* `container_insights` - (Optional, Default: false) A boolean that indicates whether to enable [Container Insight](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights.html)
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes https://github.com/terraform-providers/terraform-provider-aws/issues/9294 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_ecs_cluster: Add `container_insights` argument 
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSEcsCluster_basic'

...
```
