### PR TITLE
Security group retries

### DIFF
--- a/aws/resource_aws_security_group.go
+++ b/aws/resource_aws_security_group.go
@@ -458,31 +458,34 @@ func resourceAwsSecurityGroupDelete(d *schema.ResourceData, meta interface{}) er
 			return err
 		}
 	}
-
-	return resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
-		_, err := conn.DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{
-			GroupId: aws.String(d.Id()),
-		})
+	input := &ec2.DeleteSecurityGroupInput{
+		GroupId: aws.String(d.Id()),
+	}
+	err := resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		_, err := conn.DeleteSecurityGroup(input)
 		if err != nil {
-			ec2err, ok := err.(awserr.Error)
-			if !ok {
-				return resource.RetryableError(err)
-			}
-
-			switch ec2err.Code() {
-			case "InvalidGroup.NotFound":
+			if isAWSErr(err, "InvalidGroup.NotFound", "") {
 				return nil
-			case "DependencyViolation":
+			}
+			if isAWSErr(err, "DependencyViolation", "") {
 				// If it is a dependency violation, we want to retry
 				return resource.RetryableError(err)
-			default:
-				// Any other error, we want to quit the retry loop immediately
-				return resource.NonRetryableError(err)
 			}
+			return resource.NonRetryableError(err)
 		}
 
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.DeleteSecurityGroup(input)
+		if err != nil && isAWSErr(err, "InvalidGroup.NotFound", "") {
+			return nil
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("Error deleting security group: %s", err)
+	}
+	return nil
 }
 
 // Revoke all ingress/egress rules that a Security Group has

--- a/aws/resource_aws_security_group.go
+++ b/aws/resource_aws_security_group.go
@@ -482,7 +482,7 @@ func resourceAwsSecurityGroupDelete(d *schema.ResourceData, meta interface{}) er
 	})
 	if isResourceTimeoutError(err) {
 		_, err = conn.DeleteSecurityGroup(input)
-		if err != nil && isAWSErr(err, "InvalidGroup.NotFound", "") {
+		if isAWSErr(err, "InvalidGroup.NotFound", "") {
 			return nil
 		}
 	}

--- a/aws/resource_aws_security_group.go
+++ b/aws/resource_aws_security_group.go
@@ -471,7 +471,11 @@ func resourceAwsSecurityGroupDelete(d *schema.ResourceData, meta interface{}) er
 				// If it is a dependency violation, we want to retry
 				return resource.RetryableError(err)
 			}
-			return resource.NonRetryableError(err)
+			if err != nil {
+				resource.NonRetryableError(err)
+			}
+
+			return nil
 		}
 
 		return nil

--- a/aws/resource_aws_security_group.go
+++ b/aws/resource_aws_security_group.go
@@ -471,13 +471,8 @@ func resourceAwsSecurityGroupDelete(d *schema.ResourceData, meta interface{}) er
 				// If it is a dependency violation, we want to retry
 				return resource.RetryableError(err)
 			}
-			if err != nil {
-				resource.NonRetryableError(err)
-			}
-
-			return nil
+			resource.NonRetryableError(err)
 		}
-
 		return nil
 	})
 	if isResourceTimeoutError(err) {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_security_group: Final retry after timeout deleting security group
* resource/aws_security_group_rule: Final retry after timeout creating security group rule
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSSecurityGroup'

--- PASS: TestAccAWSSecurityGroup_namePrefix (18.49s)
--- PASS: TestAccAWSSecurityGroup_basic (24.95s)
--- PASS: TestAccAWSSecurityGroup_vpc (28.56s)
--- PASS: TestAccAWSSecurityGroup_self (31.39s)
--- PASS: TestAccAWSSecurityGroup_vpcProtoNumIngress (33.24s)
--- PASS: TestAccAWSSecurityGroup_importIpv6 (33.53s)
--- PASS: TestAccAWSSecurityGroup_MultiIngress (34.07s)
--- SKIP: TestAccAWSSecurityGroup_DefaultEgress_Classic (1.27s)
--- PASS: TestAccAWSSecurityGroup_invalidCIDRBlock (1.54s)
--- PASS: TestAccAWSSecurityGroup_ipv6 (41.63s)
--- PASS: TestAccAWSSecurityGroup_vpcNegOneIngress (43.93s)
--- PASS: TestAccAWSSecurityGroup_importSelf (49.10s)
--- SKIP: TestAccAWSSecurityGroup_ingressWithCidrAndSGs_classic (1.08s)
--- PASS: TestAccAWSSecurityGroup_generatedName (21.67s)
--- PASS: TestAccAWSSecurityGroup_DefaultEgress_VPC (18.96s)
--- PASS: TestAccAWSSecurityGroup_importIPRangesWithSameRules (50.93s)
--- PASS: TestAccAWSSecurityGroup_importSourceSecurityGroup (54.09s)
--- PASS: TestAccAWSSecurityGroup_ruleGathering (56.87s)
--- PASS: TestAccAWSSecurityGroup_importBasic (57.19s)
--- PASS: TestAccAWSSecurityGroup_drift (26.57s)
--- PASS: TestAccAWSSecurityGroup_importPrefixList (71.47s)
--- PASS: TestAccAWSSecurityGroup_ipv4andipv6Egress (26.60s)
--- PASS: TestAccAWSSecurityGroup_drift_complex (48.79s)
--- PASS: TestAccAWSSecurityGroup_ingressWithPrefixList (33.52s)
--- PASS: TestAccAWSSecurityGroup_Change (68.55s)
--- PASS: TestAccAWSSecurityGroup_importIPRangeAndSecurityGroupWithSameRules (87.63s)
--- PASS: TestAccAWSSecurityGroup_Egress_ConfigMode (89.60s)
--- PASS: TestAccAWSSecurityGroup_egressWithPrefixList (42.79s)
--- PASS: TestAccAWSSecurityGroup_ruleLimitCidrBlockExceededAppend (39.49s)
--- PASS: TestAccAWSSecurityGroup_Ingress_ConfigMode (97.10s)
--- PASS: TestAccAWSSecurityGroup_ruleLimitExceededAppend (50.16s)
--- PASS: TestAccAWSSecurityGroup_rulesDropOnError (32.88s)
--- PASS: TestAccAWSSecurityGroup_failWithDiffMismatch (55.87s)
--- PASS: TestAccAWSSecurityGroup_ingressWithCidrAndSGs (64.23s)
--- PASS: TestAccAWSSecurityGroup_ruleLimitExceededPrepend (52.41s)
--- PASS: TestAccAWSSecurityGroup_CIDRandGroups (68.15s)
--- PASS: TestAccAWSSecurityGroup_RuleDescription (85.12s)
--- PASS: TestAccAWSSecurityGroup_tags (74.72s)
--- PASS: TestAccAWSSecurityGroup_ruleLimitExceededAllNew (61.32s)
--- PASS: TestAccAWSSecurityGroup_forceRevokeRules_false (1251.66s)
--- PASS: TestAccAWSSecurityGroup_forceRevokeRules_true (1310.60s)


make testacc TESTARGS="-run=TestAccAWSSecurityGroupRule"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSSecurityGroupRule -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSSecurityGroupRule_Ingress_VPC
=== PAUSE TestAccAWSSecurityGroupRule_Ingress_VPC
=== RUN   TestAccAWSSecurityGroupRule_Ingress_Protocol
=== PAUSE TestAccAWSSecurityGroupRule_Ingress_Protocol
=== RUN   TestAccAWSSecurityGroupRule_Ingress_Ipv6
=== PAUSE TestAccAWSSecurityGroupRule_Ingress_Ipv6
=== RUN   TestAccAWSSecurityGroupRule_Ingress_Classic
=== PAUSE TestAccAWSSecurityGroupRule_Ingress_Classic
=== RUN   TestAccAWSSecurityGroupRule_MultiIngress
=== PAUSE TestAccAWSSecurityGroupRule_MultiIngress
=== RUN   TestAccAWSSecurityGroupRule_Egress
=== PAUSE TestAccAWSSecurityGroupRule_Egress
=== RUN   TestAccAWSSecurityGroupRule_SelfReference
=== PAUSE TestAccAWSSecurityGroupRule_SelfReference
=== RUN   TestAccAWSSecurityGroupRule_ExpectInvalidTypeError
=== PAUSE TestAccAWSSecurityGroupRule_ExpectInvalidTypeError
=== RUN   TestAccAWSSecurityGroupRule_ExpectInvalidCIDR
=== PAUSE TestAccAWSSecurityGroupRule_ExpectInvalidCIDR
=== RUN   TestAccAWSSecurityGroupRule_PartialMatching_basic
=== PAUSE TestAccAWSSecurityGroupRule_PartialMatching_basic
=== RUN   TestAccAWSSecurityGroupRule_PartialMatching_Source
=== PAUSE TestAccAWSSecurityGroupRule_PartialMatching_Source
=== RUN   TestAccAWSSecurityGroupRule_Issue5310
=== PAUSE TestAccAWSSecurityGroupRule_Issue5310
=== RUN   TestAccAWSSecurityGroupRule_Race
=== PAUSE TestAccAWSSecurityGroupRule_Race
=== RUN   TestAccAWSSecurityGroupRule_SelfSource
=== PAUSE TestAccAWSSecurityGroupRule_SelfSource
=== RUN   TestAccAWSSecurityGroupRule_PrefixListEgress
=== PAUSE TestAccAWSSecurityGroupRule_PrefixListEgress
=== RUN   TestAccAWSSecurityGroupRule_IngressDescription
=== PAUSE TestAccAWSSecurityGroupRule_IngressDescription
=== RUN   TestAccAWSSecurityGroupRule_EgressDescription
=== PAUSE TestAccAWSSecurityGroupRule_EgressDescription
=== RUN   TestAccAWSSecurityGroupRule_IngressDescription_updates
=== PAUSE TestAccAWSSecurityGroupRule_IngressDescription_updates
=== RUN   TestAccAWSSecurityGroupRule_EgressDescription_updates
=== PAUSE TestAccAWSSecurityGroupRule_EgressDescription_updates
=== RUN   TestAccAWSSecurityGroupRule_Description_AllPorts
=== PAUSE TestAccAWSSecurityGroupRule_Description_AllPorts
=== RUN   TestAccAWSSecurityGroupRule_Description_AllPorts_NonZeroPorts
=== PAUSE TestAccAWSSecurityGroupRule_Description_AllPorts_NonZeroPorts
=== RUN   TestAccAWSSecurityGroupRule_MultipleRuleSearching_AllProtocolCrash
=== PAUSE TestAccAWSSecurityGroupRule_MultipleRuleSearching_AllProtocolCrash
=== RUN   TestAccAWSSecurityGroupRule_MultiDescription
=== PAUSE TestAccAWSSecurityGroupRule_MultiDescription
=== CONT  TestAccAWSSecurityGroupRule_Ingress_VPC
=== CONT  TestAccAWSSecurityGroupRule_MultiDescription
=== CONT  TestAccAWSSecurityGroupRule_PartialMatching_Source
=== CONT  TestAccAWSSecurityGroupRule_Issue5310
=== CONT  TestAccAWSSecurityGroupRule_MultipleRuleSearching_AllProtocolCrash
=== CONT  TestAccAWSSecurityGroupRule_Description_AllPorts_NonZeroPorts
=== CONT  TestAccAWSSecurityGroupRule_Description_AllPorts
=== CONT  TestAccAWSSecurityGroupRule_EgressDescription_updates
=== CONT  TestAccAWSSecurityGroupRule_IngressDescription_updates
=== CONT  TestAccAWSSecurityGroupRule_EgressDescription
=== CONT  TestAccAWSSecurityGroupRule_IngressDescription
=== CONT  TestAccAWSSecurityGroupRule_PrefixListEgress
=== CONT  TestAccAWSSecurityGroupRule_Race
=== CONT  TestAccAWSSecurityGroupRule_Ingress_Classic
=== CONT  TestAccAWSSecurityGroupRule_Egress
=== CONT  TestAccAWSSecurityGroupRule_SelfReference
=== CONT  TestAccAWSSecurityGroupRule_SelfSource
=== CONT  TestAccAWSSecurityGroupRule_Ingress_Ipv6
=== CONT  TestAccAWSSecurityGroupRule_MultiIngress
=== CONT  TestAccAWSSecurityGroupRule_ExpectInvalidTypeError
--- PASS: TestAccAWSSecurityGroupRule_ExpectInvalidTypeError (3.70s)
=== CONT  TestAccAWSSecurityGroupRule_Ingress_Protocol
--- PASS: TestAccAWSSecurityGroupRule_Issue5310 (37.19s)
=== CONT  TestAccAWSSecurityGroupRule_PartialMatching_basic
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Classic (38.19s)
=== CONT  TestAccAWSSecurityGroupRule_ExpectInvalidCIDR
--- PASS: TestAccAWSSecurityGroupRule_Egress (38.24s)
--- PASS: TestAccAWSSecurityGroupRule_Ingress_VPC (38.25s)
--- PASS: TestAccAWSSecurityGroupRule_EgressDescription (38.31s)
--- PASS: TestAccAWSSecurityGroupRule_IngressDescription (38.31s)
--- PASS: TestAccAWSSecurityGroupRule_MultipleRuleSearching_AllProtocolCrash (39.20s)
--- PASS: TestAccAWSSecurityGroupRule_ExpectInvalidCIDR (2.28s)
--- PASS: TestAccAWSSecurityGroupRule_MultiIngress (43.16s)
--- PASS: TestAccAWSSecurityGroupRule_EgressDescription_updates (57.82s)
--- PASS: TestAccAWSSecurityGroupRule_IngressDescription_updates (58.07s)
--- PASS: TestAccAWSSecurityGroupRule_Description_AllPorts (58.70s)
--- PASS: TestAccAWSSecurityGroupRule_Description_AllPorts_NonZeroPorts (60.09s)
--- PASS: TestAccAWSSecurityGroupRule_SelfReference (63.41s)
--- PASS: TestAccAWSSecurityGroupRule_SelfSource (63.56s)
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Ipv6 (65.61s)
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Protocol (63.94s)
--- PASS: TestAccAWSSecurityGroupRule_PartialMatching_Source (70.40s)
--- PASS: TestAccAWSSecurityGroupRule_PrefixListEgress (80.94s)
--- PASS: TestAccAWSSecurityGroupRule_PartialMatching_basic (73.33s)
--- PASS: TestAccAWSSecurityGroupRule_MultiDescription (147.77s)
--- PASS: TestAccAWSSecurityGroupRule_Race (476.28s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       477.371s
```