### PR TITLE
provider: Support new me-south-1 region in various data sources

### DIFF
--- a/aws/data_source_aws_cloudtrail_service_account.go
+++ b/aws/data_source_aws_cloudtrail_service_account.go
@@ -25,6 +25,7 @@ var cloudTrailServiceAccountPerRegionMap = map[string]string{
 	"eu-west-1":      "859597730677",
 	"eu-west-2":      "282025262664",
 	"eu-west-3":      "262312530599",
+	"me-south-1":     "034638983726",
 	"sa-east-1":      "814480443879",
 	"us-east-1":      "086441151436",
 	"us-east-2":      "475085895292",

--- a/aws/data_source_aws_elastic_beanstalk_hosted_zone.go
+++ b/aws/data_source_aws_elastic_beanstalk_hosted_zone.go
@@ -19,6 +19,7 @@ var elasticBeanstalkHostedZoneIds = map[string]string{
 	"eu-west-1":      "Z2NYPWQ7DFZAZH",
 	"eu-west-2":      "Z1GKAAAUGATPF1",
 	"eu-west-3":      "Z5WN6GAYWG5OB",
+	"me-south-1":     "Z2BBTEKR2I36N2",
 	"sa-east-1":      "Z10X7K2B4QSOFV",
 	"us-east-1":      "Z117KPS5GTRQ2G",
 	"us-east-2":      "Z14LCN19Q5QHIC",

--- a/aws/data_source_aws_elb_hosted_zone_id.go
+++ b/aws/data_source_aws_elb_hosted_zone_id.go
@@ -22,6 +22,7 @@ var elbHostedZoneIdPerRegionMap = map[string]string{
 	"eu-west-1":      "Z32O12XQLNTSW2",
 	"eu-west-2":      "ZHURV8PSTC4K8",
 	"eu-west-3":      "Z3Q77PNBQS71R4",
+	"me-south-1":     "ZS929ML54UICD",
 	"sa-east-1":      "Z2P70J7HTTTPLU",
 	"us-east-1":      "Z35SXDOTRQ7X7K",
 	"us-east-2":      "Z3AADJGX6KTTL2",

--- a/aws/data_source_aws_elb_service_account.go
+++ b/aws/data_source_aws_elb_service_account.go
@@ -24,6 +24,7 @@ var elbAccountIdPerRegionMap = map[string]string{
 	"eu-west-1":      "156460612806",
 	"eu-west-2":      "652711504416",
 	"eu-west-3":      "009996457667",
+	"me-south-1":     "076674570225",
 	"sa-east-1":      "507241528517",
 	"us-east-1":      "127311923021",
 	"us-east-2":      "033677994240",

--- a/aws/hosted_zones.go
+++ b/aws/hosted_zones.go
@@ -19,6 +19,7 @@ var hostedZoneIDsMap = map[string]string{
 	"eu-west-1":      "Z1BKCTXD74EZPE",
 	"eu-west-2":      "Z3GKZC51ZF0DB4",
 	"eu-west-3":      "Z3R1K369G5AVDG",
+	"me-south-1":     "Z1MPMWCPA7YB62",
 	"sa-east-1":      "Z7KQH4QJS55SO",
 	"us-east-1":      "Z3AQBSTGFYJSTF",
 	"us-east-2":      "Z2O1EMRO9K5GLX",


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#new-region

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* data-source/aws_cloudtrail_service_account: Support `me-south-1` region
* data-source/aws_elastic_beanstalk_hosted_zone: Support `me-south-1` region
* data-source/aws_elb_hosted_zone_id: Support `me-south-1` region
* data-source/aws_elb_service_account: Support `me-south-1` region
* data-source/aws_s3_bucket: Support `me-south-1` region for `hosted_zone_id` attribute
* resource/aws_s3_bucket: Support `me-south-1` region for `hosted_zone_id` attribute
```

Output from acceptance testing:

```
--- PASS: TestAccAWSCloudTrailServiceAccount_basic (11.69s)
--- PASS: TestAccAWSCloudTrailServiceAccount_Region (16.74s)
--- PASS: TestAccAWSElbHostedZoneId_basic (22.28s)
--- PASS: TestAccAWSElbServiceAccount_basic (22.55s)
--- PASS: TestAccAWSDataSourceElasticBeanstalkHostedZone (28.96s)
```
