### PR TITLE
Final sagemaker retries

### DIFF
--- a/aws/resource_aws_sagemaker_model.go
+++ b/aws/resource_aws_sagemaker_model.go
@@ -305,23 +305,24 @@ func resourceAwsSagemakerModelDelete(d *schema.ResourceData, meta interface{}) e
 	}
 	log.Printf("[INFO] Deleting Sagemaker model: %s", d.Id())
 
-	return resource.Retry(5*time.Minute, func() *resource.RetryError {
+	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
 		_, err := conn.DeleteModel(deleteOpts)
 		if err == nil {
 			return nil
 		}
 
-		sagemakerErr, ok := err.(awserr.Error)
-		if !ok {
-			return resource.NonRetryableError(err)
-		}
-
-		if sagemakerErr.Code() == "ResourceNotFound" {
+		if isAWSErr(err, "ResourceNotFound", "") {
 			return resource.RetryableError(err)
 		}
-
-		return resource.NonRetryableError(fmt.Errorf("error deleting Sagemaker model: %s", err))
+		return resource.NonRetryableError(err)
 	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.DeleteModel(deleteOpts)
+	}
+	if err != nil {
+		return fmt.Errorf("Error deleting sagemaker model: %s", err)
+	}
+	return nil
 }
 
 func expandContainer(m map[string]interface{}) *sagemaker.ContainerDefinition {

--- a/aws/resource_aws_sagemaker_notebook_instance.go
+++ b/aws/resource_aws_sagemaker_notebook_instance.go
@@ -248,33 +248,42 @@ func resourceAwsSagemakerNotebookInstanceUpdate(d *schema.ResourceData, meta int
 			startOpts := &sagemaker.StartNotebookInstanceInput{
 				NotebookInstanceName: aws.String(d.Id()),
 			}
-
+			stateConf := &resource.StateChangeConf{
+				Pending: []string{
+					sagemaker.NotebookInstanceStatusStopped,
+				},
+				Target:  []string{sagemaker.NotebookInstanceStatusInService, sagemaker.NotebookInstanceStatusPending},
+				Refresh: sagemakerNotebookInstanceStateRefreshFunc(conn, d.Id()),
+				Timeout: 30 * time.Second,
+			}
 			// StartNotebookInstance sometimes doesn't take so we'll check for a state change and if
 			// it doesn't change we'll send another request
 			err := resource.Retry(5*time.Minute, func() *resource.RetryError {
-				if _, err := conn.StartNotebookInstance(startOpts); err != nil {
+				_, err := conn.StartNotebookInstance(startOpts)
+				if err != nil {
 					return resource.NonRetryableError(fmt.Errorf("error starting sagemaker notebook instance (%s): %s", d.Id(), err))
 				}
-				stateConf := &resource.StateChangeConf{
-					Pending: []string{
-						sagemaker.NotebookInstanceStatusStopped,
-					},
-					Target:  []string{sagemaker.NotebookInstanceStatusInService, sagemaker.NotebookInstanceStatusPending},
-					Refresh: sagemakerNotebookInstanceStateRefreshFunc(conn, d.Id()),
-					Timeout: 30 * time.Second,
-				}
-				_, err := stateConf.WaitForState()
+
+				_, err = stateConf.WaitForState()
 				if err != nil {
 					return resource.RetryableError(fmt.Errorf("error waiting for sagemaker notebook instance (%s) to start: %s", d.Id(), err))
 				}
 
 				return nil
 			})
+			if isResourceTimeoutError(err) {
+				_, err = conn.StartNotebookInstance(startOpts)
+				if err != nil {
+					return fmt.Errorf("error starting sagemaker notebook instance (%s): %s", d.Id(), err)
+				}
+
+				_, err = stateConf.WaitForState()
+			}
 			if err != nil {
-				return err
+				return fmt.Errorf("Error waiting for sagemaker notebook instance to start: %s", err)
 			}
 
-			stateConf := &resource.StateChangeConf{
+			stateConf = &resource.StateChangeConf{
 				Pending: []string{
 					sagemaker.NotebookInstanceStatusUpdating,
 					sagemaker.NotebookInstanceStatusPending,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES
* resource/aws_sagemaker_model: Final retry after timeout deleting model
* resource/aws_sagemaker_notebook_instance: Final retry after timeout updating instance
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSSagemakerModel"       
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSSagemakerModel -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSSagemakerModel_basic
=== PAUSE TestAccAWSSagemakerModel_basic
=== RUN   TestAccAWSSagemakerModel_tags
=== PAUSE TestAccAWSSagemakerModel_tags
=== RUN   TestAccAWSSagemakerModel_primaryContainerModelDataUrl
=== PAUSE TestAccAWSSagemakerModel_primaryContainerModelDataUrl
=== RUN   TestAccAWSSagemakerModel_primaryContainerHostname
=== PAUSE TestAccAWSSagemakerModel_primaryContainerHostname
=== RUN   TestAccAWSSagemakerModel_primaryContainerEnvironment
=== PAUSE TestAccAWSSagemakerModel_primaryContainerEnvironment
=== RUN   TestAccAWSSagemakerModel_containers
=== PAUSE TestAccAWSSagemakerModel_containers
=== RUN   TestAccAWSSagemakerModel_vpcConfig
=== PAUSE TestAccAWSSagemakerModel_vpcConfig
=== RUN   TestAccAWSSagemakerModel_networkIsolation
=== PAUSE TestAccAWSSagemakerModel_networkIsolation
=== CONT  TestAccAWSSagemakerModel_basic
=== CONT  TestAccAWSSagemakerModel_containers
=== CONT  TestAccAWSSagemakerModel_primaryContainerEnvironment
=== CONT  TestAccAWSSagemakerModel_networkIsolation
=== CONT  TestAccAWSSagemakerModel_primaryContainerHostname
=== CONT  TestAccAWSSagemakerModel_primaryContainerModelDataUrl
=== CONT  TestAccAWSSagemakerModel_tags
=== CONT  TestAccAWSSagemakerModel_vpcConfig
--- PASS: TestAccAWSSagemakerModel_primaryContainerEnvironment (45.14s)
--- PASS: TestAccAWSSagemakerModel_networkIsolation (48.30s)
--- PASS: TestAccAWSSagemakerModel_basic (52.88s)
--- PASS: TestAccAWSSagemakerModel_containers (57.61s)
--- PASS: TestAccAWSSagemakerModel_primaryContainerHostname (66.31s)
--- PASS: TestAccAWSSagemakerModel_vpcConfig (67.07s)
--- PASS: TestAccAWSSagemakerModel_tags (69.60s)
--- PASS: TestAccAWSSagemakerModel_primaryContainerModelDataUrl (84.11s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       85.215s

make testacc TESTARGS="-run=TestAccAWSSagemakerNotebookInstance"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSSagemakerNotebookInstance -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSSagemakerNotebookInstanceLifecycleConfiguration_Basic
=== PAUSE TestAccAWSSagemakerNotebookInstanceLifecycleConfiguration_Basic
=== RUN   TestAccAWSSagemakerNotebookInstanceLifecycleConfiguration_Update
=== PAUSE TestAccAWSSagemakerNotebookInstanceLifecycleConfiguration_Update
=== RUN   TestAccAWSSagemakerNotebookInstance_basic
=== PAUSE TestAccAWSSagemakerNotebookInstance_basic
=== RUN   TestAccAWSSagemakerNotebookInstance_update
=== PAUSE TestAccAWSSagemakerNotebookInstance_update
=== RUN   TestAccAWSSagemakerNotebookInstance_LifecycleConfigName
=== PAUSE TestAccAWSSagemakerNotebookInstance_LifecycleConfigName
=== RUN   TestAccAWSSagemakerNotebookInstance_tags
=== PAUSE TestAccAWSSagemakerNotebookInstance_tags
=== RUN   TestAccAWSSagemakerNotebookInstance_disappears
=== PAUSE TestAccAWSSagemakerNotebookInstance_disappears
=== CONT  TestAccAWSSagemakerNotebookInstanceLifecycleConfiguration_Basic
=== CONT  TestAccAWSSagemakerNotebookInstance_disappears
=== CONT  TestAccAWSSagemakerNotebookInstance_basic
=== CONT  TestAccAWSSagemakerNotebookInstance_update
=== CONT  TestAccAWSSagemakerNotebookInstance_tags
=== CONT  TestAccAWSSagemakerNotebookInstance_LifecycleConfigName
=== CONT  TestAccAWSSagemakerNotebookInstanceLifecycleConfiguration_Update
--- PASS: TestAccAWSSagemakerNotebookInstanceLifecycleConfiguration_Basic (26.17s)
--- PASS: TestAccAWSSagemakerNotebookInstanceLifecycleConfiguration_Update (44.28s)
--- PASS: TestAccAWSSagemakerNotebookInstance_basic (272.94s)
--- PASS: TestAccAWSSagemakerNotebookInstance_LifecycleConfigName (310.80s)
--- PASS: TestAccAWSSagemakerNotebookInstance_disappears (341.28s)
--- PASS: TestAccAWSSagemakerNotebookInstance_tags (369.65s)
--- PASS: TestAccAWSSagemakerNotebookInstance_update (568.52s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       569.662s
```