### PR TITLE
Final retries for routes

### DIFF
--- a/aws/resource_aws_route.go
+++ b/aws/resource_aws_route.go
@@ -269,6 +269,9 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.CreateRoute(createOpts)
+	}
 	if err != nil {
 		return fmt.Errorf("Error creating route: %s", err)
 	}
@@ -280,6 +283,9 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 			route, err = resourceAwsRouteFindRoute(conn, d.Get("route_table_id").(string), v.(string), "")
 			return resource.RetryableError(err)
 		})
+		if isResourceTimeoutError(err) {
+			route, err = resourceAwsRouteFindRoute(conn, d.Get("route_table_id").(string), v.(string), "")
+		}
 		if err != nil {
 			return fmt.Errorf("Error finding route after creating it: %s", err)
 		}
@@ -290,6 +296,9 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 			route, err = resourceAwsRouteFindRoute(conn, d.Get("route_table_id").(string), "", v.(string))
 			return resource.RetryableError(err)
 		})
+		if isResourceTimeoutError(err) {
+			route, err = resourceAwsRouteFindRoute(conn, d.Get("route_table_id").(string), "", v.(string))
+		}
 		if err != nil {
 			return fmt.Errorf("Error finding route after creating it: %s", err)
 		}
@@ -440,29 +449,30 @@ func resourceAwsRouteDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 	log.Printf("[DEBUG] Route delete opts: %s", deleteOpts)
 
-	var err error = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+	var resp *ec2.DeleteRouteOutput
+	err := resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		log.Printf("[DEBUG] Trying to delete route with opts %s", deleteOpts)
-		resp, err := conn.DeleteRoute(deleteOpts)
+		var err error
+		resp, err = conn.DeleteRoute(deleteOpts)
 		log.Printf("[DEBUG] Route delete result: %s", resp)
 
 		if err == nil {
 			return nil
 		}
 
-		ec2err, ok := err.(awserr.Error)
-		if !ok {
-			return resource.NonRetryableError(err)
-		}
-		if ec2err.Code() == "InvalidParameterException" {
-			log.Printf("[DEBUG] Trying to delete route again: %q",
-				ec2err.Message())
+		if isAWSErr(err, "InvalidParameterException", "") {
 			return resource.RetryableError(err)
 		}
 
 		return resource.NonRetryableError(err)
 	})
-
-	return err
+	if isResourceTimeoutError(err) {
+		resp, err = conn.DeleteRoute(deleteOpts)
+	}
+	if err != nil {
+		return fmt.Errorf("Error deleting route: %s", err)
+	}
+	return nil
 }
 
 func resourceAwsRouteExists(d *schema.ResourceData, meta interface{}) (bool, error) {

--- a/aws/resource_aws_route_table.go
+++ b/aws/resource_aws_route_table.go
@@ -391,8 +391,11 @@ func resourceAwsRouteTableUpdate(d *schema.ResourceData, meta interface{}) error
 				}
 				return nil
 			})
+			if isResourceTimeoutError(err) {
+				_, err = conn.CreateRoute(&opts)
+			}
 			if err != nil {
-				return err
+				return fmt.Errorf("Error creating route: %s", err)
 			}
 
 			routes.Add(route)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_route: Final retry after timeout creating route
* resource/aws_route_table: Final retry after timeout updating route table
* resource/aws_route_table_association: Final retry after timeout creating route table association
```

Output from acceptance testing:

```
$  make testacc TESTARGS="-run=TestAccAWSRoute_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSRoute_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSRoute_basic
=== PAUSE TestAccAWSRoute_basic
=== RUN   TestAccAWSRoute_ipv6Support
=== PAUSE TestAccAWSRoute_ipv6Support
=== RUN   TestAccAWSRoute_ipv6ToInternetGateway
=== PAUSE TestAccAWSRoute_ipv6ToInternetGateway
=== RUN   TestAccAWSRoute_ipv6ToInstance
=== PAUSE TestAccAWSRoute_ipv6ToInstance
=== RUN   TestAccAWSRoute_ipv6ToNetworkInterface
=== PAUSE TestAccAWSRoute_ipv6ToNetworkInterface
=== RUN   TestAccAWSRoute_ipv6ToPeeringConnection
=== PAUSE TestAccAWSRoute_ipv6ToPeeringConnection
=== RUN   TestAccAWSRoute_changeRouteTable
=== PAUSE TestAccAWSRoute_changeRouteTable
=== RUN   TestAccAWSRoute_changeCidr
=== PAUSE TestAccAWSRoute_changeCidr
=== RUN   TestAccAWSRoute_noopdiff
=== PAUSE TestAccAWSRoute_noopdiff
=== RUN   TestAccAWSRoute_doesNotCrashWithVPCEndpoint
=== PAUSE TestAccAWSRoute_doesNotCrashWithVPCEndpoint
=== RUN   TestAccAWSRoute_TransitGatewayID_DestinationCidrBlock
=== PAUSE TestAccAWSRoute_TransitGatewayID_DestinationCidrBlock
=== CONT  TestAccAWSRoute_basic
=== CONT  TestAccAWSRoute_TransitGatewayID_DestinationCidrBlock
=== CONT  TestAccAWSRoute_ipv6ToNetworkInterface
=== CONT  TestAccAWSRoute_ipv6ToInternetGateway
=== CONT  TestAccAWSRoute_noopdiff
=== CONT  TestAccAWSRoute_doesNotCrashWithVPCEndpoint
=== CONT  TestAccAWSRoute_changeRouteTable
=== CONT  TestAccAWSRoute_changeCidr
=== CONT  TestAccAWSRoute_ipv6ToInstance
=== CONT  TestAccAWSRoute_ipv6Support
=== CONT  TestAccAWSRoute_ipv6ToPeeringConnection
--- PASS: TestAccAWSRoute_ipv6Support (62.39s)
--- PASS: TestAccAWSRoute_ipv6ToPeeringConnection (66.22s)
--- PASS: TestAccAWSRoute_basic (73.64s)
--- PASS: TestAccAWSRoute_ipv6ToInternetGateway (76.03s)
--- PASS: TestAccAWSRoute_doesNotCrashWithVPCEndpoint (83.95s)
--- PASS: TestAccAWSRoute_changeCidr (121.21s)
--- PASS: TestAccAWSRoute_changeRouteTable (122.83s)
--- PASS: TestAccAWSRoute_ipv6ToInstance (159.76s)
--- PASS: TestAccAWSRoute_noopdiff (176.14s)
--- PASS: TestAccAWSRoute_ipv6ToNetworkInterface (199.13s)
--- PASS: TestAccAWSRoute_TransitGatewayID_DestinationCidrBlock (324.05s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       324.937s

make testacc TESTARGS="-run=TestAccAWSRouteTable_"     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSRouteTable_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSRouteTable_basic
=== PAUSE TestAccAWSRouteTable_basic
=== RUN   TestAccAWSRouteTable_instance
=== PAUSE TestAccAWSRouteTable_instance
=== RUN   TestAccAWSRouteTable_ipv6
=== PAUSE TestAccAWSRouteTable_ipv6
=== RUN   TestAccAWSRouteTable_tags
=== PAUSE TestAccAWSRouteTable_tags
=== RUN   TestAccAWSRouteTable_panicEmptyRoute
=== PAUSE TestAccAWSRouteTable_panicEmptyRoute
=== RUN   TestAccAWSRouteTable_Route_ConfigMode
=== PAUSE TestAccAWSRouteTable_Route_ConfigMode
=== RUN   TestAccAWSRouteTable_Route_TransitGatewayID
=== PAUSE TestAccAWSRouteTable_Route_TransitGatewayID
=== RUN   TestAccAWSRouteTable_vpcPeering
=== PAUSE TestAccAWSRouteTable_vpcPeering
=== RUN   TestAccAWSRouteTable_vgwRoutePropagation
=== PAUSE TestAccAWSRouteTable_vgwRoutePropagation
=== CONT  TestAccAWSRouteTable_basic
=== CONT  TestAccAWSRouteTable_Route_ConfigMode
=== CONT  TestAccAWSRouteTable_instance
=== CONT  TestAccAWSRouteTable_vpcPeering
=== CONT  TestAccAWSRouteTable_panicEmptyRoute
=== CONT  TestAccAWSRouteTable_tags
=== CONT  TestAccAWSRouteTable_ipv6
=== CONT  TestAccAWSRouteTable_vgwRoutePropagation
=== CONT  TestAccAWSRouteTable_Route_TransitGatewayID
--- PASS: TestAccAWSRouteTable_panicEmptyRoute (37.07s)
--- PASS: TestAccAWSRouteTable_ipv6 (61.95s)
--- PASS: TestAccAWSRouteTable_vpcPeering (71.78s)
--- PASS: TestAccAWSRouteTable_vgwRoutePropagation (75.86s)
--- PASS: TestAccAWSRouteTable_tags (87.73s)
--- PASS: TestAccAWSRouteTable_basic (109.71s)
--- PASS: TestAccAWSRouteTable_Route_ConfigMode (140.21s)
--- PASS: TestAccAWSRouteTable_instance (176.45s)
--- PASS: TestAccAWSRouteTable_Route_TransitGatewayID (367.48s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       368.599s

make testacc TESTARGS="-run=TestAccAWSRouteTableAssociation"      
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSRouteTableAssociation -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSRouteTableAssociation_basic
=== PAUSE TestAccAWSRouteTableAssociation_basic
=== RUN   TestAccAWSRouteTableAssociation_replace
=== PAUSE TestAccAWSRouteTableAssociation_replace
=== CONT  TestAccAWSRouteTableAssociation_basic
=== CONT  TestAccAWSRouteTableAssociation_replace
--- PASS: TestAccAWSRouteTableAssociation_replace (116.95s)
--- PASS: TestAccAWSRouteTableAssociation_basic (119.09s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       120.225s
```