### PR TITLE
Final retries for ELB resources

### DIFF
--- a/aws/resource_aws_elb.go
+++ b/aws/resource_aws_elb.go
@@ -311,9 +311,11 @@ func resourceAwsElbCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 		return nil
 	})
-
+	if isResourceTimeoutError(err) {
+		_, err = elbconn.CreateLoadBalancer(elbOpts)
+	}
 	if err != nil {
-		return err
+		return fmt.Errorf("Error creating ELB: %s", err)
 	}
 
 	// Assign the elb's unique identifier for use later
@@ -511,16 +513,15 @@ func resourceAwsElbUpdate(d *schema.ResourceData, meta interface{}) error {
 			// other listeners on the ELB. Retry here to eliminate that.
 			err := resource.Retry(5*time.Minute, func() *resource.RetryError {
 				log.Printf("[DEBUG] ELB Create Listeners opts: %s", createListenersOpts)
-				if _, err := elbconn.CreateLoadBalancerListeners(createListenersOpts); err != nil {
-					if awsErr, ok := err.(awserr.Error); ok {
-						if awsErr.Code() == "DuplicateListener" {
-							log.Printf("[DEBUG] Duplicate listener found for ELB (%s), retrying", d.Id())
-							return resource.RetryableError(awsErr)
-						}
-						if awsErr.Code() == "CertificateNotFound" && strings.Contains(awsErr.Message(), "Server Certificate not found for the key: arn") {
-							log.Printf("[DEBUG] SSL Cert not found for given ARN, retrying")
-							return resource.RetryableError(awsErr)
-						}
+				_, err := elbconn.CreateLoadBalancerListeners(createListenersOpts)
+				if err != nil {
+					if isAWSErr(err, "DuplicateListener", "") {
+						log.Printf("[DEBUG] Duplicate listener found for ELB (%s), retrying", d.Id())
+						return resource.RetryableError(err)
+					}
+					if isAWSErr(err, "CertificateNotFound", "Server Certificate not found for the key: arn") {
+						log.Printf("[DEBUG] SSL Cert not found for given ARN, retrying")
+						return resource.RetryableError(err)
 					}
 
 					// Didn't recognize the error, so shouldn't retry.
@@ -529,6 +530,9 @@ func resourceAwsElbUpdate(d *schema.ResourceData, meta interface{}) error {
 				// Successful creation
 				return nil
 			})
+			if isResourceTimeoutError(err) {
+				_, err = elbconn.CreateLoadBalancerListeners(createListenersOpts)
+			}
 			if err != nil {
 				return fmt.Errorf("Failure adding new or updated ELB listeners: %s", err)
 			}
@@ -765,18 +769,19 @@ func resourceAwsElbUpdate(d *schema.ResourceData, meta interface{}) error {
 			err := resource.Retry(5*time.Minute, func() *resource.RetryError {
 				_, err := elbconn.AttachLoadBalancerToSubnets(attachOpts)
 				if err != nil {
-					if awsErr, ok := err.(awserr.Error); ok {
+					if isAWSErr(err, "InvalidConfigurationRequest", "cannot be attached to multiple subnets in the same AZ") {
 						// eventually consistent issue with removing a subnet in AZ1 and
 						// immediately adding a new one in the same AZ
-						if awsErr.Code() == "InvalidConfigurationRequest" && strings.Contains(awsErr.Message(), "cannot be attached to multiple subnets in the same AZ") {
-							log.Printf("[DEBUG] retrying az association")
-							return resource.RetryableError(awsErr)
-						}
+						log.Printf("[DEBUG] retrying az association")
+						return resource.RetryableError(err)
 					}
 					return resource.NonRetryableError(err)
 				}
 				return nil
 			})
+			if isResourceTimeoutError(err) {
+				_, err = elbconn.AttachLoadBalancerToSubnets(attachOpts)
+			}
 			if err != nil {
 				return fmt.Errorf("Failure adding ELB subnets: %s", err)
 			}

--- a/aws/resource_aws_elb_attachment.go
+++ b/aws/resource_aws_elb_attachment.go
@@ -59,7 +59,9 @@ func resourceAwsElbAttachmentCreate(d *schema.ResourceData, meta interface{}) er
 
 		return nil
 	})
-
+	if isResourceTimeoutError(err) {
+		_, err = elbconn.RegisterInstancesWithLoadBalancer(&registerInstancesOpts)
+	}
 	if err != nil {
 		return fmt.Errorf("Failure registering instances with ELB: %s", err)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES
* resource/aws_elb: Final retries after timeouts creating and updating ELBs
* resource/aws_elb_attachment: Final retry after timout creating ELB attachment

```

Output from acceptance testing:

```
NOTE test failure is not new

$ make testacc TESTARGS="-run=TestAccAWSELB"                         
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSELB -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSELBAttachment_basic
=== PAUSE TestAccAWSELBAttachment_basic
=== RUN   TestAccAWSELBAttachment_drift
=== PAUSE TestAccAWSELBAttachment_drift
=== RUN   TestAccAWSELB_importBasic
=== PAUSE TestAccAWSELB_importBasic
=== RUN   TestAccAWSELB_basic
=== PAUSE TestAccAWSELB_basic
=== RUN   TestAccAWSELB_disappears
=== PAUSE TestAccAWSELB_disappears
=== RUN   TestAccAWSELB_fullCharacterRange
=== PAUSE TestAccAWSELB_fullCharacterRange
=== RUN   TestAccAWSELB_AccessLogs_enabled
=== PAUSE TestAccAWSELB_AccessLogs_enabled
=== RUN   TestAccAWSELB_AccessLogs_disabled
=== PAUSE TestAccAWSELB_AccessLogs_disabled
=== RUN   TestAccAWSELB_namePrefix
=== PAUSE TestAccAWSELB_namePrefix
=== RUN   TestAccAWSELB_generatedName
=== PAUSE TestAccAWSELB_generatedName
=== RUN   TestAccAWSELB_generatesNameForZeroValue
=== PAUSE TestAccAWSELB_generatesNameForZeroValue
=== RUN   TestAccAWSELB_availabilityZones
=== PAUSE TestAccAWSELB_availabilityZones
=== RUN   TestAccAWSELB_tags
=== PAUSE TestAccAWSELB_tags
=== RUN   TestAccAWSELB_Listener_SSLCertificateID_IAMServerCertificate
=== PAUSE TestAccAWSELB_Listener_SSLCertificateID_IAMServerCertificate
=== RUN   TestAccAWSELB_swap_subnets
=== PAUSE TestAccAWSELB_swap_subnets
=== RUN   TestAccAWSELB_InstanceAttaching
=== PAUSE TestAccAWSELB_InstanceAttaching
=== RUN   TestAccAWSELB_listener
=== PAUSE TestAccAWSELB_listener
=== RUN   TestAccAWSELB_HealthCheck
=== PAUSE TestAccAWSELB_HealthCheck
=== RUN   TestAccAWSELBUpdate_HealthCheck
=== PAUSE TestAccAWSELBUpdate_HealthCheck
=== RUN   TestAccAWSELB_Timeout
=== PAUSE TestAccAWSELB_Timeout
=== RUN   TestAccAWSELBUpdate_Timeout
=== PAUSE TestAccAWSELBUpdate_Timeout
=== RUN   TestAccAWSELB_ConnectionDraining
=== PAUSE TestAccAWSELB_ConnectionDraining
=== RUN   TestAccAWSELBUpdate_ConnectionDraining
=== PAUSE TestAccAWSELBUpdate_ConnectionDraining
=== RUN   TestAccAWSELB_SecurityGroups
=== PAUSE TestAccAWSELB_SecurityGroups
=== CONT  TestAccAWSELBAttachment_basic
=== CONT  TestAccAWSELB_SecurityGroups
=== CONT  TestAccAWSELB_importBasic
=== CONT  TestAccAWSELBUpdate_Timeout
=== CONT  TestAccAWSELB_generatesNameForZeroValue
=== CONT  TestAccAWSELB_namePrefix
=== CONT  TestAccAWSELB_Timeout
=== CONT  TestAccAWSELBUpdate_HealthCheck
=== CONT  TestAccAWSELB_HealthCheck
=== CONT  TestAccAWSELB_listener
=== CONT  TestAccAWSELB_InstanceAttaching
=== CONT  TestAccAWSELB_swap_subnets
=== CONT  TestAccAWSELB_Listener_SSLCertificateID_IAMServerCertificate
=== CONT  TestAccAWSELB_tags
=== CONT  TestAccAWSELB_AccessLogs_disabled
=== CONT  TestAccAWSELB_basic
=== CONT  TestAccAWSELB_disappears
=== CONT  TestAccAWSELBUpdate_ConnectionDraining
=== CONT  TestAccAWSELB_availabilityZones
=== CONT  TestAccAWSELB_generatedName
--- PASS: TestAccAWSELB_generatesNameForZeroValue (78.70s)
=== CONT  TestAccAWSELB_AccessLogs_enabled
--- PASS: TestAccAWSELB_disappears (99.32s)
=== CONT  TestAccAWSELB_fullCharacterRange
--- PASS: TestAccAWSELB_availabilityZones (106.87s)
=== CONT  TestAccAWSELB_ConnectionDraining
--- PASS: TestAccAWSELB_SecurityGroups (127.35s)
=== CONT  TestAccAWSELBAttachment_drift
--- PASS: TestAccAWSELB_importBasic (141.14s)
--- PASS: TestAccAWSELB_ConnectionDraining (46.77s)
--- PASS: TestAccAWSELB_AccessLogs_disabled (179.85s)
--- PASS: TestAccAWSELB_Listener_SSLCertificateID_IAMServerCertificate (183.13s)
--- PASS: TestAccAWSELBUpdate_ConnectionDraining (188.44s)
--- PASS: TestAccAWSELB_InstanceAttaching (190.42s)
--- PASS: TestAccAWSELB_fullCharacterRange (94.47s)
--- PASS: TestAccAWSELB_AccessLogs_enabled (125.78s)
--- PASS: TestAccAWSELB_HealthCheck (214.15s)
--- PASS: TestAccAWSELB_basic (230.86s)
--- PASS: TestAccAWSELBAttachment_drift (125.03s)
--- PASS: TestAccAWSELB_Timeout (253.26s)
--- PASS: TestAccAWSELB_namePrefix (275.97s)
--- PASS: TestAccAWSELB_generatedName (280.78s)
--- PASS: TestAccAWSELBUpdate_HealthCheck (289.43s)
--- PASS: TestAccAWSELB_tags (292.36s)
--- PASS: TestAccAWSELBUpdate_Timeout (297.26s)
--- FAIL: TestAccAWSELB_listener (357.93s)
    testing.go:568: Step 4 error: errors during plan:
        
        Error: insufficient items for attribute "listener"; must have at least 1
        
        
    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: errors during refresh: insufficient items for attribute "listener"; must have at least 1
        
        State: <nil>
--- PASS: TestAccAWSELBAttachment_basic (394.43s)
--- PASS: TestAccAWSELB_swap_subnets (398.89s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-aws/aws       401.028s
make: *** [testacc] Error 1

 make testacc TESTARGS="-run=TestAccAWSELBAttachment_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSELBAttachment_basic -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSELBAttachment_basic
=== PAUSE TestAccAWSELBAttachment_basic
=== CONT  TestAccAWSELBAttachment_basic
--- PASS: TestAccAWSELBAttachment_basic (206.90s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       208.275s
```