### PR TITLE
provider: Ensure needs-triage issue labeling step in GitHub Actions v2 is conditional on opened action

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -7,7 +7,8 @@ jobs:
     steps:
     - uses: actions/checkout@v1.0.0
     - uses: actions/github@v1.0.0
+      if: github.event.action == 'opened'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        args: label needs-triage --action=opened
+        args: label needs-triage


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
The payload is slightly different in v2, so actions/github@v1.0.0 fails with the action flag and does not return a neutral status. Instead, we will pre-filter the step via if.

References:

- https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idif
- https://github.com/actions/github/blob/4f0213ed102c4b518a7ce8bc4e6268bdd710770e/entrypoint.js#L73-L85

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing: N/A