### PR TITLE
Final retries after internet gateway timeouts

### DIFF
--- a/aws/resource_aws_internet_gateway.go
+++ b/aws/resource_aws_internet_gateway.go
@@ -51,9 +51,9 @@ func resourceAwsInternetGatewayCreate(d *schema.ResourceData, meta interface{}) 
 	ig := *resp.InternetGateway
 	d.SetId(*ig.InternetGatewayId)
 	log.Printf("[INFO] InternetGateway ID: %s", d.Id())
-
+	var igRaw interface{}
 	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
-		igRaw, _, err := IGStateRefreshFunc(conn, d.Id())()
+		igRaw, _, err = IGStateRefreshFunc(conn, d.Id())()
 		if igRaw != nil {
 			return nil
 		}
@@ -63,9 +63,14 @@ func resourceAwsInternetGatewayCreate(d *schema.ResourceData, meta interface{}) 
 			return resource.NonRetryableError(err)
 		}
 	})
-
+	if isResourceTimeoutError(err) {
+		igRaw, _, err = IGStateRefreshFunc(conn, d.Id())()
+		if igRaw == nil {
+			return fmt.Errorf("Error refreshing internet gateway state: nil state received")
+		}
+	}
 	if err != nil {
-		return fmt.Errorf("%s", err)
+		return fmt.Errorf("Error refreshing internet gateway state: %s", err)
 	}
 
 	err = setTags(conn, d)
@@ -142,29 +147,32 @@ func resourceAwsInternetGatewayDelete(d *schema.ResourceData, meta interface{}) 
 	}
 
 	log.Printf("[INFO] Deleting Internet Gateway: %s", d.Id())
-
-	return resource.Retry(10*time.Minute, func() *resource.RetryError {
-		_, err := conn.DeleteInternetGateway(&ec2.DeleteInternetGatewayInput{
-			InternetGatewayId: aws.String(d.Id()),
-		})
+	input := &ec2.DeleteInternetGatewayInput{
+		InternetGatewayId: aws.String(d.Id()),
+	}
+	err := resource.Retry(10*time.Minute, func() *resource.RetryError {
+		_, err := conn.DeleteInternetGateway(input)
 		if err == nil {
 			return nil
 		}
 
-		ec2err, ok := err.(awserr.Error)
-		if !ok {
-			return resource.RetryableError(err)
+		if isAWSErr(err, "InvalidInternetGatewayID.NotFound", "") {
+			return nil
 		}
 
-		switch ec2err.Code() {
-		case "InvalidInternetGatewayID.NotFound":
-			return nil
-		case "DependencyViolation":
-			return resource.RetryableError(err) // retry
+		if isAWSErr(err, "DependencyViolation", "") {
+			return resource.RetryableError(err)
 		}
 
 		return resource.NonRetryableError(err)
 	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.DeleteInternetGateway(input)
+	}
+	if err != nil {
+		return fmt.Errorf("Error deleting internet gateway: %s", err)
+	}
+	return nil
 }
 
 func resourceAwsInternetGatewayAttach(d *schema.ResourceData, meta interface{}) error {
@@ -181,25 +189,26 @@ func resourceAwsInternetGatewayAttach(d *schema.ResourceData, meta interface{}) 
 		"[INFO] Attaching Internet Gateway '%s' to VPC '%s'",
 		d.Id(),
 		d.Get("vpc_id").(string))
-
+	input := &ec2.AttachInternetGatewayInput{
+		InternetGatewayId: aws.String(d.Id()),
+		VpcId:             aws.String(d.Get("vpc_id").(string)),
+	}
 	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
-		_, err := conn.AttachInternetGateway(&ec2.AttachInternetGatewayInput{
-			InternetGatewayId: aws.String(d.Id()),
-			VpcId:             aws.String(d.Get("vpc_id").(string)),
-		})
+		_, err := conn.AttachInternetGateway(input)
 		if err == nil {
 			return nil
 		}
-		if ec2err, ok := err.(awserr.Error); ok {
-			switch ec2err.Code() {
-			case "InvalidInternetGatewayID.NotFound":
-				return resource.RetryableError(err) // retry
-			}
+		if isAWSErr(err, "InvalidInternetGatewayID.NotFound", "") {
+			return resource.RetryableError(err)
 		}
+
 		return resource.NonRetryableError(err)
 	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.AttachInternetGateway(input)
+	}
 	if err != nil {
-		return err
+		return fmt.Errorf("Error attaching internet gateway: %s", err)
 	}
 
 	// A note on the states below: the AWS docs (as of July, 2014) say

--- a/aws/resource_aws_internet_gateway.go
+++ b/aws/resource_aws_internet_gateway.go
@@ -66,7 +66,7 @@ func resourceAwsInternetGatewayCreate(d *schema.ResourceData, meta interface{}) 
 	if isResourceTimeoutError(err) {
 		igRaw, _, err = IGStateRefreshFunc(conn, d.Id())()
 		if igRaw == nil {
-			return fmt.Errorf("Error refreshing internet gateway state: nil state received")
+			return fmt.Errorf("error finding Internet Gateway (%s) after creation; retry running Terraform", d.Id())
 		}
 	}
 	if err != nil {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_internet_gateway: Final retries after timeouts creating, attaching, and deleting gateways

```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSInternetGateway"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSInternetGateway -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSInternetGateway_importBasic
=== PAUSE TestAccAWSInternetGateway_importBasic
=== RUN   TestAccAWSInternetGateway_basic
=== PAUSE TestAccAWSInternetGateway_basic
=== RUN   TestAccAWSInternetGateway_delete
=== PAUSE TestAccAWSInternetGateway_delete
=== RUN   TestAccAWSInternetGateway_tags
=== PAUSE TestAccAWSInternetGateway_tags
=== CONT  TestAccAWSInternetGateway_importBasic
=== CONT  TestAccAWSInternetGateway_delete
=== CONT  TestAccAWSInternetGateway_basic
=== CONT  TestAccAWSInternetGateway_tags
--- PASS: TestAccAWSInternetGateway_importBasic (66.69s)
--- PASS: TestAccAWSInternetGateway_delete (93.20s)
--- PASS: TestAccAWSInternetGateway_tags (98.69s)
--- PASS: TestAccAWSInternetGateway_basic (121.75s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       123.228s
```