### PR TITLE
Remove non-existant status attribute from docdb_cluster_instance resource doc

### DIFF
--- a/website/docs/r/docdb_cluster_instance.html.markdown
+++ b/website/docs/r/docdb_cluster_instance.html.markdown
@@ -75,7 +75,6 @@ In addition to all arguments above, the following attributes are exported:
 * `kms_key_id` - The ARN for the KMS encryption key if one is set to the cluster.
 * `port` - The database port
 * `preferred_backup_window` - The daily time range during which automated backups are created if automated backups are enabled.
-* `status` - The DocDB instance status
 * `storage_encrypted` - Specifies whether the DB cluster is encrypted.
 * `writer` – Boolean indicating if this instance is writable. `False` indicates this instance is a read replica.
 


### PR DESCRIPTION
See

https://github.com/terraform-providers/terraform-provider-aws/blob/b0470db5ead2ba92f08e4d91c2fa6c0c1d295b73/aws/resource_aws_docdb_cluster_instance.go#L33

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Relates #9823

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Remove non-existant status attribute from docdb_cluster_instance resource doc
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
