### PR TITLE
WAF and wafregional token final retries

### DIFF
--- a/aws/waf_token_handlers.go
+++ b/aws/waf_token_handlers.go
@@ -20,10 +20,9 @@ func (t *WafRetryer) RetryWithToken(f withTokenFunc) (interface{}, error) {
 	defer awsMutexKV.Unlock("WafRetryer")
 
 	var out interface{}
+	var tokenOut *waf.GetChangeTokenOutput
 	err := resource.Retry(15*time.Minute, func() *resource.RetryError {
 		var err error
-		var tokenOut *waf.GetChangeTokenOutput
-
 		tokenOut, err = t.Connection.GetChangeToken(&waf.GetChangeTokenInput{})
 		if err != nil {
 			return resource.NonRetryableError(fmt.Errorf("Failed to acquire change token: %s", err))
@@ -39,8 +38,16 @@ func (t *WafRetryer) RetryWithToken(f withTokenFunc) (interface{}, error) {
 		}
 		return nil
 	})
-
-	return out, err
+	if isResourceTimeoutError(err) {
+		tokenOut, err = t.Connection.GetChangeToken(&waf.GetChangeTokenInput{})
+		if err == nil {
+			out, err = f(tokenOut.ChangeToken)
+		}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("Error getting WAF change token: %s", err)
+	}
+	return out, nil
 }
 
 func newWafRetryer(conn *waf.WAF) *WafRetryer {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES
* service/waf: Final retry after timeout getting change token
* service/wafregional: Final retry after timeout getting change token
```

Output from acceptance testing:

```
$ make test
==> Checking that code complies with gofmt requirements...
go test ./... -timeout=30s -parallel=4
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
ok      github.com/terraform-providers/terraform-provider-aws/aws       1.343s
```