### PR TITLE
provider: Implement replacement functions for tls_private_key and tls_self_signed_certificate test configuration resources

### DIFF
--- a/aws/data_source_aws_acm_certificate_test.go
+++ b/aws/data_source_aws_acm_certificate_test.go
@@ -180,13 +180,15 @@ func TestAccAWSAcmCertificateDataSource_noMatchReturnsError(t *testing.T) {
 func TestAccAWSAcmCertificateDataSource_KeyTypes(t *testing.T) {
 	resourceName := "aws_acm_certificate.test"
 	dataSourceName := "data.aws_acm_certificate.test"
+	key := tlsRsaPrivateKeyPem(4096)
+	certificate := tlsRsaX509SelfSignedCertificatePem(key, "example.com")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProvidersWithTLS,
+		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsAcmCertificateDataSourceConfigKeyTypes(),
+				Config: testAccAwsAcmCertificateDataSourceConfigKeyTypes(tlsPemEscapeNewlines(certificate), tlsPemEscapeNewlines(key)),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
 				),
@@ -250,38 +252,16 @@ data "aws_acm_certificate" "test" {
 `, domain, certType, mostRecent)
 }
 
-func testAccAwsAcmCertificateDataSourceConfigKeyTypes() string {
+func testAccAwsAcmCertificateDataSourceConfigKeyTypes(certificate, key string) string {
 	return fmt.Sprintf(`
-resource "tls_private_key" "test" {
-  algorithm = "RSA"
-  rsa_bits  = 4096
-}
-
-resource "tls_self_signed_cert" "test" {
-  allowed_uses = [
-    "key_encipherment",
-    "digital_signature",
-    "server_auth",
-  ]
-
-  key_algorithm         = "RSA"
-  private_key_pem       = "${tls_private_key.test.private_key_pem}"
-  validity_period_hours = 12
-
-  subject {
-    common_name  = "example.com"
-    organization = "ACME Examples, Inc"
-  }
-}
-
 resource "aws_acm_certificate" "test" {
-  certificate_body = "${tls_self_signed_cert.test.cert_pem}"
-  private_key      = "${tls_private_key.test.private_key_pem}"
+  certificate_body = "%[1]s"
+  private_key      = "%[2]s"
 }
 
 data "aws_acm_certificate" "test" {
   domain    = "${aws_acm_certificate.test.domain_name}"
   key_types = ["RSA_4096"]
 }
-`)
+`, certificate, key)
 }

--- a/aws/tls.go
+++ b/aws/tls.go
@@ -12,15 +12,15 @@ import (
 )
 
 const (
-	pemBlockTypeCertificate = `CERTIFICATE`
+	pemBlockTypeCertificate   = `CERTIFICATE`
 	pemBlockTypeRsaPrivateKey = `RSA PRIVATE KEY`
 )
 
 var tlsX509CertificateSerialNumberLimit = new(big.Int).Lsh(big.NewInt(1), 128)
 
 // tlsRsaPrivateKeyPem generates a RSA private key PEM string.
-// To allow simple fmt.Sprintf() configurations such as: private_key_pem = %[1]q
-// Escape the result with strings.ReplaceAll(key, "\n", "\\n")
+// Wrap with tlsPemEscapeNewlines() to allow simple fmt.Sprintf()
+// configurations such as: private_key_pem = "%[1]s"
 func tlsRsaPrivateKeyPem(bits int) string {
 	key, err := rsa.GenerateKey(rand.Reader, bits)
 
@@ -37,8 +37,8 @@ func tlsRsaPrivateKeyPem(bits int) string {
 }
 
 // tlsRsaX509SelfSignedCertificatePem generates a x509 certificate PEM string.
-// To allow simple fmt.Sprintf() configurations such as: certificate_pem = %[1]q
-// Escape the result with strings.ReplaceAll(certificate, "\n", "\\n")
+// Wrap with tlsPemEscapeNewlines() to allow simple fmt.Sprintf()
+// configurations such as: private_key_pem = "%[1]s"
 func tlsRsaX509SelfSignedCertificatePem(keyPem, commonName string) string {
 	keyBlock, _ := pem.Decode([]byte(keyPem))
 

--- a/aws/tls.go
+++ b/aws/tls.go
@@ -1,0 +1,86 @@
+package aws
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"strings"
+	"time"
+)
+
+const (
+	pemBlockTypeCertificate = `CERTIFICATE`
+	pemBlockTypeRsaPrivateKey = `RSA PRIVATE KEY`
+)
+
+var tlsX509CertificateSerialNumberLimit = new(big.Int).Lsh(big.NewInt(1), 128)
+
+// tlsRsaPrivateKeyPem generates a RSA private key PEM string.
+// To allow simple fmt.Sprintf() configurations such as: private_key_pem = %[1]q
+// Escape the result with strings.ReplaceAll(key, "\n", "\\n")
+func tlsRsaPrivateKeyPem(bits int) string {
+	key, err := rsa.GenerateKey(rand.Reader, bits)
+
+	if err != nil {
+		panic(err)
+	}
+
+	block := &pem.Block{
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+		Type:  pemBlockTypeRsaPrivateKey,
+	}
+
+	return string(pem.EncodeToMemory(block))
+}
+
+// tlsRsaX509SelfSignedCertificatePem generates a x509 certificate PEM string.
+// To allow simple fmt.Sprintf() configurations such as: certificate_pem = %[1]q
+// Escape the result with strings.ReplaceAll(certificate, "\n", "\\n")
+func tlsRsaX509SelfSignedCertificatePem(keyPem, commonName string) string {
+	keyBlock, _ := pem.Decode([]byte(keyPem))
+
+	key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+
+	if err != nil {
+		panic(err)
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, tlsX509CertificateSerialNumberLimit)
+
+	if err != nil {
+		panic(err)
+	}
+
+	certificate := &x509.Certificate{
+		BasicConstraintsValid: true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		NotBefore:             time.Now(),
+		SerialNumber:          serialNumber,
+		Subject: pkix.Name{
+			CommonName:   commonName,
+			Organization: []string{"ACME Examples, Inc"},
+		},
+	}
+
+	certificateBytes, err := x509.CreateCertificate(rand.Reader, certificate, certificate, &key.PublicKey, key)
+
+	if err != nil {
+		panic(err)
+	}
+
+	certificateBlock := &pem.Block{
+		Bytes: certificateBytes,
+		Type:  pemBlockTypeCertificate,
+	}
+
+	return string(pem.EncodeToMemory(certificateBlock))
+}
+
+func tlsPemEscapeNewlines(pem string) string {
+	return strings.ReplaceAll(pem, "\n", "\\n")
+}

--- a/aws/tls_test.go
+++ b/aws/tls_test.go
@@ -1,0 +1,23 @@
+package aws
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTlsRsaPrivateKeyPem(t *testing.T) {
+	key := tlsRsaPrivateKeyPem(2048)
+
+	if !strings.Contains(key, pemBlockTypeRsaPrivateKey) {
+		t.Errorf("key does not contain RSA PRIVATE KEY: %s", key)
+	}
+}
+
+func TestTlsRsaX509CertificatePem(t *testing.T) {
+	key := tlsRsaPrivateKeyPem(2048)
+	certificate := tlsRsaX509SelfSignedCertificatePem(key, "example.com")
+
+	if !strings.Contains(certificate, pemBlockTypeCertificate) {
+		t.Errorf("key does not contain CERTIFICATE: %s", certificate)
+	}
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10023

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
--- PASS: TestAccAWSAcmCertificateDataSource_KeyTypes (18.45s)
```
