### PR TITLE
Update `final_snapshot_identifier ` in db_instance.html.markdown

### DIFF
--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -118,7 +118,8 @@ this attribute will ignore differences in the patch version automatically (e.g. 
 For supported values, see the EngineVersion parameter in [API action CreateDBInstance](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html).
 Note that for Amazon Aurora instances the engine version must match the [DB cluster](/docs/providers/aws/r/rds_cluster.html)'s engine version'.
 * `final_snapshot_identifier` - (Optional) The name of your final DB snapshot
-when this DB instance is deleted. If omitted, no final snapshot will be made.
+when this DB instance is deleted. Must be provided if `skip_final_snapshot` is
+set to `false`.
 * `iam_database_authentication_enabled` - (Optional) Specifies whether or
 mappings of AWS Identity and Access Management (IAM) accounts to database
 accounts is enabled.


### PR DESCRIPTION
The description of `final_snapshot_identifier` is not accurate.
When `skip_final_snapshot` is by default set to false and `final_snapshot_identifier`
is omitted, the provider errored with 
> RDS Cluster FinalSnapshotIdentifier is required when a final snapshot is required

The document is updated to reflect this behaviour

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #4910 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
- Update documentation of `final_snapshot_identifier` to reflect it's required when 
`skip_final_snapshot` is set to false.

```
