### PR TITLE
Final retries after timeouts for ECS resources

### DIFF
--- a/aws/resource_aws_ecs_service.go
+++ b/aws/resource_aws_ecs_service.go
@@ -486,6 +486,9 @@ func resourceAwsEcsServiceCreate(d *schema.ResourceData, meta interface{}) error
 
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		out, err = conn.CreateService(&input)
+	}
 	if err != nil {
 		return fmt.Errorf("%s %q", err, d.Get("name").(string))
 	}
@@ -535,11 +538,17 @@ func resourceAwsEcsServiceRead(d *schema.ResourceData, meta interface{}) error {
 
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		out, err = conn.DescribeServices(&input)
+	}
 	if err != nil {
-		return err
+		return fmt.Errorf("Error reading ECS service: %s", err)
 	}
 
 	if len(out.Services) < 1 {
+		if d.IsNewResource() {
+			return fmt.Errorf("ECS service not created: %q", d.Id())
+		}
 		log.Printf("[WARN] Removing ECS service %s (%s) because it's gone", d.Get("name").(string), d.Id())
 		d.SetId("")
 		return nil
@@ -837,7 +846,7 @@ func resourceAwsEcsServiceUpdate(d *schema.ResourceData, meta interface{}) error
 		log.Printf("[DEBUG] Updating ECS Service (%s): %s", d.Id(), input)
 		// Retry due to IAM eventual consistency
 		err := resource.Retry(2*time.Minute, func() *resource.RetryError {
-			out, err := conn.UpdateService(&input)
+			_, err := conn.UpdateService(&input)
 			if err != nil {
 				if isAWSErr(err, ecs.ErrCodeInvalidParameterException, "Please verify that the ECS service role being passed has the proper permissions.") {
 					return resource.RetryableError(err)
@@ -847,12 +856,13 @@ func resourceAwsEcsServiceUpdate(d *schema.ResourceData, meta interface{}) error
 				}
 				return resource.NonRetryableError(err)
 			}
-
-			log.Printf("[DEBUG] Updated ECS service %s", out.Service)
 			return nil
 		})
+		if isResourceTimeoutError(err) {
+			_, err = conn.UpdateService(&input)
+		}
 		if err != nil {
-			return fmt.Errorf("error updating ECS Service (%s): %s", d.Id(), err)
+			return fmt.Errorf("Error updating ECS Service (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -951,9 +961,11 @@ func resourceAwsEcsServiceDelete(d *schema.ResourceData, meta interface{}) error
 		}
 		return nil
 	})
-
+	if isResourceTimeoutError(err) {
+		_, err = conn.DeleteService(&input)
+	}
 	if err != nil {
-		return err
+		return fmt.Errorf("Error deleting ECS service: %s", err)
 	}
 
 	// Wait until it's deleted


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES: 
* resource/aws_ecs_cluster: Final retries after timeouts reading and deleting ECS cluster
* resource/aws_ecs_service: Final retries after timeouts creating, updating, and deleting ECS service
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSEcsCluster"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSEcsCluster -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEcsCluster_basic
=== PAUSE TestAccAWSEcsCluster_basic
=== RUN   TestAccAWSEcsCluster_disappears
=== PAUSE TestAccAWSEcsCluster_disappears
=== RUN   TestAccAWSEcsCluster_Tags
=== PAUSE TestAccAWSEcsCluster_Tags
=== CONT  TestAccAWSEcsCluster_basic
=== CONT  TestAccAWSEcsCluster_Tags
=== CONT  TestAccAWSEcsCluster_disappears
--- PASS: TestAccAWSEcsCluster_disappears (19.66s)
--- PASS: TestAccAWSEcsCluster_basic (27.09s)
--- PASS: TestAccAWSEcsCluster_Tags (61.43s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       62.544s

make testacc TESTARGS="-run=TestAccAWSEcsService"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSEcsService -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEcsServiceDataSource_basic
=== PAUSE TestAccAWSEcsServiceDataSource_basic
=== RUN   TestAccAWSEcsService_withARN
=== PAUSE TestAccAWSEcsService_withARN
=== RUN   TestAccAWSEcsService_basicImport
=== PAUSE TestAccAWSEcsService_basicImport
=== RUN   TestAccAWSEcsService_disappears
=== PAUSE TestAccAWSEcsService_disappears
=== RUN   TestAccAWSEcsService_withUnnormalizedPlacementStrategy
=== PAUSE TestAccAWSEcsService_withUnnormalizedPlacementStrategy
=== RUN   TestAccAWSEcsService_withFamilyAndRevision
=== PAUSE TestAccAWSEcsService_withFamilyAndRevision
=== RUN   TestAccAWSEcsService_withRenamedCluster
=== PAUSE TestAccAWSEcsService_withRenamedCluster
=== RUN   TestAccAWSEcsService_healthCheckGracePeriodSeconds
=== PAUSE TestAccAWSEcsService_healthCheckGracePeriodSeconds
=== RUN   TestAccAWSEcsService_withIamRole
=== PAUSE TestAccAWSEcsService_withIamRole
=== RUN   TestAccAWSEcsService_withDeploymentController_Type_CodeDeploy
=== PAUSE TestAccAWSEcsService_withDeploymentController_Type_CodeDeploy
=== RUN   TestAccAWSEcsService_withDeploymentValues
=== PAUSE TestAccAWSEcsService_withDeploymentValues
=== RUN   TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred
=== PAUSE TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred
=== RUN   TestAccAWSEcsService_withLbChanges
=== PAUSE TestAccAWSEcsService_withLbChanges
=== RUN   TestAccAWSEcsService_withEcsClusterName
=== PAUSE TestAccAWSEcsService_withEcsClusterName
=== RUN   TestAccAWSEcsService_withAlb
=== PAUSE TestAccAWSEcsService_withAlb
=== RUN   TestAccAWSEcsService_withMultipleTargetGroups
=== PAUSE TestAccAWSEcsService_withMultipleTargetGroups
=== RUN   TestAccAWSEcsService_withPlacementStrategy
=== PAUSE TestAccAWSEcsService_withPlacementStrategy
=== RUN   TestAccAWSEcsService_withPlacementConstraints
=== PAUSE TestAccAWSEcsService_withPlacementConstraints
=== RUN   TestAccAWSEcsService_withPlacementConstraints_emptyExpression
=== PAUSE TestAccAWSEcsService_withPlacementConstraints_emptyExpression
=== RUN   TestAccAWSEcsService_withLaunchTypeFargate
=== PAUSE TestAccAWSEcsService_withLaunchTypeFargate
=== RUN   TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion
=== PAUSE TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion
=== RUN   TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration
=== PAUSE TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration
=== RUN   TestAccAWSEcsService_withDaemonSchedulingStrategy
=== PAUSE TestAccAWSEcsService_withDaemonSchedulingStrategy
=== RUN   TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum
=== PAUSE TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum
=== RUN   TestAccAWSEcsService_withReplicaSchedulingStrategy
=== PAUSE TestAccAWSEcsService_withReplicaSchedulingStrategy
=== RUN   TestAccAWSEcsService_withServiceRegistries
=== PAUSE TestAccAWSEcsService_withServiceRegistries
=== RUN   TestAccAWSEcsService_withServiceRegistries_container
=== PAUSE TestAccAWSEcsService_withServiceRegistries_container
=== RUN   TestAccAWSEcsService_Tags
=== PAUSE TestAccAWSEcsService_Tags
=== RUN   TestAccAWSEcsService_ManagedTags
=== PAUSE TestAccAWSEcsService_ManagedTags
=== RUN   TestAccAWSEcsService_PropagateTags
=== PAUSE TestAccAWSEcsService_PropagateTags
=== CONT  TestAccAWSEcsServiceDataSource_basic
=== CONT  TestAccAWSEcsService_withServiceRegistries_container
=== CONT  TestAccAWSEcsService_PropagateTags
=== CONT  TestAccAWSEcsService_withServiceRegistries
=== CONT  TestAccAWSEcsService_withReplicaSchedulingStrategy
=== CONT  TestAccAWSEcsService_Tags
=== CONT  TestAccAWSEcsService_ManagedTags
=== CONT  TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum
=== CONT  TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred
=== CONT  TestAccAWSEcsService_withDeploymentValues
=== CONT  TestAccAWSEcsService_withDeploymentController_Type_CodeDeploy
=== CONT  TestAccAWSEcsService_withIamRole
=== CONT  TestAccAWSEcsService_healthCheckGracePeriodSeconds
=== CONT  TestAccAWSEcsService_withRenamedCluster
=== CONT  TestAccAWSEcsService_withFamilyAndRevision
=== CONT  TestAccAWSEcsService_withUnnormalizedPlacementStrategy
=== CONT  TestAccAWSEcsService_disappears
=== CONT  TestAccAWSEcsService_basicImport
=== CONT  TestAccAWSEcsService_withLbChanges
=== CONT  TestAccAWSEcsService_withARN
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum (60.18s)
=== CONT  TestAccAWSEcsService_withDaemonSchedulingStrategy
--- PASS: TestAccAWSEcsService_disappears (67.61s)
=== CONT  TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration
--- PASS: TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred (70.91s)
=== CONT  TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion
--- PASS: TestAccAWSEcsService_ManagedTags (71.62s)
=== CONT  TestAccAWSEcsService_withLaunchTypeFargate
--- PASS: TestAccAWSEcsService_withDeploymentValues (71.82s)
=== CONT  TestAccAWSEcsService_withPlacementConstraints_emptyExpression
--- PASS: TestAccAWSEcsService_basicImport (78.05s)
=== CONT  TestAccAWSEcsService_withPlacementConstraints
--- PASS: TestAccAWSEcsService_withFamilyAndRevision (78.35s)
=== CONT  TestAccAWSEcsService_withPlacementStrategy
--- PASS: TestAccAWSEcsService_withUnnormalizedPlacementStrategy (81.90s)
=== CONT  TestAccAWSEcsService_withMultipleTargetGroups
--- PASS: TestAccAWSEcsService_withReplicaSchedulingStrategy (82.56s)
=== CONT  TestAccAWSEcsService_withAlb
--- PASS: TestAccAWSEcsServiceDataSource_basic (86.78s)
=== CONT  TestAccAWSEcsService_withEcsClusterName
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategy (47.10s)
--- PASS: TestAccAWSEcsService_Tags (111.94s)
--- PASS: TestAccAWSEcsService_withARN (111.96s)
--- PASS: TestAccAWSEcsService_withPlacementConstraints_emptyExpression (80.82s)
--- PASS: TestAccAWSEcsService_withServiceRegistries_container (153.40s)
--- PASS: TestAccAWSEcsService_withEcsClusterName (70.18s)
--- PASS: TestAccAWSEcsService_withIamRole (161.99s)
--- PASS: TestAccAWSEcsService_withPlacementConstraints (87.09s)
--- PASS: TestAccAWSEcsService_withRenamedCluster (179.90s)
--- PASS: TestAccAWSEcsService_withServiceRegistries (183.67s)
--- PASS: TestAccAWSEcsService_PropagateTags (195.14s)
--- PASS: TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration (159.72s)
--- PASS: TestAccAWSEcsService_withLaunchTypeFargate (204.64s)
--- PASS: TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion (215.92s)
--- PASS: TestAccAWSEcsService_withLbChanges (288.00s)
--- PASS: TestAccAWSEcsService_withDeploymentController_Type_CodeDeploy (302.17s)
--- PASS: TestAccAWSEcsService_withPlacementStrategy (267.86s)
--- PASS: TestAccAWSEcsService_healthCheckGracePeriodSeconds (355.35s)
--- PASS: TestAccAWSEcsService_withAlb (313.97s)
--- PASS: TestAccAWSEcsService_withMultipleTargetGroups (317.14s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       400.197s
```