### PR TITLE
docs/provider: Add line item for creating GitHub release during Release Process

### DIFF
--- a/.github/MAINTAINING.md
+++ b/.github/MAINTAINING.md
@@ -264,4 +264,4 @@ The fix for this has been merged and will release with version X.Y.Z of the Terr
 - Run the HashiCorp (non-OSS) TeamCity release job with the `DEPLOYMENT_TARGET_VERSION` matching the expected release milestone and `DEPLOYMENT_NEXT_VERSION` matching the next release milestone
 - Wait for the TeamCity release job and TeamCity website deployment jobs to complete either by watching the build logs or Slack notifications
 - Close the release milestone
-- Create a new GitHub release with the release title exactly matching the tag and milestone (e.g. `v2.22.0`). This will trigger hashibot release comments.
+- Create a new GitHub release with the release title exactly matching the tag and milestone (e.g. `v2.22.0`). This will trigger [HashiBot](https://github.com/apps/hashibot) release comments.

--- a/.github/MAINTAINING.md
+++ b/.github/MAINTAINING.md
@@ -264,3 +264,4 @@ The fix for this has been merged and will release with version X.Y.Z of the Terr
 - Run the HashiCorp (non-OSS) TeamCity release job with the `DEPLOYMENT_TARGET_VERSION` matching the expected release milestone and `DEPLOYMENT_NEXT_VERSION` matching the next release milestone
 - Wait for the TeamCity release job and TeamCity website deployment jobs to complete either by watching the build logs or Slack notifications
 - Close the release milestone
+- Create a new GitHub release with the release title exactly matching the tag and milestone (e.g. `v2.22.0`). This will trigger hashibot release comments.


### PR DESCRIPTION
This is what currently triggers hashibot commenting on release behavior. This will likely be automated as part of the provider deployment process in the future.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing: N/A
