### PR TITLE
Allow creation of everlasting spot fleet requests

### DIFF
--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -686,9 +686,6 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 			return err
 		}
 		spotFleetConfig.ValidUntil = aws.Time(valid_until)
-	} else {
-		valid_until := time.Now().Add(24 * time.Hour)
-		spotFleetConfig.ValidUntil = aws.Time(valid_until)
 	}
 
 	if v, ok := d.GetOk("load_balancers"); ok && v.(*schema.Set).Len() > 0 {

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -123,7 +123,7 @@ across different markets and instance types.
   `terminate`.
 * `fleet_type` - (Optional) The type of fleet request. Indicates whether the Spot Fleet only requests the target
   capacity or also attempts to maintain it. Default is `maintain`.
-* `valid_until` - (Optional) The end date and time of the request, in UTC [RFC3339](https://tools.ietf.org/html/rfc3339#section-5.8) format(for example, YYYY-MM-DDTHH:MM:SSZ). At this point, no new Spot instance requests are placed or enabled to fulfill the request. Defaults to 24 hours.
+* `valid_until` - (Optional) The end date and time of the request, in UTC [RFC3339](https://tools.ietf.org/html/rfc3339#section-5.8) format(for example, YYYY-MM-DDTHH:MM:SSZ). At this point, no new Spot instance requests are placed or enabled to fulfill the request.
 * `valid_from` - (Optional) The start date and time of the request, in UTC [RFC3339](https://tools.ietf.org/html/rfc3339#section-5.8) format(for example, YYYY-MM-DDTHH:MM:SSZ). The default is to start fulfilling the request immediately.
 * `load_balancers` (Optional) A list of elastic load balancer names to add to the Spot fleet.
 * `target_group_arns` (Optional) A list of `aws_alb_target_group` ARNs, for use with Application Load Balancing.


### PR DESCRIPTION
According to the AWS API doc, if `valid until` is _not_ set, then the spot fleet request "remains until you cancel it". By having a 24 hr default, then this behaviour cannot be achieved using this terraform provider - so the default it removed.

Some conversation about the default: https://github.com/terraform-providers/terraform-provider-aws/commit/5bafd4b7c9eca54d18a506e4b8c6119a4761b5d1#r34628957
The relevant AWS doc: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_SpotFleetRequestConfigData.html

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
ENHANCEMENTS:

* resource/aws_spot_fleet_request: Remove 24 hr default for `valid_until`
```
