### PR TITLE
Add IoT Core Topic Rule Action to send data to an AWS IoT Analytics channel

### DIFF
--- a/aws/resource_aws_iot_topic_rule.go
+++ b/aws/resource_aws_iot_topic_rule.go
@@ -318,6 +318,23 @@ func resourceAwsIotTopicRule() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"iot_analytics_actions": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"channel_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"role_arn": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateArn,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -334,11 +351,12 @@ func createTopicRulePayload(d *schema.ResourceData) *iot.TopicRulePayload {
 	s3Actions := d.Get("s3").(*schema.Set).List()
 	snsActions := d.Get("sns").(*schema.Set).List()
 	sqsActions := d.Get("sqs").(*schema.Set).List()
+	iotAnalyticsActions := d.Get("iot_analytics_actions").(*schema.Set).List()
 
 	numActions := len(cloudwatchAlarmActions) + len(cloudwatchMetricActions) +
 		len(dynamoDbActions) + len(elasticsearchActions) + len(firehoseActions) +
 		len(kinesisActions) + len(lambdaActions) + len(republishActions) +
-		len(s3Actions) + len(snsActions) + len(sqsActions)
+		len(s3Actions) + len(snsActions) + len(sqsActions) + len(iotAnalyticsActions)
 	actions := make([]*iot.Action, numActions)
 
 	i := 0
@@ -522,6 +540,18 @@ func createTopicRulePayload(d *schema.ResourceData) *iot.TopicRulePayload {
 		i++
 	}
 
+	// Add Analytic actions
+	for _, a := range iotAnalyticsActions {
+		raw := a.(map[string]interface{})
+		actions[i] = &iot.Action{
+			IotAnalytics: &iot.IotAnalyticsAction{
+				ChannelName: aws.String(raw["channel_name"].(string)),
+				RoleArn:     aws.String(raw["role_arn"].(string)),
+			},
+		}
+		i++
+	}
+
 	return &iot.TopicRulePayload{
 		Description:      aws.String(d.Get("description").(string)),
 		RuleDisabled:     aws.Bool(!d.Get("enabled").(bool)),
@@ -582,6 +612,7 @@ func resourceAwsIotTopicRuleRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("s3", flattenIoTRuleS3Actions(out.Rule.Actions))
 	d.Set("sns", flattenIoTRuleSnsActions(out.Rule.Actions))
 	d.Set("sqs", flattenIoTRuleSqsActions(out.Rule.Actions))
+	d.Set("iot_analytics", flattenIoTRuleIotAnalyticsActions(out.Rule.Actions))
 
 	return nil
 }

--- a/aws/resource_aws_iot_topic_rule.go
+++ b/aws/resource_aws_iot_topic_rule.go
@@ -318,7 +318,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"iot_analytics_actions": {
+			"iot_analytics": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
@@ -351,7 +351,7 @@ func createTopicRulePayload(d *schema.ResourceData) *iot.TopicRulePayload {
 	s3Actions := d.Get("s3").(*schema.Set).List()
 	snsActions := d.Get("sns").(*schema.Set).List()
 	sqsActions := d.Get("sqs").(*schema.Set).List()
-	iotAnalyticsActions := d.Get("iot_analytics_actions").(*schema.Set).List()
+	iotAnalyticsActions := d.Get("iot_analytics").(*schema.Set).List()
 
 	numActions := len(cloudwatchAlarmActions) + len(cloudwatchMetricActions) +
 		len(dynamoDbActions) + len(elasticsearchActions) + len(firehoseActions) +

--- a/aws/resource_aws_iot_topic_rule_test.go
+++ b/aws/resource_aws_iot_topic_rule_test.go
@@ -282,6 +282,24 @@ func TestAccAWSIoTTopicRule_sqs(t *testing.T) {
 	})
 }
 
+func TestAccAWSIoTTopicRule_iot_analytics(t *testing.T) {
+	rName := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSIoTTopicRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSIoTTopicRule_iot_analytics(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSIoTTopicRuleExists_basic("aws_iot_topic_rule.rule"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSIoTTopicRuleDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).iotconn
 
@@ -608,6 +626,23 @@ resource "aws_iot_topic_rule" "rule" {
     queue_url = "fakedata"
     role_arn  = "${aws_iam_role.iot_role.arn}"
     use_base64 = false
+  }
+}
+`, rName)
+}
+
+func testAccAWSIoTTopicRule_iot_analytics(rName string) string {
+	return fmt.Sprintf(testAccAWSIoTTopicRuleRole+`
+resource "aws_iot_topic_rule" "rule" {
+  name        = "test_rule_%[1]s"
+  description = "Example rule"
+  enabled     = true
+  sql         = "SELECT * FROM 'topic/test'"
+  sql_version = "2015-10-08"
+
+  iot_analytics {
+    channel_name = "fakedata"
+    role_arn  = "${aws_iam_role.iot_role.arn}"
   }
 }
 `, rName)

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -2985,6 +2985,23 @@ func flattenIoTRuleSqsActions(actions []*iot.Action) []map[string]interface{} {
 	return results
 }
 
+func flattenIoTRuleIotAnalyticsActions(actions []*iot.Action) []map[string]interface{} {
+	results := make([]map[string]interface{}, 0)
+
+	for _, a := range actions {
+		result := make(map[string]interface{})
+		v := a.IotAnalytics
+		if v != nil {
+			result["role_arn"] = aws.StringValue(v.RoleArn)
+			result["channel_name"] = aws.StringValue(v.ChannelName)
+
+			results = append(results, result)
+		}
+	}
+
+	return results
+}
+
 func flattenCognitoUserPoolPasswordPolicy(s *cognitoidentityprovider.PasswordPolicyType) []map[string]interface{} {
 	m := map[string]interface{}{}
 

--- a/website/docs/r/iot_topic_rule.html.markdown
+++ b/website/docs/r/iot_topic_rule.html.markdown
@@ -152,6 +152,10 @@ The `sqs` object takes the following arguments:
 * `role_arn` - (Required) The ARN of the IAM role that grants access.
 * `use_base64` - (Required) Specifies whether to use Base64 encoding.
 
+The `iot_analytics` object takes the following arguments:
+
+* `channel_name` - (Required) Name of AWS IOT Analytics channel.
+* `role_arn` - (Required) The ARN of the IAM role that grants access.
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:


### PR DESCRIPTION
Fixes #9829 
Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add IoT Core Topic Rule Action to send data to an AWS IoT Analytics channel
```

Output from acceptance testing:
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSIoTTopicRule_iot_analytics'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSIoTTopicRule_iot_analytics -timeout 120m
=== RUN   TestAccAWSIoTTopicRule_iot_analytics
=== PAUSE TestAccAWSIoTTopicRule_iot_analytics
=== CONT  TestAccAWSIoTTopicRule_iot_analytics
--- PASS: TestAccAWSIoTTopicRule_iot_analytics (28.42s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       28.469s
```
