### PR TITLE
resource/aws_route53_record: weighted_routing_policy can be removed from existing records

### DIFF
--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -280,6 +280,18 @@ func resourceAwsRoute53RecordUpdate(d *schema.ResourceData, meta interface{}) er
 		Type: aws.String(typeo.(string)),
 	}
 
+	// If the old record had a weighted_routing_policy we need to pass that in
+	// here because otherwise the API will give us an error.
+	if v, _ := d.GetChange("weighted_routing_policy"); v != nil {
+		if o, ok := v.([]interface{}); ok {
+			if len(o) == 1 {
+				if v, ok := o[0].(map[string]interface{}); ok {
+					oldRec.Weight = aws.Int64(int64(v["weight"].(int)))
+				}
+			}
+		}
+	}
+
 	if v, _ := d.GetChange("ttl"); v.(int) != 0 {
 		oldRec.TTL = aws.Int64(int64(v.(int)))
 	}

--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -395,6 +395,30 @@ func TestAccAWSRoute53Record_weighted_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSRoute53Record_weighted_to_simple_basic(t *testing.T) {
+	var record1 route53.ResourceRecordSet
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53RecordDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testaccRoute53RecordConfigWithWeightedRoutingPolicy,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53RecordExists("aws_route53_record.www-server1", &record1),
+				),
+			},
+			{
+				Config: testaccRoute53RecordConfigWithSimpleRoutingPolicy,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53RecordExists("aws_route53_record.www-server1", &record1),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSRoute53Record_Alias_Elb(t *testing.T) {
 	var record1 route53.ResourceRecordSet
 
@@ -1672,5 +1696,39 @@ resource "aws_route53_record" "www-server2" {
   multivalue_answer_routing_policy = true
   set_identifier = "server2"
   records = ["127.0.0.2"]
+}
+`
+
+const testaccRoute53RecordConfigWithWeightedRoutingPolicy = `
+resource "aws_route53_zone" "main" {
+  name = "notexample.com"
+}
+
+resource "aws_route53_record" "www-server1" {
+  zone_id = "${aws_route53_zone.main.zone_id}"
+  name    = "www"
+  type    = "A"
+
+  weighted_routing_policy {
+    weight = 5
+  }
+
+  ttl            = "300"
+  set_identifier = "server1"
+  records        = ["127.0.0.1"]
+}
+`
+
+const testaccRoute53RecordConfigWithSimpleRoutingPolicy = `
+resource "aws_route53_zone" "main" {
+  name = "notexample.com"
+}
+
+resource "aws_route53_record" "www-server1" {
+  zone_id        = "${aws_route53_zone.main.zone_id}"
+  name           = "www"
+  type           = "A"
+  ttl            = "300"
+  records        = ["127.0.0.1"]
 }
 `


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/terraform-providers/terraform-provider-aws/issues/4429
Relates https://github.com/terraform-providers/terraform-provider-aws/issues/6298

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_route53_record: weighted_routing_policy can now be removed from existing records
```

Output from acceptance testing:

Before
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSRoute53Record_weighted_to_simple_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSRoute53Record_weighted_to_simple_basic -timeout 120m
=== RUN   TestAccAWSRoute53Record_weighted_to_simple_basic
=== PAUSE TestAccAWSRoute53Record_weighted_to_simple_basic
=== CONT  TestAccAWSRoute53Record_weighted_to_simple_basic
--- FAIL: TestAccAWSRoute53Record_weighted_to_simple_basic (101.10s)
    testing.go:568: Step 1 error: errors during apply:

        Error: [ERR]: Error building changeset: InvalidInput: Invalid request: Expected exactly one of [Weight, Region, Failover, GeoLocation, or MultiValueAnswer], but found none in Change with [Action=DELETE, Name=www.notexample.com, Type=A, SetIdentifier=server1]
        	status code: 400, request id: 416d5699-cf8f-496a-a9a7-979293fd288e

          on /var/folders/h0/qpjyfjzx3_l8jh_371zpdmm40000gp/T/tf-test607177274/main.tf line 6:
          (source code not available)


    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: errors during apply: error deleting Route53 Hosted Zone (Z380ULEZAWYGY6): HostedZoneNotEmpty: The specified hosted zone contains non-required resource record sets and so cannot be deleted.
        	status code: 400, request id: 8f7e8a21-cc98-4bd9-a1f0-0ae888be9c25

        State: aws_route53_zone.main:
          ID = Z380ULEZAWYGY6
          provider = provider.aws
          comment = Managed by Terraform
          delegation_set_id =
          force_destroy = false
          name = notexample.com.
          name_servers.# = 4
          name_servers.0 = ns-1221.awsdns-24.org
          name_servers.1 = ns-17.awsdns-02.com
          name_servers.2 = ns-1924.awsdns-48.co.uk
          name_servers.3 = ns-731.awsdns-27.net
          tags.% = 0
          vpc.# = 0
          zone_id = Z380ULEZAWYGY6
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	101.154s
```

After
```
$  make testacc TEST=./aws TESTARGS='run=TestAccAWSRoute53Record_weighted_to_simple_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSRoute53Record_weighted_to_simple_basic -timeout 120m
=== RUN   TestAccAWSRoute53Record_weighted_to_simple_basic
=== PAUSE TestAccAWSRoute53Record_weighted_to_simple_basic
=== CONT  TestAccAWSRoute53Record_weighted_to_simple_basic
--- PASS: TestAccAWSRoute53Record_weighted_to_simple_basic (184.64s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	184.694s
```
