### PR TITLE
Final retry after timeout reading AMI

### DIFF
--- a/aws/resource_aws_ami.go
+++ b/aws/resource_aws_ami.go
@@ -299,7 +299,7 @@ func resourceAwsAmiRead(d *schema.ResourceData, meta interface{}) error {
 		var err error
 		res, err = client.DescribeImages(req)
 		if err != nil {
-			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidAMIID.NotFound" {
+			if isAWSErr(err, "InvalidAMIID.NotFound", "") {
 				if d.IsNewResource() {
 					return resource.RetryableError(err)
 				}
@@ -313,6 +313,9 @@ func resourceAwsAmiRead(d *schema.ResourceData, meta interface{}) error {
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		res, err = client.DescribeImages(req)
+	}
 	if err != nil {
 		return fmt.Errorf("Unable to find AMI after retries: %s", err)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_ami: Final retry after timeout reading AMI
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSAMICopy"           
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSAMICopy -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSAMICopy_basic
=== PAUSE TestAccAWSAMICopy_basic
=== RUN   TestAccAWSAMICopy_Description
=== PAUSE TestAccAWSAMICopy_Description
=== RUN   TestAccAWSAMICopy_EnaSupport
=== PAUSE TestAccAWSAMICopy_EnaSupport
=== CONT  TestAccAWSAMICopy_basic
=== CONT  TestAccAWSAMICopy_Description
=== CONT  TestAccAWSAMICopy_EnaSupport
--- PASS: TestAccAWSAMICopy_EnaSupport (383.51s)
--- PASS: TestAccAWSAMICopy_basic (400.90s)
--- PASS: TestAccAWSAMICopy_Description (427.69s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       428.580s
```