### PR TITLE
Detecting drift on aws_lb_target_group_attachment

### DIFF
--- a/aws/resource_aws_lb_target_group_attachment.go
+++ b/aws/resource_aws_lb_target_group_attachment.go
@@ -2,12 +2,11 @@ package aws
 
 import (
 	"fmt"
-	"log"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"log"
 )
 
 func resourceAwsLbTargetGroupAttachment() *schema.Resource {

--- a/aws/resource_aws_lb_target_group_attachment.go
+++ b/aws/resource_aws_lb_target_group_attachment.go
@@ -126,6 +126,7 @@ func resourceAwsLbAttachmentRead(d *schema.ResourceData, meta interface{}) error
 		TargetGroupArn: aws.String(d.Get("target_group_arn").(string)),
 		Targets:        []*elbv2.TargetDescription{target},
 	})
+
 	if err != nil {
 		if isAWSErr(err, elbv2.ErrCodeTargetGroupNotFoundException, "") {
 			log.Printf("[WARN] Target group does not exist, removing target attachment %s", d.Id())
@@ -138,6 +139,16 @@ func resourceAwsLbAttachmentRead(d *schema.ResourceData, meta interface{}) error
 			return nil
 		}
 		return fmt.Errorf("Error reading Target Health: %s", err)
+	}
+
+	for _, targetDesc := range resp.TargetHealthDescriptions {
+		if *targetDesc.Target.Id == d.Get("target_id").(string) {
+			if (*targetDesc.TargetHealth.State == "unused") || (*targetDesc.TargetHealth.State == "draining") {
+				log.Printf("[WARN] Target Attachment does not exist, recreating attachment")
+				d.SetId("")
+				return nil
+			}
+		}
 	}
 
 	if len(resp.TargetHealthDescriptions) != 1 {

--- a/aws/resource_aws_lb_target_group_attachment.go
+++ b/aws/resource_aws_lb_target_group_attachment.go
@@ -143,7 +143,10 @@ func resourceAwsLbAttachmentRead(d *schema.ResourceData, meta interface{}) error
 
 	for _, targetDesc := range resp.TargetHealthDescriptions {
 		if *targetDesc.Target.Id == d.Get("target_id").(string) {
-			if (*targetDesc.TargetHealth.State == "unused") || (*targetDesc.TargetHealth.State == "draining") {
+			// These will catch targets being removed by hand (draining as we plan) or that have been removed for a while
+			// without trying to re-create ones that are just not in use. For example, a target can be `unused` if the
+			// target group isnt assigned to anything, a scenario where we don't want to continuously recreate the resource.
+			if (*targetDesc.TargetHealth.Reason == "Target.NotRegistered") || (*targetDesc.TargetHealth.Reason == "Target.DeregistrationInProgress") {
 				log.Printf("[WARN] Target Attachment does not exist, recreating attachment")
 				d.SetId("")
 				return nil

--- a/aws/resource_aws_lb_target_group_attachment_test.go
+++ b/aws/resource_aws_lb_target_group_attachment_test.go
@@ -3,14 +3,13 @@ package aws
 import (
 	"errors"
 	"fmt"
-	"strconv"
-	"testing"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-
+	"strconv"
+	"testing"
 )
 
 func TestAccAWSLBTargetGroupAttachment_basic(t *testing.T) {

--- a/aws/resource_aws_lb_target_group_attachment_test.go
+++ b/aws/resource_aws_lb_target_group_attachment_test.go
@@ -3,13 +3,14 @@ package aws
 import (
 	"errors"
 	"fmt"
+	"strconv"
+	"testing"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"strconv"
-	"testing"
+
 )
 
 func TestAccAWSLBTargetGroupAttachment_basic(t *testing.T) {

--- a/aws/resource_aws_lb_target_group_attachment_test.go
+++ b/aws/resource_aws_lb_target_group_attachment_test.go
@@ -245,7 +245,7 @@ resource "aws_lb_target_group_attachment" "test" {
 }
 
 resource "aws_instance" "test" {
-  ami           = "ami-0d8e27447ec2c8410"
+  ami           = "ami-f701cb97"
   instance_type = "t2.micro"
   subnet_id     = "${aws_subnet.subnet.id}"
 }
@@ -302,7 +302,7 @@ resource "aws_lb_target_group_attachment" "test" {
 }
 
 resource "aws_instance" "test" {
-  ami           = "ami-0d8e27447ec2c8410"
+  ami           = "ami-f701cb97"
   instance_type = "t2.micro"
   subnet_id     = "${aws_subnet.subnet.id}"
 }
@@ -359,7 +359,7 @@ resource "aws_alb_target_group_attachment" "test" {
 }
 
 resource "aws_instance" "test" {
-  ami           = "ami-0d8e27447ec2c8410"
+  ami           = "ami-f701cb97"
   instance_type = "t2.micro"
   subnet_id     = "${aws_subnet.subnet.id}"
 }
@@ -416,7 +416,7 @@ resource "aws_lb_target_group_attachment" "test" {
 }
 
 resource "aws_instance" "test" {
-  ami           = "ami-0d8e27447ec2c8410"
+  ami           = "ami-f701cb97"
   instance_type = "t2.micro"
   subnet_id     = "${aws_subnet.subnet.id}"
 }

--- a/aws/resource_aws_lb_target_group_attachment_test.go
+++ b/aws/resource_aws_lb_target_group_attachment_test.go
@@ -251,7 +251,7 @@ resource "aws_lb_target_group_attachment" "test" {
 }
 
 resource "aws_instance" "test" {
-  ami           = "ami-0bdfa1adc3878cd23"
+  ami           = "ami-f701cb97"
   instance_type = "t2.micro"
   subnet_id     = "${aws_subnet.subnet.id}"
 }
@@ -308,7 +308,7 @@ resource "aws_lb_target_group_attachment" "test" {
 }
 
 resource "aws_instance" "test" {
-  ami           = "ami-0bdfa1adc3878cd23"
+  ami           = "ami-f701cb97"
   instance_type = "t2.micro"
   subnet_id     = "${aws_subnet.subnet.id}"
 }
@@ -365,7 +365,7 @@ resource "aws_alb_target_group_attachment" "test" {
 }
 
 resource "aws_instance" "test" {
-  ami           = "ami-0bdfa1adc3878cd23"
+  ami           = "ami-f701cb97"
   instance_type = "t2.micro"
   subnet_id     = "${aws_subnet.subnet.id}"
 }
@@ -422,7 +422,7 @@ resource "aws_lb_target_group_attachment" "test" {
 }
 
 resource "aws_instance" "test" {
-  ami           = "ami-0bdfa1adc3878cd23"
+  ami           = "ami-f701cb97"
   instance_type = "t2.micro"
   subnet_id     = "${aws_subnet.subnet.id}"
 }

--- a/aws/resource_aws_lb_target_group_attachment_test.go
+++ b/aws/resource_aws_lb_target_group_attachment_test.go
@@ -3,13 +3,14 @@ package aws
 import (
 	"errors"
 	"fmt"
+	"strconv"
+	"testing"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"strconv"
-	"testing"
 )
 
 func TestAccAWSLBTargetGroupAttachment_basic(t *testing.T) {
@@ -250,7 +251,7 @@ resource "aws_lb_target_group_attachment" "test" {
 }
 
 resource "aws_instance" "test" {
-  ami           = "ami-f701cb97"
+  ami           = "ami-0bdfa1adc3878cd23"
   instance_type = "t2.micro"
   subnet_id     = "${aws_subnet.subnet.id}"
 }
@@ -307,7 +308,7 @@ resource "aws_lb_target_group_attachment" "test" {
 }
 
 resource "aws_instance" "test" {
-  ami           = "ami-f701cb97"
+  ami           = "ami-0bdfa1adc3878cd23"
   instance_type = "t2.micro"
   subnet_id     = "${aws_subnet.subnet.id}"
 }
@@ -364,7 +365,7 @@ resource "aws_alb_target_group_attachment" "test" {
 }
 
 resource "aws_instance" "test" {
-  ami           = "ami-f701cb97"
+  ami           = "ami-0bdfa1adc3878cd23"
   instance_type = "t2.micro"
   subnet_id     = "${aws_subnet.subnet.id}"
 }
@@ -421,7 +422,7 @@ resource "aws_lb_target_group_attachment" "test" {
 }
 
 resource "aws_instance" "test" {
-  ami           = "ami-f701cb97"
+  ami           = "ami-0bdfa1adc3878cd23"
   instance_type = "t2.micro"
   subnet_id     = "${aws_subnet.subnet.id}"
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #5605

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_lb_target_group_attachment: perform drift detection on lb target group attachments. Target attachments defined in TF that are either unregistered or in the process of being drained will be raised in a plan/apply. Targets that are registered but *not in use* will not be picked up.
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSLBTargetGroupAttachment'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSLBTargetGroupAttachment -timeout 120m
=== RUN   TestAccAWSLBTargetGroupAttachment_basic
=== PAUSE TestAccAWSLBTargetGroupAttachment_basic
=== RUN   TestAccAWSLBTargetGroupAttachment_missingAttachmentDrift
=== PAUSE TestAccAWSLBTargetGroupAttachment_missingAttachmentDrift
=== RUN   TestAccAWSLBTargetGroupAttachmentBackwardsCompatibility
=== PAUSE TestAccAWSLBTargetGroupAttachmentBackwardsCompatibility
=== RUN   TestAccAWSLBTargetGroupAttachment_withoutPort
=== PAUSE TestAccAWSLBTargetGroupAttachment_withoutPort
=== CONT  TestAccAWSLBTargetGroupAttachment_basic
=== CONT  TestAccAWSLBTargetGroupAttachment_withoutPort
=== CONT  TestAccAWSLBTargetGroupAttachmentBackwardsCompatibility
=== CONT  TestAccAWSLBTargetGroupAttachment_missingAttachmentDrift
--- PASS: TestAccAWSLBTargetGroupAttachment_missingAttachmentDrift (107.79s)
--- PASS: TestAccAWSLBTargetGroupAttachment_withoutPort (109.34s)
--- PASS: TestAccAWSLBTargetGroupAttachmentBackwardsCompatibility (109.73s)
--- PASS: TestAccAWSLBTargetGroupAttachment_basic (111.81s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	111.866s
...
```