### PR TITLE
Docs Typo: Resource Share ID attribute reference

### DIFF
--- a/website/docs/d/ram_resource_share.html.markdown
+++ b/website/docs/d/ram_resource_share.html.markdown
@@ -47,6 +47,6 @@ The following Arguments are supported
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The Amazon Resource Name (ARN) of the resource share.
-* `id` - The Amazon Resource Name (ARN) of the resource share.
+* `id` - The ID of the resource share.
 * `status` - The Status of the RAM share.
 * `tags` - The Tags attached to the RAM share


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->



This PR fixes a typo in the AWS 'Resource Access Manager' documentation, specifically the `ID` attribute reference description.
