### PR TITLE
Final retries after timeouts creating and deleting cloud9 environments

### DIFF
--- a/aws/resource_aws_cloud9_environment_ec2.go
+++ b/aws/resource_aws_cloud9_environment_ec2.go
@@ -100,9 +100,12 @@ func resourceAwsCloud9EnvironmentEc2Create(d *schema.ResourceData, meta interfac
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		out, err = conn.CreateEnvironmentEC2(params)
+	}
 
 	if err != nil {
-		return err
+		return fmt.Errorf("Error creating Cloud9 EC2 Environment: %s", err)
 	}
 	d.SetId(*out.EnvironmentId)
 
@@ -204,10 +207,13 @@ func resourceAwsCloud9EnvironmentEc2Delete(d *schema.ResourceData, meta interfac
 	if err != nil {
 		return err
 	}
-	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
-		out, err := conn.DescribeEnvironments(&cloud9.DescribeEnvironmentsInput{
-			EnvironmentIds: []*string{aws.String(d.Id())},
-		})
+
+	input := &cloud9.DescribeEnvironmentsInput{
+		EnvironmentIds: []*string{aws.String(d.Id())},
+	}
+	var out *cloud9.DescribeEnvironmentsOutput
+	err = resource.Retry(20*time.Minute, func() *resource.RetryError { // Deleting instances can take a long time
+		out, err = conn.DescribeEnvironments(input)
 		if err != nil {
 			if isAWSErr(err, cloud9.ErrCodeNotFoundException, "") {
 				return nil
@@ -223,6 +229,17 @@ func resourceAwsCloud9EnvironmentEc2Delete(d *schema.ResourceData, meta interfac
 		}
 		return resource.RetryableError(fmt.Errorf("Cloud9 EC2 Environment %q still exists", d.Id()))
 	})
-
-	return err
+	if isResourceTimeoutError(err) {
+		out, err = conn.DescribeEnvironments(input)
+		if isAWSErr(err, cloud9.ErrCodeNotFoundException, "") {
+			return nil
+		}
+		if isAWSErr(err, "AccessDeniedException", "is not authorized to access this resource") {
+			return nil
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("Error deleting Cloud9 EC2 Environment: %s", err)
+	}
+	return nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES
* resource/aws_cloud9_environment_ec2: Final retries after timeouts creating and deleting Cloud9 environments

```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSCloud9EnvironmentEc2"      
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSCloud9EnvironmentEc2 -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCloud9EnvironmentEc2_basic
=== PAUSE TestAccAWSCloud9EnvironmentEc2_basic
=== RUN   TestAccAWSCloud9EnvironmentEc2_allFields
=== PAUSE TestAccAWSCloud9EnvironmentEc2_allFields
=== RUN   TestAccAWSCloud9EnvironmentEc2_importBasic
=== PAUSE TestAccAWSCloud9EnvironmentEc2_importBasic
=== CONT  TestAccAWSCloud9EnvironmentEc2_basic
=== CONT  TestAccAWSCloud9EnvironmentEc2_allFields
=== CONT  TestAccAWSCloud9EnvironmentEc2_importBasic
--- PASS: TestAccAWSCloud9EnvironmentEc2_importBasic (146.97s)
--- PASS: TestAccAWSCloud9EnvironmentEc2_basic (159.78s)
--- PASS: TestAccAWSCloud9EnvironmentEc2_allFields (342.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       342.852s
```