### PR TITLE
Final retries after timeouts deleting media resources

### DIFF
--- a/aws/resource_aws_media_package_channel.go
+++ b/aws/resource_aws_media_package_channel.go
@@ -151,10 +151,10 @@ func resourceAwsMediaPackageChannelDelete(d *schema.ResourceData, meta interface
 		return fmt.Errorf("error deleting MediaPackage Channel: %s", err)
 	}
 
+	dcinput := &mediapackage.DescribeChannelInput{
+		Id: aws.String(d.Id()),
+	}
 	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
-		dcinput := &mediapackage.DescribeChannelInput{
-			Id: aws.String(d.Id()),
-		}
 		_, err := conn.DescribeChannel(dcinput)
 		if err != nil {
 			if isAWSErr(err, mediapackage.ErrCodeNotFoundException, "") {
@@ -164,6 +164,9 @@ func resourceAwsMediaPackageChannelDelete(d *schema.ResourceData, meta interface
 		}
 		return resource.RetryableError(fmt.Errorf("MediaPackage Channel (%s) still exists", d.Id()))
 	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.DescribeChannel(dcinput)
+	}
 	if err != nil {
 		return fmt.Errorf("error waiting for MediaPackage Channel (%s) deletion: %s", d.Id(), err)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES
* resource/aws_media_package_channel: Final retries after timeouts deleting media package channels
* resource/aws_media_store_container: Final retries after timeouts deleting media store containers
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSMediaPackageChannel"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSMediaPackageChannel -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSMediaPackageChannel_basic
=== PAUSE TestAccAWSMediaPackageChannel_basic
=== RUN   TestAccAWSMediaPackageChannel_description
=== PAUSE TestAccAWSMediaPackageChannel_description
=== RUN   TestAccAWSMediaPackageChannel_tags
=== PAUSE TestAccAWSMediaPackageChannel_tags
=== CONT  TestAccAWSMediaPackageChannel_basic
=== CONT  TestAccAWSMediaPackageChannel_tags
=== CONT  TestAccAWSMediaPackageChannel_description
--- PASS: TestAccAWSMediaPackageChannel_basic (27.00s)
--- PASS: TestAccAWSMediaPackageChannel_description (51.31s)
--- PASS: TestAccAWSMediaPackageChannel_tags (71.51s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       72.348s

make testacc TESTARGS="-run=TestAccAWSMediaStoreContainer"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSMediaStoreContainer -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSMediaStoreContainerPolicy_basic
=== PAUSE TestAccAWSMediaStoreContainerPolicy_basic
=== RUN   TestAccAWSMediaStoreContainerPolicy_import
=== PAUSE TestAccAWSMediaStoreContainerPolicy_import
=== RUN   TestAccAWSMediaStoreContainer_basic
=== PAUSE TestAccAWSMediaStoreContainer_basic
=== RUN   TestAccAWSMediaStoreContainer_tags
=== PAUSE TestAccAWSMediaStoreContainer_tags
=== RUN   TestAccAWSMediaStoreContainer_import
=== PAUSE TestAccAWSMediaStoreContainer_import
=== CONT  TestAccAWSMediaStoreContainerPolicy_basic
=== CONT  TestAccAWSMediaStoreContainer_import
=== CONT  TestAccAWSMediaStoreContainerPolicy_import
=== CONT  TestAccAWSMediaStoreContainer_basic
=== CONT  TestAccAWSMediaStoreContainer_tags
--- PASS: TestAccAWSMediaStoreContainer_basic (144.83s)
--- PASS: TestAccAWSMediaStoreContainerPolicy_import (154.83s)
--- PASS: TestAccAWSMediaStoreContainerPolicy_basic (172.98s)
--- PASS: TestAccAWSMediaStoreContainer_import (180.47s)
--- PASS: TestAccAWSMediaStoreContainer_tags (187.42s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       188.268s
```