### PR TITLE
Missing opening parenthesis in default_route_table documentation

### DIFF
--- a/website/docs/r/default_route_table.html.markdown
+++ b/website/docs/r/default_route_table.html.markdown
@@ -71,7 +71,7 @@ The following arguments are supported:
 One of the following destination arguments must be supplied:
 
 * `cidr_block` - (Required) The CIDR block of the route.
-* `ipv6_cidr_block` - Optional) The Ipv6 CIDR block of the route
+* `ipv6_cidr_block` - (Optional) The Ipv6 CIDR block of the route
 
 One of the following target arguments must be supplied:
 


### PR DESCRIPTION
Simple typo fix to the `default_route_table` resource documentation.