### PR TITLE
provider: Remove Route 53 endpoint workaround in AWS GovCloud (US)

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -505,11 +505,6 @@ func (c *Config) Client() (interface{}, error) {
 		}
 		route53Config.Region = aws.String(endpoints.CnNorthwest1RegionID)
 	case endpoints.AwsUsGovPartitionID:
-		// The AWS Go SDK is missing endpoint information for Route 53 in the AWS GovCloud (US) partition.
-		// This can likely be removed in the future.
-		if aws.StringValue(route53Config.Endpoint) == "" {
-			route53Config.Endpoint = aws.String("https://route53.us-gov.amazonaws.com")
-		}
 		route53Config.Region = aws.String(endpoints.UsGovWest1RegionID)
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The endpoint information is now correctly included in the AWS Go SDK as of [v1.22.3](https://github.com/aws/aws-sdk-go/commit/1f4898f67806740d2a91c9dfe9a8be8a61523eb4). The AWS China endpoint information for Route 53 is still not present in the AWS Go SDK.

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAWSRoute53Zone_VPC_Single (66.92s)
--- PASS: TestAccAWSRoute53Zone_VPC_Multiple (96.71s)
--- PASS: TestAccAWSRoute53Zone_VPC_Updates (173.89s)
```
