### PR TITLE
Acceptance import test refactor for lambda

### DIFF
--- a/aws/resource_aws_lambda_event_source_mapping_test.go
+++ b/aws/resource_aws_lambda_event_source_mapping_test.go
@@ -42,6 +42,12 @@ func TestAccAWSLambdaEventSourceMapping_kinesis_basic(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"enabled", "starting_position"},
+			},
+			{
 				Config: testAccAWSLambdaEventSourceMappingConfigUpdate_kinesis(roleName, policyName, attName, streamName, funcName, uFuncName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaEventSourceMappingExists(resourceName, &conf),
@@ -85,6 +91,12 @@ func TestAccAWSLambdaEventSourceMapping_kinesis_removeBatchSize(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"enabled", "starting_position"},
+			},
+			{
 				Config: testAccAWSLambdaEventSourceMappingConfigUpdate_kinesis_removeBatchSize(roleName, policyName, attName, streamName, funcName, uFuncName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaEventSourceMappingExists(resourceName, &conf),
@@ -124,6 +136,12 @@ func TestAccAWSLambdaEventSourceMapping_sqs_basic(t *testing.T) {
 					resource.TestCheckNoResourceAttr(resourceName,
 						"starting_position"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"enabled", "starting_position"},
 			},
 			{
 				Config: testAccAWSLambdaEventSourceMappingConfigUpdate_sqs(roleName, policyName, attName, streamName, funcName, uFuncName),
@@ -167,30 +185,6 @@ func TestAccAWSLambdaEventSourceMapping_sqs_withFunctionName(t *testing.T) {
 					resource.TestCheckNoResourceAttr(resourceName, "starting_position"),
 				),
 			},
-		},
-	})
-}
-
-func TestAccAWSLambdaEventSourceMapping_kinesis_import(t *testing.T) {
-	resourceName := "aws_lambda_event_source_mapping.lambda_event_source_mapping_test"
-
-	rString := acctest.RandString(8)
-	roleName := fmt.Sprintf("tf_acc_role_lambda_esm_import_%s", rString)
-	policyName := fmt.Sprintf("tf_acc_policy_lambda_esm_import_%s", rString)
-	attName := fmt.Sprintf("tf_acc_att_lambda_esm_import_%s", rString)
-	streamName := fmt.Sprintf("tf_acc_stream_lambda_esm_import_%s", rString)
-	funcName := fmt.Sprintf("tf_acc_lambda_esm_import_%s", rString)
-	uFuncName := fmt.Sprintf("tf_acc_lambda_esm_import_updated_%s", rString)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLambdaEventSourceMappingDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSLambdaEventSourceMappingConfig_kinesis(roleName, policyName, attName, streamName, funcName, uFuncName),
-			},
-
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,

--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -61,92 +61,9 @@ func testSweepLambdaFunctions(region string) error {
 	return nil
 }
 
-func TestAccAWSLambdaFunction_importLocalFile(t *testing.T) {
-	resourceName := "aws_lambda_function.lambda_function_test"
-
-	rString := acctest.RandString(8)
-	funcName := fmt.Sprintf("tf_acc_lambda_func_import_local_%s", rString)
-	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_import_local_%s", rString)
-	roleName := fmt.Sprintf("tf_acc_role_lambda_func_import_local_%s", rString)
-	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_import_local_%s", rString)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLambdaFunctionDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSLambdaConfigBasic(funcName, policyName, roleName, sgName),
-			},
-
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"filename", "publish"},
-			},
-		},
-	})
-}
-
-func TestAccAWSLambdaFunction_importLocalFile_VPC(t *testing.T) {
-	resourceName := "aws_lambda_function.lambda_function_test"
-
-	rString := acctest.RandString(8)
-	funcName := fmt.Sprintf("tf_acc_lambda_func_import_vpc_%s", rString)
-	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_import_vpc_%s", rString)
-	roleName := fmt.Sprintf("tf_acc_role_lambda_func_import_vpc_%s", rString)
-	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_import_vpc_%s", rString)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLambdaFunctionDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSLambdaConfigWithVPC(funcName, policyName, roleName, sgName),
-			},
-
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"filename", "publish"},
-			},
-		},
-	})
-}
-
-func TestAccAWSLambdaFunction_importS3(t *testing.T) {
-	resourceName := "aws_lambda_function.lambda_function_s3test"
-
-	rString := acctest.RandString(8)
-	bucketName := fmt.Sprintf("tf-acc-bucket-lambda-func-import-s3-%s", rString)
-	roleName := fmt.Sprintf("tf_acc_role_lambda_func_import_s3_%s", rString)
-	funcName := fmt.Sprintf("tf_acc_lambda_func_import_s3_%s", rString)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLambdaFunctionDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSLambdaConfigS3(bucketName, roleName, funcName),
-			},
-
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"s3_bucket", "s3_key", "publish"},
-			},
-		},
-	})
-}
-
 func TestAccAWSLambdaFunction_basic(t *testing.T) {
 	var conf lambda.GetFunctionOutput
-	resourceName := "aws_lambda_function.lambda_function_test"
+	resourceName := "aws_lambda_function.test"
 
 	rString := acctest.RandString(8)
 	funcName := fmt.Sprintf("tf_acc_lambda_func_basic_%s", rString)
@@ -169,6 +86,12 @@ func TestAccAWSLambdaFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "reserved_concurrent_executions", "-1"),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
+			},
 		},
 	})
 }
@@ -181,6 +104,7 @@ func TestAccAWSLambdaFunction_concurrency(t *testing.T) {
 	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_concurrency_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_concurrency_%s", rString)
 	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_concurrency_%s", rString)
+	resourceName := "aws_lambda_function.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -190,19 +114,25 @@ func TestAccAWSLambdaFunction_concurrency(t *testing.T) {
 			{
 				Config: testAccAWSLambdaConfigBasicConcurrency(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "reserved_concurrent_executions", "111"),
+					resource.TestCheckResourceAttr(resourceName, "reserved_concurrent_executions", "111"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
 			},
 			{
 				Config: testAccAWSLambdaConfigConcurrencyUpdate(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "reserved_concurrent_executions", "222"),
+					resource.TestCheckResourceAttr(resourceName, "reserved_concurrent_executions", "222"),
 				),
 			},
 		},
@@ -217,6 +147,7 @@ func TestAccAWSLambdaFunction_concurrencyCycle(t *testing.T) {
 	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_concurrency_cycle_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_concurrency_cycle_%s", rString)
 	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_concurrency_cycle_%s", rString)
+	resourceName := "aws_lambda_function.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -226,28 +157,34 @@ func TestAccAWSLambdaFunction_concurrencyCycle(t *testing.T) {
 			{
 				Config: testAccAWSLambdaConfigBasic(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "reserved_concurrent_executions", "-1"),
+					resource.TestCheckResourceAttr(resourceName, "reserved_concurrent_executions", "-1"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
 			},
 			{
 				Config: testAccAWSLambdaConfigConcurrencyUpdate(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "reserved_concurrent_executions", "222"),
+					resource.TestCheckResourceAttr(resourceName, "reserved_concurrent_executions", "222"),
 				),
 			},
 			{
 				Config: testAccAWSLambdaConfigBasic(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "reserved_concurrent_executions", "-1"),
+					resource.TestCheckResourceAttr(resourceName, "reserved_concurrent_executions", "-1"),
 				),
 			},
 		},
@@ -262,6 +199,7 @@ func TestAccAWSLambdaFunction_updateRuntime(t *testing.T) {
 	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_update_runtime_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_update_runtime_%s", rString)
 	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_update_runtime_%s", rString)
+	resourceName := "aws_lambda_function.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -271,15 +209,21 @@ func TestAccAWSLambdaFunction_updateRuntime(t *testing.T) {
 			{
 				Config: testAccAWSLambdaConfigBasic(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", "nodejs8.10"),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "runtime", "nodejs8.10"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
 			},
 			{
 				Config: testAccAWSLambdaConfigBasicUpdateRuntime(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", "nodejs10.x"),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "runtime", "nodejs10.x"),
 				),
 			},
 		},
@@ -314,6 +258,7 @@ func TestAccAWSLambdaFunction_envVariables(t *testing.T) {
 	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_env_vars_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_env_vars_%s", rString)
 	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_env_vars_%s", rString)
+	resourceName := "aws_lambda_function.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -323,38 +268,44 @@ func TestAccAWSLambdaFunction_envVariables(t *testing.T) {
 			{
 				Config: testAccAWSLambdaConfigBasic(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
-					resource.TestCheckNoResourceAttr("aws_lambda_function.lambda_function_test", "environment"),
+					resource.TestCheckNoResourceAttr(resourceName, "environment"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
 			},
 			{
 				Config: testAccAWSLambdaConfigEnvVariables(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "environment.0.variables.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "environment.0.variables.foo", "bar"),
 				),
 			},
 			{
 				Config: testAccAWSLambdaConfigEnvVariablesModified(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "environment.0.variables.foo", "baz"),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "environment.0.variables.foo1", "bar1"),
+					resource.TestCheckResourceAttr(resourceName, "environment.0.variables.foo", "baz"),
+					resource.TestCheckResourceAttr(resourceName, "environment.0.variables.foo1", "bar1"),
 				),
 			},
 			{
 				Config: testAccAWSLambdaConfigEnvVariablesModifiedWithoutEnvironment(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
-					resource.TestCheckNoResourceAttr("aws_lambda_function.lambda_function_test", "environment"),
+					resource.TestCheckNoResourceAttr(resourceName, "environment"),
 				),
 			},
 		},
@@ -371,6 +322,7 @@ func TestAccAWSLambdaFunction_encryptedEnvVariables(t *testing.T) {
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_encrypted_env_%s", rString)
 	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_encrypted_env_%s", rString)
 	keyRegex := regexp.MustCompile(`^arn:aws[\w-]*:kms:`)
+	resourceName := "aws_lambda_function.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -380,21 +332,27 @@ func TestAccAWSLambdaFunction_encryptedEnvVariables(t *testing.T) {
 			{
 				Config: testAccAWSLambdaConfigEncryptedEnvVariables(keyDesc, funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "environment.0.variables.foo", "bar"),
-					resource.TestMatchResourceAttr("aws_lambda_function.lambda_function_test", "kms_key_arn", keyRegex),
+					resource.TestCheckResourceAttr(resourceName, "environment.0.variables.foo", "bar"),
+					resource.TestMatchResourceAttr(resourceName, "kms_key_arn", keyRegex),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
 			},
 			{
 				Config: testAccAWSLambdaConfigEncryptedEnvVariablesModified(keyDesc, funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "environment.0.variables.foo", "bar"),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "kms_key_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "environment.0.variables.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "kms_key_arn", ""),
 				),
 			},
 		},
@@ -409,6 +367,7 @@ func TestAccAWSLambdaFunction_versioned(t *testing.T) {
 	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_versioned_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_versioned_%s", rString)
 	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_versioned_%s", rString)
+	resourceName := "aws_lambda_function.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -418,14 +377,20 @@ func TestAccAWSLambdaFunction_versioned(t *testing.T) {
 			{
 				Config: testAccAWSLambdaConfigVersioned("test-fixtures/lambdatest.zip", funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
-					resource.TestMatchResourceAttr("aws_lambda_function.lambda_function_test", "version",
+					resource.TestMatchResourceAttr(resourceName, "version",
 						regexp.MustCompile("^[0-9]+$")),
-					resource.TestMatchResourceAttr("aws_lambda_function.lambda_function_test", "qualified_arn",
+					resource.TestMatchResourceAttr(resourceName, "qualified_arn",
 						regexp.MustCompile(":"+funcName+":[0-9]+$")),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
 			},
 		},
 	})
@@ -445,6 +410,7 @@ func TestAccAWSLambdaFunction_versionedUpdate(t *testing.T) {
 	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_versioned_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_versioned_%s", rString)
 	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_versioned_%s", rString)
+	resourceName := "aws_lambda_function.test"
 
 	var timeBeforeUpdate time.Time
 
@@ -465,17 +431,23 @@ func TestAccAWSLambdaFunction_versionedUpdate(t *testing.T) {
 				},
 				Config: testAccAWSLambdaConfigVersioned(path, funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
-					resource.TestMatchResourceAttr("aws_lambda_function.lambda_function_test", "version",
+					resource.TestMatchResourceAttr(resourceName, "version",
 						regexp.MustCompile("^2$")),
-					resource.TestMatchResourceAttr("aws_lambda_function.lambda_function_test", "qualified_arn",
-						regexp.MustCompile(fmt.Sprintf(":function:%s:2$", funcName))),
+					resource.TestMatchResourceAttr(resourceName, "qualified_arn",
+						regexp.MustCompile(":"+funcName+":[0-9]+$")),
 					func(s *terraform.State) error {
-						return testAccCheckAttributeIsDateAfter(s, "aws_lambda_function.lambda_function_test", "last_modified", timeBeforeUpdate)
+						return testAccCheckAttributeIsDateAfter(s, resourceName, "last_modified", timeBeforeUpdate)
 					},
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
 			},
 		},
 	})
@@ -490,6 +462,7 @@ func TestAccAWSLambdaFunction_DeadLetterConfig(t *testing.T) {
 	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_dlconfig_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_dlconfig_%s", rString)
 	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_dlconfig_%s", rString)
+	resourceName := "aws_lambda_function.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -499,7 +472,7 @@ func TestAccAWSLambdaFunction_DeadLetterConfig(t *testing.T) {
 			{
 				Config: testAccAWSLambdaConfigWithDeadLetterConfig(funcName, topicName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
 					func(s *terraform.State) error {
@@ -514,7 +487,7 @@ func TestAccAWSLambdaFunction_DeadLetterConfig(t *testing.T) {
 			},
 			// Ensure configuration can be imported
 			{
-				ResourceName:            "aws_lambda_function.lambda_function_test",
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"filename", "publish"},
@@ -523,7 +496,7 @@ func TestAccAWSLambdaFunction_DeadLetterConfig(t *testing.T) {
 			{
 				Config: testAccAWSLambdaConfigBasic(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 				),
 			},
 		},
@@ -541,6 +514,7 @@ func TestAccAWSLambdaFunction_DeadLetterConfigUpdated(t *testing.T) {
 	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_dlcfg_upd_%s", rString)
 	topic1Name := fmt.Sprintf("tf_acc_topic_lambda_func_dlcfg_upd_%s", rString)
 	topic2Name := fmt.Sprintf("tf_acc_topic_lambda_func_dlcfg_upd_2_%s", rString)
+	resourceName := "aws_lambda_function.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -553,7 +527,7 @@ func TestAccAWSLambdaFunction_DeadLetterConfigUpdated(t *testing.T) {
 			{
 				Config: testAccAWSLambdaConfigWithDeadLetterConfigUpdated(funcName, topic1Name, topic2Name, policyName, roleName, sgName, uFuncName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					func(s *terraform.State) error {
 						if !strings.HasSuffix(*conf.Configuration.DeadLetterConfig.TargetArn, ":"+topic2Name) {
 							return fmt.Errorf(
@@ -563,6 +537,12 @@ func TestAccAWSLambdaFunction_DeadLetterConfigUpdated(t *testing.T) {
 						return nil
 					},
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
 			},
 		},
 	})
@@ -597,6 +577,7 @@ func TestAccAWSLambdaFunction_tracingConfig(t *testing.T) {
 	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_tracing_cfg_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_tracing_cfg_%s", rString)
 	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_tracing_cfg_%s", rString)
+	resourceName := "aws_lambda_function.test"
 
 	if testAccGetPartition() == "aws-us-gov" {
 		t.Skip("Lambda tracing config is not supported in GovCloud partition")
@@ -610,19 +591,25 @@ func TestAccAWSLambdaFunction_tracingConfig(t *testing.T) {
 			{
 				Config: testAccAWSLambdaConfigWithTracingConfig(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "tracing_config.0.mode", "Active"),
+					resource.TestCheckResourceAttr(resourceName, "tracing_config.0.mode", "Active"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
 			},
 			{
 				Config: testAccAWSLambdaConfigWithTracingConfigUpdated(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "tracing_config.0.mode", "PassThrough"),
+					resource.TestCheckResourceAttr(resourceName, "tracing_config.0.mode", "PassThrough"),
 				),
 			},
 		},
@@ -638,6 +625,7 @@ func TestAccAWSLambdaFunction_Layers(t *testing.T) {
 	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_layer_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_layer_%s", rString)
 	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_layer_%s", rString)
+	resourceName := "aws_lambda_function.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -647,12 +635,18 @@ func TestAccAWSLambdaFunction_Layers(t *testing.T) {
 			{
 				Config: testAccAWSLambdaConfigWithLayers(funcName, layerName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
 					testAccCheckAWSLambdaFunctionVersion(&conf, "$LATEST"),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "layers.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "layers.#", "1"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
 			},
 		},
 	})
@@ -668,6 +662,7 @@ func TestAccAWSLambdaFunction_LayersUpdate(t *testing.T) {
 	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_vpc_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_vpc_%s", rString)
 	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_vpc_%s", rString)
+	resourceName := "aws_lambda_function.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -677,21 +672,27 @@ func TestAccAWSLambdaFunction_LayersUpdate(t *testing.T) {
 			{
 				Config: testAccAWSLambdaConfigWithLayers(funcName, layerName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
 					testAccCheckAWSLambdaFunctionVersion(&conf, "$LATEST"),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "layers.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "layers.#", "1"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
 			},
 			{
 				Config: testAccAWSLambdaConfigWithLayersUpdated(funcName, layerName, layer2Name, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
 					testAccCheckAWSLambdaFunctionVersion(&conf, "$LATEST"),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "layers.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "layers.#", "2"),
 				),
 			},
 		},
@@ -706,6 +707,7 @@ func TestAccAWSLambdaFunction_VPC(t *testing.T) {
 	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_vpc_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_vpc_%s", rString)
 	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_vpc_%s", rString)
+	resourceName := "aws_lambda_function.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -715,15 +717,21 @@ func TestAccAWSLambdaFunction_VPC(t *testing.T) {
 			{
 				Config: testAccAWSLambdaConfigWithVPC(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
 					testAccCheckAWSLambdaFunctionVersion(&conf, "$LATEST"),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "vpc_config.#", "1"),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "vpc_config.0.subnet_ids.#", "1"),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "vpc_config.0.security_group_ids.#", "1"),
-					resource.TestMatchResourceAttr("aws_lambda_function.lambda_function_test", "vpc_config.0.vpc_id", regexp.MustCompile("^vpc-")),
+					resource.TestCheckResourceAttr(resourceName, "vpc_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_config.0.subnet_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_config.0.security_group_ids.#", "1"),
+					resource.TestMatchResourceAttr(resourceName, "vpc_config.0.vpc_id", regexp.MustCompile("^vpc-")),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
 			},
 		},
 	})
@@ -733,7 +741,7 @@ func TestAccAWSLambdaFunction_VPCRemoval(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_lambda_function.lambda_function_test"
+	resourceName := "aws_lambda_function.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -746,6 +754,12 @@ func TestAccAWSLambdaFunction_VPCRemoval(t *testing.T) {
 					testAccCheckAwsLambdaFunctionExists(resourceName, rName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "vpc_config.#", "1"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
 			},
 			{
 				Config: testAccAWSLambdaConfigBasic(rName, rName, rName, rName),
@@ -767,6 +781,7 @@ func TestAccAWSLambdaFunction_VPCUpdate(t *testing.T) {
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_vpc_upd_%s", rString)
 	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_vpc_upd_%s", rString)
 	sgName2 := fmt.Sprintf("tf_acc_sg_lambda_func_2nd_vpc_upd_%s", rString)
+	resourceName := "aws_lambda_function.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -776,25 +791,31 @@ func TestAccAWSLambdaFunction_VPCUpdate(t *testing.T) {
 			{
 				Config: testAccAWSLambdaConfigWithVPC(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
 					testAccCheckAWSLambdaFunctionVersion(&conf, "$LATEST"),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "vpc_config.#", "1"),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "vpc_config.0.subnet_ids.#", "1"),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "vpc_config.0.security_group_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_config.0.subnet_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_config.0.security_group_ids.#", "1"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
 			},
 			{
 				Config: testAccAWSLambdaConfigWithVPCUpdated(funcName, policyName, roleName, sgName, sgName2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
 					testAccCheckAWSLambdaFunctionVersion(&conf, "$LATEST"),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "vpc_config.#", "1"),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "vpc_config.0.subnet_ids.#", "2"),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "vpc_config.0.security_group_ids.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_config.0.subnet_ids.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_config.0.security_group_ids.#", "2"),
 				),
 			},
 		},
@@ -811,6 +832,7 @@ func TestAccAWSLambdaFunction_VPC_withInvocation(t *testing.T) {
 	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_vpc_w_invc_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_vpc_w_invc_%s", rString)
 	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_vpc_w_invc_%s", rString)
+	resourceName := "aws_lambda_function.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -820,9 +842,15 @@ func TestAccAWSLambdaFunction_VPC_withInvocation(t *testing.T) {
 			{
 				Config: testAccAWSLambdaConfigWithVPC(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccAwsInvokeLambdaFunction(&conf),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
 			},
 		},
 	})
@@ -863,6 +891,7 @@ func TestAccAWSLambdaFunction_EmptyVpcConfig(t *testing.T) {
 	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_empty_vpc_config_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_empty_vpc_config_%s", rString)
 	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_empty_vpc_config_%s", rString)
+	resourceName := "aws_lambda_function.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -872,9 +901,15 @@ func TestAccAWSLambdaFunction_EmptyVpcConfig(t *testing.T) {
 			{
 				Config: testAccAWSLambdaConfigWithEmptyVpcConfig(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.test", funcName, &conf),
-					resource.TestCheckResourceAttr("aws_lambda_function.test", "vpc_config.#", "0"),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "vpc_config.#", "0"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
 			},
 		},
 	})
@@ -887,6 +922,7 @@ func TestAccAWSLambdaFunction_s3(t *testing.T) {
 	bucketName := fmt.Sprintf("tf-acc-bucket-lambda-func-s3-%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_s3_%s", rString)
 	funcName := fmt.Sprintf("tf_acc_lambda_func_s3_%s", rString)
+	resourceName := "aws_lambda_function.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -896,11 +932,17 @@ func TestAccAWSLambdaFunction_s3(t *testing.T) {
 			{
 				Config: testAccAWSLambdaConfigS3(bucketName, roleName, funcName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_s3test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
 					testAccCheckAWSLambdaFunctionVersion(&conf, "$LATEST"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"s3_bucket", "s3_key", "publish"},
 			},
 		},
 	})
@@ -918,6 +960,7 @@ func TestAccAWSLambdaFunction_localUpdate(t *testing.T) {
 	rString := acctest.RandString(8)
 	funcName := fmt.Sprintf("tf_acc_lambda_func_local_upd_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_local_upd_%s", rString)
+	resourceName := "aws_lambda_function.test"
 
 	var timeBeforeUpdate time.Time
 
@@ -934,11 +977,17 @@ func TestAccAWSLambdaFunction_localUpdate(t *testing.T) {
 				},
 				Config: genAWSLambdaFunctionConfig_local(path, roleName, funcName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_local", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, funcName),
 					testAccCheckAwsLambdaSourceCodeHash(&conf, "8DPiX+G1l2LQ8hjBkwRchQFf1TSCEvPrYGRKlM9UoyY="),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
 			},
 			{
 				PreConfig: func() {
@@ -949,12 +998,12 @@ func TestAccAWSLambdaFunction_localUpdate(t *testing.T) {
 				},
 				Config: genAWSLambdaFunctionConfig_local(path, roleName, funcName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_local", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, funcName),
 					testAccCheckAwsLambdaSourceCodeHash(&conf, "0tdaP9H9hsk9c2CycSwOG/sa/x5JyAmSYunA/ce99Pg="),
 					func(s *terraform.State) error {
-						return testAccCheckAttributeIsDateAfter(s, "aws_lambda_function.lambda_function_local", "last_modified", timeBeforeUpdate)
+						return testAccCheckAttributeIsDateAfter(s, resourceName, "last_modified", timeBeforeUpdate)
 					},
 				),
 			},
@@ -968,6 +1017,7 @@ func TestAccAWSLambdaFunction_localUpdate_nameOnly(t *testing.T) {
 	rString := acctest.RandString(8)
 	funcName := fmt.Sprintf("tf_acc_lambda_func_local_upd_name_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_local_upd_name_%s", rString)
+	resourceName := "aws_lambda_function.test"
 
 	path, zipFile, err := createTempFile("lambda_localUpdate")
 	if err != nil {
@@ -994,11 +1044,17 @@ func TestAccAWSLambdaFunction_localUpdate_nameOnly(t *testing.T) {
 				},
 				Config: genAWSLambdaFunctionConfig_local_name_only(path, roleName, funcName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_local", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, funcName),
 					testAccCheckAwsLambdaSourceCodeHash(&conf, "8DPiX+G1l2LQ8hjBkwRchQFf1TSCEvPrYGRKlM9UoyY="),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
 			},
 			{
 				PreConfig: func() {
@@ -1008,7 +1064,7 @@ func TestAccAWSLambdaFunction_localUpdate_nameOnly(t *testing.T) {
 				},
 				Config: genAWSLambdaFunctionConfig_local_name_only(updatedPath, roleName, funcName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_local", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, funcName),
 					testAccCheckAwsLambdaSourceCodeHash(&conf, "0tdaP9H9hsk9c2CycSwOG/sa/x5JyAmSYunA/ce99Pg="),
@@ -1031,6 +1087,7 @@ func TestAccAWSLambdaFunction_s3Update_basic(t *testing.T) {
 	bucketName := fmt.Sprintf("tf-acc-bucket-lambda-func-s3-upd-basic-%s", rString)
 	funcName := fmt.Sprintf("tf_acc_lambda_func_s3_upd_basic_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_s3_upd_basic_%s", rString)
+	resourceName := "aws_lambda_function.test"
 
 	key := "lambda-func.zip"
 
@@ -1048,11 +1105,17 @@ func TestAccAWSLambdaFunction_s3Update_basic(t *testing.T) {
 				},
 				Config: genAWSLambdaFunctionConfig_s3(bucketName, key, path, roleName, funcName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_s3", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, funcName),
 					testAccCheckAwsLambdaSourceCodeHash(&conf, "8DPiX+G1l2LQ8hjBkwRchQFf1TSCEvPrYGRKlM9UoyY="),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish", "s3_bucket", "s3_key", "s3_object_version"},
 			},
 			{
 				PreConfig: func() {
@@ -1063,7 +1126,7 @@ func TestAccAWSLambdaFunction_s3Update_basic(t *testing.T) {
 				},
 				Config: genAWSLambdaFunctionConfig_s3(bucketName, key, path, roleName, funcName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_s3", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, funcName),
 					testAccCheckAwsLambdaSourceCodeHash(&conf, "0tdaP9H9hsk9c2CycSwOG/sa/x5JyAmSYunA/ce99Pg="),
@@ -1086,7 +1149,7 @@ func TestAccAWSLambdaFunction_s3Update_unversioned(t *testing.T) {
 	bucketName := fmt.Sprintf("tf-acc-bucket-lambda-func-s3-upd-unver-%s", rString)
 	funcName := fmt.Sprintf("tf_acc_lambda_func_s3_upd_unver_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_s3_upd_unver_%s", rString)
-
+	resourceName := "aws_lambda_function.test"
 	key := "lambda-func.zip"
 	key2 := "lambda-func-modified.zip"
 
@@ -1104,11 +1167,17 @@ func TestAccAWSLambdaFunction_s3Update_unversioned(t *testing.T) {
 				},
 				Config: testAccAWSLambdaFunctionConfig_s3_unversioned_tpl(bucketName, roleName, funcName, key, path),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_s3", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, funcName),
 					testAccCheckAwsLambdaSourceCodeHash(&conf, "8DPiX+G1l2LQ8hjBkwRchQFf1TSCEvPrYGRKlM9UoyY="),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish", "s3_bucket", "s3_key"},
 			},
 			{
 				PreConfig: func() {
@@ -1119,7 +1188,7 @@ func TestAccAWSLambdaFunction_s3Update_unversioned(t *testing.T) {
 				},
 				Config: testAccAWSLambdaFunctionConfig_s3_unversioned_tpl(bucketName, roleName, funcName, key2, path),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_s3", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, funcName),
 					testAccCheckAwsLambdaSourceCodeHash(&conf, "0tdaP9H9hsk9c2CycSwOG/sa/x5JyAmSYunA/ce99Pg="),
@@ -1131,7 +1200,6 @@ func TestAccAWSLambdaFunction_s3Update_unversioned(t *testing.T) {
 
 func TestAccAWSLambdaFunction_runtimeValidation_noRuntime(t *testing.T) {
 	rString := acctest.RandString(8)
-
 	funcName := fmt.Sprintf("tf_acc_lambda_func_runtime_valid_no_%s", rString)
 	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_runtime_valid_no_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_runtime_valid_no_%s", rString)
@@ -1154,7 +1222,7 @@ func TestAccAWSLambdaFunction_runtimeValidation_NodeJs810(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
 	rString := acctest.RandString(8)
-
+	resourceName := "aws_lambda_function.test"
 	funcName := fmt.Sprintf("tf_acc_lambda_func_runtime_valid_nodejs810_%s", rString)
 	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_runtime_valid_nodejs810_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_runtime_valid_nodejs810_%s", rString)
@@ -1168,9 +1236,15 @@ func TestAccAWSLambdaFunction_runtimeValidation_NodeJs810(t *testing.T) {
 			{
 				Config: testAccAWSLambdaConfigNodeJs810Runtime(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", lambda.RuntimeNodejs810),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "runtime", lambda.RuntimeNodejs810),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
 			},
 		},
 	})
@@ -1180,7 +1254,7 @@ func TestAccAWSLambdaFunction_runtimeValidation_NodeJs10x(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
 	rString := acctest.RandString(8)
-
+	resourceName := "aws_lambda_function.test"
 	funcName := fmt.Sprintf("tf_acc_lambda_func_runtime_valid_nodejs10x_%s", rString)
 	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_runtime_valid_nodejs10x_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_runtime_valid_nodejs10x_%s", rString)
@@ -1194,9 +1268,15 @@ func TestAccAWSLambdaFunction_runtimeValidation_NodeJs10x(t *testing.T) {
 			{
 				Config: testAccAWSLambdaConfigNodeJs10xRuntime(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", lambda.RuntimeNodejs10X),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "runtime", lambda.RuntimeNodejs10X),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
 			},
 		},
 	})
@@ -1206,7 +1286,7 @@ func TestAccAWSLambdaFunction_runtimeValidation_python27(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
 	rString := acctest.RandString(8)
-
+	resourceName := "aws_lambda_function.test"
 	funcName := fmt.Sprintf("tf_acc_lambda_func_runtime_valid_p27_%s", rString)
 	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_runtime_valid_p27_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_runtime_valid_p27_%s", rString)
@@ -1220,9 +1300,15 @@ func TestAccAWSLambdaFunction_runtimeValidation_python27(t *testing.T) {
 			{
 				Config: testAccAWSLambdaConfigPython27Runtime(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", lambda.RuntimePython27),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "runtime", lambda.RuntimePython27),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
 			},
 		},
 	})
@@ -1232,7 +1318,7 @@ func TestAccAWSLambdaFunction_runtimeValidation_java8(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
 	rString := acctest.RandString(8)
-
+	resourceName := "aws_lambda_function.test"
 	funcName := fmt.Sprintf("tf_acc_lambda_func_runtime_valid_j8_%s", rString)
 	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_runtime_valid_j8_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_runtime_valid_j8_%s", rString)
@@ -1246,9 +1332,15 @@ func TestAccAWSLambdaFunction_runtimeValidation_java8(t *testing.T) {
 			{
 				Config: testAccAWSLambdaConfigJava8Runtime(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", lambda.RuntimeJava8),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "runtime", lambda.RuntimeJava8),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
 			},
 		},
 	})
@@ -1258,7 +1350,7 @@ func TestAccAWSLambdaFunction_tags(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
 	rString := acctest.RandString(8)
-
+	resourceName := "aws_lambda_function.test"
 	funcName := fmt.Sprintf("tf_acc_lambda_func_tags_%s", rString)
 	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_tags_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_tags_%s", rString)
@@ -1272,33 +1364,39 @@ func TestAccAWSLambdaFunction_tags(t *testing.T) {
 			{
 				Config: testAccAWSLambdaConfigBasic(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
-					resource.TestCheckNoResourceAttr("aws_lambda_function.lambda_function_test", "tags"),
+					resource.TestCheckNoResourceAttr(resourceName, "tags"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
 			},
 			{
 				Config: testAccAWSLambdaConfigTags(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "tags.%", "2"),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "tags.Key1", "Value One"),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "tags.Description", "Very interesting"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "Value One"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Description", "Very interesting"),
 				),
 			},
 			{
 				Config: testAccAWSLambdaConfigTagsModified(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
 					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "tags.%", "3"),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "tags.Key1", "Value One Changed"),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "tags.Key2", "Value Two"),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "tags.Key3", "Value Three"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "Value One Changed"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "Value Two"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key3", "Value Three"),
 				),
 			},
 		},
@@ -1309,7 +1407,7 @@ func TestAccAWSLambdaFunction_runtimeValidation_provided(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
 	rString := acctest.RandString(8)
-
+	resourceName := "aws_lambda_function.test"
 	funcName := fmt.Sprintf("tf_acc_lambda_func_runtime_valid_provided_%s", rString)
 	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_runtime_valid_provided_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_runtime_valid_provided_%s", rString)
@@ -1323,9 +1421,15 @@ func TestAccAWSLambdaFunction_runtimeValidation_provided(t *testing.T) {
 			{
 				Config: testAccAWSLambdaConfigProvidedRuntime(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", lambda.RuntimeProvided),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "runtime", lambda.RuntimeProvided),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
 			},
 		},
 	})
@@ -1335,7 +1439,7 @@ func TestAccAWSLambdaFunction_runtimeValidation_python36(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
 	rString := acctest.RandString(8)
-
+	resourceName := "aws_lambda_function.test"
 	funcName := fmt.Sprintf("tf_acc_lambda_func_runtime_valid_p36_%s", rString)
 	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_runtime_valid_p36_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_runtime_valid_p36_%s", rString)
@@ -1349,9 +1453,15 @@ func TestAccAWSLambdaFunction_runtimeValidation_python36(t *testing.T) {
 			{
 				Config: testAccAWSLambdaConfigPython36Runtime(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", lambda.RuntimePython36),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "runtime", lambda.RuntimePython36),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
 			},
 		},
 	})
@@ -1360,7 +1470,7 @@ func TestAccAWSLambdaFunction_runtimeValidation_python37(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
 	rString := acctest.RandString(8)
-
+	resourceName := "aws_lambda_function.test"
 	funcName := fmt.Sprintf("tf_acc_lambda_func_runtime_valid_p37_%s", rString)
 	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_runtime_valid_p37_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_runtime_valid_p37_%s", rString)
@@ -1374,9 +1484,15 @@ func TestAccAWSLambdaFunction_runtimeValidation_python37(t *testing.T) {
 			{
 				Config: testAccAWSLambdaConfigPython37Runtime(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", lambda.RuntimePython37),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "runtime", lambda.RuntimePython37),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
 			},
 		},
 	})
@@ -1386,7 +1502,7 @@ func TestAccAWSLambdaFunction_runtimeValidation_ruby25(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
 	rString := acctest.RandString(8)
-
+	resourceName := "aws_lambda_function.test"
 	funcName := fmt.Sprintf("tf_acc_lambda_func_runtime_valid_r25_%s", rString)
 	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_runtime_valid_r25_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_runtime_valid_r25_%s", rString)
@@ -1400,9 +1516,15 @@ func TestAccAWSLambdaFunction_runtimeValidation_ruby25(t *testing.T) {
 			{
 				Config: testAccAWSLambdaConfigRuby25Runtime(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", lambda.RuntimeRuby25),
+					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "runtime", lambda.RuntimeRuby25),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
 			},
 		},
 	})
@@ -1704,7 +1826,7 @@ resource "aws_security_group" "sg_for_lambda" {
 
 func testAccAWSLambdaConfigBasic(funcName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
@@ -1716,7 +1838,7 @@ resource "aws_lambda_function" "lambda_function_test" {
 
 func testAccAWSLambdaConfigBasicConcurrency(funcName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
@@ -1729,7 +1851,7 @@ resource "aws_lambda_function" "lambda_function_test" {
 
 func testAccAWSLambdaConfigConcurrencyUpdate(funcName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
@@ -1742,7 +1864,7 @@ resource "aws_lambda_function" "lambda_function_test" {
 
 func testAccAWSLambdaConfigBasicUpdateRuntime(funcName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
@@ -1754,7 +1876,7 @@ resource "aws_lambda_function" "lambda_function_test" {
 
 func testAccAWSLambdaConfigWithoutFilenameAndS3Attributes(funcName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
@@ -1765,7 +1887,7 @@ resource "aws_lambda_function" "lambda_function_test" {
 
 func testAccAWSLambdaConfigEnvVariables(funcName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
@@ -1782,7 +1904,7 @@ resource "aws_lambda_function" "lambda_function_test" {
 
 func testAccAWSLambdaConfigEnvVariablesModified(funcName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
@@ -1800,7 +1922,7 @@ resource "aws_lambda_function" "lambda_function_test" {
 
 func testAccAWSLambdaConfigEnvVariablesModifiedWithoutEnvironment(funcName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
@@ -1833,7 +1955,7 @@ resource "aws_kms_key" "foo" {
 POLICY
 }
 
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
@@ -1872,7 +1994,7 @@ resource "aws_kms_key" "foo" {
 POLICY
 }
 
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
@@ -1889,7 +2011,7 @@ resource "aws_lambda_function" "lambda_function_test" {
 
 func testAccAWSLambdaConfigVersioned(fileName, funcName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
     filename = "%s"
     function_name = "%s"
     publish = true
@@ -1979,7 +2101,7 @@ resource "aws_lambda_function" "test" {
 
 func testAccAWSLambdaConfigWithTracingConfig(funcName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
@@ -1995,7 +2117,7 @@ resource "aws_lambda_function" "lambda_function_test" {
 
 func testAccAWSLambdaConfigWithTracingConfigUpdated(funcName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
@@ -2011,7 +2133,7 @@ resource "aws_lambda_function" "lambda_function_test" {
 
 func testAccAWSLambdaConfigWithDeadLetterConfig(funcName, topicName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
@@ -2019,11 +2141,11 @@ resource "aws_lambda_function" "lambda_function_test" {
     runtime = "nodejs8.10"
 
     dead_letter_config {
-        target_arn = "${aws_sns_topic.lambda_function_test.arn}"
+        target_arn = "${aws_sns_topic.test.arn}"
     }
 }
 
-resource "aws_sns_topic" "lambda_function_test" {
+resource "aws_sns_topic" "test" {
 	name = "%s"
 }
 `, funcName, topicName)
@@ -2032,7 +2154,7 @@ resource "aws_sns_topic" "lambda_function_test" {
 func testAccAWSLambdaConfigWithDeadLetterConfigUpdated(funcName, topic1Name, topic2Name, policyName,
 	roleName, sgName, uFuncName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
@@ -2040,15 +2162,15 @@ resource "aws_lambda_function" "lambda_function_test" {
     runtime = "nodejs8.10"
 
     dead_letter_config {
-        target_arn = "${aws_sns_topic.lambda_function_test_2.arn}"
+        target_arn = "${aws_sns_topic.test_2.arn}"
     }
 }
 
-resource "aws_sns_topic" "lambda_function_test" {
+resource "aws_sns_topic" "test" {
 	name = "%s"
 }
 
-resource "aws_sns_topic" "lambda_function_test_2" {
+resource "aws_sns_topic" "test_2" {
 	name = "%s"
 }
 `, uFuncName, topic1Name, topic2Name)
@@ -2056,7 +2178,7 @@ resource "aws_sns_topic" "lambda_function_test_2" {
 
 func testAccAWSLambdaConfigWithNilDeadLetterConfig(funcName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
@@ -2072,46 +2194,46 @@ resource "aws_lambda_function" "lambda_function_test" {
 
 func testAccAWSLambdaConfigWithLayers(funcName, layerName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
-resource "aws_lambda_layer_version" "lambda_function_test" {
+resource "aws_lambda_layer_version" "test" {
     filename = "test-fixtures/lambdatest.zip"
     layer_name = "%s"
     compatible_runtimes = ["nodejs8.10"]
 }
 
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
     runtime = "nodejs8.10"
-    layers = ["${aws_lambda_layer_version.lambda_function_test.arn}"]
+    layers = ["${aws_lambda_layer_version.test.arn}"]
 }
 `, layerName, funcName)
 }
 
 func testAccAWSLambdaConfigWithLayersUpdated(funcName, layerName, layer2Name, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
-resource "aws_lambda_layer_version" "lambda_function_test" {
+resource "aws_lambda_layer_version" "test" {
     filename = "test-fixtures/lambdatest.zip"
     layer_name = "%s"
     compatible_runtimes = ["nodejs8.10"]
 }
 
-resource "aws_lambda_layer_version" "lambda_function_test_2" {
+resource "aws_lambda_layer_version" "test_2" {
     filename = "test-fixtures/lambdatest_modified.zip"
     layer_name = "%s"
     compatible_runtimes = ["nodejs8.10"]
 }
 
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
     runtime = "nodejs8.10"
     layers = [
-        "${aws_lambda_layer_version.lambda_function_test.arn}",
-        "${aws_lambda_layer_version.lambda_function_test_2.arn}",
+        "${aws_lambda_layer_version.test.arn}",
+        "${aws_lambda_layer_version.test_2.arn}",
     ]
 }
 `, layerName, layer2Name, funcName)
@@ -2119,7 +2241,7 @@ resource "aws_lambda_function" "lambda_function_test" {
 
 func testAccAWSLambdaConfigWithVPC(funcName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
@@ -2136,7 +2258,7 @@ resource "aws_lambda_function" "lambda_function_test" {
 
 func testAccAWSLambdaConfigWithVPCUpdated(funcName, policyName, roleName, sgName, sgName2 string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
@@ -2229,7 +2351,7 @@ resource "aws_iam_role" "iam_for_lambda" {
 EOF
 }
 
-resource "aws_lambda_function" "lambda_function_s3test" {
+resource "aws_lambda_function" "test" {
   s3_bucket     = "${aws_s3_bucket.lambda_bucket.id}"
   s3_key        = "${aws_s3_bucket_object.lambda_code.id}"
   function_name = "%s"
@@ -2242,7 +2364,7 @@ resource "aws_lambda_function" "lambda_function_s3test" {
 
 func testAccAWSLambdaConfigNoRuntime(funcName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
@@ -2253,7 +2375,7 @@ resource "aws_lambda_function" "lambda_function_test" {
 
 func testAccAWSLambdaConfigNodeJs810Runtime(funcName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
@@ -2265,7 +2387,7 @@ resource "aws_lambda_function" "lambda_function_test" {
 
 func testAccAWSLambdaConfigNodeJs10xRuntime(funcName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
@@ -2277,7 +2399,7 @@ resource "aws_lambda_function" "lambda_function_test" {
 
 func testAccAWSLambdaConfigPython27Runtime(funcName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
@@ -2289,7 +2411,7 @@ resource "aws_lambda_function" "lambda_function_test" {
 
 func testAccAWSLambdaConfigJava8Runtime(funcName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
@@ -2301,7 +2423,7 @@ resource "aws_lambda_function" "lambda_function_test" {
 
 func testAccAWSLambdaConfigTags(funcName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
@@ -2317,7 +2439,7 @@ resource "aws_lambda_function" "lambda_function_test" {
 
 func testAccAWSLambdaConfigTagsModified(funcName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
@@ -2334,7 +2456,7 @@ resource "aws_lambda_function" "lambda_function_test" {
 
 func testAccAWSLambdaConfigProvidedRuntime(funcName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
@@ -2346,7 +2468,7 @@ resource "aws_lambda_function" "lambda_function_test" {
 
 func testAccAWSLambdaConfigPython36Runtime(funcName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
@@ -2358,7 +2480,7 @@ resource "aws_lambda_function" "lambda_function_test" {
 
 func testAccAWSLambdaConfigPython37Runtime(funcName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
@@ -2370,7 +2492,7 @@ resource "aws_lambda_function" "lambda_function_test" {
 
 func testAccAWSLambdaConfigRuby25Runtime(funcName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
-resource "aws_lambda_function" "lambda_function_test" {
+resource "aws_lambda_function" "test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
@@ -2402,7 +2524,7 @@ resource "aws_iam_role" "iam_for_lambda" {
 EOF
 }
 
-resource "aws_lambda_function" "lambda_function_local" {
+resource "aws_lambda_function" "test" {
   filename         = "%s"
   source_code_hash = "${filebase64sha256("%s")}"
   function_name    = "%s"
@@ -2439,7 +2561,7 @@ resource "aws_iam_role" "iam_for_lambda" {
 EOF
 }
 
-resource "aws_lambda_function" "lambda_function_local" {
+resource "aws_lambda_function" "test" {
   filename      = "%s"
   function_name = "%s"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
@@ -2488,7 +2610,7 @@ resource "aws_iam_role" "iam_for_lambda" {
 EOF
 }
 
-resource "aws_lambda_function" "lambda_function_s3" {
+resource "aws_lambda_function" "test" {
   s3_bucket         = "${aws_s3_bucket_object.o.bucket}"
   s3_key            = "${aws_s3_bucket_object.o.key}"
   s3_object_version = "${aws_s3_bucket_object.o.version_id}"
@@ -2535,7 +2657,7 @@ resource "aws_iam_role" "iam_for_lambda" {
 EOF
 }
 
-resource "aws_lambda_function" "lambda_function_s3" {
+resource "aws_lambda_function" "test" {
   s3_bucket     = "${aws_s3_bucket_object.o.bucket}"
   s3_key        = "${aws_s3_bucket_object.o.key}"
   function_name = "%s"


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8944

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSLambdaEventSourceMapping"            ==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSLambdaEventSourceMapping -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
^[[A=== RUN   TestAccAWSLambdaEventSourceMapping_kinesis_basic
=== PAUSE TestAccAWSLambdaEventSourceMapping_kinesis_basic
=== RUN   TestAccAWSLambdaEventSourceMapping_kinesis_removeBatchSize
=== PAUSE TestAccAWSLambdaEventSourceMapping_kinesis_removeBatchSize
=== RUN   TestAccAWSLambdaEventSourceMapping_sqs_basic
=== PAUSE TestAccAWSLambdaEventSourceMapping_sqs_basic
=== RUN   TestAccAWSLambdaEventSourceMapping_sqs_withFunctionName
=== PAUSE TestAccAWSLambdaEventSourceMapping_sqs_withFunctionName
=== RUN   TestAccAWSLambdaEventSourceMapping_kinesis_disappears
=== PAUSE TestAccAWSLambdaEventSourceMapping_kinesis_disappears
=== RUN   TestAccAWSLambdaEventSourceMapping_sqsDisappears
=== PAUSE TestAccAWSLambdaEventSourceMapping_sqsDisappears
=== RUN   TestAccAWSLambdaEventSourceMapping_changesInEnabledAreDetected
=== PAUSE TestAccAWSLambdaEventSourceMapping_changesInEnabledAreDetected
=== RUN   TestAccAWSLambdaEventSourceMapping_StartingPositionTimestamp
=== PAUSE TestAccAWSLambdaEventSourceMapping_StartingPositionTimestamp
=== CONT  TestAccAWSLambdaEventSourceMapping_kinesis_basic
=== CONT  TestAccAWSLambdaEventSourceMapping_StartingPositionTimestamp
=== CONT  TestAccAWSLambdaEventSourceMapping_sqs_withFunctionName
=== CONT  TestAccAWSLambdaEventSourceMapping_kinesis_disappears
=== CONT  TestAccAWSLambdaEventSourceMapping_changesInEnabledAreDetected
=== CONT  TestAccAWSLambdaEventSourceMapping_sqsDisappears
=== CONT  TestAccAWSLambdaEventSourceMapping_sqs_basic
=== CONT  TestAccAWSLambdaEventSourceMapping_kinesis_removeBatchSize
--- PASS: TestAccAWSLambdaEventSourceMapping_sqs_withFunctionName (52.33s)
--- PASS: TestAccAWSLambdaEventSourceMapping_sqs_basic (85.40s)
--- PASS: TestAccAWSLambdaEventSourceMapping_kinesis_disappears (103.96s)
--- PASS: TestAccAWSLambdaEventSourceMapping_StartingPositionTimestamp (108.62s)
--- PASS: TestAccAWSLambdaEventSourceMapping_kinesis_removeBatchSize (121.78s)
--- PASS: TestAccAWSLambdaEventSourceMapping_kinesis_basic (123.17s)
--- PASS: TestAccAWSLambdaEventSourceMapping_sqsDisappears (128.20s)
--- PASS: TestAccAWSLambdaEventSourceMapping_changesInEnabledAreDetected (135.68s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       137.353s

make testacc TESTARGS="-run=TestAccAWSLambdaFunction"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSLambdaFunction -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
√=== RUN   TestAccAWSLambdaFunction_basic
=== PAUSE TestAccAWSLambdaFunction_basic
=== RUN   TestAccAWSLambdaFunction_concurrency
=== PAUSE TestAccAWSLambdaFunction_concurrency
=== RUN   TestAccAWSLambdaFunction_concurrencyCycle
=== PAUSE TestAccAWSLambdaFunction_concurrencyCycle
=== RUN   TestAccAWSLambdaFunction_updateRuntime
=== PAUSE TestAccAWSLambdaFunction_updateRuntime
=== RUN   TestAccAWSLambdaFunction_expectFilenameAndS3Attributes
=== PAUSE TestAccAWSLambdaFunction_expectFilenameAndS3Attributes
=== RUN   TestAccAWSLambdaFunction_envVariables
=== PAUSE TestAccAWSLambdaFunction_envVariables
=== RUN   TestAccAWSLambdaFunction_encryptedEnvVariables
=== PAUSE TestAccAWSLambdaFunction_encryptedEnvVariables
=== RUN   TestAccAWSLambdaFunction_versioned
=== PAUSE TestAccAWSLambdaFunction_versioned
=== RUN   TestAccAWSLambdaFunction_versionedUpdate
=== PAUSE TestAccAWSLambdaFunction_versionedUpdate
=== RUN   TestAccAWSLambdaFunction_DeadLetterConfig
=== PAUSE TestAccAWSLambdaFunction_DeadLetterConfig
=== RUN   TestAccAWSLambdaFunction_DeadLetterConfigUpdated
=== PAUSE TestAccAWSLambdaFunction_DeadLetterConfigUpdated
=== RUN   TestAccAWSLambdaFunction_nilDeadLetterConfig
=== PAUSE TestAccAWSLambdaFunction_nilDeadLetterConfig
=== RUN   TestAccAWSLambdaFunction_tracingConfig
=== PAUSE TestAccAWSLambdaFunction_tracingConfig
=== RUN   TestAccAWSLambdaFunction_Layers
=== PAUSE TestAccAWSLambdaFunction_Layers
=== RUN   TestAccAWSLambdaFunction_LayersUpdate
=== PAUSE TestAccAWSLambdaFunction_LayersUpdate
=== RUN   TestAccAWSLambdaFunction_VPC
=== PAUSE TestAccAWSLambdaFunction_VPC
=== RUN   TestAccAWSLambdaFunction_VPCRemoval
=== PAUSE TestAccAWSLambdaFunction_VPCRemoval
=== RUN   TestAccAWSLambdaFunction_VPCUpdate
=== PAUSE TestAccAWSLambdaFunction_VPCUpdate
=== RUN   TestAccAWSLambdaFunction_VPC_withInvocation
=== PAUSE TestAccAWSLambdaFunction_VPC_withInvocation
=== RUN   TestAccAWSLambdaFunction_EmptyVpcConfig
=== PAUSE TestAccAWSLambdaFunction_EmptyVpcConfig
=== RUN   TestAccAWSLambdaFunction_s3
=== PAUSE TestAccAWSLambdaFunction_s3
=== RUN   TestAccAWSLambdaFunction_localUpdate
=== PAUSE TestAccAWSLambdaFunction_localUpdate
=== RUN   TestAccAWSLambdaFunction_localUpdate_nameOnly
=== PAUSE TestAccAWSLambdaFunction_localUpdate_nameOnly
=== RUN   TestAccAWSLambdaFunction_s3Update_basic
=== PAUSE TestAccAWSLambdaFunction_s3Update_basic
=== RUN   TestAccAWSLambdaFunction_s3Update_unversioned
=== PAUSE TestAccAWSLambdaFunction_s3Update_unversioned
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_noRuntime
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_noRuntime
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_NodeJs810
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_NodeJs810
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_NodeJs10x
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_NodeJs10x
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_python27
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_python27
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_java8
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_java8
=== RUN   TestAccAWSLambdaFunction_tags
=== PAUSE TestAccAWSLambdaFunction_tags
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_provided
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_provided
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_python36
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_python36
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_python37
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_python37
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_ruby25
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_ruby25
=== CONT  TestAccAWSLambdaFunction_basic
=== CONT  TestAccAWSLambdaFunction_VPCUpdate
=== CONT  TestAccAWSLambdaFunction_VPC_withInvocation
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_ruby25
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_python37
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_python36
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_provided
=== CONT  TestAccAWSLambdaFunction_s3Update_unversioned
=== CONT  TestAccAWSLambdaFunction_s3Update_basic
=== CONT  TestAccAWSLambdaFunction_localUpdate_nameOnly
=== CONT  TestAccAWSLambdaFunction_localUpdate
=== CONT  TestAccAWSLambdaFunction_s3
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_noRuntime
=== CONT  TestAccAWSLambdaFunction_tags
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_java8
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_python27
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_NodeJs10x
=== CONT  TestAccAWSLambdaFunction_EmptyVpcConfig
=== CONT  TestAccAWSLambdaFunction_DeadLetterConfig
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_NodeJs810
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_noRuntime (3.17s)
=== CONT  TestAccAWSLambdaFunction_VPCRemoval
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python27 (61.50s)
=== CONT  TestAccAWSLambdaFunction_VPC
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_ruby25 (63.91s)
=== CONT  TestAccAWSLambdaFunction_LayersUpdate
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_provided (66.82s)
=== CONT  TestAccAWSLambdaFunction_Layers
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_NodeJs10x (68.36s)
=== CONT  TestAccAWSLambdaFunction_tracingConfig
--- PASS: TestAccAWSLambdaFunction_s3 (68.79s)
=== CONT  TestAccAWSLambdaFunction_nilDeadLetterConfig
--- PASS: TestAccAWSLambdaFunction_basic (71.38s)
=== CONT  TestAccAWSLambdaFunction_DeadLetterConfigUpdated
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_java8 (74.60s)
=== CONT  TestAccAWSLambdaFunction_envVariables
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python36 (77.76s)
=== CONT  TestAccAWSLambdaFunction_versionedUpdate
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_NodeJs810 (79.99s)
=== CONT  TestAccAWSLambdaFunction_versioned
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (80.05s)
=== CONT  TestAccAWSLambdaFunction_encryptedEnvVariables
--- PASS: TestAccAWSLambdaFunction_localUpdate (82.07s)
=== CONT  TestAccAWSLambdaFunction_updateRuntime
--- PASS: TestAccAWSLambdaFunction_EmptyVpcConfig (82.09s)
=== CONT  TestAccAWSLambdaFunction_expectFilenameAndS3Attributes
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python37 (84.26s)
=== CONT  TestAccAWSLambdaFunction_concurrencyCycle
--- PASS: TestAccAWSLambdaFunction_nilDeadLetterConfig (43.36s)
=== CONT  TestAccAWSLambdaFunction_concurrency
--- PASS: TestAccAWSLambdaFunction_VPC_withInvocation (115.13s)
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (116.32s)
--- PASS: TestAccAWSLambdaFunction_s3Update_basic (117.86s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfig (121.36s)
--- PASS: TestAccAWSLambdaFunction_expectFilenameAndS3Attributes (44.21s)
--- PASS: TestAccAWSLambdaFunction_VPCRemoval (126.54s)
--- PASS: TestAccAWSLambdaFunction_Layers (69.89s)
--- PASS: TestAccAWSLambdaFunction_tags (136.86s)
--- PASS: TestAccAWSLambdaFunction_VPCUpdate (141.89s)
--- PASS: TestAccAWSLambdaFunction_VPC (82.04s)
--- PASS: TestAccAWSLambdaFunction_versioned (64.47s)
--- PASS: TestAccAWSLambdaFunction_tracingConfig (93.09s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfigUpdated (93.40s)
--- PASS: TestAccAWSLambdaFunction_LayersUpdate (106.74s)
--- PASS: TestAccAWSLambdaFunction_versionedUpdate (98.29s)
--- PASS: TestAccAWSLambdaFunction_updateRuntime (99.69s)
--- PASS: TestAccAWSLambdaFunction_concurrency (93.47s)
--- PASS: TestAccAWSLambdaFunction_encryptedEnvVariables (130.68s)
--- PASS: TestAccAWSLambdaFunction_concurrencyCycle (129.96s)
--- PASS: TestAccAWSLambdaFunction_envVariables (161.68s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       237.276s
```