### PR TITLE
Correct document about how to import lambda_layer_version

### DIFF
--- a/website/docs/r/lambda_layer_version.html.markdown
+++ b/website/docs/r/lambda_layer_version.html.markdown
@@ -61,8 +61,10 @@ large files efficiently.
 
 ## Import
 
-Lambda Layers can be imported using `layer_name` and `version` together.
+Lambda Layers can be imported using `arn`.
 
 ```
-$ terraform import aws_lambda_layer_version.test_layer layer-name:1
+$ terraform import \
+    aws_lambda_layer_version.test_layer \
+    arn:aws:lambda:_REGION_:_ACCOUNT_ID_:layer:_LAYER_NAME_:_LAYER_VERSION_
 ```


### PR DESCRIPTION
This PR is to fix the document about how to import `lambda_layer_version`. In [the current document](https://www.terraform.io/docs/providers/aws/r/lambda_layer_version.html#import) it says to run `$ terraform import aws_lambda_layer_version.test_layer layer-name:1` but as I did, I got:

```
Error: Error parsing lambda layer ID: arn: invalid prefix
```

And the correct syntax seems to be `$ terraform import aws_lambda_layer_version.test_layer arn`.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
N/A
```