### PR TITLE
Add default setting for aws_cloudwatch_event_target ecs_target's task_count

### DIFF
--- a/aws/resource_aws_cloudwatch_event_target.go
+++ b/aws/resource_aws_cloudwatch_event_target.go
@@ -138,6 +138,7 @@ func resourceAwsCloudWatchEventTarget() *schema.Resource {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							ValidateFunc: validation.IntBetween(1, math.MaxInt32),
+							Default:      1,
 						},
 						"task_definition_arn": {
 							Type:         schema.TypeString,

--- a/aws/resource_aws_cloudwatch_event_target_test.go
+++ b/aws/resource_aws_cloudwatch_event_target_test.go
@@ -727,7 +727,7 @@ EOF
 func testAccAWSCloudWatchEventTargetConfigEcsWithBlankTaskCount(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudwatch_event_rule" "schedule" {
-  name        = "%s"
+  name        = "%[1]s"
   description = "schedule_ecs_test"
 
   schedule_expression = "rate(5 minutes)"
@@ -758,7 +758,7 @@ resource "aws_cloudwatch_event_target" "test" {
 }
 
 resource "aws_iam_role" "test_role" {
-  name = "%s"
+  name = "%[1]s"
 
   assume_role_policy = <<EOF
 {
@@ -778,7 +778,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "test_policy" {
-  name = "%s"
+  name = "%[1]s"
   role = "${aws_iam_role.test_role.id}"
 
   policy = <<EOF
@@ -800,11 +800,11 @@ EOF
 }
 
 resource "aws_ecs_cluster" "test" {
-  name = "%s"
+  name = "%[1]s"
 }
 
 resource "aws_ecs_task_definition" "task" {
-  family                   = "%s"
+  family                   = "%[1]s"
   cpu                      = 256
   memory                   = 512
   requires_compatibilities = ["FARGATE"]
@@ -822,7 +822,7 @@ resource "aws_ecs_task_definition" "task" {
 ]
 EOF
 }
-`, rName, rName, rName, rName, rName)
+`, rName)
 }
 
 func testAccAWSCloudWatchEventTargetConfigBatch(rName string) string {

--- a/aws/resource_aws_cloudwatch_event_target_test.go
+++ b/aws/resource_aws_cloudwatch_event_target_test.go
@@ -247,6 +247,32 @@ func TestAccAWSCloudWatchEventTarget_ecs(t *testing.T) {
 	})
 }
 
+func TestAccAWSCloudWatchEventTarget_ecsWithBlankTaskCount(t *testing.T) {
+	var target events.Target
+	rName := acctest.RandomWithPrefix("tf_ecs_target")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudWatchEventTargetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudWatchEventTargetConfigEcsWithBlankTaskCount(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchEventTargetExists("aws_cloudwatch_event_target.test", &target),
+					resource.TestCheckResourceAttr("aws_cloudwatch_event_target.test", "ecs_target.0.task_count", "1"),
+				),
+			},
+			{
+				ResourceName:      "aws_cloudwatch_event_target.test",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCloudWatchEventTargetImportStateIdFunc("aws_cloudwatch_event_target.test"),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSCloudWatchEventTarget_batch(t *testing.T) {
 	var target events.Target
 	rName := acctest.RandomWithPrefix("tf_batch_target")
@@ -621,6 +647,107 @@ resource "aws_cloudwatch_event_target" "test" {
 
   ecs_target {
     task_count          = 1
+    task_definition_arn = "${aws_ecs_task_definition.task.arn}"
+    launch_type         = "FARGATE"
+
+    network_configuration {
+      subnets = ["${aws_subnet.subnet.id}"]
+    }
+  }
+}
+
+resource "aws_iam_role" "test_role" {
+  name = "%s"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "events.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "test_policy" {
+  name = "%s"
+  role = "${aws_iam_role.test_role.id}"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ecs:RunTask"
+            ],
+            "Resource": [
+                "*"
+            ]
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_ecs_cluster" "test" {
+  name = "%s"
+}
+
+resource "aws_ecs_task_definition" "task" {
+  family                   = "%s"
+  cpu                      = 256
+  memory                   = 512
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+
+  container_definitions = <<EOF
+[
+  {
+    "name": "first",
+    "image": "service-first",
+    "cpu": 10,
+    "memory": 512,
+    "essential": true
+  }
+]
+EOF
+}
+`, rName, rName, rName, rName, rName)
+}
+
+func testAccAWSCloudWatchEventTargetConfigEcsWithBlankTaskCount(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_event_rule" "schedule" {
+  name        = "%s"
+  description = "schedule_ecs_test"
+
+  schedule_expression = "rate(5 minutes)"
+}
+
+resource "aws_vpc" "vpc" {
+  cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_subnet" "subnet" {
+  vpc_id     = "${aws_vpc.vpc.id}"
+  cidr_block = "10.1.1.0/24"
+}
+
+resource "aws_cloudwatch_event_target" "test" {
+  arn      = "${aws_ecs_cluster.test.id}"
+  rule     = "${aws_cloudwatch_event_rule.schedule.id}"
+  role_arn = "${aws_iam_role.test_role.arn}"
+
+  ecs_target {
     task_definition_arn = "${aws_ecs_task_definition.task.arn}"
     launch_type         = "FARGATE"
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #9680

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSCloudWatchEventTarget_ecs'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSCloudWatchEventTarget_ecs -timeout 120m
=== RUN   TestAccAWSCloudWatchEventTarget_ecs
=== PAUSE TestAccAWSCloudWatchEventTarget_ecs
=== RUN   TestAccAWSCloudWatchEventTarget_ecsWithBlankTaskCount
=== PAUSE TestAccAWSCloudWatchEventTarget_ecsWithBlankTaskCount
=== CONT  TestAccAWSCloudWatchEventTarget_ecs
=== CONT  TestAccAWSCloudWatchEventTarget_ecsWithBlankTaskCount
--- PASS: TestAccAWSCloudWatchEventTarget_ecs (17.29s)
--- PASS: TestAccAWSCloudWatchEventTarget_ecsWithBlankTaskCount (17.75s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	18.559s
```
