### PR TITLE
Final retries after timeouts creating, draining, and deleting ASGs and autoscaling helpers

### DIFF
--- a/aws/resource_aws_autoscaling_group.go
+++ b/aws/resource_aws_autoscaling_group.go
@@ -596,6 +596,9 @@ func resourceAwsAutoscalingGroupCreate(d *schema.ResourceData, meta interface{})
 
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.CreateAutoScalingGroup(&createOpts)
+	}
 	if err != nil {
 		return fmt.Errorf("Error creating AutoScaling Group: %s", err)
 	}
@@ -1005,23 +1008,38 @@ func resourceAwsAutoscalingGroupDelete(d *schema.ResourceData, meta interface{})
 		// Successful delete
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.DeleteAutoScalingGroup(&deleteopts)
+		if isAWSErr(err, "InvalidGroup.NotFound", "") {
+			return nil
+		}
+	}
 	if err != nil {
-		return err
+		return fmt.Errorf("Error deleting autoscaling group: %s", err)
 	}
 
-	return resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
-		if g, _ = getAwsAutoscalingGroup(d.Id(), conn); g != nil {
-			return resource.RetryableError(
-				fmt.Errorf("Auto Scaling Group still exists"))
+	var group *autoscaling.Group
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		group, err = getAwsAutoscalingGroup(d.Id(), conn)
+
+		if group != nil {
+			return resource.RetryableError(fmt.Errorf("Auto Scaling Group still exists"))
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		group, err = getAwsAutoscalingGroup(d.Id(), conn)
+		if group != nil {
+			return fmt.Errorf("Auto Scaling Group still exists")
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("Error deleting autoscaling group: %s", err)
+	}
+	return nil
 }
 
-func getAwsAutoscalingGroup(
-	asgName string,
-	conn *autoscaling.AutoScaling) (*autoscaling.Group, error) {
-
+func getAwsAutoscalingGroup(asgName string, conn *autoscaling.AutoScaling) (*autoscaling.Group, error) {
 	describeOpts := autoscaling.DescribeAutoScalingGroupsInput{
 		AutoScalingGroupNames: []*string{aws.String(asgName)},
 	}
@@ -1069,7 +1087,8 @@ func resourceAwsAutoscalingGroupDrain(d *schema.ResourceData, meta interface{}) 
 
 	// Next, wait for the autoscale group to drain
 	log.Printf("[DEBUG] Waiting for group to have zero instances")
-	return resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+	var g *autoscaling.Group
+	err := resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		g, err := getAwsAutoscalingGroup(d.Id(), conn)
 		if err != nil {
 			return resource.NonRetryableError(err)
@@ -1085,8 +1104,21 @@ func resourceAwsAutoscalingGroupDrain(d *schema.ResourceData, meta interface{}) 
 		}
 
 		return resource.RetryableError(
-			fmt.Errorf("group still has %d instances", len(g.Instances)))
+			fmt.Errorf("Group still has %d instances", len(g.Instances)))
 	})
+	if isResourceTimeoutError(err) {
+		g, err = getAwsAutoscalingGroup(d.Id(), conn)
+		if err != nil {
+			return fmt.Errorf("Error getting autoscaling group info when draining: %s", err)
+		}
+		if g != nil && len(g.Instances) > 0 {
+			return fmt.Errorf("Group still has %d instances", len(g.Instances))
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("Error draining autoscaling group: %s", err)
+	}
+	return nil
 }
 
 func enableASGSuspendedProcesses(d *schema.ResourceData, conn *autoscaling.AutoScaling) error {

--- a/aws/resource_aws_autoscaling_lifecycle_hook.go
+++ b/aws/resource_aws_autoscaling_lifecycle_hook.go
@@ -65,7 +65,7 @@ func resourceAwsAutoscalingLifecycleHook() *schema.Resource {
 
 func resourceAwsAutoscalingLifecycleHookPutOp(conn *autoscaling.AutoScaling, params *autoscaling.PutLifecycleHookInput) error {
 	log.Printf("[DEBUG] AutoScaling PutLifecyleHook: %s", params)
-	return resource.Retry(5*time.Minute, func() *resource.RetryError {
+	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
 		_, err := conn.PutLifecycleHook(params)
 
 		if err != nil {
@@ -78,6 +78,13 @@ func resourceAwsAutoscalingLifecycleHookPutOp(conn *autoscaling.AutoScaling, par
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.PutLifecycleHook(params)
+	}
+	if err != nil {
+		return fmt.Errorf("Error putting autoscaling lifecycle hook: %s", err)
+	}
+	return nil
 }
 
 func resourceAwsAutoscalingLifecycleHookPut(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_autoscaling_group: Final retries after timeouts creating, draining, and deleting ASGs and autoscaling helpers
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSAutoscalingLifecycleHook"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSAutoscalingLifecycleHook -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSAutoscalingLifecycleHook_basic
=== PAUSE TestAccAWSAutoscalingLifecycleHook_basic
=== RUN   TestAccAWSAutoscalingLifecycleHook_omitDefaultResult
=== PAUSE TestAccAWSAutoscalingLifecycleHook_omitDefaultResult
=== CONT  TestAccAWSAutoscalingLifecycleHook_basic
=== CONT  TestAccAWSAutoscalingLifecycleHook_omitDefaultResult
--- PASS: TestAccAWSAutoscalingLifecycleHook_omitDefaultResult (140.98s)
--- PASS: TestAccAWSAutoscalingLifecycleHook_basic (144.02s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       147.126s

make testacc TESTARGS="-run=TestAccAWSAutoScalingGroup"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSAutoScalingGroup -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSAutoScalingGroup_basic
=== PAUSE TestAccAWSAutoScalingGroup_basic
=== RUN   TestAccAWSAutoScalingGroup_namePrefix
=== PAUSE TestAccAWSAutoScalingGroup_namePrefix
=== RUN   TestAccAWSAutoScalingGroup_autoGeneratedName
=== PAUSE TestAccAWSAutoScalingGroup_autoGeneratedName
=== RUN   TestAccAWSAutoScalingGroup_terminationPolicies
=== PAUSE TestAccAWSAutoScalingGroup_terminationPolicies
=== RUN   TestAccAWSAutoScalingGroup_tags
=== PAUSE TestAccAWSAutoScalingGroup_tags
=== RUN   TestAccAWSAutoScalingGroup_VpcUpdates
=== PAUSE TestAccAWSAutoScalingGroup_VpcUpdates
=== RUN   TestAccAWSAutoScalingGroup_WithLoadBalancer
=== PAUSE TestAccAWSAutoScalingGroup_WithLoadBalancer
=== RUN   TestAccAWSAutoScalingGroup_WithLoadBalancer_ToTargetGroup
=== PAUSE TestAccAWSAutoScalingGroup_WithLoadBalancer_ToTargetGroup
=== RUN   TestAccAWSAutoScalingGroup_withPlacementGroup
=== PAUSE TestAccAWSAutoScalingGroup_withPlacementGroup
=== RUN   TestAccAWSAutoScalingGroup_enablingMetrics
=== PAUSE TestAccAWSAutoScalingGroup_enablingMetrics
=== RUN   TestAccAWSAutoScalingGroup_suspendingProcesses
=== PAUSE TestAccAWSAutoScalingGroup_suspendingProcesses
=== RUN   TestAccAWSAutoScalingGroup_withMetrics
=== PAUSE TestAccAWSAutoScalingGroup_withMetrics
=== RUN   TestAccAWSAutoScalingGroup_serviceLinkedRoleARN
=== PAUSE TestAccAWSAutoScalingGroup_serviceLinkedRoleARN
=== RUN   TestAccAWSAutoScalingGroup_ALB_TargetGroups
=== PAUSE TestAccAWSAutoScalingGroup_ALB_TargetGroups
=== RUN   TestAccAWSAutoScalingGroup_initialLifecycleHook
=== PAUSE TestAccAWSAutoScalingGroup_initialLifecycleHook
=== RUN   TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity
=== PAUSE TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity
=== RUN   TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier
=== PAUSE TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier
=== RUN   TestAccAWSAutoScalingGroup_emptyAvailabilityZones
=== PAUSE TestAccAWSAutoScalingGroup_emptyAvailabilityZones
=== RUN   TestAccAWSAutoScalingGroup_launchTemplate
=== PAUSE TestAccAWSAutoScalingGroup_launchTemplate
=== RUN   TestAccAWSAutoScalingGroup_launchTemplate_update
=== PAUSE TestAccAWSAutoScalingGroup_launchTemplate_update
=== RUN   TestAccAWSAutoScalingGroup_LaunchTemplate_IAMInstanceProfile
=== PAUSE TestAccAWSAutoScalingGroup_LaunchTemplate_IAMInstanceProfile
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandAllocationStrategy
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandAllocationStrategy
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandBaseCapacity
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandBaseCapacity
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandPercentageAboveBaseCapacity
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandPercentageAboveBaseCapacity
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotAllocationStrategy
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotAllocationStrategy
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotInstancePools
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotInstancePools
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotMaxPrice
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotMaxPrice
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_LaunchTemplateName
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_LaunchTemplateName
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_Version
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_Version
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_InstanceType
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_InstanceType
=== CONT  TestAccAWSAutoScalingGroup_basic
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandAllocationStrategy
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotAllocationStrategy
=== CONT  TestAccAWSAutoScalingGroup_launchTemplate_update
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_InstanceType
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_Version
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_LaunchTemplateName
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandBaseCapacity
=== CONT  TestAccAWSAutoScalingGroup_launchTemplate
=== CONT  TestAccAWSAutoScalingGroup_emptyAvailabilityZones
=== CONT  TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier
=== CONT  TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandPercentageAboveBaseCapacity
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotMaxPrice
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotInstancePools
=== CONT  TestAccAWSAutoScalingGroup_initialLifecycleHook
=== CONT  TestAccAWSAutoScalingGroup_ALB_TargetGroups
=== CONT  TestAccAWSAutoScalingGroup_WithLoadBalancer
=== CONT  TestAccAWSAutoScalingGroup_VpcUpdates
=== CONT  TestAccAWSAutoScalingGroup_LaunchTemplate_IAMInstanceProfile
--- PASS: TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier (55.22s)
=== CONT  TestAccAWSAutoScalingGroup_tags
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandAllocationStrategy (58.48s)
=== CONT  TestAccAWSAutoScalingGroup_terminationPolicies
--- PASS: TestAccAWSAutoScalingGroup_LaunchTemplate_IAMInstanceProfile (66.64s)
=== CONT  TestAccAWSAutoScalingGroup_autoGeneratedName
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_Version (82.50s)
=== CONT  TestAccAWSAutoScalingGroup_namePrefix
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_InstanceType (87.92s)
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotAllocationStrategy (88.56s)
=== CONT  TestAccAWSAutoScalingGroup_suspendingProcesses
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_LaunchTemplateName (88.70s)
=== CONT  TestAccAWSAutoScalingGroup_serviceLinkedRoleARN
--- PASS: TestAccAWSAutoScalingGroup_launchTemplate (90.39s)
=== CONT  TestAccAWSAutoScalingGroup_WithLoadBalancer_ToTargetGroup
--- PASS: TestAccAWSAutoScalingGroup_emptyAvailabilityZones (97.20s)
=== CONT  TestAccAWSAutoScalingGroup_withMetrics
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandPercentageAboveBaseCapacity (115.72s)
=== CONT  TestAccAWSAutoScalingGroup_enablingMetrics
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotMaxPrice (121.95s)
=== CONT  TestAccAWSAutoScalingGroup_withPlacementGroup
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandBaseCapacity (121.99s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotInstancePools (122.14s)
--- PASS: TestAccAWSAutoScalingGroup_autoGeneratedName (57.13s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy (80.65s)
--- PASS: TestAccAWSAutoScalingGroup_namePrefix (88.08s)
--- PASS: TestAccAWSAutoScalingGroup_serviceLinkedRoleARN (85.41s)
--- PASS: TestAccAWSAutoScalingGroup_VpcUpdates (177.04s)
--- PASS: TestAccAWSAutoScalingGroup_launchTemplate_update (182.81s)
--- PASS: TestAccAWSAutoScalingGroup_withMetrics (89.99s)
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups (196.67s)
--- PASS: TestAccAWSAutoScalingGroup_terminationPolicies (150.49s)
--- PASS: TestAccAWSAutoScalingGroup_initialLifecycleHook (237.09s)
--- PASS: TestAccAWSAutoScalingGroup_basic (249.62s)
--- PASS: TestAccAWSAutoScalingGroup_withPlacementGroup (183.08s)
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity (314.25s)
--- PASS: TestAccAWSAutoScalingGroup_tags (295.27s)
--- PASS: TestAccAWSAutoScalingGroup_enablingMetrics (239.71s)
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer (445.73s)
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer_ToTargetGroup (375.11s)
--- PASS: TestAccAWSAutoScalingGroup_suspendingProcesses (395.45s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       485.653s
```