### PR TITLE
aws_api_gateway_authorizer: fix authorizer_result_ttl_in_seconds cache disable

### DIFF
--- a/aws/resource_aws_api_gateway_authorizer.go
+++ b/aws/resource_aws_api_gateway_authorizer.go
@@ -12,6 +12,8 @@ import (
 	"github.com/hashicorp/terraform/helper/validation"
 )
 
+const defaultAuthorizerTTL = 300
+
 func resourceAwsApiGatewayAuthorizer() *schema.Resource {
 	return &schema.Resource{
 		Create:        resourceAwsApiGatewayAuthorizerCreate,
@@ -57,6 +59,7 @@ func resourceAwsApiGatewayAuthorizer() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				ValidateFunc: validation.IntBetween(0, 3600),
+				Default:      defaultAuthorizerTTL,
 			},
 			"identity_validation_expression": {
 				Type:     schema.TypeString,
@@ -132,7 +135,13 @@ func resourceAwsApiGatewayAuthorizerRead(d *schema.ResourceData, meta interface{
 	log.Printf("[DEBUG] Received API Gateway Authorizer: %s", authorizer)
 
 	d.Set("authorizer_credentials", authorizer.AuthorizerCredentials)
-	d.Set("authorizer_result_ttl_in_seconds", authorizer.AuthorizerResultTtlInSeconds)
+
+	if authorizer.AuthorizerResultTtlInSeconds != nil {
+		d.Set("authorizer_result_ttl_in_seconds", authorizer.AuthorizerResultTtlInSeconds)
+	} else {
+		d.Set("authorizer_result_ttl_in_seconds", defaultAuthorizerTTL)
+	}
+
 	d.Set("authorizer_uri", authorizer.AuthorizerUri)
 	d.Set("identity_source", authorizer.IdentitySource)
 	d.Set("identity_validation_expression", authorizer.IdentityValidationExpression)

--- a/aws/resource_aws_api_gateway_authorizer_test.go
+++ b/aws/resource_aws_api_gateway_authorizer_test.go
@@ -43,8 +43,8 @@ func TestAccAWSAPIGatewayAuthorizer_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "type", "TOKEN"),
 					testAccCheckAWSAPIGatewayAuthorizerAuthorizerCredentials(&conf, expectedCreds),
 					resource.TestMatchResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_credentials", expectedCreds),
-					testAccCheckAWSAPIGatewayAuthorizerAuthorizerResultTtlInSeconds(&conf, nil),
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_result_ttl_in_seconds", "0"),
+					testAccCheckAWSAPIGatewayAuthorizerAuthorizerResultTtlInSeconds(&conf, aws.Int64(defaultAuthorizerTTL)),
+					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_result_ttl_in_seconds", "300"),
 					testAccCheckAWSAPIGatewayAuthorizerIdentityValidationExpression(&conf, nil),
 					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "identity_validation_expression", ""),
 				),
@@ -142,6 +142,54 @@ func TestAccAWSAPIGatewayAuthorizer_switchAuthType(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "type", "TOKEN"),
 					resource.TestMatchResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_uri", expectedAuthUri),
 					resource.TestMatchResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_credentials", expectedCreds),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayAuthorizer_switchAuthorizerTTL(t *testing.T) {
+	var conf apigateway.Authorizer
+	rString := acctest.RandString(7)
+	apiGatewayName := "tf-acctest-apigw-" + rString
+	authorizerName := "tf-acctest-igw-authorizer-" + rString
+	lambdaName := "tf-acctest-igw-auth-lambda-" + rString
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayAuthorizerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayAuthorizerConfig_lambda(apiGatewayName, authorizerName, lambdaName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayAuthorizerExists("aws_api_gateway_authorizer.acctest", &conf),
+					testAccCheckAWSAPIGatewayAuthorizerAuthorizerResultTtlInSeconds(&conf, aws.Int64(defaultAuthorizerTTL)),
+					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_result_ttl_in_seconds", "300"),
+				),
+			},
+			{
+				Config: testAccAWSAPIGatewayAuthorizerConfig_lambdaUpdate(apiGatewayName, authorizerName, lambdaName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayAuthorizerExists("aws_api_gateway_authorizer.acctest", &conf),
+					testAccCheckAWSAPIGatewayAuthorizerAuthorizerResultTtlInSeconds(&conf, aws.Int64(360)),
+					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_result_ttl_in_seconds", "360"),
+				),
+			},
+			{
+				Config: testAccAWSAPIGatewayAuthorizerConfig_lambdaNoCache(apiGatewayName, authorizerName, lambdaName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayAuthorizerExists("aws_api_gateway_authorizer.acctest", &conf),
+					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_result_ttl_in_seconds", "0"),
+					testAccCheckAWSAPIGatewayAuthorizerAuthorizerResultTtlInSeconds(&conf, aws.Int64(0)),
+				),
+			},
+			{
+				Config: testAccAWSAPIGatewayAuthorizerConfig_lambda(apiGatewayName, authorizerName, lambdaName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayAuthorizerExists("aws_api_gateway_authorizer.acctest", &conf),
+					testAccCheckAWSAPIGatewayAuthorizerAuthorizerResultTtlInSeconds(&conf, aws.Int64(defaultAuthorizerTTL)),
+					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_result_ttl_in_seconds", "300"),
 				),
 			},
 		},
@@ -431,6 +479,19 @@ resource "aws_api_gateway_authorizer" "acctest" {
   authorizer_uri = "${aws_lambda_function.authorizer.invoke_arn}"
   authorizer_credentials = "${aws_iam_role.invocation_role.arn}"
   authorizer_result_ttl_in_seconds = 360
+  identity_validation_expression = ".*"
+}
+`, authorizerName)
+}
+
+func testAccAWSAPIGatewayAuthorizerConfig_lambdaNoCache(apiGatewayName, authorizerName, lambdaName string) string {
+	return testAccAWSAPIGatewayAuthorizerConfig_baseLambda(apiGatewayName, lambdaName) + fmt.Sprintf(`
+resource "aws_api_gateway_authorizer" "acctest" {
+  name = "%s_modified"
+  rest_api_id = "${aws_api_gateway_rest_api.acctest.id}"
+  authorizer_uri = "${aws_lambda_function.authorizer.invoke_arn}"
+  authorizer_credentials = "${aws_iam_role.invocation_role.arn}"
+  authorizer_result_ttl_in_seconds = 0
   identity_validation_expression = ".*"
 }
 `, authorizerName)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

Null value for `authorizer_result_ttl_in_seconds` means that API Gateway will use default TTL for authorizer cache, which is 300. Provider was assuming that 0 and null values are the same, causing https://github.com/terraform-providers/terraform-provider-aws/issues/705, which made disabling authorization cache impossible. This PR fixes it.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAPIGatewayAuthorizer_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSAPIGatewayAuthorizer_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSAPIGatewayAuthorizer_basic
=== PAUSE TestAccAWSAPIGatewayAuthorizer_basic
=== CONT  TestAccAWSAPIGatewayAuthorizer_basic
--- PASS: TestAccAWSAPIGatewayAuthorizer_basic (55.13s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	55.172s

$ make testacc TESTARGS='-run=TestAccAWSAPIGatewayAuthorizer_switchAuthorizerTTL'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSAPIGatewayAuthorizer_switchAuthorizerTTL -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSAPIGatewayAuthorizer_switchAuthorizerTTL
=== PAUSE TestAccAWSAPIGatewayAuthorizer_switchAuthorizerTTL
=== CONT  TestAccAWSAPIGatewayAuthorizer_switchAuthorizerTTL
--- PASS: TestAccAWSAPIGatewayAuthorizer_switchAuthorizerTTL (91.47s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	91.513s
```
