### PR TITLE
Final retries after timeouts creating and updating cloudtrails

### DIFF
--- a/aws/resource_aws_cloudtrail.go
+++ b/aws/resource_aws_cloudtrail.go
@@ -187,8 +187,11 @@ func resourceAwsCloudTrailCreate(d *schema.ResourceData, meta interface{}) error
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		t, err = conn.CreateTrail(&input)
+	}
 	if err != nil {
-		return err
+		return fmt.Errorf("Error creating CloudTrail: %s", err)
 	}
 
 	log.Printf("[DEBUG] CloudTrail created: %s", t)
@@ -358,8 +361,11 @@ func resourceAwsCloudTrailUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		t, err = conn.UpdateTrail(&input)
+	}
 	if err != nil {
-		return err
+		return fmt.Errorf("Error updating CloudTrail: %s", err)
 	}
 
 	if d.HasChange("tags") {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES
* resource/aws_cloudtrail: Final retries after timeouts creating and updating cloudtrails
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSCloudTrail"  
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSCloudTrail -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCloudTrailServiceAccount_basic
=== PAUSE TestAccAWSCloudTrailServiceAccount_basic
=== RUN   TestAccAWSCloudTrailServiceAccount_Region
=== PAUSE TestAccAWSCloudTrailServiceAccount_Region
=== RUN   TestAccAWSCloudTrail
=== RUN   TestAccAWSCloudTrail/Trail
=== RUN   TestAccAWSCloudTrail/Trail/enableLogging
=== RUN   TestAccAWSCloudTrail/Trail/includeGlobalServiceEvents
=== RUN   TestAccAWSCloudTrail/Trail/eventSelector
=== RUN   TestAccAWSCloudTrail/Trail/isOrganization
=== RUN   TestAccAWSCloudTrail/Trail/logValidation
=== RUN   TestAccAWSCloudTrail/Trail/kmsKey
=== RUN   TestAccAWSCloudTrail/Trail/tags
=== RUN   TestAccAWSCloudTrail/Trail/basic
=== RUN   TestAccAWSCloudTrail/Trail/cloudwatch
=== RUN   TestAccAWSCloudTrail/Trail/isMultiRegion
--- PASS: TestAccAWSCloudTrail (1237.98s)
    --- PASS: TestAccAWSCloudTrail/Trail (1237.98s)
        --- PASS: TestAccAWSCloudTrail/Trail/enableLogging (176.06s)
        --- PASS: TestAccAWSCloudTrail/Trail/includeGlobalServiceEvents (78.92s)
        --- PASS: TestAccAWSCloudTrail/Trail/eventSelector (138.41s)
        --- SKIP: TestAccAWSCloudTrail/Trail/isOrganization (2.80s)
            provider_test.go:247: skipping tests; this AWS account must not be an existing member of an AWS Organization
        --- PASS: TestAccAWSCloudTrail/Trail/logValidation (124.09s)
        --- PASS: TestAccAWSCloudTrail/Trail/kmsKey (101.12s)
        --- PASS: TestAccAWSCloudTrail/Trail/tags (176.01s)
        --- PASS: TestAccAWSCloudTrail/Trail/basic (127.92s)
        --- PASS: TestAccAWSCloudTrail/Trail/cloudwatch (139.08s)
        --- PASS: TestAccAWSCloudTrail/Trail/isMultiRegion (173.57s)
=== CONT  TestAccAWSCloudTrailServiceAccount_basic
=== CONT  TestAccAWSCloudTrailServiceAccount_Region
--- PASS: TestAccAWSCloudTrailServiceAccount_Region (21.70s)
--- PASS: TestAccAWSCloudTrailServiceAccount_basic (21.76s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       1260.877s
```