### PR TITLE
resource/aws_cloudfront_distribution: Fix `active_trusted_signers` attribute for Terraform 0.12

### DIFF
--- a/aws/cloudfront_distribution_configuration_structure.go
+++ b/aws/cloudfront_distribution_configuration_structure.go
@@ -1103,7 +1103,7 @@ func flattenCloudfrontActiveTrustedSigners(ats *cloudfront.ActiveTrustedSigners)
 
 	m := map[string]interface{}{
 		"enabled": aws.BoolValue(ats.Enabled),
-		"items":  flattenCloudfrontSigners(ats.Items),
+		"items":   flattenCloudfrontSigners(ats.Items),
 	}
 
 	return []interface{}{m}

--- a/aws/cloudfront_distribution_configuration_structure.go
+++ b/aws/cloudfront_distribution_configuration_structure.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
-	"github.com/hashicorp/terraform/flatmap"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -1097,20 +1096,30 @@ func flattenViewerCertificate(vc *cloudfront.ViewerCertificate) []interface{} {
 	return []interface{}{m}
 }
 
-// Convert *cloudfront.ActiveTrustedSigners to a flatmap.Map type, which ensures
-// it can probably be inserted into the schema.TypeMap type used by the
-// active_trusted_signers attribute.
-func flattenActiveTrustedSigners(ats *cloudfront.ActiveTrustedSigners) flatmap.Map {
-	m := make(map[string]interface{})
-	s := []interface{}{}
-	m["enabled"] = *ats.Enabled
-
-	for _, v := range ats.Items {
-		signer := make(map[string]interface{})
-		signer["aws_account_number"] = *v.AwsAccountNumber
-		signer["key_pair_ids"] = aws.StringValueSlice(v.KeyPairIds.Items)
-		s = append(s, signer)
+func flattenCloudfrontActiveTrustedSigners(ats *cloudfront.ActiveTrustedSigners) []interface{} {
+	if ats == nil {
+		return []interface{}{}
 	}
-	m["items"] = s
-	return flatmap.Flatten(m)
+
+	m := map[string]interface{}{
+		"enabled": aws.BoolValue(ats.Enabled),
+		"items":  flattenCloudfrontSigners(ats.Items),
+	}
+
+	return []interface{}{m}
+}
+
+func flattenCloudfrontSigners(signers []*cloudfront.Signer) []interface{} {
+	result := make([]interface{}, 0, len(signers))
+
+	for _, signer := range signers {
+		m := map[string]interface{}{
+			"aws_account_number": aws.StringValue(signer.AwsAccountNumber),
+			"key_pair_ids":       aws.StringValueSlice(signer.KeyPairIds.Items),
+		}
+
+		result = append(result, m)
+	}
+
+	return result
 }

--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -697,7 +697,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 			"active_trusted_signers": {
 				Type:     schema.TypeList,
 				Computed: true,
-				Elem:     &schema.Resource{
+				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enabled": {
 							Type:     schema.TypeBool,
@@ -706,7 +706,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 						"items": {
 							Type:     schema.TypeList,
 							Computed: true,
-							Elem:     &schema.Resource{
+							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"aws_account_number": {
 										Type:     schema.TypeString,

--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -695,8 +695,33 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 				Computed: true,
 			},
 			"active_trusted_signers": {
-				Type:     schema.TypeMap,
+				Type:     schema.TypeList,
 				Computed: true,
+				Elem:     &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"items": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"aws_account_number": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"key_pair_ids": {
+										Type:     schema.TypeSet,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 			"domain_name": {
 				Type:     schema.TypeString,
@@ -815,10 +840,11 @@ func resourceAwsCloudFrontDistributionRead(d *schema.ResourceData, meta interfac
 		return err
 	}
 	// Update other attributes outside of DistributionConfig
-	err = d.Set("active_trusted_signers", flattenActiveTrustedSigners(resp.Distribution.ActiveTrustedSigners))
-	if err != nil {
-		return err
+
+	if d.Set("active_trusted_signers", flattenCloudfrontActiveTrustedSigners(resp.Distribution.ActiveTrustedSigners)); err != nil {
+		return fmt.Errorf("error setting active_trusted_signers: %s", err)
 	}
+
 	d.Set("status", resp.Distribution.Status)
 	d.Set("domain_name", resp.Distribution.DomainName)
 	d.Set("last_modified_time", aws.String(resp.Distribution.LastModifiedTime.String()))

--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -841,7 +841,7 @@ func resourceAwsCloudFrontDistributionRead(d *schema.ResourceData, meta interfac
 	}
 	// Update other attributes outside of DistributionConfig
 
-	if d.Set("active_trusted_signers", flattenCloudfrontActiveTrustedSigners(resp.Distribution.ActiveTrustedSigners)); err != nil {
+	if err := d.Set("active_trusted_signers", flattenCloudfrontActiveTrustedSigners(resp.Distribution.ActiveTrustedSigners)); err != nil {
 		return fmt.Errorf("error setting active_trusted_signers: %s", err)
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -441,7 +441,6 @@ github.com/hashicorp/hil/scanner
 github.com/hashicorp/logutils
 # github.com/hashicorp/terraform v0.12.7
 github.com/hashicorp/terraform/plugin
-github.com/hashicorp/terraform/flatmap
 github.com/hashicorp/terraform/helper/customdiff
 github.com/hashicorp/terraform/helper/encryption
 github.com/hashicorp/terraform/helper/hashcode
@@ -460,11 +459,11 @@ github.com/hashicorp/terraform/plugin/discovery
 github.com/hashicorp/terraform/providers
 github.com/hashicorp/terraform/provisioners
 github.com/hashicorp/terraform/version
-github.com/hashicorp/terraform/configs/hcl2shim
 github.com/hashicorp/terraform/addrs
 github.com/hashicorp/terraform/command/format
 github.com/hashicorp/terraform/configs
 github.com/hashicorp/terraform/configs/configload
+github.com/hashicorp/terraform/configs/hcl2shim
 github.com/hashicorp/terraform/helper/config
 github.com/hashicorp/terraform/internal/initwd
 github.com/hashicorp/terraform/plans
@@ -484,6 +483,7 @@ github.com/hashicorp/terraform/registry/regsrc
 github.com/hashicorp/terraform/registry/response
 github.com/hashicorp/terraform/svchost/disco
 github.com/hashicorp/terraform/internal/modsdir
+github.com/hashicorp/terraform/flatmap
 github.com/hashicorp/terraform/internal/earlyconfig
 github.com/hashicorp/terraform/helper/hilmapstructure
 github.com/hashicorp/terraform/lang/blocktoattr

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -527,11 +527,11 @@ In addition to all arguments above, the following attributes are exported:
     distribution's information is fully propagated throughout the Amazon
     CloudFront system.
 
-  * `active_trusted_signers` - Nested attributes of trusted signers that CloudFront is aware, if the distribution is set up to serve private content with signed URLs.
-    * `enabled` - Enabled is `true` if any of the AWS accounts listed as trusted signers have active CloudFront key pairs.
-    * `items` - Nested attributes of each trusted signer.
+  * `active_trusted_signers` - Nested attributes of active trusted signers, if the distribution is set up to serve private content with signed URLs
+    * `enabled` - `true` if any of the AWS accounts listed as trusted signers have active CloudFront key pairs
+    * `items` - Nested attributes of each trusted signer
       * `aws_account_number` - AWS account ID or `self`
-      * `key_pair_ids` - Set of active CloudFront key pairs associated with the signer account.
+      * `key_pair_ids` - Set of active CloudFront key pairs associated with the signer account
 
   * `domain_name` - The domain name corresponding to the distribution. For
     example: `d604721fxaaqy9.cloudfront.net`.

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -307,8 +307,7 @@ of several sub-resources - these resources are laid out below.
     CloudFront to route requests to when a request matches the path pattern
     either for a cache behavior or for the default cache behavior.
 
-  * `trusted_signers` (Optional) - The AWS accounts, if any, that you want to
-    allow to create signed URLs for private content.
+  * `trusted_signers` (Optional) - List of AWS account IDs (or `self`) that you want to allow to create signed URLs for private content. See the [CloudFront User Guide]() for more information about this feature.
 
   * `viewer_protocol_policy` (Required) - Use this element to specify the
     protocol that users can use to access the files in the origin specified by
@@ -528,9 +527,11 @@ In addition to all arguments above, the following attributes are exported:
     distribution's information is fully propagated throughout the Amazon
     CloudFront system.
 
-  * `active_trusted_signers` - The key pair IDs that CloudFront is aware of for
-    each trusted signer, if the distribution is set up to serve private content
-    with signed URLs.
+  * `active_trusted_signers` - Nested attributes of trusted signers that CloudFront is aware, if the distribution is set up to serve private content with signed URLs.
+    * `enabled` - Enabled is `true` if any of the AWS accounts listed as trusted signers have active CloudFront key pairs.
+    * `items` - Nested attributes of each trusted signer.
+      * `aws_account_number` - AWS account ID or `self`
+      * `key_pair_ids` - Set of active CloudFront key pairs associated with the signer account.
 
   * `domain_name` - The domain name corresponding to the distribution. For
     example: `d604721fxaaqy9.cloudfront.net`.


### PR DESCRIPTION


<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #8902

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_cloudfront_distribution: Support accessing `active_trusted_signers` attribute `items` in Terraform 0.12
```

This attribute implemented a legacy Terraform library (`flatmap`), which does not work with Terraform 0.12's data types and whose only usage was on this single attribute. This was missed during the Terraform 0.12 upgrade since there were no covering acceptance tests and the CloudFront setup itself is fairly esoteric (requires root AWS account login to manage CloudFront Keys).

The attribute now correctly implements (in the closest approximation) the standard Terraform Provider SDK types and methodology for saved nested object data to the Terraform state. The `items` subattribute list is now accessible again in Terraform 0.12. It does, however, unavoidably switch the root `active_trusted_signers` attribute to `TypeList` instead of `TypeMap` (which does not support map elements of different types in the current Terraform Provider SDK), so any potential references to nested attributes will need to be changed in user configurations, e.g.

Previously:

```
aws_cloudfront_distribution.example.active_trusted_signers.enabled
```

Now:

```
aws_cloudfront_distribution.example.active_trusted_signers.0.enabled
```

Output from acceptance testing:

```
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_TrustedSigners (611.33s)
```
