### PR TITLE
provider: Update GitHub Actions workflows for v2

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -5,9 +5,8 @@ jobs:
     name: Apply Triage Label
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Apply Triage Label
-      uses: actions/github@v1.0.0
+    - uses: actions/checkout@v1.0.0
+    - uses: actions/github@v1.0.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,16 +1,12 @@
 on: pull_request
 name: Pull Request Updates
 jobs:
-  pr-filter-sync:
+  pr-label:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: pr-filter-sync
-      uses: actions/bin/filter@master
+    - uses: actions/checkout@v1.0.0
+    - uses: actions/labeler@v2.0.0
+      if: github.event.action == 'opened' || github.event.action == 'synchronize'
       with:
-        args: action 'opened|synchronize'
-    - name: pr-label
-      uses: actions/labeler@v1.0.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        LABEL_SPEC_FILE: .github/PULL_REQUEST_LABELS.yml
+        configuration-path: .github/PULL_REQUEST_LABELS.yml
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
References:

- https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idstepsif
- https://github.com/actions/labeler

Changes:

- The existing actions/bin/filter step from v1 of GitHub Actions was failing pretty consistently when running on v2. It appears the v2 configuration supports doing action filtering via built-in `if` configuration now.
- Update actions/labeler@v2.0.0
- Pinned actions/checkout@v1.0.0 since the tag is now available

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing: N/A