### PR TITLE
Final retry deleting iot types

### DIFF
--- a/aws/resource_aws_iot_thing_type.go
+++ b/aws/resource_aws_iot_thing_type.go
@@ -185,7 +185,7 @@ func resourceAwsIotThingTypeDelete(d *schema.ResourceData, meta interface{}) err
 	}
 	log.Printf("[DEBUG] Deleting IoT Thing Type: %s", deleteParams)
 
-	return resource.Retry(6*time.Minute, func() *resource.RetryError {
+	err = resource.Retry(6*time.Minute, func() *resource.RetryError {
 		_, err := conn.DeleteThingType(deleteParams)
 
 		if err != nil {
@@ -204,4 +204,14 @@ func resourceAwsIotThingTypeDelete(d *schema.ResourceData, meta interface{}) err
 
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.DeleteThingType(deleteParams)
+		if isAWSErr(err, iot.ErrCodeResourceNotFoundException, "") {
+			return nil
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("Error deleting IOT thing type: %s", err)
+	}
+	return nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_iot_thing_type: Final retry after timeout deleting IOT thing type
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSIotThingType"      
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSIotThingType -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSIotThingType_basic
=== PAUSE TestAccAWSIotThingType_basic
=== RUN   TestAccAWSIotThingType_full
=== PAUSE TestAccAWSIotThingType_full
=== CONT  TestAccAWSIotThingType_basic
=== CONT  TestAccAWSIotThingType_full
--- PASS: TestAccAWSIotThingType_basic (327.00s)
--- PASS: TestAccAWSIotThingType_full (343.43s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       347.034s
```