### PR TITLE
Add CreateLogGroup permission to the sample of aws_iam_policy

### DIFF
--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -103,6 +103,7 @@ resource "aws_iam_policy" "lambda_logging" {
   "Statement": [
     {
       "Action": [
+        "logs:CreateLogGroup",
         "logs:CreateLogStream",
         "logs:PutLogEvents"
       ],


### PR DESCRIPTION
`CreateLogGroup` is required to log lambda logs to CloudWatch from zero.
Add this to the sample to help people save their time.