### PR TITLE
Feature/add support resource import for aws wafregional geo match set resource

### DIFF
--- a/aws/resource_aws_wafregional_geo_match_set.go
+++ b/aws/resource_aws_wafregional_geo_match_set.go
@@ -16,6 +16,9 @@ func resourceAwsWafRegionalGeoMatchSet() *schema.Resource {
 		Read:   resourceAwsWafRegionalGeoMatchSetRead,
 		Update: resourceAwsWafRegionalGeoMatchSetUpdate,
 		Delete: resourceAwsWafRegionalGeoMatchSetDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/aws/resource_aws_wafregional_geo_match_set.go
+++ b/aws/resource_aws_wafregional_geo_match_set.go
@@ -76,16 +76,14 @@ func resourceAwsWafRegionalGeoMatchSetRead(d *schema.ResourceData, meta interfac
 	}
 
 	resp, err := conn.GetGeoMatchSet(params)
-	if err != nil {
-		// TODO: Replace with constant once it's available
-		// See https://github.com/aws/aws-sdk-go/issues/1856
-		if isAWSErr(err, "WAFNonexistentItemException", "") {
-			log.Printf("[WARN] WAF WAF Regional Geo Match Set (%s) not found, removing from state", d.Id())
-			d.SetId("")
-			return nil
-		}
 
-		return err
+	if isAWSErr(err, wafregional.ErrCodeWAFNonexistentItemException, "") {
+		log.Printf("[WARN] WAF WAF Regional Geo Match Set (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error getting WAF Regional Geo Match Set (%s): %s", d.Id(), err)
 	}
 
 	d.Set("name", resp.GeoMatchSet.Name)
@@ -103,8 +101,13 @@ func resourceAwsWafRegionalGeoMatchSetUpdate(d *schema.ResourceData, meta interf
 		oldConstraints, newConstraints := o.(*schema.Set).List(), n.(*schema.Set).List()
 
 		err := updateGeoMatchSetResourceWR(d.Id(), oldConstraints, newConstraints, conn, region)
+		if isAWSErr(err, wafregional.ErrCodeWAFNonexistentItemException, "") {
+			log.Printf("[WARN] WAF WAF Regional Geo Match Set (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
 		if err != nil {
-			return fmt.Errorf("Failed updating WAF Regional Geo Match Set: %s", err)
+			return fmt.Errorf("Failed updating WAF Regional Geo Match Set(%s): %s", d.Id(), err)
 		}
 	}
 
@@ -133,8 +136,11 @@ func resourceAwsWafRegionalGeoMatchSetDelete(d *schema.ResourceData, meta interf
 
 		return conn.DeleteGeoMatchSet(req)
 	})
+	if isAWSErr(err, wafregional.ErrCodeWAFNonexistentItemException, "") {
+		return nil
+	}
 	if err != nil {
-		return fmt.Errorf("Failed deleting WAF Regional Geo Match Set: %s", err)
+		return fmt.Errorf("Failed deleting WAF Regional Geo Match Set(%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_wafregional_geo_match_set_test.go
+++ b/aws/resource_aws_wafregional_geo_match_set_test.go
@@ -13,6 +13,7 @@ import (
 
 func TestAccAWSWafRegionalGeoMatchSet_basic(t *testing.T) {
 	var v waf.GeoMatchSet
+	resourceName := "aws_wafregional_geo_match_set.test"
 	geoMatchSet := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -23,20 +24,25 @@ func TestAccAWSWafRegionalGeoMatchSet_basic(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalGeoMatchSetConfig(geoMatchSet),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalGeoMatchSetExists("aws_wafregional_geo_match_set.test", &v),
+					testAccCheckAWSWafRegionalGeoMatchSetExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_geo_match_set.test", "name", geoMatchSet),
+						resourceName, "name", geoMatchSet),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_geo_match_set.test", "geo_match_constraint.#", "2"),
+						resourceName, "geo_match_constraint.#", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_geo_match_set.test", "geo_match_constraint.384465307.type", "Country"),
+						resourceName, "geo_match_constraint.384465307.type", "Country"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_geo_match_set.test", "geo_match_constraint.384465307.value", "US"),
+						resourceName, "geo_match_constraint.384465307.value", "US"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_geo_match_set.test", "geo_match_constraint.1991628426.type", "Country"),
+						resourceName, "geo_match_constraint.1991628426.type", "Country"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_geo_match_set.test", "geo_match_constraint.1991628426.value", "CA"),
+						resourceName, "geo_match_constraint.1991628426.value", "CA"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -44,6 +50,7 @@ func TestAccAWSWafRegionalGeoMatchSet_basic(t *testing.T) {
 
 func TestAccAWSWafRegionalGeoMatchSet_changeNameForceNew(t *testing.T) {
 	var before, after waf.GeoMatchSet
+	resourceName := "aws_wafregional_geo_match_set.test"
 	geoMatchSet := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
 	geoMatchSetNewName := fmt.Sprintf("geoMatchSetNewName-%s", acctest.RandString(5))
 
@@ -55,23 +62,28 @@ func TestAccAWSWafRegionalGeoMatchSet_changeNameForceNew(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalGeoMatchSetConfig(geoMatchSet),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalGeoMatchSetExists("aws_wafregional_geo_match_set.test", &before),
+					testAccCheckAWSWafRegionalGeoMatchSetExists(resourceName, &before),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_geo_match_set.test", "name", geoMatchSet),
+						resourceName, "name", geoMatchSet),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_geo_match_set.test", "geo_match_constraint.#", "2"),
+						resourceName, "geo_match_constraint.#", "2"),
 				),
 			},
 			{
 				Config: testAccAWSWafRegionalGeoMatchSetConfigChangeName(geoMatchSetNewName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalGeoMatchSetExists("aws_wafregional_geo_match_set.test", &after),
+					testAccCheckAWSWafRegionalGeoMatchSetExists(resourceName, &after),
 					testAccCheckAWSWafGeoMatchSetIdDiffers(&before, &after),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_geo_match_set.test", "name", geoMatchSetNewName),
+						resourceName, "name", geoMatchSetNewName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_geo_match_set.test", "geo_match_constraint.#", "2"),
+						resourceName, "geo_match_constraint.#", "2"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -79,6 +91,7 @@ func TestAccAWSWafRegionalGeoMatchSet_changeNameForceNew(t *testing.T) {
 
 func TestAccAWSWafRegionalGeoMatchSet_disappears(t *testing.T) {
 	var v waf.GeoMatchSet
+	resourceName := "aws_wafregional_geo_match_set.test"
 	geoMatchSet := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -89,7 +102,7 @@ func TestAccAWSWafRegionalGeoMatchSet_disappears(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalGeoMatchSetConfig(geoMatchSet),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalGeoMatchSetExists("aws_wafregional_geo_match_set.test", &v),
+					testAccCheckAWSWafRegionalGeoMatchSetExists(resourceName, &v),
 					testAccCheckAWSWafRegionalGeoMatchSetDisappears(&v),
 				),
 				ExpectNonEmptyPlan: true,
@@ -100,6 +113,7 @@ func TestAccAWSWafRegionalGeoMatchSet_disappears(t *testing.T) {
 
 func TestAccAWSWafRegionalGeoMatchSet_changeConstraints(t *testing.T) {
 	var before, after waf.GeoMatchSet
+	resourceName := "aws_wafregional_geo_match_set.test"
 	setName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -110,38 +124,43 @@ func TestAccAWSWafRegionalGeoMatchSet_changeConstraints(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalGeoMatchSetConfig(setName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafRegionalGeoMatchSetExists("aws_wafregional_geo_match_set.test", &before),
+					testAccCheckAWSWafRegionalGeoMatchSetExists(resourceName, &before),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_geo_match_set.test", "name", setName),
+						resourceName, "name", setName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_geo_match_set.test", "geo_match_constraint.#", "2"),
+						resourceName, "geo_match_constraint.#", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_geo_match_set.test", "geo_match_constraint.384465307.type", "Country"),
+						resourceName, "geo_match_constraint.384465307.type", "Country"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_geo_match_set.test", "geo_match_constraint.384465307.value", "US"),
+						resourceName, "geo_match_constraint.384465307.value", "US"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_geo_match_set.test", "geo_match_constraint.1991628426.type", "Country"),
+						resourceName, "geo_match_constraint.1991628426.type", "Country"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_geo_match_set.test", "geo_match_constraint.1991628426.value", "CA"),
+						resourceName, "geo_match_constraint.1991628426.value", "CA"),
 				),
 			},
 			{
 				Config: testAccAWSWafRegionalGeoMatchSetConfig_changeConstraints(setName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafRegionalGeoMatchSetExists("aws_wafregional_geo_match_set.test", &after),
+					testAccCheckAWSWafRegionalGeoMatchSetExists(resourceName, &after),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_geo_match_set.test", "name", setName),
+						resourceName, "name", setName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_geo_match_set.test", "geo_match_constraint.#", "2"),
+						resourceName, "geo_match_constraint.#", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_geo_match_set.test", "geo_match_constraint.1174390936.type", "Country"),
+						resourceName, "geo_match_constraint.1174390936.type", "Country"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_geo_match_set.test", "geo_match_constraint.1174390936.value", "RU"),
+						resourceName, "geo_match_constraint.1174390936.value", "RU"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_geo_match_set.test", "geo_match_constraint.4046309957.type", "Country"),
+						resourceName, "geo_match_constraint.4046309957.type", "Country"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_geo_match_set.test", "geo_match_constraint.4046309957.value", "CN"),
+						resourceName, "geo_match_constraint.4046309957.value", "CN"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -149,6 +168,7 @@ func TestAccAWSWafRegionalGeoMatchSet_changeConstraints(t *testing.T) {
 
 func TestAccAWSWafRegionalGeoMatchSet_noConstraints(t *testing.T) {
 	var ipset waf.GeoMatchSet
+	resourceName := "aws_wafregional_geo_match_set.test"
 	setName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -159,12 +179,17 @@ func TestAccAWSWafRegionalGeoMatchSet_noConstraints(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalGeoMatchSetConfig_noConstraints(setName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafRegionalGeoMatchSetExists("aws_wafregional_geo_match_set.test", &ipset),
+					testAccCheckAWSWafRegionalGeoMatchSetExists(resourceName, &ipset),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_geo_match_set.test", "name", setName),
+						resourceName, "name", setName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_geo_match_set.test", "geo_match_constraint.#", "0"),
+						resourceName, "geo_match_constraint.#", "0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/website/docs/r/wafregional_geo_match_set.html.markdown
+++ b/website/docs/r/wafregional_geo_match_set.html.markdown
@@ -51,3 +51,11 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the WAF Regional Geo Match Set.
+
+## Import
+
+WAF Regional Geo Match Set can be imported using the id, e.g.
+
+```
+$ terraform import aws_wafregional_geo_match_set.geo_match_set a1b2c3d4-d5f6-7777-8888-9999aaaabbbbcccc
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #9212

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_wafregional_geo_match_set: Support resource import
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSWafRegionalGeoMatchSet_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSWafRegionalGeoMatchSet_ -timeout 120m
=== RUN   TestAccAWSWafRegionalGeoMatchSet_basic
=== PAUSE TestAccAWSWafRegionalGeoMatchSet_basic
=== RUN   TestAccAWSWafRegionalGeoMatchSet_changeNameForceNew
=== PAUSE TestAccAWSWafRegionalGeoMatchSet_changeNameForceNew
=== RUN   TestAccAWSWafRegionalGeoMatchSet_disappears
=== PAUSE TestAccAWSWafRegionalGeoMatchSet_disappears
=== RUN   TestAccAWSWafRegionalGeoMatchSet_changeConstraints
=== PAUSE TestAccAWSWafRegionalGeoMatchSet_changeConstraints
=== RUN   TestAccAWSWafRegionalGeoMatchSet_noConstraints
=== PAUSE TestAccAWSWafRegionalGeoMatchSet_noConstraints
=== CONT  TestAccAWSWafRegionalGeoMatchSet_basic
=== CONT  TestAccAWSWafRegionalGeoMatchSet_changeConstraints
=== CONT  TestAccAWSWafRegionalGeoMatchSet_noConstraints
=== CONT  TestAccAWSWafRegionalGeoMatchSet_disappears
=== CONT  TestAccAWSWafRegionalGeoMatchSet_changeNameForceNew
--- PASS: TestAccAWSWafRegionalGeoMatchSet_noConstraints (45.82s)
--- PASS: TestAccAWSWafRegionalGeoMatchSet_disappears (46.75s)
--- PASS: TestAccAWSWafRegionalGeoMatchSet_basic (53.18s)
--- PASS: TestAccAWSWafRegionalGeoMatchSet_changeConstraints (70.30s)
--- PASS: TestAccAWSWafRegionalGeoMatchSet_changeNameForceNew (78.97s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	79.070s
```
