### PR TITLE
Final retries after datasync resource timeout errors

### DIFF
--- a/aws/resource_aws_datasync_agent.go
+++ b/aws/resource_aws_datasync_agent.go
@@ -85,9 +85,10 @@ func resourceAwsDataSyncAgentCreate(d *schema.ResourceData, meta interface{}) er
 			return fmt.Errorf("error creating HTTP request: %s", err)
 		}
 
+		var response *http.Response
 		err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 			log.Printf("[DEBUG] Making HTTP request: %s", request.URL.String())
-			response, err := client.Do(request)
+			response, err = client.Do(request)
 			if err != nil {
 				if err, ok := err.(net.Error); ok {
 					errMessage := fmt.Errorf("error making HTTP request: %s", err)
@@ -96,24 +97,30 @@ func resourceAwsDataSyncAgentCreate(d *schema.ResourceData, meta interface{}) er
 				}
 				return resource.NonRetryableError(fmt.Errorf("error making HTTP request: %s", err))
 			}
-
-			log.Printf("[DEBUG] Received HTTP response: %#v", response)
-			if response.StatusCode != 302 {
-				return resource.NonRetryableError(fmt.Errorf("expected HTTP status code 302, received: %d", response.StatusCode))
-			}
-
-			redirectURL, err := response.Location()
-			if err != nil {
-				return resource.NonRetryableError(fmt.Errorf("error extracting HTTP Location header: %s", err))
-			}
-
-			activationKey = redirectURL.Query().Get("activationKey")
-
 			return nil
 		})
+		if isResourceTimeoutError(err) {
+			response, err = client.Do(request)
+		}
 		if err != nil {
 			return fmt.Errorf("error retrieving activation key from IP Address (%s): %s", agentIpAddress, err)
 		}
+		if response == nil {
+			return fmt.Errorf("Error retrieving response for activation key request: %s", err)
+		}
+
+		log.Printf("[DEBUG] Received HTTP response: %#v", response)
+		if response.StatusCode != 302 {
+			return fmt.Errorf("expected HTTP status code 302, received: %d", response.StatusCode)
+		}
+
+		redirectURL, err := response.Location()
+		if err != nil {
+			return fmt.Errorf("error extracting HTTP Location header: %s", err)
+		}
+
+		activationKey = redirectURL.Query().Get("activationKey")
+
 		if activationKey == "" {
 			return fmt.Errorf("empty activationKey received from IP Address: %s", agentIpAddress)
 		}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_datasync_agent: Final retries after timeouts creating datasync agent
* resource/aws_datasync_task: Final retry after timeout error creating datasync task
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSDataSyncAgent"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSDataSyncAgent -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSDataSyncAgent_basic
=== PAUSE TestAccAWSDataSyncAgent_basic
=== RUN   TestAccAWSDataSyncAgent_disappears
=== PAUSE TestAccAWSDataSyncAgent_disappears
=== RUN   TestAccAWSDataSyncAgent_AgentName
=== PAUSE TestAccAWSDataSyncAgent_AgentName
=== RUN   TestAccAWSDataSyncAgent_Tags
=== PAUSE TestAccAWSDataSyncAgent_Tags
=== CONT  TestAccAWSDataSyncAgent_basic
=== CONT  TestAccAWSDataSyncAgent_Tags
=== CONT  TestAccAWSDataSyncAgent_disappears
=== CONT  TestAccAWSDataSyncAgent_AgentName
--- PASS: TestAccAWSDataSyncAgent_disappears (213.36s)
--- PASS: TestAccAWSDataSyncAgent_basic (238.26s)
--- PASS: TestAccAWSDataSyncAgent_AgentName (254.93s)
--- PASS: TestAccAWSDataSyncAgent_Tags (310.25s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       312.021s

make testacc TESTARGS="-run=TestAccAWSDataSyncTask"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSDataSyncTask -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSDataSyncTask_basic
=== PAUSE TestAccAWSDataSyncTask_basic
=== RUN   TestAccAWSDataSyncTask_disappears
=== PAUSE TestAccAWSDataSyncTask_disappears
=== RUN   TestAccAWSDataSyncTask_CloudWatchLogGroupARN
=== PAUSE TestAccAWSDataSyncTask_CloudWatchLogGroupARN
=== RUN   TestAccAWSDataSyncTask_DefaultSyncOptions_AtimeMtime
=== PAUSE TestAccAWSDataSyncTask_DefaultSyncOptions_AtimeMtime
=== RUN   TestAccAWSDataSyncTask_DefaultSyncOptions_BytesPerSecond
=== PAUSE TestAccAWSDataSyncTask_DefaultSyncOptions_BytesPerSecond
=== RUN   TestAccAWSDataSyncTask_DefaultSyncOptions_Gid
=== PAUSE TestAccAWSDataSyncTask_DefaultSyncOptions_Gid
=== RUN   TestAccAWSDataSyncTask_DefaultSyncOptions_PosixPermissions
=== PAUSE TestAccAWSDataSyncTask_DefaultSyncOptions_PosixPermissions
=== RUN   TestAccAWSDataSyncTask_DefaultSyncOptions_PreserveDeletedFiles
=== PAUSE TestAccAWSDataSyncTask_DefaultSyncOptions_PreserveDeletedFiles
=== RUN   TestAccAWSDataSyncTask_DefaultSyncOptions_PreserveDevices
=== PAUSE TestAccAWSDataSyncTask_DefaultSyncOptions_PreserveDevices
=== RUN   TestAccAWSDataSyncTask_DefaultSyncOptions_Uid
=== PAUSE TestAccAWSDataSyncTask_DefaultSyncOptions_Uid
=== RUN   TestAccAWSDataSyncTask_DefaultSyncOptions_VerifyMode
=== PAUSE TestAccAWSDataSyncTask_DefaultSyncOptions_VerifyMode
=== RUN   TestAccAWSDataSyncTask_Tags
--- SKIP: TestAccAWSDataSyncTask_Tags (0.00s)
    resource_aws_datasync_task_test.go:460: Tagging on creation is inconsistent
=== CONT  TestAccAWSDataSyncTask_basic
=== CONT  TestAccAWSDataSyncTask_DefaultSyncOptions_Gid
=== CONT  TestAccAWSDataSyncTask_CloudWatchLogGroupARN
=== CONT  TestAccAWSDataSyncTask_disappears
=== CONT  TestAccAWSDataSyncTask_DefaultSyncOptions_VerifyMode
=== CONT  TestAccAWSDataSyncTask_DefaultSyncOptions_Uid
=== CONT  TestAccAWSDataSyncTask_DefaultSyncOptions_PreserveDevices
=== CONT  TestAccAWSDataSyncTask_DefaultSyncOptions_AtimeMtime
=== CONT  TestAccAWSDataSyncTask_DefaultSyncOptions_PreserveDeletedFiles
=== CONT  TestAccAWSDataSyncTask_DefaultSyncOptions_BytesPerSecond
=== CONT  TestAccAWSDataSyncTask_DefaultSyncOptions_PosixPermissions
--- PASS: TestAccAWSDataSyncTask_disappears (288.40s)
--- PASS: TestAccAWSDataSyncTask_CloudWatchLogGroupARN (544.45s)
--- PASS: TestAccAWSDataSyncTask_DefaultSyncOptions_Uid (563.63s)
--- PASS: TestAccAWSDataSyncTask_DefaultSyncOptions_PreserveDeletedFiles (591.44s)
--- PASS: TestAccAWSDataSyncTask_DefaultSyncOptions_Gid (592.86s)
--- PASS: TestAccAWSDataSyncTask_DefaultSyncOptions_PreserveDevices (593.28s)
--- PASS: TestAccAWSDataSyncTask_basic (593.88s)
--- PASS: TestAccAWSDataSyncTask_DefaultSyncOptions_BytesPerSecond (594.44s)
--- PASS: TestAccAWSDataSyncTask_DefaultSyncOptions_AtimeMtime (600.14s)
--- PASS: TestAccAWSDataSyncTask_DefaultSyncOptions_PosixPermissions (600.42s)
--- PASS: TestAccAWSDataSyncTask_DefaultSyncOptions_VerifyMode (616.75s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       617.601s
```