### PR TITLE
Documentation: Remove duplicate nested lists for Global Accelerator resources

### DIFF
--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1548,23 +1548,9 @@
                                 <li>
                                     <a href="/docs/providers/aws/r/globalaccelerator_accelerator.html">aws_globalaccelerator_accelerator</a>
                                 </li>
-                            </ul>
-                        </li>
-                    </ul>
-                    <ul class="nav">
-                        <li>
-                            <a href="#">Resources</a>
-                            <ul class="nav nav-auto-expand">
                                 <li>
                                     <a href="/docs/providers/aws/r/globalaccelerator_endpoint_group.html">aws_globalaccelerator_endpoint_group</a>
                                 </li>
-                            </ul>
-                        </li>
-                    </ul>
-                    <ul class="nav">
-                        <li>
-                            <a href="#">Resources</a>
-                            <ul class="nav nav-auto-expand">
                                 <li>
                                     <a href="/docs/providers/aws/r/globalaccelerator_listener.html">aws_globalaccelerator_listener</a>
                                 </li>


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Remove the duplicate nested lists in the Global Accelerator section of the documentation navigation.
Currently looks like:

![globalaccelerator](https://user-images.githubusercontent.com/2404182/64018365-3f0d9400-cafa-11e9-84d1-50edfde73901.PNG)

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

n/a
