### PR TITLE
resource/aws_codebuild_project: Switch artifacts from TypeSet  to TypeList and verify updates

### DIFF
--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -61,8 +61,8 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								if d.Get("artifacts.0.type") == codebuild.ArtifactsTypeS3 && old == codebuild.ArtifactNamespaceNone && new == "" {
-									return true
+								if d.Get("artifacts.0.type") == codebuild.ArtifactsTypeS3 {
+									return old == codebuild.ArtifactNamespaceNone && new == ""
 								}
 								return false
 							},
@@ -75,11 +75,11 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								if d.Get("artifacts.0.type") == codebuild.ArtifactsTypeCodepipeline && new == "" {
-									return true
-								}
-								if d.Get("artifacts.0.type") == codebuild.ArtifactsTypeS3 && old == codebuild.ArtifactPackagingNone && new == "" {
-									return true
+								switch d.Get("artifacts.0.type") {
+								case codebuild.ArtifactsTypeCodepipeline:
+									return new == ""
+								case codebuild.ArtifactsTypeS3:
+									return old == codebuild.ArtifactPackagingNone && new == ""
 								}
 								return false
 							},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #755
Closes #2050
Closes #6214
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/6427
Closes #7582

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_codebuild_project: Properly perform drift detection and updates for `artifacts` configuration block arguments
```

Output from acceptance testing:

```
--- PASS: TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled (58.62s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_NamespaceType (52.17s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_OverrideArtifactName (51.88s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Packaging (51.20s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Path (52.22s)
--- PASS: TestAccAWSCodeBuildProject_BadgeEnabled (33.85s)
--- PASS: TestAccAWSCodeBuildProject_basic (24.98s)
--- PASS: TestAccAWSCodeBuildProject_BuildTimeout (42.62s)
--- PASS: TestAccAWSCodeBuildProject_Cache (70.42s)
--- PASS: TestAccAWSCodeBuildProject_Description (42.32s)
--- PASS: TestAccAWSCodeBuildProject_EncryptionKey (52.39s)
--- PASS: TestAccAWSCodeBuildProject_Environment_Certificate (36.50s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable (55.37s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type (30.64s)
--- PASS: TestAccAWSCodeBuildProject_Environment_RegistryCredential (40.62s)
--- PASS: TestAccAWSCodeBuildProject_importBasic (34.69s)
--- PASS: TestAccAWSCodeBuildProject_LogsConfig_CloudWatchLogs (48.53s)
--- PASS: TestAccAWSCodeBuildProject_LogsConfig_S3Logs (72.76s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts (37.23s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_CodeCommit (29.35s)
--- PASS: TestAccAWSCodeBuildProject_Source_Auth (30.83s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitCloneDepth (40.18s)
--- PASS: TestAccAWSCodeBuildProject_Source_InsecureSSL (31.11s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket (42.65s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub (34.28s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise (43.13s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_Bitbucket (33.90s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodeCommit (34.04s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodePipeline (29.80s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise (29.93s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSource (33.38s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid (12.23s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_S3 (36.44s)
--- PASS: TestAccAWSCodeBuildProject_Tags (43.37s)
--- PASS: TestAccAWSCodeBuildProject_VpcConfig (62.05s)
--- PASS: TestAccAWSCodeBuildProject_WindowsContainer (23.75s)
```
