### PR TITLE
Retries and retry removal for opsworks resources

### DIFF
--- a/aws/resource_aws_opsworks_rds_db_instance.go
+++ b/aws/resource_aws_opsworks_rds_db_instance.go
@@ -3,12 +3,9 @@ package aws
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/opsworks"
-	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -68,23 +65,10 @@ func resourceAwsOpsworksRdsDbInstanceUpdate(d *schema.ResourceData, meta interfa
 	if requestUpdate {
 		log.Printf("[DEBUG] Opsworks RDS DB Instance Modification request: %s", req)
 
-		err := resource.Retry(2*time.Minute, func() *resource.RetryError {
-			var cerr error
-			_, cerr = client.UpdateRdsDbInstance(req)
-			if cerr != nil {
-				log.Printf("[INFO] client error")
-				if opserr, ok := cerr.(awserr.Error); ok {
-					log.Printf("[ERROR] OpsWorks error: %s message: %s", opserr.Code(), opserr.Message())
-				}
-				return resource.NonRetryableError(cerr)
-			}
-			return nil
-		})
-
+		_, err := client.UpdateRdsDbInstance(req)
 		if err != nil {
-			return err
+			return fmt.Errorf("Error updating Opsworks RDS DB instance: %s", err)
 		}
-
 	}
 
 	d.Partial(false)
@@ -101,27 +85,17 @@ func resourceAwsOpsworksRdsDbInstanceDeregister(d *schema.ResourceData, meta int
 
 	log.Printf("[DEBUG] Unregistering rds db instance '%s' from stack: %s", d.Get("rds_db_instance_arn"), d.Get("stack_id"))
 
-	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
-		var cerr error
-		_, cerr = client.DeregisterRdsDbInstance(req)
-		if cerr != nil {
-			log.Printf("[INFO] client error")
-			if opserr, ok := cerr.(awserr.Error); ok {
-				if opserr.Code() == "ResourceNotFoundException" {
-					log.Printf("[INFO] The db instance could not be found. Remove it from state.")
-					d.SetId("")
-
-					return nil
-				}
-				log.Printf("[ERROR] OpsWorks error: %s message: %s", opserr.Code(), opserr.Message())
-			}
-			return resource.NonRetryableError(cerr)
+	_, err := client.DeregisterRdsDbInstance(req)
+	if err != nil {
+		if isAWSErr(err, "ResourceNotFoundException", "") {
+			log.Printf("[INFO] The db instance could not be found. Remove it from state.")
+			d.SetId("")
+			return nil
 		}
+		return fmt.Errorf("Error deregistering Opsworks RDS DB instance: %s", err)
+	}
 
-		return nil
-	})
-
-	return err
+	return nil
 }
 
 func resourceAwsOpsworksRdsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
@@ -171,22 +145,9 @@ func resourceAwsOpsworksRdsDbInstanceRegister(d *schema.ResourceData, meta inter
 		DbPassword:       aws.String(d.Get("db_password").(string)),
 	}
 
-	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
-		var cerr error
-		_, cerr = client.RegisterRdsDbInstance(req)
-		if cerr != nil {
-			log.Printf("[INFO] client error")
-			if opserr, ok := cerr.(awserr.Error); ok {
-				log.Printf("[ERROR] OpsWorks error: %s message: %s", opserr.Code(), opserr.Message())
-			}
-			return resource.NonRetryableError(cerr)
-		}
-
-		return nil
-	})
-
+	_, err := client.RegisterRdsDbInstance(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("Error registering Opsworks RDS DB instance: %s", err)
 	}
 
 	return resourceAwsOpsworksRdsDbInstanceRead(d, meta)

--- a/aws/resource_aws_opsworks_stack.go
+++ b/aws/resource_aws_opsworks_stack.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -436,33 +435,31 @@ func resourceAwsOpsworksStackCreate(d *schema.ResourceData, meta interface{}) er
 
 	var resp *opsworks.CreateStackOutput
 	err = resource.Retry(20*time.Minute, func() *resource.RetryError {
-		var cerr error
-		resp, cerr = client.CreateStack(req)
-		if cerr != nil {
-			if opserr, ok := cerr.(awserr.Error); ok {
-				// If Terraform is also managing the service IAM role,
-				// it may have just been created and not yet be
-				// propagated.
-				// AWS doesn't provide a machine-readable code for this
-				// specific error, so we're forced to do fragile message
-				// matching.
-				// The full error we're looking for looks something like
-				// the following:
-				// Service Role Arn: [...] is not yet propagated, please try again in a couple of minutes
-				propErr := "not yet propagated"
-				trustErr := "not the necessary trust relationship"
-				validateErr := "validate IAM role permission"
-				if opserr.Code() == "ValidationException" && (strings.Contains(opserr.Message(), trustErr) || strings.Contains(opserr.Message(), propErr) || strings.Contains(opserr.Message(), validateErr)) {
-					log.Printf("[INFO] Waiting for service IAM role to propagate")
-					return resource.RetryableError(cerr)
-				}
+		resp, err = client.CreateStack(req)
+		if err != nil {
+			// If Terraform is also managing the service IAM role, it may have just been created and not yet be
+			// propagated. AWS doesn't provide a machine-readable code for this specific error, so we're forced
+			// to do fragile message matching.
+			// The full error we're looking for looks something like the following:
+			// Service Role Arn: [...] is not yet propagated, please try again in a couple of minutes
+			propErr := "not yet propagated"
+			trustErr := "not the necessary trust relationship"
+			validateErr := "validate IAM role permission"
+
+			if isAWSErr(err, "ValidationException", propErr) || isAWSErr(err, "ValidationException", trustErr) || isAWSErr(err, "ValidationException", validateErr) {
+				log.Printf("[INFO] Waiting for service IAM role to propagate")
+				return resource.RetryableError(err)
 			}
-			return resource.NonRetryableError(cerr)
+
+			return resource.NonRetryableError(err)
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		resp, err = client.CreateStack(req)
+	}
 	if err != nil {
-		return err
+		return fmt.Errorf("Error creating Opsworks stack: %s", err)
 	}
 
 	stackId := *resp.StackId

--- a/aws/resource_aws_opsworks_stack_test.go
+++ b/aws/resource_aws_opsworks_stack_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/opsworks"
 )
 
-func TestAccAWSOpsworksStackImportBasic(t *testing.T) {
+func TestAccAWSOpsworksStack_ImportBasic(t *testing.T) {
 	name := acctest.RandString(10)
 
 	resourceName := "aws_opsworks_stack.tf-acc"
@@ -40,7 +40,7 @@ func TestAccAWSOpsworksStackImportBasic(t *testing.T) {
 //// Tests for the No-VPC case
 ///////////////////////////////
 
-func TestAccAWSOpsworksStackNoVpc(t *testing.T) {
+func TestAccAWSOpsworksStack_NoVpc(t *testing.T) {
 	stackName := fmt.Sprintf("tf-opsworks-acc-%d", acctest.RandInt())
 	var opsstack opsworks.Stack
 	resource.ParallelTest(t, resource.TestCase{
@@ -63,7 +63,7 @@ func TestAccAWSOpsworksStackNoVpc(t *testing.T) {
 	})
 }
 
-func TestAccAWSOpsworksStackNoVpcChangeServiceRoleForceNew(t *testing.T) {
+func TestAccAWSOpsworksStack_NoVpcChangeServiceRoleForceNew(t *testing.T) {
 	stackName := fmt.Sprintf("tf-opsworks-acc-%d", acctest.RandInt())
 	var before, after opsworks.Stack
 	resource.ParallelTest(t, resource.TestCase{
@@ -90,7 +90,7 @@ func TestAccAWSOpsworksStackNoVpcChangeServiceRoleForceNew(t *testing.T) {
 	})
 }
 
-func TestAccAWSOpsworksStackVpc(t *testing.T) {
+func TestAccAWSOpsworksStack_Vpc(t *testing.T) {
 	stackName := fmt.Sprintf("tf-opsworks-acc-%d", acctest.RandInt())
 	var opsstack opsworks.Stack
 	resource.ParallelTest(t, resource.TestCase{
@@ -124,7 +124,7 @@ func TestAccAWSOpsworksStackVpc(t *testing.T) {
 	})
 }
 
-func TestAccAWSOpsworksStackNoVpcCreateTags(t *testing.T) {
+func TestAccAWSOpsworksStack_NoVpcCreateTags(t *testing.T) {
 	stackName := fmt.Sprintf("tf-opsworks-acc-%d", acctest.RandInt())
 	var opsstack opsworks.Stack
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_opsworks_stack: Final retry after timeout creating stack

```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSOpsworksApplication"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSOpsworksApplication -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSOpsworksApplication
=== PAUSE TestAccAWSOpsworksApplication
=== CONT  TestAccAWSOpsworksApplication
--- PASS: TestAccAWSOpsworksApplication (99.27s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       100.393s

ake testacc TESTARGS="-run=TestAccAWSOpsworksRdsDbInstance"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSOpsworksRdsDbInstance -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSOpsworksRdsDbInstance
=== PAUSE TestAccAWSOpsworksRdsDbInstance
=== CONT  TestAccAWSOpsworksRdsDbInstance
--- PASS: TestAccAWSOpsworksRdsDbInstance (821.83s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       822.936s

--- PASS: TestAccAWSOpsworksStack_ImportBasic (22.43s)
--- PASS: TestAccAWSOpsworksStack_NoVpc (27.81s)
--- PASS: TestAccAWSOpsworksStack_Vpc (36.33s)
--- PASS: TestAccAWSOpsworksStack_NoVpcCreateTags (36.67s)
--- PASS: TestAccAWSOpsworksStack_NoVpcChangeServiceRoleForceNew (48.41s)
```