### PR TITLE
Multiple load_balancer blocks

### DIFF
--- a/website/docs/r/ecs_service.html.markdown
+++ b/website/docs/r/ecs_service.html.markdown
@@ -113,6 +113,8 @@ The `deployment_controller` configuration block supports the following:
 * `container_name` - (Required) The name of the container to associate with the load balancer (as it appears in a container definition).
 * `container_port` - (Required) The port on the container to associate with the load balancer.
 
+**Note:** With aws provider >=2.22.0 multiple load_balancer blocks are supported. This allows configuration of ECS service support for multiple target groups (https://aws.amazon.com/about-aws/whats-new/2019/07/amazon-ecs-services-now-support-multiple-load-balancer-target-groups/)
+
 ## ordered_placement_strategy
 
 `ordered_placement_strategy` supports the following:

--- a/website/docs/r/ecs_service.html.markdown
+++ b/website/docs/r/ecs_service.html.markdown
@@ -113,7 +113,7 @@ The `deployment_controller` configuration block supports the following:
 * `container_name` - (Required) The name of the container to associate with the load balancer (as it appears in a container definition).
 * `container_port` - (Required) The port on the container to associate with the load balancer.
 
-**Note:** With aws provider >=2.22.0 multiple load_balancer blocks are supported. This allows configuration of ECS service support for multiple target groups (https://aws.amazon.com/about-aws/whats-new/2019/07/amazon-ecs-services-now-support-multiple-load-balancer-target-groups/)
+-> **Version note:** Multiple `load_balancer` configuration block support was added in Terraform AWS Provider version 2.22.0. This allows configuration of [ECS service support for multiple target groups](https://aws.amazon.com/about-aws/whats-new/2019/07/amazon-ecs-services-now-support-multiple-load-balancer-target-groups/).
 
 ## ordered_placement_strategy
 


### PR DESCRIPTION
**Reasoning for docs update:**
Add a note that multiple load_balancer blocks are supported with minimum aws provider. This wasn't clear and was only through seeing an old issue that it was possible. With recent support for multiple target groups for ecs service, I think this will be something people will try and use more.

**Relevant AWS provider version:** >=2.22.0

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
