### PR TITLE
Final retries deleting and attaching VPN gateways

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -573,7 +573,7 @@ func (c *Config) Client() (interface{}, error) {
 		}
 
 		if r.Operation.Name == "AttachVpnGateway" {
-			if isAWSErr(err, "InvalidParameterValue", "This call cannot be completed because there are pending VPNs or Virtual Interfaces") {
+			if isAWSErr(r.Error, "InvalidParameterValue", "This call cannot be completed because there are pending VPNs or Virtual Interfaces") {
 				r.Retryable = aws.Bool(true)
 			}
 		}

--- a/aws/config.go
+++ b/aws/config.go
@@ -571,6 +571,12 @@ func (c *Config) Client() (interface{}, error) {
 				r.Retryable = aws.Bool(true)
 			}
 		}
+
+		if r.Operation.Name == "AttachVpnGateway" {
+			if isAWSErr(err, "InvalidParameterValue", "This call cannot be completed because there are pending VPNs or Virtual Interfaces") {
+				r.Retryable = aws.Bool(true)
+			}
+		}
 	})
 
 	client.kafkaconn.Handlers.Retry.PushBack(func(r *request.Request) {

--- a/aws/resource_aws_vpn_gateway.go
+++ b/aws/resource_aws_vpn_gateway.go
@@ -168,9 +168,6 @@ func resourceAwsVpnGatewayDelete(d *schema.ResourceData, meta interface{}) error
 		if isAWSErr(err, "IncorrectState", "") {
 			return resource.RetryableError(err)
 		}
-		if !isAWSErr(err, "", "") {
-			return resource.RetryableError(err)
-		}
 
 		return resource.NonRetryableError(err)
 	})
@@ -213,9 +210,6 @@ func resourceAwsVpnGatewayAttach(d *schema.ResourceData, meta interface{}) error
 		_, err := conn.AttachVpnGateway(req)
 		if err != nil {
 			if isAWSErr(err, "InvalidVpnGatewayID.NotFound", "") {
-				return resource.RetryableError(err)
-			}
-			if isAWSErr(err, "InvalidParameterValue", "This call cannot be completed because there are pending VPNs or Virtual Interfaces") {
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES
* resource/aws_vpn_gateway: Retry after timeouts attaching and deleting VPN gateways, and retrying attachment after pending VPN errors
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSVpnGateway"         
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSVpnGateway -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSVpnGatewayAttachment_basic
=== PAUSE TestAccAWSVpnGatewayAttachment_basic
=== RUN   TestAccAWSVpnGatewayAttachment_deleted
=== PAUSE TestAccAWSVpnGatewayAttachment_deleted
=== RUN   TestAccAWSVpnGateway_importBasic
=== PAUSE TestAccAWSVpnGateway_importBasic
=== RUN   TestAccAWSVpnGateway_basic
=== PAUSE TestAccAWSVpnGateway_basic
=== RUN   TestAccAWSVpnGateway_withAvailabilityZoneSetToState
=== PAUSE TestAccAWSVpnGateway_withAvailabilityZoneSetToState
=== RUN   TestAccAWSVpnGateway_withAmazonSideAsnSetToState
=== PAUSE TestAccAWSVpnGateway_withAmazonSideAsnSetToState
=== RUN   TestAccAWSVpnGateway_disappears
=== PAUSE TestAccAWSVpnGateway_disappears
=== RUN   TestAccAWSVpnGateway_reattach
=== PAUSE TestAccAWSVpnGateway_reattach
=== RUN   TestAccAWSVpnGateway_delete
=== PAUSE TestAccAWSVpnGateway_delete
=== RUN   TestAccAWSVpnGateway_tags
=== PAUSE TestAccAWSVpnGateway_tags
=== CONT  TestAccAWSVpnGatewayAttachment_basic
=== CONT  TestAccAWSVpnGateway_withAmazonSideAsnSetToState
=== CONT  TestAccAWSVpnGateway_disappears
=== CONT  TestAccAWSVpnGateway_basic
=== CONT  TestAccAWSVpnGateway_importBasic
=== CONT  TestAccAWSVpnGateway_withAvailabilityZoneSetToState
=== CONT  TestAccAWSVpnGateway_delete
=== CONT  TestAccAWSVpnGatewayAttachment_deleted
=== CONT  TestAccAWSVpnGateway_tags
=== CONT  TestAccAWSVpnGateway_reattach
--- PASS: TestAccAWSVpnGatewayAttachment_basic (90.48s)
--- PASS: TestAccAWSVpnGateway_disappears (103.10s)
--- PASS: TestAccAWSVpnGateway_importBasic (117.63s)
--- PASS: TestAccAWSVpnGateway_withAvailabilityZoneSetToState (120.07s)
--- PASS: TestAccAWSVpnGatewayAttachment_deleted (129.88s)
--- PASS: TestAccAWSVpnGateway_withAmazonSideAsnSetToState (138.66s)
--- PASS: TestAccAWSVpnGateway_delete (151.66s)
--- PASS: TestAccAWSVpnGateway_tags (156.99s)
--- PASS: TestAccAWSVpnGateway_basic (165.93s)
--- PASS: TestAccAWSVpnGateway_reattach (239.61s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       240.459s
```