### PR TITLE
Final retries for redshift resources

### DIFF
--- a/aws/resource_aws_redshift_cluster.go
+++ b/aws/resource_aws_redshift_cluster.go
@@ -910,6 +910,9 @@ func deleteAwsRedshiftCluster(opts *redshift.DeleteClusterInput, conn *redshift.
 
 		return resource.NonRetryableError(err)
 	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.DeleteCluster(opts)
+	}
 	if err != nil {
 		return fmt.Errorf("Error deleting Redshift Cluster (%s): %s", id, err)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES
* resource/aws_redshift_cluster: Final retry after timeout deleting cluster
* resource/aws_redshift_snapshot_copy_grant: Final retries after timeouts finding and deleting grants
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSRedshiftCluster"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSRedshiftCluster -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSRedshiftCluster_basic
=== PAUSE TestAccAWSRedshiftCluster_basic
=== RUN   TestAccAWSRedshiftCluster_withFinalSnapshot
=== PAUSE TestAccAWSRedshiftCluster_withFinalSnapshot
=== RUN   TestAccAWSRedshiftCluster_kmsKey
=== PAUSE TestAccAWSRedshiftCluster_kmsKey
=== RUN   TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled
=== PAUSE TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled
=== RUN   TestAccAWSRedshiftCluster_loggingEnabled
=== PAUSE TestAccAWSRedshiftCluster_loggingEnabled
=== RUN   TestAccAWSRedshiftCluster_snapshotCopy
=== PAUSE TestAccAWSRedshiftCluster_snapshotCopy
=== RUN   TestAccAWSRedshiftCluster_iamRoles
=== PAUSE TestAccAWSRedshiftCluster_iamRoles
=== RUN   TestAccAWSRedshiftCluster_publiclyAccessible
=== PAUSE TestAccAWSRedshiftCluster_publiclyAccessible
=== RUN   TestAccAWSRedshiftCluster_updateNodeCount
=== PAUSE TestAccAWSRedshiftCluster_updateNodeCount
=== RUN   TestAccAWSRedshiftCluster_updateNodeType
=== PAUSE TestAccAWSRedshiftCluster_updateNodeType
=== RUN   TestAccAWSRedshiftCluster_tags
=== PAUSE TestAccAWSRedshiftCluster_tags
=== RUN   TestAccAWSRedshiftCluster_forceNewUsername
=== PAUSE TestAccAWSRedshiftCluster_forceNewUsername
=== RUN   TestAccAWSRedshiftCluster_changeAvailabilityZone
=== PAUSE TestAccAWSRedshiftCluster_changeAvailabilityZone
=== RUN   TestAccAWSRedshiftCluster_changeEncryption1
=== PAUSE TestAccAWSRedshiftCluster_changeEncryption1
=== RUN   TestAccAWSRedshiftCluster_changeEncryption2
=== PAUSE TestAccAWSRedshiftCluster_changeEncryption2
=== CONT  TestAccAWSRedshiftCluster_basic
=== CONT  TestAccAWSRedshiftCluster_changeEncryption2
=== CONT  TestAccAWSRedshiftCluster_withFinalSnapshot
=== CONT  TestAccAWSRedshiftCluster_publiclyAccessible
=== CONT  TestAccAWSRedshiftCluster_changeEncryption1
=== CONT  TestAccAWSRedshiftCluster_changeAvailabilityZone
=== CONT  TestAccAWSRedshiftCluster_forceNewUsername
=== CONT  TestAccAWSRedshiftCluster_updateNodeType
=== CONT  TestAccAWSRedshiftCluster_updateNodeCount
=== CONT  TestAccAWSRedshiftCluster_loggingEnabled
=== CONT  TestAccAWSRedshiftCluster_iamRoles
=== CONT  TestAccAWSRedshiftCluster_tags
=== CONT  TestAccAWSRedshiftCluster_kmsKey
=== CONT  TestAccAWSRedshiftCluster_snapshotCopy
=== CONT  TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled
--- PASS: TestAccAWSRedshiftCluster_basic (609.49s)
--- PASS: TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled (622.87s)
--- PASS: TestAccAWSRedshiftCluster_snapshotCopy (637.76s)
--- PASS: TestAccAWSRedshiftCluster_loggingEnabled (638.27s)
--- PASS: TestAccAWSRedshiftCluster_tags (644.49s)
--- PASS: TestAccAWSRedshiftCluster_kmsKey (686.31s)
--- PASS: TestAccAWSRedshiftCluster_publiclyAccessible (702.46s)
--- PASS: TestAccAWSRedshiftCluster_iamRoles (751.41s)
--- PASS: TestAccAWSRedshiftCluster_withFinalSnapshot (898.51s)
--- PASS: TestAccAWSRedshiftCluster_forceNewUsername (966.63s)
--- PASS: TestAccAWSRedshiftCluster_changeAvailabilityZone (1090.95s)
--- PASS: TestAccAWSRedshiftCluster_changeEncryption1 (2167.83s)
--- PASS: TestAccAWSRedshiftCluster_updateNodeCount (2255.97s)
--- PASS: TestAccAWSRedshiftCluster_changeEncryption2 (2278.53s)
--- PASS: TestAccAWSRedshiftCluster_updateNodeType (2481.67s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       2482.854s

make testacc TESTARGS="-run=TestAccAWSRedshiftSnapshotCopyGrant"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSRedshiftSnapshotCopyGrant -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSRedshiftSnapshotCopyGrant_Basic
=== PAUSE TestAccAWSRedshiftSnapshotCopyGrant_Basic
=== RUN   TestAccAWSRedshiftSnapshotCopyGrant_Update
=== PAUSE TestAccAWSRedshiftSnapshotCopyGrant_Update
=== CONT  TestAccAWSRedshiftSnapshotCopyGrant_Basic
=== CONT  TestAccAWSRedshiftSnapshotCopyGrant_Update
--- PASS: TestAccAWSRedshiftSnapshotCopyGrant_Basic (26.51s)
--- PASS: TestAccAWSRedshiftSnapshotCopyGrant_Update (64.35s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       66.392s
```