### PR TITLE
Refactor import acceptance tests for s3 buckets

### DIFF
--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -136,84 +136,17 @@ func testS3BucketRegion(conn *s3.S3, bucket string) (string, error) {
 	return aws.StringValue(output.LocationConstraint), nil
 }
 
-func TestAccAWSS3Bucket_importBasic(t *testing.T) {
-	resourceName := "aws_s3_bucket.bucket"
-	rInt := acctest.RandInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSS3BucketDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSS3BucketConfig(rInt),
-			},
-
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"force_destroy", "acl"},
-			},
-		},
-	})
-}
-
-func TestAccAWSS3Bucket_importWithPolicy(t *testing.T) {
-	rInt := acctest.RandInt()
-	partition := testAccGetPartition()
-
-	checkFn := func(s []*terraform.InstanceState) error {
-		// Expect 2: bucket + policy
-		if len(s) != 2 {
-			return fmt.Errorf("expected 2 states: %#v", s)
-		}
-		bucketState, policyState := s[0], s[1]
-
-		expectedBucketId := fmt.Sprintf("tf-test-bucket-%d", rInt)
-
-		if bucketState.ID != expectedBucketId {
-			return fmt.Errorf("expected bucket of ID %s, %s received",
-				expectedBucketId, bucketState.ID)
-		}
-
-		if policyState.ID != expectedBucketId {
-			return fmt.Errorf("expected policy of ID %s, %s received",
-				expectedBucketId, bucketState.ID)
-		}
-
-		return nil
-	}
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSS3BucketDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSS3BucketConfigWithPolicy(rInt, partition),
-			},
-
-			{
-				ResourceName:     "aws_s3_bucket.bucket",
-				ImportState:      true,
-				ImportStateCheck: checkFn,
-			},
-		},
-	})
-}
-
 func TestAccAWSS3Bucket_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 	arnRegexp := regexp.MustCompile(`^arn:aws[\w-]*:s3:::`)
 	region := testAccGetRegion()
 	hostedZoneID, _ := HostedZoneIDForRegion(region)
+	resourceName := "aws_s3_bucket.bucket"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 		/*
-			IDRefreshName:   "aws_s3_bucket.bucket",
+			IDRefreshName:   resourceName,
 			IDRefreshIgnore: []string{"force_destroy"},
 		*/
 		Providers:    testAccProviders,
@@ -222,22 +155,29 @@ func TestAccAWSS3Bucket_basic(t *testing.T) {
 			{
 				Config: testAccAWSS3BucketConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "hosted_zone_id", hostedZoneID),
+						resourceName, "hosted_zone_id", hostedZoneID),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "region", region),
+						resourceName, "region", region),
 					resource.TestCheckNoResourceAttr(
-						"aws_s3_bucket.bucket", "website_endpoint"),
+						resourceName, "website_endpoint"),
 					resource.TestMatchResourceAttr(
-						"aws_s3_bucket.bucket", "arn", arnRegexp),
+						resourceName, "arn", arnRegexp),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "bucket", testAccBucketName(rInt)),
+						resourceName, "bucket", testAccBucketName(rInt)),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "bucket_domain_name", testAccBucketDomainName(rInt)),
+						resourceName, "bucket_domain_name", testAccBucketDomainName(rInt)),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "bucket_regional_domain_name", testAccBucketRegionalDomainName(rInt, region)),
+						resourceName, "bucket_regional_domain_name", testAccBucketRegionalDomainName(rInt, region)),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy", "acl"},
 			},
 		},
 	})
@@ -259,6 +199,13 @@ func TestAccAWSS3Bucket_Bucket_EmptyString(t *testing.T) {
 					testAccCheckAWSS3BucketExists(resourceName),
 					resource.TestMatchResourceAttr(resourceName, "bucket", regexp.MustCompile("^terraform-")),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy", "acl"},
 			},
 		},
 	})
@@ -283,6 +230,13 @@ func TestAccAWSS3Bucket_tagsWithNoSystemTags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "BBB"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key3", "CCC"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy", "acl"},
 			},
 			{
 				Config: testAccAWSS3BucketConfig_withUpdatedTags(bucketName),
@@ -360,6 +314,13 @@ func TestAccAWSS3Bucket_tagsWithSystemTags(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy", "acl"},
+			},
+			{
 				Config: testAccAWSS3BucketConfig_withTags(bucketName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketExists(resourceName),
@@ -397,6 +358,8 @@ func TestAccAWSS3Bucket_tagsWithSystemTags(t *testing.T) {
 
 func TestAccAWSS3MultiBucket_withTags(t *testing.T) {
 	rInt := acctest.RandInt()
+	resourceName := "aws_s3_bucket.bucket1"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -405,11 +368,20 @@ func TestAccAWSS3MultiBucket_withTags(t *testing.T) {
 			{
 				Config: testAccAWSS3MultiBucketConfigWithTags(rInt),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy", "acl"},
+			},
 		},
 	})
 }
 
 func TestAccAWSS3Bucket_namePrefix(t *testing.T) {
+	resourceName := "aws_s3_bucket.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -418,16 +390,25 @@ func TestAccAWSS3Bucket_namePrefix(t *testing.T) {
 			{
 				Config: testAccAWSS3BucketConfig_namePrefix,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.test"),
+					testAccCheckAWSS3BucketExists(resourceName),
 					resource.TestMatchResourceAttr(
-						"aws_s3_bucket.test", "bucket", regexp.MustCompile("^tf-test-")),
+						resourceName, "bucket", regexp.MustCompile("^tf-test-")),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy", "acl", "bucket_prefix"},
 			},
 		},
 	})
 }
 
 func TestAccAWSS3Bucket_generatedName(t *testing.T) {
+	resourceName := "aws_s3_bucket.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -436,8 +417,15 @@ func TestAccAWSS3Bucket_generatedName(t *testing.T) {
 			{
 				Config: testAccAWSS3BucketConfig_generatedName,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.test"),
+					testAccCheckAWSS3BucketExists(resourceName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy", "acl", "bucket_prefix"},
 			},
 		},
 	})
@@ -471,6 +459,7 @@ func TestAccAWSS3Bucket_region(t *testing.T) {
 
 func TestAccAWSS3Bucket_acceleration(t *testing.T) {
 	rInt := acctest.RandInt()
+	resourceName := "aws_s3_bucket.bucket"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -483,17 +472,24 @@ func TestAccAWSS3Bucket_acceleration(t *testing.T) {
 			{
 				Config: testAccAWSS3BucketConfigWithAcceleration(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "acceleration_status", "Enabled"),
+						resourceName, "acceleration_status", "Enabled"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy", "acl"},
 			},
 			{
 				Config: testAccAWSS3BucketConfigWithoutAcceleration(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "acceleration_status", "Suspended"),
+						resourceName, "acceleration_status", "Suspended"),
 				),
 			},
 		},
@@ -502,6 +498,7 @@ func TestAccAWSS3Bucket_acceleration(t *testing.T) {
 
 func TestAccAWSS3Bucket_RequestPayer(t *testing.T) {
 	rInt := acctest.RandInt()
+	resourceName := "aws_s3_bucket.bucket"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -511,26 +508,33 @@ func TestAccAWSS3Bucket_RequestPayer(t *testing.T) {
 			{
 				Config: testAccAWSS3BucketConfigRequestPayerBucketOwner(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket",
+						resourceName,
 						"request_payer",
 						"BucketOwner"),
 					testAccCheckAWSS3RequestPayer(
-						"aws_s3_bucket.bucket",
+						resourceName,
 						"BucketOwner"),
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy", "acl"},
+			},
+			{
 				Config: testAccAWSS3BucketConfigRequestPayerRequester(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket",
+						resourceName,
 						"request_payer",
 						"Requester"),
 					testAccCheckAWSS3RequestPayer(
-						"aws_s3_bucket.bucket",
+						resourceName,
 						"Requester"),
 				),
 			},
@@ -541,6 +545,29 @@ func TestAccAWSS3Bucket_RequestPayer(t *testing.T) {
 func TestAccAWSS3Bucket_Policy(t *testing.T) {
 	rInt := acctest.RandInt()
 	partition := testAccGetPartition()
+	resourceName := "aws_s3_bucket.bucket"
+
+	checkFn := func(s []*terraform.InstanceState) error {
+		// Expect 2: bucket + policy
+		if len(s) != 2 {
+			return fmt.Errorf("expected 2 states: %#v", s)
+		}
+		bucketState, policyState := s[0], s[1]
+
+		expectedBucketId := fmt.Sprintf("tf-test-bucket-%d", rInt)
+
+		if bucketState.ID != expectedBucketId {
+			return fmt.Errorf("expected bucket of ID %s, %s received",
+				expectedBucketId, bucketState.ID)
+		}
+
+		if policyState.ID != expectedBucketId {
+			return fmt.Errorf("expected policy of ID %s, %s received",
+				expectedBucketId, bucketState.ID)
+		}
+
+		return nil
+	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -550,25 +577,30 @@ func TestAccAWSS3Bucket_Policy(t *testing.T) {
 			{
 				Config: testAccAWSS3BucketConfigWithPolicy(rInt, partition),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
 					testAccCheckAWSS3BucketPolicy(
-						"aws_s3_bucket.bucket", testAccAWSS3BucketPolicy(rInt, partition)),
+						resourceName, testAccAWSS3BucketPolicy(rInt, partition)),
 				),
+			},
+			{
+				ResourceName:     resourceName,
+				ImportState:      true,
+				ImportStateCheck: checkFn,
 			},
 			{
 				Config: testAccAWSS3BucketConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
 					testAccCheckAWSS3BucketPolicy(
-						"aws_s3_bucket.bucket", ""),
+						resourceName, ""),
 				),
 			},
 			{
 				Config: testAccAWSS3BucketConfigWithEmptyPolicy(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
 					testAccCheckAWSS3BucketPolicy(
-						"aws_s3_bucket.bucket", ""),
+						resourceName, ""),
 				),
 			},
 		},
@@ -579,6 +611,7 @@ func TestAccAWSS3Bucket_UpdateAcl(t *testing.T) {
 	ri := acctest.RandInt()
 	preConfig := fmt.Sprintf(testAccAWSS3BucketConfigWithAcl, ri)
 	postConfig := fmt.Sprintf(testAccAWSS3BucketConfigWithAclUpdate, ri)
+	resourceName := "aws_s3_bucket.bucket"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -588,17 +621,24 @@ func TestAccAWSS3Bucket_UpdateAcl(t *testing.T) {
 			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "acl", "public-read"),
+						resourceName, "acl", "public-read"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy", "acl"},
 			},
 			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "acl", "private"),
+						resourceName, "acl", "private"),
 				),
 			},
 		},
@@ -608,6 +648,8 @@ func TestAccAWSS3Bucket_UpdateAcl(t *testing.T) {
 func TestAccAWSS3Bucket_Website_Simple(t *testing.T) {
 	rInt := acctest.RandInt()
 	region := testAccGetRegion()
+	resourceName := "aws_s3_bucket.bucket"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -616,31 +658,38 @@ func TestAccAWSS3Bucket_Website_Simple(t *testing.T) {
 			{
 				Config: testAccAWSS3BucketWebsiteConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
 					testAccCheckAWSS3BucketWebsite(
-						"aws_s3_bucket.bucket", "index.html", "", "", ""),
+						resourceName, "index.html", "", "", ""),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "website_endpoint", testAccWebsiteEndpoint(rInt, region)),
+						resourceName, "website_endpoint", testAccWebsiteEndpoint(rInt, region)),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy", "acl"},
 			},
 			{
 				Config: testAccAWSS3BucketWebsiteConfigWithError(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
 					testAccCheckAWSS3BucketWebsite(
-						"aws_s3_bucket.bucket", "index.html", "error.html", "", ""),
+						resourceName, "index.html", "error.html", "", ""),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "website_endpoint", testAccWebsiteEndpoint(rInt, region)),
+						resourceName, "website_endpoint", testAccWebsiteEndpoint(rInt, region)),
 				),
 			},
 			{
 				Config: testAccAWSS3BucketConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
 					testAccCheckAWSS3BucketWebsite(
-						"aws_s3_bucket.bucket", "", "", "", ""),
+						resourceName, "", "", "", ""),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "website_endpoint", ""),
+						resourceName, "website_endpoint", ""),
 				),
 			},
 		},
@@ -650,6 +699,8 @@ func TestAccAWSS3Bucket_Website_Simple(t *testing.T) {
 func TestAccAWSS3Bucket_WebsiteRedirect(t *testing.T) {
 	rInt := acctest.RandInt()
 	region := testAccGetRegion()
+	resourceName := "aws_s3_bucket.bucket"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -658,31 +709,38 @@ func TestAccAWSS3Bucket_WebsiteRedirect(t *testing.T) {
 			{
 				Config: testAccAWSS3BucketWebsiteConfigWithRedirect(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
 					testAccCheckAWSS3BucketWebsite(
-						"aws_s3_bucket.bucket", "", "", "", "hashicorp.com?my=query"),
+						resourceName, "", "", "", "hashicorp.com?my=query"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "website_endpoint", testAccWebsiteEndpoint(rInt, region)),
+						resourceName, "website_endpoint", testAccWebsiteEndpoint(rInt, region)),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy", "acl"},
 			},
 			{
 				Config: testAccAWSS3BucketWebsiteConfigWithHttpsRedirect(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
 					testAccCheckAWSS3BucketWebsite(
-						"aws_s3_bucket.bucket", "", "", "https", "hashicorp.com?my=query"),
+						resourceName, "", "", "https", "hashicorp.com?my=query"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "website_endpoint", testAccWebsiteEndpoint(rInt, region)),
+						resourceName, "website_endpoint", testAccWebsiteEndpoint(rInt, region)),
 				),
 			},
 			{
 				Config: testAccAWSS3BucketConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
 					testAccCheckAWSS3BucketWebsite(
-						"aws_s3_bucket.bucket", "", "", "", ""),
+						resourceName, "", "", "", ""),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "website_endpoint", ""),
+						resourceName, "website_endpoint", ""),
 				),
 			},
 		},
@@ -692,6 +750,8 @@ func TestAccAWSS3Bucket_WebsiteRedirect(t *testing.T) {
 func TestAccAWSS3Bucket_WebsiteRoutingRules(t *testing.T) {
 	rInt := acctest.RandInt()
 	region := testAccGetRegion()
+	resourceName := "aws_s3_bucket.bucket"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -700,11 +760,11 @@ func TestAccAWSS3Bucket_WebsiteRoutingRules(t *testing.T) {
 			{
 				Config: testAccAWSS3BucketWebsiteConfigWithRoutingRules(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
 					testAccCheckAWSS3BucketWebsite(
-						"aws_s3_bucket.bucket", "index.html", "error.html", "", ""),
+						resourceName, "index.html", "error.html", "", ""),
 					testAccCheckAWSS3BucketWebsiteRoutingRules(
-						"aws_s3_bucket.bucket",
+						resourceName,
 						[]*s3.RoutingRule{
 							{
 								Condition: &s3.Condition{
@@ -717,18 +777,25 @@ func TestAccAWSS3Bucket_WebsiteRoutingRules(t *testing.T) {
 						},
 					),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "website_endpoint", testAccWebsiteEndpoint(rInt, region)),
+						resourceName, "website_endpoint", testAccWebsiteEndpoint(rInt, region)),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy", "acl"},
 			},
 			{
 				Config: testAccAWSS3BucketConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
 					testAccCheckAWSS3BucketWebsite(
-						"aws_s3_bucket.bucket", "", "", "", ""),
-					testAccCheckAWSS3BucketWebsiteRoutingRules("aws_s3_bucket.bucket", nil),
+						resourceName, "", "", "", ""),
+					testAccCheckAWSS3BucketWebsiteRoutingRules(resourceName, nil),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "website_endpoint", ""),
+						resourceName, "website_endpoint", ""),
 				),
 			},
 		},
@@ -737,6 +804,8 @@ func TestAccAWSS3Bucket_WebsiteRoutingRules(t *testing.T) {
 
 func TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical(t *testing.T) {
 	rInt := acctest.RandInt()
+	resourceName := "aws_s3_bucket.arbitrary"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -745,13 +814,20 @@ func TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical(t *testing.T) {
 			{
 				Config: testAccAWSS3BucketEnableDefaultEncryption(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.arbitrary"),
-					resource.TestCheckResourceAttr("aws_s3_bucket.arbitrary", "server_side_encryption_configuration.#", "1"),
-					resource.TestCheckResourceAttr("aws_s3_bucket.arbitrary", "server_side_encryption_configuration.0.rule.#", "1"),
-					resource.TestCheckResourceAttr("aws_s3_bucket.arbitrary", "server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.#", "1"),
-					resource.TestCheckResourceAttr("aws_s3_bucket.arbitrary", "server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.0.sse_algorithm", "aws:kms"),
-					resource.TestMatchResourceAttr("aws_s3_bucket.arbitrary", "server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.0.kms_master_key_id", regexp.MustCompile("^arn")),
+					testAccCheckAWSS3BucketExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "server_side_encryption_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "server_side_encryption_configuration.0.rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.0.sse_algorithm", "aws:kms"),
+					resource.TestMatchResourceAttr(resourceName, "server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.0.kms_master_key_id", regexp.MustCompile("^arn")),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy", "acl"},
 			},
 		},
 	})
@@ -759,6 +835,8 @@ func TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical(t *testing.T) {
 
 func TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed(t *testing.T) {
 	rInt := acctest.RandInt()
+	resourceName := "aws_s3_bucket.arbitrary"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -767,13 +845,20 @@ func TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed(t *testing.T) {
 			{
 				Config: testAccAWSS3BucketEnableDefaultEncryptionWithAES256(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.arbitrary"),
-					resource.TestCheckResourceAttr("aws_s3_bucket.arbitrary", "server_side_encryption_configuration.#", "1"),
-					resource.TestCheckResourceAttr("aws_s3_bucket.arbitrary", "server_side_encryption_configuration.0.rule.#", "1"),
-					resource.TestCheckResourceAttr("aws_s3_bucket.arbitrary", "server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.#", "1"),
-					resource.TestCheckResourceAttr("aws_s3_bucket.arbitrary", "server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.0.sse_algorithm", "AES256"),
-					resource.TestCheckResourceAttr("aws_s3_bucket.arbitrary", "server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.0.kms_master_key_id", ""),
+					testAccCheckAWSS3BucketExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "server_side_encryption_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "server_side_encryption_configuration.0.rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.0.sse_algorithm", "AES256"),
+					resource.TestCheckResourceAttr(resourceName, "server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.0.kms_master_key_id", ""),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy", "acl"},
 			},
 		},
 	})
@@ -781,6 +866,8 @@ func TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed(t *testing.T) {
 
 func TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled(t *testing.T) {
 	rInt := acctest.RandInt()
+	resourceName := "aws_s3_bucket.arbitrary"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -789,14 +876,21 @@ func TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled(
 			{
 				Config: testAccAWSS3BucketEnableDefaultEncryptionWithDefaultKey(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.arbitrary"),
+					testAccCheckAWSS3BucketExists(resourceName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy", "acl"},
 			},
 			{
 				Config: testAccAWSS3BucketDisableDefaultEncryption(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.arbitrary"),
-					resource.TestCheckResourceAttr("aws_s3_bucket.arbitrary", "server_side_encryption_configuration.#", "0"),
+					testAccCheckAWSS3BucketExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "server_side_encryption_configuration.#", "0"),
 				),
 			},
 		},
@@ -808,6 +902,8 @@ func TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled(
 // See https://github.com/hashicorp/terraform/pull/2925
 func TestAccAWSS3Bucket_shouldFailNotFound(t *testing.T) {
 	rInt := acctest.RandInt()
+	resourceName := "aws_s3_bucket.bucket"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -816,8 +912,8 @@ func TestAccAWSS3Bucket_shouldFailNotFound(t *testing.T) {
 			{
 				Config: testAccAWSS3BucketDestroyedConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
-					testAccCheckAWSS3DestroyBucket("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
+					testAccCheckAWSS3DestroyBucket(resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -827,6 +923,8 @@ func TestAccAWSS3Bucket_shouldFailNotFound(t *testing.T) {
 
 func TestAccAWSS3Bucket_Versioning(t *testing.T) {
 	rInt := acctest.RandInt()
+	resourceName := "aws_s3_bucket.bucket"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -835,25 +933,32 @@ func TestAccAWSS3Bucket_Versioning(t *testing.T) {
 			{
 				Config: testAccAWSS3BucketConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
 					testAccCheckAWSS3BucketVersioning(
-						"aws_s3_bucket.bucket", ""),
+						resourceName, ""),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy", "acl"},
 			},
 			{
 				Config: testAccAWSS3BucketConfigWithVersioning(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
 					testAccCheckAWSS3BucketVersioning(
-						"aws_s3_bucket.bucket", s3.BucketVersioningStatusEnabled),
+						resourceName, s3.BucketVersioningStatusEnabled),
 				),
 			},
 			{
 				Config: testAccAWSS3BucketConfigWithDisableVersioning(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
 					testAccCheckAWSS3BucketVersioning(
-						"aws_s3_bucket.bucket", s3.BucketVersioningStatusSuspended),
+						resourceName, s3.BucketVersioningStatusSuspended),
 				),
 			},
 		},
@@ -862,6 +967,7 @@ func TestAccAWSS3Bucket_Versioning(t *testing.T) {
 
 func TestAccAWSS3Bucket_Cors_Update(t *testing.T) {
 	rInt := acctest.RandInt()
+	resourceName := "aws_s3_bucket.bucket"
 
 	updateBucketCors := func(n string) resource.TestCheckFunc {
 		return func(s *terraform.State) error {
@@ -898,9 +1004,9 @@ func TestAccAWSS3Bucket_Cors_Update(t *testing.T) {
 			{
 				Config: testAccAWSS3BucketConfigWithCORS(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
 					testAccCheckAWSS3BucketCors(
-						"aws_s3_bucket.bucket",
+						resourceName,
 						[]*s3.CORSRule{
 							{
 								AllowedHeaders: []*string{aws.String("*")},
@@ -911,16 +1017,23 @@ func TestAccAWSS3Bucket_Cors_Update(t *testing.T) {
 							},
 						},
 					),
-					updateBucketCors("aws_s3_bucket.bucket"),
+					updateBucketCors(resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy", "acl"},
+			},
+			{
 				Config: testAccAWSS3BucketConfigWithCORS(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
 					testAccCheckAWSS3BucketCors(
-						"aws_s3_bucket.bucket",
+						resourceName,
 						[]*s3.CORSRule{
 							{
 								AllowedHeaders: []*string{aws.String("*")},
@@ -939,6 +1052,7 @@ func TestAccAWSS3Bucket_Cors_Update(t *testing.T) {
 
 func TestAccAWSS3Bucket_Cors_Delete(t *testing.T) {
 	rInt := acctest.RandInt()
+	resourceName := "aws_s3_bucket.bucket"
 
 	deleteBucketCors := func(n string) resource.TestCheckFunc {
 		return func(s *terraform.State) error {
@@ -966,8 +1080,8 @@ func TestAccAWSS3Bucket_Cors_Delete(t *testing.T) {
 			{
 				Config: testAccAWSS3BucketConfigWithCORS(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
-					deleteBucketCors("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
+					deleteBucketCors(resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -977,6 +1091,7 @@ func TestAccAWSS3Bucket_Cors_Delete(t *testing.T) {
 
 func TestAccAWSS3Bucket_Cors_EmptyOrigin(t *testing.T) {
 	rInt := acctest.RandInt()
+	resourceName := "aws_s3_bucket.bucket"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -986,9 +1101,9 @@ func TestAccAWSS3Bucket_Cors_EmptyOrigin(t *testing.T) {
 			{
 				Config: testAccAWSS3BucketConfigWithCORSEmptyOrigin(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
 					testAccCheckAWSS3BucketCors(
-						"aws_s3_bucket.bucket",
+						resourceName,
 						[]*s3.CORSRule{
 							{
 								AllowedHeaders: []*string{aws.String("*")},
@@ -1001,12 +1116,21 @@ func TestAccAWSS3Bucket_Cors_EmptyOrigin(t *testing.T) {
 					),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy", "acl"},
+			},
 		},
 	})
 }
 
 func TestAccAWSS3Bucket_Logging(t *testing.T) {
 	rInt := acctest.RandInt()
+	resourceName := "aws_s3_bucket.bucket"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -1015,10 +1139,17 @@ func TestAccAWSS3Bucket_Logging(t *testing.T) {
 			{
 				Config: testAccAWSS3BucketConfigWithLogging(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
 					testAccCheckAWSS3BucketLogging(
-						"aws_s3_bucket.bucket", "aws_s3_bucket.log_bucket", "log/"),
+						resourceName, "aws_s3_bucket.log_bucket", "log/"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy", "acl"},
 			},
 		},
 	})
@@ -1026,6 +1157,8 @@ func TestAccAWSS3Bucket_Logging(t *testing.T) {
 
 func TestAccAWSS3Bucket_LifecycleBasic(t *testing.T) {
 	rInt := acctest.RandInt()
+	resourceName := "aws_s3_bucket.bucket"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -1034,133 +1167,140 @@ func TestAccAWSS3Bucket_LifecycleBasic(t *testing.T) {
 			{
 				Config: testAccAWSS3BucketConfigWithLifecycle(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.id", "id1"),
+						resourceName, "lifecycle_rule.0.id", "id1"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.prefix", "path1/"),
+						resourceName, "lifecycle_rule.0.prefix", "path1/"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.expiration.2613713285.days", "365"),
+						resourceName, "lifecycle_rule.0.expiration.2613713285.days", "365"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.expiration.2613713285.date", ""),
+						resourceName, "lifecycle_rule.0.expiration.2613713285.date", ""),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.expiration.2613713285.expired_object_delete_marker", "false"),
+						resourceName, "lifecycle_rule.0.expiration.2613713285.expired_object_delete_marker", "false"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.2000431762.date", ""),
+						resourceName, "lifecycle_rule.0.transition.2000431762.date", ""),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.2000431762.days", "30"),
+						resourceName, "lifecycle_rule.0.transition.2000431762.days", "30"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.2000431762.storage_class", "STANDARD_IA"),
+						resourceName, "lifecycle_rule.0.transition.2000431762.storage_class", "STANDARD_IA"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.3601168188.date", ""),
+						resourceName, "lifecycle_rule.0.transition.3601168188.date", ""),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.3601168188.days", "60"),
+						resourceName, "lifecycle_rule.0.transition.3601168188.days", "60"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.3601168188.storage_class", "INTELLIGENT_TIERING"),
+						resourceName, "lifecycle_rule.0.transition.3601168188.storage_class", "INTELLIGENT_TIERING"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.3854926587.date", ""),
+						resourceName, "lifecycle_rule.0.transition.3854926587.date", ""),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.3854926587.days", "90"),
+						resourceName, "lifecycle_rule.0.transition.3854926587.days", "90"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.3854926587.storage_class", "ONEZONE_IA"),
+						resourceName, "lifecycle_rule.0.transition.3854926587.storage_class", "ONEZONE_IA"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.962205413.date", ""),
+						resourceName, "lifecycle_rule.0.transition.962205413.date", ""),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.962205413.days", "120"),
+						resourceName, "lifecycle_rule.0.transition.962205413.days", "120"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.962205413.storage_class", "GLACIER"),
+						resourceName, "lifecycle_rule.0.transition.962205413.storage_class", "GLACIER"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.1571523406.date", ""),
+						resourceName, "lifecycle_rule.0.transition.1571523406.date", ""),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.1571523406.days", "210"),
+						resourceName, "lifecycle_rule.0.transition.1571523406.days", "210"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.1571523406.storage_class", "DEEP_ARCHIVE"),
+						resourceName, "lifecycle_rule.0.transition.1571523406.storage_class", "DEEP_ARCHIVE"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.1.id", "id2"),
+						resourceName, "lifecycle_rule.1.id", "id2"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.1.prefix", "path2/"),
+						resourceName, "lifecycle_rule.1.prefix", "path2/"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.1.expiration.2855832418.date", "2016-01-12"),
+						resourceName, "lifecycle_rule.1.expiration.2855832418.date", "2016-01-12"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.1.expiration.2855832418.days", "0"),
+						resourceName, "lifecycle_rule.1.expiration.2855832418.days", "0"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.1.expiration.2855832418.expired_object_delete_marker", "false"),
+						resourceName, "lifecycle_rule.1.expiration.2855832418.expired_object_delete_marker", "false"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.2.id", "id3"),
+						resourceName, "lifecycle_rule.2.id", "id3"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.2.prefix", "path3/"),
+						resourceName, "lifecycle_rule.2.prefix", "path3/"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.2.transition.460947558.days", "0"),
+						resourceName, "lifecycle_rule.2.transition.460947558.days", "0"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.3.id", "id4"),
+						resourceName, "lifecycle_rule.3.id", "id4"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.3.prefix", "path4/"),
+						resourceName, "lifecycle_rule.3.prefix", "path4/"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.3.tags.tagKey", "tagValue"),
+						resourceName, "lifecycle_rule.3.tags.tagKey", "tagValue"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.3.tags.terraform", "hashicorp"),
+						resourceName, "lifecycle_rule.3.tags.terraform", "hashicorp"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.4.id", "id5"),
+						resourceName, "lifecycle_rule.4.id", "id5"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.4.tags.tagKey", "tagValue"),
+						resourceName, "lifecycle_rule.4.tags.tagKey", "tagValue"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.4.tags.terraform", "hashicorp"),
+						resourceName, "lifecycle_rule.4.tags.terraform", "hashicorp"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.4.transition.460947558.days", "0"),
+						resourceName, "lifecycle_rule.4.transition.460947558.days", "0"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.4.transition.460947558.storage_class", "GLACIER"),
+						resourceName, "lifecycle_rule.4.transition.460947558.storage_class", "GLACIER"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.5.id", "id6"),
+						resourceName, "lifecycle_rule.5.id", "id6"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.5.tags.tagKey", "tagValue"),
+						resourceName, "lifecycle_rule.5.tags.tagKey", "tagValue"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.5.transition.460947558.days", "0"),
+						resourceName, "lifecycle_rule.5.transition.460947558.days", "0"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.5.transition.460947558.storage_class", "GLACIER"),
+						resourceName, "lifecycle_rule.5.transition.460947558.storage_class", "GLACIER"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy", "acl"},
 			},
 			{
 				Config: testAccAWSS3BucketConfigWithVersioningLifecycle(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.id", "id1"),
+						resourceName, "lifecycle_rule.0.id", "id1"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.prefix", "path1/"),
+						resourceName, "lifecycle_rule.0.prefix", "path1/"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.enabled", "true"),
+						resourceName, "lifecycle_rule.0.enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.noncurrent_version_expiration.80908210.days", "365"),
+						resourceName, "lifecycle_rule.0.noncurrent_version_expiration.80908210.days", "365"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.noncurrent_version_transition.1377917700.days", "30"),
+						resourceName, "lifecycle_rule.0.noncurrent_version_transition.1377917700.days", "30"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.noncurrent_version_transition.1377917700.storage_class", "STANDARD_IA"),
+						resourceName, "lifecycle_rule.0.noncurrent_version_transition.1377917700.storage_class", "STANDARD_IA"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.noncurrent_version_transition.2528035817.days", "60"),
+						resourceName, "lifecycle_rule.0.noncurrent_version_transition.2528035817.days", "60"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.noncurrent_version_transition.2528035817.storage_class", "GLACIER"),
+						resourceName, "lifecycle_rule.0.noncurrent_version_transition.2528035817.storage_class", "GLACIER"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.1.id", "id2"),
+						resourceName, "lifecycle_rule.1.id", "id2"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.1.prefix", "path2/"),
+						resourceName, "lifecycle_rule.1.prefix", "path2/"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.1.enabled", "false"),
+						resourceName, "lifecycle_rule.1.enabled", "false"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.1.noncurrent_version_expiration.80908210.days", "365"),
+						resourceName, "lifecycle_rule.1.noncurrent_version_expiration.80908210.days", "365"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.2.id", "id3"),
+						resourceName, "lifecycle_rule.2.id", "id3"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.2.prefix", "path3/"),
+						resourceName, "lifecycle_rule.2.prefix", "path3/"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.2.noncurrent_version_transition.3732708140.days", "0"),
+						resourceName, "lifecycle_rule.2.noncurrent_version_transition.3732708140.days", "0"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.2.noncurrent_version_transition.3732708140.storage_class", "GLACIER"),
+						resourceName, "lifecycle_rule.2.noncurrent_version_transition.3732708140.storage_class", "GLACIER"),
 				),
 			},
 			{
 				Config: testAccAWSS3BucketConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
 				),
 			},
 		},
@@ -1169,6 +1309,8 @@ func TestAccAWSS3Bucket_LifecycleBasic(t *testing.T) {
 
 func TestAccAWSS3Bucket_LifecycleExpireMarkerOnly(t *testing.T) {
 	rInt := acctest.RandInt()
+	resourceName := "aws_s3_bucket.bucket"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -1177,23 +1319,30 @@ func TestAccAWSS3Bucket_LifecycleExpireMarkerOnly(t *testing.T) {
 			{
 				Config: testAccAWSS3BucketConfigWithLifecycleExpireMarker(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.id", "id1"),
+						resourceName, "lifecycle_rule.0.id", "id1"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.prefix", "path1/"),
+						resourceName, "lifecycle_rule.0.prefix", "path1/"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.expiration.3591068768.days", "0"),
+						resourceName, "lifecycle_rule.0.expiration.3591068768.days", "0"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.expiration.3591068768.date", ""),
+						resourceName, "lifecycle_rule.0.expiration.3591068768.date", ""),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.expiration.3591068768.expired_object_delete_marker", "true"),
+						resourceName, "lifecycle_rule.0.expiration.3591068768.expired_object_delete_marker", "true"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy", "acl"},
 			},
 			{
 				Config: testAccAWSS3BucketConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketExists(resourceName),
 				),
 			},
 		},
@@ -1204,6 +1353,7 @@ func TestAccAWSS3Bucket_Replication(t *testing.T) {
 	rInt := acctest.RandInt()
 	region := testAccGetRegion()
 	partition := testAccGetPartition()
+	resourceName := "aws_s3_bucket.bucket"
 
 	// record the initialized providers so that we can use them to check for the instances in each region
 	var providers []*schema.Provider
@@ -1219,21 +1369,28 @@ func TestAccAWSS3Bucket_Replication(t *testing.T) {
 			{
 				Config: testAccAWSS3BucketConfigReplication(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.bucket", testAccAwsRegionProviderFunc(region, &providers)),
+					testAccCheckAWSS3BucketExistsWithProvider(resourceName, testAccAwsRegionProviderFunc(region, &providers)),
 					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc("eu-west-1", &providers)),
-					resource.TestCheckResourceAttr("aws_s3_bucket.bucket", "replication_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "replication_configuration.#", "0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy", "acl"},
 			},
 			{
 				Config: testAccAWSS3BucketConfigReplicationWithConfiguration(rInt, "STANDARD"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.bucket", testAccAwsRegionProviderFunc(region, &providers)),
-					resource.TestCheckResourceAttr("aws_s3_bucket.bucket", "replication_configuration.#", "1"),
-					resource.TestMatchResourceAttr("aws_s3_bucket.bucket", "replication_configuration.0.role", regexp.MustCompile(fmt.Sprintf("^arn:aws[\\w-]*:iam::[\\d+]+:role/tf-iam-role-replication-%d", rInt))),
-					resource.TestCheckResourceAttr("aws_s3_bucket.bucket", "replication_configuration.0.rules.#", "1"),
+					testAccCheckAWSS3BucketExistsWithProvider(resourceName, testAccAwsRegionProviderFunc(region, &providers)),
+					resource.TestCheckResourceAttr(resourceName, "replication_configuration.#", "1"),
+					resource.TestMatchResourceAttr(resourceName, "replication_configuration.0.role", regexp.MustCompile(fmt.Sprintf("^arn:aws[\\w-]*:iam::[\\d+]+:role/tf-iam-role-replication-%d", rInt))),
+					resource.TestCheckResourceAttr(resourceName, "replication_configuration.0.rules.#", "1"),
 					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc("eu-west-1", &providers)),
 					testAccCheckAWSS3BucketReplicationRules(
-						"aws_s3_bucket.bucket",
+						resourceName,
 						testAccAwsRegionProviderFunc(region, &providers),
 						[]*s3.ReplicationRule{
 							{
@@ -1252,13 +1409,13 @@ func TestAccAWSS3Bucket_Replication(t *testing.T) {
 			{
 				Config: testAccAWSS3BucketConfigReplicationWithConfiguration(rInt, "GLACIER"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.bucket", testAccAwsRegionProviderFunc(region, &providers)),
-					resource.TestCheckResourceAttr("aws_s3_bucket.bucket", "replication_configuration.#", "1"),
-					resource.TestMatchResourceAttr("aws_s3_bucket.bucket", "replication_configuration.0.role", regexp.MustCompile(fmt.Sprintf("^arn:aws[\\w-]*:iam::[\\d+]+:role/tf-iam-role-replication-%d", rInt))),
-					resource.TestCheckResourceAttr("aws_s3_bucket.bucket", "replication_configuration.0.rules.#", "1"),
+					testAccCheckAWSS3BucketExistsWithProvider(resourceName, testAccAwsRegionProviderFunc(region, &providers)),
+					resource.TestCheckResourceAttr(resourceName, "replication_configuration.#", "1"),
+					resource.TestMatchResourceAttr(resourceName, "replication_configuration.0.role", regexp.MustCompile(fmt.Sprintf("^arn:aws[\\w-]*:iam::[\\d+]+:role/tf-iam-role-replication-%d", rInt))),
+					resource.TestCheckResourceAttr(resourceName, "replication_configuration.0.rules.#", "1"),
 					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc("eu-west-1", &providers)),
 					testAccCheckAWSS3BucketReplicationRules(
-						"aws_s3_bucket.bucket",
+						resourceName,
 						testAccAwsRegionProviderFunc(region, &providers),
 						[]*s3.ReplicationRule{
 							{
@@ -1277,12 +1434,12 @@ func TestAccAWSS3Bucket_Replication(t *testing.T) {
 			{
 				Config: testAccAWSS3BucketConfigReplicationWithSseKmsEncryptedObjects(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.bucket", testAccAwsRegionProviderFunc(region, &providers)),
-					resource.TestCheckResourceAttr("aws_s3_bucket.bucket", "replication_configuration.#", "1"),
-					resource.TestMatchResourceAttr("aws_s3_bucket.bucket", "replication_configuration.0.role", regexp.MustCompile(fmt.Sprintf("^arn:aws[\\w-]*:iam::[\\d+]+:role/tf-iam-role-replication-%d", rInt))),
-					resource.TestCheckResourceAttr("aws_s3_bucket.bucket", "replication_configuration.0.rules.#", "1"),
+					testAccCheckAWSS3BucketExistsWithProvider(resourceName, testAccAwsRegionProviderFunc(region, &providers)),
+					resource.TestCheckResourceAttr(resourceName, "replication_configuration.#", "1"),
+					resource.TestMatchResourceAttr(resourceName, "replication_configuration.0.role", regexp.MustCompile(fmt.Sprintf("^arn:aws[\\w-]*:iam::[\\d+]+:role/tf-iam-role-replication-%d", rInt))),
+					resource.TestCheckResourceAttr(resourceName, "replication_configuration.0.rules.#", "1"),
 					testAccCheckAWSS3BucketReplicationRules(
-						"aws_s3_bucket.bucket",
+						resourceName,
 						testAccAwsRegionProviderFunc(region, &providers),
 						[]*s3.ReplicationRule{
 							{
@@ -1314,6 +1471,7 @@ func TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlT
 	rInt := acctest.RandInt()
 	region := testAccGetRegion()
 	partition := testAccGetPartition()
+	resourceName := "aws_s3_bucket.bucket"
 
 	// record the initialized providers so that we can use them to check for the instances in each region
 	var providers []*schema.Provider
@@ -1329,12 +1487,12 @@ func TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlT
 			{
 				Config: testAccAWSS3BucketConfigReplicationWithAccessControlTranslation(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.bucket", testAccAwsRegionProviderFunc(region, &providers)),
-					resource.TestCheckResourceAttr("aws_s3_bucket.bucket", "replication_configuration.#", "1"),
-					resource.TestMatchResourceAttr("aws_s3_bucket.bucket", "replication_configuration.0.role", regexp.MustCompile(fmt.Sprintf("^arn:%s:iam::[\\d+]+:role/tf-iam-role-replication-%d", partition, rInt))),
-					resource.TestCheckResourceAttr("aws_s3_bucket.bucket", "replication_configuration.0.rules.#", "1"),
+					testAccCheckAWSS3BucketExistsWithProvider(resourceName, testAccAwsRegionProviderFunc(region, &providers)),
+					resource.TestCheckResourceAttr(resourceName, "replication_configuration.#", "1"),
+					resource.TestMatchResourceAttr(resourceName, "replication_configuration.0.role", regexp.MustCompile(fmt.Sprintf("^arn:%s:iam::[\\d+]+:role/tf-iam-role-replication-%d", partition, rInt))),
+					resource.TestCheckResourceAttr(resourceName, "replication_configuration.0.rules.#", "1"),
 					testAccCheckAWSS3BucketReplicationRules(
-						"aws_s3_bucket.bucket",
+						resourceName,
 						testAccAwsRegionProviderFunc(region, &providers),
 						[]*s3.ReplicationRule{
 							{
@@ -1355,14 +1513,21 @@ func TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlT
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy", "acl"},
+			},
+			{
 				Config: testAccAWSS3BucketConfigReplicationWithSseKmsEncryptedObjectsAndAccessControlTranslation(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.bucket", testAccAwsRegionProviderFunc(region, &providers)),
-					resource.TestCheckResourceAttr("aws_s3_bucket.bucket", "replication_configuration.#", "1"),
-					resource.TestMatchResourceAttr("aws_s3_bucket.bucket", "replication_configuration.0.role", regexp.MustCompile(fmt.Sprintf("^arn:%s:iam::[\\d+]+:role/tf-iam-role-replication-%d", partition, rInt))),
-					resource.TestCheckResourceAttr("aws_s3_bucket.bucket", "replication_configuration.0.rules.#", "1"),
+					testAccCheckAWSS3BucketExistsWithProvider(resourceName, testAccAwsRegionProviderFunc(region, &providers)),
+					resource.TestCheckResourceAttr(resourceName, "replication_configuration.#", "1"),
+					resource.TestMatchResourceAttr(resourceName, "replication_configuration.0.role", regexp.MustCompile(fmt.Sprintf("^arn:%s:iam::[\\d+]+:role/tf-iam-role-replication-%d", partition, rInt))),
+					resource.TestCheckResourceAttr(resourceName, "replication_configuration.0.rules.#", "1"),
 					testAccCheckAWSS3BucketReplicationRules(
-						"aws_s3_bucket.bucket",
+						resourceName,
 						testAccAwsRegionProviderFunc(region, &providers),
 						[]*s3.ReplicationRule{
 							{
@@ -1398,6 +1563,7 @@ func TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlT
 func TestAccAWSS3Bucket_ReplicationWithoutStorageClass(t *testing.T) {
 	rInt := acctest.RandInt()
 	region := testAccGetRegion()
+	resourceName := "aws_s3_bucket.bucket"
 
 	// record the initialized providers so that we can use them to check for the instances in each region
 	var providers []*schema.Provider
@@ -1413,9 +1579,16 @@ func TestAccAWSS3Bucket_ReplicationWithoutStorageClass(t *testing.T) {
 			{
 				Config: testAccAWSS3BucketConfigReplicationWithoutStorageClass(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.bucket", testAccAwsRegionProviderFunc(region, &providers)),
+					testAccCheckAWSS3BucketExistsWithProvider(resourceName, testAccAwsRegionProviderFunc(region, &providers)),
 					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc("eu-west-1", &providers)),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy", "acl"},
 			},
 		},
 	})
@@ -1447,6 +1620,7 @@ func TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError(t *testing.T)
 func TestAccAWSS3Bucket_ReplicationWithoutPrefix(t *testing.T) {
 	rInt := acctest.RandInt()
 	region := testAccGetRegion()
+	resourceName := "aws_s3_bucket.bucket"
 
 	// record the initialized providers so that we can use them to check for the instances in each region
 	var providers []*schema.Provider
@@ -1462,9 +1636,16 @@ func TestAccAWSS3Bucket_ReplicationWithoutPrefix(t *testing.T) {
 			{
 				Config: testAccAWSS3BucketConfigReplicationWithoutPrefix(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.bucket", testAccAwsRegionProviderFunc(region, &providers)),
+					testAccCheckAWSS3BucketExistsWithProvider(resourceName, testAccAwsRegionProviderFunc(region, &providers)),
 					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc("eu-west-1", &providers)),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy", "acl"},
 			},
 		},
 	})
@@ -1474,6 +1655,7 @@ func TestAccAWSS3Bucket_ReplicationSchemaV2(t *testing.T) {
 	rInt := acctest.RandInt()
 	region := testAccGetRegion()
 	partition := testAccGetPartition()
+	resourceName := "aws_s3_bucket.bucket"
 
 	// record the initialized providers so that we can use them to check for the instances in each region
 	var providers []*schema.Provider
@@ -1489,13 +1671,13 @@ func TestAccAWSS3Bucket_ReplicationSchemaV2(t *testing.T) {
 			{
 				Config: testAccAWSS3BucketConfigReplicationWithV2ConfigurationNoTags(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.bucket", testAccAwsRegionProviderFunc(region, &providers)),
-					resource.TestCheckResourceAttr("aws_s3_bucket.bucket", "replication_configuration.#", "1"),
-					resource.TestMatchResourceAttr("aws_s3_bucket.bucket", "replication_configuration.0.role", regexp.MustCompile(fmt.Sprintf("^arn:aws[\\w-]*:iam::[\\d+]+:role/tf-iam-role-replication-%d", rInt))),
-					resource.TestCheckResourceAttr("aws_s3_bucket.bucket", "replication_configuration.0.rules.#", "1"),
+					testAccCheckAWSS3BucketExistsWithProvider(resourceName, testAccAwsRegionProviderFunc(region, &providers)),
+					resource.TestCheckResourceAttr(resourceName, "replication_configuration.#", "1"),
+					resource.TestMatchResourceAttr(resourceName, "replication_configuration.0.role", regexp.MustCompile(fmt.Sprintf("^arn:aws[\\w-]*:iam::[\\d+]+:role/tf-iam-role-replication-%d", rInt))),
+					resource.TestCheckResourceAttr(resourceName, "replication_configuration.0.rules.#", "1"),
 					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc("eu-west-1", &providers)),
 					testAccCheckAWSS3BucketReplicationRules(
-						"aws_s3_bucket.bucket",
+						resourceName,
 						testAccAwsRegionProviderFunc(region, &providers),
 						[]*s3.ReplicationRule{
 							{
@@ -1518,15 +1700,22 @@ func TestAccAWSS3Bucket_ReplicationSchemaV2(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy", "acl"},
+			},
+			{
 				Config: testAccAWSS3BucketConfigReplicationWithV2ConfigurationOnlyOneTag(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.bucket", testAccAwsRegionProviderFunc(region, &providers)),
-					resource.TestCheckResourceAttr("aws_s3_bucket.bucket", "replication_configuration.#", "1"),
-					resource.TestMatchResourceAttr("aws_s3_bucket.bucket", "replication_configuration.0.role", regexp.MustCompile(fmt.Sprintf("^arn:aws[\\w-]*:iam::[\\d+]+:role/tf-iam-role-replication-%d", rInt))),
-					resource.TestCheckResourceAttr("aws_s3_bucket.bucket", "replication_configuration.0.rules.#", "1"),
+					testAccCheckAWSS3BucketExistsWithProvider(resourceName, testAccAwsRegionProviderFunc(region, &providers)),
+					resource.TestCheckResourceAttr(resourceName, "replication_configuration.#", "1"),
+					resource.TestMatchResourceAttr(resourceName, "replication_configuration.0.role", regexp.MustCompile(fmt.Sprintf("^arn:aws[\\w-]*:iam::[\\d+]+:role/tf-iam-role-replication-%d", rInt))),
+					resource.TestCheckResourceAttr(resourceName, "replication_configuration.0.rules.#", "1"),
 					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc("eu-west-1", &providers)),
 					testAccCheckAWSS3BucketReplicationRules(
-						"aws_s3_bucket.bucket",
+						resourceName,
 						testAccAwsRegionProviderFunc(region, &providers),
 						[]*s3.ReplicationRule{
 							{
@@ -1559,13 +1748,13 @@ func TestAccAWSS3Bucket_ReplicationSchemaV2(t *testing.T) {
 			{
 				Config: testAccAWSS3BucketConfigReplicationWithV2ConfigurationPrefixAndTags(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.bucket", testAccAwsRegionProviderFunc(region, &providers)),
-					resource.TestCheckResourceAttr("aws_s3_bucket.bucket", "replication_configuration.#", "1"),
-					resource.TestMatchResourceAttr("aws_s3_bucket.bucket", "replication_configuration.0.role", regexp.MustCompile(fmt.Sprintf("^arn:aws[\\w-]*:iam::[\\d+]+:role/tf-iam-role-replication-%d", rInt))),
-					resource.TestCheckResourceAttr("aws_s3_bucket.bucket", "replication_configuration.0.rules.#", "1"),
+					testAccCheckAWSS3BucketExistsWithProvider(resourceName, testAccAwsRegionProviderFunc(region, &providers)),
+					resource.TestCheckResourceAttr(resourceName, "replication_configuration.#", "1"),
+					resource.TestMatchResourceAttr(resourceName, "replication_configuration.0.role", regexp.MustCompile(fmt.Sprintf("^arn:aws[\\w-]*:iam::[\\d+]+:role/tf-iam-role-replication-%d", rInt))),
+					resource.TestCheckResourceAttr(resourceName, "replication_configuration.0.rules.#", "1"),
 					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc("eu-west-1", &providers)),
 					testAccCheckAWSS3BucketReplicationRules(
-						"aws_s3_bucket.bucket",
+						resourceName,
 						testAccAwsRegionProviderFunc(region, &providers),
 						[]*s3.ReplicationRule{
 							{
@@ -1602,13 +1791,13 @@ func TestAccAWSS3Bucket_ReplicationSchemaV2(t *testing.T) {
 			{
 				Config: testAccAWSS3BucketConfigReplicationWithV2ConfigurationMultipleTags(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.bucket", testAccAwsRegionProviderFunc(region, &providers)),
-					resource.TestCheckResourceAttr("aws_s3_bucket.bucket", "replication_configuration.#", "1"),
-					resource.TestMatchResourceAttr("aws_s3_bucket.bucket", "replication_configuration.0.role", regexp.MustCompile(fmt.Sprintf("^arn:aws[\\w-]*:iam::[\\d+]+:role/tf-iam-role-replication-%d", rInt))),
-					resource.TestCheckResourceAttr("aws_s3_bucket.bucket", "replication_configuration.0.rules.#", "1"),
+					testAccCheckAWSS3BucketExistsWithProvider(resourceName, testAccAwsRegionProviderFunc(region, &providers)),
+					resource.TestCheckResourceAttr(resourceName, "replication_configuration.#", "1"),
+					resource.TestMatchResourceAttr(resourceName, "replication_configuration.0.role", regexp.MustCompile(fmt.Sprintf("^arn:aws[\\w-]*:iam::[\\d+]+:role/tf-iam-role-replication-%d", rInt))),
+					resource.TestCheckResourceAttr(resourceName, "replication_configuration.0.rules.#", "1"),
 					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc("eu-west-1", &providers)),
 					testAccCheckAWSS3BucketReplicationRules(
-						"aws_s3_bucket.bucket",
+						resourceName,
 						testAccAwsRegionProviderFunc(region, &providers),
 						[]*s3.ReplicationRule{
 							{
@@ -1652,6 +1841,7 @@ func TestAccAWSS3Bucket_ReplicationSchemaV2(t *testing.T) {
 
 func TestAccAWSS3Bucket_objectLock(t *testing.T) {
 	rInt := acctest.RandInt()
+	resourceName := "aws_s3_bucket.arbitrary"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1661,21 +1851,28 @@ func TestAccAWSS3Bucket_objectLock(t *testing.T) {
 			{
 				Config: testAccAWSS3BucketObjectLockEnabledNoDefaultRetention(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.arbitrary"),
-					resource.TestCheckResourceAttr("aws_s3_bucket.arbitrary", "object_lock_configuration.#", "1"),
-					resource.TestCheckResourceAttr("aws_s3_bucket.arbitrary", "object_lock_configuration.0.object_lock_enabled", "Enabled"),
-					resource.TestCheckResourceAttr("aws_s3_bucket.arbitrary", "object_lock_configuration.0.rule.#", "0"),
+					testAccCheckAWSS3BucketExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "object_lock_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "object_lock_configuration.0.object_lock_enabled", "Enabled"),
+					resource.TestCheckResourceAttr(resourceName, "object_lock_configuration.0.rule.#", "0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy", "acl"},
 			},
 			{
 				Config: testAccAWSS3BucketObjectLockEnabledWithDefaultRetention(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExists("aws_s3_bucket.arbitrary"),
-					resource.TestCheckResourceAttr("aws_s3_bucket.arbitrary", "object_lock_configuration.#", "1"),
-					resource.TestCheckResourceAttr("aws_s3_bucket.arbitrary", "object_lock_configuration.0.object_lock_enabled", "Enabled"),
-					resource.TestCheckResourceAttr("aws_s3_bucket.arbitrary", "object_lock_configuration.0.rule.#", "1"),
-					resource.TestCheckResourceAttr("aws_s3_bucket.arbitrary", "object_lock_configuration.0.rule.0.default_retention.0.mode", "COMPLIANCE"),
-					resource.TestCheckResourceAttr("aws_s3_bucket.arbitrary", "object_lock_configuration.0.rule.0.default_retention.0.days", "3"),
+					testAccCheckAWSS3BucketExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "object_lock_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "object_lock_configuration.0.object_lock_enabled", "Enabled"),
+					resource.TestCheckResourceAttr(resourceName, "object_lock_configuration.0.rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "object_lock_configuration.0.rule.0.default_retention.0.mode", "COMPLIANCE"),
+					resource.TestCheckResourceAttr(resourceName, "object_lock_configuration.0.rule.0.default_retention.0.days", "3"),
 				),
 			},
 		},

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -1375,6 +1375,7 @@ func TestAccAWSS3Bucket_Replication(t *testing.T) {
 				),
 			},
 			{
+				Config:            testAccAWSS3BucketConfigReplication(rInt),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -1513,11 +1514,12 @@ func TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlT
 				),
 			},
 			{
+				Config:            testAccAWSS3BucketConfigReplicationWithAccessControlTranslation(rInt),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"force_destroy", "acl"},
+					"force_destroy", "acl", "versioning"},
 			},
 			{
 				Config: testAccAWSS3BucketConfigReplicationWithSseKmsEncryptedObjectsAndAccessControlTranslation(rInt),
@@ -1584,6 +1586,7 @@ func TestAccAWSS3Bucket_ReplicationWithoutStorageClass(t *testing.T) {
 				),
 			},
 			{
+				Config:            testAccAWSS3BucketConfigReplicationWithoutStorageClass(rInt),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -1641,6 +1644,7 @@ func TestAccAWSS3Bucket_ReplicationWithoutPrefix(t *testing.T) {
 				),
 			},
 			{
+				Config:            testAccAWSS3BucketConfigReplicationWithoutPrefix(rInt),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -1700,6 +1704,7 @@ func TestAccAWSS3Bucket_ReplicationSchemaV2(t *testing.T) {
 				),
 			},
 			{
+				Config:            testAccAWSS3BucketConfigReplicationWithV2ConfigurationNoTags(rInt),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8944

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE

```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSS3Bucket_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3Bucket_basic -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3Bucket_basic
=== PAUSE TestAccAWSS3Bucket_basic
=== CONT  TestAccAWSS3Bucket_basic
--- PASS: TestAccAWSS3Bucket_basic (83.57s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       84.468s

make testacc TESTARGS="-run=TestAccAWSS3Bucket_Bucket_EmptyString"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3Bucket_Bucket_EmptyString -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3Bucket_Bucket_EmptyString
=== PAUSE TestAccAWSS3Bucket_Bucket_EmptyString
=== CONT  TestAccAWSS3Bucket_Bucket_EmptyString
--- PASS: TestAccAWSS3Bucket_Bucket_EmptyString (104.71s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       105.599s

make testacc TESTARGS="-run=TestAccAWSS3Bucket_tagsWithNoSystemTags"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3Bucket_tagsWithNoSystemTags -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3Bucket_tagsWithNoSystemTags
=== PAUSE TestAccAWSS3Bucket_tagsWithNoSystemTags
=== CONT  TestAccAWSS3Bucket_tagsWithNoSystemTags
--- PASS: TestAccAWSS3Bucket_tagsWithNoSystemTags (224.45s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       225.560s

make testacc TESTARGS="-run=TestAccAWSS3Bucket_tagsWithSystemTags"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3Bucket_tagsWithSystemTags -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3Bucket_tagsWithSystemTags
=== PAUSE TestAccAWSS3Bucket_tagsWithSystemTags
=== CONT  TestAccAWSS3Bucket_tagsWithSystemTags
--- PASS: TestAccAWSS3Bucket_tagsWithSystemTags (250.10s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       250.993s

make testacc TESTARGS="-run=TestAccAWSS3MultiBucket_withTags"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3MultiBucket_withTags -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3MultiBucket_withTags
=== PAUSE TestAccAWSS3MultiBucket_withTags
=== CONT  TestAccAWSS3MultiBucket_withTags
--- PASS: TestAccAWSS3MultiBucket_withTags (101.61s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       102.481s

make testacc TESTARGS="-run=TestAccAWSS3Bucket_namePrefix"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3Bucket_namePrefix -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3Bucket_namePrefix
=== PAUSE TestAccAWSS3Bucket_namePrefix
=== CONT  TestAccAWSS3Bucket_namePrefix
--- PASS: TestAccAWSS3Bucket_namePrefix (77.05s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       78.767s

make testacc TESTARGS="-run=TestAccAWSS3Bucket_generatedName"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3Bucket_generatedName -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3Bucket_generatedName
=== PAUSE TestAccAWSS3Bucket_generatedName
=== CONT  TestAccAWSS3Bucket_generatedName
--- PASS: TestAccAWSS3Bucket_generatedName (65.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       66.419s

make testacc TESTARGS="-run=TestAccAWSS3Bucket_region"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3Bucket_region -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3Bucket_region
=== PAUSE TestAccAWSS3Bucket_region
=== CONT  TestAccAWSS3Bucket_region
--- PASS: TestAccAWSS3Bucket_region (90.75s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       91.832s

make testacc TESTARGS="-run=TestAccAWSS3Bucket_acceleration"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3Bucket_acceleration -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3Bucket_acceleration
=== PAUSE TestAccAWSS3Bucket_acceleration
=== CONT  TestAccAWSS3Bucket_acceleration
--- PASS: TestAccAWSS3Bucket_acceleration (113.64s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       114.637s

make testacc TESTARGS="-run=TestAccAWSS3Bucket_RequestPayer"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3Bucket_RequestPayer -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3Bucket_RequestPayer
=== PAUSE TestAccAWSS3Bucket_RequestPayer
=== CONT  TestAccAWSS3Bucket_RequestPayer
--- PASS: TestAccAWSS3Bucket_RequestPayer (131.02s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       132.191s

make testacc TESTARGS="-run=TestAccAWSS3Bucket_Policy"      
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3Bucket_Policy -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3Bucket_Policy
=== PAUSE TestAccAWSS3Bucket_Policy
=== CONT  TestAccAWSS3Bucket_Policy
--- PASS: TestAccAWSS3Bucket_Policy (178.87s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       179.757s

make testacc TESTARGS="-run=TestAccAWSS3Bucket_UpdateAcl"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3Bucket_UpdateAcl -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3Bucket_UpdateAcl
=== PAUSE TestAccAWSS3Bucket_UpdateAcl
=== CONT  TestAccAWSS3Bucket_UpdateAcl
--- PASS: TestAccAWSS3Bucket_UpdateAcl (159.25s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       160.292s

make testacc TESTARGS="-run=TestAccAWSS3Bucket_Website_Simple"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3Bucket_Website_Simple -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3Bucket_Website_Simple
=== PAUSE TestAccAWSS3Bucket_Website_Simple
=== CONT  TestAccAWSS3Bucket_Website_Simple
--- PASS: TestAccAWSS3Bucket_Website_Simple (162.09s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       162.995s

make testacc TESTARGS="-run=TestAccAWSS3Bucket_WebsiteRedirect"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3Bucket_WebsiteRedirect -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3Bucket_WebsiteRedirect
=== PAUSE TestAccAWSS3Bucket_WebsiteRedirect
=== CONT  TestAccAWSS3Bucket_WebsiteRedirect
--- PASS: TestAccAWSS3Bucket_WebsiteRedirect (175.14s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       176.128s

make testacc TESTARGS="-run=TestAccAWSS3Bucket_WebsiteRoutingRules"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3Bucket_WebsiteRoutingRules -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3Bucket_WebsiteRoutingRules
=== PAUSE TestAccAWSS3Bucket_WebsiteRoutingRules
=== CONT  TestAccAWSS3Bucket_WebsiteRoutingRules
--- PASS: TestAccAWSS3Bucket_WebsiteRoutingRules (118.79s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       119.883s

make testacc TESTARGS="-run=TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical
=== PAUSE TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical
=== CONT  TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical (110.86s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       112.060s

make testacc TESTARGS="-run=TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed
=== PAUSE TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed
=== CONT  TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed (67.06s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       67.959s

make testacc TESTARGS="-run=TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled
=== PAUSE TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled
=== CONT  TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled
--- PASS: TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled (163.96s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       165.019s

make testacc TESTARGS="-run=TestAccAWSS3Bucket_shouldFailNotFound"              ==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3Bucket_shouldFailNotFound -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3Bucket_shouldFailNotFound
=== PAUSE TestAccAWSS3Bucket_shouldFailNotFound
=== CONT  TestAccAWSS3Bucket_shouldFailNotFound
--- PASS: TestAccAWSS3Bucket_shouldFailNotFound (30.11s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       30.973s

make testacc TESTARGS="-run=TestAccAWSS3Bucket_Cors_Delete" 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3Bucket_Cors_Delete -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3Bucket_Cors_Delete
=== PAUSE TestAccAWSS3Bucket_Cors_Delete
=== CONT  TestAccAWSS3Bucket_Cors_Delete
--- PASS: TestAccAWSS3Bucket_Cors_Delete (57.02s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       57.928s

make testacc TESTARGS="-run=TestAccAWSS3Bucket_Cors_EmptyOrigin"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3Bucket_Cors_EmptyOrigin -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3Bucket_Cors_EmptyOrigin
=== PAUSE TestAccAWSS3Bucket_Cors_EmptyOrigin
=== CONT  TestAccAWSS3Bucket_Cors_EmptyOrigin
--- PASS: TestAccAWSS3Bucket_Cors_EmptyOrigin (66.04s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       66.925s

make testacc TESTARGS="-run=TestAccAWSS3Bucket_Logging"         
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3Bucket_Logging -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3Bucket_Logging
=== PAUSE TestAccAWSS3Bucket_Logging
=== CONT  TestAccAWSS3Bucket_Logging
--- PASS: TestAccAWSS3Bucket_Logging (109.41s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       110.454s

make testacc TESTARGS="-run=TestAccAWSS3Bucket_LifecycleBasic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3Bucket_LifecycleBasic -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3Bucket_LifecycleBasic
=== PAUSE TestAccAWSS3Bucket_LifecycleBasic
=== CONT  TestAccAWSS3Bucket_LifecycleBasic
--- PASS: TestAccAWSS3Bucket_LifecycleBasic (163.09s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       164.313s

 make testacc TESTARGS="-run=TestAccAWSS3Bucket_LifecycleExpireMarkerOnly"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3Bucket_LifecycleExpireMarkerOnly -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3Bucket_LifecycleExpireMarkerOnly
=== PAUSE TestAccAWSS3Bucket_LifecycleExpireMarkerOnly
=== CONT  TestAccAWSS3Bucket_LifecycleExpireMarkerOnly
--- PASS: TestAccAWSS3Bucket_LifecycleExpireMarkerOnly (152.61s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       153.446s

make testacc TESTARGS="-run=TestAccAWSS3Bucket_objectLock"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3Bucket_objectLock -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3Bucket_objectLock
=== PAUSE TestAccAWSS3Bucket_objectLock
=== CONT  TestAccAWSS3Bucket_objectLock
--- PASS: TestAccAWSS3Bucket_objectLock (111.82s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       112.799s

--- PASS: TestAccAWSS3Bucket_Versioning (43.68s)
--- PASS: TestAccAWSS3Bucket_Cors_Update (35.67s)
--- PASS: TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError (38.53s)
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutPrefix (50.25s)
--- PASS: TestAccAWSS3Bucket_Replication (173.16s)
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutStorageClass (53.19s)
--- PASS: TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation (111.68s)
--- PASS: TestAccAWSS3Bucket_ReplicationSchemaV2 (149.57s)
```