### PR TITLE
s3_bucket_object: Fix ETAG changes not forcing new

### DIFF
--- a/aws/resource_aws_s3_bucket_object.go
+++ b/aws/resource_aws_s3_bucket_object.go
@@ -149,6 +149,7 @@ func resourceAwsS3BucketObject() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				ConflictsWith: []string{"kms_key_id"},
+				ForceNew:      true,
 			},
 
 			"version_id": {

--- a/aws/resource_aws_s3_bucket_object.go
+++ b/aws/resource_aws_s3_bucket_object.go
@@ -149,7 +149,6 @@ func resourceAwsS3BucketObject() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				ConflictsWith: []string{"kms_key_id"},
-				ForceNew:      true,
 			},
 
 			"version_id": {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2411

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_s3_bucket_object: Update object contents when the source is the same but the contents/ETAG are not [GH-2411]
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSS3BucketObject_updateSameFile'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3BucketObject_updateSameFile -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSS3BucketObject_updateSameFile
=== PAUSE TestAccAWSS3BucketObject_updateSameFile
=== CONT  TestAccAWSS3BucketObject_updateSameFile
--- PASS: TestAccAWSS3BucketObject_updateSameFile (55.93s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	55.986s
```