### PR TITLE
Final retries for IAM resources

### DIFF
--- a/aws/resource_aws_iam_instance_profile.go
+++ b/aws/resource_aws_iam_instance_profile.go
@@ -174,6 +174,9 @@ func instanceProfileAddRole(iamconn *iam.IAM, profileName, roleName string) erro
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		_, err = iamconn.AddRoleToInstanceProfile(request)
+	}
 	if err != nil {
 		return fmt.Errorf("Error adding IAM Role %s to Instance Profile %s: %s", roleName, profileName, err)
 	}

--- a/aws/resource_aws_iam_policy.go
+++ b/aws/resource_aws_iam_policy.go
@@ -141,7 +141,9 @@ func resourceAwsIamPolicyRead(d *schema.ResourceData, meta interface{}) error {
 
 		return nil
 	})
-
+	if isResourceTimeoutError(err) {
+		getPolicyResponse, err = iamconn.GetPolicy(getPolicyRequest)
+	}
 	if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
 		log.Printf("[WARN] IAM Policy (%s) not found, removing from state", d.Id())
 		d.SetId("")
@@ -187,7 +189,9 @@ func resourceAwsIamPolicyRead(d *schema.ResourceData, meta interface{}) error {
 
 		return nil
 	})
-
+	if isResourceTimeoutError(err) {
+		getPolicyVersionResponse, err = iamconn.GetPolicyVersion(getPolicyVersionRequest)
+	}
 	if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
 		log.Printf("[WARN] IAM Policy (%s) not found, removing from state", d.Id())
 		d.SetId("")

--- a/aws/resource_aws_iam_policy_attachment.go
+++ b/aws/resource_aws_iam_policy_attachment.go
@@ -4,12 +4,10 @@ import (
 	"fmt"
 	"log"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 )
@@ -217,37 +215,28 @@ func attachPolicyToRoles(conn *iam.IAM, roles []*string, arn string) error {
 			return err
 		}
 
-		var attachmentErr = resource.Retry(2*time.Minute, func() *resource.RetryError {
-
-			input := iam.ListRolePoliciesInput{
-				RoleName: r,
-			}
-
-			attachedPolicies, err := conn.ListRolePolicies(&input)
-			if err != nil {
-				return resource.NonRetryableError(err)
-			}
-
-			if len(attachedPolicies.PolicyNames) > 0 {
-				var foundPolicy bool
-				for _, policyName := range attachedPolicies.PolicyNames {
-					if strings.HasSuffix(arn, *policyName) {
-						foundPolicy = true
-						break
-					}
-				}
-
-				if !foundPolicy {
-					return resource.NonRetryableError(err)
-				}
-			}
-
-			return nil
-		})
-
-		if attachmentErr != nil {
-			return attachmentErr
+		input := iam.ListRolePoliciesInput{
+			RoleName: r,
 		}
+		attachedPolicies, err := conn.ListRolePolicies(&input)
+		if err != nil {
+			return fmt.Errorf("Error listing role policies: %s", err)
+		}
+
+		if len(attachedPolicies.PolicyNames) > 0 {
+			var foundPolicy bool
+			for _, policyName := range attachedPolicies.PolicyNames {
+				if strings.HasSuffix(arn, *policyName) {
+					foundPolicy = true
+					break
+				}
+			}
+
+			if !foundPolicy {
+				return fmt.Errorf("Error: Attached policy not found")
+			}
+		}
+
 	}
 	return nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_iam_instance_profile: Final retry after timeout adding role to profile
* resource/aws_iam_policy: Final retry after timeout reading policy
* resource/aws_iam_role: Final retries after timeouts creating and deleting IAM roles
* resource/aws_iam_user: Final retry after timeout deleting user login profile
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSIAMInstanceProfile"            
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSIAMInstanceProfile -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSIAMInstanceProfile_importBasic
=== PAUSE TestAccAWSIAMInstanceProfile_importBasic
=== RUN   TestAccAWSIAMInstanceProfile_basic
=== PAUSE TestAccAWSIAMInstanceProfile_basic
=== RUN   TestAccAWSIAMInstanceProfile_withRoleNotRoles
=== PAUSE TestAccAWSIAMInstanceProfile_withRoleNotRoles
=== RUN   TestAccAWSIAMInstanceProfile_missingRoleThrowsError
=== PAUSE TestAccAWSIAMInstanceProfile_missingRoleThrowsError
=== RUN   TestAccAWSIAMInstanceProfile_namePrefix
=== PAUSE TestAccAWSIAMInstanceProfile_namePrefix
=== CONT  TestAccAWSIAMInstanceProfile_importBasic
=== CONT  TestAccAWSIAMInstanceProfile_missingRoleThrowsError
=== CONT  TestAccAWSIAMInstanceProfile_withRoleNotRoles
=== CONT  TestAccAWSIAMInstanceProfile_basic
=== CONT  TestAccAWSIAMInstanceProfile_namePrefix
--- PASS: TestAccAWSIAMInstanceProfile_missingRoleThrowsError (9.80s)
--- PASS: TestAccAWSIAMInstanceProfile_namePrefix (26.61s)
--- PASS: TestAccAWSIAMInstanceProfile_withRoleNotRoles (26.72s)
--- PASS: TestAccAWSIAMInstanceProfile_basic (26.74s)
--- PASS: TestAccAWSIAMInstanceProfile_importBasic (28.81s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       29.965s

make testacc TESTARGS="-run=TestAccAWSIAMPolicy"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSIAMPolicy -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSIAMPolicyAttachment_basic
=== PAUSE TestAccAWSIAMPolicyAttachment_basic
=== RUN   TestAccAWSIAMPolicyAttachment_paginatedEntities
=== PAUSE TestAccAWSIAMPolicyAttachment_paginatedEntities
=== RUN   TestAccAWSIAMPolicyAttachment_Groups_RenamedGroup
=== PAUSE TestAccAWSIAMPolicyAttachment_Groups_RenamedGroup
=== RUN   TestAccAWSIAMPolicyAttachment_Roles_RenamedRole
=== PAUSE TestAccAWSIAMPolicyAttachment_Roles_RenamedRole
=== RUN   TestAccAWSIAMPolicyAttachment_Users_RenamedUser
=== PAUSE TestAccAWSIAMPolicyAttachment_Users_RenamedUser
=== RUN   TestAccAWSIAMPolicy_basic
=== PAUSE TestAccAWSIAMPolicy_basic
=== RUN   TestAccAWSIAMPolicy_description
=== PAUSE TestAccAWSIAMPolicy_description
=== RUN   TestAccAWSIAMPolicy_disappears
=== PAUSE TestAccAWSIAMPolicy_disappears
=== RUN   TestAccAWSIAMPolicy_namePrefix
=== PAUSE TestAccAWSIAMPolicy_namePrefix
=== RUN   TestAccAWSIAMPolicy_path
=== PAUSE TestAccAWSIAMPolicy_path
=== RUN   TestAccAWSIAMPolicy_policy
=== PAUSE TestAccAWSIAMPolicy_policy
=== CONT  TestAccAWSIAMPolicyAttachment_basic
=== CONT  TestAccAWSIAMPolicy_description
=== CONT  TestAccAWSIAMPolicy_basic
=== CONT  TestAccAWSIAMPolicyAttachment_Users_RenamedUser
=== CONT  TestAccAWSIAMPolicyAttachment_paginatedEntities
=== CONT  TestAccAWSIAMPolicy_namePrefix
=== CONT  TestAccAWSIAMPolicy_path
=== CONT  TestAccAWSIAMPolicy_policy
=== CONT  TestAccAWSIAMPolicyAttachment_Roles_RenamedRole
=== CONT  TestAccAWSIAMPolicyAttachment_Groups_RenamedGroup
=== CONT  TestAccAWSIAMPolicy_disappears
--- PASS: TestAccAWSIAMPolicy_disappears (18.38s)
--- PASS: TestAccAWSIAMPolicy_description (26.72s)
--- PASS: TestAccAWSIAMPolicy_namePrefix (26.81s)
--- PASS: TestAccAWSIAMPolicy_basic (26.97s)
--- PASS: TestAccAWSIAMPolicy_path (27.00s)
--- PASS: TestAccAWSIAMPolicy_policy (44.16s)
--- PASS: TestAccAWSIAMPolicyAttachment_Groups_RenamedGroup (48.12s)
--- PASS: TestAccAWSIAMPolicyAttachment_Users_RenamedUser (50.05s)
--- PASS: TestAccAWSIAMPolicyAttachment_Roles_RenamedRole (52.43s)
--- PASS: TestAccAWSIAMPolicyAttachment_basic (59.02s)
--- PASS: TestAccAWSIAMPolicyAttachment_paginatedEntities (294.94s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       296.548s

make testacc TESTARGS="-run=TestAccAWSIAMPolicyAttachment"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSIAMPolicyAttachment -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSIAMPolicyAttachment_basic
=== PAUSE TestAccAWSIAMPolicyAttachment_basic
=== RUN   TestAccAWSIAMPolicyAttachment_paginatedEntities
=== PAUSE TestAccAWSIAMPolicyAttachment_paginatedEntities
=== RUN   TestAccAWSIAMPolicyAttachment_Groups_RenamedGroup
=== PAUSE TestAccAWSIAMPolicyAttachment_Groups_RenamedGroup
=== RUN   TestAccAWSIAMPolicyAttachment_Roles_RenamedRole
=== PAUSE TestAccAWSIAMPolicyAttachment_Roles_RenamedRole
=== RUN   TestAccAWSIAMPolicyAttachment_Users_RenamedUser
=== PAUSE TestAccAWSIAMPolicyAttachment_Users_RenamedUser
=== CONT  TestAccAWSIAMPolicyAttachment_basic
=== CONT  TestAccAWSIAMPolicyAttachment_Roles_RenamedRole
=== CONT  TestAccAWSIAMPolicyAttachment_Groups_RenamedGroup
=== CONT  TestAccAWSIAMPolicyAttachment_Users_RenamedUser
=== CONT  TestAccAWSIAMPolicyAttachment_paginatedEntities
--- PASS: TestAccAWSIAMPolicyAttachment_Groups_RenamedGroup (50.19s)
--- PASS: TestAccAWSIAMPolicyAttachment_Users_RenamedUser (53.01s)
--- PASS: TestAccAWSIAMPolicyAttachment_Roles_RenamedRole (56.31s)
--- PASS: TestAccAWSIAMPolicyAttachment_basic (143.83s)
--- PASS: TestAccAWSIAMPolicyAttachment_paginatedEntities (341.18s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       343.537s

make testacc TESTARGS="-run=TestAccAWSIAMRole"            
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSIAMRole -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSIAMRolePolicy_importBasic
=== PAUSE TestAccAWSIAMRolePolicy_importBasic
=== RUN   TestAccAWSIAMRolePolicy_basic
=== PAUSE TestAccAWSIAMRolePolicy_basic
=== RUN   TestAccAWSIAMRolePolicy_disappears
=== PAUSE TestAccAWSIAMRolePolicy_disappears
=== RUN   TestAccAWSIAMRolePolicy_namePrefix
=== PAUSE TestAccAWSIAMRolePolicy_namePrefix
=== RUN   TestAccAWSIAMRolePolicy_generatedName
=== PAUSE TestAccAWSIAMRolePolicy_generatedName
=== RUN   TestAccAWSIAMRolePolicy_invalidJSON
=== PAUSE TestAccAWSIAMRolePolicy_invalidJSON
=== RUN   TestAccAWSIAMRole_importBasic
=== PAUSE TestAccAWSIAMRole_importBasic
=== RUN   TestAccAWSIAMRole_basic
=== PAUSE TestAccAWSIAMRole_basic
=== RUN   TestAccAWSIAMRole_basicWithDescription
=== PAUSE TestAccAWSIAMRole_basicWithDescription
=== RUN   TestAccAWSIAMRole_namePrefix
=== PAUSE TestAccAWSIAMRole_namePrefix
=== RUN   TestAccAWSIAMRole_testNameChange
=== PAUSE TestAccAWSIAMRole_testNameChange
=== RUN   TestAccAWSIAMRole_badJSON
=== PAUSE TestAccAWSIAMRole_badJSON
=== RUN   TestAccAWSIAMRole_disappears
=== PAUSE TestAccAWSIAMRole_disappears
=== RUN   TestAccAWSIAMRole_force_detach_policies
=== PAUSE TestAccAWSIAMRole_force_detach_policies
=== RUN   TestAccAWSIAMRole_MaxSessionDuration
=== PAUSE TestAccAWSIAMRole_MaxSessionDuration
=== RUN   TestAccAWSIAMRole_PermissionsBoundary
=== PAUSE TestAccAWSIAMRole_PermissionsBoundary
=== RUN   TestAccAWSIAMRole_tags
=== PAUSE TestAccAWSIAMRole_tags
=== CONT  TestAccAWSIAMRolePolicy_importBasic
=== CONT  TestAccAWSIAMRole_tags
=== CONT  TestAccAWSIAMRolePolicy_namePrefix
=== CONT  TestAccAWSIAMRolePolicy_basic
=== CONT  TestAccAWSIAMRolePolicy_disappears
=== CONT  TestAccAWSIAMRole_PermissionsBoundary
=== CONT  TestAccAWSIAMRole_MaxSessionDuration
=== CONT  TestAccAWSIAMRole_force_detach_policies
=== CONT  TestAccAWSIAMRole_disappears
=== CONT  TestAccAWSIAMRole_badJSON
=== CONT  TestAccAWSIAMRole_testNameChange
=== CONT  TestAccAWSIAMRolePolicy_generatedName
=== CONT  TestAccAWSIAMRole_namePrefix
=== CONT  TestAccAWSIAMRole_basic
=== CONT  TestAccAWSIAMRole_importBasic
=== CONT  TestAccAWSIAMRolePolicy_invalidJSON
=== CONT  TestAccAWSIAMRole_basicWithDescription
--- PASS: TestAccAWSIAMRolePolicy_invalidJSON (3.31s)
--- PASS: TestAccAWSIAMRole_badJSON (3.39s)
--- PASS: TestAccAWSIAMRole_disappears (18.92s)
--- PASS: TestAccAWSIAMRole_basic (22.58s)
--- PASS: TestAccAWSIAMRole_namePrefix (22.70s)
--- PASS: TestAccAWSIAMRolePolicy_disappears (24.10s)
--- PASS: TestAccAWSIAMRole_importBasic (25.01s)
--- PASS: TestAccAWSIAMRolePolicy_importBasic (27.28s)
--- PASS: TestAccAWSIAMRole_force_detach_policies (29.78s)
--- PASS: TestAccAWSIAMRole_tags (38.50s)
--- PASS: TestAccAWSIAMRole_MaxSessionDuration (41.30s)
--- PASS: TestAccAWSIAMRolePolicy_basic (42.24s)
--- PASS: TestAccAWSIAMRolePolicy_generatedName (42.73s)
--- PASS: TestAccAWSIAMRolePolicy_namePrefix (43.02s)
--- PASS: TestAccAWSIAMRole_testNameChange (50.44s)
--- PASS: TestAccAWSIAMRole_basicWithDescription (54.70s)
--- PASS: TestAccAWSIAMRole_PermissionsBoundary (87.78s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       89.423s

make testacc TESTARGS="-run=TestAccAWSUser"      
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSUser -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSUserGroupMembership_basic
=== PAUSE TestAccAWSUserGroupMembership_basic
=== RUN   TestAccAWSUserLoginProfile_basic
=== PAUSE TestAccAWSUserLoginProfile_basic
=== RUN   TestAccAWSUserLoginProfile_keybase
=== PAUSE TestAccAWSUserLoginProfile_keybase
=== RUN   TestAccAWSUserLoginProfile_keybaseDoesntExist
=== PAUSE TestAccAWSUserLoginProfile_keybaseDoesntExist
=== RUN   TestAccAWSUserLoginProfile_notAKey
=== PAUSE TestAccAWSUserLoginProfile_notAKey
=== RUN   TestAccAWSUserLoginProfile_PasswordLength
=== PAUSE TestAccAWSUserLoginProfile_PasswordLength
=== RUN   TestAccAWSUserPolicyAttachment_basic
=== PAUSE TestAccAWSUserPolicyAttachment_basic
=== RUN   TestAccAWSUserSSHKey_basic
=== PAUSE TestAccAWSUserSSHKey_basic
=== RUN   TestAccAWSUserSSHKey_pemEncoding
=== PAUSE TestAccAWSUserSSHKey_pemEncoding
=== RUN   TestAccAWSUser_importBasic
=== PAUSE TestAccAWSUser_importBasic
=== RUN   TestAccAWSUser_basic
=== PAUSE TestAccAWSUser_basic
=== RUN   TestAccAWSUser_disappears
=== PAUSE TestAccAWSUser_disappears
=== RUN   TestAccAWSUser_ForceDestroy_AccessKey
=== PAUSE TestAccAWSUser_ForceDestroy_AccessKey
=== RUN   TestAccAWSUser_ForceDestroy_LoginProfile
=== PAUSE TestAccAWSUser_ForceDestroy_LoginProfile
=== RUN   TestAccAWSUser_ForceDestroy_MFADevice
=== PAUSE TestAccAWSUser_ForceDestroy_MFADevice
=== RUN   TestAccAWSUser_ForceDestroy_SSHKey
=== PAUSE TestAccAWSUser_ForceDestroy_SSHKey
=== RUN   TestAccAWSUser_nameChange
=== PAUSE TestAccAWSUser_nameChange
=== RUN   TestAccAWSUser_pathChange
=== PAUSE TestAccAWSUser_pathChange
=== RUN   TestAccAWSUser_permissionsBoundary
=== PAUSE TestAccAWSUser_permissionsBoundary
=== RUN   TestAccAWSUser_tags
=== PAUSE TestAccAWSUser_tags
=== CONT  TestAccAWSUserGroupMembership_basic
=== CONT  TestAccAWSUser_disappears
=== CONT  TestAccAWSUserLoginProfile_basic
=== CONT  TestAccAWSUser_basic
=== CONT  TestAccAWSUser_importBasic
=== CONT  TestAccAWSUserSSHKey_pemEncoding
=== CONT  TestAccAWSUserSSHKey_basic
=== CONT  TestAccAWSUser_nameChange
=== CONT  TestAccAWSUser_tags
=== CONT  TestAccAWSUser_permissionsBoundary
=== CONT  TestAccAWSUserPolicyAttachment_basic
=== CONT  TestAccAWSUserLoginProfile_PasswordLength
=== CONT  TestAccAWSUserLoginProfile_notAKey
=== CONT  TestAccAWSUserLoginProfile_keybaseDoesntExist
=== CONT  TestAccAWSUserLoginProfile_keybase
=== CONT  TestAccAWSUser_ForceDestroy_LoginProfile
=== CONT  TestAccAWSUser_pathChange
=== CONT  TestAccAWSUser_ForceDestroy_AccessKey
=== CONT  TestAccAWSUser_ForceDestroy_SSHKey
=== CONT  TestAccAWSUser_ForceDestroy_MFADevice
--- PASS: TestAccAWSUser_disappears (20.27s)
--- PASS: TestAccAWSUser_importBasic (25.85s)
--- PASS: TestAccAWSUser_ForceDestroy_LoginProfile (26.36s)
--- PASS: TestAccAWSUser_ForceDestroy_AccessKey (26.96s)
--- PASS: TestAccAWSUser_ForceDestroy_SSHKey (27.25s)
--- PASS: TestAccAWSUser_ForceDestroy_MFADevice (27.32s)
--- PASS: TestAccAWSUserSSHKey_pemEncoding (29.55s)
--- PASS: TestAccAWSUserSSHKey_basic (29.91s)
--- PASS: TestAccAWSUserLoginProfile_keybaseDoesntExist (38.23s)
--- PASS: TestAccAWSUserLoginProfile_notAKey (38.79s)
--- PASS: TestAccAWSUser_nameChange (39.54s)
--- PASS: TestAccAWSUser_pathChange (39.57s)
--- PASS: TestAccAWSUser_basic (39.78s)
--- PASS: TestAccAWSUser_tags (40.68s)
--- PASS: TestAccAWSUserLoginProfile_PasswordLength (47.09s)
--- PASS: TestAccAWSUserLoginProfile_keybase (48.23s)
--- PASS: TestAccAWSUserPolicyAttachment_basic (51.90s)
--- PASS: TestAccAWSUserLoginProfile_basic (57.68s)
--- PASS: TestAccAWSUser_permissionsBoundary (90.60s)
--- PASS: TestAccAWSUserGroupMembership_basic (117.65s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       118.528s
```