### PR TITLE
Fix subnet_ids type in documentation.

### DIFF
--- a/website/docs/d/subnet_ids.html.markdown
+++ b/website/docs/d/subnet_ids.html.markdown
@@ -82,4 +82,4 @@ data "aws_subnet_ids" "selected" {
 
 ## Attributes Reference
 
-* `ids` - A list of all the subnet ids found. This data source will fail if none are found.
+* `ids` - A set of all the subnet ids found. This data source will fail if none are found.


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix subnet_ids type in documentation.
```