### PR TITLE
Update cloudfront_distribution.html.markdown

### DIFF
--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -232,7 +232,7 @@ of several sub-resources - these resources are laid out below.
   * `origin` (Required) - One or more [origins](#origin-arguments) for this
     distribution (multiples allowed).
 
-  * `origin_group` (Required) - One or more [origin_group](#origin-group-arguments) for this
+  * `origin_group` (Optional) - One or more [origin_group](#origin-group-arguments) for this
   distribution (multiples allowed).  
 
   * `price_class` (Optional) - The price class for this distribution. One of


### PR DESCRIPTION
origin_group marked as optional.
The examples work and they don't use it so it can't be required.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
