### PR TITLE
resource/aws_cognito_user_pool: Fix perpetual diffs on sms_verification_message

### DIFF
--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -410,6 +410,7 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 			"sms_verification_message": {
 				Type:          schema.TypeString,
 				Optional:      true,
+				Computed:      true,
 				ValidateFunc:  validateCognitoUserPoolSmsVerificationMessage,
 				ConflictsWith: []string{"verification_message_template.0.sms_message"},
 			},

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -1200,7 +1200,6 @@ resource "aws_cognito_user_pool" "pool" {
 
   email_verification_message = "Foo {####} Bar"
   email_verification_subject = "FooBar {####}"
-  sms_verification_message   = "{####} Baz"
 
   # Setting Verification template attributes like EmailMessage, EmailSubject or SmsMessage
   # will implicitly set EmailVerificationMessage, EmailVerificationSubject and SmsVerificationMessage
@@ -1209,6 +1208,7 @@ resource "aws_cognito_user_pool" "pool" {
     default_email_option  = "CONFIRM_WITH_LINK"
     email_message_by_link = "{##foobar##}"
     email_subject_by_link = "foobar"
+    sms_message           = "{####} Baz"
   }
 }
 `, name)

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -577,17 +577,34 @@ func TestAccAWSCognitoUserPool_withVerificationMessageTemplate(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolExists("aws_cognito_user_pool.pool"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "verification_message_template.0.default_email_option", "CONFIRM_WITH_LINK"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "verification_message_template.0.email_message", "Foo {####} Bar"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "verification_message_template.0.email_message", "foo {####} bar"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "verification_message_template.0.email_message_by_link", "{##foobar##}"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "verification_message_template.0.email_subject", "FooBar {####}"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "verification_message_template.0.email_subject", "foobar {####}"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "verification_message_template.0.email_subject_by_link", "foobar"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "verification_message_template.0.sms_message", "{####} Baz"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "verification_message_template.0.sms_message", "{####} baz"),
+
+					/* Setting Verification template attributes like EmailMessage, EmailSubject or SmsMessage
+					will implicitly set EmailVerificationMessage, EmailVerificationSubject and SmsVerificationMessage attributes.
+					*/
+					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_verification_message", "foo {####} bar"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_verification_subject", "foobar {####}"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "sms_verification_message", "{####} baz"),
 				),
 			},
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withVerificationMessageTemplateUpdated(name),
+				Config: testAccAWSCognitoUserPoolConfig_withVerificationMessageTemplate_DefaultEmailOption(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "verification_message_template.0.default_email_option", "CONFIRM_WITH_CODE"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_verification_message", "{####} Baz"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_verification_subject", "BazBaz {####}"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "sms_verification_message", "{####} BazBazBar?"),
+
+					/* Setting EmailVerificationMessage, EmailVerificationSubject and SmsVerificationMessage attributes
+					will implicitly set verification template attributes like EmailMessage, EmailSubject or SmsMessage.
+					*/
+					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "verification_message_template.0.email_message", "{####} Baz"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "verification_message_template.0.email_subject", "BazBaz {####}"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "verification_message_template.0.sms_message", "{####} BazBazBar?"),
 				),
 			},
 		},
@@ -1198,30 +1215,29 @@ func testAccAWSCognitoUserPoolConfig_withVerificationMessageTemplate(name string
 resource "aws_cognito_user_pool" "pool" {
   name = "terraform-test-pool-%s"
 
-  email_verification_message = "Foo {####} Bar"
-  email_verification_subject = "FooBar {####}"
-
   # Setting Verification template attributes like EmailMessage, EmailSubject or SmsMessage
   # will implicitly set EmailVerificationMessage, EmailVerificationSubject and SmsVerificationMessage
   # attributes.
   verification_message_template {
     default_email_option  = "CONFIRM_WITH_LINK"
+    email_message = "foo {####} bar"
     email_message_by_link = "{##foobar##}"
+    email_subject = "foobar {####}"
     email_subject_by_link = "foobar"
-    sms_message           = "{####} Baz"
+    sms_message           = "{####} baz"
   }
 }
 `, name)
 }
 
-func testAccAWSCognitoUserPoolConfig_withVerificationMessageTemplateUpdated(name string) string {
+func testAccAWSCognitoUserPoolConfig_withVerificationMessageTemplate_DefaultEmailOption(name string) string {
 	return fmt.Sprintf(`
 resource "aws_cognito_user_pool" "pool" {
   name = "terraform-test-pool-%s"
 
-  email_verification_message = "Foo {####} Bar"
-  email_verification_subject = "FooBar {####}"
-  sms_verification_message   = "{####} Baz"
+  email_verification_message = "{####} Baz"
+  email_verification_subject = "BazBaz {####}"
+  sms_verification_message   = "{####} BazBazBar?"
 
   verification_message_template {
     default_email_option = "CONFIRM_WITH_CODE"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates ---> 
No specific issues found that pertaining to this bug. 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_cognito_user_pool: Fix perpetual diffs on sms_verification_message

```

When using `verification_message_template.sms_message` for setting the sms message verification template the resource upon subsequent applys will trigger an update because of a diff in the conflicting `sms_verification_message` argument. This changes adds the computed property onto `sms_message_verification` to ensure it get's updated with the contents being set by `verification_message_template.sms_message`

Acceptance test before change
```
--- FAIL: TestAccAWSCognitoUserPool_withVerificationMessageTemplate (10.90s)                                                                                                                                                         [274/322]
    testing.go:568: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        UPDATE: aws_cognito_user_pool.pool
          sms_verification_message:                                "{####} Baz" => ""

```

Acceptance test after change
```
--- PASS: TestAccAWSCognitoUserPool_withVerificationMessageTemplate (27.79s)                                                                                         
```