### PR TITLE
Support for ECR repository immutable image tags

### DIFF
--- a/aws/resource_aws_ecr_repository.go
+++ b/aws/resource_aws_ecr_repository.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsEcrRepository() *schema.Resource {
@@ -32,6 +33,15 @@ func resourceAwsEcrRepository() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"image_tag_mutability": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  ecr.ImageTagMutabilityMutable,
+				ValidateFunc: validation.StringInSlice([]string{
+					ecr.ImageTagMutabilityMutable,
+					ecr.ImageTagMutabilityImmutable,
+				}, false),
+			},
 			"tags": tagsSchema(),
 			"arn": {
 				Type:     schema.TypeString,
@@ -53,8 +63,9 @@ func resourceAwsEcrRepositoryCreate(d *schema.ResourceData, meta interface{}) er
 	conn := meta.(*AWSClient).ecrconn
 
 	input := ecr.CreateRepositoryInput{
-		RepositoryName: aws.String(d.Get("name").(string)),
-		Tags:           tagsFromMapECR(d.Get("tags").(map[string]interface{})),
+		ImageTagMutability: aws.String(d.Get("image_tag_mutability").(string)),
+		RepositoryName:     aws.String(d.Get("name").(string)),
+		Tags:               tagsFromMapECR(d.Get("tags").(map[string]interface{})),
 	}
 
 	log.Printf("[DEBUG] Creating ECR repository: %#v", input)
@@ -124,6 +135,12 @@ func resourceAwsEcrRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 func resourceAwsEcrRepositoryUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ecrconn
 
+	if d.HasChange("image_tag_mutability") {
+		if err := resourceAwsEcrRepositoryUpdateImageTagMutability(conn, d); err != nil {
+			return err
+		}
+	}
+
 	if err := setTagsECR(conn, d); err != nil {
 		return fmt.Errorf("error setting ECR repository tags: %s", err)
 	}
@@ -174,6 +191,21 @@ func resourceAwsEcrRepositoryDelete(d *schema.ResourceData, meta interface{}) er
 	}
 
 	log.Printf("[DEBUG] repository %q deleted.", d.Get("name").(string))
+
+	return nil
+}
+
+func resourceAwsEcrRepositoryUpdateImageTagMutability(conn *ecr.ECR, d *schema.ResourceData) error {
+	input := &ecr.PutImageTagMutabilityInput{
+		ImageTagMutability: aws.String(d.Get("image_tag_mutability").(string)),
+		RepositoryName:     aws.String(d.Id()),
+		RegistryId:         aws.String(d.Get("registry_id").(string)),
+	}
+
+	_, err := conn.PutImageTagMutability(input)
+	if err != nil {
+		return fmt.Errorf("Error setting image tag mutability: %s", err.Error())
+	}
 
 	return nil
 }

--- a/aws/resource_aws_ecr_repository.go
+++ b/aws/resource_aws_ecr_repository.go
@@ -124,6 +124,7 @@ func resourceAwsEcrRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("name", repository.RepositoryName)
 	d.Set("registry_id", repository.RegistryId)
 	d.Set("repository_url", repository.RepositoryUri)
+	d.Set("image_tag_mutability", repository.ImageTagMutability)
 
 	if err := getTagsECR(conn, d); err != nil {
 		return fmt.Errorf("error getting ECR repository tags: %s", err)

--- a/aws/resource_aws_ecr_repository_test.go
+++ b/aws/resource_aws_ecr_repository_test.go
@@ -70,6 +70,27 @@ func TestAccAWSEcrRepository_tags(t *testing.T) {
 	})
 }
 
+func TestAccAWSEcrRepository_immutability(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ecr_repository.default"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcrRepositoryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEcrRepositoryConfig_immutability(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcrRepositoryExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "image_tag_mutability", "IMMUTABLE"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSEcrRepositoryDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).ecrconn
 
@@ -156,6 +177,15 @@ resource "aws_ecr_repository" "default" {
   tags = {
     Usage = "changed"
   }
+}
+`, rName)
+}
+
+func testAccAWSEcrRepositoryConfig_immutability(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ecr_repository" "default" {
+  name = %q
+  image_tag_mutability = "IMMUTABLE"
 }
 `, rName)
 }

--- a/aws/resource_aws_ecr_repository_test.go
+++ b/aws/resource_aws_ecr_repository_test.go
@@ -87,6 +87,11 @@ func TestAccAWSEcrRepository_immutability(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "image_tag_mutability", "IMMUTABLE"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/website/docs/r/ecr_repository.html.markdown
+++ b/website/docs/r/ecr_repository.html.markdown
@@ -23,6 +23,7 @@ resource "aws_ecr_repository" "foo" {
 The following arguments are supported:
 
 * `name` - (Required) Name of the repository.
+* `image_tag_mutability` - (Optional) The tag mutability setting for the repository. Must be one of: `MUTABLE` or `IMMUTABLE`
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference

--- a/website/docs/r/ecr_repository.html.markdown
+++ b/website/docs/r/ecr_repository.html.markdown
@@ -23,7 +23,7 @@ resource "aws_ecr_repository" "foo" {
 The following arguments are supported:
 
 * `name` - (Required) Name of the repository.
-* `image_tag_mutability` - (Optional) The tag mutability setting for the repository. Must be one of: `MUTABLE` or `IMMUTABLE`
+* `image_tag_mutability` - (Optional) The tag mutability setting for the repository. Must be one of: `MUTABLE` or `IMMUTABLE`. Defaults to `MUTABLE`.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #9517

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
esource/aws_ecr_repository: Support for image tag immutability
```

Output from acceptance testing:

```
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSEcrRepository_immutability'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAWSEcrRepository_immutability -timeout 120m
=== RUN   TestAccAWSEcrRepository_immutability
=== PAUSE TestAccAWSEcrRepository_immutability
=== CONT  TestAccAWSEcrRepository_immutability
--- PASS: TestAccAWSEcrRepository_immutability (33.04s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       33.091s
```
