### PR TITLE
Import test refactors for vpc resources

### DIFF
--- a/aws/resource_aws_vpc_dhcp_options_test.go
+++ b/aws/resource_aws_vpc_dhcp_options_test.go
@@ -87,8 +87,9 @@ func testSweepVpcDhcpOptions(region string) error {
 	return nil
 }
 
-func TestAccAWSDHCPOptions_importBasic(t *testing.T) {
-	resourceName := "aws_vpc_dhcp_options.foo"
+func TestAccAWSDHCPOptions_basic(t *testing.T) {
+	var d ec2.DhcpOptions
+	resourceName := "aws_vpc_dhcp_options.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -97,8 +98,18 @@ func TestAccAWSDHCPOptions_importBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDHCPOptionsConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDHCPOptionsExists(resourceName, &d),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", "service.consul"),
+					resource.TestCheckResourceAttr(resourceName, "domain_name_servers.0", "127.0.0.1"),
+					resource.TestCheckResourceAttr(resourceName, "domain_name_servers.1", "10.0.0.2"),
+					resource.TestCheckResourceAttr(resourceName, "ntp_servers.0", "127.0.0.1"),
+					resource.TestCheckResourceAttr(resourceName, "netbios_name_servers.0", "127.0.0.1"),
+					resource.TestCheckResourceAttr(resourceName, "netbios_node_type", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "test-name"),
+					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
+				),
 			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
@@ -108,34 +119,9 @@ func TestAccAWSDHCPOptions_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccAWSDHCPOptions_basic(t *testing.T) {
-	var d ec2.DhcpOptions
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckDHCPOptionsDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDHCPOptionsConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDHCPOptionsExists("aws_vpc_dhcp_options.foo", &d),
-					resource.TestCheckResourceAttr("aws_vpc_dhcp_options.foo", "domain_name", "service.consul"),
-					resource.TestCheckResourceAttr("aws_vpc_dhcp_options.foo", "domain_name_servers.0", "127.0.0.1"),
-					resource.TestCheckResourceAttr("aws_vpc_dhcp_options.foo", "domain_name_servers.1", "10.0.0.2"),
-					resource.TestCheckResourceAttr("aws_vpc_dhcp_options.foo", "ntp_servers.0", "127.0.0.1"),
-					resource.TestCheckResourceAttr("aws_vpc_dhcp_options.foo", "netbios_name_servers.0", "127.0.0.1"),
-					resource.TestCheckResourceAttr("aws_vpc_dhcp_options.foo", "netbios_node_type", "2"),
-					resource.TestCheckResourceAttr("aws_vpc_dhcp_options.foo", "tags.Name", "foo-name"),
-					testAccCheckResourceAttrAccountID("aws_vpc_dhcp_options.foo", "owner_id"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAWSDHCPOptions_deleteOptions(t *testing.T) {
 	var d ec2.DhcpOptions
+	resourceName := "aws_vpc_dhcp_options.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -145,8 +131,8 @@ func TestAccAWSDHCPOptions_deleteOptions(t *testing.T) {
 			{
 				Config: testAccDHCPOptionsConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDHCPOptionsExists("aws_vpc_dhcp_options.foo", &d),
-					testAccCheckDHCPOptionsDelete("aws_vpc_dhcp_options.foo"),
+					testAccCheckDHCPOptionsExists(resourceName, &d),
+					testAccCheckDHCPOptionsDelete(resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -243,7 +229,7 @@ func testAccCheckDHCPOptionsDelete(n string) resource.TestCheckFunc {
 }
 
 const testAccDHCPOptionsConfig = `
-resource "aws_vpc_dhcp_options" "foo" {
+resource "aws_vpc_dhcp_options" "test" {
 	domain_name = "service.consul"
 	domain_name_servers = ["127.0.0.1", "10.0.0.2"]
 	ntp_servers = ["127.0.0.1"]
@@ -251,7 +237,7 @@ resource "aws_vpc_dhcp_options" "foo" {
 	netbios_node_type = 2
 
 	tags = {
-		Name = "foo-name"
+		Name = "test-name"
 	}
 }
 `

--- a/aws/resource_aws_vpc_endpoint_connection_notification_test.go
+++ b/aws/resource_aws_vpc_endpoint_connection_notification_test.go
@@ -13,53 +13,37 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSVpcEndpointConnectionNotification_importBasic(t *testing.T) {
-	lbName := fmt.Sprintf("testaccawsnlb-basic-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-	resourceName := "aws_vpc_endpoint_connection_notification.foo"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckVpcEndpointConnectionNotificationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccVpcEndpointConnectionNotificationBasicConfig(lbName),
-			},
-
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAWSVpcEndpointConnectionNotification_basic(t *testing.T) {
 	lbName := fmt.Sprintf("testaccawsnlb-basic-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	resourceName := "aws_vpc_endpoint_connection_notification.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_vpc_endpoint_connection_notification.foo",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckVpcEndpointConnectionNotificationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcEndpointConnectionNotificationBasicConfig(lbName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVpcEndpointConnectionNotificationExists("aws_vpc_endpoint_connection_notification.foo"),
-					resource.TestCheckResourceAttr("aws_vpc_endpoint_connection_notification.foo", "connection_events.#", "2"),
-					resource.TestCheckResourceAttr("aws_vpc_endpoint_connection_notification.foo", "state", "Enabled"),
-					resource.TestCheckResourceAttr("aws_vpc_endpoint_connection_notification.foo", "notification_type", "Topic"),
+					testAccCheckVpcEndpointConnectionNotificationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "connection_events.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "state", "Enabled"),
+					resource.TestCheckResourceAttr(resourceName, "notification_type", "Topic"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccVpcEndpointConnectionNotificationModifiedConfig(lbName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVpcEndpointConnectionNotificationExists("aws_vpc_endpoint_connection_notification.foo"),
-					resource.TestCheckResourceAttr("aws_vpc_endpoint_connection_notification.foo", "connection_events.#", "1"),
-					resource.TestCheckResourceAttr("aws_vpc_endpoint_connection_notification.foo", "state", "Enabled"),
-					resource.TestCheckResourceAttr("aws_vpc_endpoint_connection_notification.foo", "notification_type", "Topic"),
+					testAccCheckVpcEndpointConnectionNotificationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "connection_events.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "state", "Enabled"),
+					resource.TestCheckResourceAttr(resourceName, "notification_type", "Topic"),
 				),
 			},
 		},
@@ -172,7 +156,7 @@ resource "aws_subnet" "nlb_test_2" {
 
 data "aws_caller_identity" "current" {}
 
-resource "aws_vpc_endpoint_service" "foo" {
+resource "aws_vpc_endpoint_service" "test" {
   acceptance_required = false
 
   network_load_balancer_arns = [
@@ -202,8 +186,8 @@ resource "aws_sns_topic" "topic" {
 POLICY
 }
 
-resource "aws_vpc_endpoint_connection_notification" "foo" {
-  vpc_endpoint_service_id = "${aws_vpc_endpoint_service.foo.id}"
+resource "aws_vpc_endpoint_connection_notification" "test" {
+  vpc_endpoint_service_id = "${aws_vpc_endpoint_service.test.id}"
   connection_notification_arn = "${aws_sns_topic.topic.arn}"
   connection_events = ["Accept", "Reject"]
 }
@@ -261,7 +245,7 @@ func testAccVpcEndpointConnectionNotificationModifiedConfig(lbName string) strin
 
 		data "aws_caller_identity" "current" {}
 
-		resource "aws_vpc_endpoint_service" "foo" {
+		resource "aws_vpc_endpoint_service" "test" {
 			acceptance_required = false
 
 			network_load_balancer_arns = [
@@ -291,8 +275,8 @@ func testAccVpcEndpointConnectionNotificationModifiedConfig(lbName string) strin
 		POLICY
 		}
 
-		resource "aws_vpc_endpoint_connection_notification" "foo" {
-			vpc_endpoint_service_id = "${aws_vpc_endpoint_service.foo.id}"
+		resource "aws_vpc_endpoint_connection_notification" "test" {
+			vpc_endpoint_service_id = "${aws_vpc_endpoint_service.test.id}"
 			connection_notification_arn = "${aws_sns_topic.topic.arn}"
 			connection_events = ["Accept"]
 		}

--- a/aws/resource_aws_vpc_peering_connection_options_test.go
+++ b/aws/resource_aws_vpc_peering_connection_options_test.go
@@ -8,28 +8,9 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccAWSVpcPeeringConnectionOptions_importBasic(t *testing.T) {
-	resourceName := "aws_vpc_peering_connection_options.foo"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSVpcPeeringConnectionDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccVpcPeeringConnectionOptionsConfig,
-			},
-
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAWSVpcPeeringConnectionOptions_basic(t *testing.T) {
+	resourceName := "aws_vpc_peering_connection_options.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -39,17 +20,17 @@ func TestAccAWSVpcPeeringConnectionOptions_basic(t *testing.T) {
 				Config: testAccVpcPeeringConnectionOptionsConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"aws_vpc_peering_connection_options.foo",
+						resourceName,
 						"accepter.#",
 						"1",
 					),
 					resource.TestCheckResourceAttr(
-						"aws_vpc_peering_connection_options.foo",
+						resourceName,
 						"accepter.1102046665.allow_remote_vpc_dns_resolution",
 						"true",
 					),
 					testAccCheckAWSVpcPeeringConnectionOptions(
-						"aws_vpc_peering_connection.foo",
+						"aws_vpc_peering_connection.test",
 						"accepter",
 						&ec2.VpcPeeringConnectionOptionsDescription{
 							AllowDnsResolutionFromRemoteVpc:            aws.Bool(true),
@@ -58,22 +39,22 @@ func TestAccAWSVpcPeeringConnectionOptions_basic(t *testing.T) {
 						},
 					),
 					resource.TestCheckResourceAttr(
-						"aws_vpc_peering_connection_options.foo",
+						resourceName,
 						"requester.#",
 						"1",
 					),
 					resource.TestCheckResourceAttr(
-						"aws_vpc_peering_connection_options.foo",
+						resourceName,
 						"requester.41753983.allow_classic_link_to_remote_vpc",
 						"true",
 					),
 					resource.TestCheckResourceAttr(
-						"aws_vpc_peering_connection_options.foo",
+						resourceName,
 						"requester.41753983.allow_vpc_to_remote_classic_link",
 						"true",
 					),
 					testAccCheckAWSVpcPeeringConnectionOptions(
-						"aws_vpc_peering_connection.foo",
+						"aws_vpc_peering_connection.test",
 						"requester",
 						&ec2.VpcPeeringConnectionOptionsDescription{
 							AllowDnsResolutionFromRemoteVpc:            aws.Bool(false),
@@ -83,15 +64,20 @@ func TestAccAWSVpcPeeringConnectionOptions_basic(t *testing.T) {
 					),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
 
 const testAccVpcPeeringConnectionOptionsConfig = `
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
   tags = {
-    Name = "terraform-testacc-vpc-peering-conn-options-foo"
+    Name = "terraform-testacc-vpc-peering-conn-options-test"
   }
 }
 
@@ -103,14 +89,14 @@ resource "aws_vpc" "bar" {
   }
 }
 
-resource "aws_vpc_peering_connection" "foo" {
-  vpc_id      = "${aws_vpc.foo.id}"
+resource "aws_vpc_peering_connection" "test" {
+  vpc_id      = "${aws_vpc.test.id}"
   peer_vpc_id = "${aws_vpc.bar.id}"
   auto_accept = true
 }
 
-resource "aws_vpc_peering_connection_options" "foo" {
-  vpc_peering_connection_id = "${aws_vpc_peering_connection.foo.id}"
+resource "aws_vpc_peering_connection_options" "test" {
+  vpc_peering_connection_id = "${aws_vpc_peering_connection.test.id}"
 
   accepter {
     allow_remote_vpc_dns_resolution = true


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates 8944

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSVPCPeeringConnection"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSVPCPeeringConnection -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSVPCPeeringConnectionAccepter_sameRegion
=== PAUSE TestAccAWSVPCPeeringConnectionAccepter_sameRegion
=== RUN   TestAccAWSVPCPeeringConnectionAccepter_differentRegion
=== PAUSE TestAccAWSVPCPeeringConnectionAccepter_differentRegion
=== RUN   TestAccAWSVPCPeeringConnection_basic
=== PAUSE TestAccAWSVPCPeeringConnection_basic
=== RUN   TestAccAWSVPCPeeringConnection_plan
=== PAUSE TestAccAWSVPCPeeringConnection_plan
=== RUN   TestAccAWSVPCPeeringConnection_tags
=== PAUSE TestAccAWSVPCPeeringConnection_tags
=== RUN   TestAccAWSVPCPeeringConnection_options
=== PAUSE TestAccAWSVPCPeeringConnection_options
=== RUN   TestAccAWSVPCPeeringConnection_failedState
=== PAUSE TestAccAWSVPCPeeringConnection_failedState
=== RUN   TestAccAWSVPCPeeringConnection_peerRegionAndAutoAccept
=== PAUSE TestAccAWSVPCPeeringConnection_peerRegionAndAutoAccept
=== RUN   TestAccAWSVPCPeeringConnection_region

make testacc TESTARGS="-run=TestAccAWSVpcPeeringConnectionOptions"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSVpcPeeringConnectionOptions -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSVpcPeeringConnectionOptions_basic
=== PAUSE TestAccAWSVpcPeeringConnectionOptions_basic
=== CONT  TestAccAWSVpcPeeringConnectionOptions_basic
--- PASS: TestAccAWSVpcPeeringConnectionOptions_basic (68.94s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       70.495s


make testacc TESTARGS="-run=TestAccAWSDHCPOptions"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSDHCPOptions -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSDHCPOptionsAssociation_basic
=== PAUSE TestAccAWSDHCPOptionsAssociation_basic
=== RUN   TestAccAWSDHCPOptions_basic
=== PAUSE TestAccAWSDHCPOptions_basic
=== RUN   TestAccAWSDHCPOptions_deleteOptions
=== PAUSE TestAccAWSDHCPOptions_deleteOptions
=== CONT  TestAccAWSDHCPOptionsAssociation_basic
=== CONT  TestAccAWSDHCPOptions_deleteOptions
=== CONT  TestAccAWSDHCPOptions_basic
--- PASS: TestAccAWSDHCPOptions_deleteOptions (21.93s)
--- PASS: TestAccAWSDHCPOptions_basic (28.34s)
--- PASS: TestAccAWSDHCPOptionsAssociation_basic (49.12s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       52.630s

make testacc TESTARGS="-run=TestAccAWSVpcEndpointConnectionNotification"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSVpcEndpointConnectionNotification -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSVpcEndpointConnectionNotification_basic
=== PAUSE TestAccAWSVpcEndpointConnectionNotification_basic
=== CONT  TestAccAWSVpcEndpointConnectionNotification_basic
--- PASS: TestAccAWSVpcEndpointConnectionNotification_basic (365.59s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       367.077s
```