### PR TITLE
Add support resource import for aws wafregional regex match set resource

### DIFF
--- a/aws/resource_aws_wafregional_regex_match_set.go
+++ b/aws/resource_aws_wafregional_regex_match_set.go
@@ -84,7 +84,7 @@ func resourceAwsWafRegionalRegexMatchSetCreate(d *schema.ResourceData, meta inte
 	}
 	resp := out.(*waf.CreateRegexMatchSetOutput)
 
-	d.SetId(*resp.RegexMatchSet.RegexMatchSetId)
+	d.SetId(aws.StringValue(resp.RegexMatchSet.RegexMatchSetId))
 
 	return resourceAwsWafRegionalRegexMatchSetUpdate(d, meta)
 }
@@ -97,14 +97,13 @@ func resourceAwsWafRegionalRegexMatchSetRead(d *schema.ResourceData, meta interf
 	}
 
 	resp, err := conn.GetRegexMatchSet(params)
+	if isAWSErr(err, wafregional.ErrCodeWAFNonexistentItemException, "") {
+		log.Printf("[WARN] WAF Regional Regex Match Set (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
 	if err != nil {
-		if isAWSErr(err, wafregional.ErrCodeWAFNonexistentItemException, "") {
-			log.Printf("[WARN] WAF Regional Regex Match Set (%s) not found, removing from state", d.Id())
-			d.SetId("")
-			return nil
-		}
-
-		return err
+		return fmt.Errorf("Error getting WAF Regional Regex Match Set (%s): %s", d.Id(), err)
 	}
 
 	d.Set("name", resp.RegexMatchSet.Name)
@@ -123,8 +122,13 @@ func resourceAwsWafRegionalRegexMatchSetUpdate(d *schema.ResourceData, meta inte
 		o, n := d.GetChange("regex_match_tuple")
 		oldT, newT := o.(*schema.Set).List(), n.(*schema.Set).List()
 		err := updateRegexMatchSetResourceWR(d.Id(), oldT, newT, conn, region)
+		if isAWSErr(err, wafregional.ErrCodeWAFNonexistentItemException, "") {
+			log.Printf("[WARN] WAF Regional Rate Based Rule (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
 		if err != nil {
-			return fmt.Errorf("Failed updating WAF Regional Regex Match Set: %s", err)
+			return fmt.Errorf("Failed updating WAF Regional Regex Match Set(%s): %s", d.Id(), err)
 		}
 	}
 
@@ -139,8 +143,11 @@ func resourceAwsWafRegionalRegexMatchSetDelete(d *schema.ResourceData, meta inte
 	if len(oldTuples) > 0 {
 		noTuples := []interface{}{}
 		err := updateRegexMatchSetResourceWR(d.Id(), oldTuples, noTuples, conn, region)
+		if isAWSErr(err, wafregional.ErrCodeWAFNonexistentItemException, "") {
+			return nil
+		}
 		if err != nil {
-			return fmt.Errorf("Error updating WAF Regional Regex Match Set: %s", err)
+			return fmt.Errorf("Failed updating WAF Regional Regex Match Set(%s): %s", d.Id(), err)
 		}
 	}
 
@@ -153,6 +160,11 @@ func resourceAwsWafRegionalRegexMatchSetDelete(d *schema.ResourceData, meta inte
 		log.Printf("[INFO] Deleting WAF Regional Regex Match Set: %s", req)
 		return conn.DeleteRegexMatchSet(req)
 	})
+	if isAWSErr(err, wafregional.ErrCodeWAFNonexistentItemException, "") {
+		log.Printf("[WARN] WAF Regional Regex Match Set (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("Failed deleting WAF Regional Regex Match Set: %s", err)
 	}
@@ -171,9 +183,6 @@ func updateRegexMatchSetResourceWR(id string, oldT, newT []interface{}, conn *wa
 
 		return conn.UpdateRegexMatchSet(req)
 	})
-	if err != nil {
-		return fmt.Errorf("Failed updating WAF Regional Regex Match Set: %s", err)
-	}
 
-	return nil
+	return err
 }

--- a/aws/resource_aws_wafregional_regex_match_set.go
+++ b/aws/resource_aws_wafregional_regex_match_set.go
@@ -17,6 +17,9 @@ func resourceAwsWafRegionalRegexMatchSet() *schema.Resource {
 		Read:   resourceAwsWafRegionalRegexMatchSetRead,
 		Update: resourceAwsWafRegionalRegexMatchSetUpdate,
 		Delete: resourceAwsWafRegionalRegexMatchSetDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/aws/resource_aws_wafregional_regex_match_set_test.go
+++ b/aws/resource_aws_wafregional_regex_match_set_test.go
@@ -98,6 +98,7 @@ func testAccAWSWafRegionalRegexMatchSet_basic(t *testing.T) {
 	var patternSet waf.RegexPatternSet
 	var idx int
 
+	resourceName := "aws_wafregional_regex_match_set.test"
 	matchSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
 	patternSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
 
@@ -114,16 +115,21 @@ func testAccAWSWafRegionalRegexMatchSet_basic(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalRegexMatchSetConfig(matchSetName, patternSetName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalRegexMatchSetExists("aws_wafregional_regex_match_set.test", &matchSet),
+					testAccCheckAWSWafRegionalRegexMatchSetExists(resourceName, &matchSet),
 					testAccCheckAWSWafRegionalRegexPatternSetExists("aws_wafregional_regex_pattern_set.test", &patternSet),
 					computeWafRegexMatchSetTuple(&patternSet, &fieldToMatch, "NONE", &idx),
-					resource.TestCheckResourceAttr("aws_wafregional_regex_match_set.test", "name", matchSetName),
-					resource.TestCheckResourceAttr("aws_wafregional_regex_match_set.test", "regex_match_tuple.#", "1"),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_regex_match_set.test", "regex_match_tuple.%d.field_to_match.#", &idx, "1"),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_regex_match_set.test", "regex_match_tuple.%d.field_to_match.0.data", &idx, "user-agent"),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_regex_match_set.test", "regex_match_tuple.%d.field_to_match.0.type", &idx, "HEADER"),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_regex_match_set.test", "regex_match_tuple.%d.text_transformation", &idx, "NONE"),
+					resource.TestCheckResourceAttr(resourceName, "name", matchSetName),
+					resource.TestCheckResourceAttr(resourceName, "regex_match_tuple.#", "1"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "regex_match_tuple.%d.field_to_match.#", &idx, "1"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "regex_match_tuple.%d.field_to_match.0.data", &idx, "user-agent"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "regex_match_tuple.%d.field_to_match.0.type", &idx, "HEADER"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "regex_match_tuple.%d.text_transformation", &idx, "NONE"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -134,6 +140,7 @@ func testAccAWSWafRegionalRegexMatchSet_changePatterns(t *testing.T) {
 	var patternSet waf.RegexPatternSet
 	var idx1, idx2 int
 
+	resourceName := "aws_wafregional_regex_match_set.test"
 	matchSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
 	patternSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
 
@@ -145,30 +152,35 @@ func testAccAWSWafRegionalRegexMatchSet_changePatterns(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalRegexMatchSetConfig(matchSetName, patternSetName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafRegionalRegexMatchSetExists("aws_wafregional_regex_match_set.test", &before),
+					testAccCheckAWSWafRegionalRegexMatchSetExists(resourceName, &before),
 					testAccCheckAWSWafRegionalRegexPatternSetExists("aws_wafregional_regex_pattern_set.test", &patternSet),
 					computeWafRegexMatchSetTuple(&patternSet, &waf.FieldToMatch{Data: aws.String("User-Agent"), Type: aws.String("HEADER")}, "NONE", &idx1),
-					resource.TestCheckResourceAttr("aws_wafregional_regex_match_set.test", "name", matchSetName),
-					resource.TestCheckResourceAttr("aws_wafregional_regex_match_set.test", "regex_match_tuple.#", "1"),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_regex_match_set.test", "regex_match_tuple.%d.field_to_match.#", &idx1, "1"),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_regex_match_set.test", "regex_match_tuple.%d.field_to_match.0.data", &idx1, "user-agent"),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_regex_match_set.test", "regex_match_tuple.%d.field_to_match.0.type", &idx1, "HEADER"),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_regex_match_set.test", "regex_match_tuple.%d.text_transformation", &idx1, "NONE"),
+					resource.TestCheckResourceAttr(resourceName, "name", matchSetName),
+					resource.TestCheckResourceAttr(resourceName, "regex_match_tuple.#", "1"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "regex_match_tuple.%d.field_to_match.#", &idx1, "1"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "regex_match_tuple.%d.field_to_match.0.data", &idx1, "user-agent"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "regex_match_tuple.%d.field_to_match.0.type", &idx1, "HEADER"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "regex_match_tuple.%d.text_transformation", &idx1, "NONE"),
 				),
 			},
 			{
 				Config: testAccAWSWafRegionalRegexMatchSetConfig_changePatterns(matchSetName, patternSetName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafRegionalRegexMatchSetExists("aws_wafregional_regex_match_set.test", &after),
-					resource.TestCheckResourceAttr("aws_wafregional_regex_match_set.test", "name", matchSetName),
-					resource.TestCheckResourceAttr("aws_wafregional_regex_match_set.test", "regex_match_tuple.#", "1"),
+					testAccCheckAWSWafRegionalRegexMatchSetExists(resourceName, &after),
+					resource.TestCheckResourceAttr(resourceName, "name", matchSetName),
+					resource.TestCheckResourceAttr(resourceName, "regex_match_tuple.#", "1"),
 
 					computeWafRegexMatchSetTuple(&patternSet, &waf.FieldToMatch{Data: aws.String("Referer"), Type: aws.String("HEADER")}, "COMPRESS_WHITE_SPACE", &idx2),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_regex_match_set.test", "regex_match_tuple.%d.field_to_match.#", &idx2, "1"),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_regex_match_set.test", "regex_match_tuple.%d.field_to_match.0.data", &idx2, "referer"),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_regex_match_set.test", "regex_match_tuple.%d.field_to_match.0.type", &idx2, "HEADER"),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_regex_match_set.test", "regex_match_tuple.%d.text_transformation", &idx2, "COMPRESS_WHITE_SPACE"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "regex_match_tuple.%d.field_to_match.#", &idx2, "1"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "regex_match_tuple.%d.field_to_match.0.data", &idx2, "referer"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "regex_match_tuple.%d.field_to_match.0.type", &idx2, "HEADER"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "regex_match_tuple.%d.text_transformation", &idx2, "COMPRESS_WHITE_SPACE"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -176,6 +188,7 @@ func testAccAWSWafRegionalRegexMatchSet_changePatterns(t *testing.T) {
 
 func testAccAWSWafRegionalRegexMatchSet_noPatterns(t *testing.T) {
 	var matchSet waf.RegexMatchSet
+	resourceName := "aws_wafregional_regex_match_set.test"
 	matchSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
@@ -186,10 +199,15 @@ func testAccAWSWafRegionalRegexMatchSet_noPatterns(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalRegexMatchSetConfig_noPatterns(matchSetName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafRegionalRegexMatchSetExists("aws_wafregional_regex_match_set.test", &matchSet),
-					resource.TestCheckResourceAttr("aws_wafregional_regex_match_set.test", "name", matchSetName),
-					resource.TestCheckResourceAttr("aws_wafregional_regex_match_set.test", "regex_match_tuple.#", "0"),
+					testAccCheckAWSWafRegionalRegexMatchSetExists(resourceName, &matchSet),
+					resource.TestCheckResourceAttr(resourceName, "name", matchSetName),
+					resource.TestCheckResourceAttr(resourceName, "regex_match_tuple.#", "0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -197,6 +215,7 @@ func testAccAWSWafRegionalRegexMatchSet_noPatterns(t *testing.T) {
 
 func testAccAWSWafRegionalRegexMatchSet_disappears(t *testing.T) {
 	var matchSet waf.RegexMatchSet
+	resourceName := "aws_wafregional_regex_match_set.test"
 	matchSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
 	patternSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
 
@@ -208,7 +227,7 @@ func testAccAWSWafRegionalRegexMatchSet_disappears(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalRegexMatchSetConfig(matchSetName, patternSetName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalRegexMatchSetExists("aws_wafregional_regex_match_set.test", &matchSet),
+					testAccCheckAWSWafRegionalRegexMatchSetExists(resourceName, &matchSet),
 					testAccCheckAWSWafRegionalRegexMatchSetDisappears(&matchSet),
 				),
 				ExpectNonEmptyPlan: true,

--- a/website/docs/r/wafregional_regex_match_set.html.markdown
+++ b/website/docs/r/wafregional_regex_match_set.html.markdown
@@ -66,3 +66,11 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the WAF Regional Regex Match Set.
+
+## Import
+
+WAF Regional Regex Match Set can be imported using the id, e.g.
+
+```
+$ terraform import aws_wafregional_regex_match_set.example a1b2c3d4-d5f6-7777-8888-9999aaaabbbbcccc
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #9212

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_wafregional_regex_match_set: Support resource import
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSWafRegionalRegexMatchSet'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSWafRegionalRegexMatchSet -timeout 120m
=== RUN   TestAccAWSWafRegionalRegexMatchSet
=== RUN   TestAccAWSWafRegionalRegexMatchSet/basic
=== RUN   TestAccAWSWafRegionalRegexMatchSet/changePatterns
=== RUN   TestAccAWSWafRegionalRegexMatchSet/noPatterns
=== RUN   TestAccAWSWafRegionalRegexMatchSet/disappears
--- PASS: TestAccAWSWafRegionalRegexMatchSet (166.99s)
    --- PASS: TestAccAWSWafRegionalRegexMatchSet/basic (46.82s)
    --- PASS: TestAccAWSWafRegionalRegexMatchSet/changePatterns (56.52s)
    --- PASS: TestAccAWSWafRegionalRegexMatchSet/noPatterns (27.43s)
    --- PASS: TestAccAWSWafRegionalRegexMatchSet/disappears (36.22s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	167.094s
```
