### PR TITLE
Final retries for ACM cert

### DIFF
--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -170,7 +170,7 @@ func resourceAwsAcmCertificateCreateImported(d *schema.ResourceData, meta interf
 	acmconn := meta.(*AWSClient).acmconn
 	resp, err := resourceAwsAcmCertificateImport(acmconn, d, false)
 	if err != nil {
-		return fmt.Errorf("Error importing certificate: %s", err)
+		return fmt.Errorf("error importing certificate: %s", err)
 	}
 
 	d.SetId(*resp.CertificateArn)
@@ -182,7 +182,7 @@ func resourceAwsAcmCertificateCreateImported(d *schema.ResourceData, meta interf
 		_, err := acmconn.AddTagsToCertificate(params)
 
 		if err != nil {
-			return fmt.Errorf("Error requesting certificate: %s", err)
+			return fmt.Errorf("error requesting certificate: %s", err)
 		}
 	}
 
@@ -217,7 +217,7 @@ func resourceAwsAcmCertificateCreateRequested(d *schema.ResourceData, meta inter
 	resp, err := acmconn.RequestCertificate(params)
 
 	if err != nil {
-		return fmt.Errorf("Error requesting certificate: %s", err)
+		return fmt.Errorf("error requesting certificate: %s", err)
 	}
 
 	d.SetId(*resp.CertificateArn)
@@ -229,7 +229,7 @@ func resourceAwsAcmCertificateCreateRequested(d *schema.ResourceData, meta inter
 		_, err := acmconn.AddTagsToCertificate(params)
 
 		if err != nil {
-			return fmt.Errorf("Error requesting certificate: %s", err)
+			return fmt.Errorf("error requesting certificate: %s", err)
 		}
 	}
 
@@ -249,18 +249,18 @@ func resourceAwsAcmCertificateRead(d *schema.ResourceData, meta interface{}) err
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error describing certificate: %s", err)
+		return fmt.Errorf("error describing certificate: %s", err)
 	}
 
 	if resp == nil {
-		return fmt.Errorf("Empty response received when describing ACM certificate")
+		return fmt.Errorf("empty response received when describing ACM certificate")
 	}
 	d.Set("domain_name", resp.Certificate.DomainName)
 	d.Set("arn", resp.Certificate.CertificateArn)
 	d.Set("certificate_authority_arn", resp.Certificate.CertificateAuthorityArn)
 
 	if err := d.Set("subject_alternative_names", cleanUpSubjectAlternativeNames(resp.Certificate)); err != nil {
-		return fmt.Errorf("Error setting subject alternative nates: %s", err)
+		return fmt.Errorf("error setting subject alternative nates: %s", err)
 	}
 
 	var domainValidationOptions []map[string]interface{}
@@ -278,14 +278,14 @@ func resourceAwsAcmCertificateRead(d *schema.ResourceData, meta interface{}) err
 		domainValidationOptions, emailValidationOptions, err = convertValidationOptions(resp.Certificate)
 	}
 	if err != nil {
-		return fmt.Errorf("Error getting validation options for ACM certificate: %s", err)
+		return fmt.Errorf("error getting validation options for ACM certificate: %s", err)
 	}
 
 	if err := d.Set("domain_validation_options", domainValidationOptions); err != nil {
-		return fmt.Errorf("Error setting domain validation options: %s", err)
+		return fmt.Errorf("error setting domain validation options: %s", err)
 	}
 	if err := d.Set("validation_emails", emailValidationOptions); err != nil {
-		return fmt.Errorf("Error setting email validation options: %s", err)
+		return fmt.Errorf("error setting email validation options: %s", err)
 	}
 
 	d.Set("validation_method", resourceAwsAcmCertificateGuessValidationMethod(domainValidationOptions, emailValidationOptions))
@@ -303,7 +303,7 @@ func resourceAwsAcmCertificateRead(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("error listing tags for certificate (%s): %s", d.Id(), err)
 	}
 	if err := d.Set("tags", tagsToMapACM(tagResp.Tags)); err != nil {
-		return fmt.Errorf("Error setting tags for certificate: %s", err)
+		return fmt.Errorf("error setting tags for certificate: %s", err)
 	}
 
 	return nil
@@ -326,7 +326,7 @@ func resourceAwsAcmCertificateUpdate(d *schema.ResourceData, meta interface{}) e
 	if d.HasChange("private_key") || d.HasChange("certificate_body") || d.HasChange("certificate_chain") {
 		_, err := resourceAwsAcmCertificateImport(acmconn, d, true)
 		if err != nil {
-			return fmt.Errorf("Error updating certificate: %s", err)
+			return fmt.Errorf("error updating certificate: %s", err)
 		}
 	}
 
@@ -359,7 +359,7 @@ func convertValidationOptions(certificate *acm.CertificateDetail) ([]map[string]
 	case acm.CertificateTypeAmazonIssued:
 		if len(certificate.DomainValidationOptions) == 0 && aws.StringValue(certificate.Status) == acm.DomainStatusPendingValidation {
 			log.Printf("[DEBUG] No validation options need to retry.")
-			return nil, nil, fmt.Errorf("No validation options need to retry.")
+			return nil, nil, fmt.Errorf("no validation options need to retry.")
 		}
 		for _, o := range certificate.DomainValidationOptions {
 			if o.ResourceRecord != nil {
@@ -376,7 +376,7 @@ func convertValidationOptions(certificate *acm.CertificateDetail) ([]map[string]
 				}
 			} else if o.ValidationStatus == nil || aws.StringValue(o.ValidationStatus) == acm.DomainStatusPendingValidation {
 				log.Printf("[DEBUG] No validation options need to retry: %#v", o)
-				return nil, nil, fmt.Errorf("No validation options need to retry: %#v", o)
+				return nil, nil, fmt.Errorf("no validation options need to retry: %#v", o)
 			}
 		}
 	case acm.CertificateTypePrivate:
@@ -414,7 +414,7 @@ func resourceAwsAcmCertificateDelete(d *schema.ResourceData, meta interface{}) e
 		_, err = acmconn.DeleteCertificate(params)
 	}
 	if err != nil && !isAWSErr(err, acm.ErrCodeResourceNotFoundException, "") {
-		return fmt.Errorf("Error deleting certificate: %s", err)
+		return fmt.Errorf("error deleting certificate: %s", err)
 	}
 
 	return nil

--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -306,9 +306,6 @@ func resourceAwsAcmCertificateRead(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("Error setting tags for certificate: %s", err)
 	}
 
-	if err != nil {
-		return fmt.Errorf("Error reading ACM certificate: %s", err)
-	}
 	return nil
 }
 func resourceAwsAcmCertificateGuessValidationMethod(domainValidationOptions []map[string]interface{}, emailValidationOptions []string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES
* resource/aws_acm_certificate: Final retries after timeouts reading and deleting certificates
```

Output from acceptance testing:

```
--- SKIP: TestAccAWSAcmCertificate_dnsValidation (0.00s)
--- SKIP: TestAccAWSAcmCertificate_root (0.00s)
--- SKIP: TestAccAWSAcmCertificate_wildcardAndRootSan (0.00s)
--- SKIP: TestAccAWSAcmCertificate_tags (0.00s)
--- SKIP: TestAccAWSAcmCertificate_emailValidation (0.00s)
--- SKIP: TestAccAWSAcmCertificateValidation_basic (0.00s)
--- SKIP: TestAccAWSAcmCertificateDataSource_multipleIssued (0.00s)
--- SKIP: TestAccAWSAcmCertificateDataSource_singleIssued (0.00s)
--- SKIP: TestAccAWSAcmCertificate_root_TrailingPeriod (0.00s)
--- SKIP: TestAccAWSAcmCertificate_disableCTLogging (0.00s)
--- SKIP: TestAccAWSAcmCertificateDataSource_noMatchReturnsError (0.00s)
--- SKIP: TestAccAWSAcmCertificate_wildcard (0.00s)
--- SKIP: TestAccAWSAcmCertificate_san_TrailingPeriod (0.00s)
--- SKIP: TestAccAWSAcmCertificate_rootAndWildcardSan (0.00s)
--- SKIP: TestAccAWSAcmCertificate_san_single (0.00s)
--- SKIP: TestAccAWSAcmCertificateValidation_timeout (0.00s)
--- SKIP: TestAccAWSAcmCertificate_san_multiple (0.00s)
--- SKIP: TestAccAWSAcmCertificateValidation_validationRecordFqdns (0.00s)
--- SKIP: TestAccAWSAcmCertificateValidation_validationRecordFqdnsRootAndWildcard (0.00s)
--- SKIP: TestAccAWSAcmCertificateValidation_validationRecordFqdnsWildcardAndRoot (0.00s)
--- SKIP: TestAccAWSAcmCertificateValidation_validationRecordFqdnsWildcard (0.00s)
--- SKIP: TestAccAWSAcmCertificateValidation_validationRecordFqdnsSan (0.00s)
--- SKIP: TestAccAWSAcmCertificateValidation_validationRecordFqdnsRoot (0.00s)
--- SKIP: TestAccAWSAcmCertificateValidation_validationRecordFqdnsEmail (0.00s)
--- PASS: TestAccAWSAcmCertificate_imported_IpAddress (9.68s)
--- PASS: TestAccAWSAcmCertificate_privateCert (13.19s)
--- PASS: TestAccAWSAcmCertificateDataSource_KeyTypes (15.19s)
--- PASS: TestAccAWSAcmCertificate_imported_DomainName (15.18s)
```