### PR TITLE
Final retry after timeout reading egress-only gateway

### DIFF
--- a/aws/resource_aws_egress_only_internet_gateway.go
+++ b/aws/resource_aws_egress_only_internet_gateway.go
@@ -58,7 +58,7 @@ func resourceAwsEgressOnlyInternetGatewayRead(d *schema.ResourceData, meta inter
 			return resource.NonRetryableError(err)
 		}
 
-		found = gatewayFound(d.Id(), resp)
+		found = hasEc2EgressOnlyInternetGateway(d.Id(), resp)
 		if d.IsNewResource() && !found {
 			return resource.RetryableError(fmt.Errorf("Egress Only Internet Gateway (%s) not found.", d.Id()))
 		}
@@ -72,7 +72,7 @@ func resourceAwsEgressOnlyInternetGatewayRead(d *schema.ResourceData, meta inter
 		return fmt.Errorf("Error describing egress internet gateway: %s", err)
 	}
 
-	found = gatewayFound(d.Id(), resp)
+	found = hasEc2EgressOnlyInternetGateway(d.Id(), resp)
 	if !found {
 		log.Printf("[Error] Cannot find Egress Only Internet Gateway: %q", d.Id())
 		d.SetId("")

--- a/aws/resource_aws_egress_only_internet_gateway.go
+++ b/aws/resource_aws_egress_only_internet_gateway.go
@@ -82,7 +82,7 @@ func resourceAwsEgressOnlyInternetGatewayRead(d *schema.ResourceData, meta inter
 	return nil
 }
 
-func gatewayFound(id string, resp *ec2.DescribeEgressOnlyInternetGatewaysOutput) bool {
+func hasEc2EgressOnlyInternetGateway(id string, resp *ec2.DescribeEgressOnlyInternetGatewaysOutput) bool {
 	var found bool
 	if resp != nil && len(resp.EgressOnlyInternetGateways) > 0 {
 		for _, igw := range resp.EgressOnlyInternetGateways {

--- a/aws/resource_aws_egress_only_internet_gateway.go
+++ b/aws/resource_aws_egress_only_internet_gateway.go
@@ -50,29 +50,29 @@ func resourceAwsEgressOnlyInternetGatewayRead(d *schema.ResourceData, meta inter
 		EgressOnlyInternetGatewayIds: []*string{aws.String(d.Id())},
 	}
 
+	var resp *ec2.DescribeEgressOnlyInternetGatewaysOutput
 	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-		resp, err := conn.DescribeEgressOnlyInternetGateways(req)
+		var err error
+		resp, err = conn.DescribeEgressOnlyInternetGateways(req)
 		if err != nil {
 			return resource.NonRetryableError(err)
 		}
-		if resp != nil && len(resp.EgressOnlyInternetGateways) > 0 {
-			for _, igw := range resp.EgressOnlyInternetGateways {
-				if aws.StringValue(igw.EgressOnlyInternetGatewayId) == d.Id() {
-					found = true
-					break
-				}
-			}
-		}
+
+		found = gatewayFound(d.Id(), resp)
 		if d.IsNewResource() && !found {
 			return resource.RetryableError(fmt.Errorf("Egress Only Internet Gateway (%s) not found.", d.Id()))
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		resp, err = conn.DescribeEgressOnlyInternetGateways(req)
+	}
 
 	if err != nil {
 		return fmt.Errorf("Error describing egress internet gateway: %s", err)
 	}
 
+	found = gatewayFound(d.Id(), resp)
 	if !found {
 		log.Printf("[Error] Cannot find Egress Only Internet Gateway: %q", d.Id())
 		d.SetId("")
@@ -80,6 +80,19 @@ func resourceAwsEgressOnlyInternetGatewayRead(d *schema.ResourceData, meta inter
 	}
 
 	return nil
+}
+
+func gatewayFound(id string, resp *ec2.DescribeEgressOnlyInternetGatewaysOutput) bool {
+	var found bool
+	if resp != nil && len(resp.EgressOnlyInternetGateways) > 0 {
+		for _, igw := range resp.EgressOnlyInternetGateways {
+			if aws.StringValue(igw.EgressOnlyInternetGatewayId) == id {
+				found = true
+				break
+			}
+		}
+	}
+	return found
 }
 
 func resourceAwsEgressOnlyInternetGatewayDelete(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_egress_only_internet_gateway: Final retry after timeout when reading gateway
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSEgressOnlyInternetGateway"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSEgressOnlyInternetGateway -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEgressOnlyInternetGateway_basic
=== PAUSE TestAccAWSEgressOnlyInternetGateway_basic
=== CONT  TestAccAWSEgressOnlyInternetGateway_basic
--- PASS: TestAccAWSEgressOnlyInternetGateway_basic (51.28s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       52.153s
```