### PR TITLE
Final retries creating and deleting Dax clusters

### DIFF
--- a/aws/resource_aws_dax_cluster.go
+++ b/aws/resource_aws_dax_cluster.go
@@ -229,6 +229,9 @@ func resourceAwsDaxClusterCreate(d *schema.ResourceData, meta interface{}) error
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		resp, err = conn.CreateCluster(req)
+	}
 	if err != nil {
 		return fmt.Errorf("Error creating DAX cluster: %s", err)
 	}
@@ -486,8 +489,11 @@ func resourceAwsDaxClusterDelete(d *schema.ResourceData, meta interface{}) error
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.DeleteCluster(req)
+	}
 	if err != nil {
-		return err
+		return fmt.Errorf("Error deleting DAX cluster: %s", err)
 	}
 
 	log.Printf("[DEBUG] Waiting for deletion: %v", d.Id())


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES
* resource/aws_dax_cluster: Final retries after timeouts when creating and deleting Dax clusters
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSDAXCluster"          
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSDAXCluster -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSDAXCluster_importBasic
=== PAUSE TestAccAWSDAXCluster_importBasic
=== RUN   TestAccAWSDAXCluster_basic
=== PAUSE TestAccAWSDAXCluster_basic
=== RUN   TestAccAWSDAXCluster_resize
=== PAUSE TestAccAWSDAXCluster_resize
=== RUN   TestAccAWSDAXCluster_encryption_disabled
=== PAUSE TestAccAWSDAXCluster_encryption_disabled
=== RUN   TestAccAWSDAXCluster_encryption_enabled
=== PAUSE TestAccAWSDAXCluster_encryption_enabled
=== CONT  TestAccAWSDAXCluster_importBasic
=== CONT  TestAccAWSDAXCluster_encryption_disabled
=== CONT  TestAccAWSDAXCluster_resize
=== CONT  TestAccAWSDAXCluster_encryption_enabled
=== CONT  TestAccAWSDAXCluster_basic
--- PASS: TestAccAWSDAXCluster_basic (713.12s)
--- PASS: TestAccAWSDAXCluster_encryption_disabled (735.51s)
--- PASS: TestAccAWSDAXCluster_encryption_enabled (736.00s)
--- PASS: TestAccAWSDAXCluster_importBasic (793.62s)
--- PASS: TestAccAWSDAXCluster_resize (1472.41s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       1473.765s
```