### PR TITLE
bad reference for resources

### DIFF
--- a/website/docs/r/athena_named_query.html.markdown
+++ b/website/docs/r/athena_named_query.html.markdown
@@ -37,7 +37,7 @@ resource "aws_athena_workgroup" "test" {
 
 resource "aws_athena_database" "hoge" {
   name   = "users"
-  bucket = "${aws_s3_bucket.hoge.bucket}"
+  bucket = "${aws_s3_bucket.hoge.id}"
 }
 
 resource "aws_athena_named_query" "foo" {


### PR DESCRIPTION
aws_s3_bucket has `id` as an attribute for `name`, refer [this](https://www.terraform.io/docs/providers/aws/r/s3_bucket.html#attributes-reference)

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
