### PR TITLE
Add support resource import for aws wafregional regex pattern set resource

### DIFF
--- a/aws/resource_aws_wafregional_regex_pattern_set.go
+++ b/aws/resource_aws_wafregional_regex_pattern_set.go
@@ -16,6 +16,9 @@ func resourceAwsWafRegionalRegexPatternSet() *schema.Resource {
 		Read:   resourceAwsWafRegionalRegexPatternSetRead,
 		Update: resourceAwsWafRegionalRegexPatternSetUpdate,
 		Delete: resourceAwsWafRegionalRegexPatternSetDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/aws/resource_aws_wafregional_regex_pattern_set_test.go
+++ b/aws/resource_aws_wafregional_regex_pattern_set_test.go
@@ -33,6 +33,7 @@ func TestAccAWSWafRegionalRegexPatternSet(t *testing.T) {
 func testAccAWSWafRegionalRegexPatternSet_basic(t *testing.T) {
 	var patternSet waf.RegexPatternSet
 	patternSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_regex_pattern_set.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -42,12 +43,17 @@ func testAccAWSWafRegionalRegexPatternSet_basic(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalRegexPatternSetConfig(patternSetName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalRegexPatternSetExists("aws_wafregional_regex_pattern_set.test", &patternSet),
-					resource.TestCheckResourceAttr("aws_wafregional_regex_pattern_set.test", "name", patternSetName),
-					resource.TestCheckResourceAttr("aws_wafregional_regex_pattern_set.test", "regex_pattern_strings.#", "2"),
-					resource.TestCheckResourceAttr("aws_wafregional_regex_pattern_set.test", "regex_pattern_strings.2848565413", "one"),
-					resource.TestCheckResourceAttr("aws_wafregional_regex_pattern_set.test", "regex_pattern_strings.3351840846", "two"),
+					testAccCheckAWSWafRegionalRegexPatternSetExists(resourceName, &patternSet),
+					resource.TestCheckResourceAttr(resourceName, "name", patternSetName),
+					resource.TestCheckResourceAttr(resourceName, "regex_pattern_strings.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "regex_pattern_strings.2848565413", "one"),
+					resource.TestCheckResourceAttr(resourceName, "regex_pattern_strings.3351840846", "two"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -56,6 +62,7 @@ func testAccAWSWafRegionalRegexPatternSet_basic(t *testing.T) {
 func testAccAWSWafRegionalRegexPatternSet_changePatterns(t *testing.T) {
 	var before, after waf.RegexPatternSet
 	patternSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_regex_pattern_set.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -65,23 +72,28 @@ func testAccAWSWafRegionalRegexPatternSet_changePatterns(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalRegexPatternSetConfig(patternSetName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafRegionalRegexPatternSetExists("aws_wafregional_regex_pattern_set.test", &before),
-					resource.TestCheckResourceAttr("aws_wafregional_regex_pattern_set.test", "name", patternSetName),
-					resource.TestCheckResourceAttr("aws_wafregional_regex_pattern_set.test", "regex_pattern_strings.#", "2"),
-					resource.TestCheckResourceAttr("aws_wafregional_regex_pattern_set.test", "regex_pattern_strings.2848565413", "one"),
-					resource.TestCheckResourceAttr("aws_wafregional_regex_pattern_set.test", "regex_pattern_strings.3351840846", "two"),
+					testAccCheckAWSWafRegionalRegexPatternSetExists(resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "name", patternSetName),
+					resource.TestCheckResourceAttr(resourceName, "regex_pattern_strings.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "regex_pattern_strings.2848565413", "one"),
+					resource.TestCheckResourceAttr(resourceName, "regex_pattern_strings.3351840846", "two"),
 				),
 			},
 			{
 				Config: testAccAWSWafRegionalRegexPatternSetConfig_changePatterns(patternSetName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafRegionalRegexPatternSetExists("aws_wafregional_regex_pattern_set.test", &after),
-					resource.TestCheckResourceAttr("aws_wafregional_regex_pattern_set.test", "name", patternSetName),
-					resource.TestCheckResourceAttr("aws_wafregional_regex_pattern_set.test", "regex_pattern_strings.#", "3"),
-					resource.TestCheckResourceAttr("aws_wafregional_regex_pattern_set.test", "regex_pattern_strings.3351840846", "two"),
-					resource.TestCheckResourceAttr("aws_wafregional_regex_pattern_set.test", "regex_pattern_strings.2929247714", "three"),
-					resource.TestCheckResourceAttr("aws_wafregional_regex_pattern_set.test", "regex_pattern_strings.1294846542", "four"),
+					testAccCheckAWSWafRegionalRegexPatternSetExists(resourceName, &after),
+					resource.TestCheckResourceAttr(resourceName, "name", patternSetName),
+					resource.TestCheckResourceAttr(resourceName, "regex_pattern_strings.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "regex_pattern_strings.3351840846", "two"),
+					resource.TestCheckResourceAttr(resourceName, "regex_pattern_strings.2929247714", "three"),
+					resource.TestCheckResourceAttr(resourceName, "regex_pattern_strings.1294846542", "four"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -90,6 +102,7 @@ func testAccAWSWafRegionalRegexPatternSet_changePatterns(t *testing.T) {
 func testAccAWSWafRegionalRegexPatternSet_noPatterns(t *testing.T) {
 	var patternSet waf.RegexPatternSet
 	patternSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_regex_pattern_set.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -99,10 +112,15 @@ func testAccAWSWafRegionalRegexPatternSet_noPatterns(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalRegexPatternSetConfig_noPatterns(patternSetName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafRegionalRegexPatternSetExists("aws_wafregional_regex_pattern_set.test", &patternSet),
-					resource.TestCheckResourceAttr("aws_wafregional_regex_pattern_set.test", "name", patternSetName),
-					resource.TestCheckResourceAttr("aws_wafregional_regex_pattern_set.test", "regex_pattern_strings.#", "0"),
+					testAccCheckAWSWafRegionalRegexPatternSetExists(resourceName, &patternSet),
+					resource.TestCheckResourceAttr(resourceName, "name", patternSetName),
+					resource.TestCheckResourceAttr(resourceName, "regex_pattern_strings.#", "0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -111,6 +129,7 @@ func testAccAWSWafRegionalRegexPatternSet_noPatterns(t *testing.T) {
 func testAccAWSWafRegionalRegexPatternSet_disappears(t *testing.T) {
 	var patternSet waf.RegexPatternSet
 	patternSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_regex_pattern_set.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -120,7 +139,7 @@ func testAccAWSWafRegionalRegexPatternSet_disappears(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalRegexPatternSetConfig(patternSetName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalRegexPatternSetExists("aws_wafregional_regex_pattern_set.test", &patternSet),
+					testAccCheckAWSWafRegionalRegexPatternSetExists(resourceName, &patternSet),
 					testAccCheckAWSWafRegionalRegexPatternSetDisappears(&patternSet),
 				),
 				ExpectNonEmptyPlan: true,

--- a/website/docs/r/wafregional_regex_pattern_set.html.markdown
+++ b/website/docs/r/wafregional_regex_pattern_set.html.markdown
@@ -31,3 +31,11 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the WAF Regional Regex Pattern Set.
+
+## Import
+
+WAF Regional Regex Pattern Set can be imported using the id, e.g.
+
+```
+$ terraform import aws_wafregional_regex_pattern_set.example a1b2c3d4-d5f6-7777-8888-9999aaaabbbbcccc
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #9212

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_wafregional_regex_pattern_set: Support resource import
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSWafRegionalRegexPatternSet'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSWafRegionalRegexPatternSet -timeout 120m
=== RUN   TestAccAWSWafRegionalRegexPatternSet
=== RUN   TestAccAWSWafRegionalRegexPatternSet/basic
=== RUN   TestAccAWSWafRegionalRegexPatternSet/changePatterns
=== RUN   TestAccAWSWafRegionalRegexPatternSet/noPatterns
=== RUN   TestAccAWSWafRegionalRegexPatternSet/disappears
--- PASS: TestAccAWSWafRegionalRegexPatternSet (138.37s)
    --- PASS: TestAccAWSWafRegionalRegexPatternSet/basic (37.36s)
    --- PASS: TestAccAWSWafRegionalRegexPatternSet/changePatterns (49.29s)
    --- PASS: TestAccAWSWafRegionalRegexPatternSet/noPatterns (27.55s)
    --- PASS: TestAccAWSWafRegionalRegexPatternSet/disappears (24.18s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	138.442s
```
