### PR TITLE
Final retries for gamelift resources

### DIFF
--- a/aws/resource_aws_gamelift_build.go
+++ b/aws/resource_aws_gamelift_build.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 	"time"
 
@@ -93,8 +94,11 @@ func resourceAwsGameliftBuildCreate(d *schema.ResourceData, meta interface{}) er
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		out, err = conn.CreateBuild(&input)
+	}
 	if err != nil {
-		return err
+		return fmt.Errorf("Error creating Gamelift build client: %s", err)
 	}
 
 	d.SetId(*out.Build.BuildId)

--- a/aws/resource_aws_gamelift_fleet.go
+++ b/aws/resource_aws_gamelift_fleet.go
@@ -346,10 +346,11 @@ func resourceAwsGameliftFleetDelete(d *schema.ResourceData, meta interface{}) er
 	log.Printf("[INFO] Deleting Gamelift Fleet: %s", d.Id())
 	// It can take ~ 1 hr as Gamelift will keep retrying on errors like
 	// invalid launch path and remain in state when it can't be deleted :/
+	input := &gamelift.DeleteFleetInput{
+		FleetId: aws.String(d.Id()),
+	}
 	err := resource.Retry(60*time.Minute, func() *resource.RetryError {
-		_, err := conn.DeleteFleet(&gamelift.DeleteFleetInput{
-			FleetId: aws.String(d.Id()),
-		})
+		_, err := conn.DeleteFleet(input)
 		if err != nil {
 			msg := fmt.Sprintf("Cannot delete fleet %s that is in status of ", d.Id())
 			if isAWSErr(err, gamelift.ErrCodeInvalidRequestException, msg) {
@@ -359,8 +360,11 @@ func resourceAwsGameliftFleetDelete(d *schema.ResourceData, meta interface{}) er
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.DeleteFleet(input)
+	}
 	if err != nil {
-		return err
+		return fmt.Errorf("Error deleting Gamelift fleet: %s", err)
 	}
 
 	return waitForGameliftFleetToBeDeleted(conn, d.Id(), d.Timeout(schema.TimeoutDelete))


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_gamelift_build: Final retry after timeout creating gamelift build
* resource/aws_gamelift fleet: Final retry after timeout deleting gamelift fleet

```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSGameliftFleet"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSGameliftFleet -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSGameliftFleet_basic
=== PAUSE TestAccAWSGameliftFleet_basic
=== RUN   TestAccAWSGameliftFleet_allFields
=== PAUSE TestAccAWSGameliftFleet_allFields
=== CONT  TestAccAWSGameliftFleet_basic
=== CONT  TestAccAWSGameliftFleet_allFields
--- PASS: TestAccAWSGameliftFleet_basic (1366.75s)
--- PASS: TestAccAWSGameliftFleet_allFields (1393.92s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       1395.181s

 make testacc TESTARGS="-run=TestAccAWSGameliftBuild"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSGameliftBuild -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSGameliftBuild_basic
=== PAUSE TestAccAWSGameliftBuild_basic
=== CONT  TestAccAWSGameliftBuild_basic
--- PASS: TestAccAWSGameliftBuild_basic (42.45s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       43.626s
```