### PR TITLE
aws_ssm_maintenance_window_task: Fix incorrect example in documentation

### DIFF
--- a/website/docs/r/ssm_maintenance_window_task.html.markdown
+++ b/website/docs/r/ssm_maintenance_window_task.html.markdown
@@ -87,10 +87,10 @@ resource "aws_ssm_maintenance_window_task" "example" {
 
   task_invocation_parameters {
     run_command_parameters {
-      output_s3_bucket = "${aws_s3_bucket.example.bucket}"
-      output_s3_prefix = "output"
-      service_role_arn = "${aws_iam_role.example.arn}"
-      timeout_seconds  = 600
+      output_s3_bucket     = "${aws_s3_bucket.example.bucket}"
+      output_s3_key_prefix = "output"
+      service_role_arn     = "${aws_iam_role.example.arn}"
+      timeout_seconds      = 600
 
       notification_config {
         notification_arn    = "${aws_sns_topic.example.arn}"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

The documentation for aws_ssm_maintenance_window_task references output_s3_prefix, which is not a supported key. This should be replaced by output_s3_key_prefix. 