### PR TITLE
Referencing CodeCommit repository in the trigger

### DIFF
--- a/website/docs/r/codecommit_trigger.html.markdown
+++ b/website/docs/r/codecommit_trigger.html.markdown
@@ -17,12 +17,15 @@ in all regions - available regions are listed
 ## Example Usage
 
 ```hcl
+resource "aws_codecommit_repository" "test" {
+  repository_name = "test"
+}
+
 resource "aws_codecommit_trigger" "test" {
-  depends_on      = ["aws_codecommit_repository.test"]
-  repository_name = "my_test_repository"
+  repository_name = "${aws_codecommit_repository.test.repository_name}"
 
   trigger {
-    name            = "noname"
+    name            = "all"
     events          = ["all"]
     destination_arn = "${aws_sns_topic.test.arn}"
   }


### PR DESCRIPTION
Means the example does not require `depends_on`, following [best practices](https://learn.hashicorp.com/terraform/getting-started/dependencies.html#implicit-and-explicit-dependencies).

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
NONE
```