### PR TITLE
Add support resource tags for configservice

### DIFF
--- a/aws/resource_aws_config_aggregate_authorization_test.go
+++ b/aws/resource_aws_config_aggregate_authorization_test.go
@@ -59,6 +59,7 @@ func testSweepConfigAggregateAuthorizations(region string) error {
 
 func TestAccAWSConfigAggregateAuthorization_basic(t *testing.T) {
 	rString := acctest.RandStringFromCharSet(12, "0123456789")
+	resourceName := "aws_config_aggregate_authorization.example"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -68,13 +69,13 @@ func TestAccAWSConfigAggregateAuthorization_basic(t *testing.T) {
 			{
 				Config: testAccAWSConfigAggregateAuthorizationConfig_basic(rString),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_config_aggregate_authorization.example", "account_id", rString),
-					resource.TestCheckResourceAttr("aws_config_aggregate_authorization.example", "region", "eu-west-1"),
-					resource.TestMatchResourceAttr("aws_config_aggregate_authorization.example", "arn", regexp.MustCompile(`^arn:aws:config:[\w-]+:\d{12}:aggregation-authorization/\d{12}/[\w-]+$`)),
+					resource.TestCheckResourceAttr(resourceName, "account_id", rString),
+					resource.TestCheckResourceAttr(resourceName, "region", "eu-west-1"),
+					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(`^arn:aws:config:[\w-]+:\d{12}:aggregation-authorization/\d{12}/[\w-]+$`)),
 				),
 			},
 			{
-				ResourceName:      "aws_config_aggregate_authorization.example",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -114,7 +115,7 @@ func testAccCheckAWSConfigAggregateAuthorizationDestroy(s *terraform.State) erro
 func testAccAWSConfigAggregateAuthorizationConfig_basic(rString string) string {
 	return fmt.Sprintf(`
 resource "aws_config_aggregate_authorization" "example" {
-  account_id = "%s"
+  account_id = %[1]q
   region     = "eu-west-1"
 }
 `, rString)

--- a/aws/resource_aws_config_config_rule.go
+++ b/aws/resource_aws_config_config_rule.go
@@ -136,6 +136,7 @@ func resourceAwsConfigConfigRule() *schema.Resource {
 					},
 				},
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -162,6 +163,7 @@ func resourceAwsConfigConfigRulePut(d *schema.ResourceData, meta interface{}) er
 
 	input := configservice.PutConfigRuleInput{
 		ConfigRule: &ruleInput,
+		Tags:       tagsFromMapConfigService(d.Get("tags").(map[string]interface{})),
 	}
 	log.Printf("[DEBUG] Creating AWSConfig config rule: %s", input)
 	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
@@ -189,6 +191,17 @@ func resourceAwsConfigConfigRulePut(d *schema.ResourceData, meta interface{}) er
 	d.SetId(name)
 
 	log.Printf("[DEBUG] AWSConfig config rule %q created", name)
+
+	if !d.IsNewResource() {
+		if err := setTagsConfigService(conn, d, d.Get("arn").(string)); err != nil {
+			if isAWSErr(err, configservice.ErrCodeResourceNotFoundException, "") {
+				log.Printf("[WARN] Config Rule not found: %s, removing from state", d.Id())
+				d.SetId("")
+				return nil
+			}
+			return fmt.Errorf("Error updating tags for %s: %s", d.Id(), err)
+		}
+	}
 
 	return resourceAwsConfigConfigRuleRead(d, meta)
 }
@@ -235,6 +248,15 @@ func resourceAwsConfigConfigRuleRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	d.Set("source", flattenConfigRuleSource(rule.Source))
+
+	if err := saveTagsConfigService(conn, d, aws.StringValue(rule.ConfigRuleArn)); err != nil {
+		if isAWSErr(err, configservice.ErrCodeResourceNotFoundException, "") {
+			log.Printf("[WARN] Config Rule not found: %s, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error setting tags for %s: %s", d.Id(), err)
+	}
 
 	return nil
 }

--- a/aws/resource_aws_config_config_rule_test.go
+++ b/aws/resource_aws_config_config_rule_test.go
@@ -14,8 +14,8 @@ import (
 
 func testAccConfigConfigRule_basic(t *testing.T) {
 	var cr configservice.ConfigRule
-	rInt := acctest.RandInt()
-	expectedName := fmt.Sprintf("tf-acc-test-%d", rInt)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_config_config_rule.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -23,14 +23,14 @@ func testAccConfigConfigRule_basic(t *testing.T) {
 		CheckDestroy: testAccCheckConfigConfigRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigConfigRuleConfig_basic(rInt),
+				Config: testAccConfigConfigRuleConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckConfigConfigRuleExists("aws_config_config_rule.foo", &cr),
-					testAccCheckConfigConfigRuleName("aws_config_config_rule.foo", expectedName, &cr),
-					resource.TestCheckResourceAttr("aws_config_config_rule.foo", "name", expectedName),
-					resource.TestCheckResourceAttr("aws_config_config_rule.foo", "source.#", "1"),
-					resource.TestCheckResourceAttr("aws_config_config_rule.foo", "source.0.owner", "AWS"),
-					resource.TestCheckResourceAttr("aws_config_config_rule.foo", "source.0.source_identifier", "S3_BUCKET_VERSIONING_ENABLED"),
+					testAccCheckConfigConfigRuleExists(resourceName, &cr),
+					testAccCheckConfigConfigRuleName(resourceName, rName, &cr),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "source.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "source.0.owner", "AWS"),
+					resource.TestCheckResourceAttr(resourceName, "source.0.source_identifier", "S3_BUCKET_VERSIONING_ENABLED"),
 				),
 			},
 		},
@@ -39,8 +39,8 @@ func testAccConfigConfigRule_basic(t *testing.T) {
 
 func testAccConfigConfigRule_ownerAws(t *testing.T) {
 	var cr configservice.ConfigRule
-	rInt := acctest.RandInt()
-	expectedName := fmt.Sprintf("tf-acc-test-%d", rInt)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_config_config_rule.test"
 	expectedArn := regexp.MustCompile("arn:aws:config:[a-z0-9-]+:[0-9]{12}:config-rule/config-rule-([a-z0-9]+)")
 	expectedRuleId := regexp.MustCompile("config-rule-[a-z0-9]+")
 
@@ -50,22 +50,22 @@ func testAccConfigConfigRule_ownerAws(t *testing.T) {
 		CheckDestroy: testAccCheckConfigConfigRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigConfigRuleConfig_ownerAws(rInt),
+				Config: testAccConfigConfigRuleConfig_ownerAws(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckConfigConfigRuleExists("aws_config_config_rule.foo", &cr),
-					testAccCheckConfigConfigRuleName("aws_config_config_rule.foo", expectedName, &cr),
-					resource.TestMatchResourceAttr("aws_config_config_rule.foo", "arn", expectedArn),
-					resource.TestCheckResourceAttr("aws_config_config_rule.foo", "name", expectedName),
-					resource.TestMatchResourceAttr("aws_config_config_rule.foo", "rule_id", expectedRuleId),
-					resource.TestCheckResourceAttr("aws_config_config_rule.foo", "description", "Terraform Acceptance tests"),
-					resource.TestCheckResourceAttr("aws_config_config_rule.foo", "source.#", "1"),
-					resource.TestCheckResourceAttr("aws_config_config_rule.foo", "source.0.owner", "AWS"),
-					resource.TestCheckResourceAttr("aws_config_config_rule.foo", "source.0.source_identifier", "REQUIRED_TAGS"),
-					resource.TestCheckResourceAttr("aws_config_config_rule.foo", "source.0.source_detail.#", "0"),
-					resource.TestCheckResourceAttr("aws_config_config_rule.foo", "scope.#", "1"),
-					resource.TestCheckResourceAttr("aws_config_config_rule.foo", "scope.0.compliance_resource_id", "blablah"),
-					resource.TestCheckResourceAttr("aws_config_config_rule.foo", "scope.0.compliance_resource_types.#", "1"),
-					resource.TestCheckResourceAttr("aws_config_config_rule.foo", "scope.0.compliance_resource_types.3865728585", "AWS::EC2::Instance"),
+					testAccCheckConfigConfigRuleExists(resourceName, &cr),
+					testAccCheckConfigConfigRuleName(resourceName, rName, &cr),
+					resource.TestMatchResourceAttr(resourceName, "arn", expectedArn),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestMatchResourceAttr(resourceName, "rule_id", expectedRuleId),
+					resource.TestCheckResourceAttr(resourceName, "description", "Terraform Acceptance tests"),
+					resource.TestCheckResourceAttr(resourceName, "source.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "source.0.owner", "AWS"),
+					resource.TestCheckResourceAttr(resourceName, "source.0.source_identifier", "REQUIRED_TAGS"),
+					resource.TestCheckResourceAttr(resourceName, "source.0.source_detail.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "scope.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scope.0.compliance_resource_id", "blablah"),
+					resource.TestCheckResourceAttr(resourceName, "scope.0.compliance_resource_types.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scope.0.compliance_resource_types.3865728585", "AWS::EC2::Instance"),
 				),
 			},
 		},
@@ -114,8 +114,8 @@ func testAccConfigConfigRule_customlambda(t *testing.T) {
 }
 
 func testAccConfigConfigRule_importAws(t *testing.T) {
-	resourceName := "aws_config_config_rule.foo"
-	rInt := acctest.RandInt()
+	resourceName := "aws_config_config_rule.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -123,7 +123,7 @@ func testAccConfigConfigRule_importAws(t *testing.T) {
 		CheckDestroy: testAccCheckConfigConfigRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigConfigRuleConfig_ownerAws(rInt),
+				Config: testAccConfigConfigRuleConfig_ownerAws(rName),
 			},
 
 			{
@@ -239,6 +239,52 @@ func testAccConfigConfigRule_Scope_TagValue(t *testing.T) {
 	})
 }
 
+func testAccConfigConfigRule_tags(t *testing.T) {
+	var cr configservice.ConfigRule
+	resourceName := "aws_config_config_rule.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckConfigConfigRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigConfigRuleConfig_Tags(rName, "foo", "bar", "fizz", "buzz"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigConfigRuleExists(resourceName, &cr),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.fizz", "buzz"),
+				),
+			},
+			{
+				Config: testAccConfigConfigRuleConfig_Tags(rName, "foo", "bar2", "fizz2", "buzz2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigConfigRuleExists(resourceName, &cr),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.fizz2", "buzz2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccConfigConfigRuleConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigConfigRuleExists(resourceName, &cr),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckConfigConfigRuleName(n, desired string, obj *configservice.ConfigRule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -340,69 +386,26 @@ resource "aws_iam_role_policy_attachment" "test" {
 `, rName, rName)
 }
 
-func testAccConfigConfigRuleConfig_basic(randInt int) string {
-	return fmt.Sprintf(`
-resource "aws_config_config_rule" "foo" {
-  name = "tf-acc-test-%d"
+func testAccConfigConfigRuleConfig_basic(rName string) string {
+	return testAccConfigConfigRuleConfig_base(rName) + fmt.Sprintf(`
+resource "aws_config_config_rule" "test" {
+  name = %[1]q
 
   source {
     owner             = "AWS"
     source_identifier = "S3_BUCKET_VERSIONING_ENABLED"
   }
 
-  depends_on = ["aws_config_configuration_recorder.foo"]
+  depends_on = ["aws_config_configuration_recorder.test"]
 }
 
-resource "aws_config_configuration_recorder" "foo" {
-  name     = "tf-acc-test-%d"
-  role_arn = "${aws_iam_role.r.arn}"
+`, rName)
 }
 
-resource "aws_iam_role" "r" {
-  name = "tf-acc-test-awsconfig-%d"
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "config.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy" "p" {
-  name = "tf-acc-test-awsconfig-%d"
-  role = "${aws_iam_role.r.id}"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-        "Action": "config:Put*",
-        "Effect": "Allow",
-        "Resource": "*"
-
-    }
-  ]
-}
-EOF
-}
-`, randInt, randInt, randInt, randInt)
-}
-
-func testAccConfigConfigRuleConfig_ownerAws(randInt int) string {
-	return fmt.Sprintf(`
-resource "aws_config_config_rule" "foo" {
-  name        = "tf-acc-test-%d"
+func testAccConfigConfigRuleConfig_ownerAws(rName string) string {
+	return testAccConfigConfigRuleConfig_base(rName) + fmt.Sprintf(`
+resource "aws_config_config_rule" "test" {
+  name        = %[1]q
   description = "Terraform Acceptance tests"
 
   source {
@@ -419,53 +422,10 @@ resource "aws_config_config_rule" "foo" {
 {"tag1Key":"CostCenter", "tag2Key":"Owner"}
 PARAMS
 
-  depends_on = ["aws_config_configuration_recorder.foo"]
+  depends_on = ["aws_config_configuration_recorder.test"]
 }
 
-resource "aws_config_configuration_recorder" "foo" {
-  name     = "tf-acc-test-%d"
-  role_arn = "${aws_iam_role.r.arn}"
-}
-
-resource "aws_iam_role" "r" {
-  name = "tf-acc-test-awsconfig-%d"
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "config.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy" "p" {
-  name = "tf-acc-test-awsconfig-%d"
-  role = "${aws_iam_role.r.id}"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-        "Action": "config:Put*",
-        "Effect": "Allow",
-        "Resource": "*"
-
-    }
-  ]
-}
-EOF
-}
-`, randInt, randInt, randInt, randInt)
+`, rName)
 }
 
 func testAccConfigConfigRuleConfig_customLambda(randInt int, path string) string {
@@ -647,4 +607,25 @@ resource "aws_config_config_rule" "test" {
   depends_on = ["aws_config_configuration_recorder.test"]
 }
 `, rName, tagValue)
+}
+
+func testAccConfigConfigRuleConfig_Tags(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return testAccConfigConfigRuleConfig_base(rName) + fmt.Sprintf(`
+resource "aws_config_config_rule" "test" {
+  name = %[1]q
+
+  source {
+    owner = "AWS"
+    source_identifier = "S3_BUCKET_VERSIONING_ENABLED"
+  }
+
+  tags = {
+	Name  = %[1]q
+	%[2]s = %[3]q
+	%[4]s = %[5]q
+  }
+
+  depends_on = ["aws_config_configuration_recorder.test"]
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }

--- a/aws/resource_aws_config_configuration_aggregator_test.go
+++ b/aws/resource_aws_config_configuration_aggregator_test.go
@@ -59,8 +59,8 @@ func testSweepConfigConfigurationAggregators(region string) error {
 
 func TestAccAWSConfigConfigurationAggregator_account(t *testing.T) {
 	var ca configservice.ConfigurationAggregator
-	rString := acctest.RandString(10)
-	expectedName := fmt.Sprintf("tf-%s", rString)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_config_configuration_aggregator.example"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -68,20 +68,20 @@ func TestAccAWSConfigConfigurationAggregator_account(t *testing.T) {
 		CheckDestroy: testAccCheckAWSConfigConfigurationAggregatorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSConfigConfigurationAggregatorConfig_account(rString),
+				Config: testAccAWSConfigConfigurationAggregatorConfig_account(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSConfigConfigurationAggregatorExists("aws_config_configuration_aggregator.example", &ca),
-					testAccCheckAWSConfigConfigurationAggregatorName("aws_config_configuration_aggregator.example", expectedName, &ca),
-					resource.TestCheckResourceAttr("aws_config_configuration_aggregator.example", "name", expectedName),
-					resource.TestCheckResourceAttr("aws_config_configuration_aggregator.example", "account_aggregation_source.#", "1"),
-					resource.TestCheckResourceAttr("aws_config_configuration_aggregator.example", "account_aggregation_source.0.account_ids.#", "1"),
-					resource.TestMatchResourceAttr("aws_config_configuration_aggregator.example", "account_aggregation_source.0.account_ids.0", regexp.MustCompile(`^\d{12}$`)),
-					resource.TestCheckResourceAttr("aws_config_configuration_aggregator.example", "account_aggregation_source.0.regions.#", "1"),
-					resource.TestCheckResourceAttr("aws_config_configuration_aggregator.example", "account_aggregation_source.0.regions.0", "us-west-2"),
+					testAccCheckAWSConfigConfigurationAggregatorExists(resourceName, &ca),
+					testAccCheckAWSConfigConfigurationAggregatorName(resourceName, rName, &ca),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "account_aggregation_source.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "account_aggregation_source.0.account_ids.#", "1"),
+					resource.TestMatchResourceAttr(resourceName, "account_aggregation_source.0.account_ids.0", regexp.MustCompile(`^\d{12}$`)),
+					resource.TestCheckResourceAttr(resourceName, "account_aggregation_source.0.regions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "account_aggregation_source.0.regions.0", "us-west-2"),
 				),
 			},
 			{
-				ResourceName:      "aws_config_configuration_aggregator.example",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -91,8 +91,8 @@ func TestAccAWSConfigConfigurationAggregator_account(t *testing.T) {
 
 func TestAccAWSConfigConfigurationAggregator_organization(t *testing.T) {
 	var ca configservice.ConfigurationAggregator
-	rString := acctest.RandString(10)
-	expectedName := fmt.Sprintf("tf-%s", rString)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_config_configuration_aggregator.example"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },
@@ -100,18 +100,18 @@ func TestAccAWSConfigConfigurationAggregator_organization(t *testing.T) {
 		CheckDestroy: testAccCheckAWSConfigConfigurationAggregatorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSConfigConfigurationAggregatorConfig_organization(rString),
+				Config: testAccAWSConfigConfigurationAggregatorConfig_organization(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSConfigConfigurationAggregatorExists("aws_config_configuration_aggregator.example", &ca),
-					testAccCheckAWSConfigConfigurationAggregatorName("aws_config_configuration_aggregator.example", expectedName, &ca),
-					resource.TestCheckResourceAttr("aws_config_configuration_aggregator.example", "name", expectedName),
-					resource.TestCheckResourceAttr("aws_config_configuration_aggregator.example", "organization_aggregation_source.#", "1"),
-					resource.TestMatchResourceAttr("aws_config_configuration_aggregator.example", "organization_aggregation_source.0.role_arn", regexp.MustCompile(`^arn:aws:iam::\d+:role/`)),
-					resource.TestCheckResourceAttr("aws_config_configuration_aggregator.example", "organization_aggregation_source.0.all_regions", "true"),
+					testAccCheckAWSConfigConfigurationAggregatorExists(resourceName, &ca),
+					testAccCheckAWSConfigConfigurationAggregatorName(resourceName, rName, &ca),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "organization_aggregation_source.#", "1"),
+					resource.TestMatchResourceAttr(resourceName, "organization_aggregation_source.0.role_arn", regexp.MustCompile(`^arn:aws:iam::\d+:role/`)),
+					resource.TestCheckResourceAttr(resourceName, "organization_aggregation_source.0.all_regions", "true"),
 				),
 			},
 			{
-				ResourceName:      "aws_config_configuration_aggregator.example",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -120,7 +120,8 @@ func TestAccAWSConfigConfigurationAggregator_organization(t *testing.T) {
 }
 
 func TestAccAWSConfigConfigurationAggregator_switch(t *testing.T) {
-	rString := acctest.RandString(10)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_config_configuration_aggregator.example"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },
@@ -128,17 +129,17 @@ func TestAccAWSConfigConfigurationAggregator_switch(t *testing.T) {
 		CheckDestroy: testAccCheckAWSConfigConfigurationAggregatorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSConfigConfigurationAggregatorConfig_account(rString),
+				Config: testAccAWSConfigConfigurationAggregatorConfig_account(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_config_configuration_aggregator.example", "account_aggregation_source.#", "1"),
-					resource.TestCheckResourceAttr("aws_config_configuration_aggregator.example", "organization_aggregation_source.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "account_aggregation_source.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "organization_aggregation_source.#", "0"),
 				),
 			},
 			{
-				Config: testAccAWSConfigConfigurationAggregatorConfig_organization(rString),
+				Config: testAccAWSConfigConfigurationAggregatorConfig_organization(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_config_configuration_aggregator.example", "account_aggregation_source.#", "0"),
-					resource.TestCheckResourceAttr("aws_config_configuration_aggregator.example", "organization_aggregation_source.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "account_aggregation_source.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "organization_aggregation_source.#", "1"),
 				),
 			},
 		},
@@ -210,10 +211,10 @@ func testAccCheckAWSConfigConfigurationAggregatorDestroy(s *terraform.State) err
 	return nil
 }
 
-func testAccAWSConfigConfigurationAggregatorConfig_account(rString string) string {
+func testAccAWSConfigConfigurationAggregatorConfig_account(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_config_configuration_aggregator" "example" {
-  name = "tf-%s"
+  name = %[1]q
 
   account_aggregation_source {
     account_ids = ["${data.aws_caller_identity.current.account_id}"]
@@ -222,17 +223,17 @@ resource "aws_config_configuration_aggregator" "example" {
 }
 
 data "aws_caller_identity" "current" {}
-`, rString)
+`, rName)
 }
 
-func testAccAWSConfigConfigurationAggregatorConfig_organization(rString string) string {
+func testAccAWSConfigConfigurationAggregatorConfig_organization(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_organizations_organization" "test" {}
 
 resource "aws_config_configuration_aggregator" "example" {
   depends_on = ["aws_iam_role_policy_attachment.example"]
 
-  name = "tf-%s"
+  name = %[1]q
 
   organization_aggregation_source {
     all_regions = true
@@ -241,7 +242,7 @@ resource "aws_config_configuration_aggregator" "example" {
 }
 
 resource "aws_iam_role" "example" {
-  name = "tf-%s"
+  name = %[1]q
 
   assume_role_policy = <<EOF
 {
@@ -264,5 +265,5 @@ resource "aws_iam_role_policy_attachment" "example" {
   role       = "${aws_iam_role.example.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSConfigRoleForOrganizations"
 }
-`, rString, rString)
+`, rName)
 }

--- a/aws/resource_aws_config_test.go
+++ b/aws/resource_aws_config_test.go
@@ -15,6 +15,7 @@ func TestAccAWSConfig(t *testing.T) {
 			"scopeTagKey":      testAccConfigConfigRule_Scope_TagKey,
 			"scopeTagKeyEmpty": testAccConfigConfigRule_Scope_TagKey_Empty,
 			"scopeTagValue":    testAccConfigConfigRule_Scope_TagValue,
+			"tags":             testAccConfigConfigRule_tags,
 		},
 		"ConfigurationRecorderStatus": {
 			"basic":        testAccConfigConfigurationRecorderStatus_basic,

--- a/aws/tagsConfigService.go
+++ b/aws/tagsConfigService.go
@@ -1,0 +1,135 @@
+package aws
+
+import (
+	"log"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/configservice"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// setTags is a helper to set the tags for a resource. It expects the
+// tags field to be named "tags"
+func setTagsConfigService(conn *configservice.ConfigService, d *schema.ResourceData, arn string) error {
+	if d.HasChange("tags") {
+		oraw, nraw := d.GetChange("tags")
+		o := oraw.(map[string]interface{})
+		n := nraw.(map[string]interface{})
+		create, remove := diffTagsConfigService(tagsFromMapConfigService(o), tagsFromMapConfigService(n))
+
+		// Set tags
+		if len(remove) > 0 {
+			log.Printf("[DEBUG] Removing tags: %s", remove)
+			k := make([]*string, len(remove))
+			for i, t := range remove {
+				k[i] = t.Key
+			}
+
+			_, err := conn.UntagResource(&configservice.UntagResourceInput{
+				ResourceArn: aws.String(arn),
+				TagKeys:     k,
+			})
+			if err != nil {
+				return err
+			}
+		}
+		if len(create) > 0 {
+			log.Printf("[DEBUG] Creating tags: %s", create)
+			_, err := conn.TagResource(&configservice.TagResourceInput{
+				ResourceArn: aws.String(arn),
+				Tags:        create,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// diffTags takes our tags locally and the ones remotely and returns
+// the set of tags that must be created, and the set of tags that must
+// be destroyed.
+func diffTagsConfigService(oldTags, newTags []*configservice.Tag) ([]*configservice.Tag, []*configservice.Tag) {
+	// First, we're creating everything we have
+	create := make(map[string]interface{})
+	for _, t := range newTags {
+		create[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+	}
+
+	// Build the list of what to remove
+	var remove []*configservice.Tag
+	for _, t := range oldTags {
+		old, ok := create[aws.StringValue(t.Key)]
+		if !ok || old != aws.StringValue(t.Value) {
+			// Delete it!
+			remove = append(remove, t)
+		} else if ok {
+			delete(create, aws.StringValue(t.Key))
+		}
+	}
+
+	return tagsFromMapConfigService(create), remove
+}
+
+// tagsFromMap returns the tags for the given map of data.
+func tagsFromMapConfigService(m map[string]interface{}) []*configservice.Tag {
+	result := make([]*configservice.Tag, 0, len(m))
+	for k, v := range m {
+		t := &configservice.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v.(string)),
+		}
+		if !tagIgnoredConfigService(t) {
+			result = append(result, t)
+		}
+	}
+
+	return result
+}
+
+// tagsToMap turns the list of tags into a map.
+func tagsToMapConfigService(ts []*configservice.Tag) map[string]string {
+	result := make(map[string]string)
+	for _, t := range ts {
+		if !tagIgnoredConfigService(t) {
+			result[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+		}
+	}
+
+	return result
+}
+
+// compare a tag against a list of strings and checks if it should
+// be ignored or not
+func tagIgnoredConfigService(t *configservice.Tag) bool {
+	filter := []string{"^aws:"}
+	for _, v := range filter {
+		log.Printf("[DEBUG] Matching %v with %v\n", v, aws.StringValue(t.Key))
+		r, _ := regexp.MatchString(v, aws.StringValue(t.Key))
+		if r {
+			log.Printf("[DEBUG] Found AWS specific tag %s (val: %s), ignoring.\n", aws.StringValue(t.Key), aws.StringValue(t.Value))
+			return true
+		}
+	}
+	return false
+}
+
+func saveTagsConfigService(conn *configservice.ConfigService, d *schema.ResourceData, arn string) error {
+	resp, err := conn.ListTagsForResource(&configservice.ListTagsForResourceInput{
+		ResourceArn: aws.String(arn),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	var dt []*configservice.Tag
+	if len(resp.Tags) > 0 {
+		dt = resp.Tags
+	}
+
+	return d.Set("tags", tagsToMapConfigService(dt))
+}

--- a/aws/tagsConfigService_test.go
+++ b/aws/tagsConfigService_test.go
@@ -1,0 +1,112 @@
+package aws
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/configservice"
+)
+
+// go test -v -run="TestDiffConfigServiceTags"
+func TestDiffConfigServiceTags(t *testing.T) {
+	cases := []struct {
+		Old, New       map[string]interface{}
+		Create, Remove map[string]string
+	}{
+		// Basic add/remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"bar": "baz",
+			},
+			Create: map[string]string{
+				"bar": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Modify
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "baz",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Overlap
+		{
+			Old: map[string]interface{}{
+				"foo":   "bar",
+				"hello": "world",
+			},
+			New: map[string]interface{}{
+				"foo":   "baz",
+				"hello": "world",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+				"bar": "baz",
+			},
+			New: map[string]interface{}{
+				"foo": "bar",
+			},
+			Create: map[string]string{},
+			Remove: map[string]string{
+				"bar": "baz",
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		c, r := diffTagsConfigService(tagsFromMapConfigService(tc.Old), tagsFromMapConfigService(tc.New))
+		cm := tagsToMapConfigService(c)
+		rm := tagsToMapConfigService(r)
+		if !reflect.DeepEqual(cm, tc.Create) {
+			t.Fatalf("%d: bad create: %#v", i, cm)
+		}
+		if !reflect.DeepEqual(rm, tc.Remove) {
+			t.Fatalf("%d: bad remove: %#v", i, rm)
+		}
+	}
+}
+
+// go test -v -run="TestIgnoringTagsConfigService"
+func TestIgnoringTagsConfigService(t *testing.T) {
+	var ignoredTags []*configservice.Tag
+	ignoredTags = append(ignoredTags, &configservice.Tag{
+		Key:   aws.String("aws:cloudformation:logical-id"),
+		Value: aws.String("foo"),
+	})
+	ignoredTags = append(ignoredTags, &configservice.Tag{
+		Key:   aws.String("aws:foo:bar"),
+		Value: aws.String("baz"),
+	})
+	for _, tag := range ignoredTags {
+		if !tagIgnoredConfigService(tag) {
+			t.Fatalf("Tag %v with value %v not ignored, but should be!", *tag.Key, *tag.Value)
+		}
+	}
+}

--- a/website/docs/r/config_aggregate_authorization.markdown
+++ b/website/docs/r/config_aggregate_authorization.markdown
@@ -25,6 +25,7 @@ The following arguments are supported:
 
 * `account_id` - (Required) Account ID
 * `region` - (Required) Region
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference
 

--- a/website/docs/r/config_config_rule.html.markdown
+++ b/website/docs/r/config_config_rule.html.markdown
@@ -118,6 +118,7 @@ The following arguments are supported:
 * `scope` - (Optional) Scope defines which resources can trigger an evaluation for the rule as documented below.
 * `source` - (Required) Source specifies the rule owner, the rule identifier, and the notifications that cause
 	the function to evaluate your AWS resources as documented below.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ### `scope`
 

--- a/website/docs/r/config_configuration_aggregator.html.markdown
+++ b/website/docs/r/config_configuration_aggregator.html.markdown
@@ -72,6 +72,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the configuration aggregator.
 * `account_aggregation_source` - (Optional) The account(s) to aggregate config data from as documented below.
 * `organization_aggregation_source` - (Optional) The organization to aggregate config data from as documented below.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 Either `account_aggregation_source` or `organization_aggregation_source` must be specified.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9353

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_config_config_rule: support tags attribute
resource/aws_config_configuration_aggregator: support tags attribute
resource/aws_config_aggregate_authorization : support tags attribute
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSConfig'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSConfig -timeout 120m
=== RUN   TestAccAWSConfigAggregateAuthorization_basic
=== PAUSE TestAccAWSConfigAggregateAuthorization_basic
=== RUN   TestAccAWSConfigAggregateAuthorization_tags
=== PAUSE TestAccAWSConfigAggregateAuthorization_tags
=== RUN   TestAccAWSConfigConfigurationAggregator_account
=== PAUSE TestAccAWSConfigConfigurationAggregator_account
=== RUN   TestAccAWSConfigConfigurationAggregator_organization
=== PAUSE TestAccAWSConfigConfigurationAggregator_organization
=== RUN   TestAccAWSConfigConfigurationAggregator_switch
=== PAUSE TestAccAWSConfigConfigurationAggregator_switch
=== RUN   TestAccAWSConfigConfigurationAggregator_tags
=== PAUSE TestAccAWSConfigConfigurationAggregator_tags
=== RUN   TestAccAWSConfig
=== RUN   TestAccAWSConfig/Config
=== RUN   TestAccAWSConfig/Config/scopeTagKeyEmpty
=== RUN   TestAccAWSConfig/Config/scopeTagValue
=== RUN   TestAccAWSConfig/Config/tags
=== RUN   TestAccAWSConfig/Config/basic
=== RUN   TestAccAWSConfig/Config/ownerAws
=== RUN   TestAccAWSConfig/Config/customlambda
=== RUN   TestAccAWSConfig/Config/importAws
=== RUN   TestAccAWSConfig/Config/importLambda
=== RUN   TestAccAWSConfig/Config/scopeTagKey
=== RUN   TestAccAWSConfig/ConfigurationRecorderStatus
=== RUN   TestAccAWSConfig/ConfigurationRecorderStatus/basic
=== RUN   TestAccAWSConfig/ConfigurationRecorderStatus/startEnabled
=== RUN   TestAccAWSConfig/ConfigurationRecorderStatus/importBasic
=== RUN   TestAccAWSConfig/ConfigurationRecorder
=== RUN   TestAccAWSConfig/ConfigurationRecorder/basic
=== RUN   TestAccAWSConfig/ConfigurationRecorder/allParams
=== RUN   TestAccAWSConfig/ConfigurationRecorder/importBasic
=== RUN   TestAccAWSConfig/DeliveryChannel
=== RUN   TestAccAWSConfig/DeliveryChannel/basic
=== RUN   TestAccAWSConfig/DeliveryChannel/allParams
=== RUN   TestAccAWSConfig/DeliveryChannel/importBasic
--- PASS: TestAccAWSConfig (1881.97s)
    --- PASS: TestAccAWSConfig/Config (1233.67s)
        --- PASS: TestAccAWSConfig/Config/scopeTagKeyEmpty (122.98s)
        --- PASS: TestAccAWSConfig/Config/scopeTagValue (142.01s)
        --- PASS: TestAccAWSConfig/Config/tags (171.49s)
        --- PASS: TestAccAWSConfig/Config/basic (120.07s)
        --- PASS: TestAccAWSConfig/Config/ownerAws (119.95s)
        --- PASS: TestAccAWSConfig/Config/customlambda (145.95s)
        --- PASS: TestAccAWSConfig/Config/importAws (119.98s)
        --- PASS: TestAccAWSConfig/Config/importLambda (148.99s)
        --- PASS: TestAccAWSConfig/Config/scopeTagKey (142.25s)
    --- PASS: TestAccAWSConfig/ConfigurationRecorderStatus (268.93s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorderStatus/basic (64.79s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorderStatus/startEnabled (137.50s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorderStatus/importBasic (66.64s)
    --- PASS: TestAccAWSConfig/ConfigurationRecorder (193.25s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorder/basic (64.20s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorder/allParams (63.88s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorder/importBasic (65.17s)
    --- PASS: TestAccAWSConfig/DeliveryChannel (186.12s)
        --- PASS: TestAccAWSConfig/DeliveryChannel/basic (63.05s)
        --- PASS: TestAccAWSConfig/DeliveryChannel/allParams (62.62s)
        --- PASS: TestAccAWSConfig/DeliveryChannel/importBasic (60.45s)
=== CONT  TestAccAWSConfigAggregateAuthorization_basic
=== CONT  TestAccAWSConfigConfigurationAggregator_account
=== CONT  TestAccAWSConfigConfigurationAggregator_switch
=== CONT  TestAccAWSConfigConfigurationAggregator_tags
=== CONT  TestAccAWSConfigConfigurationAggregator_organization
=== CONT  TestAccAWSConfigAggregateAuthorization_tags
--- SKIP: TestAccAWSConfigConfigurationAggregator_switch (3.38s)
    provider_test.go:247: skipping tests; this AWS account must not be an existing member of an AWS Organization
--- SKIP: TestAccAWSConfigConfigurationAggregator_organization (3.39s)
    provider_test.go:247: skipping tests; this AWS account must not be an existing member of an AWS Organization
--- PASS: TestAccAWSConfigAggregateAuthorization_basic (31.60s)
--- PASS: TestAccAWSConfigConfigurationAggregator_account (35.99s)
--- PASS: TestAccAWSConfigAggregateAuthorization_tags (70.54s)
--- PASS: TestAccAWSConfigConfigurationAggregator_tags (85.65s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1967.740s
```
