### PR TITLE
resource/aws_network_acl_rule: Remove resource from Terraform state on `InvalidNetworkAclID.NotFound` errors

### DIFF
--- a/aws/resource_aws_network_acl_rule.go
+++ b/aws/resource_aws_network_acl_rule.go
@@ -269,6 +269,11 @@ func findNetworkAclRule(d *schema.ResourceData, meta interface{}) (*ec2.NetworkA
 	log.Printf("[INFO] Describing Network Acl: %s", d.Get("network_acl_id").(string))
 	log.Printf("[INFO] Describing Network Acl with the Filters %#v", params)
 	resp, err := conn.DescribeNetworkAcls(params)
+
+	if isAWSErr(err, "InvalidNetworkAclID.NotFound", "") {
+		return nil, nil
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("Error Finding Network Acl Rule %d: %s", d.Get("rule_number").(int), err.Error())
 	}

--- a/aws/resource_aws_network_acl_rule_test.go
+++ b/aws/resource_aws_network_acl_rule_test.go
@@ -34,6 +34,47 @@ func TestAccAWSNetworkAclRule_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSNetworkAclRule_disappears(t *testing.T) {
+	var networkAcl ec2.NetworkAcl
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNetworkAclRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSNetworkAclRuleBasicConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSNetworkAclRuleExists("aws_network_acl_rule.baz", &networkAcl),
+					testAccCheckAWSNetworkAclRuleDelete("aws_network_acl_rule.baz"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSNetworkAclRule_disappears_NetworkAcl(t *testing.T) {
+	var networkAcl ec2.NetworkAcl
+	resourceName := "aws_network_acl.bar"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNetworkAclRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSNetworkAclRuleBasicConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSNetworkAclExists(resourceName, &networkAcl),
+					testAccCheckAWSNetworkAclDisappears(&networkAcl),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSNetworkAclRule_missingParam(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -208,26 +249,6 @@ func TestResourceAWSNetworkAclRule_validateICMPArgumentValue(t *testing.T) {
 		}
 	}
 
-}
-
-func TestAccAWSNetworkAclRule_deleteRule(t *testing.T) {
-	var networkAcl ec2.NetworkAcl
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSNetworkAclRuleDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSNetworkAclRuleBasicConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNetworkAclRuleExists("aws_network_acl_rule.baz", &networkAcl),
-					testAccCheckAWSNetworkAclRuleDelete("aws_network_acl_rule.baz"),
-				),
-				ExpectNonEmptyPlan: true,
-			},
-		},
-	})
 }
 
 func testAccCheckAWSNetworkAclRuleDestroy(s *terraform.State) error {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2291

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_network_acl_rule: Remove resource from Terraform state on `InvalidNetworkAclID.NotFound` errors
```

Before code update:

```
--- FAIL: TestAccAWSNetworkAclRule_disappears_NetworkAcl (24.71s)
    testing.go:568: Step 0 error: errors during follow-up refresh:

        Error: Error Finding Network Acl Rule 400: InvalidNetworkAclID.NotFound: The networkAcl ID 'acl-0d709bc679c758a63' does not exist
          status code: 400, request id: 52adcd9e-3bba-42a0-bff1-1a345a20f084

        Error: Error Finding Network Acl Rule 200: InvalidNetworkAclID.NotFound: The networkAcl ID 'acl-0d709bc679c758a63' does not exist
          status code: 400, request id: b9e489d1-0610-4534-8df8-fcecd5217e1f

        Error: Error Finding Network Acl Rule 300: InvalidNetworkAclID.NotFound: The networkAcl ID 'acl-0d709bc679c758a63' does not exist
          status code: 400, request id: cdb09484-2cd0-4b3d-a3f0-759db25037b6
```

Output from acceptance testing:

```
--- PASS: TestAccAWSNetworkAcl_disappears (28.17s)

--- PASS: TestAccAWSNetworkAclRule_disappears_NetworkAcl (25.67s)
--- PASS: TestAccAWSNetworkAclRule_disappears (28.40s)
```
