### PR TITLE
Correct validations for AWS Cloud Map service discovery information for App Mesh virtual nodes

### DIFF
--- a/aws/resource_aws_appmesh_virtual_node.go
+++ b/aws/resource_aws_appmesh_virtual_node.go
@@ -235,12 +235,13 @@ func resourceAwsAppmeshVirtualNode() *schema.Resource {
 												"namespace_name": {
 													Type:         schema.TypeString,
 													Required:     true,
-													ValidateFunc: validateServiceDiscoveryHttpNamespaceName,
+													ValidateFunc: validation.StringLenBetween(1, 1024),
 												},
 
 												"service_name": {
-													Type:     schema.TypeString,
-													Required: true,
+													Type:         schema.TypeString,
+													Required:     true,
+													ValidateFunc: validation.StringLenBetween(1, 1024),
 												},
 											},
 										},

--- a/aws/resource_aws_appmesh_virtual_node_test.go
+++ b/aws/resource_aws_appmesh_virtual_node_test.go
@@ -55,7 +55,8 @@ func testAccAwsAppmeshVirtualNode_cloudMapServiceDiscovery(t *testing.T) {
 	nsResourceName := "aws_service_discovery_http_namespace.test"
 	meshName := fmt.Sprintf("tf-test-mesh-%d", acctest.RandInt())
 	vnName := fmt.Sprintf("tf-test-node-%d", acctest.RandInt())
-	rName := fmt.Sprintf("tf-testacc-appmeshvn-%s", acctest.RandStringFromCharSet(11, acctest.CharSetAlphaNum))
+	// Avoid 'config is invalid: last character of "name" must be a letter' for aws_service_discovery_http_namespace.
+	rName := fmt.Sprintf("tf-testacc-appmeshvn-%s", acctest.RandStringFromCharSet(11, acctest.CharSetAlpha))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/aws/resource_aws_service_discovery_service_test.go
+++ b/aws/resource_aws_service_discovery_service_test.go
@@ -93,7 +93,7 @@ func TestAccAWSServiceDiscoveryService_public(t *testing.T) {
 }
 
 func TestAccAWSServiceDiscoveryService_http(t *testing.T) {
-	rName := acctest.RandString(5)
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	resourceName := "aws_service_discovery_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/9764.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIX: resource/aws_appmesh_virtual_node: Correct validations for AWS Cloud Map service discovery information
```

Output from acceptance testing:

```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAppmesh/VirtualNode'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSAppmesh/VirtualNode -timeout 120m
=== RUN   TestAccAWSAppmesh
=== RUN   TestAccAWSAppmesh/VirtualNode
=== RUN   TestAccAWSAppmesh/VirtualNode/cloudMapServiceDiscovery
=== RUN   TestAccAWSAppmesh/VirtualNode/listenerHealthChecks
=== RUN   TestAccAWSAppmesh/VirtualNode/logging
=== RUN   TestAccAWSAppmesh/VirtualNode/tags
=== RUN   TestAccAWSAppmesh/VirtualNode/basic
--- PASS: TestAccAWSAppmesh (277.61s)
    --- PASS: TestAccAWSAppmesh/VirtualNode (277.61s)
        --- PASS: TestAccAWSAppmesh/VirtualNode/cloudMapServiceDiscovery (113.18s)
        --- PASS: TestAccAWSAppmesh/VirtualNode/listenerHealthChecks (41.33s)
        --- PASS: TestAccAWSAppmesh/VirtualNode/logging (40.46s)
        --- PASS: TestAccAWSAppmesh/VirtualNode/tags (57.66s)
        --- PASS: TestAccAWSAppmesh/VirtualNode/basic (24.99s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	277.675s
```
