### PR TITLE
Retry ACM certificate domain validation

### DIFF
--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -292,6 +292,10 @@ func convertValidationOptions(certificate *acm.CertificateDetail) ([]map[string]
 	var emailValidationResult []string
 
 	if *certificate.Type == acm.CertificateTypeAmazonIssued {
+		if len(certificate.DomainValidationOptions) == 0 {
+			log.Printf("[DEBUG] No validation options need to retry.")
+			return nil, nil, fmt.Errorf("No validation options need to retry.")
+		}
 		for _, o := range certificate.DomainValidationOptions {
 			if o.ResourceRecord != nil {
 				validationOption := map[string]interface{}{


### PR DESCRIPTION
When the DomainValidationOptions array is completely empty, retry the validation options retrieval.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9596 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Resolves certification validation issues in AWS ap-southeast-2 region where the DomainValidationOptions array may be initially returned by AWS as completely empty.
```

Output from acceptance testing:

```
$ AWS_DEFAULT_REGION=ap-southeast-2 make testacc TESTARGS='-run=TestAccAWSAcmCertificate_dnsValidation'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSAcmCertificate_dnsValidation -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSAcmCertificate_dnsValidation
=== PAUSE TestAccAWSAcmCertificate_dnsValidation
=== CONT  TestAccAWSAcmCertificate_dnsValidation
--- PASS: TestAccAWSAcmCertificate_dnsValidation (35.06s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       35.091s
```
