### PR TITLE
Refactor import testing for KMS resources

### DIFF
--- a/aws/resource_aws_kms_alias_test.go
+++ b/aws/resource_aws_kms_alias_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSKmsAlias_importBasic(t *testing.T) {
-	resourceName := "aws_kms_alias.single"
+func TestAccAWSKmsAlias_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 	kmsAliasTimestamp := time.Now().Format(time.RFC1123)
+	resourceName := "aws_kms_alias.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -22,36 +22,20 @@ func TestAccAWSKmsAlias_importBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSKmsSingleAlias(rInt, kmsAliasTimestamp),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSKmsAliasExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "target_key_arn"),
+				),
 			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-		},
-	})
-}
-
-func TestAccAWSKmsAlias_basic(t *testing.T) {
-	rInt := acctest.RandInt()
-	kmsAliasTimestamp := time.Now().Format(time.RFC1123)
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSKmsAliasDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSKmsSingleAlias(rInt, kmsAliasTimestamp),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsAliasExists("aws_kms_alias.single"),
-					resource.TestCheckResourceAttrSet("aws_kms_alias.single", "target_key_arn"),
-				),
-			},
 			{
 				Config: testAccAWSKmsSingleAlias_modified(rInt, kmsAliasTimestamp),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsAliasExists("aws_kms_alias.single"),
+					testAccCheckAWSKmsAliasExists(resourceName),
 				),
 			},
 		},
@@ -61,6 +45,8 @@ func TestAccAWSKmsAlias_basic(t *testing.T) {
 func TestAccAWSKmsAlias_name_prefix(t *testing.T) {
 	rInt := acctest.RandInt()
 	kmsAliasTimestamp := time.Now().Format(time.RFC1123)
+	resourceName := "aws_kms_alias.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -73,6 +59,11 @@ func TestAccAWSKmsAlias_name_prefix(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aws_kms_alias.name_prefix", "target_key_arn"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -80,6 +71,8 @@ func TestAccAWSKmsAlias_name_prefix(t *testing.T) {
 func TestAccAWSKmsAlias_no_name(t *testing.T) {
 	rInt := acctest.RandInt()
 	kmsAliasTimestamp := time.Now().Format(time.RFC1123)
+	resourceName := "aws_kms_alias.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -92,6 +85,11 @@ func TestAccAWSKmsAlias_no_name(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aws_kms_alias.nothing", "target_key_arn"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -99,6 +97,8 @@ func TestAccAWSKmsAlias_no_name(t *testing.T) {
 func TestAccAWSKmsAlias_multiple(t *testing.T) {
 	rInt := acctest.RandInt()
 	kmsAliasTimestamp := time.Now().Format(time.RFC1123)
+	resourceName := "aws_kms_alias.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -107,11 +107,16 @@ func TestAccAWSKmsAlias_multiple(t *testing.T) {
 			{
 				Config: testAccAWSKmsMultipleAliases(rInt, kmsAliasTimestamp),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsAliasExists("aws_kms_alias.one"),
-					resource.TestCheckResourceAttrSet("aws_kms_alias.one", "target_key_arn"),
-					testAccCheckAWSKmsAliasExists("aws_kms_alias.two"),
-					resource.TestCheckResourceAttrSet("aws_kms_alias.two", "target_key_arn"),
+					testAccCheckAWSKmsAliasExists("aws_kms_alias.test"),
+					resource.TestCheckResourceAttrSet("aws_kms_alias.test", "target_key_arn"),
+					testAccCheckAWSKmsAliasExists("aws_kms_alias.test2"),
+					resource.TestCheckResourceAttrSet("aws_kms_alias.test2", "target_key_arn"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -120,6 +125,8 @@ func TestAccAWSKmsAlias_multiple(t *testing.T) {
 func TestAccAWSKmsAlias_ArnDiffSuppress(t *testing.T) {
 	rInt := acctest.RandInt()
 	kmsAliasTimestamp := time.Now().Format(time.RFC1123)
+	resourceName := "aws_kms_alias.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -128,9 +135,14 @@ func TestAccAWSKmsAlias_ArnDiffSuppress(t *testing.T) {
 			{
 				Config: testAccAWSKmsArnDiffSuppress(rInt, kmsAliasTimestamp),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsAliasExists("aws_kms_alias.bar"),
-					resource.TestCheckResourceAttrSet("aws_kms_alias.bar", "target_key_arn"),
+					testAccCheckAWSKmsAliasExists("aws_kms_alias.test"),
+					resource.TestCheckResourceAttrSet("aws_kms_alias.test", "target_key_arn"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				ExpectNonEmptyPlan: false,
@@ -176,80 +188,80 @@ func testAccCheckAWSKmsAliasExists(name string) resource.TestCheckFunc {
 
 func testAccAWSKmsSingleAlias(rInt int, timestamp string) string {
 	return fmt.Sprintf(`
-resource "aws_kms_key" "one" {
+resource "aws_kms_key" "test" {
   description             = "Terraform acc test One %s"
   deletion_window_in_days = 7
 }
 
-resource "aws_kms_key" "two" {
+resource "aws_kms_key" "test2" {
   description             = "Terraform acc test Two %s"
   deletion_window_in_days = 7
 }
 
 resource "aws_kms_alias" "name_prefix" {
   name_prefix   = "alias/tf-acc-key-alias-%d"
-  target_key_id = "${aws_kms_key.one.key_id}"
+  target_key_id = "${aws_kms_key.test.key_id}"
 }
 
 resource "aws_kms_alias" "nothing" {
-  target_key_id = "${aws_kms_key.one.key_id}"
+  target_key_id = "${aws_kms_key.test.key_id}"
 }
 
-resource "aws_kms_alias" "single" {
+resource "aws_kms_alias" "test" {
   name          = "alias/tf-acc-key-alias-%d"
-  target_key_id = "${aws_kms_key.one.key_id}"
+  target_key_id = "${aws_kms_key.test.key_id}"
 }
 `, timestamp, timestamp, rInt, rInt)
 }
 
 func testAccAWSKmsSingleAlias_modified(rInt int, timestamp string) string {
 	return fmt.Sprintf(`
-resource "aws_kms_key" "one" {
+resource "aws_kms_key" "test" {
   description             = "Terraform acc test One %s"
   deletion_window_in_days = 7
 }
 
-resource "aws_kms_key" "two" {
+resource "aws_kms_key" "test2" {
   description             = "Terraform acc test Two %s"
   deletion_window_in_days = 7
 }
 
-resource "aws_kms_alias" "single" {
+resource "aws_kms_alias" "test" {
   name          = "alias/tf-acc-key-alias-%d"
-  target_key_id = "${aws_kms_key.two.key_id}"
+  target_key_id = "${aws_kms_key.test2.key_id}"
 }
 `, timestamp, timestamp, rInt)
 }
 
 func testAccAWSKmsMultipleAliases(rInt int, timestamp string) string {
 	return fmt.Sprintf(`
-resource "aws_kms_key" "single" {
+resource "aws_kms_key" "test" {
   description             = "Terraform acc test One %s"
   deletion_window_in_days = 7
 }
 
-resource "aws_kms_alias" "one" {
-  name          = "alias/tf-acc-alias-one-%d"
-  target_key_id = "${aws_kms_key.single.key_id}"
+resource "aws_kms_alias" "test" {
+  name          = "alias/tf-acc-alias-test-%d"
+  target_key_id = "${aws_kms_key.test.key_id}"
 }
 
-resource "aws_kms_alias" "two" {
-  name          = "alias/tf-acc-alias-two-%d"
-  target_key_id = "${aws_kms_key.single.key_id}"
+resource "aws_kms_alias" "test2" {
+  name          = "alias/tf-acc-alias-test2-%d"
+  target_key_id = "${aws_kms_key.test.key_id}"
 }
 `, timestamp, rInt, rInt)
 }
 
 func testAccAWSKmsArnDiffSuppress(rInt int, timestamp string) string {
 	return fmt.Sprintf(`
-resource "aws_kms_key" "foo" {
-  description             = "Terraform acc test foo %s"
+resource "aws_kms_key" "test" {
+  description             = "Terraform acc test test %s"
   deletion_window_in_days = 7
 }
 
-resource "aws_kms_alias" "bar" {
+resource "aws_kms_alias" "test" {
   name          = "alias/tf-acc-key-alias-%d"
-  target_key_id = "${aws_kms_key.foo.arn}"
+  target_key_id = "${aws_kms_key.test.arn}"
 }
 `, timestamp, rInt)
 }

--- a/aws/resource_aws_kms_key_test.go
+++ b/aws/resource_aws_kms_key_test.go
@@ -67,9 +67,10 @@ func testSweepKmsKeys(region string) error {
 	return nil
 }
 
-func TestAccAWSKmsKey_importBasic(t *testing.T) {
-	resourceName := "aws_kms_key.foo"
+func TestAccAWSKmsKey_basic(t *testing.T) {
+	var keyBefore, keyAfter kms.KeyMetadata
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	resourceName := "aws_kms_key.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -78,37 +79,20 @@ func TestAccAWSKmsKey_importBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSKmsKey(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSKmsKeyExists(resourceName, &keyBefore),
+				),
 			},
-
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"deletion_window_in_days"},
 			},
-		},
-	})
-}
-
-func TestAccAWSKmsKey_basic(t *testing.T) {
-	var keyBefore, keyAfter kms.KeyMetadata
-	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSKmsKeyDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSKmsKey(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsKeyExists("aws_kms_key.foo", &keyBefore),
-				),
-			},
 			{
 				Config: testAccAWSKmsKey_removedPolicy(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsKeyExists("aws_kms_key.foo", &keyAfter),
+					testAccCheckAWSKmsKeyExists(resourceName, &keyAfter),
 				),
 			},
 		},
@@ -118,6 +102,7 @@ func TestAccAWSKmsKey_basic(t *testing.T) {
 func TestAccAWSKmsKey_disappears(t *testing.T) {
 	var key kms.KeyMetadata
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	resourceName := "aws_kms_key.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -127,7 +112,7 @@ func TestAccAWSKmsKey_disappears(t *testing.T) {
 			{
 				Config: testAccAWSKmsKey(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsKeyExists("aws_kms_key.foo", &key),
+					testAccCheckAWSKmsKeyExists(resourceName, &key),
 				),
 			},
 			{
@@ -142,6 +127,7 @@ func TestAccAWSKmsKey_disappears(t *testing.T) {
 func TestAccAWSKmsKey_policy(t *testing.T) {
 	var key kms.KeyMetadata
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	resourceName := "aws_kms_key.test"
 	expectedPolicyText := `{"Version":"2012-10-17","Id":"kms-tf-1","Statement":[{"Sid":"Enable IAM User Permissions","Effect":"Allow","Principal":{"AWS":"*"},"Action":"kms:*","Resource":"*"}]}`
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -152,9 +138,15 @@ func TestAccAWSKmsKey_policy(t *testing.T) {
 			{
 				Config: testAccAWSKmsKey(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsKeyExists("aws_kms_key.foo", &key),
-					testAccCheckAWSKmsKeyHasPolicy("aws_kms_key.foo", expectedPolicyText),
+					testAccCheckAWSKmsKeyExists(resourceName, &key),
+					testAccCheckAWSKmsKeyHasPolicy(resourceName, expectedPolicyText),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_window_in_days"},
 			},
 		},
 	})
@@ -163,6 +155,7 @@ func TestAccAWSKmsKey_policy(t *testing.T) {
 func TestAccAWSKmsKey_isEnabled(t *testing.T) {
 	var key1, key2, key3 kms.KeyMetadata
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	resourceName := "aws_kms_key.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -172,28 +165,34 @@ func TestAccAWSKmsKey_isEnabled(t *testing.T) {
 			{
 				Config: testAccAWSKmsKey_enabledRotation(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsKeyExists("aws_kms_key.bar", &key1),
-					resource.TestCheckResourceAttr("aws_kms_key.bar", "is_enabled", "true"),
+					testAccCheckAWSKmsKeyExists("aws_kms_key.test", &key1),
+					resource.TestCheckResourceAttr("aws_kms_key.test", "is_enabled", "true"),
 					testAccCheckAWSKmsKeyIsEnabled(&key1, true),
-					resource.TestCheckResourceAttr("aws_kms_key.bar", "enable_key_rotation", "true"),
+					resource.TestCheckResourceAttr("aws_kms_key.test", "enable_key_rotation", "true"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_window_in_days"},
 			},
 			{
 				Config: testAccAWSKmsKey_disabled(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsKeyExists("aws_kms_key.bar", &key2),
-					resource.TestCheckResourceAttr("aws_kms_key.bar", "is_enabled", "false"),
+					testAccCheckAWSKmsKeyExists("aws_kms_key.test", &key2),
+					resource.TestCheckResourceAttr("aws_kms_key.test", "is_enabled", "false"),
 					testAccCheckAWSKmsKeyIsEnabled(&key2, false),
-					resource.TestCheckResourceAttr("aws_kms_key.bar", "enable_key_rotation", "false"),
+					resource.TestCheckResourceAttr("aws_kms_key.test", "enable_key_rotation", "false"),
 				),
 			},
 			{
 				Config: testAccAWSKmsKey_enabled(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsKeyExists("aws_kms_key.bar", &key3),
-					resource.TestCheckResourceAttr("aws_kms_key.bar", "is_enabled", "true"),
+					testAccCheckAWSKmsKeyExists("aws_kms_key.test", &key3),
+					resource.TestCheckResourceAttr("aws_kms_key.test", "is_enabled", "true"),
 					testAccCheckAWSKmsKeyIsEnabled(&key3, true),
-					resource.TestCheckResourceAttr("aws_kms_key.bar", "enable_key_rotation", "true"),
+					resource.TestCheckResourceAttr("aws_kms_key.test", "enable_key_rotation", "true"),
 				),
 			},
 		},
@@ -203,6 +202,7 @@ func TestAccAWSKmsKey_isEnabled(t *testing.T) {
 func TestAccAWSKmsKey_tags(t *testing.T) {
 	var keyBefore kms.KeyMetadata
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	resourceName := "aws_kms_key.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -212,9 +212,15 @@ func TestAccAWSKmsKey_tags(t *testing.T) {
 			{
 				Config: testAccAWSKmsKey_tags(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsKeyExists("aws_kms_key.foo", &keyBefore),
-					resource.TestCheckResourceAttr("aws_kms_key.foo", "tags.%", "3"),
+					testAccCheckAWSKmsKeyExists(resourceName, &keyBefore),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_window_in_days"},
 			},
 		},
 	})
@@ -324,7 +330,7 @@ func testAccCheckAWSKmsKeyIsEnabled(key *kms.KeyMetadata, isEnabled bool) resour
 
 func testAccAWSKmsKey(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_kms_key" "foo" {
+resource "aws_kms_key" "test" {
   description             = "Terraform acc test %s"
   deletion_window_in_days = 7
 
@@ -359,7 +365,7 @@ provider "aws" {
   region = "us-east-1"
 }
 
-resource "aws_kms_key" "foo" {
+resource "aws_kms_key" "test" {
   description             = "Terraform acc test %s"
   deletion_window_in_days = 7
 
@@ -390,7 +396,7 @@ POLICY
 
 func testAccAWSKmsKey_removedPolicy(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_kms_key" "foo" {
+resource "aws_kms_key" "test" {
   description             = "Terraform acc test %s"
   deletion_window_in_days = 7
 
@@ -403,7 +409,7 @@ resource "aws_kms_key" "foo" {
 
 func testAccAWSKmsKey_enabledRotation(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_kms_key" "bar" {
+resource "aws_kms_key" "test" {
   description             = "Terraform acc test is_enabled %s"
   deletion_window_in_days = 7
   enable_key_rotation     = true
@@ -417,7 +423,7 @@ resource "aws_kms_key" "bar" {
 
 func testAccAWSKmsKey_disabled(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_kms_key" "bar" {
+resource "aws_kms_key" "test" {
   description             = "Terraform acc test is_enabled %s"
   deletion_window_in_days = 7
   enable_key_rotation     = false
@@ -432,7 +438,7 @@ resource "aws_kms_key" "bar" {
 
 func testAccAWSKmsKey_enabled(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_kms_key" "bar" {
+resource "aws_kms_key" "test" {
   description             = "Terraform acc test is_enabled %s"
   deletion_window_in_days = 7
   enable_key_rotation     = true
@@ -447,7 +453,7 @@ resource "aws_kms_key" "bar" {
 
 func testAccAWSKmsKey_tags(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_kms_key" "foo" {
+resource "aws_kms_key" "test" {
   description = "Terraform acc test %s"
 
   tags = {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8944

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$  make testacc TESTARGS="-run=TestAccAWSKmsKey_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSKmsKey_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSKmsKey_basic
=== PAUSE TestAccAWSKmsKey_basic
=== RUN   TestAccAWSKmsKey_disappears
=== PAUSE TestAccAWSKmsKey_disappears
=== RUN   TestAccAWSKmsKey_policy
=== PAUSE TestAccAWSKmsKey_policy
=== RUN   TestAccAWSKmsKey_isEnabled
=== PAUSE TestAccAWSKmsKey_isEnabled
=== RUN   TestAccAWSKmsKey_tags
=== PAUSE TestAccAWSKmsKey_tags
=== CONT  TestAccAWSKmsKey_basic
=== CONT  TestAccAWSKmsKey_tags
=== CONT  TestAccAWSKmsKey_disappears
=== CONT  TestAccAWSKmsKey_policy
=== CONT  TestAccAWSKmsKey_isEnabled
--- PASS: TestAccAWSKmsKey_disappears (32.72s)
--- PASS: TestAccAWSKmsKey_tags (64.73s)
--- PASS: TestAccAWSKmsKey_policy (66.53s)
--- PASS: TestAccAWSKmsKey_basic (88.55s)
--- PASS: TestAccAWSKmsKey_isEnabled (444.36s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       446.421s

make testacc TESTARGS="-run=TestAccAWSKmsAlias_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSKmsAlias_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSKmsAlias_basic
=== PAUSE TestAccAWSKmsAlias_basic
=== RUN   TestAccAWSKmsAlias_name_prefix
=== PAUSE TestAccAWSKmsAlias_name_prefix
=== RUN   TestAccAWSKmsAlias_no_name
=== PAUSE TestAccAWSKmsAlias_no_name
=== RUN   TestAccAWSKmsAlias_multiple
=== PAUSE TestAccAWSKmsAlias_multiple
=== RUN   TestAccAWSKmsAlias_ArnDiffSuppress
=== PAUSE TestAccAWSKmsAlias_ArnDiffSuppress
=== CONT  TestAccAWSKmsAlias_basic
=== CONT  TestAccAWSKmsAlias_ArnDiffSuppress
=== CONT  TestAccAWSKmsAlias_multiple
=== CONT  TestAccAWSKmsAlias_no_name
=== CONT  TestAccAWSKmsAlias_name_prefix
--- PASS: TestAccAWSKmsAlias_multiple (65.63s)
--- PASS: TestAccAWSKmsAlias_name_prefix (65.79s)
--- PASS: TestAccAWSKmsAlias_no_name (65.85s)
--- PASS: TestAccAWSKmsAlias_ArnDiffSuppress (85.97s)
--- PASS: TestAccAWSKmsAlias_basic (91.28s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       92.454s
```
