### PR TITLE
Add support for maximum Spot price set equal to the On-Demand price On EMR

### DIFF
--- a/website/docs/r/emr_cluster.html.markdown
+++ b/website/docs/r/emr_cluster.html.markdown
@@ -45,6 +45,7 @@ EOF
 
   master_instance_group {
     instance_type = "m4.large"
+    market        = "SPOT"
   }
 
   core_instance_group {
@@ -57,6 +58,7 @@ EOF
       volumes_per_instance = 1
     }
 
+    market = "SPOT"
     bid_price = "0.30"
 
     autoscaling_policy = <<EOF
@@ -282,7 +284,8 @@ Supported arguments for the `core_instance_group` configuration block:
 
 * `instance_type` - (Required) EC2 instance type for all instances in the instance group.
 * `autoscaling_policy` - (Optional) String containing the [EMR Auto Scaling Policy](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-automatic-scaling.html) JSON.
-* `bid_price` - (Optional) Bid price for each EC2 instance in the instance group, expressed in USD. By setting this attribute, the instance group is being declared as a Spot Instance, and will implicitly create a Spot request. Leave this blank to use On-Demand Instances.
+* `market` - (Required) The instance purchasing option. Valid values are ON_DEMAND or SPOT. 
+* `bid_price` - (Optional) The maximum Spot price your are willing to pay for EC2 instances. An optional, nullable field that applies if the MarketType for the instance group is specified as SPOT. Specify the maximum spot price in USD. If the value is NULL and SPOT is specified, the maximum Spot price is set equal to the On-Demand price.
 * `ebs_config` - (Optional) Configuration block(s) for EBS volumes attached to each instance in the instance group. Detailed below.
 * `instance_count` - (Optional) Target number of instances for the instance group. Must be at least 1. Defaults to 1.
 * `name` - (Optional) Friendly name given to the instance group.
@@ -333,7 +336,8 @@ Attributes for each task instance group in the cluster
 * `instance_type` - (Required) The EC2 instance type for all instances in the instance group
 * `instance_count` - (Optional) Target number of instances for the instance group
 * `name` - (Optional) Friendly name given to the instance group
-* `bid_price` - (Optional) If set, the bid price for each EC2 instance in the instance group, expressed in USD. By setting this attribute, the instance group is being declared as a Spot Instance, and will implicitly create a Spot request. Leave this blank to use On-Demand Instances.
+* `market` - (Required) The instance purchasing option. Valid values are ON_DEMAND or SPOT. 
+* `bid_price` - (Optional) The maximum Spot price your are willing to pay for EC2 instances. An optional, nullable field that applies if the MarketType for the instance group is specified as SPOT. Specify the maximum spot price in USD. If the value is NULL and SPOT is specified, the maximum Spot price is set equal to the On-Demand price.
 * `ebs_config` - (Optional) A list of attributes for the EBS volumes attached to each instance in the instance group. Each `ebs_config` defined will result in additional EBS volumes being attached to _each_ instance in the instance group. Defined below
 * `autoscaling_policy` - (Optional) The autoscaling policy document. This is a JSON formatted string. See [EMR Auto Scaling](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-automatic-scaling.html)
 
@@ -342,7 +346,8 @@ Attributes for each task instance group in the cluster
 Supported nested arguments for the `master_instance_group` configuration block:
 
 * `instance_type` - (Required) EC2 instance type for all instances in the instance group.
-* `bid_price` - (Optional) Bid price for each EC2 instance in the instance group, expressed in USD. By setting this attribute, the instance group is being declared as a Spot Instance, and will implicitly create a Spot request. Leave this blank to use On-Demand Instances.
+* `market` - (Required) The instance purchasing option. Valid values are ON_DEMAND or SPOT. 
+* `bid_price` - (Optional) The maximum Spot price your are willing to pay for EC2 instances. An optional, nullable field that applies if the MarketType for the instance group is specified as SPOT. Specify the maximum spot price in USD. If the value is NULL and SPOT is specified, the maximum Spot price is set equal to the On-Demand price.
 * `ebs_config` - (Optional) Configuration block(s) for EBS volumes attached to each instance in the instance group. Detailed below.
 * `instance_count` - (Optional) Target number of instances for the instance group. Must be 1 or 3. Defaults to 1. Launching with multiple master nodes is only supported in EMR version 5.23.0+, and requires this resource's `core_instance_group` to be configured. Public (Internet accessible) instances must be created in VPC subnets that have [map public IP on launch](/docs/providers/aws/r/subnet.html#map_public_ip_on_launch) enabled. Termination protection is automatically enabled when launched with multiple master nodes and Terraform must have the `termination_protection = false` configuration applied before destroying this resource.
 * `name` - (Optional) Friendly name given to the instance group.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

This change bring completly the new pricing EC2 model on `aws_emr_cluster` terraform resource.

New pricing EC2 model what does this mean? 
* Reliable Spot costs – prices change less frequently 
* No “bidding” required – if you choose to bid you’re setting a “Maximum price” 
	* No requirement to even set maximum price 
	* If you don’t set a max price you’ll never be charged more than On-Demand price  **( This Pull Request bring this fonctionnality )**
* Price no longer changes to reclaim instances

A new required parameter `market=ON_DEMAND | SPOT` must be set.
If choose `SPOT` value without to specify the `bid_price=` parameter you will pay the current market price and you’ll never be charged more than On-Demand price.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes: #7155

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_emr_cluster: Add support for maximum Spot price set equal to the On-Demand price
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS="-run=TestAccAWSEMRCluster_MasterInstanceGroup_Market"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSEMRCluster_MasterInstanceGroup_Market -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSEMRCluster_MasterInstanceGroup_Market
=== PAUSE TestAccAWSEMRCluster_MasterInstanceGroup_Market
=== CONT  TestAccAWSEMRCluster_MasterInstanceGroup_Market
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_Market (1220.04s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1220.152s


$ make testacc TEST=./aws TESTARGS="-run=TestAccAWSEMRCluster_CoreInstanceGroup_Market"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSEMRCluster_CoreInstanceGroup_Market -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSEMRCluster_CoreInstanceGroup_Market
=== PAUSE TestAccAWSEMRCluster_CoreInstanceGroup_Market
=== CONT  TestAccAWSEMRCluster_CoreInstanceGroup_Market
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_Market (1117.16s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1117.261s

```

Special thanks to @anouvel 
