### PR TITLE
Fixes EC2 capacity reservation in state not found

### DIFF
--- a/aws/resource_aws_ec2_capacity_reservation.go
+++ b/aws/resource_aws_ec2_capacity_reservation.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
@@ -166,7 +165,7 @@ func resourceAwsEc2CapacityReservationRead(d *schema.ResourceData, meta interfac
 	})
 
 	if err != nil {
-		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidCapacityReservationId.NotFound" {
+		if isAWSErr(err, "InvalidCapacityReservationId.NotFound", "") {
 			log.Printf("[WARN] EC2 Capacity Reservation (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

When an EC2 Capacity Reservation is created with terraform, but is then manually deleted, the next `terraform plan` gives:

```Error describing EC2 Capacity Reservations: InvalidCapacityReservationId.NotFound: An error occurred when calling the DescribeCapacityReservations operation: The capacity reservation ID 'cr-xxx' was not found```

As the EC2 Capacity Reservation ID is still in the state, terraform tries to read it, but the error handling doesn't check the `InvalidCapacityReservationId.NotFound` case. It returns the error directly, instead of doing a simple `d.SetId(""); return nil` to notify that the resource doesn't exist anymore.

I used a structure similar to https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/resource_aws_ebs_volume.go#L242 to fix the issue.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fixes error handling when an EC2 Capacity Reservation is deleted manually but is still in state.
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEc2CapacityReservation'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSEc2CapacityReservation -timeout 120m
=== RUN   TestAccAWSEc2CapacityReservation_basic
=== PAUSE TestAccAWSEc2CapacityReservation_basic
=== RUN   TestAccAWSEc2CapacityReservation_ebsOptimized
=== PAUSE TestAccAWSEc2CapacityReservation_ebsOptimized
=== RUN   TestAccAWSEc2CapacityReservation_endDate
=== PAUSE TestAccAWSEc2CapacityReservation_endDate
=== RUN   TestAccAWSEc2CapacityReservation_endDateType
=== PAUSE TestAccAWSEc2CapacityReservation_endDateType
=== RUN   TestAccAWSEc2CapacityReservation_ephemeralStorage
=== PAUSE TestAccAWSEc2CapacityReservation_ephemeralStorage
=== RUN   TestAccAWSEc2CapacityReservation_instanceCount
=== PAUSE TestAccAWSEc2CapacityReservation_instanceCount
=== RUN   TestAccAWSEc2CapacityReservation_instanceMatchCriteria
=== PAUSE TestAccAWSEc2CapacityReservation_instanceMatchCriteria
=== RUN   TestAccAWSEc2CapacityReservation_instanceType
=== PAUSE TestAccAWSEc2CapacityReservation_instanceType
=== RUN   TestAccAWSEc2CapacityReservation_tags
=== PAUSE TestAccAWSEc2CapacityReservation_tags
=== RUN   TestAccAWSEc2CapacityReservation_tenancy
--- SKIP: TestAccAWSEc2CapacityReservation_tenancy (0.00s)
    resource_aws_ec2_capacity_reservation_test.go:362: EC2 Capacity Reservations do not currently support dedicated tenancy.
=== CONT  TestAccAWSEc2CapacityReservation_instanceCount
=== CONT  TestAccAWSEc2CapacityReservation_basic
=== CONT  TestAccAWSEc2CapacityReservation_ephemeralStorage
=== CONT  TestAccAWSEc2CapacityReservation_endDateType
=== CONT  TestAccAWSEc2CapacityReservation_endDate
=== CONT  TestAccAWSEc2CapacityReservation_ebsOptimized
=== CONT  TestAccAWSEc2CapacityReservation_instanceType
=== CONT  TestAccAWSEc2CapacityReservation_tags
=== CONT  TestAccAWSEc2CapacityReservation_instanceMatchCriteria
--- PASS: TestAccAWSEc2CapacityReservation_ephemeralStorage (30.28s)
--- PASS: TestAccAWSEc2CapacityReservation_instanceMatchCriteria (30.29s)
--- PASS: TestAccAWSEc2CapacityReservation_basic (30.34s)
--- PASS: TestAccAWSEc2CapacityReservation_ebsOptimized (30.36s)
--- PASS: TestAccAWSEc2CapacityReservation_endDate (50.49s)
--- PASS: TestAccAWSEc2CapacityReservation_instanceCount (50.52s)
--- PASS: TestAccAWSEc2CapacityReservation_instanceType (50.94s)
--- PASS: TestAccAWSEc2CapacityReservation_endDateType (67.30s)
--- PASS: TestAccAWSEc2CapacityReservation_tags (69.69s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	69.757s
```
