### PR TITLE
Final retries for msk cluster

### DIFF
--- a/aws/resource_aws_msk_cluster.go
+++ b/aws/resource_aws_msk_cluster.go
@@ -248,10 +248,11 @@ func resourceAwsMskClusterCreate(d *schema.ResourceData, meta interface{}) error
 }
 
 func waitForMskClusterCreation(conn *kafka.Kafka, arn string) error {
-	return resource.Retry(60*time.Minute, func() *resource.RetryError {
-		out, err := conn.DescribeCluster(&kafka.DescribeClusterInput{
-			ClusterArn: aws.String(arn),
-		})
+	input := &kafka.DescribeClusterInput{
+		ClusterArn: aws.String(arn),
+	}
+	err := resource.Retry(60*time.Minute, func() *resource.RetryError {
+		out, err := conn.DescribeCluster(input)
 		if err != nil {
 			return resource.NonRetryableError(err)
 		}
@@ -265,6 +266,24 @@ func waitForMskClusterCreation(conn *kafka.Kafka, arn string) error {
 		}
 		return resource.RetryableError(fmt.Errorf("%q: cluster still creating", arn))
 	})
+	if isResourceTimeoutError(err) {
+		out, err := conn.DescribeCluster(input)
+		if err != nil {
+			return fmt.Errorf("Error describing MSK cluster state: %s", err)
+		}
+		if out.ClusterInfo != nil {
+			if aws.StringValue(out.ClusterInfo.State) == kafka.ClusterStateFailed {
+				return fmt.Errorf("Cluster creation failed with cluster state %q", kafka.ClusterStateFailed)
+			}
+			if aws.StringValue(out.ClusterInfo.State) == kafka.ClusterStateActive {
+				return nil
+			}
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("Error waiting for MSK cluster creation: %s", err)
+	}
+	return nil
 }
 
 func resourceAwsMskClusterRead(d *schema.ResourceData, meta interface{}) error {
@@ -597,10 +616,11 @@ func resourceAwsMskClusterDelete(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceAwsMskClusterDeleteWaiter(conn *kafka.Kafka, arn string) error {
-	return resource.Retry(60*time.Minute, func() *resource.RetryError {
-		_, err := conn.DescribeCluster(&kafka.DescribeClusterInput{
-			ClusterArn: aws.String(arn),
-		})
+	input := &kafka.DescribeClusterInput{
+		ClusterArn: aws.String(arn),
+	}
+	err := resource.Retry(60*time.Minute, func() *resource.RetryError {
+		_, err := conn.DescribeCluster(input)
 
 		if err != nil {
 			if isAWSErr(err, kafka.ErrCodeNotFoundException, "") {
@@ -611,6 +631,16 @@ func resourceAwsMskClusterDeleteWaiter(conn *kafka.Kafka, arn string) error {
 
 		return resource.RetryableError(fmt.Errorf("timeout while waiting for the cluster %q to be deleted", arn))
 	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.DescribeCluster(input)
+		if err != nil && isAWSErr(err, kafka.ErrCodeNotFoundException, "") {
+			return nil
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("Error waiting for MSK cluster to be deleted: %s", err)
+	}
+	return nil
 }
 
 func mskClusterOperationRefreshFunc(conn *kafka.Kafka, clusterOperationARN string) resource.StateRefreshFunc {

--- a/aws/resource_aws_msk_cluster.go
+++ b/aws/resource_aws_msk_cluster.go
@@ -633,7 +633,7 @@ func resourceAwsMskClusterDeleteWaiter(conn *kafka.Kafka, arn string) error {
 	})
 	if isResourceTimeoutError(err) {
 		_, err = conn.DescribeCluster(input)
-		if err != nil && isAWSErr(err, kafka.ErrCodeNotFoundException, "") {
+		if isAWSErr(err, kafka.ErrCodeNotFoundException, "") {
 			return nil
 		}
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_msk_cluster: Final retries after timeouts creating and deleting clusters
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSMskCluster"==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSMskCluster -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSMskClusterDataSource_Name
=== PAUSE TestAccAWSMskClusterDataSource_Name
=== RUN   TestAccAWSMskCluster_basic
=== PAUSE TestAccAWSMskCluster_basic
=== RUN   TestAccAWSMskCluster_BrokerNodeGroupInfo_EbsVolumeSize
=== PAUSE TestAccAWSMskCluster_BrokerNodeGroupInfo_EbsVolumeSize
=== RUN   TestAccAWSMskCluster_ClientAuthentication_Tls_CertificateAuthorityArns
--- SKIP: TestAccAWSMskCluster_ClientAuthentication_Tls_CertificateAuthorityArns (0.00s)
    resource_aws_msk_cluster_test.go:155: Requires the aws_acmpca_certificate_authority resource to support importing the root CA certificate
=== RUN   TestAccAWSMskCluster_ConfigurationInfo_Revision
--- SKIP: TestAccAWSMskCluster_ConfigurationInfo_Revision (0.00s)
    resource_aws_msk_cluster_test.go:189: aws_msk_cluster is correctly calling UpdateClusterConfiguration however API is always returning 429 and 500 errors
=== RUN   TestAccAWSMskCluster_EncryptionInfo_EncryptionAtRestKmsKeyArn
=== PAUSE TestAccAWSMskCluster_EncryptionInfo_EncryptionAtRestKmsKeyArn
=== RUN   TestAccAWSMskCluster_EncryptionInfo_EncryptionInTransit_ClientBroker
=== PAUSE TestAccAWSMskCluster_EncryptionInfo_EncryptionInTransit_ClientBroker
=== RUN   TestAccAWSMskCluster_EncryptionInfo_EncryptionInTransit_InCluster
=== PAUSE TestAccAWSMskCluster_EncryptionInfo_EncryptionInTransit_InCluster
=== RUN   TestAccAWSMskCluster_EnhancedMonitoring
=== PAUSE TestAccAWSMskCluster_EnhancedMonitoring
=== RUN   TestAccAWSMskCluster_NumberOfBrokerNodes
=== PAUSE TestAccAWSMskCluster_NumberOfBrokerNodes
=== RUN   TestAccAWSMskCluster_Tags
=== PAUSE TestAccAWSMskCluster_Tags
=== CONT  TestAccAWSMskClusterDataSource_Name
=== CONT  TestAccAWSMskCluster_EncryptionInfo_EncryptionInTransit_ClientBroker
=== CONT  TestAccAWSMskCluster_basic
=== CONT  TestAccAWSMskCluster_EncryptionInfo_EncryptionInTransit_InCluster
=== CONT  TestAccAWSMskCluster_NumberOfBrokerNodes
=== CONT  TestAccAWSMskCluster_EnhancedMonitoring
=== CONT  TestAccAWSMskCluster_BrokerNodeGroupInfo_EbsVolumeSize
=== CONT  TestAccAWSMskCluster_Tags
=== CONT  TestAccAWSMskCluster_EncryptionInfo_EncryptionAtRestKmsKeyArn
--- PASS: TestAccAWSMskCluster_EncryptionInfo_EncryptionInTransit_InCluster (771.22s)
--- FAIL: TestAccAWSMskCluster_Tags (845.03s)
    testing.go:568: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
...    
        
        STATE:
...
--- FAIL: TestAccAWSMskCluster_BrokerNodeGroupInfo_EbsVolumeSize (880.78s)
    testing.go:568: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
...   
        
        STATE:
        
...
--- PASS: TestAccAWSMskCluster_EncryptionInfo_EncryptionInTransit_ClientBroker (887.45s)
--- FAIL: TestAccAWSMskCluster_NumberOfBrokerNodes (889.94s)
    testing.go:568: Step 0 error: Check failed: Check 2/9 error: aws_msk_cluster.test: Attribute 'bootstrap_brokers' didn't match "^(([-\\w]+\\.){1,}[\\w]+:\\d+,){2,}([-\\w]+\\.){1,}[\\w]+:\\d+$", got ""
--- FAIL: TestAccAWSMskCluster_EncryptionInfo_EncryptionAtRestKmsKeyArn (923.87s)
    testing.go:568: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
...
        
        STATE:
        
...
--- FAIL: TestAccAWSMskCluster_basic (954.09s)
    testing.go:568: Step 0 error: Check failed: Check 3/27 error: aws_msk_cluster.test: Attribute 'bootstrap_brokers' didn't match "^(([-\\w]+\\.){1,}[\\w]+:\\d+,){2,}([-\\w]+\\.){1,}[\\w]+:\\d+$", got ""
--- FAIL: TestAccAWSMskClusterDataSource_Name (1000.95s)
    testing.go:568: Step 0 error: Check failed: Check 2/8 error: data.aws_msk_cluster.test: Attribute 'bootstrap_brokers' expected to be set
--- FAIL: TestAccAWSMskCluster_EnhancedMonitoring (1005.55s)
    testing.go:568: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
... 
        
        STATE:
        
...
FAIL
FAIL    github.com/terraform-providers/terraform-provider-aws/aws       1006.420s
make: *** [testacc] Error 1
```