### PR TITLE
Acceptance test import refactor for rds cluster resources

### DIFF
--- a/aws/resource_aws_rds_cluster_parameter_group_test.go
+++ b/aws/resource_aws_rds_cluster_parameter_group_test.go
@@ -83,9 +83,9 @@ func testSweepRdsClusterParameterGroups(region string) error {
 	return nil
 }
 
-func TestAccAWSDBClusterParameterGroup_importBasic(t *testing.T) {
-	resourceName := "aws_rds_cluster_parameter_group.bar"
-
+func TestAccAWSDBClusterParameterGroup_basic(t *testing.T) {
+	var v rds.DBClusterParameterGroup
+	resourceName := "aws_rds_cluster_parameter_group.test"
 	parameterGroupName := fmt.Sprintf("cluster-parameter-group-test-terraform-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -95,88 +95,70 @@ func TestAccAWSDBClusterParameterGroup_importBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSDBClusterParameterGroupConfig(parameterGroupName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBClusterParameterGroupExists(resourceName, &v),
+					testAccCheckAWSDBClusterParameterGroupAttributes(&v, parameterGroupName),
+					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(`^arn:[^:]+:rds:[^:]+:\d{12}:cluster-pg:.+`)),
+					resource.TestCheckResourceAttr(
+						resourceName, "name", parameterGroupName),
+					resource.TestCheckResourceAttr(
+						resourceName, "family", "aurora5.6"),
+					resource.TestCheckResourceAttr(
+						resourceName, "description", "Test cluster parameter group for terraform"),
+					resource.TestCheckResourceAttr(
+						resourceName, "parameter.1708034931.name", "character_set_results"),
+					resource.TestCheckResourceAttr(
+						resourceName, "parameter.1708034931.value", "utf8"),
+					resource.TestCheckResourceAttr(
+						resourceName, "parameter.2421266705.name", "character_set_server"),
+					resource.TestCheckResourceAttr(
+						resourceName, "parameter.2421266705.value", "utf8"),
+					resource.TestCheckResourceAttr(
+						resourceName, "parameter.2478663599.name", "character_set_client"),
+					resource.TestCheckResourceAttr(
+						resourceName, "parameter.2478663599.value", "utf8"),
+					resource.TestCheckResourceAttr(
+						resourceName, "tags.%", "1"),
+				),
 			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-		},
-	})
-}
-
-func TestAccAWSDBClusterParameterGroup_basic(t *testing.T) {
-	var v rds.DBClusterParameterGroup
-
-	parameterGroupName := fmt.Sprintf("cluster-parameter-group-test-terraform-%d", acctest.RandInt())
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSDBClusterParameterGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSDBClusterParameterGroupConfig(parameterGroupName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDBClusterParameterGroupExists("aws_rds_cluster_parameter_group.bar", &v),
-					testAccCheckAWSDBClusterParameterGroupAttributes(&v, parameterGroupName),
-					resource.TestMatchResourceAttr("aws_rds_cluster_parameter_group.bar", "arn", regexp.MustCompile(`^arn:[^:]+:rds:[^:]+:\d{12}:cluster-pg:.+`)),
-					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "name", parameterGroupName),
-					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "family", "aurora5.6"),
-					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "description", "Test cluster parameter group for terraform"),
-					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "parameter.1708034931.name", "character_set_results"),
-					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "parameter.1708034931.value", "utf8"),
-					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "parameter.2421266705.name", "character_set_server"),
-					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "parameter.2421266705.value", "utf8"),
-					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "parameter.2478663599.name", "character_set_client"),
-					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "parameter.2478663599.value", "utf8"),
-					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "tags.%", "1"),
-				),
-			},
 			{
 				Config: testAccAWSDBClusterParameterGroupAddParametersConfig(parameterGroupName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDBClusterParameterGroupExists("aws_rds_cluster_parameter_group.bar", &v),
+					testAccCheckAWSDBClusterParameterGroupExists(resourceName, &v),
 					testAccCheckAWSDBClusterParameterGroupAttributes(&v, parameterGroupName),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "name", parameterGroupName),
+						resourceName, "name", parameterGroupName),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "family", "aurora5.6"),
+						resourceName, "family", "aurora5.6"),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "description", "Test cluster parameter group for terraform"),
+						resourceName, "description", "Test cluster parameter group for terraform"),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "parameter.1706463059.name", "collation_connection"),
+						resourceName, "parameter.1706463059.name", "collation_connection"),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "parameter.1706463059.value", "utf8_unicode_ci"),
+						resourceName, "parameter.1706463059.value", "utf8_unicode_ci"),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "parameter.1708034931.name", "character_set_results"),
+						resourceName, "parameter.1708034931.name", "character_set_results"),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "parameter.1708034931.value", "utf8"),
+						resourceName, "parameter.1708034931.value", "utf8"),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "parameter.2421266705.name", "character_set_server"),
+						resourceName, "parameter.2421266705.name", "character_set_server"),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "parameter.2421266705.value", "utf8"),
+						resourceName, "parameter.2421266705.value", "utf8"),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "parameter.2475805061.name", "collation_server"),
+						resourceName, "parameter.2475805061.name", "collation_server"),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "parameter.2475805061.value", "utf8_unicode_ci"),
+						resourceName, "parameter.2475805061.value", "utf8_unicode_ci"),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "parameter.2478663599.name", "character_set_client"),
+						resourceName, "parameter.2478663599.name", "character_set_client"),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "parameter.2478663599.value", "utf8"),
+						resourceName, "parameter.2478663599.value", "utf8"),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "tags.%", "2"),
+						resourceName, "tags.%", "2"),
 				),
 			},
 		},
@@ -186,6 +168,7 @@ func TestAccAWSDBClusterParameterGroup_basic(t *testing.T) {
 func TestAccAWSDBClusterParameterGroup_withApplyMethod(t *testing.T) {
 	var v rds.DBClusterParameterGroup
 	parameterGroupName := fmt.Sprintf("cluster-parameter-group-test-terraform-%d", acctest.RandInt())
+	resourceName := "aws_rds_cluster_parameter_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -195,29 +178,34 @@ func TestAccAWSDBClusterParameterGroup_withApplyMethod(t *testing.T) {
 			{
 				Config: testAccAWSDBClusterParameterGroupConfigWithApplyMethod(parameterGroupName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDBClusterParameterGroupExists("aws_rds_cluster_parameter_group.bar", &v),
+					testAccCheckAWSDBClusterParameterGroupExists(resourceName, &v),
 					testAccCheckAWSDBClusterParameterGroupAttributes(&v, parameterGroupName),
 					resource.TestMatchResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "arn", regexp.MustCompile(`^arn:[^:]+:rds:[^:]+:\d{12}:cluster-pg:.+`)),
+						resourceName, "arn", regexp.MustCompile(`^arn:[^:]+:rds:[^:]+:\d{12}:cluster-pg:.+`)),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "name", parameterGroupName),
+						resourceName, "name", parameterGroupName),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "family", "aurora5.6"),
+						resourceName, "family", "aurora5.6"),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "description", "Test cluster parameter group for terraform"),
+						resourceName, "description", "Test cluster parameter group for terraform"),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "parameter.2421266705.name", "character_set_server"),
+						resourceName, "parameter.2421266705.name", "character_set_server"),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "parameter.2421266705.value", "utf8"),
+						resourceName, "parameter.2421266705.value", "utf8"),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "parameter.2421266705.apply_method", "immediate"),
+						resourceName, "parameter.2421266705.apply_method", "immediate"),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "parameter.2478663599.name", "character_set_client"),
+						resourceName, "parameter.2478663599.name", "character_set_client"),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "parameter.2478663599.value", "utf8"),
+						resourceName, "parameter.2478663599.value", "utf8"),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "parameter.2478663599.apply_method", "pending-reboot"),
+						resourceName, "parameter.2478663599.apply_method", "pending-reboot"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -225,6 +213,7 @@ func TestAccAWSDBClusterParameterGroup_withApplyMethod(t *testing.T) {
 
 func TestAccAWSDBClusterParameterGroup_namePrefix(t *testing.T) {
 	var v rds.DBClusterParameterGroup
+	resourceName := "aws_rds_cluster_parameter_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -234,10 +223,16 @@ func TestAccAWSDBClusterParameterGroup_namePrefix(t *testing.T) {
 			{
 				Config: testAccAWSDBClusterParameterGroupConfig_namePrefix,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDBClusterParameterGroupExists("aws_rds_cluster_parameter_group.test", &v),
+					testAccCheckAWSDBClusterParameterGroupExists(resourceName, &v),
 					resource.TestMatchResourceAttr(
-						"aws_rds_cluster_parameter_group.test", "name", regexp.MustCompile("^tf-test-")),
+						resourceName, "name", regexp.MustCompile("^tf-test-")),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name_prefix"},
 			},
 		},
 	})
@@ -245,6 +240,7 @@ func TestAccAWSDBClusterParameterGroup_namePrefix(t *testing.T) {
 
 func TestAccAWSDBClusterParameterGroup_namePrefix_Parameter(t *testing.T) {
 	var v rds.DBClusterParameterGroup
+	resourceName := "aws_rds_cluster_parameter_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -254,10 +250,16 @@ func TestAccAWSDBClusterParameterGroup_namePrefix_Parameter(t *testing.T) {
 			{
 				Config: testAccAWSDBClusterParameterGroupConfig_namePrefix_Parameter,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDBClusterParameterGroupExists("aws_rds_cluster_parameter_group.test", &v),
+					testAccCheckAWSDBClusterParameterGroupExists(resourceName, &v),
 					resource.TestMatchResourceAttr(
-						"aws_rds_cluster_parameter_group.test", "name", regexp.MustCompile("^tf-test-")),
+						resourceName, "name", regexp.MustCompile("^tf-test-")),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name_prefix"},
 			},
 		},
 	})
@@ -265,6 +267,7 @@ func TestAccAWSDBClusterParameterGroup_namePrefix_Parameter(t *testing.T) {
 
 func TestAccAWSDBClusterParameterGroup_generatedName(t *testing.T) {
 	var v rds.DBClusterParameterGroup
+	resourceName := "aws_rds_cluster_parameter_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -274,8 +277,13 @@ func TestAccAWSDBClusterParameterGroup_generatedName(t *testing.T) {
 			{
 				Config: testAccAWSDBClusterParameterGroupConfig_generatedName,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDBClusterParameterGroupExists("aws_rds_cluster_parameter_group.test", &v),
+					testAccCheckAWSDBClusterParameterGroupExists(resourceName, &v),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -283,6 +291,7 @@ func TestAccAWSDBClusterParameterGroup_generatedName(t *testing.T) {
 
 func TestAccAWSDBClusterParameterGroup_generatedName_Parameter(t *testing.T) {
 	var v rds.DBClusterParameterGroup
+	resourceName := "aws_rds_cluster_parameter_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -292,8 +301,13 @@ func TestAccAWSDBClusterParameterGroup_generatedName_Parameter(t *testing.T) {
 			{
 				Config: testAccAWSDBClusterParameterGroupConfig_generatedName_Parameter,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDBClusterParameterGroupExists("aws_rds_cluster_parameter_group.test", &v),
+					testAccCheckAWSDBClusterParameterGroupExists(resourceName, &v),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -301,7 +315,7 @@ func TestAccAWSDBClusterParameterGroup_generatedName_Parameter(t *testing.T) {
 
 func TestAccAWSDBClusterParameterGroup_disappears(t *testing.T) {
 	var v rds.DBClusterParameterGroup
-
+	resourceName := "aws_rds_cluster_parameter_group.test"
 	parameterGroupName := fmt.Sprintf("cluster-parameter-group-test-terraform-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -312,7 +326,7 @@ func TestAccAWSDBClusterParameterGroup_disappears(t *testing.T) {
 			{
 				Config: testAccAWSDBClusterParameterGroupConfig(parameterGroupName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDBClusterParameterGroupExists("aws_rds_cluster_parameter_group.bar", &v),
+					testAccCheckAWSDBClusterParameterGroupExists(resourceName, &v),
 					testAccAWSDBClusterParameterGroupDisappears(&v),
 				),
 				ExpectNonEmptyPlan: true,
@@ -321,9 +335,9 @@ func TestAccAWSDBClusterParameterGroup_disappears(t *testing.T) {
 	})
 }
 
-func TestAccAWSDBClusterParameterGroupOnly(t *testing.T) {
+func TestAccAWSDBClusterParameterGroup_only(t *testing.T) {
 	var v rds.DBClusterParameterGroup
-
+	resourceName := "aws_rds_cluster_parameter_group.test"
 	parameterGroupName := fmt.Sprintf("cluster-parameter-group-test-tf-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -334,15 +348,20 @@ func TestAccAWSDBClusterParameterGroupOnly(t *testing.T) {
 			{
 				Config: testAccAWSDBClusterParameterGroupOnlyConfig(parameterGroupName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDBClusterParameterGroupExists("aws_rds_cluster_parameter_group.bar", &v),
+					testAccCheckAWSDBClusterParameterGroupExists(resourceName, &v),
 					testAccCheckAWSDBClusterParameterGroupAttributes(&v, parameterGroupName),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "name", parameterGroupName),
+						resourceName, "name", parameterGroupName),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "family", "aurora5.6"),
+						resourceName, "family", "aurora5.6"),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_parameter_group.bar", "description", "Managed by Terraform"),
+						resourceName, "description", "Managed by Terraform"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -461,7 +480,7 @@ func testAccCheckAWSDBClusterParameterGroupExists(n string, v *rds.DBClusterPara
 
 func testAccAWSDBClusterParameterGroupConfig(name string) string {
 	return fmt.Sprintf(`
-resource "aws_rds_cluster_parameter_group" "bar" {
+resource "aws_rds_cluster_parameter_group" "test" {
   name        = "%s"
   family      = "aurora5.6"
   description = "Test cluster parameter group for terraform"
@@ -490,7 +509,7 @@ resource "aws_rds_cluster_parameter_group" "bar" {
 
 func testAccAWSDBClusterParameterGroupConfigWithApplyMethod(name string) string {
 	return fmt.Sprintf(`
-resource "aws_rds_cluster_parameter_group" "bar" {
+resource "aws_rds_cluster_parameter_group" "test" {
   name        = "%s"
   family      = "aurora5.6"
   description = "Test cluster parameter group for terraform"
@@ -515,7 +534,7 @@ resource "aws_rds_cluster_parameter_group" "bar" {
 
 func testAccAWSDBClusterParameterGroupAddParametersConfig(name string) string {
 	return fmt.Sprintf(`
-resource "aws_rds_cluster_parameter_group" "bar" {
+resource "aws_rds_cluster_parameter_group" "test" {
   name        = "%s"
   family      = "aurora5.6"
   description = "Test cluster parameter group for terraform"
@@ -555,7 +574,7 @@ resource "aws_rds_cluster_parameter_group" "bar" {
 
 func testAccAWSDBClusterParameterGroupOnlyConfig(name string) string {
 	return fmt.Sprintf(`
-resource "aws_rds_cluster_parameter_group" "bar" {
+resource "aws_rds_cluster_parameter_group" "test" {
   name   = "%s"
   family = "aurora5.6"
 }

--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -100,39 +100,10 @@ func testSweepRdsClusters(region string) error {
 	return nil
 }
 
-func TestAccAWSRDSCluster_importBasic(t *testing.T) {
-	resourceName := "aws_rds_cluster.default"
-	ri := acctest.RandInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSClusterDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSClusterConfig(ri),
-			},
-
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"apply_immediately",
-					"cluster_identifier_prefix",
-					"master_password",
-					"skip_final_snapshot",
-					"snapshot_identifier",
-				},
-			},
-		},
-	})
-}
-
 func TestAccAWSRDSCluster_basic(t *testing.T) {
 	var dbCluster rds.DBCluster
 	rInt := acctest.RandInt()
-	resourceName := "aws_rds_cluster.default"
+	resourceName := "aws_rds_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -158,6 +129,18 @@ func TestAccAWSRDSCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "scaling_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"master_password",
+					"skip_final_snapshot",
+					"snapshot_identifier",
+				},
 			},
 		},
 	})
@@ -234,6 +217,7 @@ func TestAccAWSRDSCluster_BacktrackWindow(t *testing.T) {
 
 func TestAccAWSRDSCluster_ClusterIdentifierPrefix(t *testing.T) {
 	var v rds.DBCluster
+	resourceName := "aws_rds_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -243,10 +227,22 @@ func TestAccAWSRDSCluster_ClusterIdentifierPrefix(t *testing.T) {
 			{
 				Config: testAccAWSClusterConfig_ClusterIdentifierPrefix("tf-test-"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSClusterExists("aws_rds_cluster.test", &v),
+					testAccCheckAWSClusterExists(resourceName, &v),
 					resource.TestMatchResourceAttr(
-						"aws_rds_cluster.test", "cluster_identifier", regexp.MustCompile("^tf-test-")),
+						resourceName, "cluster_identifier", regexp.MustCompile("^tf-test-")),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"master_password",
+					"skip_final_snapshot",
+					"snapshot_identifier",
+				},
 			},
 		},
 	})
@@ -298,9 +294,21 @@ func TestAccAWSRDSCluster_s3Restore(t *testing.T) {
 			{
 				Config: testAccAWSClusterConfig_s3Restore(bucket, bucketPrefix, uniqueId),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSClusterExists("aws_rds_cluster.test", &v),
+					testAccCheckAWSClusterExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "engine", "aurora"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"master_password",
+					"skip_final_snapshot",
+					"snapshot_identifier",
+				},
 			},
 		},
 	})
@@ -308,6 +316,7 @@ func TestAccAWSRDSCluster_s3Restore(t *testing.T) {
 
 func TestAccAWSRDSCluster_generatedName(t *testing.T) {
 	var v rds.DBCluster
+	resourceName := "aws_rds_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -317,10 +326,22 @@ func TestAccAWSRDSCluster_generatedName(t *testing.T) {
 			{
 				Config: testAccAWSClusterConfig_generatedName(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSClusterExists("aws_rds_cluster.test", &v),
+					testAccCheckAWSClusterExists(resourceName, &v),
 					resource.TestMatchResourceAttr(
-						"aws_rds_cluster.test", "cluster_identifier", regexp.MustCompile("^tf-")),
+						resourceName, "cluster_identifier", regexp.MustCompile("^tf-")),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"master_password",
+					"skip_final_snapshot",
+					"snapshot_identifier",
+				},
 			},
 		},
 	})
@@ -329,6 +350,7 @@ func TestAccAWSRDSCluster_generatedName(t *testing.T) {
 func TestAccAWSRDSCluster_takeFinalSnapshot(t *testing.T) {
 	var v rds.DBCluster
 	rInt := acctest.RandInt()
+	resourceName := "aws_rds_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -338,8 +360,21 @@ func TestAccAWSRDSCluster_takeFinalSnapshot(t *testing.T) {
 			{
 				Config: testAccAWSClusterConfigWithFinalSnapshot(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
+					testAccCheckAWSClusterExists(resourceName, &v),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"master_password",
+					"skip_final_snapshot",
+					"snapshot_identifier",
+					"final_snapshot_identifier",
+				},
 			},
 		},
 	})
@@ -474,6 +509,7 @@ func TestAccAWSRDSCluster_EnabledCloudwatchLogsExports(t *testing.T) {
 func TestAccAWSRDSCluster_updateIamRoles(t *testing.T) {
 	var v rds.DBCluster
 	ri := acctest.RandInt()
+	resourceName := "aws_rds_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -483,23 +519,35 @@ func TestAccAWSRDSCluster_updateIamRoles(t *testing.T) {
 			{
 				Config: testAccAWSClusterConfigIncludingIamRoles(ri),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
+					testAccCheckAWSClusterExists(resourceName, &v),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"master_password",
+					"skip_final_snapshot",
+					"snapshot_identifier",
+				},
 			},
 			{
 				Config: testAccAWSClusterConfigAddIamRoles(ri),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
+					testAccCheckAWSClusterExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster.default", "iam_roles.#", "2"),
+						resourceName, "iam_roles.#", "2"),
 				),
 			},
 			{
 				Config: testAccAWSClusterConfigRemoveIamRoles(ri),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
+					testAccCheckAWSClusterExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster.default", "iam_roles.#", "1"),
+						resourceName, "iam_roles.#", "1"),
 				),
 			},
 		},
@@ -509,7 +557,7 @@ func TestAccAWSRDSCluster_updateIamRoles(t *testing.T) {
 func TestAccAWSRDSCluster_kmsKey(t *testing.T) {
 	var dbCluster1 rds.DBCluster
 	kmsKeyResourceName := "aws_kms_key.foo"
-	resourceName := "aws_rds_cluster.default"
+	resourceName := "aws_rds_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -523,12 +571,25 @@ func TestAccAWSRDSCluster_kmsKey(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", kmsKeyResourceName, "arn"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"master_password",
+					"skip_final_snapshot",
+					"snapshot_identifier",
+				},
+			},
 		},
 	})
 }
 
 func TestAccAWSRDSCluster_encrypted(t *testing.T) {
 	var v rds.DBCluster
+	resourceName := "aws_rds_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -538,12 +599,24 @@ func TestAccAWSRDSCluster_encrypted(t *testing.T) {
 			{
 				Config: testAccAWSClusterConfig_encrypted(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
+					testAccCheckAWSClusterExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster.default", "storage_encrypted", "true"),
+						resourceName, "storage_encrypted", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster.default", "db_cluster_parameter_group_name", "default.aurora5.6"),
+						resourceName, "db_cluster_parameter_group_name", "default.aurora5.6"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"master_password",
+					"skip_final_snapshot",
+					"snapshot_identifier",
+				},
 			},
 		},
 	})
@@ -552,7 +625,7 @@ func TestAccAWSRDSCluster_encrypted(t *testing.T) {
 func TestAccAWSRDSCluster_copyTagsToSnapshot(t *testing.T) {
 	var v rds.DBCluster
 	rInt := acctest.RandInt()
-	resourceName := "aws_rds_cluster.default"
+	resourceName := "aws_rds_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -565,6 +638,18 @@ func TestAccAWSRDSCluster_copyTagsToSnapshot(t *testing.T) {
 					testAccCheckAWSClusterExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "copy_tags_to_snapshot", "true"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"master_password",
+					"skip_final_snapshot",
+					"snapshot_identifier",
+				},
 			},
 			{
 				Config: testAccAWSClusterConfigWithCopyTagsToSnapshot(rInt, false),
@@ -587,6 +672,8 @@ func TestAccAWSRDSCluster_copyTagsToSnapshot(t *testing.T) {
 func TestAccAWSRDSCluster_EncryptedCrossRegionReplication(t *testing.T) {
 	var primaryCluster rds.DBCluster
 	var replicaCluster rds.DBCluster
+	resourceName := "aws_rds_cluster.test_primary"
+	resourceName2 := "aws_rds_cluster.test_replica"
 
 	// record the initialized providers so that we can use them to
 	// check for the cluster in each region
@@ -600,11 +687,24 @@ func TestAccAWSRDSCluster_EncryptedCrossRegionReplication(t *testing.T) {
 			{
 				Config: testAccAWSClusterConfigEncryptedCrossRegionReplica(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSClusterExistsWithProvider("aws_rds_cluster.test_primary",
+					testAccCheckAWSClusterExistsWithProvider(resourceName,
 						&primaryCluster, testAccAwsRegionProviderFunc("us-west-2", &providers)),
-					testAccCheckAWSClusterExistsWithProvider("aws_rds_cluster.test_replica",
+					testAccCheckAWSClusterExistsWithProvider(resourceName2,
 						&replicaCluster, testAccAwsRegionProviderFunc("us-east-1", &providers)),
 				),
+			},
+			{
+				Config:            testAccAWSClusterConfigEncryptedCrossRegionReplica(acctest.RandInt()),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"master_password",
+					"skip_final_snapshot",
+					"snapshot_identifier",
+				},
 			},
 		},
 	})
@@ -612,6 +712,7 @@ func TestAccAWSRDSCluster_EncryptedCrossRegionReplication(t *testing.T) {
 
 func TestAccAWSRDSCluster_backupsUpdate(t *testing.T) {
 	var v rds.DBCluster
+	resourceName := "aws_rds_cluster.test"
 
 	ri := acctest.RandInt()
 	resource.ParallelTest(t, resource.TestCase{
@@ -622,26 +723,37 @@ func TestAccAWSRDSCluster_backupsUpdate(t *testing.T) {
 			{
 				Config: testAccAWSClusterConfig_backups(ri),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
+					testAccCheckAWSClusterExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster.default", "preferred_backup_window", "07:00-09:00"),
+						resourceName, "preferred_backup_window", "07:00-09:00"),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster.default", "backup_retention_period", "5"),
+						resourceName, "backup_retention_period", "5"),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster.default", "preferred_maintenance_window", "tue:04:00-tue:04:30"),
+						resourceName, "preferred_maintenance_window", "tue:04:00-tue:04:30"),
 				),
 			},
-
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"master_password",
+					"skip_final_snapshot",
+					"snapshot_identifier",
+				},
+			},
 			{
 				Config: testAccAWSClusterConfig_backupsUpdate(ri),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
+					testAccCheckAWSClusterExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster.default", "preferred_backup_window", "03:00-09:00"),
+						resourceName, "preferred_backup_window", "03:00-09:00"),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster.default", "backup_retention_period", "10"),
+						resourceName, "backup_retention_period", "10"),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster.default", "preferred_maintenance_window", "wed:01:00-wed:01:30"),
+						resourceName, "preferred_maintenance_window", "wed:01:00-wed:01:30"),
 				),
 			},
 		},
@@ -650,6 +762,7 @@ func TestAccAWSRDSCluster_backupsUpdate(t *testing.T) {
 
 func TestAccAWSRDSCluster_iamAuth(t *testing.T) {
 	var v rds.DBCluster
+	resourceName := "aws_rds_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -659,10 +772,22 @@ func TestAccAWSRDSCluster_iamAuth(t *testing.T) {
 			{
 				Config: testAccAWSClusterConfig_iamAuth(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
+					testAccCheckAWSClusterExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster.default", "iam_database_authentication_enabled", "true"),
+						resourceName, "iam_database_authentication_enabled", "true"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"master_password",
+					"skip_final_snapshot",
+					"snapshot_identifier",
+				},
 			},
 		},
 	})
@@ -883,6 +1008,18 @@ func TestAccAWSRDSCluster_EngineVersion(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"master_password",
+					"skip_final_snapshot",
+					"snapshot_identifier",
+				},
+			},
+			{
 				Config:      testAccAWSClusterConfig_EngineVersion(rInt, "aurora-postgresql", "9.6.6"),
 				ExpectError: regexp.MustCompile(`Cannot modify engine version without a primary instance in DB cluster`),
 			},
@@ -907,6 +1044,18 @@ func TestAccAWSRDSCluster_EngineVersionWithPrimaryInstance(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "engine", "aurora-postgresql"),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "9.6.3"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"master_password",
+					"skip_final_snapshot",
+					"snapshot_identifier",
+				},
 			},
 			{
 				Config: testAccAWSClusterConfig_EngineVersionWithPrimaryInstance(rInt, "aurora-postgresql", "9.6.6"),
@@ -974,6 +1123,18 @@ func TestAccAWSRDSCluster_GlobalClusterIdentifier_Add(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"master_password",
+					"skip_final_snapshot",
+					"snapshot_identifier",
+				},
+			},
+			{
 				Config:      testAccAWSRDSClusterConfig_GlobalClusterIdentifier(rName),
 				ExpectError: regexp.MustCompile(`Existing RDS Clusters cannot be added to an existing RDS Global Cluster`),
 			},
@@ -999,6 +1160,18 @@ func TestAccAWSRDSCluster_GlobalClusterIdentifier_Remove(t *testing.T) {
 					testAccCheckAWSClusterExists(resourceName, &dbCluster1),
 					resource.TestCheckResourceAttrPair(resourceName, "global_cluster_identifier", globalClusterResourceName, "id"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"master_password",
+					"skip_final_snapshot",
+					"snapshot_identifier",
+				},
 			},
 			{
 				Config: testAccAWSRDSClusterConfig_EngineMode(rName, "global"),
@@ -1032,6 +1205,18 @@ func TestAccAWSRDSCluster_GlobalClusterIdentifier_Update(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"master_password",
+					"skip_final_snapshot",
+					"snapshot_identifier",
+				},
+			},
+			{
 				Config:      testAccAWSRDSClusterConfig_GlobalClusterIdentifier_Update(rName, globalClusterResourceName2),
 				ExpectError: regexp.MustCompile(`Existing RDS Clusters cannot be migrated between existing RDS Global Clusters`),
 			},
@@ -1055,6 +1240,18 @@ func TestAccAWSRDSCluster_Port(t *testing.T) {
 					testAccCheckAWSClusterExists(resourceName, &dbCluster1),
 					resource.TestCheckResourceAttr(resourceName, "port", "5432"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"master_password",
+					"skip_final_snapshot",
+					"snapshot_identifier",
+				},
 			},
 			{
 				Config: testAccAWSClusterConfig_Port(rInt, 2345),
@@ -1140,6 +1337,18 @@ func TestAccAWSRDSCluster_SnapshotIdentifier(t *testing.T) {
 					testAccCheckDbClusterSnapshotExists(snapshotResourceName, &dbClusterSnapshot),
 					testAccCheckAWSClusterExists(resourceName, &dbCluster),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"master_password",
+					"skip_final_snapshot",
+					"snapshot_identifier",
+				},
 			},
 		},
 	})
@@ -1577,6 +1786,18 @@ func TestAccAWSRDSCluster_SnapshotIdentifier_Tags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"master_password",
+					"skip_final_snapshot",
+					"snapshot_identifier",
+				},
+			},
 		},
 	})
 }
@@ -1602,6 +1823,18 @@ func TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds(t *testing.T) {
 					testAccCheckDbClusterSnapshotExists(snapshotResourceName, &dbClusterSnapshot),
 					testAccCheckAWSClusterExists(resourceName, &dbCluster),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"master_password",
+					"skip_final_snapshot",
+					"snapshot_identifier",
+				},
 			},
 		},
 	})
@@ -1635,6 +1868,18 @@ func TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds_Tags(t *testing
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"master_password",
+					"skip_final_snapshot",
+					"snapshot_identifier",
+				},
+			},
 		},
 	})
 }
@@ -1663,6 +1908,18 @@ func TestAccAWSRDSCluster_SnapshotIdentifier_EncryptedRestore(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", kmsKeyResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "storage_encrypted", "true"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"master_password",
+					"skip_final_snapshot",
+					"snapshot_identifier",
+				},
 			},
 		},
 	})
@@ -1805,7 +2062,7 @@ func testAccCheckAWSClusterRecreated(i, j *rds.DBCluster) resource.TestCheckFunc
 
 func testAccAWSClusterConfig(n int) string {
 	return fmt.Sprintf(`
-resource "aws_rds_cluster" "default" {
+resource "aws_rds_cluster" "test" {
   cluster_identifier              = "tf-aurora-cluster-%d"
   database_name                   = "mydb"
   master_username                 = "foo"
@@ -2008,7 +2265,7 @@ resource "aws_rds_cluster" "test" {
 
 func testAccAWSClusterConfigWithFinalSnapshot(n int) string {
 	return fmt.Sprintf(`
-resource "aws_rds_cluster" "default" {
+resource "aws_rds_cluster" "test" {
   cluster_identifier              = "tf-aurora-cluster-%d"
   database_name                   = "mydb"
   master_username                 = "foo"
@@ -2125,7 +2382,7 @@ func testAccAWSClusterConfig_kmsKey(n int) string {
  POLICY
  }
 
- resource "aws_rds_cluster" "default" {
+ resource "aws_rds_cluster" "test" {
    cluster_identifier = "tf-aurora-cluster-%d"
    database_name = "mydb"
    master_username = "foo"
@@ -2139,7 +2396,7 @@ func testAccAWSClusterConfig_kmsKey(n int) string {
 
 func testAccAWSClusterConfig_encrypted(n int) string {
 	return fmt.Sprintf(`
-resource "aws_rds_cluster" "default" {
+resource "aws_rds_cluster" "test" {
   cluster_identifier = "tf-aurora-cluster-%d"
   database_name = "mydb"
   master_username = "foo"
@@ -2152,7 +2409,7 @@ resource "aws_rds_cluster" "default" {
 
 func testAccAWSClusterConfig_backups(n int) string {
 	return fmt.Sprintf(`
-resource "aws_rds_cluster" "default" {
+resource "aws_rds_cluster" "test" {
   cluster_identifier           = "tf-aurora-cluster-%d"
   database_name                = "mydb"
   master_username              = "foo"
@@ -2167,7 +2424,7 @@ resource "aws_rds_cluster" "default" {
 
 func testAccAWSClusterConfig_backupsUpdate(n int) string {
 	return fmt.Sprintf(`
-resource "aws_rds_cluster" "default" {
+resource "aws_rds_cluster" "test" {
   cluster_identifier           = "tf-aurora-cluster-%d"
   database_name                = "mydb"
   master_username              = "foo"
@@ -2183,7 +2440,7 @@ resource "aws_rds_cluster" "default" {
 
 func testAccAWSClusterConfig_iamAuth(n int) string {
 	return fmt.Sprintf(`
-resource "aws_rds_cluster" "default" {
+resource "aws_rds_cluster" "test" {
   cluster_identifier                  = "tf-aurora-cluster-%d"
   database_name                       = "mydb"
   master_username                     = "foo"
@@ -2238,7 +2495,7 @@ func testAccAWSClusterConfig_Port(rInt, port int) string {
 resource "aws_rds_cluster" "test" {
   cluster_identifier              = "tf-acc-test-%d"
   database_name                   = "mydb"
-  db_cluster_parameter_group_name = "default.aurora-postgresql9.6"
+  db_cluster_parameter_group_name = "default.aurora-postgresql10"
   engine                          = "aurora-postgresql"
   master_password                 = "mustbeeightcharaters"
   master_username                 = "foo"
@@ -2324,7 +2581,7 @@ resource "aws_iam_role_policy" "another_rds_policy" {
 EOF
 }
 
-resource "aws_rds_cluster" "default" {
+resource "aws_rds_cluster" "test" {
   cluster_identifier              = "tf-aurora-cluster-%d"
   database_name                   = "mydb"
   master_username                 = "foo"
@@ -2417,7 +2674,7 @@ resource "aws_iam_role_policy" "another_rds_policy" {
 EOF
 }
 
-resource "aws_rds_cluster" "default" {
+resource "aws_rds_cluster" "test" {
   cluster_identifier              = "tf-aurora-cluster-%d"
   database_name                   = "mydb"
   master_username                 = "foo"
@@ -2474,7 +2731,7 @@ resource "aws_iam_role_policy" "another_rds_policy" {
 EOF
 }
 
-resource "aws_rds_cluster" "default" {
+resource "aws_rds_cluster" "test" {
   cluster_identifier              = "tf-aurora-cluster-%d"
   database_name                   = "mydb"
   master_username                 = "foo"
@@ -3052,7 +3309,7 @@ resource "aws_rds_cluster" "test" {
 
 func testAccAWSClusterConfigWithCopyTagsToSnapshot(n int, f bool) string {
 	return fmt.Sprintf(`
-resource "aws_rds_cluster" "default" {
+resource "aws_rds_cluster" "test" {
   cluster_identifier              = "tf-aurora-cluster-%[1]d"
   database_name                   = "mydb"
   master_username                 = "foo"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8944

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
NOTE: TestAccAWSRDSCluster_EngineMode, TestAccAWSRDSCluster_s3Restore, TestAccAWSRDSCluster_GlobalClusterIdentifier failures are not new

make testacc TESTARGS="-run=TestAccAWSRDSCluster_"                 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSRDSCluster_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSRDSCluster_basic
=== PAUSE TestAccAWSRDSCluster_basic
=== RUN   TestAccAWSRDSCluster_AvailabilityZones
=== PAUSE TestAccAWSRDSCluster_AvailabilityZones
=== RUN   TestAccAWSRDSCluster_BacktrackWindow
=== PAUSE TestAccAWSRDSCluster_BacktrackWindow
=== RUN   TestAccAWSRDSCluster_ClusterIdentifierPrefix
=== PAUSE TestAccAWSRDSCluster_ClusterIdentifierPrefix
=== RUN   TestAccAWSRDSCluster_DbSubnetGroupName
=== PAUSE TestAccAWSRDSCluster_DbSubnetGroupName
=== RUN   TestAccAWSRDSCluster_s3Restore
=== PAUSE TestAccAWSRDSCluster_s3Restore
=== RUN   TestAccAWSRDSCluster_generatedName
=== PAUSE TestAccAWSRDSCluster_generatedName
=== RUN   TestAccAWSRDSCluster_takeFinalSnapshot
=== PAUSE TestAccAWSRDSCluster_takeFinalSnapshot
=== RUN   TestAccAWSRDSCluster_missingUserNameCausesError
=== PAUSE TestAccAWSRDSCluster_missingUserNameCausesError
=== RUN   TestAccAWSRDSCluster_Tags
=== PAUSE TestAccAWSRDSCluster_Tags
=== RUN   TestAccAWSRDSCluster_EnabledCloudwatchLogsExports
=== PAUSE TestAccAWSRDSCluster_EnabledCloudwatchLogsExports
=== RUN   TestAccAWSRDSCluster_updateIamRoles
=== PAUSE TestAccAWSRDSCluster_updateIamRoles
=== RUN   TestAccAWSRDSCluster_kmsKey
=== PAUSE TestAccAWSRDSCluster_kmsKey
=== RUN   TestAccAWSRDSCluster_encrypted
=== PAUSE TestAccAWSRDSCluster_encrypted
=== RUN   TestAccAWSRDSCluster_copyTagsToSnapshot
=== PAUSE TestAccAWSRDSCluster_copyTagsToSnapshot
=== RUN   TestAccAWSRDSCluster_EncryptedCrossRegionReplication
=== PAUSE TestAccAWSRDSCluster_EncryptedCrossRegionReplication
=== RUN   TestAccAWSRDSCluster_backupsUpdate
=== PAUSE TestAccAWSRDSCluster_backupsUpdate
=== RUN   TestAccAWSRDSCluster_iamAuth
=== PAUSE TestAccAWSRDSCluster_iamAuth
=== RUN   TestAccAWSRDSCluster_DeletionProtection
=== PAUSE TestAccAWSRDSCluster_DeletionProtection
=== RUN   TestAccAWSRDSCluster_EngineMode
=== PAUSE TestAccAWSRDSCluster_EngineMode
=== RUN   TestAccAWSRDSCluster_EngineMode_Global
=== PAUSE TestAccAWSRDSCluster_EngineMode_Global
=== RUN   TestAccAWSRDSCluster_EngineMode_Multimaster
=== PAUSE TestAccAWSRDSCluster_EngineMode_Multimaster
=== RUN   TestAccAWSRDSCluster_EngineMode_ParallelQuery
=== PAUSE TestAccAWSRDSCluster_EngineMode_ParallelQuery
=== RUN   TestAccAWSRDSCluster_EngineVersion
=== PAUSE TestAccAWSRDSCluster_EngineVersion
=== RUN   TestAccAWSRDSCluster_EngineVersionWithPrimaryInstance
=== PAUSE TestAccAWSRDSCluster_EngineVersionWithPrimaryInstance
=== RUN   TestAccAWSRDSCluster_GlobalClusterIdentifier
=== PAUSE TestAccAWSRDSCluster_GlobalClusterIdentifier
=== RUN   TestAccAWSRDSCluster_GlobalClusterIdentifier_Add
=== PAUSE TestAccAWSRDSCluster_GlobalClusterIdentifier_Add
=== RUN   TestAccAWSRDSCluster_GlobalClusterIdentifier_Remove
=== PAUSE TestAccAWSRDSCluster_GlobalClusterIdentifier_Remove
=== RUN   TestAccAWSRDSCluster_GlobalClusterIdentifier_Update
=== PAUSE TestAccAWSRDSCluster_GlobalClusterIdentifier_Update
=== RUN   TestAccAWSRDSCluster_Port
=== PAUSE TestAccAWSRDSCluster_Port
=== RUN   TestAccAWSRDSCluster_ScalingConfiguration
=== PAUSE TestAccAWSRDSCluster_ScalingConfiguration
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_DeletionProtection
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_DeletionProtection
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_ParallelQuery
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_ParallelQuery
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Provisioned
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Provisioned
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Serverless
--- SKIP: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Serverless (0.00s)
    resource_aws_rds_cluster_test.go:1487: serverless does not support snapshot restore on an empty volume
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Different
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Different
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Equal
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Equal
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_MasterPassword
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_MasterPassword
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_MasterUsername
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_MasterUsername
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_PreferredBackupWindow
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_PreferredBackupWindow
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_PreferredMaintenanceWindow
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_PreferredMaintenanceWindow
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_Tags
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_Tags
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds_Tags
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds_Tags
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_EncryptedRestore
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_EncryptedRestore
=== CONT  TestAccAWSRDSCluster_basic
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_EncryptedRestore
=== CONT  TestAccAWSRDSCluster_iamAuth
=== CONT  TestAccAWSRDSCluster_updateIamRoles
=== CONT  TestAccAWSRDSCluster_kmsKey
=== CONT  TestAccAWSRDSCluster_EnabledCloudwatchLogsExports
=== CONT  TestAccAWSRDSCluster_EngineVersion
=== CONT  TestAccAWSRDSCluster_Tags
=== CONT  TestAccAWSRDSCluster_EngineMode_ParallelQuery
=== CONT  TestAccAWSRDSCluster_missingUserNameCausesError
=== CONT  TestAccAWSRDSCluster_backupsUpdate
=== CONT  TestAccAWSRDSCluster_EncryptedCrossRegionReplication
=== CONT  TestAccAWSRDSCluster_copyTagsToSnapshot
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds_Tags
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds
=== CONT  TestAccAWSRDSCluster_encrypted
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_Tags
=== CONT  TestAccAWSRDSCluster_takeFinalSnapshot
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_PreferredMaintenanceWindow
=== CONT  TestAccAWSRDSCluster_EngineVersionWithPrimaryInstance
--- PASS: TestAccAWSRDSCluster_missingUserNameCausesError (9.63s)
=== CONT  TestAccAWSRDSCluster_DbSubnetGroupName
--- PASS: TestAccAWSRDSCluster_iamAuth (125.81s)
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_PreferredBackupWindow
--- PASS: TestAccAWSRDSCluster_encrypted (126.23s)
=== CONT  TestAccAWSRDSCluster_generatedName
--- PASS: TestAccAWSRDSCluster_EngineMode_ParallelQuery (137.74s)
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_MasterUsername
--- PASS: TestAccAWSRDSCluster_EngineVersion (145.81s)
=== CONT  TestAccAWSRDSCluster_s3Restore
--- PASS: TestAccAWSRDSCluster_basic (167.73s)
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_MasterPassword
--- PASS: TestAccAWSRDSCluster_takeFinalSnapshot (169.15s)
=== CONT  TestAccAWSRDSCluster_ClusterIdentifierPrefix
--- PASS: TestAccAWSRDSCluster_backupsUpdate (187.90s)
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Equal
--- PASS: TestAccAWSRDSCluster_DbSubnetGroupName (188.13s)
=== CONT  TestAccAWSRDSCluster_BacktrackWindow
--- PASS: TestAccAWSRDSCluster_updateIamRoles (212.95s)
=== CONT  TestAccAWSRDSCluster_AvailabilityZones
--- PASS: TestAccAWSRDSCluster_kmsKey (219.72s)
=== CONT  TestAccAWSRDSCluster_EngineMode_Global
--- PASS: TestAccAWSRDSCluster_copyTagsToSnapshot (226.01s)
=== CONT  TestAccAWSRDSCluster_ScalingConfiguration
--- PASS: TestAccAWSRDSCluster_Tags (230.99s)
=== CONT  TestAccAWSRDSCluster_EngineMode_Multimaster
--- PASS: TestAccAWSRDSCluster_ClusterIdentifierPrefix (135.16s)
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Provisioned
--- PASS: TestAccAWSRDSCluster_generatedName (211.08s)
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Different
--- PASS: TestAccAWSRDSCluster_AvailabilityZones (127.64s)
=== CONT  TestAccAWSRDSCluster_GlobalClusterIdentifier_Add
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EncryptedRestore (348.03s)
=== CONT  TestAccAWSRDSCluster_GlobalClusterIdentifier
--- PASS: TestAccAWSRDSCluster_EngineMode_Global (128.39s)
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_ParallelQuery
--- PASS: TestAccAWSRDSCluster_BacktrackWindow (174.68s)
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_DeletionProtection
--- PASS: TestAccAWSRDSCluster_EnabledCloudwatchLogsExports (373.67s)
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_PreferredMaintenanceWindow (387.11s)
=== CONT  TestAccAWSRDSCluster_Port
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_Tags (388.24s)
=== CONT  TestAccAWSRDSCluster_GlobalClusterIdentifier_Update
--- PASS: TestAccAWSRDSCluster_EngineMode_Multimaster (157.26s)
=== CONT  TestAccAWSRDSCluster_GlobalClusterIdentifier_Remove
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds_Tags (406.24s)
=== CONT  TestAccAWSRDSCluster_EngineMode
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds (461.04s)
=== CONT  TestAccAWSRDSCluster_DeletionProtection
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_PreferredBackupWindow (356.82s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_MasterPassword (365.10s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_MasterUsername (397.45s)
--- PASS: TestAccAWSRDSCluster_ScalingConfiguration (327.87s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Equal (398.50s)
--- PASS: TestAccAWSRDSCluster_Port (260.75s)
--- PASS: TestAccAWSRDSCluster_DeletionProtection (197.22s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Provisioned (379.51s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier (354.42s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_ParallelQuery (386.52s)
--- FAIL: TestAccAWSRDSCluster_EngineMode (343.51s)
    testing.go:569: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        ...
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Different (419.81s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_DeletionProtection (412.31s)
--- PASS: TestAccAWSRDSCluster_EngineVersionWithPrimaryInstance (1150.84s)
--- FAIL: TestAccAWSRDSCluster_s3Restore (1457.87s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error waiting for RDS Cluster state to be "available": unexpected state 'migration-failed', wanted target 'available'. last error: %!s(<nil>)
        
          on /var/folders/pd/swwl85ks1nvbfy2pht84q2m40000gq/T/tf-test823076002/main.tf line 72:
          (source code not available)
        
        
--- PASS: TestAccAWSRDSCluster_EncryptedCrossRegionReplication (1642.29s)
--- FAIL: TestAccAWSRDSCluster_GlobalClusterIdentifier (2320.03s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: error creating RDS Global Cluster: InternalFailure: An internal error has occurred. Please try your query again at a later time.
                status code: 500, request id: 92e21452-88b4-48a1-83ba-9f0d0ca306a5
        
          on /var/folders/pd/swwl85ks1nvbfy2pht84q2m40000gq/T/tf-test510079212/main.tf line 2:
          (source code not available)
        
        
--- FAIL: TestAccAWSRDSCluster_GlobalClusterIdentifier_Add (2554.67s)
    testing.go:562: Step 2, expected error:
        
        errors during apply: error creating RDS Global Cluster: InternalFailure: An internal error has occurred. Please try your query again at a later time.
                status code: 500, request id: a4bb77da-283d-4147-b0b5-f1d60e8db2c3
        
        To match:
        
        Existing RDS Clusters cannot be added to an existing RDS Global Cluster
        
        
--- FAIL: TestAccAWSRDSCluster_GlobalClusterIdentifier_Update (2600.94s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: error creating RDS Global Cluster: InternalFailure: An internal error has occurred. Please try your query again at a later time.
                status code: 500, request id: f8d3b4e9-b83a-4f24-a439-18a3d6142f25
        
          on /var/folders/pd/swwl85ks1nvbfy2pht84q2m40000gq/T/tf-test005863526/main.tf line 2:
          (source code not available)
        
        
        
        Error: error creating RDS Global Cluster: InternalFailure: An internal error has occurred. Please try your query again at a later time.
                status code: 500, request id: d7f6d768-a7a3-4b6a-bc4e-8e85d7d124a2
        
          on /var/folders/pd/swwl85ks1nvbfy2pht84q2m40000gq/T/tf-test005863526/main.tf line 2:
          (source code not available)
        
        
--- FAIL: TestAccAWSRDSCluster_GlobalClusterIdentifier_Remove (2672.95s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: error creating RDS Global Cluster: InternalFailure: An internal error has occurred. Please try your query again at a later time.
                status code: 500, request id: 59cd3f19-e765-4e8a-bf86-3ec5d391fe10
        
          on /var/folders/pd/swwl85ks1nvbfy2pht84q2m40000gq/T/tf-test833822861/main.tf line 2:
          (source code not available)
        
        
FAIL
FAIL    github.com/terraform-providers/terraform-provider-aws/aws       3062.089s
make: *** [testacc] Error 1

make testacc TESTARGS="-run=TestAccAWSDBClusterParameterGroup"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSDBClusterParameterGroup -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSDBClusterParameterGroup_basic
=== PAUSE TestAccAWSDBClusterParameterGroup_basic
=== RUN   TestAccAWSDBClusterParameterGroup_withApplyMethod
=== PAUSE TestAccAWSDBClusterParameterGroup_withApplyMethod
=== RUN   TestAccAWSDBClusterParameterGroup_namePrefix
=== PAUSE TestAccAWSDBClusterParameterGroup_namePrefix
=== RUN   TestAccAWSDBClusterParameterGroup_namePrefix_Parameter
=== PAUSE TestAccAWSDBClusterParameterGroup_namePrefix_Parameter
=== RUN   TestAccAWSDBClusterParameterGroup_generatedName
=== PAUSE TestAccAWSDBClusterParameterGroup_generatedName
=== RUN   TestAccAWSDBClusterParameterGroup_generatedName_Parameter
=== PAUSE TestAccAWSDBClusterParameterGroup_generatedName_Parameter
=== RUN   TestAccAWSDBClusterParameterGroup_disappears
=== PAUSE TestAccAWSDBClusterParameterGroup_disappears
=== RUN   TestAccAWSDBClusterParameterGroup_only
=== PAUSE TestAccAWSDBClusterParameterGroup_only
=== CONT  TestAccAWSDBClusterParameterGroup_basic
=== CONT  TestAccAWSDBClusterParameterGroup_only
=== CONT  TestAccAWSDBClusterParameterGroup_withApplyMethod
=== CONT  TestAccAWSDBClusterParameterGroup_generatedName
=== CONT  TestAccAWSDBClusterParameterGroup_disappears
=== CONT  TestAccAWSDBClusterParameterGroup_namePrefix_Parameter
=== CONT  TestAccAWSDBClusterParameterGroup_namePrefix
=== CONT  TestAccAWSDBClusterParameterGroup_generatedName_Parameter
--- PASS: TestAccAWSDBClusterParameterGroup_disappears (24.23s)
--- PASS: TestAccAWSDBClusterParameterGroup_namePrefix (32.67s)
--- PASS: TestAccAWSDBClusterParameterGroup_generatedName (32.70s)
--- PASS: TestAccAWSDBClusterParameterGroup_only (32.70s)
--- PASS: TestAccAWSDBClusterParameterGroup_generatedName_Parameter (33.54s)
--- PASS: TestAccAWSDBClusterParameterGroup_namePrefix_Parameter (33.60s)
--- PASS: TestAccAWSDBClusterParameterGroup_withApplyMethod (33.93s)
--- PASS: TestAccAWSDBClusterParameterGroup_basic (56.09s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       57.644s
```
