### PR TITLE
tests/data-source/aws_organizations_organization: Add Organizations PreCheck

### DIFF
--- a/aws/data_source_aws_organizations_organization_test.go
+++ b/aws/data_source_aws_organizations_organization_test.go
@@ -13,6 +13,7 @@ func testAccDataSourceAwsOrganizationsOrganization_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccOrganizationsAccountPreCheck(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

For consistency with other Organizations testing and to prevent the following failure:

```
       --- FAIL: TestAccAWSOrganizations/Organization/DataSource (3.55s)
            testing.go:568: Step 0 error: errors during apply:

                Error: Error creating organization: AlreadyInOrganizationException: The AWS account is already a member of an organization.
```

Acceptance testing from Organizations member account:

```
        --- SKIP: TestAccAWSOrganizations/Organization/DataSource (1.57s)
            provider_test.go:247: skipping tests; this AWS account must not be an existing member of an AWS Organization
```

Acceptance testing from standalone account:

```
        --- PASS: TestAccAWSOrganizations/Organization/DataSource (29.70s)
```

