### PR TITLE
Remove usage of terraform.NewResourceConfig

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -78,7 +78,7 @@ func testAccPreCheck(t *testing.T) {
 	log.Printf("[INFO] Test: Using %s as test region", region)
 	os.Setenv("AWS_DEFAULT_REGION", region)
 
-	err := testAccProvider.Configure(terraform.NewResourceConfig(nil))
+	err := testAccProvider.Configure(terraform.NewResourceConfigRaw(nil))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
the `config` package (co-dependent of `terraform.NewResourceConfig`) is being removed. The new function `terraform.NewResourceConfigRaw` should replace both of them.