### PR TITLE
Final retries for s3 timeouts

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -653,8 +653,7 @@ func resourceAwsS3BucketCreate(d *schema.ResourceData, meta interface{}) error {
 			if awsErr.Code() == "OperationAborted" {
 				log.Printf("[WARN] Got an error while trying to create S3 bucket %s: %s", bucket, err)
 				return resource.RetryableError(
-					fmt.Errorf("Error creating S3 bucket %s, retrying: %s",
-						bucket, err))
+					fmt.Errorf("Error creating S3 bucket %s, retrying: %s", bucket, err))
 			}
 		}
 		if err != nil {
@@ -663,7 +662,9 @@ func resourceAwsS3BucketCreate(d *schema.ResourceData, meta interface{}) error {
 
 		return nil
 	})
-
+	if isResourceTimeoutError(err) {
+		_, err = s3conn.CreateBucket(req)
+	}
 	if err != nil {
 		return fmt.Errorf("Error creating S3 bucket: %s", err)
 	}
@@ -1328,17 +1329,18 @@ func resourceAwsS3BucketPolicyUpdate(s3conn *s3.S3, d *schema.ResourceData) erro
 		}
 
 		err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-			if _, err := s3conn.PutBucketPolicy(params); err != nil {
-				if awserr, ok := err.(awserr.Error); ok {
-					if awserr.Code() == "MalformedPolicy" || awserr.Code() == s3.ErrCodeNoSuchBucket {
-						return resource.RetryableError(awserr)
-					}
-				}
+			_, err := s3conn.PutBucketPolicy(params)
+			if isAWSErr(err, "MalformedPolicy", "") || isAWSErr(err, s3.ErrCodeNoSuchBucket, "") {
+				return resource.RetryableError(err)
+			}
+			if err != nil {
 				return resource.NonRetryableError(err)
 			}
 			return nil
 		})
-
+		if isResourceTimeoutError(err) {
+			_, err = s3conn.PutBucketPolicy(params)
+		}
 		if err != nil {
 			return fmt.Errorf("Error putting S3 policy: %s", err)
 		}
@@ -1769,12 +1771,7 @@ func resourceAwsS3BucketServerSideEncryptionConfigurationUpdate(s3conn *s3.S3, d
 			Bucket: aws.String(bucket),
 		}
 
-		err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-			if _, err := s3conn.DeleteBucketEncryption(i); err != nil {
-				return resource.NonRetryableError(err)
-			}
-			return nil
-		})
+		_, err := s3conn.DeleteBucketEncryption(i)
 		if err != nil {
 			return fmt.Errorf("error removing S3 bucket server side encryption: %s", err)
 		}
@@ -1848,12 +1845,7 @@ func resourceAwsS3BucketReplicationConfigurationUpdate(s3conn *s3.S3, d *schema.
 			Bucket: aws.String(bucket),
 		}
 
-		err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-			if _, err := s3conn.DeleteBucketReplication(i); err != nil {
-				return resource.NonRetryableError(err)
-			}
-			return nil
-		})
+		_, err := s3conn.DeleteBucketReplication(i)
 		if err != nil {
 			return fmt.Errorf("Error removing S3 bucket replication: %s", err)
 		}
@@ -1974,15 +1966,18 @@ func resourceAwsS3BucketReplicationConfigurationUpdate(s3conn *s3.S3, d *schema.
 	log.Printf("[DEBUG] S3 put bucket replication configuration: %#v", i)
 
 	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-		if _, err := s3conn.PutBucketReplication(i); err != nil {
-			if isAWSErr(err, s3.ErrCodeNoSuchBucket, "") ||
-				isAWSErr(err, "InvalidRequest", "Versioning must be 'Enabled' on the bucket") {
-				return resource.RetryableError(err)
-			}
+		_, err := s3conn.PutBucketReplication(i)
+		if isAWSErr(err, s3.ErrCodeNoSuchBucket, "") || isAWSErr(err, "InvalidRequest", "Versioning must be 'Enabled' on the bucket") {
+			return resource.RetryableError(err)
+		}
+		if err != nil {
 			return resource.NonRetryableError(err)
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		_, err = s3conn.PutBucketReplication(i)
+	}
 	if err != nil {
 		return fmt.Errorf("Error putting S3 replication configuration: %s", err)
 	}
@@ -2000,12 +1995,7 @@ func resourceAwsS3BucketLifecycleUpdate(s3conn *s3.S3, d *schema.ResourceData) e
 			Bucket: aws.String(bucket),
 		}
 
-		err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-			if _, err := s3conn.DeleteBucketLifecycle(i); err != nil {
-				return resource.NonRetryableError(err)
-			}
-			return nil
-		})
+		_, err := s3conn.DeleteBucketLifecycle(i)
 		if err != nil {
 			return fmt.Errorf("Error removing S3 lifecycle: %s", err)
 		}

--- a/aws/resource_aws_s3_bucket_inventory.go
+++ b/aws/resource_aws_s3_bucket_inventory.go
@@ -240,6 +240,9 @@ func resourceAwsS3BucketInventoryPut(d *schema.ResourceData, meta interface{}) e
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.PutBucketInventoryConfiguration(input)
+	}
 	if err != nil {
 		return fmt.Errorf("Error putting S3 bucket inventory configuration: %s", err)
 	}
@@ -306,6 +309,14 @@ func resourceAwsS3BucketInventoryRead(d *schema.ResourceData, meta interface{}) 
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		output, err = conn.GetBucketInventoryConfiguration(input)
+		if isAWSErr(err, s3.ErrCodeNoSuchBucket, "") || isAWSErr(err, "NoSuchConfiguration", "The specified configuration does not exist.") {
+			if !d.IsNewResource() {
+				return nil
+			}
+		}
+	}
 	if err != nil {
 		return fmt.Errorf("error getting S3 Bucket Inventory (%s): %s", d.Id(), err)
 	}

--- a/aws/resource_aws_s3_bucket_metric.go
+++ b/aws/resource_aws_s3_bucket_metric.go
@@ -84,6 +84,9 @@ func resourceAwsS3BucketMetricPut(d *schema.ResourceData, meta interface{}) erro
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.PutBucketMetricsConfiguration(input)
+	}
 	if err != nil {
 		return fmt.Errorf("Error putting S3 metric configuration: %s", err)
 	}

--- a/aws/resource_aws_s3_bucket_notification.go
+++ b/aws/resource_aws_s3_bucket_notification.go
@@ -310,7 +310,8 @@ func resourceAwsS3BucketNotificationPut(d *schema.ResourceData, meta interface{}
 
 	log.Printf("[DEBUG] S3 bucket: %s, Putting notification: %v", bucket, i)
 	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-		if _, err := s3conn.PutBucketNotificationConfiguration(i); err != nil {
+		_, err := s3conn.PutBucketNotificationConfiguration(i)
+		if err != nil {
 			if awserr, ok := err.(awserr.Error); ok {
 				switch awserr.Message() {
 				case "Unable to validate the following destination configurations":
@@ -323,6 +324,9 @@ func resourceAwsS3BucketNotificationPut(d *schema.ResourceData, meta interface{}
 		// Successful put configuration
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		_, err = s3conn.PutBucketNotificationConfiguration(i)
+	}
 	if err != nil {
 		return fmt.Errorf("Error putting S3 notification configuration: %s", err)
 	}

--- a/aws/resource_aws_s3_bucket_public_access_block.go
+++ b/aws/resource_aws_s3_bucket_public_access_block.go
@@ -85,6 +85,9 @@ func resourceAwsS3BucketPublicAccessBlockCreate(d *schema.ResourceData, meta int
 
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		_, err = s3conn.PutPublicAccessBlock(input)
+	}
 	if err != nil {
 		return fmt.Errorf("error creating public access block policy for S3 bucket (%s): %s", bucket, err)
 	}
@@ -117,7 +120,9 @@ func resourceAwsS3BucketPublicAccessBlockRead(d *schema.ResourceData, meta inter
 
 		return nil
 	})
-
+	if isResourceTimeoutError(err) {
+		output, err = s3conn.GetPublicAccessBlock(input)
+	}
 	if isAWSErr(err, s3control.ErrCodeNoSuchPublicAccessBlockConfiguration, "") {
 		log.Printf("[WARN] S3 Bucket Public Access Block (%s) not found, removing from state", d.Id())
 		d.SetId("")


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_s3_bucket: Final retries after timeouts creating, updating and updating replication configuration for s3 buckets
* resource/aws_s3_bucket_inventory: Final retries after timeous reading and putting bucket inventories
* resource/aws_s3_bucket_metric: Final retry after timeout putting bucket metric
* resource/aws_s3_bucket_notification: Final retry after timeout putting notification
* resource/aws_s3_bucket_policy: Final retry after timeout putting policy
* resource/aws_s3_bucket_public_access_block: Final retries after timeouts creating and reading blocks
```

Output from acceptance testing:

```
NOTE: TestAccAWSS3Bucket_Versioning failure is existing intermittent failure


$ make testacc TESTARGS="-run=TestAccAWSS3BucketInventory"      
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3BucketInventory -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3BucketInventory_basic
=== PAUSE TestAccAWSS3BucketInventory_basic
=== RUN   TestAccAWSS3BucketInventory_encryptWithSSES3
=== PAUSE TestAccAWSS3BucketInventory_encryptWithSSES3
=== RUN   TestAccAWSS3BucketInventory_encryptWithSSEKMS
=== PAUSE TestAccAWSS3BucketInventory_encryptWithSSEKMS
=== CONT  TestAccAWSS3BucketInventory_basic
=== CONT  TestAccAWSS3BucketInventory_encryptWithSSES3
=== CONT  TestAccAWSS3BucketInventory_encryptWithSSEKMS
--- PASS: TestAccAWSS3BucketInventory_encryptWithSSES3 (59.53s)
--- PASS: TestAccAWSS3BucketInventory_basic (60.97s)
--- PASS: TestAccAWSS3BucketInventory_encryptWithSSEKMS (85.78s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       86.898s

make testacc TESTARGS="-run=TestAccAWSS3BucketMetric"   
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3BucketMetric -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3BucketMetric_basic
=== PAUSE TestAccAWSS3BucketMetric_basic
=== RUN   TestAccAWSS3BucketMetric_WithEmptyFilter
=== PAUSE TestAccAWSS3BucketMetric_WithEmptyFilter
=== RUN   TestAccAWSS3BucketMetric_WithFilterPrefix
=== PAUSE TestAccAWSS3BucketMetric_WithFilterPrefix
=== RUN   TestAccAWSS3BucketMetric_WithFilterPrefixAndMultipleTags
=== PAUSE TestAccAWSS3BucketMetric_WithFilterPrefixAndMultipleTags
=== RUN   TestAccAWSS3BucketMetric_WithFilterPrefixAndSingleTag
=== PAUSE TestAccAWSS3BucketMetric_WithFilterPrefixAndSingleTag
=== RUN   TestAccAWSS3BucketMetric_WithFilterMultipleTags
=== PAUSE TestAccAWSS3BucketMetric_WithFilterMultipleTags
=== RUN   TestAccAWSS3BucketMetric_WithFilterSingleTag
=== PAUSE TestAccAWSS3BucketMetric_WithFilterSingleTag
=== CONT  TestAccAWSS3BucketMetric_basic
=== CONT  TestAccAWSS3BucketMetric_WithFilterPrefixAndSingleTag
=== CONT  TestAccAWSS3BucketMetric_WithEmptyFilter
=== CONT  TestAccAWSS3BucketMetric_WithFilterSingleTag
=== CONT  TestAccAWSS3BucketMetric_WithFilterPrefixAndMultipleTags
=== CONT  TestAccAWSS3BucketMetric_WithFilterPrefix
=== CONT  TestAccAWSS3BucketMetric_WithFilterMultipleTags
--- PASS: TestAccAWSS3BucketMetric_WithEmptyFilter (60.13s)
--- PASS: TestAccAWSS3BucketMetric_basic (61.80s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterSingleTag (107.24s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterPrefixAndSingleTag (107.98s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterPrefixAndMultipleTags (108.43s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterPrefix (109.35s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterMultipleTags (109.73s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       110.901s

make testacc TESTARGS="-run=TestAccAWSS3BucketPolicy"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3BucketPolicy -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3BucketPolicy_basic
=== PAUSE TestAccAWSS3BucketPolicy_basic
=== RUN   TestAccAWSS3BucketPolicy_policyUpdate
=== PAUSE TestAccAWSS3BucketPolicy_policyUpdate
=== CONT  TestAccAWSS3BucketPolicy_basic
=== CONT  TestAccAWSS3BucketPolicy_policyUpdate
--- PASS: TestAccAWSS3BucketPolicy_basic (62.59s)
--- PASS: TestAccAWSS3BucketPolicy_policyUpdate (119.55s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       120.717s


--- PASS: TestAccAWSS3BucketObject_noNameNoKey (5.68s)
--- PASS: TestAccAWSS3BucketObject_content (18.28s)
--- PASS: TestAccAWSS3BucketInventory_basic (18.49s)
--- PASS: TestAccAWSS3BucketObject_source (19.57s)
--- PASS: TestAccAWSS3BucketMetric_WithEmptyFilter (19.83s)
--- PASS: TestAccAWSS3BucketObject_empty (19.66s)
--- PASS: TestAccAWSS3BucketMetric_basic (21.30s)
--- PASS: TestAccAWSS3BucketObject_etagEncryption (16.47s)
--- PASS: TestAccAWSS3BucketInventory_encryptWithSSES3 (22.51s)
--- PASS: TestAccAWSS3BucketNotification_Topic (22.84s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterSingleTag (30.20s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterPrefix (30.09s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterPrefixAndMultipleTags (30.31s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterMultipleTags (30.99s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterPrefixAndSingleTag (33.75s)
--- PASS: TestAccAWSS3BucketObject_contentBase64 (15.98s)
--- PASS: TestAccAWSS3BucketNotification_update (36.04s)
--- PASS: TestAccAWSS3BucketObject_withContentCharacteristics (18.46s)
--- PASS: TestAccAWSS3BucketObject_sse (17.18s)
--- PASS: TestAccAWSS3BucketNotification_LambdaFunction (37.66s)
--- PASS: TestAccAWSS3BucketNotification_LambdaFunction_LambdaFunctionArn_Alias (38.22s)
--- PASS: TestAccAWSS3BucketInventory_encryptWithSSEKMS (40.64s)
--- PASS: TestAccAWSS3BucketObject_updates (27.34s)
--- PASS: TestAccAWSS3BucketObject_updatesWithVersioning (29.34s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_basic (19.60s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_disappears (20.42s)
--- PASS: TestAccAWSS3BucketPolicy_basic (21.96s)
--- PASS: TestAccAWSS3Bucket_basic (16.19s)
--- PASS: TestAccAWSS3Bucket_importBasic (17.08s)
--- PASS: TestAccAWSS3Bucket_importWithPolicy (17.91s)
--- PASS: TestAccAWSS3BucketObject_kms (36.74s)
--- PASS: TestAccAWSS3Bucket_Bucket_EmptyString (16.19s)
--- PASS: TestAccAWSS3BucketObject_acl (39.49s)
--- PASS: TestAccAWSS3BucketObject_metadata (39.19s)
--- PASS: TestAccAWSS3BucketPolicy_policyUpdate (33.82s)
--- PASS: TestAccAWSS3Bucket_namePrefix (17.53s)
--- PASS: TestAccAWSS3Bucket_generatedName (17.51s)
--- PASS: TestAccAWSS3BucketObject_tagsLeadingSlash (51.08s)
--- PASS: TestAccAWSS3BucketObject_tags (53.86s)
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed (15.95s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_BlockPublicAcls (42.86s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_IgnorePublicAcls (41.26s)
--- PASS: TestAccAWSS3Bucket_shouldFailNotFound (13.55s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_BlockPublicPolicy (44.61s)
--- PASS: TestAccAWSS3Bucket_RequestPayer (30.07s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_RestrictPublicBuckets (45.45s)
--- PASS: TestAccAWSS3Bucket_UpdateAcl (29.60s)
--- PASS: TestAccAWSS3Bucket_acceleration (32.71s)
--- PASS: TestAccAWSS3BucketObject_storageClass (62.65s)
--- PASS: TestAccAWSS3Bucket_WebsiteRoutingRules (28.08s)
--- PASS: TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled (29.88s)
--- PASS: TestAccAWSS3Bucket_Policy (39.67s)
--- PASS: TestAccAWSS3Bucket_Cors_Delete (18.04s)
--- PASS: TestAccAWSS3Bucket_Cors_EmptyOrigin (18.82s)
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical (35.90s)
--- PASS: TestAccAWSS3Bucket_Website_Simple (40.46s)
--- PASS: TestAccAWSS3Bucket_WebsiteRedirect (39.88s)
--- PASS: TestAccAWSS3Bucket_Logging (20.60s)
--- FAIL: TestAccAWSS3Bucket_Versioning (33.15s)
--- PASS: TestAccAWSS3Bucket_Cors_Update (26.20s)
--- PASS: TestAccAWSS3Bucket_region (50.40s)
--- PASS: TestAccAWSS3Bucket_LifecycleExpireMarkerOnly (24.87s)
--- PASS: TestAccAWSS3Bucket_objectLock (20.96s)
--- PASS: TestAccAWSS3Bucket_LifecycleBasic (31.28s)
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutStorageClass (57.36s)
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutPrefix (56.27s)
--- PASS: TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation (117.63s)
--- PASS: TestAccAWSS3Bucket_ReplicationSchemaV2 (159.30s)
--- PASS: TestAccAWSS3Bucket_Replication (178.64s)

make testacc TESTARGS="-run=TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError
=== PAUSE TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError
=== CONT  TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError
--- PASS: TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError (55.55s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       56.923s

make testacc TESTARGS="-run=TestAccAWSS3BucketNotification_Queue"    ==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3BucketNotification_Queue -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3BucketNotification_Queue
=== PAUSE TestAccAWSS3BucketNotification_Queue
=== CONT  TestAccAWSS3BucketNotification_Queue
--- PASS: TestAccAWSS3BucketNotification_Queue (84.26s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       85.344s

make testacc TESTARGS="-run=TestAccAWSS3BucketNotification_Topic_Multiple"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3BucketNotification_Topic_Multiple -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3BucketNotification_Topic_Multiple
=== PAUSE TestAccAWSS3BucketNotification_Topic_Multiple
=== CONT  TestAccAWSS3BucketNotification_Topic_Multiple
--- PASS: TestAccAWSS3BucketNotification_Topic_Multiple (74.34s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       75.330s
```