### PR TITLE
Acceptance test import refactor for r53 records

### DIFF
--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -118,7 +118,7 @@ func TestAccAWSRoute53Record_basic(t *testing.T) {
 			{
 				Config: testAccRoute53RecordConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.default", &record1),
+					testAccCheckRoute53RecordExists(resourceName, &record1),
 				),
 			},
 			{

--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -111,7 +111,7 @@ func TestAccAWSRoute53Record_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_route53_record.default",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -143,7 +143,7 @@ func TestAccAWSRoute53Record_underscored(t *testing.T) {
 			{
 				Config: testAccRoute53RecordConfigUnderscoreInName,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.underscore", &record1),
+					testAccCheckRoute53RecordExists(resourceName, &record1),
 				),
 			},
 			{

--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -105,50 +105,9 @@ func TestParseRecordId(t *testing.T) {
 	}
 }
 
-func TestAccAWSRoute53Record_importBasic(t *testing.T) {
-	resourceName := "aws_route53_record.default"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckRoute53RecordDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccRoute53RecordConfig,
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
-			},
-		},
-	})
-}
-
-func TestAccAWSRoute53Record_importUnderscored(t *testing.T) {
-	resourceName := "aws_route53_record.underscore"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckRoute53RecordDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccRoute53RecordConfigUnderscoreInName,
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
-			},
-		},
-	})
-}
-
 func TestAccAWSRoute53Record_basic(t *testing.T) {
 	var record1 route53.ResourceRecordSet
+	resourceName := "aws_route53_record.default"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -162,6 +121,37 @@ func TestAccAWSRoute53Record_basic(t *testing.T) {
 					testAccCheckRoute53RecordExists("aws_route53_record.default", &record1),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute53Record_underscored(t *testing.T) {
+	var record1 route53.ResourceRecordSet
+	resourceName := "aws_route53_record.underscore"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53RecordDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53RecordConfigUnderscoreInName,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53RecordExists("aws_route53_record.underscore", &record1),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
+			},
 		},
 	})
 }
@@ -169,6 +159,7 @@ func TestAccAWSRoute53Record_basic(t *testing.T) {
 func TestAccAWSRoute53Record_disappears(t *testing.T) {
 	var record1 route53.ResourceRecordSet
 	var zone1 route53.GetHostedZoneOutput
+	resourceName := "aws_route53_record.default"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -179,7 +170,7 @@ func TestAccAWSRoute53Record_disappears(t *testing.T) {
 				Config: testAccRoute53RecordConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53ZoneExists("aws_route53_zone.main", &zone1),
-					testAccCheckRoute53RecordExists("aws_route53_record.default", &record1),
+					testAccCheckRoute53RecordExists(resourceName, &record1),
 					testAccCheckRoute53RecordDisappears(&zone1, &record1),
 				),
 				ExpectNonEmptyPlan: true,
@@ -216,18 +207,25 @@ func TestAccAWSRoute53Record_disappears_MultipleRecords(t *testing.T) {
 
 func TestAccAWSRoute53Record_basic_fqdn(t *testing.T) {
 	var record1, record2 route53.ResourceRecordSet
+	resourceName := "aws_route53_record.default"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_route53_record.default",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53RecordConfig_fqdn,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.default", &record1),
+					testAccCheckRoute53RecordExists(resourceName, &record1),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
 			},
 
 			// Ensure that changing the name to include a trailing "dot" results in
@@ -239,7 +237,7 @@ func TestAccAWSRoute53Record_basic_fqdn(t *testing.T) {
 			{
 				Config: testAccRoute53RecordConfig_fqdn_no_op,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.default", &record2),
+					testAccCheckRoute53RecordExists(resourceName, &record2),
 				),
 			},
 		},
@@ -248,10 +246,11 @@ func TestAccAWSRoute53Record_basic_fqdn(t *testing.T) {
 
 func TestAccAWSRoute53Record_txtSupport(t *testing.T) {
 	var record1 route53.ResourceRecordSet
+	resourceName := "aws_route53_record.default"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
-		IDRefreshName:   "aws_route53_record.default",
+		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"zone_id"}, // just for this test
 		Providers:       testAccProviders,
 		CheckDestroy:    testAccCheckRoute53RecordDestroy,
@@ -259,8 +258,14 @@ func TestAccAWSRoute53Record_txtSupport(t *testing.T) {
 			{
 				Config: testAccRoute53RecordConfigTXT,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.default", &record1),
+					testAccCheckRoute53RecordExists(resourceName, &record1),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight", "zone_id"},
 			},
 		},
 	})
@@ -268,20 +273,27 @@ func TestAccAWSRoute53Record_txtSupport(t *testing.T) {
 
 func TestAccAWSRoute53Record_spfSupport(t *testing.T) {
 	var record1 route53.ResourceRecordSet
+	resourceName := "aws_route53_record.default"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_route53_record.default",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53RecordConfigSPF,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.default", &record1),
+					testAccCheckRoute53RecordExists(resourceName, &record1),
 					resource.TestCheckResourceAttr(
-						"aws_route53_record.default", "records.2930149397", "include:notexample.com"),
+						resourceName, "records.2930149397", "include:notexample.com"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
 			},
 		},
 	})
@@ -289,20 +301,27 @@ func TestAccAWSRoute53Record_spfSupport(t *testing.T) {
 
 func TestAccAWSRoute53Record_caaSupport(t *testing.T) {
 	var record1 route53.ResourceRecordSet
+	resourceName := "aws_route53_record.default"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_route53_record.default",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53RecordConfigCAA,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.default", &record1),
+					testAccCheckRoute53RecordExists(resourceName, &record1),
 					resource.TestCheckResourceAttr(
-						"aws_route53_record.default", "records.2965463512", "0 issue \"exampleca.com;\""),
+						resourceName, "records.2965463512", "0 issue \"exampleca.com;\""),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
 			},
 		},
 	})
@@ -310,18 +329,25 @@ func TestAccAWSRoute53Record_caaSupport(t *testing.T) {
 
 func TestAccAWSRoute53Record_generatesSuffix(t *testing.T) {
 	var record1 route53.ResourceRecordSet
+	resourceName := "aws_route53_record.default"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_route53_record.default",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53RecordConfigSuffix,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.default", &record1),
+					testAccCheckRoute53RecordExists(resourceName, &record1),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
 			},
 		},
 	})
@@ -329,25 +355,32 @@ func TestAccAWSRoute53Record_generatesSuffix(t *testing.T) {
 
 func TestAccAWSRoute53Record_wildcard(t *testing.T) {
 	var record1, record2 route53.ResourceRecordSet
+	resourceName := "aws_route53_record.wildcard"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_route53_record.wildcard",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53WildCardRecordConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.wildcard", &record1),
+					testAccCheckRoute53RecordExists(resourceName, &record1),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
 			},
 
 			// Cause a change, which will trigger a refresh
 			{
 				Config: testAccRoute53WildCardRecordConfigUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.wildcard", &record2),
+					testAccCheckRoute53RecordExists(resourceName, &record2),
 				),
 			},
 		},
@@ -356,19 +389,26 @@ func TestAccAWSRoute53Record_wildcard(t *testing.T) {
 
 func TestAccAWSRoute53Record_failover(t *testing.T) {
 	var record1, record2 route53.ResourceRecordSet
+	resourceName := "aws_route53_record.www-primary"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_route53_record.www-primary",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53FailoverCNAMERecord,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.www-primary", &record1),
+					testAccCheckRoute53RecordExists(resourceName, &record1),
 					testAccCheckRoute53RecordExists("aws_route53_record.www-secondary", &record2),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
 			},
 		},
 	})
@@ -376,6 +416,7 @@ func TestAccAWSRoute53Record_failover(t *testing.T) {
 
 func TestAccAWSRoute53Record_weighted_basic(t *testing.T) {
 	var record1, record2, record3 route53.ResourceRecordSet
+	resourceName := "aws_route53_record.www-live"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -387,9 +428,15 @@ func TestAccAWSRoute53Record_weighted_basic(t *testing.T) {
 				Config: testAccRoute53WeightedCNAMERecord,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53RecordExists("aws_route53_record.www-dev", &record1),
-					testAccCheckRoute53RecordExists("aws_route53_record.www-live", &record2),
+					testAccCheckRoute53RecordExists(resourceName, &record2),
 					testAccCheckRoute53RecordExists("aws_route53_record.www-off", &record3),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
 			},
 		},
 	})
@@ -397,6 +444,7 @@ func TestAccAWSRoute53Record_weighted_basic(t *testing.T) {
 
 func TestAccAWSRoute53Record_weighted_to_simple_basic(t *testing.T) {
 	var record1 route53.ResourceRecordSet
+	resourceName := "aws_route53_record.www-server1"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -406,13 +454,19 @@ func TestAccAWSRoute53Record_weighted_to_simple_basic(t *testing.T) {
 			{
 				Config: testaccRoute53RecordConfigWithWeightedRoutingPolicy,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.www-server1", &record1),
+					testAccCheckRoute53RecordExists(resourceName, &record1),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
 			},
 			{
 				Config: testaccRoute53RecordConfigWithSimpleRoutingPolicy,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.www-server1", &record1),
+					testAccCheckRoute53RecordExists(resourceName, &record1),
 				),
 			},
 		},
@@ -421,20 +475,27 @@ func TestAccAWSRoute53Record_weighted_to_simple_basic(t *testing.T) {
 
 func TestAccAWSRoute53Record_Alias_Elb(t *testing.T) {
 	var record1 route53.ResourceRecordSet
+	resourceName := "aws_route53_record.alias"
 
 	rs := acctest.RandString(10)
 	config := fmt.Sprintf(testAccRoute53RecordConfigAliasElb, rs)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_route53_record.alias",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.alias", &record1),
+					testAccCheckRoute53RecordExists(resourceName, &record1),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
 			},
 		},
 	})
@@ -443,6 +504,7 @@ func TestAccAWSRoute53Record_Alias_Elb(t *testing.T) {
 func TestAccAWSRoute53Record_Alias_S3(t *testing.T) {
 	var record1 route53.ResourceRecordSet
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_route53_record.alias"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -452,8 +514,14 @@ func TestAccAWSRoute53Record_Alias_S3(t *testing.T) {
 			{
 				Config: testAccRoute53RecordConfigAliasS3(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.alias", &record1),
+					testAccCheckRoute53RecordExists(resourceName, &record1),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
 			},
 		},
 	})
@@ -479,26 +547,39 @@ func TestAccAWSRoute53Record_Alias_VpcEndpoint(t *testing.T) {
 					testAccCheckRoute53RecordExists(resourceName, &record1),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
+			},
 		},
 	})
 }
 
 func TestAccAWSRoute53Record_Alias_Uppercase(t *testing.T) {
 	var record1 route53.ResourceRecordSet
+	resourceName := "aws_route53_record.alias"
 
 	rs := acctest.RandString(10)
 	config := fmt.Sprintf(testAccRoute53RecordConfigAliasElbUppercase, rs)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_route53_record.alias",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.alias", &record1),
+					testAccCheckRoute53RecordExists(resourceName, &record1),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
 			},
 		},
 	})
@@ -506,19 +587,26 @@ func TestAccAWSRoute53Record_Alias_Uppercase(t *testing.T) {
 
 func TestAccAWSRoute53Record_weighted_alias(t *testing.T) {
 	var record1, record2, record3, record4, record5, record6 route53.ResourceRecordSet
+	resourceName := "aws_route53_record.elb_weighted_alias_live"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_route53_record.elb_weighted_alias_live",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53WeightedElbAliasRecord,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.elb_weighted_alias_live", &record1),
+					testAccCheckRoute53RecordExists(resourceName, &record1),
 					testAccCheckRoute53RecordExists("aws_route53_record.elb_weighted_alias_dev", &record2),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
 			},
 
 			{
@@ -536,6 +624,7 @@ func TestAccAWSRoute53Record_weighted_alias(t *testing.T) {
 
 func TestAccAWSRoute53Record_geolocation_basic(t *testing.T) {
 	var record1, record2, record3, record4 route53.ResourceRecordSet
+	resourceName := "aws_route53_record.default"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -551,12 +640,19 @@ func TestAccAWSRoute53Record_geolocation_basic(t *testing.T) {
 					testAccCheckRoute53RecordExists("aws_route53_record.denmark", &record4),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
+			},
 		},
 	})
 }
 
 func TestAccAWSRoute53Record_latency_basic(t *testing.T) {
 	var record1, record2, record3 route53.ResourceRecordSet
+	resourceName := "aws_route53_record.us-east-1"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -566,10 +662,16 @@ func TestAccAWSRoute53Record_latency_basic(t *testing.T) {
 			{
 				Config: testAccRoute53LatencyCNAMERecord,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.us-east-1", &record1),
+					testAccCheckRoute53RecordExists(resourceName, &record1),
 					testAccCheckRoute53RecordExists("aws_route53_record.eu-west-1", &record2),
 					testAccCheckRoute53RecordExists("aws_route53_record.ap-northeast-1", &record3),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
 			},
 		},
 	})
@@ -577,25 +679,32 @@ func TestAccAWSRoute53Record_latency_basic(t *testing.T) {
 
 func TestAccAWSRoute53Record_TypeChange(t *testing.T) {
 	var record1, record2 route53.ResourceRecordSet
+	resourceName := "aws_route53_record.sample"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_route53_record.sample",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53RecordTypeChangePre,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.sample", &record1),
+					testAccCheckRoute53RecordExists(resourceName, &record1),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
 			},
 
 			// Cause a change, which will trigger a refresh
 			{
 				Config: testAccRoute53RecordTypeChangePost,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.sample", &record2),
+					testAccCheckRoute53RecordExists(resourceName, &record2),
 				),
 			},
 		},
@@ -604,25 +713,32 @@ func TestAccAWSRoute53Record_TypeChange(t *testing.T) {
 
 func TestAccAWSRoute53Record_SetIdentifierChange(t *testing.T) {
 	var record1, record2 route53.ResourceRecordSet
+	resourceName := "aws_route53_record.basic_to_weighted"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_route53_record.basic_to_weighted",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53RecordSetIdentifierChangePre,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.basic_to_weighted", &record1),
+					testAccCheckRoute53RecordExists(resourceName, &record1),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
 			},
 
 			// Cause a change, which will trigger a refresh
 			{
 				Config: testAccRoute53RecordSetIdentifierChangePost,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.basic_to_weighted", &record2),
+					testAccCheckRoute53RecordExists(resourceName, &record2),
 				),
 			},
 		},
@@ -631,25 +747,32 @@ func TestAccAWSRoute53Record_SetIdentifierChange(t *testing.T) {
 
 func TestAccAWSRoute53Record_AliasChange(t *testing.T) {
 	var record1, record2 route53.ResourceRecordSet
+	resourceName := "aws_route53_record.elb_alias_change"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_route53_record.elb_alias_change",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53RecordAliasChangePre,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.elb_alias_change", &record1),
+					testAccCheckRoute53RecordExists(resourceName, &record1),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
 			},
 
 			// Cause a change, which will trigger a refresh
 			{
 				Config: testAccRoute53RecordAliasChangePost,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.elb_alias_change", &record2),
+					testAccCheckRoute53RecordExists(resourceName, &record2),
 				),
 			},
 		},
@@ -658,17 +781,18 @@ func TestAccAWSRoute53Record_AliasChange(t *testing.T) {
 
 func TestAccAWSRoute53Record_empty(t *testing.T) {
 	var record1 route53.ResourceRecordSet
+	resourceName := "aws_route53_record.empty"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_route53_record.empty",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53RecordConfigEmptyName,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.empty", &record1),
+					testAccCheckRoute53RecordExists(resourceName, &record1),
 				),
 			},
 		},
@@ -678,18 +802,25 @@ func TestAccAWSRoute53Record_empty(t *testing.T) {
 // Regression test for https://github.com/hashicorp/terraform/issues/8423
 func TestAccAWSRoute53Record_longTXTrecord(t *testing.T) {
 	var record1 route53.ResourceRecordSet
+	resourceName := "aws_route53_record.long_txt"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_route53_record.long_txt",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53RecordDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53RecordConfigLongTxtRecord,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.long_txt", &record1),
+					testAccCheckRoute53RecordExists(resourceName, &record1),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
 			},
 		},
 	})
@@ -697,6 +828,7 @@ func TestAccAWSRoute53Record_longTXTrecord(t *testing.T) {
 
 func TestAccAWSRoute53Record_multivalue_answer_basic(t *testing.T) {
 	var record1, record2 route53.ResourceRecordSet
+	resourceName := "aws_route53_record.www-server1"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -710,12 +842,19 @@ func TestAccAWSRoute53Record_multivalue_answer_basic(t *testing.T) {
 					testAccCheckRoute53RecordExists("aws_route53_record.www-server2", &record2),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
+			},
 		},
 	})
 }
 
 func TestAccAWSRoute53Record_allowOverwrite(t *testing.T) {
 	var record1 route53.ResourceRecordSet
+	resourceName := "aws_route53_record.overwriting"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -729,6 +868,12 @@ func TestAccAWSRoute53Record_allowOverwrite(t *testing.T) {
 			{
 				Config: testAccRoute53RecordConfig_allowOverwrite(true),
 				Check:  resource.ComposeTestCheckFunc(testAccCheckRoute53RecordExists("aws_route53_record.overwriting", &record1)),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
 			},
 		},
 	})


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8944

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSRoute53Record_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSRoute53Record_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSRoute53Record_basic
=== PAUSE TestAccAWSRoute53Record_basic
=== RUN   TestAccAWSRoute53Record_underscored
=== PAUSE TestAccAWSRoute53Record_underscored
=== RUN   TestAccAWSRoute53Record_disappears
=== PAUSE TestAccAWSRoute53Record_disappears
=== RUN   TestAccAWSRoute53Record_disappears_MultipleRecords
=== PAUSE TestAccAWSRoute53Record_disappears_MultipleRecords
=== RUN   TestAccAWSRoute53Record_basic_fqdn
=== PAUSE TestAccAWSRoute53Record_basic_fqdn
=== RUN   TestAccAWSRoute53Record_txtSupport
=== PAUSE TestAccAWSRoute53Record_txtSupport
=== RUN   TestAccAWSRoute53Record_spfSupport
=== PAUSE TestAccAWSRoute53Record_spfSupport
=== RUN   TestAccAWSRoute53Record_caaSupport
=== PAUSE TestAccAWSRoute53Record_caaSupport
=== RUN   TestAccAWSRoute53Record_generatesSuffix
=== PAUSE TestAccAWSRoute53Record_generatesSuffix
=== RUN   TestAccAWSRoute53Record_wildcard
=== PAUSE TestAccAWSRoute53Record_wildcard
=== RUN   TestAccAWSRoute53Record_failover
=== PAUSE TestAccAWSRoute53Record_failover
=== RUN   TestAccAWSRoute53Record_weighted_basic
=== PAUSE TestAccAWSRoute53Record_weighted_basic
=== RUN   TestAccAWSRoute53Record_weighted_to_simple_basic
=== PAUSE TestAccAWSRoute53Record_weighted_to_simple_basic
=== RUN   TestAccAWSRoute53Record_Alias_Elb
=== PAUSE TestAccAWSRoute53Record_Alias_Elb
=== RUN   TestAccAWSRoute53Record_Alias_S3
=== PAUSE TestAccAWSRoute53Record_Alias_S3
=== RUN   TestAccAWSRoute53Record_Alias_VpcEndpoint
=== PAUSE TestAccAWSRoute53Record_Alias_VpcEndpoint
=== RUN   TestAccAWSRoute53Record_Alias_Uppercase
=== PAUSE TestAccAWSRoute53Record_Alias_Uppercase
=== RUN   TestAccAWSRoute53Record_weighted_alias
=== PAUSE TestAccAWSRoute53Record_weighted_alias
=== RUN   TestAccAWSRoute53Record_geolocation_basic
=== PAUSE TestAccAWSRoute53Record_geolocation_basic
=== RUN   TestAccAWSRoute53Record_latency_basic
=== PAUSE TestAccAWSRoute53Record_latency_basic
=== RUN   TestAccAWSRoute53Record_TypeChange
=== PAUSE TestAccAWSRoute53Record_TypeChange
=== RUN   TestAccAWSRoute53Record_SetIdentifierChange
=== PAUSE TestAccAWSRoute53Record_SetIdentifierChange
=== RUN   TestAccAWSRoute53Record_AliasChange
=== PAUSE TestAccAWSRoute53Record_AliasChange
=== RUN   TestAccAWSRoute53Record_empty
=== PAUSE TestAccAWSRoute53Record_empty
=== RUN   TestAccAWSRoute53Record_longTXTrecord
=== PAUSE TestAccAWSRoute53Record_longTXTrecord
=== RUN   TestAccAWSRoute53Record_multivalue_answer_basic
=== PAUSE TestAccAWSRoute53Record_multivalue_answer_basic
=== RUN   TestAccAWSRoute53Record_allowOverwrite
=== PAUSE TestAccAWSRoute53Record_allowOverwrite
=== CONT  TestAccAWSRoute53Record_basic
=== CONT  TestAccAWSRoute53Record_Alias_Elb
=== CONT  TestAccAWSRoute53Record_Alias_VpcEndpoint
=== CONT  TestAccAWSRoute53Record_Alias_S3
=== CONT  TestAccAWSRoute53Record_allowOverwrite
=== CONT  TestAccAWSRoute53Record_multivalue_answer_basic
=== CONT  TestAccAWSRoute53Record_longTXTrecord
=== CONT  TestAccAWSRoute53Record_empty
=== CONT  TestAccAWSRoute53Record_AliasChange
=== CONT  TestAccAWSRoute53Record_SetIdentifierChange
=== CONT  TestAccAWSRoute53Record_TypeChange
=== CONT  TestAccAWSRoute53Record_latency_basic
=== CONT  TestAccAWSRoute53Record_geolocation_basic
=== CONT  TestAccAWSRoute53Record_weighted_alias
=== CONT  TestAccAWSRoute53Record_Alias_Uppercase
=== CONT  TestAccAWSRoute53Record_spfSupport
=== CONT  TestAccAWSRoute53Record_txtSupport
=== CONT  TestAccAWSRoute53Record_caaSupport
=== CONT  TestAccAWSRoute53Record_basic_fqdn
=== CONT  TestAccAWSRoute53Record_weighted_to_simple_basic
--- PASS: TestAccAWSRoute53Record_txtSupport (131.68s)
=== CONT  TestAccAWSRoute53Record_disappears_MultipleRecords
--- PASS: TestAccAWSRoute53Record_empty (135.77s)
=== CONT  TestAccAWSRoute53Record_weighted_basic
--- PASS: TestAccAWSRoute53Record_caaSupport (146.84s)
=== CONT  TestAccAWSRoute53Record_disappears
--- PASS: TestAccAWSRoute53Record_longTXTrecord (150.76s)
=== CONT  TestAccAWSRoute53Record_failover
--- PASS: TestAccAWSRoute53Record_basic_fqdn (153.18s)
=== CONT  TestAccAWSRoute53Record_underscored
--- PASS: TestAccAWSRoute53Record_latency_basic (169.31s)
=== CONT  TestAccAWSRoute53Record_wildcard
--- PASS: TestAccAWSRoute53Record_Alias_S3 (177.27s)
=== CONT  TestAccAWSRoute53Record_generatesSuffix
--- PASS: TestAccAWSRoute53Record_spfSupport (177.89s)
--- PASS: TestAccAWSRoute53Record_Alias_Uppercase (178.86s)
--- PASS: TestAccAWSRoute53Record_basic (179.61s)
--- PASS: TestAccAWSRoute53Record_geolocation_basic (193.14s)
--- PASS: TestAccAWSRoute53Record_AliasChange (202.45s)
--- PASS: TestAccAWSRoute53Record_SetIdentifierChange (206.83s)
--- PASS: TestAccAWSRoute53Record_multivalue_answer_basic (211.11s)
--- PASS: TestAccAWSRoute53Record_Alias_Elb (216.21s)
--- PASS: TestAccAWSRoute53Record_TypeChange (238.67s)
--- PASS: TestAccAWSRoute53Record_allowOverwrite (246.12s)
--- PASS: TestAccAWSRoute53Record_disappears (122.84s)
--- PASS: TestAccAWSRoute53Record_weighted_basic (140.08s)
--- PASS: TestAccAWSRoute53Record_failover (138.76s)
--- PASS: TestAccAWSRoute53Record_underscored (136.46s)
--- PASS: TestAccAWSRoute53Record_weighted_to_simple_basic (290.96s)
--- PASS: TestAccAWSRoute53Record_weighted_alias (308.00s)
--- PASS: TestAccAWSRoute53Record_generatesSuffix (132.58s)
--- PASS: TestAccAWSRoute53Record_disappears_MultipleRecords (179.81s)
--- PASS: TestAccAWSRoute53Record_wildcard (195.77s)
--- PASS: TestAccAWSRoute53Record_Alias_VpcEndpoint (698.87s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       700.329s
```