### PR TITLE
Add support resource import for aws wafregional rate based rule resource

### DIFF
--- a/aws/resource_aws_wafregional_rate_based_rule.go
+++ b/aws/resource_aws_wafregional_rate_based_rule.go
@@ -17,6 +17,9 @@ func resourceAwsWafRegionalRateBasedRule() *schema.Resource {
 		Read:   resourceAwsWafRegionalRateBasedRuleRead,
 		Update: resourceAwsWafRegionalRateBasedRuleUpdate,
 		Delete: resourceAwsWafRegionalRateBasedRuleDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/aws/resource_aws_wafregional_rate_based_rule.go
+++ b/aws/resource_aws_wafregional_rate_based_rule.go
@@ -82,7 +82,7 @@ func resourceAwsWafRegionalRateBasedRuleCreate(d *schema.ResourceData, meta inte
 		return conn.CreateRateBasedRule(params)
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("Error creating WAF Regional Rate Based Rule (%s): %s", d.Id(), err)
 	}
 	resp := out.(*waf.CreateRateBasedRuleOutput)
 	d.SetId(*resp.Rule.RuleId)
@@ -97,14 +97,13 @@ func resourceAwsWafRegionalRateBasedRuleRead(d *schema.ResourceData, meta interf
 	}
 
 	resp, err := conn.GetRateBasedRule(params)
+	if isAWSErr(err, wafregional.ErrCodeWAFNonexistentItemException, "") {
+		log.Printf("[WARN] WAF Regional Rate Based Rule (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
 	if err != nil {
-		if isAWSErr(err, wafregional.ErrCodeWAFNonexistentItemException, "") {
-			log.Printf("[WARN] WAF Regional Rate Based Rule (%s) not found, removing from state", d.Id())
-			d.SetId("")
-			return nil
-		}
-
-		return err
+		return fmt.Errorf("Error getting WAF Regional Rate Based Rule (%s): %s", d.Id(), err)
 	}
 
 	var predicates []map[string]interface{}
@@ -136,8 +135,13 @@ func resourceAwsWafRegionalRateBasedRuleUpdate(d *schema.ResourceData, meta inte
 		rateLimit := d.Get("rate_limit")
 
 		err := updateWafRateBasedRuleResourceWR(d.Id(), oldP, newP, rateLimit, conn, region)
+		if isAWSErr(err, wafregional.ErrCodeWAFNonexistentItemException, "") {
+			log.Printf("[WARN] WAF Regional Rate Based Rule (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
 		if err != nil {
-			return fmt.Errorf("Error Updating WAF Rule: %s", err)
+			return fmt.Errorf("Error updating WAF Regional Rate Based Rule Predicates (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -154,8 +158,11 @@ func resourceAwsWafRegionalRateBasedRuleDelete(d *schema.ResourceData, meta inte
 		rateLimit := d.Get("rate_limit")
 
 		err := updateWafRateBasedRuleResourceWR(d.Id(), oldPredicates, noPredicates, rateLimit, conn, region)
+		if isAWSErr(err, wafregional.ErrCodeWAFNonexistentItemException, "") {
+			return nil
+		}
 		if err != nil {
-			return fmt.Errorf("Error updating WAF Regional Rate Based Rule Predicates: %s", err)
+			return fmt.Errorf("Error updating WAF Regional Rate Based Rule Predicates (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -168,8 +175,11 @@ func resourceAwsWafRegionalRateBasedRuleDelete(d *schema.ResourceData, meta inte
 		log.Printf("[INFO] Deleting WAF Regional Rate Based Rule")
 		return conn.DeleteRateBasedRule(req)
 	})
+	if isAWSErr(err, wafregional.ErrCodeWAFNonexistentItemException, "") {
+		return nil
+	}
 	if err != nil {
-		return fmt.Errorf("Error deleting WAF Regional Rate Based Rule: %s", err)
+		return fmt.Errorf("Error deleting WAF Regional Rate Based Rule (%s): %s", d.Id(), err)
 	}
 
 	return nil
@@ -187,9 +197,6 @@ func updateWafRateBasedRuleResourceWR(id string, oldP, newP []interface{}, rateL
 
 		return conn.UpdateRateBasedRule(req)
 	})
-	if err != nil {
-		return fmt.Errorf("Error Updating WAF Regional Rate Based Rule: %s", err)
-	}
 
-	return nil
+	return err
 }

--- a/aws/resource_aws_wafregional_rate_based_rule_test.go
+++ b/aws/resource_aws_wafregional_rate_based_rule_test.go
@@ -119,6 +119,7 @@ func testSweepWafRegionalRateBasedRules(region string) error {
 
 func TestAccAWSWafRegionalRateBasedRule_basic(t *testing.T) {
 	var v waf.RateBasedRule
+	resourceName := "aws_wafregional_rate_based_rule.wafrule"
 	wafRuleName := fmt.Sprintf("wafrule%s", acctest.RandString(5))
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -128,14 +129,19 @@ func TestAccAWSWafRegionalRateBasedRule_basic(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalRateBasedRuleConfig(wafRuleName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalRateBasedRuleExists("aws_wafregional_rate_based_rule.wafrule", &v),
+					testAccCheckAWSWafRegionalRateBasedRuleExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_rate_based_rule.wafrule", "name", wafRuleName),
+						resourceName, "name", wafRuleName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_rate_based_rule.wafrule", "predicate.#", "1"),
+						resourceName, "predicate.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_rate_based_rule.wafrule", "metric_name", wafRuleName),
+						resourceName, "metric_name", wafRuleName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -143,6 +149,7 @@ func TestAccAWSWafRegionalRateBasedRule_basic(t *testing.T) {
 
 func TestAccAWSWafRegionalRateBasedRule_changeNameForceNew(t *testing.T) {
 	var before, after waf.RateBasedRule
+	resourceName := "aws_wafregional_rate_based_rule.wafrule"
 	wafRuleName := fmt.Sprintf("wafrule%s", acctest.RandString(5))
 	wafRuleNewName := fmt.Sprintf("wafrulenew%s", acctest.RandString(5))
 
@@ -154,27 +161,32 @@ func TestAccAWSWafRegionalRateBasedRule_changeNameForceNew(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalRateBasedRuleConfig(wafRuleName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalRateBasedRuleExists("aws_wafregional_rate_based_rule.wafrule", &before),
+					testAccCheckAWSWafRegionalRateBasedRuleExists(resourceName, &before),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_rate_based_rule.wafrule", "name", wafRuleName),
+						resourceName, "name", wafRuleName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_rate_based_rule.wafrule", "predicate.#", "1"),
+						resourceName, "predicate.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_rate_based_rule.wafrule", "metric_name", wafRuleName),
+						resourceName, "metric_name", wafRuleName),
 				),
 			},
 			{
 				Config: testAccAWSWafRegionalRateBasedRuleConfigChangeName(wafRuleNewName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalRateBasedRuleExists("aws_wafregional_rate_based_rule.wafrule", &after),
+					testAccCheckAWSWafRegionalRateBasedRuleExists(resourceName, &after),
 					testAccCheckAWSWafRateBasedRuleIdDiffers(&before, &after),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_rate_based_rule.wafrule", "name", wafRuleNewName),
+						resourceName, "name", wafRuleNewName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_rate_based_rule.wafrule", "predicate.#", "1"),
+						resourceName, "predicate.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_rate_based_rule.wafrule", "metric_name", wafRuleNewName),
+						resourceName, "metric_name", wafRuleNewName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -182,6 +194,7 @@ func TestAccAWSWafRegionalRateBasedRule_changeNameForceNew(t *testing.T) {
 
 func TestAccAWSWafRegionalRateBasedRule_disappears(t *testing.T) {
 	var v waf.RateBasedRule
+	resourceName := "aws_wafregional_rate_based_rule.wafrule"
 	wafRuleName := fmt.Sprintf("wafrule%s", acctest.RandString(5))
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -191,7 +204,7 @@ func TestAccAWSWafRegionalRateBasedRule_disappears(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalRateBasedRuleConfig(wafRuleName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalRateBasedRuleExists("aws_wafregional_rate_based_rule.wafrule", &v),
+					testAccCheckAWSWafRegionalRateBasedRuleExists(resourceName, &v),
 					testAccCheckAWSWafRegionalRateBasedRuleDisappears(&v),
 				),
 				ExpectNonEmptyPlan: true,
@@ -206,6 +219,7 @@ func TestAccAWSWafRegionalRateBasedRule_changePredicates(t *testing.T) {
 
 	var before, after waf.RateBasedRule
 	var idx int
+	resourceName := "aws_wafregional_rate_based_rule.wafrule"
 	ruleName := fmt.Sprintf("wafrule%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -217,25 +231,30 @@ func TestAccAWSWafRegionalRateBasedRule_changePredicates(t *testing.T) {
 				Config: testAccAWSWafRegionalRateBasedRuleConfig(ruleName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSWafRegionalIPSetExists("aws_wafregional_ipset.ipset", &ipset),
-					testAccCheckAWSWafRegionalRateBasedRuleExists("aws_wafregional_rate_based_rule.wafrule", &before),
-					resource.TestCheckResourceAttr("aws_wafregional_rate_based_rule.wafrule", "name", ruleName),
-					resource.TestCheckResourceAttr("aws_wafregional_rate_based_rule.wafrule", "predicate.#", "1"),
+					testAccCheckAWSWafRegionalRateBasedRuleExists(resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "name", ruleName),
+					resource.TestCheckResourceAttr(resourceName, "predicate.#", "1"),
 					computeWafRegionalRateBasedRulePredicateWithIpSet(&ipset, false, "IPMatch", &idx),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rate_based_rule.wafrule", "predicate.%d.negated", &idx, "false"),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rate_based_rule.wafrule", "predicate.%d.type", &idx, "IPMatch"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "predicate.%d.negated", &idx, "false"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "predicate.%d.type", &idx, "IPMatch"),
 				),
 			},
 			{
 				Config: testAccAWSWafRegionalRateBasedRuleConfig_changePredicates(ruleName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSWafRegionalByteMatchSetExists("aws_wafregional_byte_match_set.set", &byteMatchSet),
-					testAccCheckAWSWafRegionalRateBasedRuleExists("aws_wafregional_rate_based_rule.wafrule", &after),
-					resource.TestCheckResourceAttr("aws_wafregional_rate_based_rule.wafrule", "name", ruleName),
-					resource.TestCheckResourceAttr("aws_wafregional_rate_based_rule.wafrule", "predicate.#", "1"),
+					testAccCheckAWSWafRegionalRateBasedRuleExists(resourceName, &after),
+					resource.TestCheckResourceAttr(resourceName, "name", ruleName),
+					resource.TestCheckResourceAttr(resourceName, "predicate.#", "1"),
 					computeWafRegionalRateBasedRulePredicateWithByteMatchSet(&byteMatchSet, true, "ByteMatch", &idx),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rate_based_rule.wafrule", "predicate.%d.negated", &idx, "true"),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rate_based_rule.wafrule", "predicate.%d.type", &idx, "ByteMatch"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "predicate.%d.negated", &idx, "true"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "predicate.%d.type", &idx, "ByteMatch"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -243,6 +262,7 @@ func TestAccAWSWafRegionalRateBasedRule_changePredicates(t *testing.T) {
 
 func TestAccAWSWafRegionalRateBasedRule_changeRateLimit(t *testing.T) {
 	var before, after waf.RateBasedRule
+	resourceName := "aws_wafregional_rate_based_rule.wafrule"
 	ruleName := fmt.Sprintf("wafrule%s", acctest.RandString(5))
 	rateLimitBefore := "2000"
 	rateLimitAfter := "2001"
@@ -255,18 +275,23 @@ func TestAccAWSWafRegionalRateBasedRule_changeRateLimit(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalRateBasedRuleWithRateLimitConfig(ruleName, rateLimitBefore),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafRegionalRateBasedRuleExists("aws_wafregional_rate_based_rule.wafrule", &before),
-					resource.TestCheckResourceAttr("aws_wafregional_rate_based_rule.wafrule", "name", ruleName),
-					resource.TestCheckResourceAttr("aws_wafregional_rate_based_rule.wafrule", "rate_limit", rateLimitBefore),
+					testAccCheckAWSWafRegionalRateBasedRuleExists(resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "name", ruleName),
+					resource.TestCheckResourceAttr(resourceName, "rate_limit", rateLimitBefore),
 				),
 			},
 			{
 				Config: testAccAWSWafRegionalRateBasedRuleWithRateLimitConfig(ruleName, rateLimitAfter),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafRegionalRateBasedRuleExists("aws_wafregional_rate_based_rule.wafrule", &after),
-					resource.TestCheckResourceAttr("aws_wafregional_rate_based_rule.wafrule", "name", ruleName),
-					resource.TestCheckResourceAttr("aws_wafregional_rate_based_rule.wafrule", "rate_limit", rateLimitAfter),
+					testAccCheckAWSWafRegionalRateBasedRuleExists(resourceName, &after),
+					resource.TestCheckResourceAttr(resourceName, "name", ruleName),
+					resource.TestCheckResourceAttr(resourceName, "rate_limit", rateLimitAfter),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -312,6 +337,7 @@ func computeWafRegionalRateBasedRulePredicateWithByteMatchSet(set *waf.ByteMatch
 
 func TestAccAWSWafRegionalRateBasedRule_noPredicates(t *testing.T) {
 	var rule waf.RateBasedRule
+	resourceName := "aws_wafregional_rate_based_rule.wafrule"
 	ruleName := fmt.Sprintf("wafrule%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -322,12 +348,17 @@ func TestAccAWSWafRegionalRateBasedRule_noPredicates(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalRateBasedRuleConfig_noPredicates(ruleName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafRegionalRateBasedRuleExists("aws_wafregional_rate_based_rule.wafrule", &rule),
+					testAccCheckAWSWafRegionalRateBasedRuleExists(resourceName, &rule),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_rate_based_rule.wafrule", "name", ruleName),
+						resourceName, "name", ruleName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_rate_based_rule.wafrule", "predicate.#", "0"),
+						resourceName, "predicate.#", "0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/website/docs/r/wafregional_rate_based_rule.html.markdown
+++ b/website/docs/r/wafregional_rate_based_rule.html.markdown
@@ -68,3 +68,11 @@ See the [WAF Documentation](https://docs.aws.amazon.com/waf/latest/APIReference/
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the WAF Regional rate based rule.
+
+## Import
+
+WAF Regional Rate Based Rule can be imported using the id, e.g.
+
+```
+$ terraform import aws_wafregional_rate_based_rule.wafrule a1b2c3d4-d5f6-7777-8888-9999aaaabbbbcccc
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #9620

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_wafregional_rate_based_rule: Support resource import
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSWafRegionalRateBasedRule_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSWafRegionalRateBasedRule_ -timeout 120m
=== RUN   TestAccAWSWafRegionalRateBasedRule_basic
=== PAUSE TestAccAWSWafRegionalRateBasedRule_basic
=== RUN   TestAccAWSWafRegionalRateBasedRule_changeNameForceNew
=== PAUSE TestAccAWSWafRegionalRateBasedRule_changeNameForceNew
=== RUN   TestAccAWSWafRegionalRateBasedRule_disappears
=== PAUSE TestAccAWSWafRegionalRateBasedRule_disappears
=== RUN   TestAccAWSWafRegionalRateBasedRule_changePredicates
=== PAUSE TestAccAWSWafRegionalRateBasedRule_changePredicates
=== RUN   TestAccAWSWafRegionalRateBasedRule_changeRateLimit
=== PAUSE TestAccAWSWafRegionalRateBasedRule_changeRateLimit
=== RUN   TestAccAWSWafRegionalRateBasedRule_noPredicates
=== PAUSE TestAccAWSWafRegionalRateBasedRule_noPredicates
=== CONT  TestAccAWSWafRegionalRateBasedRule_basic
=== CONT  TestAccAWSWafRegionalRateBasedRule_changeRateLimit
=== CONT  TestAccAWSWafRegionalRateBasedRule_noPredicates
=== CONT  TestAccAWSWafRegionalRateBasedRule_disappears
=== CONT  TestAccAWSWafRegionalRateBasedRule_changePredicates
=== CONT  TestAccAWSWafRegionalRateBasedRule_changeNameForceNew
--- FAIL: TestAccAWSWafRegionalRateBasedRule_disappears (50.17s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error creating WAF Regional Rate Based Rule (): WAFLimitsExceededException: Operation would result in exceeding resource limits.
        	status code: 400, request id: f4738384-b684-11e9-9455-ef575923e2eb

          on /var/folders/w9/yq_zm9bj24z06tlty8163139j7txby/T/tf-test496410440/main.tf line 11:
          (source code not available)


--- PASS: TestAccAWSWafRegionalRateBasedRule_noPredicates (53.22s)
--- PASS: TestAccAWSWafRegionalRateBasedRule_changeRateLimit (72.60s)
--- PASS: TestAccAWSWafRegionalRateBasedRule_basic (80.40s)
--- PASS: TestAccAWSWafRegionalRateBasedRule_changePredicates (98.57s)
--- PASS: TestAccAWSWafRegionalRateBasedRule_changeNameForceNew (113.13s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	113.218s
make: *** [testacc] Error 1
```

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSWafRegionalRateBasedRule_disappears'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSWafRegionalRateBasedRule_disappears -timeout 120m
=== RUN   TestAccAWSWafRegionalRateBasedRule_disappears
=== PAUSE TestAccAWSWafRegionalRateBasedRule_disappears
=== CONT  TestAccAWSWafRegionalRateBasedRule_disappears
--- PASS: TestAccAWSWafRegionalRateBasedRule_disappears (46.93s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	47.019s
```
