### PR TITLE
test/datasource/aws_elasticsearch_domain: Remove service role resource creation

### DIFF
--- a/aws/data_source_aws_elasticsearch_domain_test.go
+++ b/aws/data_source_aws_elasticsearch_domain_test.go
@@ -79,15 +79,15 @@ provider "aws" {
 locals {
 	random_name = "test-es-%d"
 }
-		
+
 data "aws_region" "current" {}
-		
+
 data "aws_caller_identity" "current" {}
-					
+
 resource "aws_elasticsearch_domain" "test" {
 	domain_name = "${local.random_name}"
 	elasticsearch_version = "1.5"
-	
+
 	access_policies = <<POLICY
 {
 	"Version": "2012-10-17",
@@ -135,9 +135,9 @@ func testAccAWSElasticsearchDomainConfigAdvancedWithDataSource(rInt int) string 
 provider "aws" {
 	region = "us-east-1"
 }
-		
+
 data "aws_region" "current" {}
-		
+
 data "aws_caller_identity" "current" {}
 
 locals {
@@ -200,14 +200,10 @@ resource "aws_security_group_rule" "test" {
 	security_group_id = "${aws_security_group.test.id}"
 }
 
-resource "aws_iam_service_linked_role" "test" {
-	aws_service_name = "es.amazonaws.com"
-}
-
 resource "aws_elasticsearch_domain" "test" {
 	domain_name = "${local.random_name}"
 	elasticsearch_version = "1.5"
-	
+
 	access_policies = <<POLICY
 {
 	"Version": "2012-10-17",
@@ -256,10 +252,6 @@ POLICY
   tags = {
 	Domain = "TestDomain"
   }
-	
-  depends_on = [
-    "aws_iam_service_linked_role.test",
-  ]
 }
 
 data "aws_elasticsearch_domain" "test" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
none
```

Acceptance test before change:
```
--- FAIL: TestAccAWSDataElasticsearchDomain_advanced (18.37s)
    testing.go:569: Step 0 error: errors during apply:

        Error: Error creating service-linked role with name es.amazonaws.com: InvalidInput: Service role name AWSServiceRoleForAmazonElasticsearchService has been taken in this account, please try a different suffix.
        	status code: 400, request id: e62f1d43-d04c-11e9-ae4f-bb716bff761d

          on /opt/teamcity-agent/temp/buildTmp/tf-test399323254/main.tf line 70:
          (source code not available)
```

Acceptance test after change:
```
--- PASS: TestAccAWSDataElasticsearchDomain_advanced (18.37s)
```