### PR TITLE
Add support resource import for aws wafregional sql injection match set resource

### DIFF
--- a/aws/resource_aws_wafregional_sql_injection_match_set.go
+++ b/aws/resource_aws_wafregional_sql_injection_match_set.go
@@ -19,6 +19,9 @@ func resourceAwsWafRegionalSqlInjectionMatchSet() *schema.Resource {
 		Read:   resourceAwsWafRegionalSqlInjectionMatchSetRead,
 		Update: resourceAwsWafRegionalSqlInjectionMatchSetUpdate,
 		Delete: resourceAwsWafRegionalSqlInjectionMatchSetDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/aws/resource_aws_wafregional_sql_injection_match_set_test.go
+++ b/aws/resource_aws_wafregional_sql_injection_match_set_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestAccAWSWafRegionalSqlInjectionMatchSet_basic(t *testing.T) {
 	var v waf.SqlInjectionMatchSet
+	resourceName := "aws_wafregional_sql_injection_match_set.sql_injection_match_set"
 	sqlInjectionMatchSet := fmt.Sprintf("sqlInjectionMatchSet-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -24,20 +25,25 @@ func TestAccAWSWafRegionalSqlInjectionMatchSet_basic(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalSqlInjectionMatchSetConfig(sqlInjectionMatchSet),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalSqlInjectionMatchSetExists("aws_wafregional_sql_injection_match_set.sql_injection_match_set", &v),
+					testAccCheckAWSWafRegionalSqlInjectionMatchSetExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "name", sqlInjectionMatchSet),
+						resourceName, "name", sqlInjectionMatchSet),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.#", "1"),
+						resourceName, "sql_injection_match_tuple.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.1913782288.field_to_match.#", "1"),
+						resourceName, "sql_injection_match_tuple.1913782288.field_to_match.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.1913782288.field_to_match.0.data", ""),
+						resourceName, "sql_injection_match_tuple.1913782288.field_to_match.0.data", ""),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.1913782288.field_to_match.0.type", "QUERY_STRING"),
+						resourceName, "sql_injection_match_tuple.1913782288.field_to_match.0.type", "QUERY_STRING"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.1913782288.text_transformation", "URL_DECODE"),
+						resourceName, "sql_injection_match_tuple.1913782288.text_transformation", "URL_DECODE"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -45,6 +51,7 @@ func TestAccAWSWafRegionalSqlInjectionMatchSet_basic(t *testing.T) {
 
 func TestAccAWSWafRegionalSqlInjectionMatchSet_changeNameForceNew(t *testing.T) {
 	var before, after waf.SqlInjectionMatchSet
+	resourceName := "aws_wafregional_sql_injection_match_set.sql_injection_match_set"
 	sqlInjectionMatchSet := fmt.Sprintf("sqlInjectionMatchSet-%s", acctest.RandString(5))
 	sqlInjectionMatchSetNewName := fmt.Sprintf("sqlInjectionMatchSetNewName-%s", acctest.RandString(5))
 
@@ -56,22 +63,27 @@ func TestAccAWSWafRegionalSqlInjectionMatchSet_changeNameForceNew(t *testing.T) 
 			{
 				Config: testAccAWSWafRegionalSqlInjectionMatchSetConfig(sqlInjectionMatchSet),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalSqlInjectionMatchSetExists("aws_wafregional_sql_injection_match_set.sql_injection_match_set", &before),
+					testAccCheckAWSWafRegionalSqlInjectionMatchSetExists(resourceName, &before),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "name", sqlInjectionMatchSet),
+						resourceName, "name", sqlInjectionMatchSet),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.#", "1"),
+						resourceName, "sql_injection_match_tuple.#", "1"),
 				),
 			},
 			{
 				Config: testAccAWSWafRegionalSqlInjectionMatchSetConfig(sqlInjectionMatchSetNewName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalSqlInjectionMatchSetExists("aws_wafregional_sql_injection_match_set.sql_injection_match_set", &after),
+					testAccCheckAWSWafRegionalSqlInjectionMatchSetExists(resourceName, &after),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "name", sqlInjectionMatchSetNewName),
+						resourceName, "name", sqlInjectionMatchSetNewName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.#", "1"),
+						resourceName, "sql_injection_match_tuple.#", "1"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -79,6 +91,7 @@ func TestAccAWSWafRegionalSqlInjectionMatchSet_changeNameForceNew(t *testing.T) 
 
 func TestAccAWSWafRegionalSqlInjectionMatchSet_disappears(t *testing.T) {
 	var v waf.SqlInjectionMatchSet
+	resourceName := "aws_wafregional_sql_injection_match_set.sql_injection_match_set"
 	sqlInjectionMatchSet := fmt.Sprintf("sqlInjectionMatchSet-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -89,7 +102,7 @@ func TestAccAWSWafRegionalSqlInjectionMatchSet_disappears(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalSqlInjectionMatchSetConfig(sqlInjectionMatchSet),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalSqlInjectionMatchSetExists("aws_wafregional_sql_injection_match_set.sql_injection_match_set", &v),
+					testAccCheckAWSWafRegionalSqlInjectionMatchSetExists(resourceName, &v),
 					testAccCheckAWSWafRegionalSqlInjectionMatchSetDisappears(&v),
 				),
 				ExpectNonEmptyPlan: true,
@@ -100,6 +113,7 @@ func TestAccAWSWafRegionalSqlInjectionMatchSet_disappears(t *testing.T) {
 
 func TestAccAWSWafRegionalSqlInjectionMatchSet_changeTuples(t *testing.T) {
 	var before, after waf.SqlInjectionMatchSet
+	resourceName := "aws_wafregional_sql_injection_match_set.sql_injection_match_set"
 	setName := fmt.Sprintf("sqlInjectionMatchSet-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -110,38 +124,43 @@ func TestAccAWSWafRegionalSqlInjectionMatchSet_changeTuples(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalSqlInjectionMatchSetConfig(setName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafRegionalSqlInjectionMatchSetExists("aws_wafregional_sql_injection_match_set.sql_injection_match_set", &before),
+					testAccCheckAWSWafRegionalSqlInjectionMatchSetExists(resourceName, &before),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "name", setName),
+						resourceName, "name", setName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.#", "1"),
+						resourceName, "sql_injection_match_tuple.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.1913782288.field_to_match.#", "1"),
+						resourceName, "sql_injection_match_tuple.1913782288.field_to_match.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.1913782288.field_to_match.0.data", ""),
+						resourceName, "sql_injection_match_tuple.1913782288.field_to_match.0.data", ""),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.1913782288.field_to_match.0.type", "QUERY_STRING"),
+						resourceName, "sql_injection_match_tuple.1913782288.field_to_match.0.type", "QUERY_STRING"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.1913782288.text_transformation", "URL_DECODE"),
+						resourceName, "sql_injection_match_tuple.1913782288.text_transformation", "URL_DECODE"),
 				),
 			},
 			{
 				Config: testAccAWSWafRegionalSqlInjectionMatchSetConfig_changeTuples(setName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafRegionalSqlInjectionMatchSetExists("aws_wafregional_sql_injection_match_set.sql_injection_match_set", &after),
+					testAccCheckAWSWafRegionalSqlInjectionMatchSetExists(resourceName, &after),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "name", setName),
+						resourceName, "name", setName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.#", "1"),
+						resourceName, "sql_injection_match_tuple.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.3961339938.field_to_match.#", "1"),
+						resourceName, "sql_injection_match_tuple.3961339938.field_to_match.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.3961339938.field_to_match.0.data", "user-agent"),
+						resourceName, "sql_injection_match_tuple.3961339938.field_to_match.0.data", "user-agent"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.3961339938.field_to_match.0.type", "HEADER"),
+						resourceName, "sql_injection_match_tuple.3961339938.field_to_match.0.type", "HEADER"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.3961339938.text_transformation", "NONE"),
+						resourceName, "sql_injection_match_tuple.3961339938.text_transformation", "NONE"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -149,6 +168,7 @@ func TestAccAWSWafRegionalSqlInjectionMatchSet_changeTuples(t *testing.T) {
 
 func TestAccAWSWafRegionalSqlInjectionMatchSet_noTuples(t *testing.T) {
 	var ipset waf.SqlInjectionMatchSet
+	resourceName := "aws_wafregional_sql_injection_match_set.sql_injection_match_set"
 	setName := fmt.Sprintf("sqlInjectionMatchSet-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -159,12 +179,17 @@ func TestAccAWSWafRegionalSqlInjectionMatchSet_noTuples(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalSqlInjectionMatchSetConfig_noTuples(setName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafRegionalSqlInjectionMatchSetExists("aws_wafregional_sql_injection_match_set.sql_injection_match_set", &ipset),
+					testAccCheckAWSWafRegionalSqlInjectionMatchSetExists(resourceName, &ipset),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "name", setName),
+						resourceName, "name", setName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.#", "0"),
+						resourceName, "sql_injection_match_tuple.#", "0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/website/docs/r/wafregional_sql_injection_match_set.html.markdown
+++ b/website/docs/r/wafregional_sql_injection_match_set.html.markdown
@@ -58,3 +58,11 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the WAF SqlInjectionMatchSet.
+
+## Import
+
+WAF Regional Sql Injection Match Set can be imported using the id, e.g.
+
+```
+$ terraform import aws_wafregional_sql_injection_match_set.sql_injection_match_set a1b2c3d4-d5f6-7777-8888-9999aaaabbbbcccc
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #9212


Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_wafregional_sql_injection_match_set: Support resource import
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSWafRegionalSqlInjectionMatchSet_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSWafRegionalSqlInjectionMatchSet_ -timeout 120m
=== RUN   TestAccAWSWafRegionalSqlInjectionMatchSet_basic
=== PAUSE TestAccAWSWafRegionalSqlInjectionMatchSet_basic
=== RUN   TestAccAWSWafRegionalSqlInjectionMatchSet_changeNameForceNew
=== PAUSE TestAccAWSWafRegionalSqlInjectionMatchSet_changeNameForceNew
=== RUN   TestAccAWSWafRegionalSqlInjectionMatchSet_disappears
=== PAUSE TestAccAWSWafRegionalSqlInjectionMatchSet_disappears
=== RUN   TestAccAWSWafRegionalSqlInjectionMatchSet_changeTuples
=== PAUSE TestAccAWSWafRegionalSqlInjectionMatchSet_changeTuples
=== RUN   TestAccAWSWafRegionalSqlInjectionMatchSet_noTuples
=== PAUSE TestAccAWSWafRegionalSqlInjectionMatchSet_noTuples
=== CONT  TestAccAWSWafRegionalSqlInjectionMatchSet_basic
=== CONT  TestAccAWSWafRegionalSqlInjectionMatchSet_changeTuples
=== CONT  TestAccAWSWafRegionalSqlInjectionMatchSet_noTuples
=== CONT  TestAccAWSWafRegionalSqlInjectionMatchSet_disappears
=== CONT  TestAccAWSWafRegionalSqlInjectionMatchSet_changeNameForceNew
--- PASS: TestAccAWSWafRegionalSqlInjectionMatchSet_noTuples (54.17s)
--- PASS: TestAccAWSWafRegionalSqlInjectionMatchSet_disappears (54.18s)
--- PASS: TestAccAWSWafRegionalSqlInjectionMatchSet_basic (60.00s)
--- PASS: TestAccAWSWafRegionalSqlInjectionMatchSet_changeTuples (83.37s)
--- PASS: TestAccAWSWafRegionalSqlInjectionMatchSet_changeNameForceNew (95.08s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	95.173s
```
