### PR TITLE
Final retries after timeouts in docdb resources

### DIFF
--- a/aws/resource_aws_docdb_cluster_instance.go
+++ b/aws/resource_aws_docdb_cluster_instance.go
@@ -213,6 +213,9 @@ func resourceAwsDocDBClusterInstanceCreate(d *schema.ResourceData, meta interfac
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		resp, err = conn.CreateDBInstance(createOpts)
+	}
 	if err != nil {
 		return fmt.Errorf("error creating DocDB Instance: %s", err)
 	}
@@ -356,6 +359,9 @@ func resourceAwsDocDBClusterInstanceUpdate(d *schema.ResourceData, meta interfac
 			}
 			return nil
 		})
+		if isResourceTimeoutError(err) {
+			_, err = conn.ModifyDBInstance(req)
+		}
 		if err != nil {
 			return fmt.Errorf("Error modifying DB Instance %s: %s", d.Id(), err)
 		}

--- a/aws/resource_aws_docdb_cluster_parameter_group.go
+++ b/aws/resource_aws_docdb_cluster_parameter_group.go
@@ -266,7 +266,7 @@ func waitForDocDBClusterParameterGroupDeletion(conn *docdb.DocDB, name string) e
 		DBClusterParameterGroupName: aws.String(name),
 	}
 
-	return resource.Retry(10*time.Minute, func() *resource.RetryError {
+	err := resource.Retry(10*time.Minute, func() *resource.RetryError {
 		_, err := conn.DescribeDBClusterParameterGroups(params)
 
 		if isAWSErr(err, docdb.ErrCodeDBParameterGroupNotFoundFault, "") {
@@ -279,4 +279,14 @@ func waitForDocDBClusterParameterGroupDeletion(conn *docdb.DocDB, name string) e
 
 		return resource.RetryableError(fmt.Errorf("DocDB Parameter Group (%s) still exists", name))
 	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.DescribeDBClusterParameterGroups(params)
+		if isAWSErr(err, docdb.ErrCodeDBParameterGroupNotFoundFault, "") {
+			return nil
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("Error deleting DocDB cluster parameter group: %s", err)
+	}
+	return nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES
* resource/aws_docdb_cluster_instance: Final retries after timeouts creating and updating DocDB cluster instances
* resource/aws_docdb_cluster_parameter_group: Final retry after timeout deleting DocDB cluster parameter groups
* resource/aws_docdb_subnet_group: Final retry after timeout deleting DocDB subnet groups
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSDocDBClusterInstance"      
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSDocDBClusterInstance -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSDocDBClusterInstance_basic
=== PAUSE TestAccAWSDocDBClusterInstance_basic
=== RUN   TestAccAWSDocDBClusterInstance_az
=== PAUSE TestAccAWSDocDBClusterInstance_az
=== RUN   TestAccAWSDocDBClusterInstance_namePrefix
=== PAUSE TestAccAWSDocDBClusterInstance_namePrefix
=== RUN   TestAccAWSDocDBClusterInstance_generatedName
=== PAUSE TestAccAWSDocDBClusterInstance_generatedName
=== RUN   TestAccAWSDocDBClusterInstance_kmsKey
=== PAUSE TestAccAWSDocDBClusterInstance_kmsKey
=== RUN   TestAccAWSDocDBClusterInstance_disappears
=== PAUSE TestAccAWSDocDBClusterInstance_disappears
=== CONT  TestAccAWSDocDBClusterInstance_basic
=== CONT  TestAccAWSDocDBClusterInstance_kmsKey
=== CONT  TestAccAWSDocDBClusterInstance_disappears
=== CONT  TestAccAWSDocDBClusterInstance_generatedName
=== CONT  TestAccAWSDocDBClusterInstance_namePrefix
=== CONT  TestAccAWSDocDBClusterInstance_az
--- PASS: TestAccAWSDocDBClusterInstance_kmsKey (575.36s)
--- PASS: TestAccAWSDocDBClusterInstance_az (680.64s)
--- PASS: TestAccAWSDocDBClusterInstance_namePrefix (684.96s)
--- PASS: TestAccAWSDocDBClusterInstance_disappears (701.13s)
--- PASS: TestAccAWSDocDBClusterInstance_generatedName (703.06s)
--- PASS: TestAccAWSDocDBClusterInstance_basic (1406.39s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       1408.673s

make testacc TESTARGS="-run=TestAccAWSDocDBClusterParameterGroup"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSDocDBClusterParameterGroup -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSDocDBClusterParameterGroup_basic
=== PAUSE TestAccAWSDocDBClusterParameterGroup_basic
=== RUN   TestAccAWSDocDBClusterParameterGroup_namePrefix
=== PAUSE TestAccAWSDocDBClusterParameterGroup_namePrefix
=== RUN   TestAccAWSDocDBClusterParameterGroup_generatedName
=== PAUSE TestAccAWSDocDBClusterParameterGroup_generatedName
=== RUN   TestAccAWSDocDBClusterParameterGroup_Description
=== PAUSE TestAccAWSDocDBClusterParameterGroup_Description
=== RUN   TestAccAWSDocDBClusterParameterGroup_disappears
=== PAUSE TestAccAWSDocDBClusterParameterGroup_disappears
=== RUN   TestAccAWSDocDBClusterParameterGroup_Parameter
=== PAUSE TestAccAWSDocDBClusterParameterGroup_Parameter
=== RUN   TestAccAWSDocDBClusterParameterGroup_Tags
=== PAUSE TestAccAWSDocDBClusterParameterGroup_Tags
=== CONT  TestAccAWSDocDBClusterParameterGroup_basic
=== CONT  TestAccAWSDocDBClusterParameterGroup_Parameter
=== CONT  TestAccAWSDocDBClusterParameterGroup_disappears
=== CONT  TestAccAWSDocDBClusterParameterGroup_generatedName
=== CONT  TestAccAWSDocDBClusterParameterGroup_namePrefix
=== CONT  TestAccAWSDocDBClusterParameterGroup_Description
=== CONT  TestAccAWSDocDBClusterParameterGroup_Tags
--- PASS: TestAccAWSDocDBClusterParameterGroup_disappears (23.03s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_namePrefix (34.53s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_Description (34.53s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_generatedName (34.54s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_basic (34.65s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_Parameter (57.72s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_Tags (79.74s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       81.929s

make testacc TESTARGS="-run=TestAccAWSDocDBSubnetGroup"          
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSDocDBSubnetGroup -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSDocDBSubnetGroup_basic
=== PAUSE TestAccAWSDocDBSubnetGroup_basic
=== RUN   TestAccAWSDocDBSubnetGroup_disappears
=== PAUSE TestAccAWSDocDBSubnetGroup_disappears
=== RUN   TestAccAWSDocDBSubnetGroup_namePrefix
=== PAUSE TestAccAWSDocDBSubnetGroup_namePrefix
=== RUN   TestAccAWSDocDBSubnetGroup_generatedName
=== PAUSE TestAccAWSDocDBSubnetGroup_generatedName
=== RUN   TestAccAWSDocDBSubnetGroup_updateDescription
=== PAUSE TestAccAWSDocDBSubnetGroup_updateDescription
=== CONT  TestAccAWSDocDBSubnetGroup_basic
=== CONT  TestAccAWSDocDBSubnetGroup_updateDescription
=== CONT  TestAccAWSDocDBSubnetGroup_namePrefix
=== CONT  TestAccAWSDocDBSubnetGroup_generatedName
=== CONT  TestAccAWSDocDBSubnetGroup_disappears
--- PASS: TestAccAWSDocDBSubnetGroup_disappears (57.28s)
--- PASS: TestAccAWSDocDBSubnetGroup_generatedName (63.62s)
--- PASS: TestAccAWSDocDBSubnetGroup_namePrefix (64.19s)
--- PASS: TestAccAWSDocDBSubnetGroup_basic (64.20s)
--- PASS: TestAccAWSDocDBSubnetGroup_updateDescription (99.74s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       102.895s
```