### PR TITLE
resource/aws_spot_fleet_request: Add ebs_block_device and root_block_device kms_key_id argument (support encryption on launch)

### DIFF
--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -99,6 +99,12 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 										Computed: true,
 										ForceNew: true,
 									},
+									"kms_key_id": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
 									"snapshot_id": {
 										Type:     schema.TypeString,
 										Optional: true,
@@ -159,8 +165,20 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 										Default:  true,
 										ForceNew: true,
 									},
+									"encrypted": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
 									"iops": {
 										Type:     schema.TypeInt,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
+									"kms_key_id": {
+										Type:     schema.TypeString,
 										Optional: true,
 										Computed: true,
 										ForceNew: true,
@@ -512,6 +530,10 @@ func readSpotFleetBlockDeviceMappingsFromConfig(
 				ebs.Encrypted = aws.Bool(v)
 			}
 
+			if v, ok := bd["kms_key_id"].(string); ok && v != "" {
+				ebs.KmsKeyId = aws.String(v)
+			}
+
 			if v, ok := bd["volume_size"].(int); ok && v != 0 {
 				ebs.VolumeSize = aws.Int64(int64(v))
 			}
@@ -551,6 +573,14 @@ func readSpotFleetBlockDeviceMappingsFromConfig(
 			bd := v.(map[string]interface{})
 			ebs := &ec2.EbsBlockDevice{
 				DeleteOnTermination: aws.Bool(bd["delete_on_termination"].(bool)),
+			}
+
+			if v, ok := bd["encrypted"].(bool); ok && v {
+				ebs.Encrypted = aws.Bool(v)
+			}
+
+			if v, ok := bd["kms_key_id"].(string); ok && v != "" {
+				ebs.KmsKeyId = aws.String(v)
 			}
 
 			if v, ok := bd["volume_size"].(int); ok && v != 0 {
@@ -1065,6 +1095,10 @@ func ebsBlockDevicesToSet(bdm []*ec2.BlockDeviceMapping, rootDevName *string) *s
 				m["encrypted"] = aws.BoolValue(ebs.Encrypted)
 			}
 
+			if ebs.KmsKeyId != nil {
+				m["kms_key_id"] = aws.StringValue(ebs.KmsKeyId)
+			}
+
 			if ebs.VolumeSize != nil {
 				m["volume_size"] = aws.Int64Value(ebs.VolumeSize)
 			}
@@ -1115,6 +1149,14 @@ func rootBlockDeviceToSet(
 				m := make(map[string]interface{})
 				if val.Ebs.DeleteOnTermination != nil {
 					m["delete_on_termination"] = aws.BoolValue(val.Ebs.DeleteOnTermination)
+				}
+
+				if val.Ebs.Encrypted != nil {
+					m["encrypted"] = aws.BoolValue(val.Ebs.Encrypted)
+				}
+
+				if val.Ebs.KmsKeyId != nil {
+					m["kms_key_id"] = aws.StringValue(val.Ebs.KmsKeyId)
 				}
 
 				if val.Ebs.VolumeSize != nil {


### PR DESCRIPTION
NOTE: No documentation updates because the `launch_specification` argument documentation points to the `aws_instance` resource documentation.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #8624

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_spot_fleet_request: Add ebs_block_device and root_block_device kms_key_id argument (support encryption on launch)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSSpotFleetRequest_associatePublicIpAddress (270.69s)
--- PASS: TestAccAWSSpotFleetRequest_basic (405.39s)
--- PASS: TestAccAWSSpotFleetRequest_changePriceForcesNewRequest (529.67s)
--- PASS: TestAccAWSSpotFleetRequest_diversifiedAllocation (327.08s)
--- PASS: TestAccAWSSpotFleetRequest_fleetType (261.37s)
--- PASS: TestAccAWSSpotFleetRequest_iamInstanceProfileArn (324.47s)
--- PASS: TestAccAWSSpotFleetRequest_instanceInterruptionBehavior (195.94s)
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDevice_KmsKeyId (142.16s)
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDevice_KmsKeyId (141.99s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList (334.76s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion (260.11s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList (262.82s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstancePools (327.36s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz (263.10s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet (260.47s)
--- PASS: TestAccAWSSpotFleetRequest_overriddingSpotPrice (263.28s)
--- PASS: TestAccAWSSpotFleetRequest_placementTenancy (68.47s)
--- PASS: TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy (517.31s)
--- PASS: TestAccAWSSpotFleetRequest_updateTargetCapacity (797.62s)
--- PASS: TestAccAWSSpotFleetRequest_withEBSDisk (404.38s)
--- PASS: TestAccAWSSpotFleetRequest_WithELBs (313.70s)
--- PASS: TestAccAWSSpotFleetRequest_withoutSpotPrice (263.82s)
--- PASS: TestAccAWSSpotFleetRequest_withTags (261.37s)
--- PASS: TestAccAWSSpotFleetRequest_WithTargetGroups (429.61s)
--- PASS: TestAccAWSSpotFleetRequest_withWeightedCapacity (334.88s)
```

