### PR TITLE
Correct `name` -> `bucket` in flog_log docs

### DIFF
--- a/website/docs/r/flow_log.html.markdown
+++ b/website/docs/r/flow_log.html.markdown
@@ -83,7 +83,7 @@ resource "aws_flow_log" "example" {
 }
 
 resource "aws_s3_bucket" "example" {
-  name = "example"
+  bucket = "example"
 }
 ```
 


### PR DESCRIPTION
This is a small update to docs. The example was using a non-existing argument for `aws_s3_bucket`