### PR TITLE
Final retries for various lambda functions

### DIFF
--- a/aws/resource_aws_lambda_event_source_mapping.go
+++ b/aws/resource_aws_lambda_event_source_mapping.go
@@ -160,8 +160,10 @@ func resourceAwsLambdaEventSourceMappingCreate(d *schema.ResourceData, meta inte
 	//
 	// The role may exist, but the permissions may not have propagated, so we
 	// retry
-	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
-		eventSourceMappingConfiguration, err := conn.CreateEventSourceMapping(params)
+	var eventSourceMappingConfiguration *lambda.EventSourceMappingConfiguration
+	var err error
+	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+		eventSourceMappingConfiguration, err = conn.CreateEventSourceMapping(params)
 		if err != nil {
 			if awserr, ok := err.(awserr.Error); ok {
 				if awserr.Code() == "InvalidParameterValueException" {
@@ -170,16 +172,18 @@ func resourceAwsLambdaEventSourceMappingCreate(d *schema.ResourceData, meta inte
 			}
 			return resource.NonRetryableError(err)
 		}
-		// No error
-		d.Set("uuid", eventSourceMappingConfiguration.UUID)
-		d.SetId(*eventSourceMappingConfiguration.UUID)
 		return nil
 	})
-
+	if isResourceTimeoutError(err) {
+		eventSourceMappingConfiguration, err = conn.CreateEventSourceMapping(params)
+	}
 	if err != nil {
 		return fmt.Errorf("Error creating Lambda event source mapping: %s", err)
 	}
 
+	// No error
+	d.Set("uuid", eventSourceMappingConfiguration.UUID)
+	d.SetId(*eventSourceMappingConfiguration.UUID)
 	return resourceAwsLambdaEventSourceMappingRead(d, meta)
 }
 
@@ -196,7 +200,7 @@ func resourceAwsLambdaEventSourceMappingRead(d *schema.ResourceData, meta interf
 
 	eventSourceMappingConfiguration, err := conn.GetEventSourceMapping(params)
 	if err != nil {
-		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "ResourceNotFoundException" {
+		if isAWSErr(err, "ResourceNotFoundException", "") {
 			log.Printf("[DEBUG] Lambda event source mapping (%s) not found", d.Id())
 			d.SetId("")
 
@@ -250,7 +254,9 @@ func resourceAwsLambdaEventSourceMappingDelete(d *schema.ResourceData, meta inte
 		}
 		return nil
 	})
-
+	if isResourceTimeoutError(err) {
+		_, err = conn.DeleteEventSourceMapping(params)
+	}
 	if err != nil {
 		return fmt.Errorf("Error deleting Lambda event source mapping: %s", err)
 	}
@@ -284,7 +290,9 @@ func resourceAwsLambdaEventSourceMappingUpdate(d *schema.ResourceData, meta inte
 		}
 		return nil
 	})
-
+	if isResourceTimeoutError(err) {
+		_, err = conn.UpdateEventSourceMapping(params)
+	}
 	if err != nil {
 		return fmt.Errorf("Error updating Lambda event source mapping: %s", err)
 	}

--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -434,6 +434,9 @@ func resourceAwsLambdaFunctionCreate(d *schema.ResourceData, meta interface{}) e
 			}
 			return nil
 		})
+		if isResourceTimeoutError(err) {
+			_, err = conn.CreateFunction(params)
+		}
 		if err != nil {
 			return fmt.Errorf("Error creating Lambda function: %s", err)
 		}
@@ -460,6 +463,9 @@ func resourceAwsLambdaFunctionCreate(d *schema.ResourceData, meta interface{}) e
 			}
 			return nil
 		})
+		if isResourceTimeoutError(err) {
+			_, err = conn.PutFunctionConcurrency(concurrencyParams)
+		}
 		if err != nil {
 			return fmt.Errorf("Error setting concurrency for Lambda %s: %s", functionName, err)
 		}
@@ -802,6 +808,9 @@ func resourceAwsLambdaFunctionUpdate(d *schema.ResourceData, meta interface{}) e
 				}
 				return nil
 			})
+			if isResourceTimeoutError(err) {
+				_, err = conn.UpdateFunctionConfiguration(configReq)
+			}
 			if err != nil {
 				return fmt.Errorf("Error modifying Lambda Function Configuration %s: %s", d.Id(), err)
 			}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_lambda_event_source_mapping: Final retries after timeout when creating, updating, and deleting event source mappings
* resource/aws_lambda_function: Final retry when creating lambda function
* resource/aws_lambda_permission: Final retries when creating, reading, and deleting lambda permissions


```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSLambdaPermission"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSLambdaPermission -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSLambdaPermission_basic
=== PAUSE TestAccAWSLambdaPermission_basic
=== RUN   TestAccAWSLambdaPermission_StatementId_Duplicate
=== PAUSE TestAccAWSLambdaPermission_StatementId_Duplicate
=== RUN   TestAccAWSLambdaPermission_withRawFunctionName
=== PAUSE TestAccAWSLambdaPermission_withRawFunctionName
=== RUN   TestAccAWSLambdaPermission_withStatementIdPrefix
=== PAUSE TestAccAWSLambdaPermission_withStatementIdPrefix
=== RUN   TestAccAWSLambdaPermission_withQualifier
=== PAUSE TestAccAWSLambdaPermission_withQualifier
=== RUN   TestAccAWSLambdaPermission_multiplePerms
=== PAUSE TestAccAWSLambdaPermission_multiplePerms
=== RUN   TestAccAWSLambdaPermission_withS3
=== PAUSE TestAccAWSLambdaPermission_withS3
=== RUN   TestAccAWSLambdaPermission_withSNS
=== PAUSE TestAccAWSLambdaPermission_withSNS
=== RUN   TestAccAWSLambdaPermission_withIAMRole
=== PAUSE TestAccAWSLambdaPermission_withIAMRole
=== CONT  TestAccAWSLambdaPermission_basic
=== CONT  TestAccAWSLambdaPermission_multiplePerms
=== CONT  TestAccAWSLambdaPermission_withQualifier
=== CONT  TestAccAWSLambdaPermission_StatementId_Duplicate
=== CONT  TestAccAWSLambdaPermission_withStatementIdPrefix
=== CONT  TestAccAWSLambdaPermission_withRawFunctionName
=== CONT  TestAccAWSLambdaPermission_withSNS
=== CONT  TestAccAWSLambdaPermission_withIAMRole
=== CONT  TestAccAWSLambdaPermission_withS3
--- PASS: TestAccAWSLambdaPermission_withIAMRole (42.35s)
--- PASS: TestAccAWSLambdaPermission_basic (47.74s)
--- PASS: TestAccAWSLambdaPermission_withRawFunctionName (49.44s)
--- PASS: TestAccAWSLambdaPermission_withQualifier (55.80s)
--- PASS: TestAccAWSLambdaPermission_withSNS (59.94s)
--- PASS: TestAccAWSLambdaPermission_withStatementIdPrefix (62.38s)
--- PASS: TestAccAWSLambdaPermission_withS3 (77.22s)
--- PASS: TestAccAWSLambdaPermission_multiplePerms (78.99s)
--- PASS: TestAccAWSLambdaPermission_StatementId_Duplicate (106.08s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       110.612s

make testacc TESTARGS="-run=TestAccAWSLambdaEventSourceMapping"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSLambdaEventSourceMapping -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSLambdaEventSourceMapping_kinesis_basic
=== PAUSE TestAccAWSLambdaEventSourceMapping_kinesis_basic
=== RUN   TestAccAWSLambdaEventSourceMapping_kinesis_removeBatchSize
=== PAUSE TestAccAWSLambdaEventSourceMapping_kinesis_removeBatchSize
=== RUN   TestAccAWSLambdaEventSourceMapping_sqs_basic
=== PAUSE TestAccAWSLambdaEventSourceMapping_sqs_basic
=== RUN   TestAccAWSLambdaEventSourceMapping_sqs_withFunctionName
=== PAUSE TestAccAWSLambdaEventSourceMapping_sqs_withFunctionName
=== RUN   TestAccAWSLambdaEventSourceMapping_kinesis_import
=== PAUSE TestAccAWSLambdaEventSourceMapping_kinesis_import
=== RUN   TestAccAWSLambdaEventSourceMapping_kinesis_disappears
=== PAUSE TestAccAWSLambdaEventSourceMapping_kinesis_disappears
=== RUN   TestAccAWSLambdaEventSourceMapping_sqsDisappears
=== PAUSE TestAccAWSLambdaEventSourceMapping_sqsDisappears
=== RUN   TestAccAWSLambdaEventSourceMapping_changesInEnabledAreDetected
=== PAUSE TestAccAWSLambdaEventSourceMapping_changesInEnabledAreDetected
=== RUN   TestAccAWSLambdaEventSourceMapping_StartingPositionTimestamp
=== PAUSE TestAccAWSLambdaEventSourceMapping_StartingPositionTimestamp
=== CONT  TestAccAWSLambdaEventSourceMapping_kinesis_basic
=== CONT  TestAccAWSLambdaEventSourceMapping_kinesis_import
=== CONT  TestAccAWSLambdaEventSourceMapping_kinesis_disappears
=== CONT  TestAccAWSLambdaEventSourceMapping_sqs_basic
=== CONT  TestAccAWSLambdaEventSourceMapping_sqs_withFunctionName
=== CONT  TestAccAWSLambdaEventSourceMapping_kinesis_removeBatchSize
=== CONT  TestAccAWSLambdaEventSourceMapping_sqsDisappears
=== CONT  TestAccAWSLambdaEventSourceMapping_changesInEnabledAreDetected
=== CONT  TestAccAWSLambdaEventSourceMapping_StartingPositionTimestamp
--- PASS: TestAccAWSLambdaEventSourceMapping_sqs_withFunctionName (73.63s)
--- PASS: TestAccAWSLambdaEventSourceMapping_kinesis_disappears (100.12s)
--- PASS: TestAccAWSLambdaEventSourceMapping_StartingPositionTimestamp (109.34s)
--- PASS: TestAccAWSLambdaEventSourceMapping_kinesis_import (109.40s)
--- PASS: TestAccAWSLambdaEventSourceMapping_sqs_basic (122.75s)
--- PASS: TestAccAWSLambdaEventSourceMapping_kinesis_removeBatchSize (126.63s)
--- PASS: TestAccAWSLambdaEventSourceMapping_kinesis_basic (128.39s)
--- PASS: TestAccAWSLambdaEventSourceMapping_sqsDisappears (160.19s)
--- PASS: TestAccAWSLambdaEventSourceMapping_changesInEnabledAreDetected (168.35s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       169.202s


make testacc TESTARGS="-run=TestAccAWSLambdaFunction"          
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSLambdaFunction -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSLambdaFunction_importLocalFile
=== PAUSE TestAccAWSLambdaFunction_importLocalFile
=== RUN   TestAccAWSLambdaFunction_importLocalFile_VPC
=== PAUSE TestAccAWSLambdaFunction_importLocalFile_VPC
=== RUN   TestAccAWSLambdaFunction_importS3
=== PAUSE TestAccAWSLambdaFunction_importS3
=== RUN   TestAccAWSLambdaFunction_basic
=== PAUSE TestAccAWSLambdaFunction_basic
=== RUN   TestAccAWSLambdaFunction_concurrency
=== PAUSE TestAccAWSLambdaFunction_concurrency
=== RUN   TestAccAWSLambdaFunction_concurrencyCycle
=== PAUSE TestAccAWSLambdaFunction_concurrencyCycle
=== RUN   TestAccAWSLambdaFunction_updateRuntime
=== PAUSE TestAccAWSLambdaFunction_updateRuntime
=== RUN   TestAccAWSLambdaFunction_expectFilenameAndS3Attributes
=== PAUSE TestAccAWSLambdaFunction_expectFilenameAndS3Attributes
=== RUN   TestAccAWSLambdaFunction_envVariables
=== PAUSE TestAccAWSLambdaFunction_envVariables
=== RUN   TestAccAWSLambdaFunction_encryptedEnvVariables
=== PAUSE TestAccAWSLambdaFunction_encryptedEnvVariables
=== RUN   TestAccAWSLambdaFunction_versioned
=== PAUSE TestAccAWSLambdaFunction_versioned
=== RUN   TestAccAWSLambdaFunction_versionedUpdate
=== PAUSE TestAccAWSLambdaFunction_versionedUpdate
=== RUN   TestAccAWSLambdaFunction_DeadLetterConfig
=== PAUSE TestAccAWSLambdaFunction_DeadLetterConfig
=== RUN   TestAccAWSLambdaFunction_DeadLetterConfigUpdated
=== PAUSE TestAccAWSLambdaFunction_DeadLetterConfigUpdated
=== RUN   TestAccAWSLambdaFunction_nilDeadLetterConfig
=== PAUSE TestAccAWSLambdaFunction_nilDeadLetterConfig
=== RUN   TestAccAWSLambdaFunction_tracingConfig
=== PAUSE TestAccAWSLambdaFunction_tracingConfig
=== RUN   TestAccAWSLambdaFunction_Layers
=== PAUSE TestAccAWSLambdaFunction_Layers
=== RUN   TestAccAWSLambdaFunction_LayersUpdate
=== PAUSE TestAccAWSLambdaFunction_LayersUpdate
=== RUN   TestAccAWSLambdaFunction_VPC
=== PAUSE TestAccAWSLambdaFunction_VPC
=== RUN   TestAccAWSLambdaFunction_VPCRemoval
=== PAUSE TestAccAWSLambdaFunction_VPCRemoval
=== RUN   TestAccAWSLambdaFunction_VPCUpdate
=== PAUSE TestAccAWSLambdaFunction_VPCUpdate
=== RUN   TestAccAWSLambdaFunction_VPC_withInvocation
=== PAUSE TestAccAWSLambdaFunction_VPC_withInvocation
=== RUN   TestAccAWSLambdaFunction_EmptyVpcConfig
=== PAUSE TestAccAWSLambdaFunction_EmptyVpcConfig
=== RUN   TestAccAWSLambdaFunction_s3
=== PAUSE TestAccAWSLambdaFunction_s3
=== RUN   TestAccAWSLambdaFunction_localUpdate
=== PAUSE TestAccAWSLambdaFunction_localUpdate
=== RUN   TestAccAWSLambdaFunction_localUpdate_nameOnly
=== PAUSE TestAccAWSLambdaFunction_localUpdate_nameOnly
=== RUN   TestAccAWSLambdaFunction_s3Update_basic
=== PAUSE TestAccAWSLambdaFunction_s3Update_basic
=== RUN   TestAccAWSLambdaFunction_s3Update_unversioned
=== PAUSE TestAccAWSLambdaFunction_s3Update_unversioned
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_noRuntime
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_noRuntime
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_NodeJs810
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_NodeJs810
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_NodeJs10x
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_NodeJs10x
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_python27
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_python27
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_java8
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_java8
=== RUN   TestAccAWSLambdaFunction_tags
=== PAUSE TestAccAWSLambdaFunction_tags
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_provided
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_provided
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_python36
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_python36
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_python37
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_python37
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_ruby25
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_ruby25
=== CONT  TestAccAWSLambdaFunction_importLocalFile
=== CONT  TestAccAWSLambdaFunction_VPCRemoval
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_python27
=== CONT  TestAccAWSLambdaFunction_VPCUpdate
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_ruby25
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_python37
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_python36
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_provided
=== CONT  TestAccAWSLambdaFunction_tags
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_java8
=== CONT  TestAccAWSLambdaFunction_s3Update_basic
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_NodeJs10x
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_NodeJs810
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_noRuntime
=== CONT  TestAccAWSLambdaFunction_s3Update_unversioned
=== CONT  TestAccAWSLambdaFunction_versioned
=== CONT  TestAccAWSLambdaFunction_VPC
=== CONT  TestAccAWSLambdaFunction_LayersUpdate
=== CONT  TestAccAWSLambdaFunction_Layers
=== CONT  TestAccAWSLambdaFunction_tracingConfig
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_noRuntime (3.53s)
=== CONT  TestAccAWSLambdaFunction_nilDeadLetterConfig
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_ruby25 (61.68s)
=== CONT  TestAccAWSLambdaFunction_DeadLetterConfigUpdated
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python37 (62.17s)
=== CONT  TestAccAWSLambdaFunction_DeadLetterConfig
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python27 (64.24s)
=== CONT  TestAccAWSLambdaFunction_versionedUpdate
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_java8 (67.60s)
=== CONT  TestAccAWSLambdaFunction_s3
--- PASS: TestAccAWSLambdaFunction_nilDeadLetterConfig (64.77s)
=== CONT  TestAccAWSLambdaFunction_localUpdate_nameOnly
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_provided (69.57s)
=== CONT  TestAccAWSLambdaFunction_localUpdate
--- PASS: TestAccAWSLambdaFunction_versioned (72.22s)
=== CONT  TestAccAWSLambdaFunction_concurrencyCycle
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_NodeJs810 (74.10s)
=== CONT  TestAccAWSLambdaFunction_encryptedEnvVariables
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python36 (76.34s)
=== CONT  TestAccAWSLambdaFunction_envVariables
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_NodeJs10x (81.96s)
=== CONT  TestAccAWSLambdaFunction_expectFilenameAndS3Attributes
--- PASS: TestAccAWSLambdaFunction_importLocalFile (85.79s)
=== CONT  TestAccAWSLambdaFunction_updateRuntime
--- PASS: TestAccAWSLambdaFunction_Layers (90.39s)
=== CONT  TestAccAWSLambdaFunction_EmptyVpcConfig
--- PASS: TestAccAWSLambdaFunction_VPC (99.18s)
=== CONT  TestAccAWSLambdaFunction_basic
--- PASS: TestAccAWSLambdaFunction_tracingConfig (111.65s)
=== CONT  TestAccAWSLambdaFunction_concurrency
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (113.68s)
=== CONT  TestAccAWSLambdaFunction_importS3
--- PASS: TestAccAWSLambdaFunction_s3Update_basic (113.80s)
=== CONT  TestAccAWSLambdaFunction_importLocalFile_VPC
--- PASS: TestAccAWSLambdaFunction_expectFilenameAndS3Attributes (42.81s)
=== CONT  TestAccAWSLambdaFunction_VPC_withInvocation
--- PASS: TestAccAWSLambdaFunction_tags (125.64s)
--- PASS: TestAccAWSLambdaFunction_LayersUpdate (127.78s)
--- PASS: TestAccAWSLambdaFunction_VPCRemoval (131.25s)
--- PASS: TestAccAWSLambdaFunction_s3 (64.99s)
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (75.18s)
--- PASS: TestAccAWSLambdaFunction_VPCUpdate (144.55s)
--- PASS: TestAccAWSLambdaFunction_localUpdate (75.64s)
--- PASS: TestAccAWSLambdaFunction_EmptyVpcConfig (59.19s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfigUpdated (93.46s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfig (97.67s)
--- PASS: TestAccAWSLambdaFunction_basic (60.68s)
--- PASS: TestAccAWSLambdaFunction_versionedUpdate (98.74s)
--- PASS: TestAccAWSLambdaFunction_updateRuntime (92.47s)
--- PASS: TestAccAWSLambdaFunction_importLocalFile_VPC (65.92s)
--- PASS: TestAccAWSLambdaFunction_importS3 (68.53s)
--- PASS: TestAccAWSLambdaFunction_encryptedEnvVariables (119.67s)
--- PASS: TestAccAWSLambdaFunction_concurrencyCycle (130.30s)
--- PASS: TestAccAWSLambdaFunction_concurrency (92.13s)
--- PASS: TestAccAWSLambdaFunction_VPC_withInvocation (91.62s)
--- PASS: TestAccAWSLambdaFunction_envVariables (159.61s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       237.122s
```