### PR TITLE
Add deletion_protection attribute for aws_docdb_cluster

### DIFF
--- a/aws/resource_aws_docdb_cluster.go
+++ b/aws/resource_aws_docdb_cluster.go
@@ -83,6 +83,11 @@ func resourceAwsDocDBCluster() *schema.Resource {
 				Computed: true,
 			},
 
+			"deletion_protection": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
 			"endpoint": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -275,6 +280,7 @@ func resourceAwsDocDBClusterCreate(d *schema.ResourceData, meta interface{}) err
 	if _, ok := d.GetOk("snapshot_identifier"); ok {
 		opts := docdb.RestoreDBClusterFromSnapshotInput{
 			DBClusterIdentifier: aws.String(identifier),
+			DeletionProtection:  aws.Bool(d.Get("deletion_protection").(bool)),
 			Engine:              aws.String(d.Get("engine").(string)),
 			SnapshotIdentifier:  aws.String(d.Get("snapshot_identifier").(string)),
 			Tags:                tags,
@@ -356,6 +362,7 @@ func resourceAwsDocDBClusterCreate(d *schema.ResourceData, meta interface{}) err
 
 		createOpts := &docdb.CreateDBClusterInput{
 			DBClusterIdentifier: aws.String(identifier),
+			DeletionProtection:  aws.Bool(d.Get("deletion_protection").(bool)),
 			Engine:              aws.String(d.Get("engine").(string)),
 			MasterUserPassword:  aws.String(d.Get("master_password").(string)),
 			MasterUsername:      aws.String(d.Get("master_username").(string)),
@@ -532,6 +539,7 @@ func resourceAwsDocDBClusterRead(d *schema.ResourceData, meta interface{}) error
 
 	d.Set("db_cluster_parameter_group_name", dbc.DBClusterParameterGroup)
 	d.Set("db_subnet_group_name", dbc.DBSubnetGroup)
+	d.Set("deletion_protection", dbc.DeletionProtection)
 
 	if err := d.Set("enabled_cloudwatch_logs_exports", aws.StringValueSlice(dbc.EnabledCloudwatchLogsExports)); err != nil {
 		return fmt.Errorf("error setting enabled_cloudwatch_logs_exports: %s", err)
@@ -612,6 +620,11 @@ func resourceAwsDocDBClusterUpdate(d *schema.ResourceData, meta interface{}) err
 	if d.HasChange("db_cluster_parameter_group_name") {
 		d.SetPartial("db_cluster_parameter_group_name")
 		req.DBClusterParameterGroupName = aws.String(d.Get("db_cluster_parameter_group_name").(string))
+		requestUpdate = true
+	}
+
+	if d.HasChange("deletion_protection") {
+		req.DeletionProtection = aws.Bool(d.Get("deletion_protection").(bool))
 		requestUpdate = true
 	}
 

--- a/website/docs/r/docdb_cluster.html.markdown
+++ b/website/docs/r/docdb_cluster.html.markdown
@@ -51,6 +51,7 @@ The following arguments are supported:
 * `cluster_identifier` - (Optional, Forces new resources) The cluster identifier. If omitted, Terraform will assign a random, unique identifier.
 * `db_subnet_group_name` - (Optional) A DB subnet group to associate with this DB instance.
 * `db_cluster_parameter_group_name` - (Optional) A cluster parameter group to associate with the cluster.
+* `deletion_protection` - (Optional) If the DB cluster should have deletion protection enabled. The cluster can't be deleted when this value is set to `true`. The default is `false`.
 * `enabled_cloudwatch_logs_exports` - (Optional) List of log types to export to cloudwatch. If omitted, no logs will be exported.
    The following log types are supported: `audit`.
 * `engine_version` - (Optional) The database engine version. Updating this argument results in an outage.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9723

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_docdb_cluster: Add `deletion_protection` attribute
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDocDBCluster_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSDocDBCluster_ -timeout 120m
=== RUN   TestAccAWSDocDBCluster_basic
=== PAUSE TestAccAWSDocDBCluster_basic
=== RUN   TestAccAWSDocDBCluster_namePrefix
=== PAUSE TestAccAWSDocDBCluster_namePrefix
=== RUN   TestAccAWSDocDBCluster_generatedName
=== PAUSE TestAccAWSDocDBCluster_generatedName
=== RUN   TestAccAWSDocDBCluster_takeFinalSnapshot
=== PAUSE TestAccAWSDocDBCluster_takeFinalSnapshot
=== RUN   TestAccAWSDocDBCluster_DeletionProtection
=== PAUSE TestAccAWSDocDBCluster_DeletionProtection
=== RUN   TestAccAWSDocDBCluster_missingUserNameCausesError
=== PAUSE TestAccAWSDocDBCluster_missingUserNameCausesError
=== RUN   TestAccAWSDocDBCluster_updateTags
=== PAUSE TestAccAWSDocDBCluster_updateTags
=== RUN   TestAccAWSDocDBCluster_updateCloudwatchLogsExports
=== PAUSE TestAccAWSDocDBCluster_updateCloudwatchLogsExports
=== RUN   TestAccAWSDocDBCluster_kmsKey
=== PAUSE TestAccAWSDocDBCluster_kmsKey
=== RUN   TestAccAWSDocDBCluster_encrypted
=== PAUSE TestAccAWSDocDBCluster_encrypted
=== RUN   TestAccAWSDocDBCluster_backupsUpdate
=== PAUSE TestAccAWSDocDBCluster_backupsUpdate
=== RUN   TestAccAWSDocDBCluster_Port
=== PAUSE TestAccAWSDocDBCluster_Port
=== CONT  TestAccAWSDocDBCluster_basic
=== CONT  TestAccAWSDocDBCluster_Port
=== CONT  TestAccAWSDocDBCluster_missingUserNameCausesError
=== CONT  TestAccAWSDocDBCluster_DeletionProtection
=== CONT  TestAccAWSDocDBCluster_takeFinalSnapshot
=== CONT  TestAccAWSDocDBCluster_generatedName
=== CONT  TestAccAWSDocDBCluster_namePrefix
=== CONT  TestAccAWSDocDBCluster_encrypted
=== CONT  TestAccAWSDocDBCluster_backupsUpdate
=== CONT  TestAccAWSDocDBCluster_kmsKey
=== CONT  TestAccAWSDocDBCluster_updateCloudwatchLogsExports
=== CONT  TestAccAWSDocDBCluster_updateTags
--- PASS: TestAccAWSDocDBCluster_missingUserNameCausesError (22.93s)
--- PASS: TestAccAWSDocDBCluster_generatedName (138.24s)
--- PASS: TestAccAWSDocDBCluster_basic (138.79s)
--- PASS: TestAccAWSDocDBCluster_namePrefix (169.57s)
--- PASS: TestAccAWSDocDBCluster_encrypted (169.59s)
--- PASS: TestAccAWSDocDBCluster_updateCloudwatchLogsExports (196.19s)
--- PASS: TestAccAWSDocDBCluster_updateTags (198.59s)
--- PASS: TestAccAWSDocDBCluster_backupsUpdate (201.55s)
--- PASS: TestAccAWSDocDBCluster_takeFinalSnapshot (202.77s)
--- PASS: TestAccAWSDocDBCluster_kmsKey (214.53s)
--- PASS: TestAccAWSDocDBCluster_DeletionProtection (221.19s)
--- PASS: TestAccAWSDocDBCluster_Port (285.84s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	285.965s
```
