### PR TITLE
Acceptance test import refactor for redshift resources

### DIFF
--- a/aws/resource_aws_redshift_parameter_group_test.go
+++ b/aws/resource_aws_redshift_parameter_group_test.go
@@ -12,8 +12,9 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSRedshiftParameterGroup_importBasic(t *testing.T) {
-	resourceName := "aws_redshift_parameter_group.bar"
+func TestAccAWSRedshiftParameterGroup_basic(t *testing.T) {
+	var v redshift.ClusterParameterGroup
+	resourceName := "aws_redshift_parameter_group.test"
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -23,8 +24,10 @@ func TestAccAWSRedshiftParameterGroup_importBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSRedshiftParameterGroupConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRedshiftParameterGroupExists(resourceName, &v),
+				),
 			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
@@ -37,6 +40,7 @@ func TestAccAWSRedshiftParameterGroup_importBasic(t *testing.T) {
 func TestAccAWSRedshiftParameterGroup_withParameters(t *testing.T) {
 	var v redshift.ClusterParameterGroup
 	rInt := acctest.RandInt()
+	resourceName := "aws_redshift_parameter_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -46,26 +50,31 @@ func TestAccAWSRedshiftParameterGroup_withParameters(t *testing.T) {
 			{
 				Config: testAccAWSRedshiftParameterGroupConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRedshiftParameterGroupExists("aws_redshift_parameter_group.bar", &v),
+					testAccCheckAWSRedshiftParameterGroupExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_redshift_parameter_group.bar", "name", fmt.Sprintf("test-terraform-%d", rInt)),
+						resourceName, "name", fmt.Sprintf("test-terraform-%d", rInt)),
 					resource.TestCheckResourceAttr(
-						"aws_redshift_parameter_group.bar", "family", "redshift-1.0"),
+						resourceName, "family", "redshift-1.0"),
 					resource.TestCheckResourceAttr(
-						"aws_redshift_parameter_group.bar", "description", "Managed by Terraform"),
+						resourceName, "description", "Managed by Terraform"),
 					resource.TestCheckResourceAttr(
-						"aws_redshift_parameter_group.bar", "parameter.490804664.name", "require_ssl"),
+						resourceName, "parameter.490804664.name", "require_ssl"),
 					resource.TestCheckResourceAttr(
-						"aws_redshift_parameter_group.bar", "parameter.490804664.value", "true"),
+						resourceName, "parameter.490804664.value", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_redshift_parameter_group.bar", "parameter.2036118857.name", "query_group"),
+						resourceName, "parameter.2036118857.name", "query_group"),
 					resource.TestCheckResourceAttr(
-						"aws_redshift_parameter_group.bar", "parameter.2036118857.value", "example"),
+						resourceName, "parameter.2036118857.value", "example"),
 					resource.TestCheckResourceAttr(
-						"aws_redshift_parameter_group.bar", "parameter.484080973.name", "enable_user_activity_logging"),
+						resourceName, "parameter.484080973.name", "enable_user_activity_logging"),
 					resource.TestCheckResourceAttr(
-						"aws_redshift_parameter_group.bar", "parameter.484080973.value", "true"),
+						resourceName, "parameter.484080973.value", "true"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -74,6 +83,7 @@ func TestAccAWSRedshiftParameterGroup_withParameters(t *testing.T) {
 func TestAccAWSRedshiftParameterGroup_withoutParameters(t *testing.T) {
 	var v redshift.ClusterParameterGroup
 	rInt := acctest.RandInt()
+	resourceName := "aws_redshift_parameter_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -83,14 +93,19 @@ func TestAccAWSRedshiftParameterGroup_withoutParameters(t *testing.T) {
 			{
 				Config: testAccAWSRedshiftParameterGroupOnlyConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRedshiftParameterGroupExists("aws_redshift_parameter_group.bar", &v),
+					testAccCheckAWSRedshiftParameterGroupExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_redshift_parameter_group.bar", "name", fmt.Sprintf("test-terraform-%d", rInt)),
+						resourceName, "name", fmt.Sprintf("test-terraform-%d", rInt)),
 					resource.TestCheckResourceAttr(
-						"aws_redshift_parameter_group.bar", "family", "redshift-1.0"),
+						resourceName, "family", "redshift-1.0"),
 					resource.TestCheckResourceAttr(
-						"aws_redshift_parameter_group.bar", "description", "Test parameter group for terraform"),
+						resourceName, "description", "Test parameter group for terraform"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -98,9 +113,8 @@ func TestAccAWSRedshiftParameterGroup_withoutParameters(t *testing.T) {
 
 func TestAccAWSRedshiftParameterGroup_withTags(t *testing.T) {
 	var v redshift.ClusterParameterGroup
-
 	rInt := acctest.RandInt()
-	resourceName := "aws_redshift_parameter_group.default"
+	resourceName := "aws_redshift_parameter_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -117,6 +131,11 @@ func TestAccAWSRedshiftParameterGroup_withTags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.environment", "Production"),
 					resource.TestCheckResourceAttr(resourceName, "tags.description", fmt.Sprintf("Test parameter group for terraform %s", "aaa")),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSRedshiftParameterGroupConfigWithTags(rInt, "bbb"),
@@ -250,7 +269,7 @@ func testAccCheckAWSRedshiftParameterGroupExists(n string, v *redshift.ClusterPa
 
 func testAccAWSRedshiftParameterGroupOnlyConfig(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_redshift_parameter_group" "bar" {
+resource "aws_redshift_parameter_group" "test" {
   name        = "test-terraform-%d"
   family      = "redshift-1.0"
   description = "Test parameter group for terraform"
@@ -260,7 +279,7 @@ resource "aws_redshift_parameter_group" "bar" {
 
 func testAccAWSRedshiftParameterGroupConfig(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_redshift_parameter_group" "bar" {
+resource "aws_redshift_parameter_group" "test" {
   name   = "test-terraform-%d"
   family = "redshift-1.0"
 
@@ -284,7 +303,7 @@ resource "aws_redshift_parameter_group" "bar" {
 
 func testAccAWSRedshiftParameterGroupConfigWithTags(rInt int, rString string) string {
 	return fmt.Sprintf(`
-resource "aws_redshift_parameter_group" "default" {
+resource "aws_redshift_parameter_group" "test" {
   name        = "test-terraform-%[1]d"
   family      = "redshift-1.0"
   description = "Test parameter group for terraform"
@@ -300,7 +319,7 @@ resource "aws_redshift_parameter_group" "default" {
 
 func testAccAWSRedshiftParameterGroupConfigWithTagsUpdate(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_redshift_parameter_group" "default" {
+resource "aws_redshift_parameter_group" "test" {
   name        = "test-terraform-%[1]d"
   family      = "redshift-1.0"
   description = "Test parameter group for terraform"

--- a/aws/resource_aws_redshift_security_group_test.go
+++ b/aws/resource_aws_redshift_security_group_test.go
@@ -44,6 +44,10 @@ func TestAccAWSRedshiftSecurityGroup_basic(t *testing.T) {
 }
 
 func TestAccAWSRedshiftSecurityGroup_ingressCidr(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
 	var v redshift.ClusterSecurityGroup
 	rInt := acctest.RandInt()
 	resourceName := "aws_redshift_security_group.test"
@@ -77,6 +81,10 @@ func TestAccAWSRedshiftSecurityGroup_ingressCidr(t *testing.T) {
 }
 
 func TestAccAWSRedshiftSecurityGroup_updateIngressCidr(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
 	var v redshift.ClusterSecurityGroup
 	rInt := acctest.RandInt()
 	resourceName := "aws_redshift_security_group.test"
@@ -120,6 +128,10 @@ func TestAccAWSRedshiftSecurityGroup_updateIngressCidr(t *testing.T) {
 }
 
 func TestAccAWSRedshiftSecurityGroup_ingressSecurityGroup(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
 	var v redshift.ClusterSecurityGroup
 	rInt := acctest.RandInt()
 	resourceName := "aws_redshift_security_group.test"
@@ -151,6 +163,10 @@ func TestAccAWSRedshiftSecurityGroup_ingressSecurityGroup(t *testing.T) {
 }
 
 func TestAccAWSRedshiftSecurityGroup_updateIngressSecurityGroup(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
 	var v redshift.ClusterSecurityGroup
 	rInt := acctest.RandInt()
 	resourceName := "aws_redshift_security_group.test"
@@ -295,10 +311,6 @@ func TestResourceAWSRedshiftSecurityGroupNameValidation(t *testing.T) {
 
 func testAccAWSRedshiftSecurityGroupConfig_ingressCidr(rInt int) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
 resource "aws_redshift_security_group" "test" {
   name = "redshift-sg-terraform-%d"
 
@@ -311,10 +323,6 @@ resource "aws_redshift_security_group" "test" {
 
 func testAccAWSRedshiftSecurityGroupConfig_ingressCidrAdd(rInt int) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
 resource "aws_redshift_security_group" "test" {
   name        = "redshift-sg-terraform-%d"
   description = "this is a description"
@@ -336,10 +344,6 @@ resource "aws_redshift_security_group" "test" {
 
 func testAccAWSRedshiftSecurityGroupConfig_ingressCidrReduce(rInt int) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
 resource "aws_redshift_security_group" "test" {
   name        = "redshift-sg-terraform-%d"
   description = "this is a description"
@@ -357,10 +361,6 @@ resource "aws_redshift_security_group" "test" {
 
 func testAccAWSRedshiftSecurityGroupConfig_ingressSgId(rInt int) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
 resource "aws_security_group" "redshift" {
   name        = "terraform_redshift_test_%d"
   description = "Used in the redshift acceptance tests"
@@ -387,10 +387,6 @@ resource "aws_redshift_security_group" "test" {
 
 func testAccAWSRedshiftSecurityGroupConfig_ingressSgIdAdd(rInt int) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
 resource "aws_security_group" "redshift" {
   name        = "terraform_redshift_test_%d"
   description = "Used in the redshift acceptance tests"
@@ -451,10 +447,6 @@ resource "aws_redshift_security_group" "test" {
 
 func testAccAWSRedshiftSecurityGroupConfig_ingressSgIdReduce(rInt int) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
 resource "aws_security_group" "redshift" {
   name        = "terraform_redshift_test_%d"
   description = "Used in the redshift acceptance tests"

--- a/aws/resource_aws_redshift_subnet_group_test.go
+++ b/aws/resource_aws_redshift_subnet_group_test.go
@@ -12,9 +12,10 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSRedshiftSubnetGroup_importBasic(t *testing.T) {
-	resourceName := "aws_redshift_subnet_group.foo"
+func TestAccAWSRedshiftSubnetGroup_basic(t *testing.T) {
+	var v redshift.ClusterSubnetGroup
 	rInt := acctest.RandInt()
+	resourceName := "aws_redshift_subnet_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -23,8 +24,14 @@ func TestAccAWSRedshiftSubnetGroup_importBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRedshiftSubnetGroupConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRedshiftSubnetGroupExists(resourceName, &v),
+					resource.TestCheckResourceAttr(
+						resourceName, "subnet_ids.#", "2"),
+					resource.TestCheckResourceAttr(
+						resourceName, "description", "test description"),
+				),
 			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
@@ -36,32 +43,10 @@ func TestAccAWSRedshiftSubnetGroup_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccAWSRedshiftSubnetGroup_basic(t *testing.T) {
-	var v redshift.ClusterSubnetGroup
-	rInt := acctest.RandInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckRedshiftSubnetGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccRedshiftSubnetGroupConfig(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRedshiftSubnetGroupExists("aws_redshift_subnet_group.foo", &v),
-					resource.TestCheckResourceAttr(
-						"aws_redshift_subnet_group.foo", "subnet_ids.#", "2"),
-					resource.TestCheckResourceAttr(
-						"aws_redshift_subnet_group.foo", "description", "foo description"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAWSRedshiftSubnetGroup_updateDescription(t *testing.T) {
 	var v redshift.ClusterSubnetGroup
 	rInt := acctest.RandInt()
+	resourceName := "aws_redshift_subnet_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -71,18 +56,24 @@ func TestAccAWSRedshiftSubnetGroup_updateDescription(t *testing.T) {
 			{
 				Config: testAccRedshiftSubnetGroupConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRedshiftSubnetGroupExists("aws_redshift_subnet_group.foo", &v),
+					testAccCheckRedshiftSubnetGroupExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_redshift_subnet_group.foo", "description", "foo description"),
+						resourceName, "description", "test description"),
 				),
 			},
-
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"description"},
+			},
 			{
 				Config: testAccRedshiftSubnetGroup_updateDescription(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRedshiftSubnetGroupExists("aws_redshift_subnet_group.foo", &v),
+					testAccCheckRedshiftSubnetGroupExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_redshift_subnet_group.foo", "description", "foo description updated"),
+						resourceName, "description", "test description updated"),
 				),
 			},
 		},
@@ -92,6 +83,7 @@ func TestAccAWSRedshiftSubnetGroup_updateDescription(t *testing.T) {
 func TestAccAWSRedshiftSubnetGroup_updateSubnetIds(t *testing.T) {
 	var v redshift.ClusterSubnetGroup
 	rInt := acctest.RandInt()
+	resourceName := "aws_redshift_subnet_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -101,18 +93,24 @@ func TestAccAWSRedshiftSubnetGroup_updateSubnetIds(t *testing.T) {
 			{
 				Config: testAccRedshiftSubnetGroupConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRedshiftSubnetGroupExists("aws_redshift_subnet_group.foo", &v),
+					testAccCheckRedshiftSubnetGroupExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_redshift_subnet_group.foo", "subnet_ids.#", "2"),
+						resourceName, "subnet_ids.#", "2"),
 				),
 			},
-
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"description"},
+			},
 			{
 				Config: testAccRedshiftSubnetGroupConfig_updateSubnetIds(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRedshiftSubnetGroupExists("aws_redshift_subnet_group.foo", &v),
+					testAccCheckRedshiftSubnetGroupExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_redshift_subnet_group.foo", "subnet_ids.#", "3"),
+						resourceName, "subnet_ids.#", "3"),
 				),
 			},
 		},
@@ -122,6 +120,7 @@ func TestAccAWSRedshiftSubnetGroup_updateSubnetIds(t *testing.T) {
 func TestAccAWSRedshiftSubnetGroup_tags(t *testing.T) {
 	var v redshift.ClusterSubnetGroup
 	rInt := acctest.RandInt()
+	resourceName := "aws_redshift_subnet_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -131,21 +130,28 @@ func TestAccAWSRedshiftSubnetGroup_tags(t *testing.T) {
 			{
 				Config: testAccRedshiftSubnetGroupConfigWithTags(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRedshiftSubnetGroupExists("aws_redshift_subnet_group.foo", &v),
+					testAccCheckRedshiftSubnetGroupExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_redshift_subnet_group.foo", "tags.%", "1"),
-					resource.TestCheckResourceAttr("aws_redshift_subnet_group.foo", "tags.Name", "tf-redshift-subnetgroup"),
+						resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "tf-redshift-subnetgroup"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"description"},
 			},
 			{
 				Config: testAccRedshiftSubnetGroupConfigWithTagsUpdated(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRedshiftSubnetGroupExists("aws_redshift_subnet_group.foo", &v),
+					testAccCheckRedshiftSubnetGroupExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_redshift_subnet_group.foo", "tags.%", "3"),
-					resource.TestCheckResourceAttr("aws_redshift_subnet_group.foo", "tags.environment", "production"),
-					resource.TestCheckResourceAttr("aws_redshift_subnet_group.foo", "tags.Name", "tf-redshift-subnetgroup"),
-					resource.TestCheckResourceAttr("aws_redshift_subnet_group.foo", "tags.foo", "bar"),
+						resourceName, "tags.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.environment", "production"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "tf-redshift-subnetgroup"),
+					resource.TestCheckResourceAttr(resourceName, "tags.test", "test2"),
 				),
 			},
 		},
@@ -252,7 +258,7 @@ func testAccCheckRedshiftSubnetGroupExists(n string, v *redshift.ClusterSubnetGr
 
 func testAccRedshiftSubnetGroupConfig(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
   tags = {
@@ -260,37 +266,37 @@ resource "aws_vpc" "foo" {
   }
 }
 
-resource "aws_subnet" "foo" {
+resource "aws_subnet" "test" {
   cidr_block        = "10.1.1.0/24"
   availability_zone = "us-west-2a"
-  vpc_id            = "${aws_vpc.foo.id}"
+  vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
-    Name = "tf-acc-redshift-subnet-group-foo"
+    Name = "tf-acc-redshift-subnet-group-test"
   }
 }
 
-resource "aws_subnet" "bar" {
+resource "aws_subnet" "test2" {
   cidr_block        = "10.1.2.0/24"
   availability_zone = "us-west-2b"
-  vpc_id            = "${aws_vpc.foo.id}"
+  vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
-    Name = "tf-acc-redshift-subnet-group-bar"
+    Name = "tf-acc-redshift-subnet-group-test2"
   }
 }
 
-resource "aws_redshift_subnet_group" "foo" {
-  name        = "foo-%d"
-  description = "foo description"
-  subnet_ids  = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
+resource "aws_redshift_subnet_group" "test" {
+  name        = "test-%d"
+  description = "test description"
+  subnet_ids  = ["${aws_subnet.test.id}", "${aws_subnet.test2.id}"]
 }
 `, rInt)
 }
 
 func testAccRedshiftSubnetGroup_updateDescription(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
   tags = {
@@ -298,37 +304,37 @@ resource "aws_vpc" "foo" {
   }
 }
 
-resource "aws_subnet" "foo" {
+resource "aws_subnet" "test" {
   cidr_block        = "10.1.1.0/24"
   availability_zone = "us-west-2a"
-  vpc_id            = "${aws_vpc.foo.id}"
+  vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
-    Name = "tf-acc-redshift-subnet-group-upd-description-foo"
+    Name = "tf-acc-redshift-subnet-group-upd-description-test"
   }
 }
 
-resource "aws_subnet" "bar" {
+resource "aws_subnet" "test2" {
   cidr_block        = "10.1.2.0/24"
   availability_zone = "us-west-2b"
-  vpc_id            = "${aws_vpc.foo.id}"
+  vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
-    Name = "tf-acc-redshift-subnet-group-upd-description-bar"
+    Name = "tf-acc-redshift-subnet-group-upd-description-test2"
   }
 }
 
-resource "aws_redshift_subnet_group" "foo" {
-  name        = "foo-%d"
-  description = "foo description updated"
-  subnet_ids  = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
+resource "aws_redshift_subnet_group" "test" {
+  name        = "test-%d"
+  description = "test description updated"
+  subnet_ids  = ["${aws_subnet.test.id}", "${aws_subnet.test2.id}"]
 }
 `, rInt)
 }
 
 func testAccRedshiftSubnetGroupConfigWithTags(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
   tags = {
@@ -336,29 +342,29 @@ resource "aws_vpc" "foo" {
   }
 }
 
-resource "aws_subnet" "foo" {
+resource "aws_subnet" "test" {
   cidr_block        = "10.1.1.0/24"
   availability_zone = "us-west-2a"
-  vpc_id            = "${aws_vpc.foo.id}"
+  vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
-    Name = "tf-acc-redshift-subnet-group-with-tags-foo"
+    Name = "tf-acc-redshift-subnet-group-with-tags-test"
   }
 }
 
-resource "aws_subnet" "bar" {
+resource "aws_subnet" "test2" {
   cidr_block        = "10.1.2.0/24"
   availability_zone = "us-west-2b"
-  vpc_id            = "${aws_vpc.foo.id}"
+  vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
-    Name = "tf-acc-redshift-subnet-group-with-tags-bar"
+    Name = "tf-acc-redshift-subnet-group-with-tags-test2"
   }
 }
 
-resource "aws_redshift_subnet_group" "foo" {
-  name       = "foo-%d"
-  subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
+resource "aws_redshift_subnet_group" "test" {
+  name       = "test-%d"
+  subnet_ids = ["${aws_subnet.test.id}", "${aws_subnet.test2.id}"]
 
   tags = {
     Name = "tf-redshift-subnetgroup"
@@ -369,7 +375,7 @@ resource "aws_redshift_subnet_group" "foo" {
 
 func testAccRedshiftSubnetGroupConfigWithTagsUpdated(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
   tags = {
@@ -377,34 +383,34 @@ resource "aws_vpc" "foo" {
   }
 }
 
-resource "aws_subnet" "foo" {
+resource "aws_subnet" "test" {
   cidr_block        = "10.1.1.0/24"
   availability_zone = "us-west-2a"
-  vpc_id            = "${aws_vpc.foo.id}"
+  vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
-    Name = "tf-acc-redshift-subnet-group-with-tags-foo"
+    Name = "tf-acc-redshift-subnet-group-with-tags-test"
   }
 }
 
-resource "aws_subnet" "bar" {
+resource "aws_subnet" "test2" {
   cidr_block        = "10.1.2.0/24"
   availability_zone = "us-west-2b"
-  vpc_id            = "${aws_vpc.foo.id}"
+  vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
-    Name = "tf-acc-redshift-subnet-group-with-tags-bar"
+    Name = "tf-acc-redshift-subnet-group-with-tags-test2"
   }
 }
 
-resource "aws_redshift_subnet_group" "foo" {
-  name       = "foo-%d"
-  subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
+resource "aws_redshift_subnet_group" "test" {
+  name       = "test-%d"
+  subnet_ids = ["${aws_subnet.test.id}", "${aws_subnet.test2.id}"]
 
   tags = {
     Name        = "tf-redshift-subnetgroup"
     environment = "production"
-    foo         = "bar"
+    test         = "test2"
   }
 }
 `, rInt)
@@ -412,7 +418,7 @@ resource "aws_redshift_subnet_group" "foo" {
 
 func testAccRedshiftSubnetGroupConfig_updateSubnetIds(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
   tags = {
@@ -420,39 +426,39 @@ resource "aws_vpc" "foo" {
   }
 }
 
-resource "aws_subnet" "foo" {
+resource "aws_subnet" "test" {
   cidr_block        = "10.1.1.0/24"
   availability_zone = "us-west-2a"
-  vpc_id            = "${aws_vpc.foo.id}"
+  vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
-    Name = "tf-acc-redshift-subnet-group-upd-subnet-ids-foo"
+    Name = "tf-acc-redshift-subnet-group-upd-subnet-ids-test"
   }
 }
 
-resource "aws_subnet" "bar" {
+resource "aws_subnet" "test2" {
   cidr_block        = "10.1.2.0/24"
   availability_zone = "us-west-2b"
-  vpc_id            = "${aws_vpc.foo.id}"
+  vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
-    Name = "tf-acc-redshift-subnet-group-upd-subnet-ids-bar"
+    Name = "tf-acc-redshift-subnet-group-upd-subnet-ids-test2"
   }
 }
 
-resource "aws_subnet" "foobar" {
+resource "aws_subnet" "testtest2" {
   cidr_block        = "10.1.3.0/24"
   availability_zone = "us-west-2c"
-  vpc_id            = "${aws_vpc.foo.id}"
+  vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
-    Name = "tf-acc-redshift-subnet-group-upd-subnet-ids-foobar"
+    Name = "tf-acc-redshift-subnet-group-upd-subnet-ids-testtest2"
   }
 }
 
-resource "aws_redshift_subnet_group" "foo" {
-  name       = "foo-%d"
-  subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}", "${aws_subnet.foobar.id}"]
+resource "aws_redshift_subnet_group" "test" {
+  name       = "test-%d"
+  subnet_ids = ["${aws_subnet.test.id}", "${aws_subnet.test2.id}", "${aws_subnet.testtest2.id}"]
 }
 `, rInt)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8944

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSRedshiftParameterGroup"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSRedshiftParameterGroup -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSRedshiftParameterGroup_basic
=== PAUSE TestAccAWSRedshiftParameterGroup_basic
=== RUN   TestAccAWSRedshiftParameterGroup_withParameters
=== PAUSE TestAccAWSRedshiftParameterGroup_withParameters
=== RUN   TestAccAWSRedshiftParameterGroup_withoutParameters
=== PAUSE TestAccAWSRedshiftParameterGroup_withoutParameters
=== RUN   TestAccAWSRedshiftParameterGroup_withTags
=== PAUSE TestAccAWSRedshiftParameterGroup_withTags
=== CONT  TestAccAWSRedshiftParameterGroup_basic
=== CONT  TestAccAWSRedshiftParameterGroup_withTags
=== CONT  TestAccAWSRedshiftParameterGroup_withoutParameters
=== CONT  TestAccAWSRedshiftParameterGroup_withParameters
--- PASS: TestAccAWSRedshiftParameterGroup_withoutParameters (31.15s)
--- PASS: TestAccAWSRedshiftParameterGroup_withParameters (31.55s)
--- PASS: TestAccAWSRedshiftParameterGroup_basic (31.56s)
--- PASS: TestAccAWSRedshiftParameterGroup_withTags (71.52s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       75.468s

make testacc TESTARGS="-run=TestAccAWSRedshiftSubnetGroup"     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSRedshiftSubnetGroup -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSRedshiftSubnetGroup_basic
=== PAUSE TestAccAWSRedshiftSubnetGroup_basic
=== RUN   TestAccAWSRedshiftSubnetGroup_updateDescription
=== PAUSE TestAccAWSRedshiftSubnetGroup_updateDescription
=== RUN   TestAccAWSRedshiftSubnetGroup_updateSubnetIds
=== PAUSE TestAccAWSRedshiftSubnetGroup_updateSubnetIds
=== RUN   TestAccAWSRedshiftSubnetGroup_tags
=== PAUSE TestAccAWSRedshiftSubnetGroup_tags
=== CONT  TestAccAWSRedshiftSubnetGroup_basic
=== CONT  TestAccAWSRedshiftSubnetGroup_updateSubnetIds
=== CONT  TestAccAWSRedshiftSubnetGroup_updateDescription
=== CONT  TestAccAWSRedshiftSubnetGroup_tags
--- PASS: TestAccAWSRedshiftSubnetGroup_basic (59.54s)
--- PASS: TestAccAWSRedshiftSubnetGroup_tags (93.09s)
--- PASS: TestAccAWSRedshiftSubnetGroup_updateSubnetIds (106.19s)
--- PASS: TestAccAWSRedshiftSubnetGroup_updateDescription (106.32s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       108.163s

make testacc TESTARGS="-run=TestAccAWSRedshiftSecurityGroup"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSRedshiftSecurityGroup -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSRedshiftSecurityGroup_basic
=== PAUSE TestAccAWSRedshiftSecurityGroup_basic
=== RUN   TestAccAWSRedshiftSecurityGroup_ingressCidr
=== PAUSE TestAccAWSRedshiftSecurityGroup_ingressCidr
=== RUN   TestAccAWSRedshiftSecurityGroup_updateIngressCidr
=== PAUSE TestAccAWSRedshiftSecurityGroup_updateIngressCidr
=== RUN   TestAccAWSRedshiftSecurityGroup_ingressSecurityGroup
=== PAUSE TestAccAWSRedshiftSecurityGroup_ingressSecurityGroup
=== RUN   TestAccAWSRedshiftSecurityGroup_updateIngressSecurityGroup
=== PAUSE TestAccAWSRedshiftSecurityGroup_updateIngressSecurityGroup
=== CONT  TestAccAWSRedshiftSecurityGroup_basic
=== CONT  TestAccAWSRedshiftSecurityGroup_updateIngressSecurityGroup
=== CONT  TestAccAWSRedshiftSecurityGroup_ingressCidr
=== CONT  TestAccAWSRedshiftSecurityGroup_updateIngressCidr
=== CONT  TestAccAWSRedshiftSecurityGroup_ingressSecurityGroup
--- PASS: TestAccAWSRedshiftSecurityGroup_ingressCidr (25.88s)
--- PASS: TestAccAWSRedshiftSecurityGroup_basic (26.38s)
--- PASS: TestAccAWSRedshiftSecurityGroup_ingressSecurityGroup (32.05s)
--- PASS: TestAccAWSRedshiftSecurityGroup_updateIngressCidr (59.55s)
--- PASS: TestAccAWSRedshiftSecurityGroup_updateIngressSecurityGroup (67.93s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       68.932s
```