### PR TITLE
resource/aws_rds_cluster_instance: Ensure performance_insights_kms_key_id updates include performance_insights_enabled

### DIFF
--- a/aws/resource_aws_rds_cluster_instance.go
+++ b/aws/resource_aws_rds_cluster_instance.go
@@ -434,15 +434,15 @@ func resourceAwsRDSClusterInstanceUpdate(d *schema.ResourceData, meta interface{
 		requestUpdate = true
 	}
 
-	if d.HasChange("performance_insights_enabled") {
+	if d.HasChange("performance_insights_enabled") || d.HasChange("performance_insights_kms_key_id") {
 		d.SetPartial("performance_insights_enabled")
 		req.EnablePerformanceInsights = aws.Bool(d.Get("performance_insights_enabled").(bool))
-		requestUpdate = true
-	}
 
-	if d.HasChange("performance_insights_kms_key_id") {
-		d.SetPartial("performance_insights_kms_key_id")
-		req.PerformanceInsightsKMSKeyId = aws.String(d.Get("performance_insights_kms_key_id").(string))
+		if v, ok := d.GetOk("performance_insights_kms_key_id"); ok {
+			d.SetPartial("performance_insights_kms_key_id")
+			req.PerformanceInsightsKMSKeyId = aws.String(v.(string))
+		}
+
 		requestUpdate = true
 	}
 

--- a/aws/resource_aws_rds_cluster_instance_test.go
+++ b/aws/resource_aws_rds_cluster_instance_test.go
@@ -384,7 +384,6 @@ func TestAccAWSRDSClusterInstance_withInstanceEnhancedMonitor(t *testing.T) {
 
 func TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraMysql1(t *testing.T) {
 	var dbInstance rds.DBInstance
-	kmsKeyResourceName := "aws_kms_key.test"
 	resourceName := "aws_rds_cluster_instance.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
@@ -398,7 +397,6 @@ func TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraMysql1(t *tes
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
-					resource.TestCheckResourceAttrPair(resourceName, "performance_insights_kms_key_id", kmsKeyResourceName, "arn"),
 				),
 			},
 			{
@@ -416,7 +414,6 @@ func TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraMysql1(t *tes
 
 func TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraMysql2(t *testing.T) {
 	var dbInstance rds.DBInstance
-	kmsKeyResourceName := "aws_kms_key.test"
 	resourceName := "aws_rds_cluster_instance.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
@@ -427,6 +424,67 @@ func TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraMysql2(t *tes
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSClusterInstanceConfigPerformanceInsightsEnabledAuroraMysql2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSClusterInstanceExists(resourceName, &dbInstance),
+					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"identifier_prefix",
+				},
+			},
+		},
+	})
+}
+
+func TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraPostgresql(t *testing.T) {
+	var dbInstance rds.DBInstance
+	resourceName := "aws_rds_cluster_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSClusterInstanceConfigPerformanceInsightsEnabledAuroraPostgresql(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSClusterInstanceExists(resourceName, &dbInstance),
+					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"identifier_prefix",
+				},
+			},
+		},
+	})
+}
+
+func TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql1(t *testing.T) {
+	var dbInstance rds.DBInstance
+	kmsKeyResourceName := "aws_kms_key.test"
+	resourceName := "aws_rds_cluster_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSClusterInstanceConfigPerformanceInsightsKmsKeyIdAuroraMysql1(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
@@ -446,7 +504,41 @@ func TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraMysql2(t *tes
 	})
 }
 
-func TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraPostgresql(t *testing.T) {
+func TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql1_DefaultKeyToCustomKey(t *testing.T) {
+	var dbInstance rds.DBInstance
+	resourceName := "aws_rds_cluster_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSClusterInstanceConfigPerformanceInsightsEnabledAuroraMysql1(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSClusterInstanceExists(resourceName, &dbInstance),
+					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"identifier_prefix",
+				},
+			},
+			{
+				Config:      testAccAWSClusterInstanceConfigPerformanceInsightsKmsKeyIdAuroraMysql1(rName),
+				ExpectError: regexp.MustCompile(`InvalidParameterCombination: You cannot change your Performance Insights KMS key`),
+			},
+		},
+	})
+}
+
+func TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql2(t *testing.T) {
 	var dbInstance rds.DBInstance
 	kmsKeyResourceName := "aws_kms_key.test"
 	resourceName := "aws_rds_cluster_instance.test"
@@ -458,7 +550,7 @@ func TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraPostgresql(t 
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSClusterInstanceConfigPerformanceInsightsEnabledAuroraPostgresql(rName),
+				Config: testAccAWSClusterInstanceConfigPerformanceInsightsKmsKeyIdAuroraMysql2(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
@@ -473,6 +565,106 @@ func TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraPostgresql(t 
 					"apply_immediately",
 					"identifier_prefix",
 				},
+			},
+		},
+	})
+}
+
+func TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql2_DefaultKeyToCustomKey(t *testing.T) {
+	var dbInstance rds.DBInstance
+	resourceName := "aws_rds_cluster_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSClusterInstanceConfigPerformanceInsightsEnabledAuroraMysql2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSClusterInstanceExists(resourceName, &dbInstance),
+					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"identifier_prefix",
+				},
+			},
+			{
+				Config:      testAccAWSClusterInstanceConfigPerformanceInsightsKmsKeyIdAuroraMysql2(rName),
+				ExpectError: regexp.MustCompile(`InvalidParameterCombination: You cannot change your Performance Insights KMS key`),
+			},
+		},
+	})
+}
+
+func TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraPostgresql(t *testing.T) {
+	var dbInstance rds.DBInstance
+	kmsKeyResourceName := "aws_kms_key.test"
+	resourceName := "aws_rds_cluster_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSClusterInstanceConfigPerformanceInsightsKmsKeyIdAuroraPostgresql(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSClusterInstanceExists(resourceName, &dbInstance),
+					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "performance_insights_kms_key_id", kmsKeyResourceName, "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"identifier_prefix",
+				},
+			},
+		},
+	})
+}
+
+func TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraPostgresql_DefaultKeyToCustomKey(t *testing.T) {
+	var dbInstance rds.DBInstance
+	resourceName := "aws_rds_cluster_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSClusterInstanceConfigPerformanceInsightsEnabledAuroraPostgresql(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSClusterInstanceExists(resourceName, &dbInstance),
+					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"identifier_prefix",
+				},
+			},
+			{
+				Config:      testAccAWSClusterInstanceConfigPerformanceInsightsKmsKeyIdAuroraPostgresql(rName),
+				ExpectError: regexp.MustCompile(`InvalidParameterCombination: You cannot change your Performance Insights KMS key`),
 			},
 		},
 	})
@@ -852,6 +1044,71 @@ resource "aws_db_parameter_group" "bar" {
 
 func testAccAWSClusterInstanceConfigPerformanceInsightsEnabledAuroraMysql1(rName string) string {
 	return fmt.Sprintf(`
+resource "aws_rds_cluster" "test" {
+  cluster_identifier  = %[1]q
+  database_name       = "mydb"
+  engine              = "aurora"
+  master_password     = "mustbeeightcharaters"
+  master_username     = "foo"
+  skip_final_snapshot = true
+}
+
+resource "aws_rds_cluster_instance" "test" {
+  cluster_identifier           = "${aws_rds_cluster.test.id}"
+  engine                       = "${aws_rds_cluster.test.engine}"
+  identifier                   = %[1]q
+  instance_class               = "db.r4.large"
+  performance_insights_enabled = true
+}
+`, rName)
+}
+
+func testAccAWSClusterInstanceConfigPerformanceInsightsEnabledAuroraMysql2(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_rds_cluster" "test" {
+  cluster_identifier  = %[1]q
+  database_name       = "mydb"
+  engine              = "aurora-mysql"
+  engine_version      = "5.7.mysql_aurora.2.04.2"
+  master_password     = "mustbeeightcharaters"
+  master_username     = "foo"
+  skip_final_snapshot = true
+}
+
+resource "aws_rds_cluster_instance" "test" {
+  cluster_identifier           = "${aws_rds_cluster.test.id}"
+  engine                       = "${aws_rds_cluster.test.engine}"
+  engine_version               = "${aws_rds_cluster.test.engine_version}"
+  identifier                   = %[1]q
+  instance_class               = "db.r4.large"
+  performance_insights_enabled = true
+}
+`, rName)
+}
+
+func testAccAWSClusterInstanceConfigPerformanceInsightsEnabledAuroraPostgresql(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_rds_cluster" "test" {
+  cluster_identifier  = %[1]q
+  database_name       = "mydb"
+  engine              = "aurora-postgresql"
+  master_password     = "mustbeeightcharaters"
+  master_username     = "foo"
+  skip_final_snapshot = true
+}
+
+resource "aws_rds_cluster_instance" "test" {
+  cluster_identifier           = "${aws_rds_cluster.test.id}"
+  engine                       = "${aws_rds_cluster.test.engine}"
+  identifier                   = %[1]q
+  instance_class               = "db.r4.large"
+  performance_insights_enabled = true
+}
+`, rName)
+}
+
+func testAccAWSClusterInstanceConfigPerformanceInsightsKmsKeyIdAuroraMysql1(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
 }
@@ -876,7 +1133,7 @@ resource "aws_rds_cluster_instance" "test" {
 `, rName)
 }
 
-func testAccAWSClusterInstanceConfigPerformanceInsightsEnabledAuroraMysql2(rName string) string {
+func testAccAWSClusterInstanceConfigPerformanceInsightsKmsKeyIdAuroraMysql2(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
@@ -904,7 +1161,7 @@ resource "aws_rds_cluster_instance" "test" {
 `, rName)
 }
 
-func testAccAWSClusterInstanceConfigPerformanceInsightsEnabledAuroraPostgresql(rName string) string {
+func testAccAWSClusterInstanceConfigPerformanceInsightsKmsKeyIdAuroraPostgresql(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7

--- a/aws/resource_aws_rds_cluster_instance_test.go
+++ b/aws/resource_aws_rds_cluster_instance_test.go
@@ -678,7 +678,7 @@ resource "aws_rds_cluster" "default" {
   availability_zones  = ["us-west-2a", "us-west-2b", "us-west-2c"]
   database_name       = "mydb"
   master_username     = "foo"
-  master_password     = "mustbeeightcharaters"
+  master_password     = "mustbeeightcharacters"
   skip_final_snapshot = true
 }
 
@@ -714,7 +714,7 @@ resource "aws_rds_cluster" "default" {
   availability_zones  = ["us-west-2a", "us-west-2b", "us-west-2c"]
   database_name       = "mydb"
   master_username     = "foo"
-  master_password     = "mustbeeightcharaters"
+  master_password     = "mustbeeightcharacters"
   skip_final_snapshot = true
 }
 
@@ -753,7 +753,7 @@ resource "aws_rds_cluster" "default" {
   availability_zones  = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
   database_name       = "mydb"
   master_username     = "foo"
-  master_password     = "mustbeeightcharaters"
+  master_password     = "mustbeeightcharacters"
   skip_final_snapshot = true
 }
 
@@ -913,7 +913,7 @@ resource "aws_rds_cluster" "default" {
   availability_zones  = ["us-west-2a", "us-west-2b", "us-west-2c"]
   database_name       = "mydb"
   master_username     = "foo"
-  master_password     = "mustbeeightcharaters"
+  master_password     = "mustbeeightcharacters"
   storage_encrypted   = true
   kms_key_id          = "${aws_kms_key.foo.arn}"
   skip_final_snapshot = true
@@ -950,7 +950,7 @@ resource "aws_rds_cluster" "default" {
   availability_zones  = ["us-west-2a", "us-west-2b", "us-west-2c"]
   database_name       = "mydb"
   master_username     = "foo"
-  master_password     = "mustbeeightcharaters"
+  master_password     = "mustbeeightcharacters"
   skip_final_snapshot = true
 }
 
@@ -1048,7 +1048,7 @@ resource "aws_rds_cluster" "test" {
   cluster_identifier  = %[1]q
   database_name       = "mydb"
   engine              = "aurora"
-  master_password     = "mustbeeightcharaters"
+  master_password     = "mustbeeightcharacters"
   master_username     = "foo"
   skip_final_snapshot = true
 }
@@ -1070,7 +1070,7 @@ resource "aws_rds_cluster" "test" {
   database_name       = "mydb"
   engine              = "aurora-mysql"
   engine_version      = "5.7.mysql_aurora.2.04.2"
-  master_password     = "mustbeeightcharaters"
+  master_password     = "mustbeeightcharacters"
   master_username     = "foo"
   skip_final_snapshot = true
 }
@@ -1092,7 +1092,7 @@ resource "aws_rds_cluster" "test" {
   cluster_identifier  = %[1]q
   database_name       = "mydb"
   engine              = "aurora-postgresql"
-  master_password     = "mustbeeightcharaters"
+  master_password     = "mustbeeightcharacters"
   master_username     = "foo"
   skip_final_snapshot = true
 }
@@ -1117,7 +1117,7 @@ resource "aws_rds_cluster" "test" {
   cluster_identifier  = %[1]q
   database_name       = "mydb"
   engine              = "aurora"
-  master_password     = "mustbeeightcharaters"
+  master_password     = "mustbeeightcharacters"
   master_username     = "foo"
   skip_final_snapshot = true
 }
@@ -1144,7 +1144,7 @@ resource "aws_rds_cluster" "test" {
   database_name       = "mydb"
   engine              = "aurora-mysql"
   engine_version      = "5.7.mysql_aurora.2.04.2"
-  master_password     = "mustbeeightcharaters"
+  master_password     = "mustbeeightcharacters"
   master_username     = "foo"
   skip_final_snapshot = true
 }
@@ -1171,7 +1171,7 @@ resource "aws_rds_cluster" "test" {
   cluster_identifier  = %[1]q
   database_name       = "mydb"
   engine              = "aurora-postgresql"
-  master_password     = "mustbeeightcharaters"
+  master_password     = "mustbeeightcharacters"
   master_username     = "foo"
   skip_final_snapshot = true
 }
@@ -1192,7 +1192,7 @@ func testAccAWSRDSClusterInstanceConfig_PubliclyAccessible(rName string, publicl
 resource "aws_rds_cluster" "test" {
   cluster_identifier  = %q
   master_username     = "foo"
-  master_password     = "mustbeeightcharaters"
+  master_password     = "mustbeeightcharacters"
   skip_final_snapshot = true
 }
 
@@ -1213,7 +1213,7 @@ resource "aws_rds_cluster" "default" {
   availability_zones  = ["us-west-2a", "us-west-2b", "us-west-2c"]
   database_name       = "mydb"
   master_username     = "foo"
-  master_password     = "mustbeeightcharaters"
+  master_password     = "mustbeeightcharacters"
   skip_final_snapshot = true
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #3015

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

This update ensures the correct RDS API error is shown when attempting to modify the Performance Insights KMS Key ID (we use `ExpectError` in the testing so this passes):

```
--- FAIL: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_DefaultKeyToCustomKey (691.76s)
    testing.go:568: Step 2 error: errors during apply:

        Error: Error modifying DB Instance tf-acc-test-2133090011528324987: InvalidParameterCombination: You cannot change your Performance Insights KMS key
```

Previously before code update:

```
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraMysql2 (587.54s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraMysql1 (594.85s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_CustomKey (660.70s)
--- FAIL: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_DefaultKeyToCustomKey (667.49s)
    testing.go:568: Step 2 error: errors during apply:

        Error: Error modifying DB Instance tf-acc-test-4757962708939555369: InvalidParameterCombination: Can not set PerformanceInsightsKMSKeyId without EnablePerformanceInsights
        	status code: 400, request id: c64b9f56-1b56-420c-9575-c5cfed87270b

          on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test833219777/main.tf line 15:
          (source code not available)

--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraPostgresql (699.46s)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql2_DefaultKeyToCustomKey (630.56s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraMysql1 (649.52s)
--- PASS: TestAccAWSRDSClusterInstance_generatedName (651.77s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql1_DefaultKeyToCustomKey (652.94s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraPostgresql (670.18s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_CustomKey (671.61s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraPostgresql_DefaultKeyToCustomKey (672.19s)
--- PASS: TestAccAWSRDSClusterInstance_PubliclyAccessible (683.28s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraMysql2 (690.78s)
--- PASS: TestAccAWSRDSClusterInstance_disappears (730.05s)
--- PASS: TestAccAWSRDSClusterInstance_CopyTagsToSnapshot (732.08s)
--- PASS: TestAccAWSRDSClusterInstance_az (747.28s)
--- PASS: TestAccAWSRDSClusterInstance_namePrefix (764.03s)
--- PASS: TestAccAWSRDSClusterInstance_kmsKey (792.98s)
--- PASS: TestAccAWSRDSClusterInstance_withInstanceEnhancedMonitor (822.65s)
--- PASS: TestAccAWSRDSClusterInstance_basic (1516.75s)
```
