### PR TITLE
Acceptance test import refactor for network acls

### DIFF
--- a/aws/resource_aws_network_acl_test.go
+++ b/aws/resource_aws_network_acl_test.go
@@ -102,7 +102,10 @@ func testSweepNetworkAcls(region string) error {
 	return nil
 }
 
-func TestAccAWSNetworkAcl_importBasic(t *testing.T) {
+func TestAccAWSNetworkAcl_basic(t *testing.T) {
+	resourceName := "aws_network_acl.test"
+	var networkAcl ec2.NetworkAcl
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -110,10 +113,12 @@ func TestAccAWSNetworkAcl_importBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSNetworkAclEgressNIngressConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSNetworkAclExists(resourceName, &networkAcl),
+				),
 			},
-
 			{
-				ResourceName:      "aws_network_acl.bar",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -123,7 +128,7 @@ func TestAccAWSNetworkAcl_importBasic(t *testing.T) {
 
 func TestAccAWSNetworkAcl_disappears(t *testing.T) {
 	var networkAcl ec2.NetworkAcl
-	resourceName := "aws_network_acl.bar"
+	resourceName := "aws_network_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -248,43 +253,49 @@ func TestAccAWSNetworkAcl_Ingress_ConfigMode(t *testing.T) {
 
 func TestAccAWSNetworkAcl_EgressAndIngressRules(t *testing.T) {
 	var networkAcl ec2.NetworkAcl
+	resourceName := "aws_network_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_network_acl.bar",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSNetworkAclEgressNIngressConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSNetworkAclExists("aws_network_acl.bar", &networkAcl),
+					testAccCheckAWSNetworkAclExists(resourceName, &networkAcl),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "ingress.1871939009.protocol", "6"),
+						resourceName, "ingress.1871939009.protocol", "6"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "ingress.1871939009.rule_no", "1"),
+						resourceName, "ingress.1871939009.rule_no", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "ingress.1871939009.from_port", "80"),
+						resourceName, "ingress.1871939009.from_port", "80"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "ingress.1871939009.to_port", "80"),
+						resourceName, "ingress.1871939009.to_port", "80"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "ingress.1871939009.action", "allow"),
+						resourceName, "ingress.1871939009.action", "allow"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "ingress.1871939009.cidr_block", "10.3.0.0/18"),
+						resourceName, "ingress.1871939009.cidr_block", "10.3.0.0/18"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "egress.3111164687.protocol", "6"),
+						resourceName, "egress.3111164687.protocol", "6"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "egress.3111164687.rule_no", "2"),
+						resourceName, "egress.3111164687.rule_no", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "egress.3111164687.from_port", "443"),
+						resourceName, "egress.3111164687.from_port", "443"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "egress.3111164687.to_port", "443"),
+						resourceName, "egress.3111164687.to_port", "443"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "egress.3111164687.cidr_block", "10.3.0.0/18"),
+						resourceName, "egress.3111164687.cidr_block", "10.3.0.0/18"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "egress.3111164687.action", "allow"),
-					testAccCheckResourceAttrAccountID("aws_network_acl.bar", "owner_id"),
+						resourceName, "egress.3111164687.action", "allow"),
+					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -292,31 +303,37 @@ func TestAccAWSNetworkAcl_EgressAndIngressRules(t *testing.T) {
 
 func TestAccAWSNetworkAcl_OnlyIngressRules_basic(t *testing.T) {
 	var networkAcl ec2.NetworkAcl
+	resourceName := "aws_network_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_network_acl.foos",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSNetworkAclIngressConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSNetworkAclExists("aws_network_acl.foos", &networkAcl),
+					testAccCheckAWSNetworkAclExists(resourceName, &networkAcl),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.4245812720.protocol", "6"),
+						resourceName, "ingress.4245812720.protocol", "6"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.4245812720.rule_no", "2"),
+						resourceName, "ingress.4245812720.rule_no", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.4245812720.from_port", "443"),
+						resourceName, "ingress.4245812720.from_port", "443"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.4245812720.to_port", "443"),
+						resourceName, "ingress.4245812720.to_port", "443"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.4245812720.action", "deny"),
+						resourceName, "ingress.4245812720.action", "deny"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.4245812720.cidr_block", "10.2.0.0/18"),
-					testAccCheckResourceAttrAccountID("aws_network_acl.foos", "owner_id"),
+						resourceName, "ingress.4245812720.cidr_block", "10.2.0.0/18"),
+					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -324,55 +341,61 @@ func TestAccAWSNetworkAcl_OnlyIngressRules_basic(t *testing.T) {
 
 func TestAccAWSNetworkAcl_OnlyIngressRules_update(t *testing.T) {
 	var networkAcl ec2.NetworkAcl
+	resourceName := "aws_network_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_network_acl.foos",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSNetworkAclIngressConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSNetworkAclExists("aws_network_acl.foos", &networkAcl),
+					testAccCheckAWSNetworkAclExists(resourceName, &networkAcl),
 					testIngressRuleLength(&networkAcl, 2),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.401088754.protocol", "6"),
+						resourceName, "ingress.401088754.protocol", "6"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.401088754.rule_no", "1"),
+						resourceName, "ingress.401088754.rule_no", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.401088754.from_port", "0"),
+						resourceName, "ingress.401088754.from_port", "0"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.401088754.to_port", "22"),
+						resourceName, "ingress.401088754.to_port", "22"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.401088754.action", "deny"),
+						resourceName, "ingress.401088754.action", "deny"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.4245812720.cidr_block", "10.2.0.0/18"),
+						resourceName, "ingress.4245812720.cidr_block", "10.2.0.0/18"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.4245812720.from_port", "443"),
+						resourceName, "ingress.4245812720.from_port", "443"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.4245812720.rule_no", "2"),
-					testAccCheckResourceAttrAccountID("aws_network_acl.foos", "owner_id"),
+						resourceName, "ingress.4245812720.rule_no", "2"),
+					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSNetworkAclIngressConfigChange,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSNetworkAclExists("aws_network_acl.foos", &networkAcl),
+					testAccCheckAWSNetworkAclExists(resourceName, &networkAcl),
 					testIngressRuleLength(&networkAcl, 1),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.401088754.protocol", "6"),
+						resourceName, "ingress.401088754.protocol", "6"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.401088754.rule_no", "1"),
+						resourceName, "ingress.401088754.rule_no", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.401088754.from_port", "0"),
+						resourceName, "ingress.401088754.from_port", "0"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.401088754.to_port", "22"),
+						resourceName, "ingress.401088754.to_port", "22"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.401088754.action", "deny"),
+						resourceName, "ingress.401088754.action", "deny"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.401088754.cidr_block", "10.2.0.0/18"),
-					testAccCheckResourceAttrAccountID("aws_network_acl.foos", "owner_id"),
+						resourceName, "ingress.401088754.cidr_block", "10.2.0.0/18"),
+					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 				),
 			},
 		},
@@ -381,18 +404,24 @@ func TestAccAWSNetworkAcl_OnlyIngressRules_update(t *testing.T) {
 
 func TestAccAWSNetworkAcl_CaseSensitivityNoChanges(t *testing.T) {
 	var networkAcl ec2.NetworkAcl
+	resourceName := "aws_network_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_network_acl.foos",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSNetworkAclCaseSensitiveConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSNetworkAclExists("aws_network_acl.foos", &networkAcl),
+					testAccCheckAWSNetworkAclExists(resourceName, &networkAcl),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -400,19 +429,25 @@ func TestAccAWSNetworkAcl_CaseSensitivityNoChanges(t *testing.T) {
 
 func TestAccAWSNetworkAcl_OnlyEgressRules(t *testing.T) {
 	var networkAcl ec2.NetworkAcl
+	resourceName := "aws_network_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_network_acl.bond",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSNetworkAclEgressConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNetworkAclExists("aws_network_acl.bond", &networkAcl),
+					testAccCheckAWSNetworkAclExists(resourceName, &networkAcl),
 					testAccCheckTags(&networkAcl.Tags, "foo", "bar"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -420,26 +455,32 @@ func TestAccAWSNetworkAcl_OnlyEgressRules(t *testing.T) {
 
 func TestAccAWSNetworkAcl_SubnetChange(t *testing.T) {
 	var networkAcl ec2.NetworkAcl
+	resourceName := "aws_network_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_network_acl.bar",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSNetworkAclSubnetConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNetworkAclExists("aws_network_acl.bar", &networkAcl),
-					testAccCheckSubnetIsAssociatedWithAcl("aws_network_acl.bar", "aws_subnet.old"),
+					testAccCheckAWSNetworkAclExists(resourceName, &networkAcl),
+					testAccCheckSubnetIsAssociatedWithAcl(resourceName, "aws_subnet.old"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSNetworkAclSubnetConfigChange,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNetworkAclExists("aws_network_acl.bar", &networkAcl),
-					testAccCheckSubnetIsNotAssociatedWithAcl("aws_network_acl.bar", "aws_subnet.old"),
-					testAccCheckSubnetIsAssociatedWithAcl("aws_network_acl.bar", "aws_subnet.new"),
+					testAccCheckAWSNetworkAclExists(resourceName, &networkAcl),
+					testAccCheckSubnetIsNotAssociatedWithAcl(resourceName, "aws_subnet.old"),
+					testAccCheckSubnetIsAssociatedWithAcl(resourceName, "aws_subnet.new"),
 				),
 			},
 		},
@@ -449,6 +490,7 @@ func TestAccAWSNetworkAcl_SubnetChange(t *testing.T) {
 
 func TestAccAWSNetworkAcl_Subnets(t *testing.T) {
 	var networkAcl ec2.NetworkAcl
+	resourceName := "aws_network_acl.test"
 
 	checkACLSubnets := func(acl *ec2.NetworkAcl, count int) resource.TestCheckFunc {
 		return func(*terraform.State) (err error) {
@@ -462,27 +504,31 @@ func TestAccAWSNetworkAcl_Subnets(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_network_acl.bar",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSNetworkAclSubnet_SubnetIds,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNetworkAclExists("aws_network_acl.bar", &networkAcl),
-					testAccCheckSubnetIsAssociatedWithAcl("aws_network_acl.bar", "aws_subnet.one"),
-					testAccCheckSubnetIsAssociatedWithAcl("aws_network_acl.bar", "aws_subnet.two"),
+					testAccCheckAWSNetworkAclExists(resourceName, &networkAcl),
+					testAccCheckSubnetIsAssociatedWithAcl(resourceName, "aws_subnet.one"),
+					testAccCheckSubnetIsAssociatedWithAcl(resourceName, "aws_subnet.two"),
 					checkACLSubnets(&networkAcl, 2),
 				),
 			},
-
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 			{
 				Config: testAccAWSNetworkAclSubnet_SubnetIdsUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNetworkAclExists("aws_network_acl.bar", &networkAcl),
-					testAccCheckSubnetIsAssociatedWithAcl("aws_network_acl.bar", "aws_subnet.one"),
-					testAccCheckSubnetIsAssociatedWithAcl("aws_network_acl.bar", "aws_subnet.three"),
-					testAccCheckSubnetIsAssociatedWithAcl("aws_network_acl.bar", "aws_subnet.four"),
+					testAccCheckAWSNetworkAclExists(resourceName, &networkAcl),
+					testAccCheckSubnetIsAssociatedWithAcl(resourceName, "aws_subnet.one"),
+					testAccCheckSubnetIsAssociatedWithAcl(resourceName, "aws_subnet.three"),
+					testAccCheckSubnetIsAssociatedWithAcl(resourceName, "aws_subnet.four"),
 					checkACLSubnets(&networkAcl, 3),
 				),
 			},
@@ -492,6 +538,7 @@ func TestAccAWSNetworkAcl_Subnets(t *testing.T) {
 
 func TestAccAWSNetworkAcl_SubnetsDelete(t *testing.T) {
 	var networkAcl ec2.NetworkAcl
+	resourceName := "aws_network_acl.test"
 
 	checkACLSubnets := func(acl *ec2.NetworkAcl, count int) resource.TestCheckFunc {
 		return func(*terraform.State) (err error) {
@@ -505,25 +552,29 @@ func TestAccAWSNetworkAcl_SubnetsDelete(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_network_acl.bar",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSNetworkAclSubnet_SubnetIds,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNetworkAclExists("aws_network_acl.bar", &networkAcl),
-					testAccCheckSubnetIsAssociatedWithAcl("aws_network_acl.bar", "aws_subnet.one"),
-					testAccCheckSubnetIsAssociatedWithAcl("aws_network_acl.bar", "aws_subnet.two"),
+					testAccCheckAWSNetworkAclExists(resourceName, &networkAcl),
+					testAccCheckSubnetIsAssociatedWithAcl(resourceName, "aws_subnet.one"),
+					testAccCheckSubnetIsAssociatedWithAcl(resourceName, "aws_subnet.two"),
 					checkACLSubnets(&networkAcl, 2),
 				),
 			},
-
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 			{
 				Config: testAccAWSNetworkAclSubnet_SubnetIdsDeleteOne,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNetworkAclExists("aws_network_acl.bar", &networkAcl),
-					testAccCheckSubnetIsAssociatedWithAcl("aws_network_acl.bar", "aws_subnet.one"),
+					testAccCheckAWSNetworkAclExists(resourceName, &networkAcl),
+					testAccCheckSubnetIsAssociatedWithAcl(resourceName, "aws_subnet.one"),
 					checkACLSubnets(&networkAcl, 1),
 				),
 			},
@@ -533,32 +584,38 @@ func TestAccAWSNetworkAcl_SubnetsDelete(t *testing.T) {
 
 func TestAccAWSNetworkAcl_ipv6Rules(t *testing.T) {
 	var networkAcl ec2.NetworkAcl
+	resourceName := "aws_network_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_network_acl.foos",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSNetworkAclIpv6Config,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNetworkAclExists("aws_network_acl.foos", &networkAcl),
+					testAccCheckAWSNetworkAclExists(resourceName, &networkAcl),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.#", "1"),
+						resourceName, "ingress.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.1976110835.protocol", "6"),
+						resourceName, "ingress.1976110835.protocol", "6"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.1976110835.rule_no", "1"),
+						resourceName, "ingress.1976110835.rule_no", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.1976110835.from_port", "0"),
+						resourceName, "ingress.1976110835.from_port", "0"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.1976110835.to_port", "22"),
+						resourceName, "ingress.1976110835.to_port", "22"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.1976110835.action", "allow"),
+						resourceName, "ingress.1976110835.action", "allow"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.1976110835.ipv6_cidr_block", "::/0"),
+						resourceName, "ingress.1976110835.ipv6_cidr_block", "::/0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -586,22 +643,28 @@ func TestAccAWSNetworkAcl_ipv6ICMPRules(t *testing.T) {
 
 func TestAccAWSNetworkAcl_ipv6VpcRules(t *testing.T) {
 	var networkAcl ec2.NetworkAcl
+	resourceName := "aws_network_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_network_acl.foos",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSNetworkAclIpv6VpcConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNetworkAclExists("aws_network_acl.foos", &networkAcl),
+					testAccCheckAWSNetworkAclExists(resourceName, &networkAcl),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.#", "1"),
+						resourceName, "ingress.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.1296304962.ipv6_cidr_block", "2600:1f16:d1e:9a00::/56"),
+						resourceName, "ingress.1296304962.ipv6_cidr_block", "2600:1f16:d1e:9a00::/56"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -609,18 +672,24 @@ func TestAccAWSNetworkAcl_ipv6VpcRules(t *testing.T) {
 
 func TestAccAWSNetworkAcl_espProtocol(t *testing.T) {
 	var networkAcl ec2.NetworkAcl
+	resourceName := "aws_network_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_network_acl.testesp",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSNetworkAclEsp,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNetworkAclExists("aws_network_acl.testesp", &networkAcl),
+					testAccCheckAWSNetworkAclExists(resourceName, &networkAcl),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -835,10 +904,10 @@ resource "aws_subnet" "blob" {
   }
 }
 
-resource "aws_network_acl" "foos" {
+resource "aws_network_acl" "test" {
   vpc_id = "${aws_vpc.foo.id}"
   ingress {
-    protocol = "tcp"
+    protocol = 6
     rule_no = 1
     action = "allow"
     ipv6_cidr_block =  "::/0"
@@ -863,10 +932,10 @@ resource "aws_vpc" "foo" {
   }
 }
 
-resource "aws_network_acl" "foos" {
+resource "aws_network_acl" "test" {
   vpc_id = "${aws_vpc.foo.id}"
   ingress {
-    protocol = "tcp"
+    protocol = 6
     rule_no = 1
     action = "allow"
     ipv6_cidr_block =  "2600:1f16:d1e:9a00::/56"
@@ -896,10 +965,10 @@ resource "aws_subnet" "blob" {
   }
 }
 
-resource "aws_network_acl" "foos" {
+resource "aws_network_acl" "test" {
   vpc_id = "${aws_vpc.foo.id}"
   ingress {
-    protocol = "tcp"
+    protocol = 6
     rule_no = 1
     action = "deny"
     cidr_block =  "10.2.0.0/18"
@@ -907,7 +976,7 @@ resource "aws_network_acl" "foos" {
     to_port = 22
   }
   ingress {
-    protocol = "tcp"
+    protocol = 6
     rule_no = 2
     action = "deny"
     cidr_block =  "10.2.0.0/18"
@@ -939,10 +1008,10 @@ resource "aws_subnet" "blob" {
   }
 }
 
-resource "aws_network_acl" "foos" {
+resource "aws_network_acl" "test" {
   vpc_id = "${aws_vpc.foo.id}"
   ingress {
-    protocol = "tcp"
+    protocol = 6
     rule_no = 1
     action = "Allow"
     cidr_block =  "10.2.0.0/18"
@@ -973,10 +1042,10 @@ resource "aws_subnet" "blob" {
   }
 }
 
-resource "aws_network_acl" "foos" {
+resource "aws_network_acl" "test" {
   vpc_id = "${aws_vpc.foo.id}"
   ingress {
-    protocol = "tcp"
+    protocol = 6
     rule_no = 1
     action = "deny"
     cidr_block =  "10.2.0.0/18"
@@ -1007,10 +1076,10 @@ resource "aws_subnet" "blob" {
   }
 }
 
-resource "aws_network_acl" "bond" {
+resource "aws_network_acl" "test" {
   vpc_id = "${aws_vpc.foo.id}"
   egress {
-    protocol = "tcp"
+    protocol = 6
     rule_no = 2
     action = "allow"
     cidr_block =  "10.2.0.0/18"
@@ -1028,7 +1097,7 @@ resource "aws_network_acl" "bond" {
   }
 
   egress {
-    protocol = "tcp"
+    protocol = 6
     rule_no = 1
     action = "allow"
     cidr_block =  "10.2.0.0/18"
@@ -1037,7 +1106,7 @@ resource "aws_network_acl" "bond" {
   }
 
   egress {
-    protocol = "tcp"
+    protocol = 6
     rule_no = 3
     action = "allow"
     cidr_block =  "10.2.0.0/18"
@@ -1069,10 +1138,10 @@ resource "aws_subnet" "blob" {
   }
 }
 
-resource "aws_network_acl" "bar" {
+resource "aws_network_acl" "test" {
   vpc_id = "${aws_vpc.foo.id}"
   egress {
-    protocol = "tcp"
+    protocol = 6
     rule_no = 2
     action = "allow"
     cidr_block =  "10.3.0.0/18"
@@ -1081,7 +1150,7 @@ resource "aws_network_acl" "bar" {
   }
 
   ingress {
-    protocol = "tcp"
+    protocol = 6
     rule_no = 1
     action = "allow"
     cidr_block =  "10.3.0.0/18"
@@ -1127,11 +1196,11 @@ resource "aws_network_acl" "roll" {
   }
 }
 
-resource "aws_network_acl" "bar" {
+resource "aws_network_acl" "test" {
   vpc_id = "${aws_vpc.foo.id}"
   subnet_ids = ["${aws_subnet.old.id}"]
   tags = {
-    Name = "tf-acc-acl-subnet-change-bar"
+    Name = "tf-acc-acl-subnet-change-test"
   }
 }
 `
@@ -1162,11 +1231,11 @@ resource "aws_subnet" "new" {
   }
 }
 
-resource "aws_network_acl" "bar" {
+resource "aws_network_acl" "test" {
   vpc_id = "${aws_vpc.foo.id}"
   subnet_ids = ["${aws_subnet.new.id}"]
   tags = {
-    Name = "tf-acc-acl-subnet-change-bar"
+    Name = "tf-acc-acl-subnet-change-test"
   }
 }
 `
@@ -1195,7 +1264,7 @@ resource "aws_subnet" "two" {
   }
 }
 
-resource "aws_network_acl" "bar" {
+resource "aws_network_acl" "test" {
   vpc_id = "${aws_vpc.foo.id}"
   subnet_ids = ["${aws_subnet.one.id}", "${aws_subnet.two.id}"]
   tags = {
@@ -1244,7 +1313,7 @@ resource "aws_subnet" "four" {
   }
 }
 
-resource "aws_network_acl" "bar" {
+resource "aws_network_acl" "test" {
   vpc_id = "${aws_vpc.foo.id}"
   subnet_ids = [
     "${aws_subnet.one.id}",
@@ -1273,7 +1342,7 @@ resource "aws_subnet" "one" {
   }
 }
 
-resource "aws_network_acl" "bar" {
+resource "aws_network_acl" "test" {
   vpc_id = "${aws_vpc.foo.id}"
   subnet_ids = ["${aws_subnet.one.id}"]
   tags = {
@@ -1283,15 +1352,15 @@ resource "aws_network_acl" "bar" {
 `
 
 const testAccAWSNetworkAclEsp = `
-resource "aws_vpc" "testespvpc" {
+resource "aws_vpc" "testvpc" {
   cidr_block = "10.1.0.0/16"
   tags = {
     Name = "terraform-testacc-network-acl-esp"
   }
 }
 
-resource "aws_network_acl" "testesp" {
-  vpc_id = "${aws_vpc.testespvpc.id}"
+resource "aws_network_acl" "test" {
+  vpc_id = "${aws_vpc.testvpc.id}"
 
   egress {
     protocol   = "esp"
@@ -1329,7 +1398,7 @@ resource "aws_network_acl" "test" {
     action     = "allow"
     cidr_block = "${aws_vpc.test.cidr_block}"
     from_port  = 0
-    protocol   = "tcp"
+    protocol   = 6
     rule_no    = 1
     to_port    = 0
   }
@@ -1409,7 +1478,7 @@ resource "aws_network_acl" "test" {
     action     = "allow"
     cidr_block = "${aws_vpc.test.cidr_block}"
     from_port  = 0
-    protocol   = "tcp"
+    protocol   = 6
     rule_no    = 1
     to_port    = 0
   }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8944

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSNetworkAcl"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSNetworkAcl -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSNetworkAclRule_basic
=== PAUSE TestAccAWSNetworkAclRule_basic
=== RUN   TestAccAWSNetworkAclRule_disappears
=== PAUSE TestAccAWSNetworkAclRule_disappears
=== RUN   TestAccAWSNetworkAclRule_disappears_NetworkAcl
=== PAUSE TestAccAWSNetworkAclRule_disappears_NetworkAcl
=== RUN   TestAccAWSNetworkAclRule_missingParam
=== PAUSE TestAccAWSNetworkAclRule_missingParam
=== RUN   TestAccAWSNetworkAclRule_ipv6
=== PAUSE TestAccAWSNetworkAclRule_ipv6
=== RUN   TestAccAWSNetworkAclRule_ipv6ICMP
=== PAUSE TestAccAWSNetworkAclRule_ipv6ICMP
=== RUN   TestAccAWSNetworkAclRule_ipv6VpcAssignGeneratedIpv6CidrBlockUpdate
=== PAUSE TestAccAWSNetworkAclRule_ipv6VpcAssignGeneratedIpv6CidrBlockUpdate
=== RUN   TestAccAWSNetworkAclRule_allProtocol
=== PAUSE TestAccAWSNetworkAclRule_allProtocol
=== RUN   TestAccAWSNetworkAclRule_tcpProtocol
--- PASS: TestAccAWSNetworkAclRule_tcpProtocol (93.48s)
=== RUN   TestAccAWSNetworkAcl_basic
=== PAUSE TestAccAWSNetworkAcl_basic
=== RUN   TestAccAWSNetworkAcl_disappears
=== PAUSE TestAccAWSNetworkAcl_disappears
=== RUN   TestAccAWSNetworkAcl_Egress_ConfigMode
=== PAUSE TestAccAWSNetworkAcl_Egress_ConfigMode
=== RUN   TestAccAWSNetworkAcl_Ingress_ConfigMode
=== PAUSE TestAccAWSNetworkAcl_Ingress_ConfigMode
=== RUN   TestAccAWSNetworkAcl_EgressAndIngressRules
=== PAUSE TestAccAWSNetworkAcl_EgressAndIngressRules
=== RUN   TestAccAWSNetworkAcl_OnlyIngressRules_basic
=== PAUSE TestAccAWSNetworkAcl_OnlyIngressRules_basic
=== RUN   TestAccAWSNetworkAcl_OnlyIngressRules_update
=== PAUSE TestAccAWSNetworkAcl_OnlyIngressRules_update
=== RUN   TestAccAWSNetworkAcl_CaseSensitivityNoChanges
=== PAUSE TestAccAWSNetworkAcl_CaseSensitivityNoChanges
=== RUN   TestAccAWSNetworkAcl_OnlyEgressRules
=== PAUSE TestAccAWSNetworkAcl_OnlyEgressRules
=== RUN   TestAccAWSNetworkAcl_SubnetChange
=== PAUSE TestAccAWSNetworkAcl_SubnetChange
=== RUN   TestAccAWSNetworkAcl_Subnets
=== PAUSE TestAccAWSNetworkAcl_Subnets
=== RUN   TestAccAWSNetworkAcl_SubnetsDelete
=== PAUSE TestAccAWSNetworkAcl_SubnetsDelete
=== RUN   TestAccAWSNetworkAcl_ipv6Rules
=== PAUSE TestAccAWSNetworkAcl_ipv6Rules
=== RUN   TestAccAWSNetworkAcl_ipv6ICMPRules
=== PAUSE TestAccAWSNetworkAcl_ipv6ICMPRules
=== RUN   TestAccAWSNetworkAcl_ipv6VpcRules
=== PAUSE TestAccAWSNetworkAcl_ipv6VpcRules
=== RUN   TestAccAWSNetworkAcl_espProtocol
=== PAUSE TestAccAWSNetworkAcl_espProtocol
=== CONT  TestAccAWSNetworkAclRule_basic
=== CONT  TestAccAWSNetworkAclRule_allProtocol
=== CONT  TestAccAWSNetworkAcl_OnlyEgressRules
=== CONT  TestAccAWSNetworkAclRule_disappears
=== CONT  TestAccAWSNetworkAclRule_ipv6VpcAssignGeneratedIpv6CidrBlockUpdate
=== CONT  TestAccAWSNetworkAcl_espProtocol
=== CONT  TestAccAWSNetworkAcl_ipv6VpcRules
=== CONT  TestAccAWSNetworkAcl_ipv6ICMPRules
=== CONT  TestAccAWSNetworkAcl_ipv6Rules
=== CONT  TestAccAWSNetworkAcl_SubnetsDelete
=== CONT  TestAccAWSNetworkAcl_Subnets
=== CONT  TestAccAWSNetworkAcl_SubnetChange
=== CONT  TestAccAWSNetworkAclRule_ipv6ICMP
=== CONT  TestAccAWSNetworkAclRule_ipv6
=== CONT  TestAccAWSNetworkAclRule_missingParam
=== CONT  TestAccAWSNetworkAclRule_disappears_NetworkAcl
=== CONT  TestAccAWSNetworkAcl_OnlyIngressRules_update
=== CONT  TestAccAWSNetworkAcl_CaseSensitivityNoChanges
=== CONT  TestAccAWSNetworkAcl_Ingress_ConfigMode
=== CONT  TestAccAWSNetworkAcl_OnlyIngressRules_basic
--- PASS: TestAccAWSNetworkAclRule_missingParam (36.11s)
=== CONT  TestAccAWSNetworkAcl_EgressAndIngressRules
--- PASS: TestAccAWSNetworkAcl_ipv6ICMPRules (51.38s)
=== CONT  TestAccAWSNetworkAcl_disappears
--- PASS: TestAccAWSNetworkAclRule_disappears_NetworkAcl (52.52s)
=== CONT  TestAccAWSNetworkAcl_Egress_ConfigMode
--- PASS: TestAccAWSNetworkAcl_espProtocol (54.71s)
=== CONT  TestAccAWSNetworkAcl_basic
--- PASS: TestAccAWSNetworkAclRule_ipv6ICMP (55.65s)
--- PASS: TestAccAWSNetworkAclRule_ipv6 (55.92s)
--- PASS: TestAccAWSNetworkAcl_ipv6VpcRules (55.99s)
--- PASS: TestAccAWSNetworkAclRule_basic (58.10s)
--- PASS: TestAccAWSNetworkAcl_OnlyEgressRules (58.11s)
--- PASS: TestAccAWSNetworkAclRule_disappears (58.44s)
--- PASS: TestAccAWSNetworkAcl_ipv6Rules (67.19s)
--- PASS: TestAccAWSNetworkAcl_CaseSensitivityNoChanges (68.47s)
--- PASS: TestAccAWSNetworkAcl_OnlyIngressRules_basic (69.27s)
--- PASS: TestAccAWSNetworkAcl_SubnetChange (107.33s)
--- PASS: TestAccAWSNetworkAcl_SubnetsDelete (117.61s)
--- PASS: TestAccAWSNetworkAcl_EgressAndIngressRules (56.33s)
--- PASS: TestAccAWSNetworkAclRule_ipv6VpcAssignGeneratedIpv6CidrBlockUpdate (97.96s)
--- PASS: TestAccAWSNetworkAclRule_allProtocol (98.05s)
--- PASS: TestAccAWSNetworkAcl_OnlyIngressRules_update (101.69s)
--- PASS: TestAccAWSNetworkAcl_disappears (53.03s)
--- PASS: TestAccAWSNetworkAcl_basic (55.29s)
--- PASS: TestAccAWSNetworkAcl_Subnets (116.01s)
--- PASS: TestAccAWSNetworkAcl_Ingress_ConfigMode (125.71s)
--- PASS: TestAccAWSNetworkAcl_Egress_ConfigMode (126.36s)
```
