### PR TITLE
Acceptance test import refactor for service resources

### DIFF
--- a/aws/resource_aws_service_discovery_service_test.go
+++ b/aws/resource_aws_service_discovery_service_test.go
@@ -12,7 +12,9 @@ import (
 )
 
 func TestAccAWSServiceDiscoveryService_private(t *testing.T) {
+	resourceName := "aws_service_discovery_service.test"
 	rName := acctest.RandString(5)
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceDiscovery(t) },
 		Providers:    testAccProviders,
@@ -21,25 +23,30 @@ func TestAccAWSServiceDiscoveryService_private(t *testing.T) {
 			{
 				Config: testAccServiceDiscoveryServiceConfig_private(rName, 5),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsServiceDiscoveryServiceExists("aws_service_discovery_service.test"),
-					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "health_check_custom_config.0.failure_threshold", "5"),
-					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "dns_config.0.dns_records.#", "1"),
-					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "dns_config.0.dns_records.0.type", "A"),
-					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "dns_config.0.dns_records.0.ttl", "5"),
-					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "dns_config.0.routing_policy", "MULTIVALUE"),
-					resource.TestCheckResourceAttrSet("aws_service_discovery_service.test", "arn"),
+					testAccCheckAwsServiceDiscoveryServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "health_check_custom_config.0.failure_threshold", "5"),
+					resource.TestCheckResourceAttr(resourceName, "dns_config.0.dns_records.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "dns_config.0.dns_records.0.type", "A"),
+					resource.TestCheckResourceAttr(resourceName, "dns_config.0.dns_records.0.ttl", "5"),
+					resource.TestCheckResourceAttr(resourceName, "dns_config.0.routing_policy", "MULTIVALUE"),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccServiceDiscoveryServiceConfig_private_update(rName, 5),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsServiceDiscoveryServiceExists("aws_service_discovery_service.test"),
-					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "dns_config.0.dns_records.#", "2"),
-					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "dns_config.0.dns_records.0.type", "A"),
-					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "dns_config.0.dns_records.0.ttl", "10"),
-					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "dns_config.0.dns_records.1.type", "AAAA"),
-					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "dns_config.0.dns_records.1.ttl", "5"),
-					resource.TestCheckResourceAttrSet("aws_service_discovery_service.test", "arn"),
+					testAccCheckAwsServiceDiscoveryServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "dns_config.0.dns_records.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "dns_config.0.dns_records.0.type", "A"),
+					resource.TestCheckResourceAttr(resourceName, "dns_config.0.dns_records.0.ttl", "10"),
+					resource.TestCheckResourceAttr(resourceName, "dns_config.0.dns_records.1.type", "AAAA"),
+					resource.TestCheckResourceAttr(resourceName, "dns_config.0.dns_records.1.ttl", "5"),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
 				),
 			},
 		},
@@ -48,56 +55,6 @@ func TestAccAWSServiceDiscoveryService_private(t *testing.T) {
 
 func TestAccAWSServiceDiscoveryService_public(t *testing.T) {
 	rName := acctest.RandString(5)
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceDiscovery(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsServiceDiscoveryServiceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccServiceDiscoveryServiceConfig_public(rName, 5, "/path"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsServiceDiscoveryServiceExists("aws_service_discovery_service.test"),
-					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "health_check_config.0.type", "HTTP"),
-					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "health_check_config.0.failure_threshold", "5"),
-					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "health_check_config.0.resource_path", "/path"),
-					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "dns_config.0.routing_policy", "WEIGHTED"),
-					resource.TestCheckResourceAttrSet("aws_service_discovery_service.test", "arn"),
-				),
-			},
-			{
-				Config: testAccServiceDiscoveryServiceConfig_public(rName, 3, "/updated-path"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsServiceDiscoveryServiceExists("aws_service_discovery_service.test"),
-					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "health_check_config.0.type", "HTTP"),
-					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "health_check_config.0.failure_threshold", "3"),
-					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "health_check_config.0.resource_path", "/updated-path"),
-					resource.TestCheckResourceAttrSet("aws_service_discovery_service.test", "arn"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSServiceDiscoveryService_http(t *testing.T) {
-	rName := acctest.RandString(5)
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsServiceDiscoveryServiceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccServiceDiscoveryServiceConfig_http(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsServiceDiscoveryServiceExists("aws_service_discovery_service.test"),
-					resource.TestCheckResourceAttrSet("aws_service_discovery_service.test", "namespace_id"),
-					resource.TestCheckResourceAttrSet("aws_service_discovery_service.test", "arn"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSServiceDiscoveryService_import(t *testing.T) {
 	resourceName := "aws_service_discovery_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -106,9 +63,52 @@ func TestAccAWSServiceDiscoveryService_import(t *testing.T) {
 		CheckDestroy: testAccCheckAwsServiceDiscoveryServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceDiscoveryServiceConfig_private(acctest.RandString(5), 5),
+				Config: testAccServiceDiscoveryServiceConfig_public(rName, 5, "/path"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceDiscoveryServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "health_check_config.0.type", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "health_check_config.0.failure_threshold", "5"),
+					resource.TestCheckResourceAttr(resourceName, "health_check_config.0.resource_path", "/path"),
+					resource.TestCheckResourceAttr(resourceName, "dns_config.0.routing_policy", "WEIGHTED"),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccServiceDiscoveryServiceConfig_public(rName, 3, "/updated-path"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceDiscoveryServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "health_check_config.0.type", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "health_check_config.0.failure_threshold", "3"),
+					resource.TestCheckResourceAttr(resourceName, "health_check_config.0.resource_path", "/updated-path"),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+				),
+			},
+		},
+	})
+}
 
+func TestAccAWSServiceDiscoveryService_http(t *testing.T) {
+	rName := acctest.RandString(5)
+	resourceName := "aws_service_discovery_service.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceDiscoveryServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDiscoveryServiceConfig_http(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceDiscoveryServiceExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "namespace_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+				),
+			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,

--- a/aws/resource_aws_servicecatalog_portfolio_test.go
+++ b/aws/resource_aws_servicecatalog_portfolio_test.go
@@ -14,8 +14,10 @@ import (
 )
 
 func TestAccAWSServiceCatalogPortfolio_Basic(t *testing.T) {
+	resourceName := "aws_servicecatalog_portfolio.test"
 	name := acctest.RandString(5)
 	var dpo servicecatalog.DescribePortfolioOutput
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -24,41 +26,46 @@ func TestAccAWSServiceCatalogPortfolio_Basic(t *testing.T) {
 			{
 				Config: testAccCheckAwsServiceCatalogPortfolioResourceConfigBasic1(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPortfolio("aws_servicecatalog_portfolio.test", &dpo),
-					resource.TestCheckResourceAttrSet("aws_servicecatalog_portfolio.test", "arn"),
-					resource.TestCheckResourceAttrSet("aws_servicecatalog_portfolio.test", "created_time"),
-					resource.TestCheckResourceAttr("aws_servicecatalog_portfolio.test", "name", name),
-					resource.TestCheckResourceAttr("aws_servicecatalog_portfolio.test", "description", "test-2"),
-					resource.TestCheckResourceAttr("aws_servicecatalog_portfolio.test", "provider_name", "test-3"),
-					resource.TestCheckResourceAttr("aws_servicecatalog_portfolio.test", "tags.%", "1"),
-					resource.TestCheckResourceAttr("aws_servicecatalog_portfolio.test", "tags.Key1", "Value One"),
+					testAccCheckPortfolio(resourceName, &dpo),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_time"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test-2"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", "test-3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "Value One"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccCheckAwsServiceCatalogPortfolioResourceConfigBasic2(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPortfolio("aws_servicecatalog_portfolio.test", &dpo),
-					resource.TestCheckResourceAttrSet("aws_servicecatalog_portfolio.test", "arn"),
-					resource.TestCheckResourceAttrSet("aws_servicecatalog_portfolio.test", "created_time"),
-					resource.TestCheckResourceAttr("aws_servicecatalog_portfolio.test", "name", name),
-					resource.TestCheckResourceAttr("aws_servicecatalog_portfolio.test", "description", "test-b"),
-					resource.TestCheckResourceAttr("aws_servicecatalog_portfolio.test", "provider_name", "test-c"),
-					resource.TestCheckResourceAttr("aws_servicecatalog_portfolio.test", "tags.%", "2"),
-					resource.TestCheckResourceAttr("aws_servicecatalog_portfolio.test", "tags.Key1", "Value 1"),
-					resource.TestCheckResourceAttr("aws_servicecatalog_portfolio.test", "tags.Key2", "Value Two"),
+					testAccCheckPortfolio(resourceName, &dpo),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_time"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test-b"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", "test-c"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "Value 1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "Value Two"),
 				),
 			},
 			{
 				Config: testAccCheckAwsServiceCatalogPortfolioResourceConfigBasic3(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPortfolio("aws_servicecatalog_portfolio.test", &dpo),
-					resource.TestCheckResourceAttrSet("aws_servicecatalog_portfolio.test", "arn"),
-					resource.TestCheckResourceAttrSet("aws_servicecatalog_portfolio.test", "created_time"),
-					resource.TestCheckResourceAttr("aws_servicecatalog_portfolio.test", "name", name),
-					resource.TestCheckResourceAttr("aws_servicecatalog_portfolio.test", "description", "test-only-change-me"),
-					resource.TestCheckResourceAttr("aws_servicecatalog_portfolio.test", "provider_name", "test-c"),
-					resource.TestCheckResourceAttr("aws_servicecatalog_portfolio.test", "tags.%", "1"),
-					resource.TestCheckResourceAttr("aws_servicecatalog_portfolio.test", "tags.Key3", "Value Three"),
+					testAccCheckPortfolio(resourceName, &dpo),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_time"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test-only-change-me"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", "test-c"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key3", "Value Three"),
 				),
 			},
 		},
@@ -67,7 +74,9 @@ func TestAccAWSServiceCatalogPortfolio_Basic(t *testing.T) {
 
 func TestAccAWSServiceCatalogPortfolio_Disappears(t *testing.T) {
 	name := acctest.RandString(5)
+	resourceName := "aws_servicecatalog_portfolio.test"
 	var dpo servicecatalog.DescribePortfolioOutput
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -76,33 +85,10 @@ func TestAccAWSServiceCatalogPortfolio_Disappears(t *testing.T) {
 			{
 				Config: testAccCheckAwsServiceCatalogPortfolioResourceConfigBasic1(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPortfolio("aws_servicecatalog_portfolio.test", &dpo),
+					testAccCheckPortfolio(resourceName, &dpo),
 					testAccCheckServiceCatlaogPortfolioDisappears(&dpo),
 				),
 				ExpectNonEmptyPlan: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSServiceCatalogPortfolio_Import(t *testing.T) {
-	resourceName := "aws_servicecatalog_portfolio.test"
-
-	name := acctest.RandString(5)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckServiceCatlaogPortfolioDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckAwsServiceCatalogPortfolioResourceConfigBasic1(name),
-			},
-
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8944

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSServiceDiscoveryService"        
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSServiceDiscoveryService -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSServiceDiscoveryService_private
=== PAUSE TestAccAWSServiceDiscoveryService_private
=== RUN   TestAccAWSServiceDiscoveryService_public
=== PAUSE TestAccAWSServiceDiscoveryService_public
=== RUN   TestAccAWSServiceDiscoveryService_http
=== PAUSE TestAccAWSServiceDiscoveryService_http
=== CONT  TestAccAWSServiceDiscoveryService_private
=== CONT  TestAccAWSServiceDiscoveryService_http
=== CONT  TestAccAWSServiceDiscoveryService_public
--- PASS: TestAccAWSServiceDiscoveryService_http (108.73s)
--- PASS: TestAccAWSServiceDiscoveryService_public (138.16s)
--- PASS: TestAccAWSServiceDiscoveryService_private (168.48s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       170.671s

make testacc TESTARGS="-run=TestAccAWSServiceCatalogPortfolio"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSServiceCatalogPortfolio -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSServiceCatalogPortfolio_Basic
=== PAUSE TestAccAWSServiceCatalogPortfolio_Basic
=== RUN   TestAccAWSServiceCatalogPortfolio_Disappears
=== PAUSE TestAccAWSServiceCatalogPortfolio_Disappears
=== CONT  TestAccAWSServiceCatalogPortfolio_Basic
=== CONT  TestAccAWSServiceCatalogPortfolio_Disappears
--- PASS: TestAccAWSServiceCatalogPortfolio_Disappears (20.11s)
--- PASS: TestAccAWSServiceCatalogPortfolio_Basic (62.93s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       63.766s
```