### PR TITLE
Final retry after timeout creating EKS cluster

### DIFF
--- a/aws/resource_aws_eks_cluster.go
+++ b/aws/resource_aws_eks_cluster.go
@@ -177,7 +177,9 @@ func resourceAwsEksClusterCreate(d *schema.ResourceData, meta interface{}) error
 		}
 		return nil
 	})
-
+	if isResourceTimeoutError(err) {
+		_, err = conn.CreateCluster(input)
+	}
 	if err != nil {
 		return fmt.Errorf("error creating EKS Cluster (%s): %s", name, err)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_eks_cluster: Final retry after timeout creating EKS cluster

```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSEksCluster"      
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSEksCluster -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEksClusterAuthDataSource_basic
=== PAUSE TestAccAWSEksClusterAuthDataSource_basic
=== RUN   TestAccAWSEksClusterDataSource_basic
=== PAUSE TestAccAWSEksClusterDataSource_basic
=== RUN   TestAccAWSEksCluster_basic
=== PAUSE TestAccAWSEksCluster_basic
=== RUN   TestAccAWSEksCluster_Version
=== PAUSE TestAccAWSEksCluster_Version
=== RUN   TestAccAWSEksCluster_Logging
=== PAUSE TestAccAWSEksCluster_Logging
=== RUN   TestAccAWSEksCluster_VpcConfig_SecurityGroupIds
=== PAUSE TestAccAWSEksCluster_VpcConfig_SecurityGroupIds
=== RUN   TestAccAWSEksCluster_VpcConfig_EndpointPrivateAccess
=== PAUSE TestAccAWSEksCluster_VpcConfig_EndpointPrivateAccess
=== RUN   TestAccAWSEksCluster_VpcConfig_EndpointPublicAccess
=== PAUSE TestAccAWSEksCluster_VpcConfig_EndpointPublicAccess
=== CONT  TestAccAWSEksClusterAuthDataSource_basic
=== CONT  TestAccAWSEksCluster_Version
=== CONT  TestAccAWSEksCluster_VpcConfig_SecurityGroupIds
=== CONT  TestAccAWSEksCluster_basic
=== CONT  TestAccAWSEksCluster_Logging
=== CONT  TestAccAWSEksClusterDataSource_basic
=== CONT  TestAccAWSEksCluster_VpcConfig_EndpointPublicAccess
=== CONT  TestAccAWSEksCluster_VpcConfig_EndpointPrivateAccess
--- PASS: TestAccAWSEksClusterAuthDataSource_basic (22.04s)
--- PASS: TestAccAWSEksCluster_VpcConfig_SecurityGroupIds (1153.99s)
--- PASS: TestAccAWSEksCluster_basic (1268.29s)
--- PASS: TestAccAWSEksClusterDataSource_basic (1346.00s)
--- PASS: TestAccAWSEksCluster_Logging (1376.92s)
--- PASS: TestAccAWSEksCluster_VpcConfig_EndpointPublicAccess (1757.17s)
--- PASS: TestAccAWSEksCluster_VpcConfig_EndpointPrivateAccess (1830.59s)
--- PASS: TestAccAWSEksCluster_Version (2645.26s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       2646.563s
```