### PR TITLE
Final retries for storage gateway functions plus changing test config syntax to fix some long-standing test failures

### DIFF
--- a/aws/resource_aws_storagegateway_cached_iscsi_volume.go
+++ b/aws/resource_aws_storagegateway_cached_iscsi_volume.go
@@ -195,6 +195,9 @@ func resourceAwsStorageGatewayCachedIscsiVolumeDelete(d *schema.ResourceData, me
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.DeleteVolume(input)
+	}
 	if err != nil {
 		return fmt.Errorf("error deleting Storage Gateway cached iSCSI volume %q: %s", d.Id(), err)
 	}

--- a/aws/resource_aws_storagegateway_gateway_test.go
+++ b/aws/resource_aws_storagegateway_gateway_test.go
@@ -655,7 +655,7 @@ resource "aws_directory_service_directory" "test" {
   size     = "Small"
 
   vpc_settings {
-    subnet_ids = ["${aws_subnet.test.*.id}"]
+    subnet_ids = aws_subnet.test[*].id
     vpc_id     = "${aws_vpc.test.id}"
   }
 
@@ -666,7 +666,7 @@ resource "aws_directory_service_directory" "test" {
 
 resource "aws_vpc_dhcp_options" "test" {
   domain_name         = "${aws_directory_service_directory.test.name}"
-  domain_name_servers = ["${aws_directory_service_directory.test.dns_ip_addresses}"]
+  domain_name_servers = aws_directory_service_directory.test.dns_ip_addresses
 
   tags = {
     Name = %q


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES
* resource/aws_storagegateway_cached_iscsi_volume: Retry after timeout deleting volume
* resource/aws_storagegateway_gateway: Retry after timeouts creating gateway
```

Output from acceptance testing:

```
NOTE: Failures are long-standing, not new


$ make testacc TESTARGS="-run=TestAccAWSStorageGatewayCachedIscsiVolume"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSStorageGatewayCachedIscsiVolume -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSStorageGatewayCachedIscsiVolume_Basic
=== PAUSE TestAccAWSStorageGatewayCachedIscsiVolume_Basic
=== RUN   TestAccAWSStorageGatewayCachedIscsiVolume_SnapshotId
=== PAUSE TestAccAWSStorageGatewayCachedIscsiVolume_SnapshotId
=== RUN   TestAccAWSStorageGatewayCachedIscsiVolume_SourceVolumeArn
--- SKIP: TestAccAWSStorageGatewayCachedIscsiVolume_SourceVolumeArn (0.00s)
    resource_aws_storagegateway_cached_iscsi_volume_test.go:146: This test can cause Storage Gateway 2.0.10.0 to enter an irrecoverable state during volume deletion.
=== CONT  TestAccAWSStorageGatewayCachedIscsiVolume_Basic
=== CONT  TestAccAWSStorageGatewayCachedIscsiVolume_SnapshotId
--- FAIL: TestAccAWSStorageGatewayCachedIscsiVolume_SnapshotId (252.29s)
    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Check failed: InvalidGatewayRequestException: The specified volume was not found.
                status code: 400, request id: f4c99f09-b207-11e9-8847-dbf549e868f9
        
        State: <no state>
--- FAIL: TestAccAWSStorageGatewayCachedIscsiVolume_Basic (274.25s)
    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Check failed: InvalidGatewayRequestException: The specified volume was not found.
                status code: 400, request id: 01df13a8-b208-11e9-b332-690fcbe662d9
        
        State: <no state>
FAIL
FAIL    github.com/terraform-providers/terraform-provider-aws/aws       275.165s
make: *** [testacc] Error 1


make testacc TESTARGS="-run=TestAccAWSStorageGatewayGateway"==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSStorageGatewayGateway -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSStorageGatewayGateway_GatewayType_Cached
=== PAUSE TestAccAWSStorageGatewayGateway_GatewayType_Cached
=== RUN   TestAccAWSStorageGatewayGateway_GatewayType_FileS3
=== PAUSE TestAccAWSStorageGatewayGateway_GatewayType_FileS3
=== RUN   TestAccAWSStorageGatewayGateway_GatewayType_Stored
=== PAUSE TestAccAWSStorageGatewayGateway_GatewayType_Stored
=== RUN   TestAccAWSStorageGatewayGateway_GatewayType_Vtl
=== PAUSE TestAccAWSStorageGatewayGateway_GatewayType_Vtl
=== RUN   TestAccAWSStorageGatewayGateway_GatewayName
=== PAUSE TestAccAWSStorageGatewayGateway_GatewayName
=== RUN   TestAccAWSStorageGatewayGateway_GatewayTimezone
=== PAUSE TestAccAWSStorageGatewayGateway_GatewayTimezone
=== RUN   TestAccAWSStorageGatewayGateway_SmbActiveDirectorySettings
=== PAUSE TestAccAWSStorageGatewayGateway_SmbActiveDirectorySettings
=== RUN   TestAccAWSStorageGatewayGateway_SmbGuestPassword
=== PAUSE TestAccAWSStorageGatewayGateway_SmbGuestPassword
=== CONT  TestAccAWSStorageGatewayGateway_GatewayType_Cached
=== CONT  TestAccAWSStorageGatewayGateway_GatewayName
=== CONT  TestAccAWSStorageGatewayGateway_GatewayType_FileS3
=== CONT  TestAccAWSStorageGatewayGateway_GatewayType_Vtl
=== CONT  TestAccAWSStorageGatewayGateway_GatewayType_Stored
=== CONT  TestAccAWSStorageGatewayGateway_SmbActiveDirectorySettings
=== CONT  TestAccAWSStorageGatewayGateway_SmbGuestPassword
=== CONT  TestAccAWSStorageGatewayGateway_GatewayTimezone
--- PASS: TestAccAWSStorageGatewayGateway_SmbGuestPassword (352.60s)
--- PASS: TestAccAWSStorageGatewayGateway_GatewayType_Stored (249.81s)
--- PASS: TestAccAWSStorageGatewayGateway_GatewayType_Vtl (250.56s)
--- PASS: TestAccAWSStorageGatewayGateway_GatewayType_Cached (250.94s)
--- PASS: TestAccAWSStorageGatewayGateway_GatewayType_FileS3 (286.95s)
--- PASS: TestAccAWSStorageGatewayGateway_GatewayTimezone (335.65s)
--- PASS: TestAccAWSStorageGatewayGateway_GatewayName (381.81s)
--- PASS: TestAccAWSStorageGatewayGateway_SmbActiveDirectorySettings (804.16s)
```