### PR TITLE
Add support for S3 Object Lock legal holds, retention modes and retention periods

### DIFF
--- a/aws/data_source_aws_s3_bucket_object.go
+++ b/aws/data_source_aws_s3_bucket_object.go
@@ -78,6 +78,14 @@ func dataSourceAwsS3BucketObject() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"object_lock_mode": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"object_lock_retain_until_date": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"range": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -160,6 +168,8 @@ func dataSourceAwsS3BucketObjectRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("last_modified", out.LastModified.Format(time.RFC1123))
 	d.Set("metadata", pointersMapToStringList(out.Metadata))
 	d.Set("object_lock_legal_hold_status", out.ObjectLockLegalHoldStatus)
+	d.Set("object_lock_mode", out.ObjectLockMode)
+	d.Set("object_lock_retain_until_date", flattenS3ObjectLockRetainUntilDate(out.ObjectLockRetainUntilDate))
 	d.Set("server_side_encryption", out.ServerSideEncryption)
 	d.Set("sse_kms_key_id", out.SSEKMSKeyId)
 	d.Set("version_id", out.VersionId)

--- a/aws/data_source_aws_s3_bucket_object.go
+++ b/aws/data_source_aws_s3_bucket_object.go
@@ -74,6 +74,10 @@ func dataSourceAwsS3BucketObject() *schema.Resource {
 				Type:     schema.TypeMap,
 				Computed: true,
 			},
+			"object_lock_legal_hold_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"range": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -155,6 +159,7 @@ func dataSourceAwsS3BucketObjectRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("expires", out.Expires)
 	d.Set("last_modified", out.LastModified.Format(time.RFC1123))
 	d.Set("metadata", pointersMapToStringList(out.Metadata))
+	d.Set("object_lock_legal_hold_status", out.ObjectLockLegalHoldStatus)
 	d.Set("server_side_encryption", out.ServerSideEncryption)
 	d.Set("sse_kms_key_id", out.SSEKMSKeyId)
 	d.Set("version_id", out.VersionId)

--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -1261,10 +1261,10 @@ func resourceAwsS3BucketDelete(d *schema.ResourceData, meta interface{}) error {
 
 			// Delete everything including locked objects.
 			// Don't ignore any object errors or we could recurse infinitely.
-			objectLockEnabled := false
+			var objectLockEnabled bool
 			objectLockConfiguration := expandS3ObjectLockConfiguration(d.Get("object_lock_configuration").([]interface{}))
-			if objectLockConfiguration != nil && aws.StringValue(objectLockConfiguration.ObjectLockEnabled) == s3.ObjectLockEnabledEnabled {
-				objectLockEnabled = true
+			if objectLockConfiguration != nil {
+				objectLockEnabled = aws.StringValue(objectLockConfiguration.ObjectLockEnabled) == s3.ObjectLockEnabledEnabled
 			}
 			err = deleteAllS3ObjectVersions(s3conn, d.Id(), "", objectLockEnabled, false)
 

--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -1261,7 +1261,12 @@ func resourceAwsS3BucketDelete(d *schema.ResourceData, meta interface{}) error {
 
 			// Delete everything including locked objects.
 			// Don't ignore any object errors or we could recurse infinitely.
-			err = deleteAllS3ObjectVersions(s3conn, d.Id(), "", true, false)
+			objectLockEnabled := false
+			objectLockConfiguration := expandS3ObjectLockConfiguration(d.Get("object_lock_configuration").([]interface{}))
+			if objectLockConfiguration != nil && aws.StringValue(objectLockConfiguration.ObjectLockEnabled) == s3.ObjectLockEnabledEnabled {
+				objectLockEnabled = true
+			}
+			err = deleteAllS3ObjectVersions(s3conn, d.Id(), "", objectLockEnabled, false)
 
 			if err != nil {
 				return fmt.Errorf("error S3 Bucket force_destroy: %s", err)

--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -567,8 +567,8 @@ func resourceAwsS3Bucket() *schema.Resource {
 													Type:     schema.TypeString,
 													Required: true,
 													ValidateFunc: validation.StringInSlice([]string{
-														s3.ObjectLockModeGovernance,
-														s3.ObjectLockModeCompliance,
+														s3.ObjectLockRetentionModeGovernance,
+														s3.ObjectLockRetentionModeCompliance,
 													}, false),
 												},
 
@@ -1259,49 +1259,12 @@ func resourceAwsS3BucketDelete(d *schema.ResourceData, meta interface{}) error {
 			// bucket may have things delete them
 			log.Printf("[DEBUG] S3 Bucket attempting to forceDestroy %+v", err)
 
-			bucket := d.Get("bucket").(string)
-			resp, err := s3conn.ListObjectVersions(
-				&s3.ListObjectVersionsInput{
-					Bucket: aws.String(bucket),
-				},
-			)
+			// Delete everything including locked objects.
+			// Don't ignore any object errors or we could recurse infinitely.
+			err = deleteAllS3ObjectVersions(s3conn, d.Id(), "", true, false)
 
 			if err != nil {
-				return fmt.Errorf("Error S3 Bucket list Object Versions err: %s", err)
-			}
-
-			objectsToDelete := make([]*s3.ObjectIdentifier, 0)
-
-			if len(resp.DeleteMarkers) != 0 {
-
-				for _, v := range resp.DeleteMarkers {
-					objectsToDelete = append(objectsToDelete, &s3.ObjectIdentifier{
-						Key:       v.Key,
-						VersionId: v.VersionId,
-					})
-				}
-			}
-
-			if len(resp.Versions) != 0 {
-				for _, v := range resp.Versions {
-					objectsToDelete = append(objectsToDelete, &s3.ObjectIdentifier{
-						Key:       v.Key,
-						VersionId: v.VersionId,
-					})
-				}
-			}
-
-			params := &s3.DeleteObjectsInput{
-				Bucket: aws.String(bucket),
-				Delete: &s3.Delete{
-					Objects: objectsToDelete,
-				},
-			}
-
-			_, err = s3conn.DeleteObjects(params)
-
-			if err != nil {
-				return fmt.Errorf("Error S3 Bucket force_destroy error deleting: %s", err)
+				return fmt.Errorf("error S3 Bucket force_destroy: %s", err)
 			}
 
 			// this line recurses until all objects are deleted or an error is returned
@@ -2472,7 +2435,7 @@ type S3Website struct {
 // S3 Object Lock functions.
 //
 
-func readS3ObjectLockConfiguration(conn *s3.S3, bucket string) (interface{}, error) {
+func readS3ObjectLockConfiguration(conn *s3.S3, bucket string) ([]interface{}, error) {
 	resp, err := retryOnAwsCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
 		return conn.GetObjectLockConfiguration(&s3.GetObjectLockConfigurationInput{
 			Bucket: aws.String(bucket),

--- a/aws/resource_aws_s3_bucket_object.go
+++ b/aws/resource_aws_s3_bucket_object.go
@@ -516,7 +516,7 @@ func resourceAwsS3BucketObjectCustomizeDiff(d *schema.ResourceDiff, meta interfa
 
 // deleteAllS3ObjectVersions deletes all versions of a specified key from an S3 bucket.
 // If key is empty then all versions of all objects are deleted.
-// Set force to true to override any S3 object lock protections.
+// Set force to true to override any S3 object lock protections on object lock enabled buckets.
 func deleteAllS3ObjectVersions(conn *s3.S3, bucketName, key string, force, ignoreObjectErrors bool) error {
 	input := &s3.ListObjectVersionsInput{
 		Bucket: aws.String(bucketName),

--- a/aws/resource_aws_s3_bucket_object_test.go
+++ b/aws/resource_aws_s3_bucket_object_test.go
@@ -82,8 +82,15 @@ func testSweepS3BucketObjects(region string) error {
 			continue
 		}
 
+		objectLockEnabled, err := testS3BucketObjectLockEnabled(conn, bucketName)
+
+		if err != nil {
+			log.Printf("[ERROR] Error getting S3 Bucket (%s) Object Lock: %s", bucketName, err)
+			continue
+		}
+
 		// Delete everything including locked objects. Ignore any object errors.
-		err = deleteAllS3ObjectVersions(conn, bucketName, "", true, true)
+		err = deleteAllS3ObjectVersions(conn, bucketName, "", objectLockEnabled, true)
 
 		if err != nil {
 			return fmt.Errorf("error listing S3 Bucket (%s) Objects: %s", bucketName, err)

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -136,6 +136,24 @@ func testS3BucketRegion(conn *s3.S3, bucket string) (string, error) {
 	return aws.StringValue(output.LocationConstraint), nil
 }
 
+func testS3BucketObjectLockEnabled(conn *s3.S3, bucket string) (bool, error) {
+	input := &s3.GetObjectLockConfigurationInput{
+		Bucket: aws.String(bucket),
+	}
+
+	output, err := conn.GetObjectLockConfiguration(input)
+
+	if isAWSErr(err, "ObjectLockConfigurationNotFoundError", "") {
+		return false, nil
+	}
+
+	if err != nil {
+		return false, err
+	}
+
+	return aws.StringValue(output.ObjectLockConfiguration.ObjectLockEnabled) == s3.ObjectLockEnabledEnabled, nil
+}
+
 func TestAccAWSS3Bucket_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 	arnRegexp := regexp.MustCompile(`^arn:aws[\w-]*:s3:::`)

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -1884,6 +1884,48 @@ func TestAccAWSS3Bucket_objectLock(t *testing.T) {
 	})
 }
 
+func TestAccAWSS3Bucket_forceDestroy(t *testing.T) {
+	resourceName := "aws_s3_bucket.bucket"
+	rInt := acctest.RandInt()
+	bucketName := fmt.Sprintf("tf-test-bucket-%d", rInt)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSS3BucketConfig_forceDestroy(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketExists(resourceName),
+					testAccCheckAWSS3BucketAddObjects(resourceName, "data.txt", "prefix/more_data.txt"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSS3Bucket_forceDestroyWithObjectLockEnabled(t *testing.T) {
+	resourceName := "aws_s3_bucket.bucket"
+	rInt := acctest.RandInt()
+	bucketName := fmt.Sprintf("tf-test-bucket-%d", rInt)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSS3BucketConfig_forceDestroyWithObjectLockEnabled(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketExists(resourceName),
+					testAccCheckAWSS3BucketAddObjectsWithLegalHold(resourceName, "data.txt", "prefix/more_data.txt"),
+				),
+			},
+		},
+	})
+}
+
 func TestAWSS3BucketName(t *testing.T) {
 	validDnsNames := []string{
 		"foobar",
@@ -2094,6 +2136,47 @@ func testAccCheckAWSS3DestroyBucket(n string) resource.TestCheckFunc {
 		if err != nil {
 			return fmt.Errorf("Error destroying Bucket (%s) in testAccCheckAWSS3DestroyBucket: %s", rs.Primary.ID, err)
 		}
+		return nil
+	}
+}
+
+func testAccCheckAWSS3BucketAddObjects(n string, keys ...string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs := s.RootModule().Resources[n]
+		conn := testAccProvider.Meta().(*AWSClient).s3conn
+
+		for _, key := range keys {
+			_, err := conn.PutObject(&s3.PutObjectInput{
+				Bucket: aws.String(rs.Primary.ID),
+				Key:    aws.String(key),
+			})
+
+			if err != nil {
+				return fmt.Errorf("PutObject error: %s", err)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSS3BucketAddObjectsWithLegalHold(n string, keys ...string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs := s.RootModule().Resources[n]
+		conn := testAccProvider.Meta().(*AWSClient).s3conn
+
+		for _, key := range keys {
+			_, err := conn.PutObject(&s3.PutObjectInput{
+				Bucket:                    aws.String(rs.Primary.ID),
+				Key:                       aws.String(key),
+				ObjectLockLegalHoldStatus: aws.String(s3.ObjectLockLegalHoldStatusOn),
+			})
+
+			if err != nil {
+				return fmt.Errorf("PutObject error: %s", err)
+			}
+		}
+
 		return nil
 	}
 }
@@ -3695,6 +3778,34 @@ resource "aws_s3_bucket" "arbitrary" {
   }
 }
 `, randInt)
+}
+
+func testAccAWSS3BucketConfig_forceDestroy(bucketName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "bucket" {
+  bucket = "%s"
+  acl = "private"
+  force_destroy = true
+}
+`, bucketName)
+}
+
+func testAccAWSS3BucketConfig_forceDestroyWithObjectLockEnabled(bucketName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "bucket" {
+  bucket = "%s"
+  acl = "private"
+  force_destroy = true
+
+  versioning {
+    enabled = true
+  }
+
+  object_lock_configuration {
+    object_lock_enabled = "Enabled"
+  }
+}
+`, bucketName)
 }
 
 const testAccAWSS3BucketConfigBucketEmptyString = `

--- a/website/docs/d/s3_bucket_object.html.markdown
+++ b/website/docs/d/s3_bucket_object.html.markdown
@@ -77,6 +77,7 @@ In addition to all arguments above, the following attributes are exported:
 * `expires` - The date and time at which the object is no longer cacheable.
 * `last_modified` - Last modified date of the object in RFC1123 format (e.g. `Mon, 02 Jan 2006 15:04:05 MST`)
 * `metadata` - A map of metadata stored with the object in S3
+* `object_lock_legal_hold_status` - Indicates whether this object has an active [legal hold](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html#object-lock-legal-holds). This field is only returned if you have permission to view an object's legal hold status.
 * `server_side_encryption` - If the object is stored using server-side encryption (KMS or Amazon S3-managed encryption key), this field includes the chosen encryption and algorithm used.
 * `sse_kms_key_id` - If present, specifies the ID of the Key Management Service (KMS) master encryption key that was used for the object.
 * `storage_class` - [Storage class](http://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html) information of the object. Available for all objects except for `Standard` storage class objects.

--- a/website/docs/d/s3_bucket_object.html.markdown
+++ b/website/docs/d/s3_bucket_object.html.markdown
@@ -78,6 +78,8 @@ In addition to all arguments above, the following attributes are exported:
 * `last_modified` - Last modified date of the object in RFC1123 format (e.g. `Mon, 02 Jan 2006 15:04:05 MST`)
 * `metadata` - A map of metadata stored with the object in S3
 * `object_lock_legal_hold_status` - Indicates whether this object has an active [legal hold](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html#object-lock-legal-holds). This field is only returned if you have permission to view an object's legal hold status.
+* `object_lock_mode` - The object lock [retention mode](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html#object-lock-retention-modes) currently in place for this object.
+* `object_lock_retain_until_date` - The date and time when this object's object lock will expire.
 * `server_side_encryption` - If the object is stored using server-side encryption (KMS or Amazon S3-managed encryption key), this field includes the chosen encryption and algorithm used.
 * `sse_kms_key_id` - If present, specifies the ID of the Key Management Service (KMS) master encryption key that was used for the object.
 * `storage_class` - [Storage class](http://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html) information of the object. Available for all objects except for `Standard` storage class objects.

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -320,7 +320,7 @@ The following arguments are supported:
 * `policy` - (Optional) A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a `terraform plan`. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](/docs/providers/aws/guides/iam-policy-documents.html).
 
 * `tags` - (Optional) A mapping of tags to assign to the bucket.
-* `force_destroy` - (Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
+* `force_destroy` - (Optional, Default:`false`) A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
 * `website` - (Optional) A website object (documented below).
 * `cors_rule` - (Optional) A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
 * `versioning` - (Optional) A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)

--- a/website/docs/r/s3_bucket_object.html.markdown
+++ b/website/docs/r/s3_bucket_object.html.markdown
@@ -109,7 +109,7 @@ use the exported `arn` attribute:
       `kms_key_id = "${aws_kms_key.foo.arn}"`
 * `metadata` - (Optional) A mapping of keys/values to provision metadata (will be automatically prefixed by `x-amz-meta-`, note that only lowercase label are currently supported by the AWS Go API).
 * `tags` - (Optional) A mapping of tags to assign to the object.
-`force_destroy` - (Optional) Allow the object to be deleted by removing any legal hold on any object version.
+* `force_destroy` - (Optional) Allow the object to be deleted by removing any legal hold on any object version.
 Default is `false`.
 * `object_lock_legal_hold_status` - (Optional) The [legal hold](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html#object-lock-legal-holds) status that you want to apply to the specified object. Valid values are `ON` and `OFF`.
 * `object_lock_mode` - (Optional) The object lock [retention mode](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html#object-lock-retention-modes) that you want to apply to this object. Valid values are `GOVERNANCE` and `COMPLIANCE`.

--- a/website/docs/r/s3_bucket_object.html.markdown
+++ b/website/docs/r/s3_bucket_object.html.markdown
@@ -86,6 +86,14 @@ resource "aws_s3_bucket_object" "examplebucket_object" {
 resource "aws_s3_bucket" "examplebucket" {
   bucket = "examplebuckettftest"
   acl    = "private"
+
+  versioning {
+    enabled = true
+  }
+
+  object_lock_configuration {
+    object_lock_enabled = "Enabled"
+  }
 }
 
 resource "aws_s3_bucket_object" "examplebucket_object" {
@@ -96,6 +104,8 @@ resource "aws_s3_bucket_object" "examplebucket_object" {
   object_lock_legal_hold_status = "ON"
   object_lock_mode              = "GOVERNANCE"
   object_lock_retain_until_date = "2021-12-31T23:59:60Z"
+
+  force_destroy = true
 }
 ```
 

--- a/website/docs/r/s3_bucket_object.html.markdown
+++ b/website/docs/r/s3_bucket_object.html.markdown
@@ -111,7 +111,9 @@ use the exported `arn` attribute:
 * `tags` - (Optional) A mapping of tags to assign to the object.
 `force_destroy` - (Optional) Allow the object to be deleted by removing any legal hold on any object version.
 Default is `false`.
-* `object_lock_legal_hold_status` - (Optional) Indicates whether this object has an active [legal hold](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html#object-lock-legal-holds). Valid values are `ON` and `OFF`.
+* `object_lock_legal_hold_status` - (Optional) The [legal hold](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html#object-lock-legal-holds) status that you want to apply to the specified object. Valid values are `ON` and `OFF`.
+* `object_lock_mode` - (Optional) The object lock [retention mode](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html#object-lock-retention-modes) that you want to apply to this object. Valid values are `GOVERNANCE` and `COMPLIANCE`.
+* `object_lock_retain_until_date` - (Optional) The date and time, in [RFC3339 format](https://tools.ietf.org/html/rfc3339#section-5.8), when this object's object lock will [expire](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html#object-lock-retention-periods).
 
 If no content is provided through `source`, `content` or `content_base64`, then the object will be empty.
 

--- a/website/docs/r/s3_bucket_object.html.markdown
+++ b/website/docs/r/s3_bucket_object.html.markdown
@@ -109,6 +109,7 @@ use the exported `arn` attribute:
       `kms_key_id = "${aws_kms_key.foo.arn}"`
 * `metadata` - (Optional) A mapping of keys/values to provision metadata (will be automatically prefixed by `x-amz-meta-`, note that only lowercase label are currently supported by the AWS Go API).
 * `tags` - (Optional) A mapping of tags to assign to the object.
+* `object_lock_legal_hold_status` - (Optional) Indicates whether this object has an active [legal hold](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html#object-lock-legal-holds). Valid values are `ON` and `OFF`.
 
 If no content is provided through `source`, `content` or `content_base64`, then the object will be empty.
 

--- a/website/docs/r/s3_bucket_object.html.markdown
+++ b/website/docs/r/s3_bucket_object.html.markdown
@@ -109,6 +109,8 @@ use the exported `arn` attribute:
       `kms_key_id = "${aws_kms_key.foo.arn}"`
 * `metadata` - (Optional) A mapping of keys/values to provision metadata (will be automatically prefixed by `x-amz-meta-`, note that only lowercase label are currently supported by the AWS Go API).
 * `tags` - (Optional) A mapping of tags to assign to the object.
+`force_destroy` - (Optional) Allow the object to be deleted by removing any legal hold on any object version.
+Default is `false`.
 * `object_lock_legal_hold_status` - (Optional) Indicates whether this object has an active [legal hold](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html#object-lock-legal-holds). Valid values are `ON` and `OFF`.
 
 If no content is provided through `source`, `content` or `content_base64`, then the object will be empty.

--- a/website/docs/r/s3_bucket_object.html.markdown
+++ b/website/docs/r/s3_bucket_object.html.markdown
@@ -80,6 +80,25 @@ resource "aws_s3_bucket_object" "examplebucket_object" {
 }
 ```
 
+### S3 Object Lock
+
+```hcl
+resource "aws_s3_bucket" "examplebucket" {
+  bucket = "examplebuckettftest"
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_object" "examplebucket_object" {
+  key    = "someobject"
+  bucket = "${aws_s3_bucket.examplebucket.id}"
+  source = "important.txt"
+
+  object_lock_legal_hold_status = "ON"
+  object_lock_mode              = "GOVERNANCE"
+  object_lock_retain_until_date = "2021-12-31T23:59:60Z"
+}
+```
+
 ## Argument Reference
 
 -> **Note:** If you specify `content_encoding` you are responsible for encoding the body appropriately. `source`, `content`, and `content_base64` all expect already encoded/compressed bytes.
@@ -110,7 +129,7 @@ use the exported `arn` attribute:
 * `metadata` - (Optional) A mapping of keys/values to provision metadata (will be automatically prefixed by `x-amz-meta-`, note that only lowercase label are currently supported by the AWS Go API).
 * `tags` - (Optional) A mapping of tags to assign to the object.
 * `force_destroy` - (Optional) Allow the object to be deleted by removing any legal hold on any object version.
-Default is `false`.
+Default is `false`. This value should be set to `true` only if the bucket has S3 object lock enabled.
 * `object_lock_legal_hold_status` - (Optional) The [legal hold](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html#object-lock-legal-holds) status that you want to apply to the specified object. Valid values are `ON` and `OFF`.
 * `object_lock_mode` - (Optional) The object lock [retention mode](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html#object-lock-retention-modes) that you want to apply to this object. Valid values are `GOVERNANCE` and `COMPLIANCE`.
 * `object_lock_retain_until_date` - (Optional) The date and time, in [RFC3339 format](https://tools.ietf.org/html/rfc3339#section-5.8), when this object's object lock will [expire](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html#object-lock-retention-periods).


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #7158.
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/7159.
Replaces https://github.com/terraform-providers/terraform-provider-aws/pull/7179.

Add support for [S3 Object Lock](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html) [legal holds](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html#object-lock-legal-holds), [retention modes](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html#object-lock-retention-modes) and [retention periods](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html#object-lock-retention-periods).
.
Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data-source/aws_s3_bucket_object: Add `object_lock_legal_hold_status`, `object_lock_mode` and `object_lock_retain_until_date` attributes
resource/aws_s3_bucket_object: Add `force_destroy`, `object_lock_legal_hold_status`, `object_lock_mode` and `object_lock_retain_until_date` attributes
```

Output from acceptance testing:

#### aws_s3_bucket_object

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccDataSourceAWSS3BucketObject_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccDataSourceAWSS3BucketObject_ -timeout 120m
=== RUN   TestAccDataSourceAWSS3BucketObject_basic
=== PAUSE TestAccDataSourceAWSS3BucketObject_basic
=== RUN   TestAccDataSourceAWSS3BucketObject_readableBody
=== PAUSE TestAccDataSourceAWSS3BucketObject_readableBody
=== RUN   TestAccDataSourceAWSS3BucketObject_kmsEncrypted
=== PAUSE TestAccDataSourceAWSS3BucketObject_kmsEncrypted
=== RUN   TestAccDataSourceAWSS3BucketObject_allParams
=== PAUSE TestAccDataSourceAWSS3BucketObject_allParams
=== RUN   TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOff
=== PAUSE TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOff
=== RUN   TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOn
=== PAUSE TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOn
=== CONT  TestAccDataSourceAWSS3BucketObject_basic
=== CONT  TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOn
=== CONT  TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOff
=== CONT  TestAccDataSourceAWSS3BucketObject_allParams
=== CONT  TestAccDataSourceAWSS3BucketObject_kmsEncrypted
=== CONT  TestAccDataSourceAWSS3BucketObject_readableBody
--- PASS: TestAccDataSourceAWSS3BucketObject_readableBody (57.06s)
--- PASS: TestAccDataSourceAWSS3BucketObject_basic (57.09s)
--- PASS: TestAccDataSourceAWSS3BucketObject_allParams (57.60s)
--- PASS: TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOff (58.27s)
--- PASS: TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOn (59.89s)
--- PASS: TestAccDataSourceAWSS3BucketObject_kmsEncrypted (80.70s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	80.768s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSS3BucketObject_'==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAWSS3BucketObject_ -timeout 120m
=== RUN   TestAccAWSS3BucketObject_noNameNoKey
=== PAUSE TestAccAWSS3BucketObject_noNameNoKey
=== RUN   TestAccAWSS3BucketObject_empty
=== PAUSE TestAccAWSS3BucketObject_empty
=== RUN   TestAccAWSS3BucketObject_source
=== PAUSE TestAccAWSS3BucketObject_source
=== RUN   TestAccAWSS3BucketObject_content
=== PAUSE TestAccAWSS3BucketObject_content
=== RUN   TestAccAWSS3BucketObject_etagEncryption
=== PAUSE TestAccAWSS3BucketObject_etagEncryption
=== RUN   TestAccAWSS3BucketObject_contentBase64
=== PAUSE TestAccAWSS3BucketObject_contentBase64
=== RUN   TestAccAWSS3BucketObject_withContentCharacteristics
=== PAUSE TestAccAWSS3BucketObject_withContentCharacteristics
=== RUN   TestAccAWSS3BucketObject_updates
=== PAUSE TestAccAWSS3BucketObject_updates
=== RUN   TestAccAWSS3BucketObject_updateSameFile
=== PAUSE TestAccAWSS3BucketObject_updateSameFile
=== RUN   TestAccAWSS3BucketObject_updatesWithVersioning
=== PAUSE TestAccAWSS3BucketObject_updatesWithVersioning
=== RUN   TestAccAWSS3BucketObject_kms
=== PAUSE TestAccAWSS3BucketObject_kms
=== RUN   TestAccAWSS3BucketObject_sse
=== PAUSE TestAccAWSS3BucketObject_sse
=== RUN   TestAccAWSS3BucketObject_acl
=== PAUSE TestAccAWSS3BucketObject_acl
=== RUN   TestAccAWSS3BucketObject_metadata
=== PAUSE TestAccAWSS3BucketObject_metadata
=== RUN   TestAccAWSS3BucketObject_storageClass
=== PAUSE TestAccAWSS3BucketObject_storageClass
=== RUN   TestAccAWSS3BucketObject_tags
=== PAUSE TestAccAWSS3BucketObject_tags
=== RUN   TestAccAWSS3BucketObject_tagsLeadingSlash
=== PAUSE TestAccAWSS3BucketObject_tagsLeadingSlash
=== RUN   TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithNone
=== PAUSE TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithNone
=== RUN   TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithOn
=== PAUSE TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithOn
=== RUN   TestAccAWSS3BucketObject_ObjectLockRetentionStartWithNone
=== PAUSE TestAccAWSS3BucketObject_ObjectLockRetentionStartWithNone
=== RUN   TestAccAWSS3BucketObject_ObjectLockRetentionStartWithSet
=== PAUSE TestAccAWSS3BucketObject_ObjectLockRetentionStartWithSet
=== CONT  TestAccAWSS3BucketObject_noNameNoKey
=== CONT  TestAccAWSS3BucketObject_ObjectLockRetentionStartWithSet
=== CONT  TestAccAWSS3BucketObject_ObjectLockRetentionStartWithNone
=== CONT  TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithOn
=== CONT  TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithNone
=== CONT  TestAccAWSS3BucketObject_tagsLeadingSlash
=== CONT  TestAccAWSS3BucketObject_tags
=== CONT  TestAccAWSS3BucketObject_storageClass
=== CONT  TestAccAWSS3BucketObject_metadata
=== CONT  TestAccAWSS3BucketObject_acl
=== CONT  TestAccAWSS3BucketObject_sse
=== CONT  TestAccAWSS3BucketObject_kms
=== CONT  TestAccAWSS3BucketObject_updatesWithVersioning
=== CONT  TestAccAWSS3BucketObject_updateSameFile
=== CONT  TestAccAWSS3BucketObject_updates
=== CONT  TestAccAWSS3BucketObject_withContentCharacteristics
=== CONT  TestAccAWSS3BucketObject_contentBase64
=== CONT  TestAccAWSS3BucketObject_etagEncryption
=== CONT  TestAccAWSS3BucketObject_content
=== CONT  TestAccAWSS3BucketObject_source
--- PASS: TestAccAWSS3BucketObject_noNameNoKey (7.34s)
=== CONT  TestAccAWSS3BucketObject_empty
--- PASS: TestAccAWSS3BucketObject_etagEncryption (47.60s)
--- PASS: TestAccAWSS3BucketObject_source (47.78s)
--- PASS: TestAccAWSS3BucketObject_withContentCharacteristics (47.85s)
--- PASS: TestAccAWSS3BucketObject_content (47.98s)
--- PASS: TestAccAWSS3BucketObject_contentBase64 (48.08s)
--- PASS: TestAccAWSS3BucketObject_sse (48.59s)
--- PASS: TestAccAWSS3BucketObject_empty (41.82s)
--- PASS: TestAccAWSS3BucketObject_kms (72.71s)
--- PASS: TestAccAWSS3BucketObject_updates (74.49s)
--- PASS: TestAccAWSS3BucketObject_updatesWithVersioning (75.76s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithOn (76.17s)
--- PASS: TestAccAWSS3BucketObject_updateSameFile (76.36s)
--- PASS: TestAccAWSS3BucketObject_metadata (100.03s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockRetentionStartWithNone (101.45s)
--- PASS: TestAccAWSS3BucketObject_acl (101.77s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithNone (102.23s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockRetentionStartWithSet (121.94s)
--- PASS: TestAccAWSS3BucketObject_tagsLeadingSlash (122.56s)
--- PASS: TestAccAWSS3BucketObject_tags (122.82s)
--- PASS: TestAccAWSS3BucketObject_storageClass (143.16s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	143.193s
$ go test ./aws -v -sweep=us-east-1,us-west-2 -sweep-run=aws_s3_bucket_object
2019/09/02 15:04:33 [DEBUG] Running Sweepers for region (us-east-1):
2019/09/02 15:04:33 [INFO] Building AWS auth structure
2019/09/02 15:04:33 [INFO] Setting AWS metadata API timeout to 100ms
2019/09/02 15:04:34 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2019/09/02 15:04:34 [INFO] AWS Auth provider used: "EnvProvider"
2019/09/02 15:04:34 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/09/02 15:04:34 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/09/02 15:04:35 [INFO] Skipping S3 Bucket: 346386234494-awsmacietrail-dataevent
2019/09/02 15:04:35 [INFO] Skipping S3 Bucket: ewbankkit-object-lock-enabled-compliance
2019/09/02 15:04:35 [INFO] Skipping S3 Bucket: ewbankkit-object-lock-enabled-governance
2019/09/02 15:04:35 [INFO] Skipping S3 Bucket: ewbankkit-object-lock-enabled-no-mode
2019/09/02 15:04:35 [INFO] Skipping S3 Bucket (tf-test-bucket-5621812836250344014) in different region: us-west-2
2019/09/02 15:04:35 [INFO] Deleting S3 Bucket (tf-test-bucket-5621812836250344015) Object (it.pdf) Version: z2Wpp3t1SMvP4xrbO83oOuEt8HynXJDL
2019/09/02 15:04:35 [WARN] Error deleting S3 Bucket (tf-test-bucket-5621812836250344015) Object (it.pdf) Version (z2Wpp3t1SMvP4xrbO83oOuEt8HynXJDL): AccessDenied: Access Denied
	status code: 403, request id: A44BEE7F6482C2C1, host id: TsFLNnBowL7SJmvQs+CVshwXD8zuSTOe4f2yYxDyBJCLF5iZ2ad/pm4x6q0m+BJ/DvbIMzzCHio=
2019/09/02 15:04:35 [INFO] Deleting S3 Bucket (tf-test-bucket-5621812836250344015) Object (it.pdf) Version: z2Wpp3t1SMvP4xrbO83oOuEt8HynXJDL
2019/09/02 15:04:35 Sweeper Tests ran:
	- aws_s3_bucket_object
2019/09/02 15:04:35 [DEBUG] Running Sweepers for region (us-west-2):
2019/09/02 15:04:35 [INFO] Building AWS auth structure
2019/09/02 15:04:35 [INFO] Setting AWS metadata API timeout to 100ms
2019/09/02 15:04:36 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2019/09/02 15:04:36 [INFO] AWS Auth provider used: "EnvProvider"
2019/09/02 15:04:36 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/09/02 15:04:36 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/09/02 15:04:37 [INFO] Skipping S3 Bucket: 346386234494-awsmacietrail-dataevent
2019/09/02 15:04:37 [INFO] Skipping S3 Bucket: ewbankkit-object-lock-enabled-compliance
2019/09/02 15:04:37 [INFO] Skipping S3 Bucket: ewbankkit-object-lock-enabled-governance
2019/09/02 15:04:37 [INFO] Skipping S3 Bucket: ewbankkit-object-lock-enabled-no-mode
2019/09/02 15:04:38 [INFO] Deleting S3 Bucket (tf-test-bucket-5621812836250344014) Object (it.pdf) Version: null
2019/09/02 15:04:39 [INFO] Deleting S3 Bucket (tf-test-bucket-5621812836250344014) Object (link.pdf) Version: null
2019/09/02 15:04:39 [INFO] Deleting S3 Bucket (tf-test-bucket-5621812836250344014) Object (tpu.pdf) Version: null
2019/09/02 15:04:40 [INFO] Skipping S3 Bucket (tf-test-bucket-5621812836250344015) in different region: us-east-1
2019/09/02 15:04:40 Sweeper Tests ran:
	- aws_s3_bucket_object
ok  	github.com/terraform-providers/terraform-provider-aws/aws	6.634s
```

#### aws_s3_bucket

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSS3Bucket_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAWSS3Bucket_ -timeout 120m
=== RUN   TestAccAWSS3Bucket_importBasic
=== PAUSE TestAccAWSS3Bucket_importBasic
=== RUN   TestAccAWSS3Bucket_importWithPolicy
=== PAUSE TestAccAWSS3Bucket_importWithPolicy
=== RUN   TestAccAWSS3Bucket_basic
=== PAUSE TestAccAWSS3Bucket_basic
=== RUN   TestAccAWSS3Bucket_Bucket_EmptyString
=== PAUSE TestAccAWSS3Bucket_Bucket_EmptyString
=== RUN   TestAccAWSS3Bucket_tagsWithNoSystemTags
=== PAUSE TestAccAWSS3Bucket_tagsWithNoSystemTags
=== RUN   TestAccAWSS3Bucket_tagsWithSystemTags
=== PAUSE TestAccAWSS3Bucket_tagsWithSystemTags
=== RUN   TestAccAWSS3Bucket_namePrefix
=== PAUSE TestAccAWSS3Bucket_namePrefix
=== RUN   TestAccAWSS3Bucket_generatedName
=== PAUSE TestAccAWSS3Bucket_generatedName
=== RUN   TestAccAWSS3Bucket_region
=== PAUSE TestAccAWSS3Bucket_region
=== RUN   TestAccAWSS3Bucket_acceleration
=== PAUSE TestAccAWSS3Bucket_acceleration
=== RUN   TestAccAWSS3Bucket_RequestPayer
=== PAUSE TestAccAWSS3Bucket_RequestPayer
=== RUN   TestAccAWSS3Bucket_Policy
=== PAUSE TestAccAWSS3Bucket_Policy
=== RUN   TestAccAWSS3Bucket_UpdateAcl
=== PAUSE TestAccAWSS3Bucket_UpdateAcl
=== RUN   TestAccAWSS3Bucket_Website_Simple
=== PAUSE TestAccAWSS3Bucket_Website_Simple
=== RUN   TestAccAWSS3Bucket_WebsiteRedirect
=== PAUSE TestAccAWSS3Bucket_WebsiteRedirect
=== RUN   TestAccAWSS3Bucket_WebsiteRoutingRules
=== PAUSE TestAccAWSS3Bucket_WebsiteRoutingRules
=== RUN   TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical
=== PAUSE TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical
=== RUN   TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed
=== PAUSE TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed
=== RUN   TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled
=== PAUSE TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled
=== RUN   TestAccAWSS3Bucket_shouldFailNotFound
=== PAUSE TestAccAWSS3Bucket_shouldFailNotFound
=== RUN   TestAccAWSS3Bucket_Versioning
=== PAUSE TestAccAWSS3Bucket_Versioning
=== RUN   TestAccAWSS3Bucket_Cors_Update
=== PAUSE TestAccAWSS3Bucket_Cors_Update
=== RUN   TestAccAWSS3Bucket_Cors_Delete
=== PAUSE TestAccAWSS3Bucket_Cors_Delete
=== RUN   TestAccAWSS3Bucket_Cors_EmptyOrigin
=== PAUSE TestAccAWSS3Bucket_Cors_EmptyOrigin
=== RUN   TestAccAWSS3Bucket_Logging
=== PAUSE TestAccAWSS3Bucket_Logging
=== RUN   TestAccAWSS3Bucket_LifecycleBasic
=== PAUSE TestAccAWSS3Bucket_LifecycleBasic
=== RUN   TestAccAWSS3Bucket_LifecycleExpireMarkerOnly
=== PAUSE TestAccAWSS3Bucket_LifecycleExpireMarkerOnly
=== RUN   TestAccAWSS3Bucket_Replication
=== PAUSE TestAccAWSS3Bucket_Replication
=== RUN   TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation
=== PAUSE TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation
=== RUN   TestAccAWSS3Bucket_ReplicationWithoutStorageClass
=== PAUSE TestAccAWSS3Bucket_ReplicationWithoutStorageClass
=== RUN   TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError
=== PAUSE TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError
=== RUN   TestAccAWSS3Bucket_ReplicationWithoutPrefix
=== PAUSE TestAccAWSS3Bucket_ReplicationWithoutPrefix
=== RUN   TestAccAWSS3Bucket_ReplicationSchemaV2
=== PAUSE TestAccAWSS3Bucket_ReplicationSchemaV2
=== RUN   TestAccAWSS3Bucket_objectLock
=== PAUSE TestAccAWSS3Bucket_objectLock
=== RUN   TestAccAWSS3Bucket_forceDestroy
=== PAUSE TestAccAWSS3Bucket_forceDestroy
=== RUN   TestAccAWSS3Bucket_forceDestroyWithObjectLockEnabled
=== PAUSE TestAccAWSS3Bucket_forceDestroyWithObjectLockEnabled
=== CONT  TestAccAWSS3Bucket_importBasic
=== CONT  TestAccAWSS3Bucket_forceDestroyWithObjectLockEnabled
=== CONT  TestAccAWSS3Bucket_forceDestroy
=== CONT  TestAccAWSS3Bucket_objectLock
=== CONT  TestAccAWSS3Bucket_ReplicationSchemaV2
=== CONT  TestAccAWSS3Bucket_ReplicationWithoutPrefix
=== CONT  TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError
=== CONT  TestAccAWSS3Bucket_ReplicationWithoutStorageClass
=== CONT  TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation
=== CONT  TestAccAWSS3Bucket_Replication
=== CONT  TestAccAWSS3Bucket_LifecycleExpireMarkerOnly
=== CONT  TestAccAWSS3Bucket_LifecycleBasic
=== CONT  TestAccAWSS3Bucket_Logging
=== CONT  TestAccAWSS3Bucket_Cors_EmptyOrigin
=== CONT  TestAccAWSS3Bucket_Cors_Delete
=== CONT  TestAccAWSS3Bucket_Cors_Update
=== CONT  TestAccAWSS3Bucket_Versioning
=== CONT  TestAccAWSS3Bucket_shouldFailNotFound
=== CONT  TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled
=== CONT  TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed
--- PASS: TestAccAWSS3Bucket_shouldFailNotFound (28.69s)
=== CONT  TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical
--- PASS: TestAccAWSS3Bucket_Cors_EmptyOrigin (45.70s)
=== CONT  TestAccAWSS3Bucket_WebsiteRoutingRules
--- PASS: TestAccAWSS3Bucket_Cors_Delete (45.90s)
=== CONT  TestAccAWSS3Bucket_WebsiteRedirect
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed (45.94s)
=== CONT  TestAccAWSS3Bucket_Website_Simple
--- PASS: TestAccAWSS3Bucket_forceDestroy (47.74s)
=== CONT  TestAccAWSS3Bucket_UpdateAcl
--- PASS: TestAccAWSS3Bucket_importBasic (51.02s)
=== CONT  TestAccAWSS3Bucket_Policy
--- PASS: TestAccAWSS3Bucket_forceDestroyWithObjectLockEnabled (51.62s)
=== CONT  TestAccAWSS3Bucket_RequestPayer
--- PASS: TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError (57.06s)
=== CONT  TestAccAWSS3Bucket_acceleration
--- FAIL: TestAccAWSS3Bucket_LifecycleExpireMarkerOnly (67.60s)
    testing.go:568: Step 1 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        UPDATE: aws_s3_bucket.bucket
          acceleration_status:                                        "" => ""
          acl:                                                        "public-read" => "public-read"
          arn:                                                        "arn:aws:s3:::tf-test-bucket-8342519326936755730" => "arn:aws:s3:::tf-test-bucket-8342519326936755730"
          bucket:                                                     "tf-test-bucket-8342519326936755730" => "tf-test-bucket-8342519326936755730"
          bucket_domain_name:                                         "tf-test-bucket-8342519326936755730.s3.amazonaws.com" => "tf-test-bucket-8342519326936755730.s3.amazonaws.com"
          bucket_regional_domain_name:                                "tf-test-bucket-8342519326936755730.s3.us-west-2.amazonaws.com" => "tf-test-bucket-8342519326936755730.s3.us-west-2.amazonaws.com"
          cors_rule.#:                                                "0" => "0"
          force_destroy:                                              "false" => "false"
          hosted_zone_id:                                             "Z3BJ6K6RIION7M" => "Z3BJ6K6RIION7M"
          id:                                                         "tf-test-bucket-8342519326936755730" => "tf-test-bucket-8342519326936755730"
          lifecycle_rule.#:                                           "1" => "0"
          lifecycle_rule.0.abort_incomplete_multipart_upload_days:    "0" => ""
          lifecycle_rule.0.enabled:                                   "true" => ""
          lifecycle_rule.0.expiration.#:                              "1" => ""
          lifecycle_rule.0.expiration.0.date:                         "" => ""
          lifecycle_rule.0.expiration.0.days:                         "0" => ""
          lifecycle_rule.0.expiration.0.expired_object_delete_marker: "true" => ""
          lifecycle_rule.0.id:                                        "id1" => ""
          lifecycle_rule.0.noncurrent_version_expiration.#:           "0" => ""
          lifecycle_rule.0.noncurrent_version_transition.#:           "0" => ""
          lifecycle_rule.0.prefix:                                    "path1/" => ""
          lifecycle_rule.0.transition.#:                              "0" => ""
          logging.#:                                                  "0" => "0"
          object_lock_configuration.#:                                "0" => "0"
          region:                                                     "us-west-2" => "us-west-2"
          replication_configuration.#:                                "0" => "0"
          request_payer:                                              "BucketOwner" => "BucketOwner"
          server_side_encryption_configuration.#:                     "0" => "0"
          versioning.#:                                               "1" => "1"
          versioning.0.enabled:                                       "false" => "false"
          versioning.0.mfa_delete:                                    "false" => "false"
          website.#:                                                  "0" => "0"
        
        
        
        STATE:
        
        aws_s3_bucket.bucket:
          ID = tf-test-bucket-8342519326936755730
          provider = provider.aws
          acceleration_status = 
          acl = public-read
          arn = arn:aws:s3:::tf-test-bucket-8342519326936755730
          bucket = tf-test-bucket-8342519326936755730
          bucket_domain_name = tf-test-bucket-8342519326936755730.s3.amazonaws.com
          bucket_regional_domain_name = tf-test-bucket-8342519326936755730.s3.us-west-2.amazonaws.com
          force_destroy = false
          hosted_zone_id = Z3BJ6K6RIION7M
          lifecycle_rule.# = 1
          lifecycle_rule.0.abort_incomplete_multipart_upload_days = 0
          lifecycle_rule.0.enabled = true
          lifecycle_rule.0.expiration.# = 1
          lifecycle_rule.0.expiration.0.date = 
          lifecycle_rule.0.expiration.0.days = 0
          lifecycle_rule.0.expiration.0.expired_object_delete_marker = true
          lifecycle_rule.0.id = id1
          lifecycle_rule.0.prefix = path1/
          region = us-west-2
          request_payer = BucketOwner
          versioning.# = 1
          versioning.0.enabled = false
          versioning.0.mfa_delete = false
=== CONT  TestAccAWSS3Bucket_region
--- PASS: TestAccAWSS3Bucket_Logging (67.71s)
=== CONT  TestAccAWSS3Bucket_generatedName
--- PASS: TestAccAWSS3Bucket_objectLock (77.00s)
=== CONT  TestAccAWSS3Bucket_namePrefix
--- PASS: TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled (77.55s)
=== CONT  TestAccAWSS3Bucket_tagsWithSystemTags
--- PASS: TestAccAWSS3Bucket_Cors_Update (78.45s)
=== CONT  TestAccAWSS3Bucket_tagsWithNoSystemTags
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutStorageClass (93.81s)
=== CONT  TestAccAWSS3Bucket_Bucket_EmptyString
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutPrefix (94.49s)
=== CONT  TestAccAWSS3Bucket_basic
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical (71.10s)
=== CONT  TestAccAWSS3Bucket_importWithPolicy
--- PASS: TestAccAWSS3Bucket_generatedName (35.85s)
--- PASS: TestAccAWSS3Bucket_LifecycleBasic (106.34s)
--- PASS: TestAccAWSS3Bucket_Versioning (107.00s)
--- PASS: TestAccAWSS3Bucket_namePrefix (33.27s)
--- PASS: TestAccAWSS3Bucket_region (43.60s)
--- PASS: TestAccAWSS3Bucket_UpdateAcl (66.55s)
--- PASS: TestAccAWSS3Bucket_WebsiteRoutingRules (69.46s)
--- PASS: TestAccAWSS3Bucket_RequestPayer (67.33s)
--- PASS: TestAccAWSS3Bucket_acceleration (66.50s)
--- PASS: TestAccAWSS3Bucket_Bucket_EmptyString (33.01s)
--- PASS: TestAccAWSS3Bucket_basic (34.03s)
--- PASS: TestAccAWSS3Bucket_Policy (89.73s)
--- PASS: TestAccAWSS3Bucket_WebsiteRedirect (95.82s)
--- PASS: TestAccAWSS3Bucket_importWithPolicy (41.96s)
--- PASS: TestAccAWSS3Bucket_Website_Simple (96.06s)
--- PASS: TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation (180.86s)
--- PASS: TestAccAWSS3Bucket_tagsWithNoSystemTags (114.48s)
--- PASS: TestAccAWSS3Bucket_tagsWithSystemTags (147.98s)
--- PASS: TestAccAWSS3Bucket_ReplicationSchemaV2 (261.99s)
--- PASS: TestAccAWSS3Bucket_Replication (270.09s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	270.184s
GNUmakefile:20: recipe for target 'testacc' failed
make: *** [testacc] Error 1
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSS3Bucket_LifecycleExpireMarkerOnly'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAWSS3Bucket_LifecycleExpireMarkerOnly -timeout 120m
=== RUN   TestAccAWSS3Bucket_LifecycleExpireMarkerOnly
=== PAUSE TestAccAWSS3Bucket_LifecycleExpireMarkerOnly
=== CONT  TestAccAWSS3Bucket_LifecycleExpireMarkerOnly
--- PASS: TestAccAWSS3Bucket_LifecycleExpireMarkerOnly (54.82s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	54.863s
```
It looks like that failure is an S3 eventual consistency problem.