### PR TITLE
Fix the lightsail name validation to reflect actual minimum length

### DIFF
--- a/aws/resource_aws_lightsail_instance.go
+++ b/aws/resource_aws_lightsail_instance.go
@@ -31,7 +31,7 @@ func resourceAwsLightsailInstance() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 				ValidateFunc: validation.All(
-					validation.StringLenBetween(3, 255),
+					validation.StringLenBetween(2, 255),
 					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z]`), "must begin with an alphabetic character"),
 					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9_\-.]+[^._\-]$`), "must contain only alphanumeric characters, underscores, hyphens, and dots"),
 				),


### PR DESCRIPTION
As the lightsail API [documents](https://docs.aws.amazon.com/lightsail/2016-11-28/api-reference/API_Instance.html), 2 characters is actually the minimum, not 3.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10042

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_lightsail_instance: Fixes an issue where 2-character lightsail instance names didn't get validated properly
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSLightsailInstance_"        
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSLightsailInstance_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSLightsailInstance_basic
=== PAUSE TestAccAWSLightsailInstance_basic
=== RUN   TestAccAWSLightsailInstance_Name
=== PAUSE TestAccAWSLightsailInstance_Name
=== RUN   TestAccAWSLightsailInstance_Tags
=== PAUSE TestAccAWSLightsailInstance_Tags
=== RUN   TestAccAWSLightsailInstance_disapear
=== PAUSE TestAccAWSLightsailInstance_disapear
=== CONT  TestAccAWSLightsailInstance_basic
=== CONT  TestAccAWSLightsailInstance_disapear
=== CONT  TestAccAWSLightsailInstance_Name
=== CONT  TestAccAWSLightsailInstance_Tags
--- PASS: TestAccAWSLightsailInstance_disapear (81.48s)
--- PASS: TestAccAWSLightsailInstance_basic (83.75s)
--- PASS: TestAccAWSLightsailInstance_Tags (117.23s)
--- PASS: TestAccAWSLightsailInstance_Name (151.58s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       152.726s
```
