### PR TITLE
Small change to fix bug where only 1 tag would be created when multiple specified

### DIFF
--- a/aws/resource_aws_cloudhsm2_cluster.go
+++ b/aws/resource_aws_cloudhsm2_cluster.go
@@ -333,7 +333,7 @@ func setTagsAwsCloudHsm2Cluster(conn *cloudhsmv2.CloudHSMV2, d *schema.ResourceD
 			tagList := make([]*cloudhsmv2.Tag, 0, len(create))
 			for k, v := range create {
 				tagList = append(tagList, &cloudhsmv2.Tag{
-					Key:   &k,
+					Key:   aws.String(k),
 					Value: v,
 				})
 			}


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #9871

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fixes a bug in the cloudhsm2 provider that would result in a single tag being created when multiple tags are specified.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccDataSourceCloudHsm2Cluster_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccDataSourceCloudHsm2Cluster_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccDataSourceCloudHsm2Cluster_basic
--- PASS: TestAccDataSourceCloudHsm2Cluster_basic (339.65s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	340.585s
$
```
