### PR TITLE
resource/ecs_cluster: Add ability to enable ECS Cluster Insights

### DIFF
--- a/aws/data_source_aws_ecs_cluster.go
+++ b/aws/data_source_aws_ecs_cluster.go
@@ -44,6 +44,23 @@ func dataSourceAwsEcsCluster() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+
+			"setting": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -76,6 +93,10 @@ func dataSourceAwsEcsClusterRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("pending_tasks_count", cluster.PendingTasksCount)
 	d.Set("running_tasks_count", cluster.RunningTasksCount)
 	d.Set("registered_container_instances_count", cluster.RegisteredContainerInstancesCount)
+
+	if err := d.Set("setting", flattenEcsSettings(cluster.Settings)); err != nil {
+		return fmt.Errorf("error setting setting: %s", err)
+	}
 
 	return nil
 }

--- a/aws/data_source_aws_ecs_cluster_test.go
+++ b/aws/data_source_aws_ecs_cluster_test.go
@@ -27,9 +27,68 @@ func TestAccAWSEcsDataSource_ecsCluster(t *testing.T) {
 	})
 }
 
+func TestAccAWSEcsDataSource_ecsClusterContainerInsights(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsEcsClusterDataSourceConfigContainerInsights,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_ecs_cluster.default", "status", "ACTIVE"),
+					resource.TestCheckResourceAttr("data.aws_ecs_cluster.default", "pending_tasks_count", "0"),
+					resource.TestCheckResourceAttr("data.aws_ecs_cluster.default", "running_tasks_count", "0"),
+					resource.TestCheckResourceAttr("data.aws_ecs_cluster.default", "registered_container_instances_count", "0"),
+					resource.TestCheckResourceAttrSet("data.aws_ecs_cluster.default", "arn"),
+					resource.TestCheckResourceAttr("data.aws_ecs_cluster.default", "setting.#", "1"),
+					resource.TestCheckResourceAttr("data.aws_ecs_cluster.default", "setting.4047805881.name", "containerInsights"),
+					resource.TestCheckResourceAttr("data.aws_ecs_cluster.default", "setting.4047805881.value", "enabled"),
+				),
+			},
+		},
+	})
+}
+
 var testAccCheckAwsEcsClusterDataSourceConfig = fmt.Sprintf(`
 resource "aws_ecs_cluster" "default" {
   name = "default-%d"
+}
+
+resource "aws_ecs_task_definition" "mongo" {
+  family = "mongodb"
+  container_definitions = <<DEFINITION
+[
+  {
+    "cpu": 128,
+    "essential": true,
+    "image": "mongo:latest",
+    "memory": 128,
+    "memoryReservation": 64,
+    "name": "mongodb"
+  }
+]
+DEFINITION
+}
+
+resource "aws_ecs_service" "mongo" {
+  name = "mongodb"
+  cluster = "${aws_ecs_cluster.default.id}"
+  task_definition = "${aws_ecs_task_definition.mongo.arn}"
+  desired_count = 1
+}
+
+data "aws_ecs_cluster" "default" {
+  cluster_name = "${aws_ecs_cluster.default.name}"
+}
+`, acctest.RandInt())
+
+var testAccCheckAwsEcsClusterDataSourceConfigContainerInsights = fmt.Sprintf(`
+resource "aws_ecs_cluster" "default" {
+  name = "default-%d"
+  setting {
+    name = "containerInsights"
+    value = "enabled"
+  }
 }
 
 resource "aws_ecs_task_definition" "mongo" {

--- a/aws/resource_aws_ecs_cluster.go
+++ b/aws/resource_aws_ecs_cluster.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsEcsCluster() *schema.Resource {
@@ -33,6 +34,26 @@ func resourceAwsEcsCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"setting": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								ecs.ClusterSettingNameContainerInsights,
+							}, false),
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -55,10 +76,16 @@ func resourceAwsEcsClusterCreate(d *schema.ResourceData, meta interface{}) error
 	clusterName := d.Get("name").(string)
 	log.Printf("[DEBUG] Creating ECS cluster %s", clusterName)
 
-	out, err := conn.CreateCluster(&ecs.CreateClusterInput{
+	input := ecs.CreateClusterInput{
 		ClusterName: aws.String(clusterName),
 		Tags:        tagsFromMapECS(d.Get("tags").(map[string]interface{})),
-	})
+	}
+
+	if v, ok := d.GetOk("setting"); ok {
+		input.Settings = expandEcsSettings(v.(*schema.Set).List())
+	}
+
+	out, err := conn.CreateCluster(&input)
 	if err != nil {
 		return err
 	}
@@ -134,6 +161,10 @@ func resourceAwsEcsClusterRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("arn", cluster.ClusterArn)
 	d.Set("name", cluster.ClusterName)
 
+	if err := d.Set("setting", flattenEcsSettings(cluster.Settings)); err != nil {
+		return fmt.Errorf("error setting setting: %s", err)
+	}
+
 	if err := d.Set("tags", tagsToMapECS(cluster.Tags)); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
@@ -143,6 +174,18 @@ func resourceAwsEcsClusterRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceAwsEcsClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ecsconn
+
+	if d.HasChange("setting") {
+		input := ecs.UpdateClusterSettingsInput{
+			Cluster:  aws.String(d.Id()),
+			Settings: expandEcsSettings(d.Get("setting").(*schema.Set).List()),
+		}
+
+		_, err := conn.UpdateClusterSettings(&input)
+		if err != nil {
+			return fmt.Errorf("error changing ECS cluster settings (%s): %s", d.Id(), err)
+		}
+	}
 
 	if d.HasChange("tags") {
 		oldTagsRaw, newTagsRaw := d.GetChange("tags")
@@ -259,4 +302,42 @@ func ecsClusterInactive(out *ecs.DescribeClustersOutput, clusterName string) boo
 		}
 	}
 	return false
+}
+
+func expandEcsSettings(configured []interface{}) []*ecs.ClusterSetting {
+	if len(configured) == 0 {
+		return nil
+	}
+
+	settings := make([]*ecs.ClusterSetting, 0, len(configured))
+
+	for _, raw := range configured {
+		data := raw.(map[string]interface{})
+
+		setting := &ecs.ClusterSetting{
+			Name:  aws.String(data["name"].(string)),
+			Value: aws.String(data["value"].(string)),
+		}
+
+		settings = append(settings, setting)
+	}
+
+	return settings
+}
+
+func flattenEcsSettings(list []*ecs.ClusterSetting) []map[string]interface{} {
+	if len(list) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(list))
+	for _, setting := range list {
+		l := map[string]interface{}{
+			"name":  *setting.Name,
+			"value": *setting.Value,
+		}
+
+		result = append(result, l)
+	}
+	return result
 }

--- a/website/docs/d/ecs_cluster.html.markdown
+++ b/website/docs/d/ecs_cluster.html.markdown
@@ -34,3 +34,4 @@ In addition to all arguments above, the following attributes are exported:
 * `pending_tasks_count` - The number of pending tasks for the ECS Cluster
 * `running_tasks_count` - The number of running tasks for the ECS Cluster
 * `registered_container_instances_count` - The number of registered container instances for the ECS Cluster
+* `setting` - The settings associated with the ECS Cluster.

--- a/website/docs/r/ecs_cluster.html.markdown
+++ b/website/docs/r/ecs_cluster.html.markdown
@@ -24,7 +24,15 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the cluster (up to 255 letters, numbers, hyphens, and underscores)
 * `tags` - (Optional) Key-value mapping of resource tags
+* `setting` - (Optional) The setting to use when creating a cluster. This parameter is used to enable CloudWatch Container Insights for a cluster. Defined below.
+ 
+## setting
 
+The `setting` configuration block supports the following:
+
+* `name` - (Required) Name of the setting to manage. Valid values: `containerInsights`.
+* `value` -  (Required) The value to assign to the setting. Value values are `enabled` and `disabled`.
+ 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:


### PR DESCRIPTION
Fixes: #9294

DataSource Tests:

```
acctests aws TestAccAWSEcsDataSource_
=== RUN   TestAccAWSEcsDataSource_ecsCluster
=== PAUSE TestAccAWSEcsDataSource_ecsCluster
=== RUN   TestAccAWSEcsDataSource_ecsClusterContainerInsights
=== PAUSE TestAccAWSEcsDataSource_ecsClusterContainerInsights
=== RUN   TestAccAWSEcsDataSource_ecsContainerDefinition
=== PAUSE TestAccAWSEcsDataSource_ecsContainerDefinition
=== RUN   TestAccAWSEcsDataSource_ecsTaskDefinition
=== PAUSE TestAccAWSEcsDataSource_ecsTaskDefinition
=== CONT  TestAccAWSEcsDataSource_ecsCluster
=== CONT  TestAccAWSEcsDataSource_ecsClusterContainerInsights
=== CONT  TestAccAWSEcsDataSource_ecsTaskDefinition
=== CONT  TestAccAWSEcsDataSource_ecsContainerDefinition
--- PASS: TestAccAWSEcsDataSource_ecsTaskDefinition (36.34s)
--- PASS: TestAccAWSEcsDataSource_ecsContainerDefinition (89.19s)
--- PASS: TestAccAWSEcsDataSource_ecsClusterContainerInsights (89.21s)
--- PASS: TestAccAWSEcsDataSource_ecsCluster (89.22s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	89.280s
```

Resource Tests:

```
acctests aws TestAccAWSEcsCluster_
=== RUN   TestAccAWSEcsCluster_basic
=== PAUSE TestAccAWSEcsCluster_basic
=== RUN   TestAccAWSEcsCluster_disappears
=== PAUSE TestAccAWSEcsCluster_disappears
=== RUN   TestAccAWSEcsCluster_Tags
=== PAUSE TestAccAWSEcsCluster_Tags
=== RUN   TestAccAWSEcsCluster_containerInsights
=== PAUSE TestAccAWSEcsCluster_containerInsights
=== CONT  TestAccAWSEcsCluster_basic
=== CONT  TestAccAWSEcsCluster_Tags
=== CONT  TestAccAWSEcsCluster_disappears
=== CONT  TestAccAWSEcsCluster_containerInsights
--- PASS: TestAccAWSEcsCluster_disappears (19.46s)
--- PASS: TestAccAWSEcsCluster_containerInsights (28.05s)
--- PASS: TestAccAWSEcsCluster_basic (31.04s)
--- PASS: TestAccAWSEcsCluster_Tags (64.71s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	64.770s
```