### PR TITLE
resource/aws_db_instance: Only send performance_insights_kms_key_id on update if configured

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -1630,11 +1630,16 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 		d.SetPartial("performance_insights_enabled")
 		req.EnablePerformanceInsights = aws.Bool(d.Get("performance_insights_enabled").(bool))
 
-		d.SetPartial("performance_insights_kms_key_id")
-		req.PerformanceInsightsKMSKeyId = aws.String(d.Get("performance_insights_kms_key_id").(string))
+		if v, ok := d.GetOk("performance_insights_kms_key_id"); ok {
+			d.SetPartial("performance_insights_kms_key_id")
+			req.PerformanceInsightsKMSKeyId = aws.String(v.(string))
+		}
 
-		d.SetPartial("performance_insights_retention_period")
-		req.PerformanceInsightsRetentionPeriod = aws.Int64(int64(d.Get("performance_insights_retention_period").(int)))
+		if v, ok := d.GetOk("performance_insights_retention_period"); ok {
+			d.SetPartial("performance_insights_retention_period")
+			req.PerformanceInsightsRetentionPeriod = aws.Int64(int64(v.(int)))
+		}
+
 		requestUpdate = true
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #8792
Closes #9399
Closes #9406

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_db_instance: Fix enabling Performance Insights on update without Performance Insights KMS Key ID
```

Previously before code update:

```
--- PASS: TestAccAWSRDSDBInstance_PerformanceInsightsRetentionPeriod (667.32s)
--- PASS: TestAccAWSRDSDBInstance_PerformanceInsightsEnabled_EnabledToDisabled (733.03s)
--- PASS: TestAccAWSRDSDBInstance_PerformanceInsightsKmsKeyId (862.56s)
--- FAIL: TestAccAWSRDSDBInstance_PerformanceInsightsEnabled_DisabledToEnabled (5686.66s)
    testing.go:568: Step 2 error: errors during apply:

        Error: Error modifying DB Instance tf-acc-test-5551941564373291595: InternalFailure:
        	status code: 500, request id: 9ad8b0ff-c5a2-43d0-a531-60aa047b8570
```

Output from acceptance testing (full run pending in TeamCity):

```
--- PASS: TestAccAWSRDSDBInstance_PerformanceInsightsEnabled_EnabledToDisabled (680.88s)
--- PASS: TestAccAWSRDSDBInstance_PerformanceInsightsEnabled_DisabledToEnabled (680.95s)
--- PASS: TestAccAWSRDSDBInstance_PerformanceInsightsRetentionPeriod (685.18s)
--- PASS: TestAccAWSRDSDBInstance_PerformanceInsightsKmsKeyId (851.11s)
```
