### PR TITLE
Add support resource import for aws wafregional size constraint set resource

### DIFF
--- a/aws/resource_aws_wafregional_size_constraint_set.go
+++ b/aws/resource_aws_wafregional_size_constraint_set.go
@@ -16,6 +16,9 @@ func resourceAwsWafRegionalSizeConstraintSet() *schema.Resource {
 		Read:   resourceAwsWafRegionalSizeConstraintSetRead,
 		Update: resourceAwsWafRegionalSizeConstraintSetUpdate,
 		Delete: resourceAwsWafRegionalSizeConstraintSetDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: wafSizeConstraintSetSchema(),
 	}

--- a/aws/resource_aws_wafregional_size_constraint_set.go
+++ b/aws/resource_aws_wafregional_size_constraint_set.go
@@ -43,7 +43,7 @@ func resourceAwsWafRegionalSizeConstraintSetCreate(d *schema.ResourceData, meta 
 	}
 	resp := out.(*waf.CreateSizeConstraintSetOutput)
 
-	d.SetId(*resp.SizeConstraintSet.SizeConstraintSetId)
+	d.SetId(aws.StringValue(resp.SizeConstraintSet.SizeConstraintSetId))
 
 	return resourceAwsWafRegionalSizeConstraintSetUpdate(d, meta)
 }
@@ -57,13 +57,13 @@ func resourceAwsWafRegionalSizeConstraintSetRead(d *schema.ResourceData, meta in
 	}
 
 	resp, err := conn.GetSizeConstraintSet(params)
+	if isAWSErr(err, wafregional.ErrCodeWAFNonexistentItemException, "") {
+		log.Printf("[WARN] WAF Regional SizeConstraintSet (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
 	if err != nil {
-		if isAWSErr(err, wafregional.ErrCodeWAFNonexistentItemException, "") {
-			log.Printf("[WARN] WAF Regional SizeConstraintSet (%s) not found, removing from state", d.Id())
-			d.SetId("")
-			return nil
-		}
-		return err
+		return fmt.Errorf("Error getting WAF Regional Size Constraint Set (%s): %s", d.Id(), err)
 	}
 
 	d.Set("name", resp.SizeConstraintSet.Name)
@@ -79,8 +79,14 @@ func resourceAwsWafRegionalSizeConstraintSetUpdate(d *schema.ResourceData, meta 
 		o, n := d.GetChange("size_constraints")
 		oldConstraints, newConstraints := o.(*schema.Set).List(), n.(*schema.Set).List()
 
-		if err := updateRegionalSizeConstraintSetResource(d.Id(), oldConstraints, newConstraints, client.wafregionalconn, client.region); err != nil {
-			return fmt.Errorf("Error updating WAF Regional SizeConstraintSet: %s", err)
+		err := updateRegionalSizeConstraintSetResource(d.Id(), oldConstraints, newConstraints, client.wafregionalconn, client.region)
+		if isAWSErr(err, wafregional.ErrCodeWAFNonexistentItemException, "") {
+			log.Printf("[WARN] WAF Regional SizeConstraintSet (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("Error updating WAF Regional SizeConstraintSet(%s): %s", d.Id(), err)
 		}
 	}
 
@@ -95,8 +101,12 @@ func resourceAwsWafRegionalSizeConstraintSetDelete(d *schema.ResourceData, meta 
 
 	if len(oldConstraints) > 0 {
 		noConstraints := []interface{}{}
-		if err := updateRegionalSizeConstraintSetResource(d.Id(), oldConstraints, noConstraints, conn, region); err != nil {
-			return fmt.Errorf("Error deleting WAF Regional SizeConstraintSet: %s", err)
+		err := updateRegionalSizeConstraintSetResource(d.Id(), oldConstraints, noConstraints, conn, region)
+		if isAWSErr(err, wafregional.ErrCodeWAFNonexistentItemException, "") {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("Error deleting WAF Regional SizeConstraintSet(%s): %s", d.Id(), err)
 		}
 	}
 
@@ -108,6 +118,9 @@ func resourceAwsWafRegionalSizeConstraintSetDelete(d *schema.ResourceData, meta 
 		}
 		return conn.DeleteSizeConstraintSet(req)
 	})
+	if isAWSErr(err, wafregional.ErrCodeWAFNonexistentItemException, "") {
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("Error deleting WAF Regional SizeConstraintSet: %s", err)
 	}
@@ -127,9 +140,6 @@ func updateRegionalSizeConstraintSetResource(id string, oldConstraints, newConst
 		log.Printf("[INFO] Updating WAF Regional SizeConstraintSet: %s", req)
 		return conn.UpdateSizeConstraintSet(req)
 	})
-	if err != nil {
-		return fmt.Errorf("Error updating WAF Regional SizeConstraintSet: %s", err)
-	}
 
-	return nil
+	return err
 }

--- a/aws/resource_aws_wafregional_size_constraint_set_test.go
+++ b/aws/resource_aws_wafregional_size_constraint_set_test.go
@@ -16,6 +16,7 @@ import (
 func TestAccAWSWafRegionalSizeConstraintSet_basic(t *testing.T) {
 	var constraints waf.SizeConstraintSet
 	sizeConstraintSet := fmt.Sprintf("sizeConstraintSet-%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_size_constraint_set.size_constraint_set"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -25,24 +26,29 @@ func TestAccAWSWafRegionalSizeConstraintSet_basic(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalSizeConstraintSetConfig(sizeConstraintSet),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalSizeConstraintSetExists("aws_wafregional_size_constraint_set.size_constraint_set", &constraints),
+					testAccCheckAWSWafRegionalSizeConstraintSetExists(resourceName, &constraints),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_size_constraint_set.size_constraint_set", "name", sizeConstraintSet),
+						resourceName, "name", sizeConstraintSet),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.#", "1"),
+						resourceName, "size_constraints.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.2029852522.comparison_operator", "EQ"),
+						resourceName, "size_constraints.2029852522.comparison_operator", "EQ"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.2029852522.field_to_match.#", "1"),
+						resourceName, "size_constraints.2029852522.field_to_match.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.2029852522.field_to_match.281401076.data", ""),
+						resourceName, "size_constraints.2029852522.field_to_match.281401076.data", ""),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.2029852522.field_to_match.281401076.type", "BODY"),
+						resourceName, "size_constraints.2029852522.field_to_match.281401076.type", "BODY"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.2029852522.size", "4096"),
+						resourceName, "size_constraints.2029852522.size", "4096"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.2029852522.text_transformation", "NONE"),
+						resourceName, "size_constraints.2029852522.text_transformation", "NONE"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -52,6 +58,7 @@ func TestAccAWSWafRegionalSizeConstraintSet_changeNameForceNew(t *testing.T) {
 	var before, after waf.SizeConstraintSet
 	sizeConstraintSet := fmt.Sprintf("sizeConstraintSet-%s", acctest.RandString(5))
 	sizeConstraintSetNewName := fmt.Sprintf("sizeConstraintSet-%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_size_constraint_set.size_constraint_set"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -61,22 +68,27 @@ func TestAccAWSWafRegionalSizeConstraintSet_changeNameForceNew(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalSizeConstraintSetConfig(sizeConstraintSet),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalSizeConstraintSetExists("aws_wafregional_size_constraint_set.size_constraint_set", &before),
+					testAccCheckAWSWafRegionalSizeConstraintSetExists(resourceName, &before),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_size_constraint_set.size_constraint_set", "name", sizeConstraintSet),
+						resourceName, "name", sizeConstraintSet),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.#", "1"),
+						resourceName, "size_constraints.#", "1"),
 				),
 			},
 			{
 				Config: testAccAWSWafRegionalSizeConstraintSetConfigChangeName(sizeConstraintSetNewName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalSizeConstraintSetExists("aws_wafregional_size_constraint_set.size_constraint_set", &after),
+					testAccCheckAWSWafRegionalSizeConstraintSetExists(resourceName, &after),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_size_constraint_set.size_constraint_set", "name", sizeConstraintSetNewName),
+						resourceName, "name", sizeConstraintSetNewName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.#", "1"),
+						resourceName, "size_constraints.#", "1"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -85,6 +97,7 @@ func TestAccAWSWafRegionalSizeConstraintSet_changeNameForceNew(t *testing.T) {
 func TestAccAWSWafRegionalSizeConstraintSet_disappears(t *testing.T) {
 	var constraints waf.SizeConstraintSet
 	sizeConstraintSet := fmt.Sprintf("sizeConstraintSet-%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_size_constraint_set.size_constraint_set"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -94,7 +107,7 @@ func TestAccAWSWafRegionalSizeConstraintSet_disappears(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalSizeConstraintSetConfig(sizeConstraintSet),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalSizeConstraintSetExists("aws_wafregional_size_constraint_set.size_constraint_set", &constraints),
+					testAccCheckAWSWafRegionalSizeConstraintSetExists(resourceName, &constraints),
 					testAccCheckAWSWafRegionalSizeConstraintSetDisappears(&constraints),
 				),
 				ExpectNonEmptyPlan: true,
@@ -106,6 +119,7 @@ func TestAccAWSWafRegionalSizeConstraintSet_disappears(t *testing.T) {
 func TestAccAWSWafRegionalSizeConstraintSet_changeConstraints(t *testing.T) {
 	var before, after waf.SizeConstraintSet
 	setName := fmt.Sprintf("sizeConstraintSet-%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_size_constraint_set.size_constraint_set"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -115,46 +129,51 @@ func TestAccAWSWafRegionalSizeConstraintSet_changeConstraints(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalSizeConstraintSetConfig(setName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafRegionalSizeConstraintSetExists("aws_wafregional_size_constraint_set.size_constraint_set", &before),
+					testAccCheckAWSWafRegionalSizeConstraintSetExists(resourceName, &before),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_size_constraint_set.size_constraint_set", "name", setName),
+						resourceName, "name", setName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.#", "1"),
+						resourceName, "size_constraints.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.2029852522.comparison_operator", "EQ"),
+						resourceName, "size_constraints.2029852522.comparison_operator", "EQ"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.2029852522.field_to_match.#", "1"),
+						resourceName, "size_constraints.2029852522.field_to_match.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.2029852522.field_to_match.281401076.data", ""),
+						resourceName, "size_constraints.2029852522.field_to_match.281401076.data", ""),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.2029852522.field_to_match.281401076.type", "BODY"),
+						resourceName, "size_constraints.2029852522.field_to_match.281401076.type", "BODY"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.2029852522.size", "4096"),
+						resourceName, "size_constraints.2029852522.size", "4096"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.2029852522.text_transformation", "NONE"),
+						resourceName, "size_constraints.2029852522.text_transformation", "NONE"),
 				),
 			},
 			{
 				Config: testAccAWSWafRegionalSizeConstraintSetConfig_changeConstraints(setName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafRegionalSizeConstraintSetExists("aws_wafregional_size_constraint_set.size_constraint_set", &after),
+					testAccCheckAWSWafRegionalSizeConstraintSetExists(resourceName, &after),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_size_constraint_set.size_constraint_set", "name", setName),
+						resourceName, "name", setName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.#", "1"),
+						resourceName, "size_constraints.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.3222308386.comparison_operator", "GE"),
+						resourceName, "size_constraints.3222308386.comparison_operator", "GE"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.3222308386.field_to_match.#", "1"),
+						resourceName, "size_constraints.3222308386.field_to_match.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.3222308386.field_to_match.281401076.data", ""),
+						resourceName, "size_constraints.3222308386.field_to_match.281401076.data", ""),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.3222308386.field_to_match.281401076.type", "BODY"),
+						resourceName, "size_constraints.3222308386.field_to_match.281401076.type", "BODY"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.3222308386.size", "1024"),
+						resourceName, "size_constraints.3222308386.size", "1024"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.3222308386.text_transformation", "NONE"),
+						resourceName, "size_constraints.3222308386.text_transformation", "NONE"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -163,6 +182,7 @@ func TestAccAWSWafRegionalSizeConstraintSet_changeConstraints(t *testing.T) {
 func TestAccAWSWafRegionalSizeConstraintSet_noConstraints(t *testing.T) {
 	var constraints waf.SizeConstraintSet
 	setName := fmt.Sprintf("sizeConstraintSet-%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_size_constraint_set.size_constraint_set"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -172,12 +192,17 @@ func TestAccAWSWafRegionalSizeConstraintSet_noConstraints(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalSizeConstraintSetConfig_noConstraints(setName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafRegionalSizeConstraintSetExists("aws_wafregional_size_constraint_set.size_constraint_set", &constraints),
+					testAccCheckAWSWafRegionalSizeConstraintSetExists(resourceName, &constraints),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_size_constraint_set.size_constraint_set", "name", setName),
+						resourceName, "name", setName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.#", "0"),
+						resourceName, "size_constraints.#", "0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/website/docs/r/wafregional_size_constraint_set.html.markdown
+++ b/website/docs/r/wafregional_size_constraint_set.html.markdown
@@ -70,3 +70,11 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the WAF Size Constraint Set.
+
+## Import
+
+WAF Size Constraint Set can be imported using the id, e.g.
+
+```
+$ terraform import aws_wafregional_size_constraint_set.size_constraint_set a1b2c3d4-d5f6-7777-8888-9999aaaabbbbcccc
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #9212

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_wafregional_size_constraint_set: Support resource import
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSWafRegionalSizeConstraintSet_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSWafRegionalSizeConstraintSet_ -timeout 120m
=== RUN   TestAccAWSWafRegionalSizeConstraintSet_basic
=== PAUSE TestAccAWSWafRegionalSizeConstraintSet_basic
=== RUN   TestAccAWSWafRegionalSizeConstraintSet_changeNameForceNew
=== PAUSE TestAccAWSWafRegionalSizeConstraintSet_changeNameForceNew
=== RUN   TestAccAWSWafRegionalSizeConstraintSet_disappears
=== PAUSE TestAccAWSWafRegionalSizeConstraintSet_disappears
=== RUN   TestAccAWSWafRegionalSizeConstraintSet_changeConstraints
=== PAUSE TestAccAWSWafRegionalSizeConstraintSet_changeConstraints
=== RUN   TestAccAWSWafRegionalSizeConstraintSet_noConstraints
=== PAUSE TestAccAWSWafRegionalSizeConstraintSet_noConstraints
=== CONT  TestAccAWSWafRegionalSizeConstraintSet_basic
=== CONT  TestAccAWSWafRegionalSizeConstraintSet_changeConstraints
=== CONT  TestAccAWSWafRegionalSizeConstraintSet_noConstraints
=== CONT  TestAccAWSWafRegionalSizeConstraintSet_disappears
=== CONT  TestAccAWSWafRegionalSizeConstraintSet_changeNameForceNew
--- PASS: TestAccAWSWafRegionalSizeConstraintSet_noConstraints (33.34s)
--- PASS: TestAccAWSWafRegionalSizeConstraintSet_disappears (40.18s)
--- PASS: TestAccAWSWafRegionalSizeConstraintSet_basic (43.92s)
--- PASS: TestAccAWSWafRegionalSizeConstraintSet_changeConstraints (59.74s)
--- PASS: TestAccAWSWafRegionalSizeConstraintSet_changeNameForceNew (69.45s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	69.530s
```
