### PR TITLE
provider: Use real Terraform version in UA header

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -137,7 +137,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/xray"
 	awsbase "github.com/hashicorp/aws-sdk-go-base"
 	"github.com/hashicorp/terraform/helper/logging"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 type Config struct {
@@ -166,6 +165,8 @@ type Config struct {
 	SkipRequestingAccountId bool
 	SkipMetadataApiCheck    bool
 	S3ForcePathStyle        bool
+
+	terraformVersion string
 }
 
 type AWSClient struct {
@@ -335,7 +336,8 @@ func (c *Config) Client() (interface{}, error) {
 		UserAgentProducts: []*awsbase.UserAgentProduct{
 			{Name: "APN", Version: "1.0"},
 			{Name: "HashiCorp", Version: "1.0"},
-			{Name: "Terraform", Version: terraform.VersionString()},
+			{Name: "Terraform", Version: c.terraformVersion,
+				Extra: []string{"+https://www.terraform.io"}},
 		},
 	}
 

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -15,7 +15,7 @@ func Provider() terraform.ResourceProvider {
 	// TODO: Move the configuration to this, requires validation
 
 	// The actual provider
-	return &schema.Provider{
+	provider := &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"access_key": {
 				Type:        schema.TypeString,
@@ -827,8 +827,19 @@ func Provider() terraform.ResourceProvider {
 			"aws_alb_target_group_attachment": resourceAwsLbTargetGroupAttachment(),
 			"aws_lb_target_group_attachment":  resourceAwsLbTargetGroupAttachment(),
 		},
-		ConfigureFunc: providerConfigure,
 	}
+
+	provider.ConfigureFunc = func(d *schema.ResourceData) (interface{}, error) {
+		terraformVersion := provider.TerraformVersion
+		if terraformVersion == "" {
+			// Terraform 0.12 introduced this field to the protocol
+			// We can therefore assume that if it's missing it's 0.10 or 0.11
+			terraformVersion = "0.11+compatible"
+		}
+		return providerConfigure(d, terraformVersion)
+	}
+
+	return provider
 }
 
 var descriptions map[string]string
@@ -1025,7 +1036,7 @@ func init() {
 	}
 }
 
-func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+func providerConfigure(d *schema.ResourceData, terraformVersion string) (interface{}, error) {
 	config := Config{
 		AccessKey:               d.Get("access_key").(string),
 		SecretKey:               d.Get("secret_key").(string),
@@ -1041,6 +1052,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		SkipRequestingAccountId: d.Get("skip_requesting_account_id").(bool),
 		SkipMetadataApiCheck:    d.Get("skip_metadata_api_check").(bool),
 		S3ForcePathStyle:        d.Get("s3_force_path_style").(bool),
+		terraformVersion:        terraformVersion,
 	}
 
 	// Set CredsFilename, expanding home directory


### PR DESCRIPTION
The existing implementation leverages Terraform's `version` package as Terraform currently provides the SDK for interacting with core and is therefore imported by the provider, including the `version` package.

The side effect of this is that provider reports version of vendored Terraform (i.e. plugin SDK), not the version which actually talks to the provider's gRPC server and parses the configuration.

This PR is leveraging recent changes introduced in 0.12 to fix that and report accurate version.

----

I also wanted to change the header from the following

```
APN/1.0 HashiCorp/1.0 Terraform/X.Y.Z (+https://www.terraform.io)
```
to
```
APN/1.0 HashiCorp Terraform/X.Y.Z (+https://www.terraform.io)
```
to align it better with other providers.

The point of versioning of `HashiCorp` was (IMO rightfully) questioned during the implementation of https://github.com/hashicorp/terraform/pull/22272 and the version was dropped from that helper function.

However the upstream AWS SDK helpers used here for building the UA string may need to be tuned to reflect [the RFC](https://tools.ietf.org/html/rfc7231#section-5.5.3) where version of products is optional. Dropping the `Version` part would otherwise produce

```
APN/1.0 HashiCorp/ Terraform/X.Y.Z (+https://www.terraform.io)
```
which is most likely undesired.

An example of a full UA string with this patch follows
```
aws-sdk-go/1.23.0 (go1.12.7; darwin; amd64) APN/1.0 HashiCorp/1.0 Terraform/0.12.7 (+https://www.terraform.io)
```
I think it would be worth exploring ways of moving SDK/Go versions towards the end, to reflect [RFC7231](https://tools.ietf.org/html/rfc7231#section-5.5.3), specifically this part:

> By convention, the product identifiers are listed in decreasing order of their significance for identifying the user agent software.  Each product identifier consists of a name and optional version.

IMO Terraform is more significant in this context than the SDK - but I will leave that for another discussion/PR.