### PR TITLE
Change engine_version for rds_global_cluster to Required

### DIFF
--- a/aws/resource_aws_rds_global_cluster.go
+++ b/aws/resource_aws_rds_global_cluster.go
@@ -48,8 +48,7 @@ func resourceAwsRDSGlobalCluster() *schema.Resource {
 			},
 			"engine_version": {
 				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Required: true,
 				ForceNew: true,
 			},
 			"global_cluster_identifier": {
@@ -76,6 +75,7 @@ func resourceAwsRDSGlobalClusterCreate(d *schema.ResourceData, meta interface{})
 	input := &rds.CreateGlobalClusterInput{
 		DeletionProtection:      aws.Bool(d.Get("deletion_protection").(bool)),
 		GlobalClusterIdentifier: aws.String(d.Get("global_cluster_identifier").(string)),
+		EngineVersion:           aws.String(d.Get("engine_version").(string)),
 		StorageEncrypted:        aws.Bool(d.Get("storage_encrypted").(bool)),
 	}
 
@@ -85,10 +85,6 @@ func resourceAwsRDSGlobalClusterCreate(d *schema.ResourceData, meta interface{})
 
 	if v, ok := d.GetOk("engine"); ok {
 		input.Engine = aws.String(v.(string))
-	}
-
-	if v, ok := d.GetOk("engine_version"); ok {
-		input.EngineVersion = aws.String(v.(string))
 	}
 
 	log.Printf("[DEBUG] Creating RDS Global Cluster: %s", input)

--- a/aws/resource_aws_rds_global_cluster_test.go
+++ b/aws/resource_aws_rds_global_cluster_test.go
@@ -72,6 +72,7 @@ func testSweepRdsGlobalClusters(region string) error {
 func TestAccAWSRdsGlobalCluster_basic(t *testing.T) {
 	var globalCluster1 rds.GlobalCluster
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	engineVersion := "5.6.10a"
 	resourceName := "aws_rds_global_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -80,14 +81,14 @@ func TestAccAWSRdsGlobalCluster_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSRdsGlobalClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSRdsGlobalClusterConfig(rName),
+				Config: testAccAWSRdsGlobalClusterConfig(engineVersion, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRdsGlobalClusterExists(resourceName, &globalCluster1),
 					testAccCheckResourceAttrGlobalARN(resourceName, "arn", "rds", fmt.Sprintf("global-cluster:%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "database_name", ""),
 					resource.TestCheckResourceAttr(resourceName, "deletion_protection", "false"),
 					resource.TestCheckResourceAttrSet(resourceName, "engine"),
-					resource.TestCheckResourceAttrSet(resourceName, "engine_version"),
+					resource.TestCheckResourceAttr(resourceName, "engine_version", engineVersion),
 					resource.TestCheckResourceAttr(resourceName, "global_cluster_identifier", rName),
 					resource.TestMatchResourceAttr(resourceName, "global_cluster_resource_id", regexp.MustCompile(`cluster-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "storage_encrypted", "false"),
@@ -105,6 +106,7 @@ func TestAccAWSRdsGlobalCluster_basic(t *testing.T) {
 func TestAccAWSRdsGlobalCluster_disappears(t *testing.T) {
 	var globalCluster1 rds.GlobalCluster
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	engineVersion := "5.6.10a"
 	resourceName := "aws_rds_global_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -113,7 +115,7 @@ func TestAccAWSRdsGlobalCluster_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAWSRdsGlobalClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSRdsGlobalClusterConfig(rName),
+				Config: testAccAWSRdsGlobalClusterConfig(engineVersion, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRdsGlobalClusterExists(resourceName, &globalCluster1),
 					testAccCheckAWSRdsGlobalClusterDisappears(&globalCluster1),
@@ -127,6 +129,7 @@ func TestAccAWSRdsGlobalCluster_disappears(t *testing.T) {
 func TestAccAWSRdsGlobalCluster_DatabaseName(t *testing.T) {
 	var globalCluster1, globalCluster2 rds.GlobalCluster
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	engineVersion := "5.6.10a"
 	resourceName := "aws_rds_global_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -135,7 +138,7 @@ func TestAccAWSRdsGlobalCluster_DatabaseName(t *testing.T) {
 		CheckDestroy: testAccCheckAWSRdsGlobalClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSRdsGlobalClusterConfigDatabaseName(rName, "database1"),
+				Config: testAccAWSRdsGlobalClusterConfigDatabaseName(engineVersion, rName, "database1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRdsGlobalClusterExists(resourceName, &globalCluster1),
 					resource.TestCheckResourceAttr(resourceName, "database_name", "database1"),
@@ -147,7 +150,7 @@ func TestAccAWSRdsGlobalCluster_DatabaseName(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSRdsGlobalClusterConfigDatabaseName(rName, "database2"),
+				Config: testAccAWSRdsGlobalClusterConfigDatabaseName(engineVersion, rName, "database2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRdsGlobalClusterExists(resourceName, &globalCluster2),
 					testAccCheckAWSRdsGlobalClusterRecreated(&globalCluster1, &globalCluster2),
@@ -161,6 +164,7 @@ func TestAccAWSRdsGlobalCluster_DatabaseName(t *testing.T) {
 func TestAccAWSRdsGlobalCluster_DeletionProtection(t *testing.T) {
 	var globalCluster1, globalCluster2 rds.GlobalCluster
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	engineVersion := "5.6.10a"
 	resourceName := "aws_rds_global_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -169,7 +173,7 @@ func TestAccAWSRdsGlobalCluster_DeletionProtection(t *testing.T) {
 		CheckDestroy: testAccCheckAWSRdsGlobalClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSRdsGlobalClusterConfigDeletionProtection(rName, true),
+				Config: testAccAWSRdsGlobalClusterConfigDeletionProtection(engineVersion, rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRdsGlobalClusterExists(resourceName, &globalCluster1),
 					resource.TestCheckResourceAttr(resourceName, "deletion_protection", "true"),
@@ -181,7 +185,7 @@ func TestAccAWSRdsGlobalCluster_DeletionProtection(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSRdsGlobalClusterConfigDeletionProtection(rName, false),
+				Config: testAccAWSRdsGlobalClusterConfigDeletionProtection(engineVersion, rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRdsGlobalClusterExists(resourceName, &globalCluster2),
 					testAccCheckAWSRdsGlobalClusterNotRecreated(&globalCluster1, &globalCluster2),
@@ -195,6 +199,7 @@ func TestAccAWSRdsGlobalCluster_DeletionProtection(t *testing.T) {
 func TestAccAWSRdsGlobalCluster_Engine_Aurora(t *testing.T) {
 	var globalCluster1 rds.GlobalCluster
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	engineVersion := "5.6.10a"
 	resourceName := "aws_rds_global_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -203,7 +208,7 @@ func TestAccAWSRdsGlobalCluster_Engine_Aurora(t *testing.T) {
 		CheckDestroy: testAccCheckAWSRdsGlobalClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSRdsGlobalClusterConfigEngine(rName, "aurora"),
+				Config: testAccAWSRdsGlobalClusterConfigEngine(engineVersion, rName, "aurora"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRdsGlobalClusterExists(resourceName, &globalCluster1),
 					resource.TestCheckResourceAttr(resourceName, "engine", "aurora"),
@@ -221,6 +226,7 @@ func TestAccAWSRdsGlobalCluster_Engine_Aurora(t *testing.T) {
 func TestAccAWSRdsGlobalCluster_EngineVersion_Aurora(t *testing.T) {
 	var globalCluster1 rds.GlobalCluster
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	engineVersion := "5.6.10a"
 	resourceName := "aws_rds_global_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -229,7 +235,7 @@ func TestAccAWSRdsGlobalCluster_EngineVersion_Aurora(t *testing.T) {
 		CheckDestroy: testAccCheckAWSRdsGlobalClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSRdsGlobalClusterConfigEngineVersion(rName, "aurora", "5.6.10a"),
+				Config: testAccAWSRdsGlobalClusterConfigEngineVersion(engineVersion, rName, "aurora"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRdsGlobalClusterExists(resourceName, &globalCluster1),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.6.10a"),
@@ -247,6 +253,7 @@ func TestAccAWSRdsGlobalCluster_EngineVersion_Aurora(t *testing.T) {
 func TestAccAWSRdsGlobalCluster_StorageEncrypted(t *testing.T) {
 	var globalCluster1, globalCluster2 rds.GlobalCluster
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	engineVersion := "5.6.10a"
 	resourceName := "aws_rds_global_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -255,7 +262,7 @@ func TestAccAWSRdsGlobalCluster_StorageEncrypted(t *testing.T) {
 		CheckDestroy: testAccCheckAWSRdsGlobalClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSRdsGlobalClusterConfigStorageEncrypted(rName, true),
+				Config: testAccAWSRdsGlobalClusterConfigStorageEncrypted(engineVersion, rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRdsGlobalClusterExists(resourceName, &globalCluster1),
 					resource.TestCheckResourceAttr(resourceName, "storage_encrypted", "true"),
@@ -267,7 +274,7 @@ func TestAccAWSRdsGlobalCluster_StorageEncrypted(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSRdsGlobalClusterConfigStorageEncrypted(rName, false),
+				Config: testAccAWSRdsGlobalClusterConfigStorageEncrypted(engineVersion, rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRdsGlobalClusterExists(resourceName, &globalCluster2),
 					testAccCheckAWSRdsGlobalClusterRecreated(&globalCluster1, &globalCluster2),
@@ -393,42 +400,36 @@ func testAccPreCheckAWSRdsGlobalCluster(t *testing.T) {
 	}
 }
 
-func testAccAWSRdsGlobalClusterConfig(rName string) string {
+func testAccAWSRdsGlobalClusterConfig(engineVersion, rName string) string {
 	return fmt.Sprintf(`
 resource "aws_rds_global_cluster" "test" {
+  engine_version            = %q
   global_cluster_identifier = %q
 }
-`, rName)
+`, engineVersion, rName)
 }
 
-func testAccAWSRdsGlobalClusterConfigDatabaseName(rName, databaseName string) string {
+func testAccAWSRdsGlobalClusterConfigDatabaseName(engineVersion, rName, databaseName string) string {
 	return fmt.Sprintf(`
 resource "aws_rds_global_cluster" "test" {
   database_name             = %q
+  engine_version            = %q
   global_cluster_identifier = %q
 }
-`, databaseName, rName)
+`, databaseName, engineVersion, rName)
 }
 
-func testAccAWSRdsGlobalClusterConfigDeletionProtection(rName string, deletionProtection bool) string {
+func testAccAWSRdsGlobalClusterConfigDeletionProtection(engineVersion, rName string, deletionProtection bool) string {
 	return fmt.Sprintf(`
 resource "aws_rds_global_cluster" "test" {
   deletion_protection       = %t
+  engine_version            = %q
   global_cluster_identifier = %q
 }
-`, deletionProtection, rName)
+`, deletionProtection, engineVersion, rName)
 }
 
-func testAccAWSRdsGlobalClusterConfigEngine(rName, engine string) string {
-	return fmt.Sprintf(`
-resource "aws_rds_global_cluster" "test" {
-  engine                    = %q
-  global_cluster_identifier = %q
-}
-`, engine, rName)
-}
-
-func testAccAWSRdsGlobalClusterConfigEngineVersion(rName, engine, engineVersion string) string {
+func testAccAWSRdsGlobalClusterConfigEngine(engineVersion, rName, engine string) string {
 	return fmt.Sprintf(`
 resource "aws_rds_global_cluster" "test" {
   engine                    = %q
@@ -438,11 +439,22 @@ resource "aws_rds_global_cluster" "test" {
 `, engine, engineVersion, rName)
 }
 
-func testAccAWSRdsGlobalClusterConfigStorageEncrypted(rName string, storageEncrypted bool) string {
+func testAccAWSRdsGlobalClusterConfigEngineVersion(engineVersion, rName, engine string) string {
 	return fmt.Sprintf(`
 resource "aws_rds_global_cluster" "test" {
+  engine                    = %q
+  engine_version            = %q
   global_cluster_identifier = %q
-  storage_encrypted         = %t
 }
-`, rName, storageEncrypted)
+`, engine, engineVersion, rName)
+}
+
+func testAccAWSRdsGlobalClusterConfigStorageEncrypted(engineVersion, rName string, storageEncrypted bool) string {
+	return fmt.Sprintf(`
+resource "aws_rds_global_cluster" "test" {
+  storage_encrypted         = %t
+  engine_version            = %q
+  global_cluster_identifier = %q
+}
+`, storageEncrypted, engineVersion, rName)
 }

--- a/website/docs/r/rds_global_cluster.html.markdown
+++ b/website/docs/r/rds_global_cluster.html.markdown
@@ -31,6 +31,7 @@ resource "aws_rds_global_cluster" "example" {
   provider = "aws.primary"
 
   global_cluster_identifier = "example"
+  engine_version = "5.6.10a" 
 }
 
 resource "aws_rds_cluster" "primary" {
@@ -73,7 +74,7 @@ The following arguments are supported:
 * `database_name` - (Optional, Forces new resources) Name for an automatically created database on cluster creation.
 * `deletion_protection` - (Optional) If the Global Cluster should have deletion protection enabled. The database can't be deleted when this value is set to `true`. The default is `false`.
 * `engine` - (Optional, Forces new resources) Name of the database engine to be used for this DB cluster. Valid values: `aurora`. Defaults to `aurora`.
-* `engine_version` - (Optional, Forces new resources) Engine version of the Aurora global database.
+* `engine_version` - (Required, Forces new resources) Engine version of the Aurora global database.
 * `storage_encrypted` - (Optional, Forces new resources) Specifies whether the DB cluster is encrypted. The default is `false`.
 
 ## Attribute Reference


### PR DESCRIPTION
AWS recently made engine_version parameter required for rds global cluster deployment. No updates have been made to the [documentation](https://docs.aws.amazon.com/cli/latest/reference/rds/create-global-cluster.html) but the builds started failing.

Closes #9856 

```release-note
Made engine_version required parameter for aws_rds_global_cluster resource
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSRdsGlobalCluster'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSRdsGlobalCluster -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSRdsGlobalCluster_basic
=== PAUSE TestAccAWSRdsGlobalCluster_basic
=== RUN   TestAccAWSRdsGlobalCluster_disappears
=== PAUSE TestAccAWSRdsGlobalCluster_disappears
=== RUN   TestAccAWSRdsGlobalCluster_DatabaseName
=== PAUSE TestAccAWSRdsGlobalCluster_DatabaseName
=== RUN   TestAccAWSRdsGlobalCluster_DeletionProtection
=== PAUSE TestAccAWSRdsGlobalCluster_DeletionProtection
=== RUN   TestAccAWSRdsGlobalCluster_Engine_Aurora
=== PAUSE TestAccAWSRdsGlobalCluster_Engine_Aurora
=== RUN   TestAccAWSRdsGlobalCluster_EngineVersion_Aurora
=== PAUSE TestAccAWSRdsGlobalCluster_EngineVersion_Aurora
=== RUN   TestAccAWSRdsGlobalCluster_StorageEncrypted
=== PAUSE TestAccAWSRdsGlobalCluster_StorageEncrypted
=== CONT  TestAccAWSRdsGlobalCluster_basic
=== CONT  TestAccAWSRdsGlobalCluster_Engine_Aurora
=== CONT  TestAccAWSRdsGlobalCluster_disappears
=== CONT  TestAccAWSRdsGlobalCluster_EngineVersion_Aurora
=== CONT  TestAccAWSRdsGlobalCluster_StorageEncrypted
=== CONT  TestAccAWSRdsGlobalCluster_DatabaseName
=== CONT  TestAccAWSRdsGlobalCluster_DeletionProtection
--- PASS: TestAccAWSRdsGlobalCluster_disappears (12.62s)
--- PASS: TestAccAWSRdsGlobalCluster_Engine_Aurora (15.58s)
--- PASS: TestAccAWSRdsGlobalCluster_EngineVersion_Aurora (15.88s)
--- PASS: TestAccAWSRdsGlobalCluster_basic (15.93s)
--- PASS: TestAccAWSRdsGlobalCluster_DeletionProtection (24.17s)
--- PASS: TestAccAWSRdsGlobalCluster_StorageEncrypted (24.93s)
--- PASS: TestAccAWSRdsGlobalCluster_DatabaseName (25.44s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	25.524s
```
