### PR TITLE
Rfd retry eip

### DIFF
--- a/aws/resource_aws_eip_association.go
+++ b/aws/resource_aws_eip_association.go
@@ -105,6 +105,9 @@ func resourceAwsEipAssociationCreate(d *schema.ResourceData, meta interface{}) e
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		resp, err = conn.AssociateAddress(request)
+	}
 	if err != nil {
 		return fmt.Errorf("Error associating EIP: %s", err)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES
* resource/aws_eip: Final retries after timeouts reading, updating, and deleting EIPs
* resource/aws_eip_association: Final retry after timeout creating EIP association
```

Output from acceptance testing:

```
NOTE: Failures are due to resource limits on the account

$ --- SKIP: TestAccAWSEIP_PublicIpv4Pool_custom (0.00s)
--- SKIP: TestAccAWSEIP_importEc2Classic (1.66s)
--- SKIP: TestAccAWSEIP_classic_disassociate (1.97s)
--- SKIP: TestAccAWSEIPAssociation_ec2Classic (1.96s)
--- PASS: TestAccAWSEIP_basic (9.43s)
--- PASS: TestAccAWSEIP_disappears (11.21s)
--- PASS: TestAccAWSEIP_PublicIpv4Pool_default (12.20s)
--- PASS: TestAccAWSEIP_tags (17.23s)
--- FAIL: TestAccAWSEIP_twoEIPsOneNetworkInterface (21.37s)
--- FAIL: TestAccAWSEIP_importVpc (22.21s)
--- PASS: TestAccAWSEIP_network_interface (24.45s)
--- PASS: TestAccAWSEIPAssociation_importNetworkInterface (25.17s)
--- PASS: TestAccAWSEIPAssociation_disappears (74.33s)
--- FAIL: TestAccAWSEIPAssociation_basic (77.12s)
--- FAIL: TestAccAWSEIPAssociation_spotInstance (98.33s)
--- PASS: TestAccAWSEIP_associated_user_private_ip (98.97s)
--- PASS: TestAccAWSEIP_instance (175.56s)
--- PASS: TestAccAWSEIPAssociation_importInstance (223.42s)
--- FAIL: TestAccAWSEIPAssociate_not_associated (253.42s)
```
