### PR TITLE
Final retries and deleting extraneous retry blocks from cognito resources

### DIFF
--- a/aws/resource_aws_cognito_identity_pool.go
+++ b/aws/resource_aws_cognito_identity_pool.go
@@ -3,13 +3,11 @@ package aws
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/cognitoidentity"
-	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -245,15 +243,12 @@ func resourceAwsCognitoIdentityPoolDelete(d *schema.ResourceData, meta interface
 	conn := meta.(*AWSClient).cognitoconn
 	log.Printf("[DEBUG] Deleting Cognito Identity Pool: %s", d.Id())
 
-	return resource.Retry(5*time.Minute, func() *resource.RetryError {
-		_, err := conn.DeleteIdentityPool(&cognitoidentity.DeleteIdentityPoolInput{
-			IdentityPoolId: aws.String(d.Id()),
-		})
-
-		if err == nil {
-			return nil
-		}
-
-		return resource.NonRetryableError(err)
+	_, err := conn.DeleteIdentityPool(&cognitoidentity.DeleteIdentityPoolInput{
+		IdentityPoolId: aws.String(d.Id()),
 	})
+
+	if err != nil {
+		return fmt.Errorf("Error deleting Cognito identity pool: %s", err)
+	}
+	return nil
 }

--- a/aws/resource_aws_cognito_identity_pool_roles_attachment.go
+++ b/aws/resource_aws_cognito_identity_pool_roles_attachment.go
@@ -3,12 +3,10 @@ package aws
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/cognitoidentity"
-	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 )
@@ -222,19 +220,17 @@ func resourceAwsCognitoIdentityPoolRolesAttachmentDelete(d *schema.ResourceData,
 	conn := meta.(*AWSClient).cognitoconn
 	log.Printf("[DEBUG] Deleting Cognito Identity Pool Roles Association: %s", d.Id())
 
-	return resource.Retry(5*time.Minute, func() *resource.RetryError {
-		_, err := conn.SetIdentityPoolRoles(&cognitoidentity.SetIdentityPoolRolesInput{
-			IdentityPoolId: aws.String(d.Get("identity_pool_id").(string)),
-			Roles:          expandCognitoIdentityPoolRoles(make(map[string]interface{})),
-			RoleMappings:   expandCognitoIdentityPoolRoleMappingsAttachment([]interface{}{}),
-		})
-
-		if err == nil {
-			return nil
-		}
-
-		return resource.NonRetryableError(err)
+	_, err := conn.SetIdentityPoolRoles(&cognitoidentity.SetIdentityPoolRolesInput{
+		IdentityPoolId: aws.String(d.Get("identity_pool_id").(string)),
+		Roles:          expandCognitoIdentityPoolRoles(make(map[string]interface{})),
+		RoleMappings:   expandCognitoIdentityPoolRoleMappingsAttachment([]interface{}{}),
 	})
+
+	if err != nil {
+		return fmt.Errorf("Error deleting Cognito identity pool roles association: %s", err)
+	}
+
+	return nil
 }
 
 // Validating that each role_mapping ambiguous_role_resolution

--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -673,6 +673,9 @@ func resourceAwsCognitoUserPoolCreate(d *schema.ResourceData, meta interface{}) 
 
 		return resource.NonRetryableError(err)
 	})
+	if isResourceTimeoutError(err) {
+		resp, err = conn.CreateUserPool(params)
+	}
 	if err != nil {
 		return fmt.Errorf("Error creating Cognito User Pool: %s", err)
 	}
@@ -944,6 +947,9 @@ func resourceAwsCognitoUserPoolUpdate(d *schema.ResourceData, meta interface{}) 
 
 		return resource.NonRetryableError(err)
 	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.UpdateUserPool(params)
+	}
 	if err != nil {
 		return fmt.Errorf("Error updating Cognito User pool: %s", err)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES
* resource/aws_cognito_user_pool: Final retries after timeouts creating and updating Cognito user pools

```

Output from acceptance testing:

```
NOTE that test failure is an existing one


$ make testacc TESTARGS="-run=TestAccAWSCognitoIdentityPoolRolesAttachment"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSCognitoIdentityPoolRolesAttachment -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCognitoIdentityPoolRolesAttachment_basic
=== PAUSE TestAccAWSCognitoIdentityPoolRolesAttachment_basic
=== RUN   TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings
=== PAUSE TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings
=== RUN   TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleResolutionError
=== PAUSE TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleResolutionError
=== RUN   TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithRulesTypeError
=== PAUSE TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithRulesTypeError
=== RUN   TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithTokenTypeError
=== PAUSE TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithTokenTypeError
=== CONT  TestAccAWSCognitoIdentityPoolRolesAttachment_basic
=== CONT  TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithTokenTypeError
=== CONT  TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings
=== CONT  TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleResolutionError
=== CONT  TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithRulesTypeError
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithTokenTypeError (20.24s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleResolutionError (20.36s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithRulesTypeError (20.67s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_basic (55.48s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings (89.03s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       90.268s

make testacc TESTARGS="-run=TestAccAWSCognitoUserPool"                   
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSCognitoUserPool -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCognitoUserPoolClient_basic
=== PAUSE TestAccAWSCognitoUserPoolClient_basic
=== RUN   TestAccAWSCognitoUserPoolClient_importBasic
=== PAUSE TestAccAWSCognitoUserPoolClient_importBasic
=== RUN   TestAccAWSCognitoUserPoolClient_RefreshTokenValidity
=== PAUSE TestAccAWSCognitoUserPoolClient_RefreshTokenValidity
=== RUN   TestAccAWSCognitoUserPoolClient_Name
=== PAUSE TestAccAWSCognitoUserPoolClient_Name
=== RUN   TestAccAWSCognitoUserPoolClient_allFields
=== PAUSE TestAccAWSCognitoUserPoolClient_allFields
=== RUN   TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField
=== PAUSE TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField
=== RUN   TestAccAWSCognitoUserPoolDomain_basic
=== PAUSE TestAccAWSCognitoUserPoolDomain_basic
=== RUN   TestAccAWSCognitoUserPoolDomain_custom
--- SKIP: TestAccAWSCognitoUserPoolDomain_custom (0.00s)
    resource_aws_cognito_user_pool_domain_test.go:56: Environment variable AWS_COGNITO_USER_POOL_DOMAIN_ROOT_DOMAIN is not set. This environment variable must be set to the fqdn of an ISSUED ACM certificate in us-east-1 to enable this test.
=== RUN   TestAccAWSCognitoUserPool_importBasic
=== PAUSE TestAccAWSCognitoUserPool_importBasic
=== RUN   TestAccAWSCognitoUserPool_basic
=== PAUSE TestAccAWSCognitoUserPool_basic
=== RUN   TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration
=== PAUSE TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration
=== RUN   TestAccAWSCognitoUserPool_withAdvancedSecurityMode
=== PAUSE TestAccAWSCognitoUserPool_withAdvancedSecurityMode
=== RUN   TestAccAWSCognitoUserPool_withDeviceConfiguration
=== PAUSE TestAccAWSCognitoUserPool_withDeviceConfiguration
=== RUN   TestAccAWSCognitoUserPool_withEmailVerificationMessage
=== PAUSE TestAccAWSCognitoUserPool_withEmailVerificationMessage
=== RUN   TestAccAWSCognitoUserPool_withSmsVerificationMessage
=== PAUSE TestAccAWSCognitoUserPool_withSmsVerificationMessage
=== RUN   TestAccAWSCognitoUserPool_withEmailConfiguration
--- SKIP: TestAccAWSCognitoUserPool_withEmailConfiguration (0.00s)
    resource_aws_cognito_user_pool_test.go:278: 'TEST_AWS_SES_VERIFIED_EMAIL_ARN' not set, skipping test.
=== RUN   TestAccAWSCognitoUserPool_withSmsConfiguration
=== PAUSE TestAccAWSCognitoUserPool_withSmsConfiguration
=== RUN   TestAccAWSCognitoUserPool_withSmsConfigurationUpdated
=== PAUSE TestAccAWSCognitoUserPool_withSmsConfigurationUpdated
=== RUN   TestAccAWSCognitoUserPool_withTags
=== PAUSE TestAccAWSCognitoUserPool_withTags
=== RUN   TestAccAWSCognitoUserPool_withAliasAttributes
=== PAUSE TestAccAWSCognitoUserPool_withAliasAttributes
=== RUN   TestAccAWSCognitoUserPool_withPasswordPolicy
=== PAUSE TestAccAWSCognitoUserPool_withPasswordPolicy
=== RUN   TestAccAWSCognitoUserPool_withLambdaConfig
=== PAUSE TestAccAWSCognitoUserPool_withLambdaConfig
=== RUN   TestAccAWSCognitoUserPool_withSchemaAttributes
=== PAUSE TestAccAWSCognitoUserPool_withSchemaAttributes
=== RUN   TestAccAWSCognitoUserPool_withVerificationMessageTemplate
=== PAUSE TestAccAWSCognitoUserPool_withVerificationMessageTemplate
=== RUN   TestAccAWSCognitoUserPool_update
=== PAUSE TestAccAWSCognitoUserPool_update
=== CONT  TestAccAWSCognitoUserPoolClient_basic
=== CONT  TestAccAWSCognitoUserPool_withAliasAttributes
=== CONT  TestAccAWSCognitoUserPool_withLambdaConfig
=== CONT  TestAccAWSCognitoUserPool_withEmailVerificationMessage
=== CONT  TestAccAWSCognitoUserPool_withDeviceConfiguration
=== CONT  TestAccAWSCognitoUserPool_withAdvancedSecurityMode
=== CONT  TestAccAWSCognitoUserPool_withPasswordPolicy
=== CONT  TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration
=== CONT  TestAccAWSCognitoUserPool_basic
=== CONT  TestAccAWSCognitoUserPool_importBasic
=== CONT  TestAccAWSCognitoUserPool_update
=== CONT  TestAccAWSCognitoUserPoolDomain_basic
=== CONT  TestAccAWSCognitoUserPool_withVerificationMessageTemplate
=== CONT  TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField
=== CONT  TestAccAWSCognitoUserPool_withSchemaAttributes
=== CONT  TestAccAWSCognitoUserPoolClient_RefreshTokenValidity
=== CONT  TestAccAWSCognitoUserPool_withTags
=== CONT  TestAccAWSCognitoUserPoolClient_Name
=== CONT  TestAccAWSCognitoUserPool_withSmsConfigurationUpdated
=== CONT  TestAccAWSCognitoUserPoolClient_importBasic
--- PASS: TestAccAWSCognitoUserPool_basic (25.30s)
=== CONT  TestAccAWSCognitoUserPoolClient_allFields
--- PASS: TestAccAWSCognitoUserPool_importBasic (26.85s)
=== CONT  TestAccAWSCognitoUserPool_withSmsVerificationMessage
--- PASS: TestAccAWSCognitoUserPoolClient_basic (27.87s)
=== CONT  TestAccAWSCognitoUserPool_withSmsConfiguration
--- PASS: TestAccAWSCognitoUserPoolClient_importBasic (30.84s)
--- PASS: TestAccAWSCognitoUserPoolDomain_basic (35.29s)
--- PASS: TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration (40.96s)
--- PASS: TestAccAWSCognitoUserPool_withAliasAttributes (41.27s)
--- PASS: TestAccAWSCognitoUserPool_withTags (41.29s)
--- PASS: TestAccAWSCognitoUserPool_withDeviceConfiguration (41.31s)
--- PASS: TestAccAWSCognitoUserPool_withEmailVerificationMessage (41.49s)
--- PASS: TestAccAWSCognitoUserPool_withSchemaAttributes (44.72s)
--- PASS: TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField (45.75s)
--- PASS: TestAccAWSCognitoUserPoolClient_RefreshTokenValidity (46.03s)
--- PASS: TestAccAWSCognitoUserPoolClient_Name (47.51s)
--- PASS: TestAccAWSCognitoUserPoolClient_allFields (27.96s)
--- PASS: TestAccAWSCognitoUserPool_withPasswordPolicy (58.05s)
--- PASS: TestAccAWSCognitoUserPool_withSmsConfigurationUpdated (59.94s)
--- PASS: TestAccAWSCognitoUserPool_withVerificationMessageTemplate (60.03s)
--- PASS: TestAccAWSCognitoUserPool_withAdvancedSecurityMode (62.16s)
--- PASS: TestAccAWSCognitoUserPool_withLambdaConfig (66.80s)
--- PASS: TestAccAWSCognitoUserPool_withSmsVerificationMessage (40.85s)
--- PASS: TestAccAWSCognitoUserPool_withSmsConfiguration (44.47s)
--- PASS: TestAccAWSCognitoUserPool_update (90.07s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       90.974s

make testacc TESTARGS="-run=TestAccAWSCognitoIdentityPool"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSCognitoIdentityPool -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCognitoIdentityPoolRolesAttachment_basic
=== PAUSE TestAccAWSCognitoIdentityPoolRolesAttachment_basic
=== RUN   TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings
=== PAUSE TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings
=== RUN   TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleResolutionError
=== PAUSE TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleResolutionError
=== RUN   TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithRulesTypeError
=== PAUSE TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithRulesTypeError
=== RUN   TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithTokenTypeError
=== PAUSE TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithTokenTypeError
=== RUN   TestAccAWSCognitoIdentityPool_importBasic
=== PAUSE TestAccAWSCognitoIdentityPool_importBasic
=== RUN   TestAccAWSCognitoIdentityPool_basic
=== PAUSE TestAccAWSCognitoIdentityPool_basic
=== RUN   TestAccAWSCognitoIdentityPool_supportedLoginProviders
=== PAUSE TestAccAWSCognitoIdentityPool_supportedLoginProviders
=== RUN   TestAccAWSCognitoIdentityPool_openidConnectProviderArns
=== PAUSE TestAccAWSCognitoIdentityPool_openidConnectProviderArns
=== RUN   TestAccAWSCognitoIdentityPool_samlProviderArns
=== PAUSE TestAccAWSCognitoIdentityPool_samlProviderArns
=== RUN   TestAccAWSCognitoIdentityPool_cognitoIdentityProviders
=== PAUSE TestAccAWSCognitoIdentityPool_cognitoIdentityProviders
=== RUN   TestAccAWSCognitoIdentityPool_addingNewProviderKeepsOldProvider
--- PASS: TestAccAWSCognitoIdentityPool_addingNewProviderKeepsOldProvider (59.73s)
=== RUN   TestAccAWSCognitoIdentityPoolWithTags
=== PAUSE TestAccAWSCognitoIdentityPoolWithTags
=== CONT  TestAccAWSCognitoIdentityPoolRolesAttachment_basic
=== CONT  TestAccAWSCognitoIdentityPool_supportedLoginProviders
=== CONT  TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings
=== CONT  TestAccAWSCognitoIdentityPool_basic
=== CONT  TestAccAWSCognitoIdentityPool_importBasic
=== CONT  TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithTokenTypeError
=== CONT  TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithRulesTypeError
=== CONT  TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleResolutionError
=== CONT  TestAccAWSCognitoIdentityPool_samlProviderArns
=== CONT  TestAccAWSCognitoIdentityPool_cognitoIdentityProviders
=== CONT  TestAccAWSCognitoIdentityPool_openidConnectProviderArns
=== CONT  TestAccAWSCognitoIdentityPoolWithTags
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithRulesTypeError (18.96s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithTokenTypeError (19.00s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleResolutionError (19.15s)
--- PASS: TestAccAWSCognitoIdentityPool_importBasic (24.85s)
--- FAIL: TestAccAWSCognitoIdentityPool_openidConnectProviderArns (35.50s)
    testing.go:568: Step 1 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        UPDATE: aws_cognito_identity_pool.main
          allow_unauthenticated_identities: "false" => "false"
          arn:                              "arn:aws:cognito-identity:us-west-2:187416307283:identitypool/us-west-2:5637e737-c093-4c2c-ba99-07cabf6bb323" => "arn:aws:cognito-identity:us-west-2:187416307283:identitypool/us-west-2:5637e737-c093-4c2c-ba99-07cabf6bb323"
          cognito_identity_providers.#:     "0" => "0"
          developer_provider_name:          "" => ""
          id:                               "us-west-2:5637e737-c093-4c2c-ba99-07cabf6bb323" => "us-west-2:5637e737-c093-4c2c-ba99-07cabf6bb323"
          identity_pool_name:               "identity pool wb1f86iqvk" => "identity pool wb1f86iqvk"
          openid_connect_provider_arns.#:   "2" => "2"
          openid_connect_provider_arns.0:   "arn:aws:iam::123456789012:oidc-provider/bar.example.com" => "arn:aws:iam::123456789012:oidc-provider/foo.example.com"
          openid_connect_provider_arns.1:   "arn:aws:iam::123456789012:oidc-provider/foo.example.com" => "arn:aws:iam::123456789012:oidc-provider/bar.example.com"
          saml_provider_arns.#:             "0" => "0"
        
        
        
        STATE:
        
        aws_cognito_identity_pool.main:
          ID = us-west-2:5637e737-c093-4c2c-ba99-07cabf6bb323
          provider = provider.aws
          allow_unauthenticated_identities = false
          arn = arn:aws:cognito-identity:us-west-2:187416307283:identitypool/us-west-2:5637e737-c093-4c2c-ba99-07cabf6bb323
          developer_provider_name = 
          identity_pool_name = identity pool wb1f86iqvk
          openid_connect_provider_arns.# = 2
          openid_connect_provider_arns.0 = arn:aws:iam::123456789012:oidc-provider/bar.example.com
          openid_connect_provider_arns.1 = arn:aws:iam::123456789012:oidc-provider/foo.example.com
--- PASS: TestAccAWSCognitoIdentityPool_basic (40.16s)
--- PASS: TestAccAWSCognitoIdentityPoolWithTags (40.66s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_basic (53.70s)
--- PASS: TestAccAWSCognitoIdentityPool_supportedLoginProviders (56.58s)
--- PASS: TestAccAWSCognitoIdentityPool_cognitoIdentityProviders (56.60s)
--- PASS: TestAccAWSCognitoIdentityPool_samlProviderArns (60.15s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings (89.01s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-aws/aws       149.613s
make: *** [testacc] Error 1
```