### PR TITLE
resource/aws_ec2_client_vpn_endpoint: Move CreateClientVpnEndpoint retry logic from resource logic with hardcoded timeout into EC2 service client

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -554,6 +554,12 @@ func (c *Config) Client() (interface{}, error) {
 	})
 
 	client.ec2conn.Handlers.Retry.PushBack(func(r *request.Request) {
+		if r.Operation.Name == "CreateClientVpnEndpoint" {
+			if isAWSErr(r.Error, "OperationNotPermitted", "Endpoint cannot be created while another endpoint is being created") {
+				r.Retryable = aws.Bool(true)
+			}
+		}
+
 		if r.Operation.Name == "CreateVpnConnection" {
 			if isAWSErr(r.Error, "VpnConnectionLimitExceeded", "maximum number of mutating objects has been reached") {
 				r.Retryable = aws.Bool(true)

--- a/aws/resource_aws_ec2_client_vpn_endpoint.go
+++ b/aws/resource_aws_ec2_client_vpn_endpoint.go
@@ -3,11 +3,9 @@ package aws
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 )
@@ -173,19 +171,7 @@ func resourceAwsEc2ClientVpnEndpointCreate(d *schema.ResourceData, meta interfac
 		req.ConnectionLogOptions = connLogReq
 	}
 
-	log.Printf("[DEBUG] Creating Client VPN endpoint: %#v", req)
-	var resp *ec2.CreateClientVpnEndpointOutput
-	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-		var err error
-		resp, err = conn.CreateClientVpnEndpoint(req)
-		if isAWSErr(err, "OperationNotPermitted", "Endpoint cannot be created while another endpoint is being created") {
-			return resource.RetryableError(err)
-		}
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
-		return nil
-	})
+	resp, err := conn.CreateClientVpnEndpoint(req)
 
 	if err != nil {
 		return fmt.Errorf("Error creating Client VPN endpoint: %s", err)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #7871

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_ec2_client_vpn_endpoint: Remove hardcoded 1 minute timeout during resource creation
```

In the debug logs from running the concurrent acceptance testing, saw this with the updated logic:

```
2019/07/30 16:08:36 [DEBUG] [aws-sdk-go] DEBUG: Validate Response ec2/CreateClientVpnEndpoint failed, attempt 0/25, error OperationNotPermitted: Endpoint cannot be created while another endpoint is being created or the service linked role is being deleted
  status code: 400, request id: 791f5723-e6fd-4cf9-8754-00bd0e8c79e6
2019/07/30 16:08:36 [DEBUG] [aws-sdk-go] DEBUG: Retrying Request ec2/CreateClientVpnEndpoint, attempt 1
```

Output from acceptance testing:

```
--- PASS: TestAccAwsEc2ClientVpnEndpoint_basic (22.40s)
--- PASS: TestAccAwsEc2ClientVpnEndpoint_withDNSServers (31.58s)
--- PASS: TestAccAwsEc2ClientVpnEndpoint_withLogGroup (33.22s)
--- PASS: TestAccAwsEc2ClientVpnEndpoint_tags (38.07s)
--- PASS: TestAccAwsEc2ClientVpnEndpoint_msAD (1753.81s)
```
