### PR TITLE
Final retries for SQS resources

### DIFF
--- a/aws/resource_aws_sqs_queue.go
+++ b/aws/resource_aws_sqs_queue.go
@@ -206,6 +206,9 @@ func resourceAwsSqsQueueCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		output, err = sqsconn.CreateQueue(req)
+	}
 	if err != nil {
 		return fmt.Errorf("Error creating SQS queue: %s", err)
 	}

--- a/aws/resource_aws_sqs_queue_policy.go
+++ b/aws/resource_aws_sqs_queue_policy.go
@@ -101,7 +101,7 @@ func resourceAwsSqsQueuePolicyUpsert(d *schema.ResourceData, meta interface{}) e
 			var equivalent bool
 			equivalent, err = awspolicy.PoliciesAreEquivalent(*queuePolicy, policy)
 			if !equivalent {
-				return fmt.Errorf("SQS attribute not updated")
+				return notUpdatedError
 			}
 		}
 	}

--- a/aws/resource_aws_sqs_queue_policy.go
+++ b/aws/resource_aws_sqs_queue_policy.go
@@ -67,9 +67,11 @@ func resourceAwsSqsQueuePolicyUpsert(d *schema.ResourceData, meta interface{}) e
 		AttributeNames: []*string{aws.String(sqs.QueueAttributeNamePolicy)},
 	}
 	notUpdatedError := fmt.Errorf("SQS attribute %s not updated", sqs.QueueAttributeNamePolicy)
+	var out *sqs.GetQueueAttributesOutput
 	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
 		log.Printf("[DEBUG] Reading SQS attributes: %s", gqaInput)
-		out, err := conn.GetQueueAttributes(gqaInput)
+		var err error
+		out, err = conn.GetQueueAttributes(gqaInput)
 		if err != nil {
 			return resource.NonRetryableError(err)
 		}
@@ -88,8 +90,23 @@ func resourceAwsSqsQueuePolicyUpsert(d *schema.ResourceData, meta interface{}) e
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		out, err = conn.GetQueueAttributes(gqaInput)
+		if err == nil {
+			queuePolicy, ok := out.Attributes[sqs.QueueAttributeNamePolicy]
+			if !ok {
+				return fmt.Errorf("SQS queue attribute not found")
+			}
+
+			var equivalent bool
+			equivalent, err = awspolicy.PoliciesAreEquivalent(*queuePolicy, policy)
+			if !equivalent {
+				return fmt.Errorf("SQS attribute not updated")
+			}
+		}
+	}
 	if err != nil {
-		return err
+		return fmt.Errorf("Error updating SQS queue attributes: %s", err)
 	}
 
 	d.SetId(url)

--- a/aws/resource_aws_sqs_queue_policy.go
+++ b/aws/resource_aws_sqs_queue_policy.go
@@ -95,7 +95,7 @@ func resourceAwsSqsQueuePolicyUpsert(d *schema.ResourceData, meta interface{}) e
 		if err == nil {
 			queuePolicy, ok := out.Attributes[sqs.QueueAttributeNamePolicy]
 			if !ok {
-				return fmt.Errorf("SQS queue attribute not found")
+				return notUpdatedError
 			}
 
 			var equivalent bool


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES
* resource/aws_sqs_queue: Final retry after timeout creating queue
* resource/aws_sqs_queue_policy: Final retru after timeout updating queue policy

```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSSQSQueue"      
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSSQSQueue -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSSQSQueuePolicy_basic
=== PAUSE TestAccAWSSQSQueuePolicy_basic
=== RUN   TestAccAWSSQSQueuePolicy_import
=== PAUSE TestAccAWSSQSQueuePolicy_import
=== RUN   TestAccAWSSQSQueue_basic
=== PAUSE TestAccAWSSQSQueue_basic
=== RUN   TestAccAWSSQSQueue_tags
=== PAUSE TestAccAWSSQSQueue_tags
=== RUN   TestAccAWSSQSQueue_namePrefix
=== PAUSE TestAccAWSSQSQueue_namePrefix
=== RUN   TestAccAWSSQSQueue_namePrefix_fifo
=== PAUSE TestAccAWSSQSQueue_namePrefix_fifo
=== RUN   TestAccAWSSQSQueue_policy
=== PAUSE TestAccAWSSQSQueue_policy
=== RUN   TestAccAWSSQSQueue_queueDeletedRecently
=== PAUSE TestAccAWSSQSQueue_queueDeletedRecently
=== RUN   TestAccAWSSQSQueue_redrivePolicy
=== PAUSE TestAccAWSSQSQueue_redrivePolicy
=== RUN   TestAccAWSSQSQueue_Policybasic
=== PAUSE TestAccAWSSQSQueue_Policybasic
=== RUN   TestAccAWSSQSQueue_FIFO
=== PAUSE TestAccAWSSQSQueue_FIFO
=== RUN   TestAccAWSSQSQueue_FIFOExpectNameError
=== PAUSE TestAccAWSSQSQueue_FIFOExpectNameError
=== RUN   TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication
=== PAUSE TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication
=== RUN   TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError
=== PAUSE TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError
=== RUN   TestAccAWSSQSQueue_Encryption
=== PAUSE TestAccAWSSQSQueue_Encryption
=== CONT  TestAccAWSSQSQueuePolicy_basic
=== CONT  TestAccAWSSQSQueue_queueDeletedRecently
=== CONT  TestAccAWSSQSQueue_namePrefix
=== CONT  TestAccAWSSQSQueue_redrivePolicy
=== CONT  TestAccAWSSQSQueue_FIFOExpectNameError
=== CONT  TestAccAWSSQSQueue_FIFO
=== CONT  TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication
=== CONT  TestAccAWSSQSQueue_Encryption
=== CONT  TestAccAWSSQSQueue_Policybasic
=== CONT  TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError
=== CONT  TestAccAWSSQSQueue_policy
=== CONT  TestAccAWSSQSQueue_basic
=== CONT  TestAccAWSSQSQueue_namePrefix_fifo
=== CONT  TestAccAWSSQSQueue_tags
=== CONT  TestAccAWSSQSQueuePolicy_import
--- PASS: TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError (10.58s)
--- PASS: TestAccAWSSQSQueue_FIFOExpectNameError (10.64s)
--- PASS: TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication (31.60s)
--- PASS: TestAccAWSSQSQueue_namePrefix (31.67s)
--- PASS: TestAccAWSSQSQueue_namePrefix_fifo (31.83s)
--- PASS: TestAccAWSSQSQueue_FIFO (31.91s)
--- PASS: TestAccAWSSQSQueue_Encryption (31.99s)
--- PASS: TestAccAWSSQSQueuePolicy_basic (32.78s)
--- PASS: TestAccAWSSQSQueuePolicy_import (34.55s)
--- PASS: TestAccAWSSQSQueue_redrivePolicy (39.56s)
--- PASS: TestAccAWSSQSQueue_policy (41.75s)
--- PASS: TestAccAWSSQSQueue_Policybasic (42.96s)
--- PASS: TestAccAWSSQSQueue_basic (69.02s)
--- PASS: TestAccAWSSQSQueue_tags (72.06s)
--- PASS: TestAccAWSSQSQueue_queueDeletedRecently (111.28s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       112.552s

make testacc TESTARGS="-run=TestAccAWSSQSQueuePolicy"       
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSSQSQueuePolicy -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSSQSQueuePolicy_basic
=== PAUSE TestAccAWSSQSQueuePolicy_basic
=== RUN   TestAccAWSSQSQueuePolicy_import
=== PAUSE TestAccAWSSQSQueuePolicy_import
=== CONT  TestAccAWSSQSQueuePolicy_basic
=== CONT  TestAccAWSSQSQueuePolicy_import
--- PASS: TestAccAWSSQSQueuePolicy_basic (31.57s)
--- PASS: TestAccAWSSQSQueuePolicy_import (33.63s)
```