### PR TITLE
9775 launch config with instance store

### DIFF
--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -1402,7 +1402,7 @@ func fetchRootDeviceName(ami string, conn *ec2.EC2) (*string, error) {
 
 	// Instance store backed AMIs do not provide a root device name.
 	if *image.RootDeviceType == ec2.DeviceTypeInstanceStore {
-		return nil, fmt.Errorf("Instance store backed AMIs do not provide a root device name - Use an EBS AMI")
+		return nil, nil
 	}
 
 	// Some AMIs have a RootDeviceName like "/dev/sda1" that does not appear as a
@@ -1611,15 +1611,20 @@ func readBlockDeviceMappingsFromConfig(
 				log.Print("[WARN] IOPs is only valid for storate type io1 for EBS Volumes")
 			}
 
-			dn, err := fetchRootDeviceName(d.Get("ami").(string), conn)
-			if err != nil {
-				return nil, fmt.Errorf("Expected 1 AMI for ID: %s (%s)", d.Get("ami").(string), err)
-			}
+			if dn, err := fetchRootDeviceName(d.Get("ami").(string), conn); err == nil {
+				if dn == nil {
+					return nil, fmt.Errorf(
+						"Expected 1 AMI for ID: %s, got none",
+						d.Get("ami").(string))
+				}
 
-			blockDevices = append(blockDevices, &ec2.BlockDeviceMapping{
-				DeviceName: dn,
-				Ebs:        ebs,
-			})
+				blockDevices = append(blockDevices, &ec2.BlockDeviceMapping{
+					DeviceName: dn,
+					Ebs:        ebs,
+				})
+			} else {
+				return nil, err
+			}
 		}
 	}
 

--- a/aws/resource_aws_launch_configuration_test.go
+++ b/aws/resource_aws_launch_configuration_test.go
@@ -134,6 +134,25 @@ func TestAccAWSLaunchConfiguration_withBlockDevices(t *testing.T) {
 	})
 }
 
+func TestAccAWSLaunchConfiguration_withInstanceStoreAMI(t *testing.T) {
+	var conf autoscaling.LaunchConfiguration
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchConfigurationConfigWithInstanceStoreAMI(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.bar", &conf),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSLaunchConfiguration_updateRootBlockDevice(t *testing.T) {
 	var conf autoscaling.LaunchConfiguration
 	rInt := acctest.RandInt()
@@ -497,6 +516,35 @@ data "aws_ami" "ubuntu" {
   }
 }
 `)
+}
+
+func testAccAWSLaunchConfigurationConfig_instanceStoreAMI() string {
+	return fmt.Sprintf(`
+data "aws_ami" "ubuntu_instance_store" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+  # Latest Ubuntu 18.04 LTS amd64 instance-store HVM AMI
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-instance/ubuntu-bionic-18.04-amd64-server*"]
+  }
+}
+`)
+}
+
+func testAccAWSLaunchConfigurationConfigWithInstanceStoreAMI(rInt int) string {
+	return testAccAWSLaunchConfigurationConfig_instanceStoreAMI() + fmt.Sprintf(`
+resource "aws_launch_configuration" "bar" {
+  name_prefix = "tf-acc-test-%d"
+  image_id = "${data.aws_ami.ubuntu_instance_store.id}"
+
+	# When the instance type is updated, the new type must support ephemeral storage.
+  instance_type = "m1.small"
+  user_data = "foobar-user-data"
+  associate_public_ip_address = false
+}
+`, rInt)
 }
 
 func testAccAWSLaunchConfigurationConfigWithRootBlockDevice(rInt int) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9775

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* fix unintended breakage of aws_launch_config when combined with instance-store AMIs
```

Output from acceptance testing:

Two sections affected. 

`aws_launch_configuration`:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSLaunchConfiguration'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSLaunchConfiguration -timeout 120m
=== RUN   TestAccAWSLaunchConfigurationDataSource_basic
=== PAUSE TestAccAWSLaunchConfigurationDataSource_basic
=== RUN   TestAccAWSLaunchConfigurationDataSource_securityGroups
=== PAUSE TestAccAWSLaunchConfigurationDataSource_securityGroups
=== RUN   TestAccAWSLaunchConfiguration_importBasic
=== PAUSE TestAccAWSLaunchConfiguration_importBasic
=== RUN   TestAccAWSLaunchConfiguration_basic
=== PAUSE TestAccAWSLaunchConfiguration_basic
=== RUN   TestAccAWSLaunchConfiguration_withBlockDevices
=== PAUSE TestAccAWSLaunchConfiguration_withBlockDevices
=== RUN   TestAccAWSLaunchConfiguration_withInstanceStoreAMI
=== PAUSE TestAccAWSLaunchConfiguration_withInstanceStoreAMI
=== RUN   TestAccAWSLaunchConfiguration_updateRootBlockDevice
=== PAUSE TestAccAWSLaunchConfiguration_updateRootBlockDevice
=== RUN   TestAccAWSLaunchConfiguration_encryptedRootBlockDevice
=== PAUSE TestAccAWSLaunchConfiguration_encryptedRootBlockDevice
=== RUN   TestAccAWSLaunchConfiguration_withSpotPrice
=== PAUSE TestAccAWSLaunchConfiguration_withSpotPrice
=== RUN   TestAccAWSLaunchConfiguration_withVpcClassicLink
=== PAUSE TestAccAWSLaunchConfiguration_withVpcClassicLink
=== RUN   TestAccAWSLaunchConfiguration_withIAMProfile
=== PAUSE TestAccAWSLaunchConfiguration_withIAMProfile
=== RUN   TestAccAWSLaunchConfiguration_withEncryption
=== PAUSE TestAccAWSLaunchConfiguration_withEncryption
=== RUN   TestAccAWSLaunchConfiguration_updateEbsBlockDevices
=== PAUSE TestAccAWSLaunchConfiguration_updateEbsBlockDevices
=== RUN   TestAccAWSLaunchConfiguration_ebs_noDevice
=== PAUSE TestAccAWSLaunchConfiguration_ebs_noDevice
=== RUN   TestAccAWSLaunchConfiguration_userData
=== PAUSE TestAccAWSLaunchConfiguration_userData
=== CONT  TestAccAWSLaunchConfigurationDataSource_basic
=== CONT  TestAccAWSLaunchConfigurationDataSource_securityGroups
=== CONT  TestAccAWSLaunchConfiguration_withSpotPrice
=== CONT  TestAccAWSLaunchConfiguration_userData
=== CONT  TestAccAWSLaunchConfiguration_ebs_noDevice
=== CONT  TestAccAWSLaunchConfiguration_updateEbsBlockDevices
=== CONT  TestAccAWSLaunchConfiguration_withEncryption
=== CONT  TestAccAWSLaunchConfiguration_withIAMProfile
=== CONT  TestAccAWSLaunchConfiguration_encryptedRootBlockDevice
=== CONT  TestAccAWSLaunchConfiguration_updateRootBlockDevice
=== CONT  TestAccAWSLaunchConfiguration_withInstanceStoreAMI
=== CONT  TestAccAWSLaunchConfiguration_withBlockDevices
=== CONT  TestAccAWSLaunchConfiguration_basic
=== CONT  TestAccAWSLaunchConfiguration_importBasic
=== CONT  TestAccAWSLaunchConfiguration_withVpcClassicLink
--- PASS: TestAccAWSLaunchConfiguration_importBasic (33.94s)
--- PASS: TestAccAWSLaunchConfiguration_withSpotPrice (35.32s)
--- PASS: TestAccAWSLaunchConfiguration_withInstanceStoreAMI (35.36s)
--- PASS: TestAccAWSLaunchConfiguration_ebs_noDevice (37.86s)
--- PASS: TestAccAWSLaunchConfiguration_withEncryption (37.95s)
--- PASS: TestAccAWSLaunchConfiguration_withBlockDevices (38.67s)
--- PASS: TestAccAWSLaunchConfigurationDataSource_basic (39.52s)
--- PASS: TestAccAWSLaunchConfiguration_withIAMProfile (47.21s)
--- PASS: TestAccAWSLaunchConfiguration_basic (58.30s)
--- PASS: TestAccAWSLaunchConfiguration_userData (59.68s)
--- PASS: TestAccAWSLaunchConfiguration_updateRootBlockDevice (65.48s)
--- PASS: TestAccAWSLaunchConfiguration_encryptedRootBlockDevice (66.01s)
--- PASS: TestAccAWSLaunchConfiguration_updateEbsBlockDevices (67.17s)
--- PASS: TestAccAWSLaunchConfigurationDataSource_securityGroups (70.49s)
--- PASS: TestAccAWSLaunchConfiguration_withVpcClassicLink (75.17s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	77.472s
terraform-provider
...
```

The `aws_instance` tests are odd - no matter what I try, it keeps trying to make some of the test resources in `us-east-1`, which is not where the test AMIs are located.  I've set and exported `AWS_DEFAULT_REGION=us-west-2`, and set the region in the default aws configuration, etc... but no luck.

I suspect I'm running into some variation of what's described in https://github.com/terraform-providers/terraform-provider-aws/issues/8316 when running the `aws_instance` tests.  Running individually is working so far.  Will attach a full list of the individual tests run.