### PR TITLE
Final retries after timeouts creating and updating secrets

### DIFF
--- a/aws/resource_aws_secretsmanager_secret.go
+++ b/aws/resource_aws_secretsmanager_secret.go
@@ -144,6 +144,9 @@ func resourceAwsSecretsManagerSecretCreate(d *schema.ResourceData, meta interfac
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		output, err = conn.CreateSecret(input)
+	}
 	if err != nil {
 		return fmt.Errorf("error creating Secrets Manager Secret: %s", err)
 	}
@@ -182,6 +185,9 @@ func resourceAwsSecretsManagerSecretCreate(d *schema.ResourceData, meta interfac
 			}
 			return nil
 		})
+		if isResourceTimeoutError(err) {
+			_, err = conn.RotateSecret(input)
+		}
 		if err != nil {
 			return fmt.Errorf("error enabling Secrets Manager Secret %q rotation: %s", d.Id(), err)
 		}
@@ -318,6 +324,9 @@ func resourceAwsSecretsManagerSecretUpdate(d *schema.ResourceData, meta interfac
 				}
 				return nil
 			})
+			if isResourceTimeoutError(err) {
+				_, err = conn.RotateSecret(input)
+			}
 			if err != nil {
 				return fmt.Errorf("error updating Secrets Manager Secret %q rotation: %s", d.Id(), err)
 			}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES
* resource/aws_secretsmanager_secret: Fianl retries after timeouts creating and updating secrets

```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAwsSecretsManagerSecret"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAwsSecretsManagerSecret -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAwsSecretsManagerSecret_Basic
=== PAUSE TestAccAwsSecretsManagerSecret_Basic
=== RUN   TestAccAwsSecretsManagerSecret_withNamePrefix
=== PAUSE TestAccAwsSecretsManagerSecret_withNamePrefix
=== RUN   TestAccAwsSecretsManagerSecret_Description
=== PAUSE TestAccAwsSecretsManagerSecret_Description
=== RUN   TestAccAwsSecretsManagerSecret_KmsKeyID
=== PAUSE TestAccAwsSecretsManagerSecret_KmsKeyID
=== RUN   TestAccAwsSecretsManagerSecret_RecoveryWindowInDays_Recreate
=== PAUSE TestAccAwsSecretsManagerSecret_RecoveryWindowInDays_Recreate
=== RUN   TestAccAwsSecretsManagerSecret_RotationLambdaARN
=== PAUSE TestAccAwsSecretsManagerSecret_RotationLambdaARN
=== RUN   TestAccAwsSecretsManagerSecret_RotationRules
=== PAUSE TestAccAwsSecretsManagerSecret_RotationRules
=== RUN   TestAccAwsSecretsManagerSecret_Tags
=== PAUSE TestAccAwsSecretsManagerSecret_Tags
=== RUN   TestAccAwsSecretsManagerSecret_policy
=== PAUSE TestAccAwsSecretsManagerSecret_policy
=== RUN   TestAccAwsSecretsManagerSecretVersion_BasicString
=== PAUSE TestAccAwsSecretsManagerSecretVersion_BasicString
=== RUN   TestAccAwsSecretsManagerSecretVersion_Base64Binary
=== PAUSE TestAccAwsSecretsManagerSecretVersion_Base64Binary
=== RUN   TestAccAwsSecretsManagerSecretVersion_VersionStages
=== PAUSE TestAccAwsSecretsManagerSecretVersion_VersionStages
=== CONT  TestAccAwsSecretsManagerSecret_Basic
=== CONT  TestAccAwsSecretsManagerSecret_RotationRules
=== CONT  TestAccAwsSecretsManagerSecret_Tags
=== CONT  TestAccAwsSecretsManagerSecret_policy
=== CONT  TestAccAwsSecretsManagerSecret_RotationLambdaARN
=== CONT  TestAccAwsSecretsManagerSecret_RecoveryWindowInDays_Recreate
=== CONT  TestAccAwsSecretsManagerSecretVersion_BasicString
=== CONT  TestAccAwsSecretsManagerSecret_KmsKeyID
=== CONT  TestAccAwsSecretsManagerSecret_Description
=== CONT  TestAccAwsSecretsManagerSecretVersion_VersionStages
=== CONT  TestAccAwsSecretsManagerSecret_withNamePrefix
=== CONT  TestAccAwsSecretsManagerSecretVersion_Base64Binary
--- PASS: TestAccAwsSecretsManagerSecret_policy (28.54s)
--- PASS: TestAccAwsSecretsManagerSecret_withNamePrefix (31.63s)
--- PASS: TestAccAwsSecretsManagerSecret_Basic (31.90s)
--- PASS: TestAccAwsSecretsManagerSecretVersion_BasicString (32.40s)
--- PASS: TestAccAwsSecretsManagerSecretVersion_Base64Binary (32.55s)
--- PASS: TestAccAwsSecretsManagerSecret_Description (49.51s)
--- PASS: TestAccAwsSecretsManagerSecret_RecoveryWindowInDays_Recreate (61.49s)
--- PASS: TestAccAwsSecretsManagerSecretVersion_VersionStages (73.32s)
--- PASS: TestAccAwsSecretsManagerSecret_RotationLambdaARN (84.29s)
--- PASS: TestAccAwsSecretsManagerSecret_RotationRules (86.51s)
--- PASS: TestAccAwsSecretsManagerSecret_Tags (90.99s)
--- PASS: TestAccAwsSecretsManagerSecret_KmsKeyID (95.63s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       96.832s
```