### PR TITLE
 Support aurora-mysql engine type in performance insights

### DIFF
--- a/aws/resource_aws_rds_cluster_instance.go
+++ b/aws/resource_aws_rds_cluster_instance.go
@@ -256,14 +256,12 @@ func resourceAwsRDSClusterInstanceCreate(d *schema.ResourceData, meta interface{
 		createOpts.MonitoringRoleArn = aws.String(attr.(string))
 	}
 
-	if attr, _ := d.GetOk("engine"); attr == "aurora-postgresql" || attr == "aurora" {
-		if attr, ok := d.GetOk("performance_insights_enabled"); ok {
-			createOpts.EnablePerformanceInsights = aws.Bool(attr.(bool))
-		}
+	if attr, ok := d.GetOk("performance_insights_enabled"); ok {
+		createOpts.EnablePerformanceInsights = aws.Bool(attr.(bool))
+	}
 
-		if attr, ok := d.GetOk("performance_insights_kms_key_id"); ok {
-			createOpts.PerformanceInsightsKMSKeyId = aws.String(attr.(string))
-		}
+	if attr, ok := d.GetOk("performance_insights_kms_key_id"); ok {
+		createOpts.PerformanceInsightsKMSKeyId = aws.String(attr.(string))
 	}
 
 	if attr, ok := d.GetOk("preferred_backup_window"); ok {

--- a/aws/resource_aws_rds_cluster_instance_test.go
+++ b/aws/resource_aws_rds_cluster_instance_test.go
@@ -834,7 +834,7 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
 
 resource "aws_db_parameter_group" "bar" {
   name   = "tfcluster-test-group-%d"
-  family = "aurora-postgresql9.6"
+  family = "aurora-postgresql10"
 
   parameter {
     name  = "authentication_timeout"


### PR DESCRIPTION
Performance insights is supported on aurora-mysql (MySQL 5.7).
https://aws.amazon.com/about-aws/whats-new/2019/05/Performance-Insights-GA-Aurora-MySQL-57
Now that all the valid engine types support performance insights, remove the code to check engine type.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9227 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

resource/aws_rds_cluster_instance: Allow aurora-mysql (MySQL 5.7) engine to enable Performance Insights

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSRDSClusterInstance_withInstancePerformanceInsights'
==> Checking that code complies with gofmt requirements...                                                             
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSRDSClusterInstance_withInstancePerformanceInsights -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSRDSClusterInstance_withInstancePerformanceInsights
=== PAUSE TestAccAWSRDSClusterInstance_withInstancePerformanceInsights                                                 
=== CONT  TestAccAWSRDSClusterInstance_withInstancePerformanceInsights
--- PASS: TestAccAWSRDSClusterInstance_withInstancePerformanceInsights (756.21s)
PASS                                    
ok      github.com/terraform-providers/terraform-provider-aws/aws       756.258s
```
