### PR TITLE
Final retries after timeouts in various code-related resources

### DIFF
--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -649,9 +649,11 @@ func resourceAwsCodeBuildProjectCreate(d *schema.ResourceData, meta interface{})
 		}
 
 		return nil
-
 	})
 
+	if isResourceTimeoutError(err) {
+		resp, err = conn.CreateProject(params)
+	}
 	if err != nil {
 		return fmt.Errorf("Error creating CodeBuild project: %s", err)
 	}
@@ -1157,9 +1159,11 @@ func resourceAwsCodeBuildProjectUpdate(d *schema.ResourceData, meta interface{})
 		}
 
 		return nil
-
 	})
 
+	if isResourceTimeoutError(err) {
+		_, err = conn.UpdateProject(params)
+	}
 	if err != nil {
 		return fmt.Errorf(
 			"[ERROR] Error updating CodeBuild project (%s): %s",

--- a/aws/resource_aws_codedeploy_deployment_group.go
+++ b/aws/resource_aws_codedeploy_deployment_group.go
@@ -555,8 +555,11 @@ func resourceAwsCodeDeployDeploymentGroupCreate(d *schema.ResourceData, meta int
 		return handleCreateError(err)
 	})
 
+	if isResourceTimeoutError(err) {
+		resp, err = conn.CreateDeploymentGroup(&input)
+	}
 	if err != nil {
-		return err
+		return fmt.Errorf("Error creating CodeDeploy deployment group: %s", err)
 	}
 
 	d.SetId(*resp.DeploymentGroupId)
@@ -732,8 +735,11 @@ func resourceAwsCodeDeployDeploymentGroupUpdate(d *schema.ResourceData, meta int
 		return handleUpdateError(err)
 	})
 
+	if isResourceTimeoutError(err) {
+		_, err = conn.UpdateDeploymentGroup(&input)
+	}
 	if err != nil {
-		return err
+		return fmt.Errorf("Error updating CodeDeploy deployment group: %s", err)
 	}
 
 	return resourceAwsCodeDeployDeploymentGroupRead(d, meta)

--- a/aws/resource_aws_codepipeline.go
+++ b/aws/resource_aws_codepipeline.go
@@ -185,6 +185,9 @@ func resourceAwsCodePipelineCreate(d *schema.ResourceData, meta interface{}) err
 
 		return resource.NonRetryableError(err)
 	})
+	if isResourceTimeoutError(err) {
+		resp, err = conn.CreatePipeline(params)
+	}
 	if err != nil {
 		return fmt.Errorf("Error creating CodePipeline: %s", err)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES
* resource/aws_codebuild_project: Final retries after timeouts creating and updating codebuild projects 
* resource/aws_codedeploy_deployment_group: Final retries after timeouts creating and updating deployment groups
* resource/aws_codepipeline: Final retry after timeout creating codepipeline
```

Output from acceptance testing:

```
NOTE the CodeBuildProject failure is not new


$ make testacc TESTARGS="-run=TestAccAWSCodeBuildProject"            
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSCodeBuildProject -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCodeBuildProject_importBasic
=== PAUSE TestAccAWSCodeBuildProject_importBasic
=== RUN   TestAccAWSCodeBuildProject_basic
=== PAUSE TestAccAWSCodeBuildProject_basic
=== RUN   TestAccAWSCodeBuildProject_BadgeEnabled
=== PAUSE TestAccAWSCodeBuildProject_BadgeEnabled
=== RUN   TestAccAWSCodeBuildProject_BuildTimeout
=== PAUSE TestAccAWSCodeBuildProject_BuildTimeout
=== RUN   TestAccAWSCodeBuildProject_Cache
=== PAUSE TestAccAWSCodeBuildProject_Cache
=== RUN   TestAccAWSCodeBuildProject_Description
=== PAUSE TestAccAWSCodeBuildProject_Description
=== RUN   TestAccAWSCodeBuildProject_EncryptionKey
=== PAUSE TestAccAWSCodeBuildProject_EncryptionKey
=== RUN   TestAccAWSCodeBuildProject_Environment_EnvironmentVariable
=== PAUSE TestAccAWSCodeBuildProject_Environment_EnvironmentVariable
=== RUN   TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type
=== PAUSE TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type
=== RUN   TestAccAWSCodeBuildProject_Environment_Certificate
=== PAUSE TestAccAWSCodeBuildProject_Environment_Certificate
=== RUN   TestAccAWSCodeBuildProject_LogsConfig_CloudWatchLogs
=== PAUSE TestAccAWSCodeBuildProject_LogsConfig_CloudWatchLogs
=== RUN   TestAccAWSCodeBuildProject_LogsConfig_S3Logs
=== PAUSE TestAccAWSCodeBuildProject_LogsConfig_S3Logs
=== RUN   TestAccAWSCodeBuildProject_Source_Auth
=== PAUSE TestAccAWSCodeBuildProject_Source_Auth
=== RUN   TestAccAWSCodeBuildProject_Source_GitCloneDepth
=== PAUSE TestAccAWSCodeBuildProject_Source_GitCloneDepth
=== RUN   TestAccAWSCodeBuildProject_Source_InsecureSSL
=== PAUSE TestAccAWSCodeBuildProject_Source_InsecureSSL
=== RUN   TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket
=== PAUSE TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket
=== RUN   TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub
=== PAUSE TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub
=== RUN   TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise
=== PAUSE TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise
=== RUN   TestAccAWSCodeBuildProject_Source_Type_Bitbucket
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_Bitbucket
=== RUN   TestAccAWSCodeBuildProject_Source_Type_CodeCommit
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_CodeCommit
=== RUN   TestAccAWSCodeBuildProject_Source_Type_CodePipeline
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_CodePipeline
=== RUN   TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise
=== RUN   TestAccAWSCodeBuildProject_Source_Type_S3
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_S3
=== RUN   TestAccAWSCodeBuildProject_Source_Type_NoSource
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_NoSource
=== RUN   TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid
=== RUN   TestAccAWSCodeBuildProject_Tags
=== PAUSE TestAccAWSCodeBuildProject_Tags
=== RUN   TestAccAWSCodeBuildProject_VpcConfig
=== PAUSE TestAccAWSCodeBuildProject_VpcConfig
=== RUN   TestAccAWSCodeBuildProject_WindowsContainer
=== PAUSE TestAccAWSCodeBuildProject_WindowsContainer
=== RUN   TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled
=== RUN   TestAccAWSCodeBuildProject_Artifacts_NamespaceType
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_NamespaceType
=== RUN   TestAccAWSCodeBuildProject_Artifacts_OverrideArtifactName
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_OverrideArtifactName
=== RUN   TestAccAWSCodeBuildProject_Artifacts_Packaging
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_Packaging
=== RUN   TestAccAWSCodeBuildProject_Artifacts_Path
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_Path
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts
=== RUN   TestAccAWSCodeBuildProject_SecondarySources_CodeCommit
=== PAUSE TestAccAWSCodeBuildProject_SecondarySources_CodeCommit
=== RUN   TestAccAWSCodeBuildProject_Environment_RegistryCredential
=== PAUSE TestAccAWSCodeBuildProject_Environment_RegistryCredential
=== CONT  TestAccAWSCodeBuildProject_importBasic
=== CONT  TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise
=== CONT  TestAccAWSCodeBuildProject_Source_Type_Bitbucket
=== CONT  TestAccAWSCodeBuildProject_Environment_RegistryCredential
=== CONT  TestAccAWSCodeBuildProject_SecondarySources_CodeCommit
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts
=== CONT  TestAccAWSCodeBuildProject_Artifacts_Path
=== CONT  TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid
=== CONT  TestAccAWSCodeBuildProject_Source_Type_NoSource
=== CONT  TestAccAWSCodeBuildProject_Source_Type_S3
=== CONT  TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise
=== CONT  TestAccAWSCodeBuildProject_Source_Type_CodePipeline
=== CONT  TestAccAWSCodeBuildProject_Tags
=== CONT  TestAccAWSCodeBuildProject_Artifacts_Packaging
=== CONT  TestAccAWSCodeBuildProject_Artifacts_OverrideArtifactName
=== CONT  TestAccAWSCodeBuildProject_Artifacts_NamespaceType
=== CONT  TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled
=== CONT  TestAccAWSCodeBuildProject_WindowsContainer
=== CONT  TestAccAWSCodeBuildProject_Source_Type_CodeCommit
=== CONT  TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid (25.04s)
=== CONT  TestAccAWSCodeBuildProject_VpcConfig
--- PASS: TestAccAWSCodeBuildProject_WindowsContainer (40.05s)
=== CONT  TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type
--- PASS: TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise (40.11s)
=== CONT  TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodePipeline (40.14s)
=== CONT  TestAccAWSCodeBuildProject_Cache
--- PASS: TestAccAWSCodeBuildProject_Source_Type_Bitbucket (40.27s)
=== CONT  TestAccAWSCodeBuildProject_Source_InsecureSSL
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_CodeCommit (40.32s)
=== CONT  TestAccAWSCodeBuildProject_Environment_EnvironmentVariable
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodeCommit (40.33s)
=== CONT  TestAccAWSCodeBuildProject_Source_GitCloneDepth
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSource (48.58s)
=== CONT  TestAccAWSCodeBuildProject_EncryptionKey
--- PASS: TestAccAWSCodeBuildProject_importBasic (50.89s)
=== CONT  TestAccAWSCodeBuildProject_Source_Auth
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub (59.52s)
=== CONT  TestAccAWSCodeBuildProject_Description
--- PASS: TestAccAWSCodeBuildProject_Tags (59.57s)
=== CONT  TestAccAWSCodeBuildProject_LogsConfig_S3Logs
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts (67.38s)
=== CONT  TestAccAWSCodeBuildProject_basic
--- FAIL: TestAccAWSCodeBuildProject_Source_Auth (16.53s)
    testing.go:568: Step 1 error: errors during apply:
        
        Error: Error creating CodeBuild project: InvalidInputException: No Access token found, please visit AWS CodeBuild console to connect to GitHub
                status code: 400, request id: f6bb14e3-6c1a-4514-a83f-3c5a5ad2428e
        
          on /var/folders/pd/swwl85ks1nvbfy2pht84q2m40000gq/T/tf-test832210471/main.tf line 64:
          (source code not available)
        
        
=== CONT  TestAccAWSCodeBuildProject_LogsConfig_CloudWatchLogs
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise (68.21s)
=== CONT  TestAccAWSCodeBuildProject_Environment_Certificate
--- PASS: TestAccAWSCodeBuildProject_Source_Type_S3 (70.70s)
=== CONT  TestAccAWSCodeBuildProject_BuildTimeout
--- PASS: TestAccAWSCodeBuildProject_Environment_RegistryCredential (76.01s)
=== CONT  TestAccAWSCodeBuildProject_BadgeEnabled
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type (55.93s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled (99.00s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Path (100.36s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_OverrideArtifactName (102.77s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_NamespaceType (103.01s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Packaging (103.39s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitCloneDepth (65.89s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket (66.23s)
--- PASS: TestAccAWSCodeBuildProject_Source_InsecureSSL (66.16s)
--- PASS: TestAccAWSCodeBuildProject_BadgeEnabled (39.97s)
--- PASS: TestAccAWSCodeBuildProject_basic (50.47s)
--- PASS: TestAccAWSCodeBuildProject_EncryptionKey (75.25s)
--- PASS: TestAccAWSCodeBuildProject_Description (66.07s)
--- PASS: TestAccAWSCodeBuildProject_BuildTimeout (56.36s)
--- PASS: TestAccAWSCodeBuildProject_Environment_Certificate (63.04s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable (94.04s)
--- PASS: TestAccAWSCodeBuildProject_VpcConfig (114.89s)
--- PASS: TestAccAWSCodeBuildProject_LogsConfig_CloudWatchLogs (77.52s)
--- PASS: TestAccAWSCodeBuildProject_Cache (144.25s)
--- PASS: TestAccAWSCodeBuildProject_LogsConfig_S3Logs (140.35s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-aws/aws       200.834s
make: *** [testacc] Error 1

make testacc TESTARGS="-run=TestAccAWSCodeDeployDeploymentGroup_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSCodeDeployDeploymentGroup_basic -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCodeDeployDeploymentGroup_basic
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_basic
=== RUN   TestAccAWSCodeDeployDeploymentGroup_basic_tagSet
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_basic_tagSet
=== CONT  TestAccAWSCodeDeployDeploymentGroup_basic
=== CONT  TestAccAWSCodeDeployDeploymentGroup_basic_tagSet
--- PASS: TestAccAWSCodeDeployDeploymentGroup_basic (73.56s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_basic_tagSet (73.98s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       75.095s

make testacc TESTARGS="-run=TestAccAWSCodePipeline"                    
--- PASS: TestAccAWSCodePipelineWebhook_unauthenticated (23.74s)
--- PASS: TestAccAWSCodePipeline_emptyArtifacts (26.00s)
--- PASS: TestAccAWSCodePipeline_deployWithServiceRole (26.59s)
--- PASS: TestAccAWSCodePipelineWebhook_basic (29.19s)
--- PASS: TestAccAWSCodePipeline_basic (30.48s)
--- PASS: TestAccAWSCodePipeline_Import_basic (34.88s)
--- PASS: TestAccAWSCodePipelineWebhook_tags (37.40s)
--- PASS: TestAccAWSCodePipelineWebhook_ipAuth (37.46s)
--- PASS: TestAccAWSCodePipeline_tags (43.47s)
```