### PR TITLE
Final retry for transfer server

### DIFF
--- a/aws/resource_aws_transfer_server.go
+++ b/aws/resource_aws_transfer_server.go
@@ -292,7 +292,7 @@ func waitForTransferServerDeletion(conn *transfer.Transfer, serverID string) err
 		ServerId: aws.String(serverID),
 	}
 
-	return resource.Retry(10*time.Minute, func() *resource.RetryError {
+	err := resource.Retry(10*time.Minute, func() *resource.RetryError {
 		_, err := conn.DescribeServer(params)
 
 		if isAWSErr(err, transfer.ErrCodeResourceNotFoundException, "") {
@@ -305,6 +305,19 @@ func waitForTransferServerDeletion(conn *transfer.Transfer, serverID string) err
 
 		return resource.RetryableError(fmt.Errorf("Transfer Server (%s) still exists", serverID))
 	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.DescribeServer(params)
+		if isAWSErr(err, transfer.ErrCodeResourceNotFoundException, "") {
+			return nil
+		}
+		if err == nil {
+			return fmt.Errorf("Transfer server (%s) still exists", serverID)
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("Error waiting for transfer server deletion: %s", err)
+	}
+	return nil
 }
 
 func deleteTransferUsers(conn *transfer.Transfer, serverID string, nextToken *string) error {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES
* resource/aws_transfer_server: Final retry after timeout waiting for transfer server deletion
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSTransferServer"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSTransferServer -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSTransferServer_basic
=== PAUSE TestAccAWSTransferServer_basic
=== RUN   TestAccAWSTransferServer_apigateway
=== PAUSE TestAccAWSTransferServer_apigateway
=== RUN   TestAccAWSTransferServer_disappears
=== PAUSE TestAccAWSTransferServer_disappears
=== RUN   TestAccAWSTransferServer_forcedestroy
=== PAUSE TestAccAWSTransferServer_forcedestroy
=== RUN   TestAccAWSTransferServer_vpcEndpointId
=== PAUSE TestAccAWSTransferServer_vpcEndpointId
=== CONT  TestAccAWSTransferServer_basic
=== CONT  TestAccAWSTransferServer_vpcEndpointId
=== CONT  TestAccAWSTransferServer_apigateway
=== CONT  TestAccAWSTransferServer_disappears
=== CONT  TestAccAWSTransferServer_forcedestroy
--- PASS: TestAccAWSTransferServer_disappears (21.82s)
--- PASS: TestAccAWSTransferServer_forcedestroy (32.08s)
--- PASS: TestAccAWSTransferServer_apigateway (43.80s)
--- PASS: TestAccAWSTransferServer_basic (50.60s)
--- PASS: TestAccAWSTransferServer_vpcEndpointId (128.33s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       129.460s
...
```