### PR TITLE
Don't error on volume deletion when the volume wasn't found

### DIFF
--- a/aws/resource_aws_storagegateway_cached_iscsi_volume.go
+++ b/aws/resource_aws_storagegateway_cached_iscsi_volume.go
@@ -198,6 +198,9 @@ func resourceAwsStorageGatewayCachedIscsiVolumeDelete(d *schema.ResourceData, me
 	if isResourceTimeoutError(err) {
 		_, err = conn.DeleteVolume(input)
 	}
+	if isAWSErr(err, storagegateway.ErrCodeInvalidGatewayRequestException, "The specified volume was not found") {
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("error deleting Storage Gateway cached iSCSI volume %q: %s", d.Id(), err)
 	}

--- a/aws/resource_aws_storagegateway_cached_iscsi_volume_test.go
+++ b/aws/resource_aws_storagegateway_cached_iscsi_volume_test.go
@@ -230,6 +230,9 @@ func testAccCheckAWSStorageGatewayCachedIscsiVolumeDestroy(s *terraform.State) e
 			if isAWSErr(err, storagegateway.ErrorCodeVolumeNotFound, "") {
 				return nil
 			}
+			if isAWSErr(err, storagegateway.ErrCodeInvalidGatewayRequestException, "The specified volume was not found") {
+				return nil
+			}
 			return err
 		}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #9536

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_storagegateway_cached_iscsi_volume - Fix errors deleting volumes when volumes don't exist
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSStorageGatewayCachedIscsiVolume"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSStorageGatewayCachedIscsiVolume -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSStorageGatewayCachedIscsiVolume_Basic
=== PAUSE TestAccAWSStorageGatewayCachedIscsiVolume_Basic
=== RUN   TestAccAWSStorageGatewayCachedIscsiVolume_SnapshotId
=== PAUSE TestAccAWSStorageGatewayCachedIscsiVolume_SnapshotId
=== RUN   TestAccAWSStorageGatewayCachedIscsiVolume_SourceVolumeArn
--- SKIP: TestAccAWSStorageGatewayCachedIscsiVolume_SourceVolumeArn (0.00s)
    resource_aws_storagegateway_cached_iscsi_volume_test.go:146: This test can cause Storage Gateway 2.0.10.0 to enter an irrecoverable state during volume deletion.
=== CONT  TestAccAWSStorageGatewayCachedIscsiVolume_Basic
=== CONT  TestAccAWSStorageGatewayCachedIscsiVolume_SnapshotId
--- PASS: TestAccAWSStorageGatewayCachedIscsiVolume_SnapshotId (315.79s)
--- PASS: TestAccAWSStorageGatewayCachedIscsiVolume_Basic (316.56s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       317.445s
...
```