### PR TITLE
AWS CloudWatch Alarm - Anomaly detection

### DIFF
--- a/aws/resource_aws_cloudwatch_metric_alarm.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm.go
@@ -124,7 +124,11 @@ func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
 			},
 			"threshold": {
 				Type:     schema.TypeFloat,
-				Required: true,
+				Optional: true,
+			},
+			"threshold_metric_id": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"actions_enabled": {
 				Type:     schema.TypeBool,
@@ -307,6 +311,7 @@ func resourceAwsCloudWatchMetricAlarmRead(d *schema.ResourceData, meta interface
 	d.Set("period", a.Period)
 	d.Set("statistic", a.Statistic)
 	d.Set("threshold", a.Threshold)
+	d.Set("threshold_metric_id", a.ThresholdMetricId)
 	d.Set("unit", a.Unit)
 	d.Set("extended_statistic", a.ExtendedStatistic)
 	d.Set("treat_missing_data", a.TreatMissingData)
@@ -368,7 +373,6 @@ func getAwsCloudWatchPutMetricAlarmInput(d *schema.ResourceData) cloudwatch.PutM
 		AlarmName:          aws.String(d.Get("alarm_name").(string)),
 		ComparisonOperator: aws.String(d.Get("comparison_operator").(string)),
 		EvaluationPeriods:  aws.Int64(int64(d.Get("evaluation_periods").(int))),
-		Threshold:          aws.Float64(d.Get("threshold").(float64)),
 		TreatMissingData:   aws.String(d.Get("treat_missing_data").(string)),
 		Tags:               tagsFromMapCloudWatch(d.Get("tags").(map[string]interface{})),
 	}
@@ -410,6 +414,14 @@ func getAwsCloudWatchPutMetricAlarmInput(d *schema.ResourceData) cloudwatch.PutM
 
 	if v, ok := d.GetOk("evaluate_low_sample_count_percentiles"); ok {
 		params.EvaluateLowSampleCountPercentile = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("threshold"); ok {
+		params.Threshold = aws.Float64(v.(float64))
+	}
+
+	if v, ok := d.GetOk("threshold_metric_id"); ok {
+		params.ThresholdMetricId = aws.String(v.(string))
 	}
 
 	var alarmActions []*string

--- a/aws/resource_aws_cloudwatch_metric_alarm.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm.go
@@ -123,12 +123,15 @@ func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
 				ConflictsWith: []string{"extended_statistic", "metric_query"},
 			},
 			"threshold": {
-				Type:     schema.TypeFloat,
-				Optional: true,
+				Type:          schema.TypeFloat,
+				Optional:      true,
+				ConflictsWith: []string{"threshold_metric_id"},
 			},
 			"threshold_metric_id": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"threshold"},
+				ValidateFunc:  validation.StringLenBetween(1, 255),
 			},
 			"actions_enabled": {
 				Type:     schema.TypeBool,
@@ -416,12 +419,10 @@ func getAwsCloudWatchPutMetricAlarmInput(d *schema.ResourceData) cloudwatch.PutM
 		params.EvaluateLowSampleCountPercentile = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("threshold"); ok {
-		params.Threshold = aws.Float64(v.(float64))
-	}
-
 	if v, ok := d.GetOk("threshold_metric_id"); ok {
 		params.ThresholdMetricId = aws.String(v.(string))
+	} else {
+		params.Threshold = aws.Float64(d.Get("threshold").(float64))
 	}
 
 	var alarmActions []*string

--- a/aws/resource_aws_cloudwatch_metric_alarm_test.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm_test.go
@@ -625,6 +625,42 @@ resource "aws_cloudwatch_metric_alarm" "foobar" {
 `, rInt)
 }
 
+func testAccAWSCloudWatchMetricAlarmConfigWithAnomalyDetectionExpression(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_metric_alarm" "foobar" {
+  alarm_name                = "terraform-test-foobar%d"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "2"
+  threshold_metric_id       = "e1"
+  alarm_description         = "This metric monitors ec2 cpu utilization"
+  insufficient_data_actions = []
+
+  metric_query {
+    id          = "e1"
+    expression  = "ANOMALY_DETECTION_BAND(m1)"
+    label       = "CPUUtilization (Expected)"
+    return_data = "true"
+  }
+
+  metric_query {
+    id = "m1"
+		return_data = "true"
+    metric {
+      metric_name = "CPUUtilization"
+      namespace   = "AWS/EC2"
+      period      = "120"
+      stat        = "Average"
+      unit        = "Count"
+
+      dimensions = {
+        InstanceId = "i-abc123"
+      }
+    }
+  }
+}
+`, rInt)
+}
+
 func testAccAWSCloudWatchMetricAlarmConfigWithExpressionUpdated(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_cloudwatch_metric_alarm" "foobar" {

--- a/aws/resource_aws_cloudwatch_metric_alarm_test.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm_test.go
@@ -271,6 +271,13 @@ func TestAccAWSCloudWatchMetricAlarm_expression(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccAWSCloudWatchMetricAlarmConfigWithAnomalyDetectionExpression(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchMetricAlarmExists("aws_cloudwatch_metric_alarm.foobar", &alarm),
+					resource.TestCheckResourceAttr("aws_cloudwatch_metric_alarm.foobar", "metric_query.#", "2"),
+				),
+			},
+			{
 				Config: testAccAWSCloudWatchMetricAlarmConfigWithExpressionWithQueryUpdated(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudWatchMetricAlarmExists("aws_cloudwatch_metric_alarm.foobar", &alarm),
@@ -629,7 +636,7 @@ func testAccAWSCloudWatchMetricAlarmConfigWithAnomalyDetectionExpression(rInt in
 	return fmt.Sprintf(`
 resource "aws_cloudwatch_metric_alarm" "foobar" {
   alarm_name                = "terraform-test-foobar%d"
-  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  comparison_operator       = "GreaterThanUpperThreshold"
   evaluation_periods        = "2"
   threshold_metric_id       = "e1"
   alarm_description         = "This metric monitors ec2 cpu utilization"

--- a/aws/resource_aws_cloudwatch_metric_alarm_test.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm_test.go
@@ -650,8 +650,8 @@ resource "aws_cloudwatch_metric_alarm" "foobar" {
   }
 
   metric_query {
-    id = "m1"
-		return_data = "true"
+    id          = "m1"
+    return_data = "true"
     metric {
       metric_name = "CPUUtilization"
       namespace   = "AWS/EC2"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9293 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
ENHANCEMENTS: resource/aws_cloudwatch_metric_alarm: Add support for ThresholdMetricId field used in Anomaly Detection Alarm [GH-9293]
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSCloudWatchMetricAlarm_expression'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSCloudWatchMetricAlarm_expression -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCloudWatchMetricAlarm_expression
=== PAUSE TestAccAWSCloudWatchMetricAlarm_expression
=== CONT  TestAccAWSCloudWatchMetricAlarm_expression
--- PASS: TestAccAWSCloudWatchMetricAlarm_expression (119.49s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       119.539s
...
```
