### PR TITLE
Fix secondary_artifacts hash function for aws_codebuild_project

### DIFF
--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -38,6 +38,10 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"artifact_identifier": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 						"name": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -83,6 +87,10 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 								}
 								return false
 							},
+							ValidateFunc: validation.StringInSlice([]string{
+								codebuild.ArtifactPackagingNone,
+								codebuild.ArtifactPackagingZip,
+							}, false),
 						},
 						"path": {
 							Type:     schema.TypeString,
@@ -344,6 +352,7 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 								codebuild.ArtifactNamespaceNone,
 								codebuild.ArtifactNamespaceBuildId,
 							}, false),
+							Default: codebuild.ArtifactNamespaceNone,
 						},
 						"override_artifact_name": {
 							Type:     schema.TypeBool,
@@ -353,6 +362,11 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 						"packaging": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								codebuild.ArtifactPackagingNone,
+								codebuild.ArtifactPackagingZip,
+							}, false),
+							Default: codebuild.ArtifactPackagingNone,
 						},
 						"path": {
 							Type:     schema.TypeString,
@@ -366,9 +380,7 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 							ValidateFunc: validation.StringInSlice([]string{
-								codebuild.ArtifactsTypeCodepipeline,
 								codebuild.ArtifactsTypeS3,
-								codebuild.ArtifactsTypeNoArtifacts,
 							}, false),
 						},
 					},
@@ -1380,14 +1392,36 @@ func resourceAwsCodeBuildProjectArtifactsHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 
-	buf.WriteString(fmt.Sprintf("%s-", m["type"].(string)))
-
 	if v, ok := m["artifact_identifier"]; ok {
-		buf.WriteString(fmt.Sprintf("%s:", v.(string)))
+		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+	}
+
+	if v, ok := m["encryption_disabled"]; ok {
+		buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
+	}
+
+	if v, ok := m["location"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+	}
+
+	if v, ok := m["namespace_type"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
 	}
 
 	if v, ok := m["override_artifact_name"]; ok {
 		buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
+	}
+
+	if v, ok := m["packaging"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+	}
+
+	if v, ok := m["path"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+	}
+
+	if v, ok := m["type"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
 	}
 
 	return hashcode.String(buf.String())

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -233,6 +233,7 @@ The following arguments are supported:
 `artifacts` supports the following:
 
 * `type` - (Required) The build output artifact's type. Valid values for this parameter are: `CODEPIPELINE`, `NO_ARTIFACTS` or `S3`.
+* `artifact_identifier` - (Optional) The artifact identifier. Must be the same specified inside AWS CodeBuild buildspec.
 * `encryption_disabled` - (Optional) If set to true, output artifacts will not be encrypted. If `type` is set to `NO_ARTIFACTS` then this value will be ignored. Defaults to `false`.
 * `override_artifact_name` (Optional) If set to true, a name specified in the build spec file overrides the artifact name.
 * `location` - (Optional) Information about the build output artifact location. If `type` is set to `CODEPIPELINE` or `NO_ARTIFACTS` then this value will be ignored. If `type` is set to `S3`, this is the name of the output bucket.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

Relates to #6643

This PR fixes the hash function for `secondary_artifacts` of the `aws_codebuild_project` resource. The symptom was that changes weren't detected by Terraform when changing some of `secondary_artifacts`'s attributes.

Unfortunately, I found no good way yet to correctly detect and apply updates for the following attributes: `name`, `namespace_type`, and `packaging`. The reason is that those three attributes (if not set explicitly through Terraform configuration) are set by AWS internally and cause the hash value of `secondary_artifacts` to change after the apply. The tests complain that their is some unapplied diff in the plan.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCodeBuildProject'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSCodeBuildProject -timeout 120m
...
--- SKIP: TestAccAWSCodeBuildProject_SecondaryArtifacts_Name (0.00s)
    resource_aws_codebuild_project_test.go:1418: Currently no solution to allow updates on name attribute
...
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid (20.68s)
=== CONT  TestAccAWSCodeBuildProject_Source_Type_NoSource
--- PASS: TestAccAWSCodeBuildProject_Source_Type_Bitbucket (37.90s)
=== CONT  TestAccAWSCodeBuildProject_Source_Type_S3
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_CodeCommit (39.46s)
=== CONT  TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise
--- PASS: TestAccAWSCodeBuildProject_importBasic (40.21s)
=== CONT  TestAccAWSCodeBuildProject_Source_Type_CodePipeline
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts (41.89s)
=== CONT  TestAccAWSCodeBuildProject_Source_Type_CodeCommit
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Type (42.38s)
=== CONT  TestAccAWSCodeBuildProject_Artifacts_Location
--- PASS: TestAccAWSCodeBuildProject_Tags (51.68s)
=== CONT  TestAccAWSCodeBuildProject_Source_InsecureSSL
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSource (36.49s)
=== CONT  TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled
--- PASS: TestAccAWSCodeBuildProject_Environment_RegistryCredential (58.28s)
=== CONT  TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise
--- PASS: TestAccAWSCodeBuildProject_Artifacts_NamespaceType (60.80s)
=== CONT  TestAccAWSCodeBuildProject_Artifacts_ArtifactIdentifier
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Path (61.32s)
=== CONT  TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Type (61.47s)
=== CONT  TestAccAWSCodeBuildProject_WindowsContainer
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Path (61.54s)
=== CONT  TestAccAWSCodeBuildProject_VpcConfig
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_ArtifactIdentifier (61.78s)
=== CONT  TestAccAWSCodeBuildProject_Environment_Certificate
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Name (61.80s)
=== CONT  TestAccAWSCodeBuildProject_Source_Auth
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Packaging (61.95s)
=== CONT  TestAccAWSCodeBuildProject_LogsConfig_S3Logs
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_NamespaceType (61.97s)
=== CONT  TestAccAWSCodeBuildProject_Source_GitCloneDepth
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_EncryptionDisabled (62.00s)
=== CONT  TestAccAWSCodeBuildProject_LogsConfig_CloudWatchLogs
--- PASS: TestAccAWSCodeBuildProject_Artifacts_OverrideArtifactName (62.00s)
=== CONT  TestAccAWSCodeBuildProject_Description
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_OverrideArtifactName (62.65s)
=== CONT  TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Location (65.90s)
=== CONT  TestAccAWSCodeBuildProject_Environment_EnvironmentVariable
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodePipeline (28.37s)
=== CONT  TestAccAWSCodeBuildProject_EncryptionKey
--- PASS: TestAccAWSCodeBuildProject_Source_Type_S3 (35.88s)
=== CONT  TestAccAWSCodeBuildProject_BuildTimeout
--- FAIL: TestAccAWSCodeBuildProject_Source_Auth (13.61s)
    testing.go:568: Step 1 error: errors during apply:
        
        Error: Error creating CodeBuild project: InvalidInputException: No Access token found, please visit AWS CodeBuild console to connect to GitHub
        	status code: 400, request id: d9e431a0-4172-47d6-97f1-c7d627f5a8be
        
          on /tmp/tf-test886635756/main.tf line 64:
          (source code not available)
        
        
=== CONT  TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket
--- PASS: TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise (36.64s)
=== CONT  TestAccAWSCodeBuildProject_Cache
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodeCommit (37.10s)
=== CONT  TestAccAWSCodeBuildProject_BadgeEnabled
--- PASS: TestAccAWSCodeBuildProject_WindowsContainer (36.79s)
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_Packaging
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise (41.67s)
=== CONT  TestAccAWSCodeBuildProject_basic
--- PASS: TestAccAWSCodeBuildProject_Environment_Certificate (38.86s)
--- PASS: TestAccAWSCodeBuildProject_Source_InsecureSSL (50.37s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Location (61.54s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub (49.91s)
--- PASS: TestAccAWSCodeBuildProject_Description (50.23s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitCloneDepth (50.45s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type (49.91s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled (56.54s)
--- PASS: TestAccAWSCodeBuildProject_BuildTimeout (41.60s)
--- PASS: TestAccAWSCodeBuildProject_BadgeEnabled (36.59s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket (41.45s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_ArtifactIdentifier (58.11s)
--- PASS: TestAccAWSCodeBuildProject_EncryptionKey (51.02s)
--- PASS: TestAccAWSCodeBuildProject_LogsConfig_CloudWatchLogs (65.57s)
--- PASS: TestAccAWSCodeBuildProject_VpcConfig (71.60s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable (69.16s)
--- PASS: TestAccAWSCodeBuildProject_basic (38.72s)
--- PASS: TestAccAWSCodeBuildProject_LogsConfig_S3Logs (81.69s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Packaging (59.46s)
--- PASS: TestAccAWSCodeBuildProject_Cache (106.52s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	182.697s
...
```
