### PR TITLE
Mention "serverless" for searches

### DIFF
--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -3,12 +3,12 @@ layout: "aws"
 page_title: "AWS: aws_lambda_function"
 sidebar_current: "docs-aws-resource-lambda-function"
 description: |-
-  Provides a Lambda Function resource. Lambda allows you to trigger execution of code in response to events in AWS. The Lambda Function itself includes source code and runtime configuration.
+  Provides a Lambda Function resource. Lambda allows you to trigger execution of code in response to events in AWS, also referred to as "serverless." The Lambda Function itself includes source code and runtime configuration.
 ---
 
 # Resource: aws_lambda_function
 
-Provides a Lambda Function resource. Lambda allows you to trigger execution of code in response to events in AWS. The Lambda Function itself includes source code and runtime configuration.
+Provides a Lambda Function resource. Lambda allows you to trigger execution of code in response to events in AWS, also referred to as _serverless_. The Lambda Function itself includes source code and runtime configuration.
 
 For information about Lambda and how to use it, see [What is AWS Lambda?][1]
 


### PR DESCRIPTION
Includes the word _serverless_ in the description so searches for that word can discover this page.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
