### PR TITLE
Cost report parquet format

### DIFF
--- a/aws/resource_aws_cur_report_definition.go
+++ b/aws/resource_aws_cur_report_definition.go
@@ -39,7 +39,9 @@ func resourceAwsCurReportDefinition() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					costandusagereportservice.ReportFormatTextOrcsv}, false),
+					costandusagereportservice.ReportFormatParquet,
+					costandusagereportservice.ReportFormatTextOrcsv,
+				}, false),
 			},
 			"compression": {
 				Type:     schema.TypeString,
@@ -47,6 +49,7 @@ func resourceAwsCurReportDefinition() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					costandusagereportservice.CompressionFormatGzip,
+					costandusagereportservice.CompressionFormatParquet,
 					costandusagereportservice.CompressionFormatZip,
 				}, false),
 			},
@@ -82,6 +85,7 @@ func resourceAwsCurReportDefinition() *schema.Resource {
 				Type: schema.TypeSet,
 				Elem: &schema.Schema{Type: schema.TypeString,
 					ValidateFunc: validation.StringInSlice([]string{
+						costandusagereportservice.AdditionalArtifactAthena,
 						costandusagereportservice.AdditionalArtifactQuicksight,
 						costandusagereportservice.AdditionalArtifactRedshift,
 					}, false),

--- a/aws/resource_aws_cur_report_definition_test.go
+++ b/aws/resource_aws_cur_report_definition_test.go
@@ -31,7 +31,7 @@ func TestAccAwsCurReportDefinition_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAwsCurReportDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsCurReportDefinitionConfig_basic_redshift_quicksight(reportNameredshiftQuicksightReportName, bucketNameredshiftQuicksightBucketName, bucketRegion),
+				Config: testAccAwsCurReportDefinitionConfig_basic_redshift_quicksight(redshiftQuicksightReportName, redshiftQuicksightBucketName, bucketRegion),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsCurReportDefinitionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "report_name", redshiftQuicksightReportName),
@@ -172,8 +172,8 @@ POLICY
 `, reportName, bucketName, bucketRegion)
 }
 
-func testAccAwsCurReportDefinitionConfig_basic_redshift_quicksight(reportName string, bucketName string, bucketRegion string)(reportName string) string {
-	return testAccAwsCurReportDefinitionConfig_basic(reportName, bucketName, bucketRegion) + `
+func testAccAwsCurReportDefinitionConfig_basic_redshift_quicksight(reportName string, bucketName string, bucketRegion string) string {
+	reportDefinition := fmt.Sprintf(`
 resource "aws_cur_report_definition" "redshift_quicksight" {
   report_name                = "%[1]s"
   time_unit                  = "DAILY"
@@ -186,10 +186,13 @@ resource "aws_cur_report_definition" "redshift_quicksight" {
   additional_artifacts       = ["ATHENA"]
 }
 `, reportName)
+
+	return testAccAwsCurReportDefinitionConfig_basic(reportName, bucketName, bucketRegion) + reportDefinition
 }
 
+//``
 func testAccAwsCurReportDefinitionConfig_basic_athena(reportName string, bucketName string, bucketRegion string) string {
-	return testAccAwsCurReportDefinitionConfig_basic(reportName, bucketName, bucketRegion) + `
+	reportDefinition := fmt.Sprintf(`
 resource "aws_cur_report_definition" "athena" {
   report_name                = "%[1]s"
   time_unit                  = "DAILY"
@@ -202,4 +205,6 @@ resource "aws_cur_report_definition" "athena" {
   additional_artifacts       = ["REDSHIFT", "QUICKSIGHT"]
 }
 `, reportName)
+
+	return testAccAwsCurReportDefinitionConfig_basic(reportName, bucketName, bucketRegion) + reportDefinition
 }

--- a/aws/resource_aws_cur_report_definition_test.go
+++ b/aws/resource_aws_cur_report_definition_test.go
@@ -152,7 +152,7 @@ resource "aws_s3_bucket_policy" "test" {
 POLICY
 }
 
-resource "aws_cur_report_definition" "test" {
+resource "aws_cur_report_definition" "redshift_quicksight" {
   report_name                = "%[1]s"
   time_unit                  = "DAILY"
   format                     = "textORcsv"
@@ -162,6 +162,18 @@ resource "aws_cur_report_definition" "test" {
   s3_prefix                  = ""
   s3_region                  = "${aws_s3_bucket.test.region}"
   additional_artifacts       = ["REDSHIFT", "QUICKSIGHT"]
+}
+
+resource "aws_cur_report_definition" "athena" {
+  report_name                = "%[1]s"
+  time_unit                  = "DAILY"
+  format                     = "Parquet"
+  compression                = "Parquet"
+  additional_schema_elements = ["RESOURCES"]
+  s3_bucket                  = "${aws_s3_bucket.test.id}"
+  s3_prefix                  = ""
+  s3_region                  = "${aws_s3_bucket.test.region}"
+  additional_artifacts       = ["ATHENA"]
 }
 `, reportName, bucketName, bucketRegion)
 }

--- a/aws/resource_aws_cur_report_definition_test.go
+++ b/aws/resource_aws_cur_report_definition_test.go
@@ -20,9 +20,9 @@ func TestAccAwsCurReportDefinition_basic(t *testing.T) {
 	resourceName := "aws_cur_report_definition.test"
 
 	redshiftQuicksightReportName := acctest.RandomWithPrefix("tf_acc_test")
-	redshiftQuicksightBucketName := fmt.Sprintf("tf-test-bucket-%d-%s", acctest.RandInt(), redshiftQuicksightReportName)
+	redshiftQuicksightBucketName := fmt.Sprintf("tf-test-bucket-%d", acctest.RandInt())
 	athenaReportName := acctest.RandomWithPrefix("tf_acc_test")
-	athenaBucketName := fmt.Sprintf("tf-test-bucket-%d-%s", acctest.RandInt(), athenaReportName)
+	athenaBucketName := fmt.Sprintf("tf-test-bucket-%d", acctest.RandInt())
 	bucketRegion := "us-east-1"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/website/docs/r/cur_report_definition.html.markdown
+++ b/website/docs/r/cur_report_definition.html.markdown
@@ -35,13 +35,13 @@ The following arguments are supported:
 
 * `report_name` - (Required) Unique name for the report. Must start with a number/letter and is case sensitive. Limited to 256 characters.
 * `time_unit` - (Required) The frequency on which report data are measured and displayed.  Valid values are: HOURLY, DAILY.
-* `format` - (Required) Format for report. Valid values are: textORcsv.
-* `compression` - (Required) Compression format for report. Valid values are: GZIP, ZIP.
+* `format` - (Required) Format for report. Valid values are: Parquet, textORcsv.
+* `compression` - (Required) Compression format for report. Valid values are: GZIP, Parquet, ZIP.
 * `additional_schema_elements` - (Required) A list of schema elements. Valid values are: RESOURCES.
 * `s3_bucket` - (Required) Name of the existing S3 bucket to hold generated reports.
 * `s3_prefix` - (Optional) Report path prefix. Limited to 256 characters.
 * `s3_region` - (Required) Region of the existing S3 bucket to hold generated reports.
-* `additional_artifacts` - (Required)  A list of additional artifacts. Valid values are: REDSHIFT, QUICKSIGHT.
+* `additional_artifacts` - (Required)  A list of additional artifacts. Valid values are: ATHENA, REDSHIFT, QUICKSIGHT.
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #8765

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_cur_report_definition: Add `Parquet` as compression and report format
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAwsCurReportDefinition_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAwsCurReportDefinition_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAwsCurReportDefinition_basic
=== PAUSE TestAccAwsCurReportDefinition_basic
=== CONT  TestAccAwsCurReportDefinition_basic
--- FAIL: TestAccAwsCurReportDefinition_basic (25.33s)
    testing.go:568: Step 0 error: errors during apply:
        
        Error: Error creating AWS Cost And Usage Report Definition: ValidationException: Failed to verify customer bucket permission. accountId= 518602304359, bucket name: tf-test-bucket-4686922535518484349, bucket region: us-east-1
        	status code: 400, request id: 976347b0-2857-4601-81ff-fb3925831e17
        
          on /tmp/tf-test414826382/main.tf line 59:
          (source code not available)
        
        
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	25.358s
GNUmakefile:20: recipe for target 'testacc' failed
make: *** [testacc] Error 1
...
```
