### PR TITLE
Add import for SSM association

### DIFF
--- a/aws/resource_aws_ssm_association.go
+++ b/aws/resource_aws_ssm_association.go
@@ -17,6 +17,9 @@ func resourceAwsSsmAssociation() *schema.Resource {
 		Read:   resourceAwsSsmAssociationRead,
 		Update: resourceAwsSsmAssociationUpdate,
 		Delete: resourceAwsSsmAssociationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		MigrateState:  resourceAwsSsmAssociationMigrateState,
 		SchemaVersion: 1,

--- a/aws/resource_aws_ssm_association_test.go
+++ b/aws/resource_aws_ssm_association_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestAccAWSSSMAssociation_basic(t *testing.T) {
 	name := fmt.Sprintf("tf-acc-ssm-association-%s", acctest.RandString(10))
+	resourceName := "aws_ssm_association.test"
 
 	deleteSsmAssociaton := func() {
 		ec2conn := testAccProvider.Meta().(*AWSClient).ec2conn
@@ -53,14 +54,19 @@ func TestAccAWSSSMAssociation_basic(t *testing.T) {
 			{
 				Config: testAccAWSSSMAssociationBasicConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMAssociationExists("aws_ssm_association.foo"),
+					testAccCheckAWSSSMAssociationExists(resourceName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				PreConfig: deleteSsmAssociaton,
 				Config:    testAccAWSSSMAssociationBasicConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMAssociationExists("aws_ssm_association.foo"),
+					testAccCheckAWSSSMAssociationExists(resourceName),
 				),
 			},
 		},
@@ -69,6 +75,7 @@ func TestAccAWSSSMAssociation_basic(t *testing.T) {
 
 func TestAccAWSSSMAssociation_withTargets(t *testing.T) {
 	name := acctest.RandString(10)
+	resourceName := "aws_ssm_association.test"
 	oneTarget := `
 	targets {
     key = "tag:Name"
@@ -91,41 +98,46 @@ func TestAccAWSSSMAssociation_withTargets(t *testing.T) {
 			{
 				Config: testAccAWSSSMAssociationBasicConfigWithTargets(name, oneTarget),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMAssociationExists("aws_ssm_association.foo"),
+					testAccCheckAWSSSMAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "targets.#", "1"),
+						resourceName, "targets.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "targets.0.key", "tag:Name"),
+						resourceName, "targets.0.key", "tag:Name"),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "targets.0.values.0", "acceptanceTest"),
+						resourceName, "targets.0.values.0", "acceptanceTest"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSSSMAssociationBasicConfigWithTargets(name, twoTargets),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMAssociationExists("aws_ssm_association.foo"),
+					testAccCheckAWSSSMAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "targets.#", "2"),
+						resourceName, "targets.#", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "targets.0.key", "tag:Name"),
+						resourceName, "targets.0.key", "tag:Name"),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "targets.0.values.0", "acceptanceTest"),
+						resourceName, "targets.0.values.0", "acceptanceTest"),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "targets.1.key", "tag:ExtraName"),
+						resourceName, "targets.1.key", "tag:ExtraName"),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "targets.1.values.0", "acceptanceTest"),
+						resourceName, "targets.1.values.0", "acceptanceTest"),
 				),
 			},
 			{
 				Config: testAccAWSSSMAssociationBasicConfigWithTargets(name, oneTarget),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMAssociationExists("aws_ssm_association.foo"),
+					testAccCheckAWSSSMAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "targets.#", "1"),
+						resourceName, "targets.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "targets.0.key", "tag:Name"),
+						resourceName, "targets.0.key", "tag:Name"),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "targets.0.values.0", "acceptanceTest"),
+						resourceName, "targets.0.values.0", "acceptanceTest"),
 				),
 			},
 		},
@@ -134,6 +146,8 @@ func TestAccAWSSSMAssociation_withTargets(t *testing.T) {
 
 func TestAccAWSSSMAssociation_withParameters(t *testing.T) {
 	name := acctest.RandString(10)
+	resourceName := "aws_ssm_association.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -142,17 +156,23 @@ func TestAccAWSSSMAssociation_withParameters(t *testing.T) {
 			{
 				Config: testAccAWSSSMAssociationBasicConfigWithParameters(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMAssociationExists("aws_ssm_association.foo"),
+					testAccCheckAWSSSMAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "parameters.Directory", "myWorkSpace"),
+						resourceName, "parameters.Directory", "myWorkSpace"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parameters"},
 			},
 			{
 				Config: testAccAWSSSMAssociationBasicConfigWithParametersUpdated(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMAssociationExists("aws_ssm_association.foo"),
+					testAccCheckAWSSSMAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "parameters.Directory", "myWorkSpaceUpdated"),
+						resourceName, "parameters.Directory", "myWorkSpaceUpdated"),
 				),
 			},
 		},
@@ -163,6 +183,8 @@ func TestAccAWSSSMAssociation_withAssociationName(t *testing.T) {
 	assocName1 := acctest.RandString(10)
 	assocName2 := acctest.RandString(10)
 	rName := acctest.RandString(5)
+	resourceName := "aws_ssm_association.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -171,17 +193,22 @@ func TestAccAWSSSMAssociation_withAssociationName(t *testing.T) {
 			{
 				Config: testAccAWSSSMAssociationBasicConfigWithAssociationName(rName, assocName1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMAssociationExists("aws_ssm_association.foo"),
+					testAccCheckAWSSSMAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "association_name", assocName1),
+						resourceName, "association_name", assocName1),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSSSMAssociationBasicConfigWithAssociationName(rName, assocName2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMAssociationExists("aws_ssm_association.foo"),
+					testAccCheckAWSSSMAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "association_name", assocName2),
+						resourceName, "association_name", assocName2),
 				),
 			},
 		},
@@ -209,6 +236,11 @@ func TestAccAWSSSMAssociation_withAssociationNameAndScheduleExpression(t *testin
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAWSSSMAssociationConfigWithAssociationNameAndScheduleExpression(rName, assocName, scheduleExpression2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMAssociationExists(resourceName),
@@ -222,6 +254,8 @@ func TestAccAWSSSMAssociation_withAssociationNameAndScheduleExpression(t *testin
 
 func TestAccAWSSSMAssociation_withDocumentVersion(t *testing.T) {
 	name := acctest.RandString(10)
+	resourceName := "aws_ssm_association.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -230,10 +264,15 @@ func TestAccAWSSSMAssociation_withDocumentVersion(t *testing.T) {
 			{
 				Config: testAccAWSSSMAssociationBasicConfigWithDocumentVersion(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMAssociationExists("aws_ssm_association.foo"),
+					testAccCheckAWSSSMAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "document_version", "1"),
+						resourceName, "document_version", "1"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -241,6 +280,8 @@ func TestAccAWSSSMAssociation_withDocumentVersion(t *testing.T) {
 
 func TestAccAWSSSMAssociation_withOutputLocation(t *testing.T) {
 	name := acctest.RandString(10)
+	resourceName := "aws_ssm_association.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -249,31 +290,36 @@ func TestAccAWSSSMAssociation_withOutputLocation(t *testing.T) {
 			{
 				Config: testAccAWSSSMAssociationBasicConfigWithOutPutLocation(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMAssociationExists("aws_ssm_association.foo"),
+					testAccCheckAWSSSMAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "output_location.0.s3_bucket_name", fmt.Sprintf("tf-acc-test-ssmoutput-%s", name)),
+						resourceName, "output_location.0.s3_bucket_name", fmt.Sprintf("tf-acc-test-ssmoutput-%s", name)),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "output_location.0.s3_key_prefix", "SSMAssociation"),
+						resourceName, "output_location.0.s3_key_prefix", "SSMAssociation"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSSSMAssociationBasicConfigWithOutPutLocationUpdateBucketName(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMAssociationExists("aws_ssm_association.foo"),
+					testAccCheckAWSSSMAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "output_location.0.s3_bucket_name", fmt.Sprintf("tf-acc-test-ssmoutput-updated-%s", name)),
+						resourceName, "output_location.0.s3_bucket_name", fmt.Sprintf("tf-acc-test-ssmoutput-updated-%s", name)),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "output_location.0.s3_key_prefix", "SSMAssociation"),
+						resourceName, "output_location.0.s3_key_prefix", "SSMAssociation"),
 				),
 			},
 			{
 				Config: testAccAWSSSMAssociationBasicConfigWithOutPutLocationUpdateKeyPrefix(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMAssociationExists("aws_ssm_association.foo"),
+					testAccCheckAWSSSMAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "output_location.0.s3_bucket_name", fmt.Sprintf("tf-acc-test-ssmoutput-updated-%s", name)),
+						resourceName, "output_location.0.s3_bucket_name", fmt.Sprintf("tf-acc-test-ssmoutput-updated-%s", name)),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "output_location.0.s3_key_prefix", "UpdatedAssociation"),
+						resourceName, "output_location.0.s3_key_prefix", "UpdatedAssociation"),
 				),
 			},
 		},
@@ -282,6 +328,8 @@ func TestAccAWSSSMAssociation_withOutputLocation(t *testing.T) {
 
 func TestAccAWSSSMAssociation_withScheduleExpression(t *testing.T) {
 	name := acctest.RandString(10)
+	resourceName := "aws_ssm_association.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -290,17 +338,22 @@ func TestAccAWSSSMAssociation_withScheduleExpression(t *testing.T) {
 			{
 				Config: testAccAWSSSMAssociationBasicConfigWithScheduleExpression(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMAssociationExists("aws_ssm_association.foo"),
+					testAccCheckAWSSSMAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "schedule_expression", "cron(0 16 ? * TUE *)"),
+						resourceName, "schedule_expression", "cron(0 16 ? * TUE *)"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSSSMAssociationBasicConfigWithScheduleExpressionUpdated(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMAssociationExists("aws_ssm_association.foo"),
+					testAccCheckAWSSSMAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "schedule_expression", "cron(0 16 ? * WED *)"),
+						resourceName, "schedule_expression", "cron(0 16 ? * WED *)"),
 				),
 			},
 		},
@@ -312,6 +365,7 @@ func TestAccAWSSSMAssociation_withComplianceSeverity(t *testing.T) {
 	rName := acctest.RandString(10)
 	compSeverity1 := "HIGH"
 	compSeverity2 := "LOW"
+	resourceName := "aws_ssm_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -321,21 +375,26 @@ func TestAccAWSSSMAssociation_withComplianceSeverity(t *testing.T) {
 			{
 				Config: testAccAWSSSMAssociationBasicConfigWithComplianceSeverity(compSeverity1, rName, assocName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMAssociationExists("aws_ssm_association.foo"),
+					testAccCheckAWSSSMAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "association_name", assocName),
+						resourceName, "association_name", assocName),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "compliance_severity", compSeverity1),
+						resourceName, "compliance_severity", compSeverity1),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSSSMAssociationBasicConfigWithComplianceSeverity(compSeverity2, rName, assocName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMAssociationExists("aws_ssm_association.foo"),
+					testAccCheckAWSSSMAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "association_name", assocName),
+						resourceName, "association_name", assocName),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "compliance_severity", compSeverity2),
+						resourceName, "compliance_severity", compSeverity2),
 				),
 			},
 		},
@@ -344,6 +403,8 @@ func TestAccAWSSSMAssociation_withComplianceSeverity(t *testing.T) {
 
 func TestAccAWSSSMAssociation_rateControl(t *testing.T) {
 	name := acctest.RandString(10)
+	resourceName := "aws_ssm_association.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -352,21 +413,26 @@ func TestAccAWSSSMAssociation_rateControl(t *testing.T) {
 			{
 				Config: testAccAWSSSMAssociationRateControlConfig(name, "10%"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMAssociationExists("aws_ssm_association.foo"),
+					testAccCheckAWSSSMAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "max_concurrency", "10%"),
+						resourceName, "max_concurrency", "10%"),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "max_errors", "10%"),
+						resourceName, "max_errors", "10%"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSSSMAssociationRateControlConfig(name, "20%"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMAssociationExists("aws_ssm_association.foo"),
+					testAccCheckAWSSSMAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "max_concurrency", "20%"),
+						resourceName, "max_concurrency", "20%"),
 					resource.TestCheckResourceAttr(
-						"aws_ssm_association.foo", "max_errors", "20%"),
+						resourceName, "max_errors", "20%"),
 				),
 			},
 		},
@@ -430,7 +496,7 @@ func testAccCheckAWSSSMAssociationDestroy(s *terraform.State) error {
 
 func testAccAWSSSMAssociationBasicConfigWithParameters(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_ssm_document" "foo_document" {
+resource "aws_ssm_document" "test" {
   name          = "test_document_association-%s"
   document_type = "Command"
 
@@ -460,8 +526,8 @@ resource "aws_ssm_document" "foo_document" {
   DOC
 }
 
-resource "aws_ssm_association" "foo" {
-  name = "${aws_ssm_document.foo_document.name}"
+resource "aws_ssm_association" "test" {
+  name = "${aws_ssm_document.test.name}"
 
   parameters = {
     Directory = "myWorkSpace"
@@ -477,7 +543,7 @@ resource "aws_ssm_association" "foo" {
 
 func testAccAWSSSMAssociationBasicConfigWithParametersUpdated(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_ssm_document" "foo_document" {
+resource "aws_ssm_document" "test" {
   name          = "test_document_association-%s"
   document_type = "Command"
 
@@ -507,8 +573,8 @@ resource "aws_ssm_document" "foo_document" {
   DOC
 }
 
-resource "aws_ssm_association" "foo" {
-  name = "${aws_ssm_document.foo_document.name}"
+resource "aws_ssm_association" "test" {
+  name = "${aws_ssm_document.test.name}"
 
   parameters = {
     Directory = "myWorkSpaceUpdated"
@@ -524,7 +590,7 @@ resource "aws_ssm_association" "foo" {
 
 func testAccAWSSSMAssociationBasicConfigWithTargets(rName, targetsStr string) string {
 	return fmt.Sprintf(`
-resource "aws_ssm_document" "foo_document" {
+resource "aws_ssm_document" "test" {
   name = "test_document_association-%s"
   document_type = "Command"
   content = <<DOC
@@ -548,8 +614,8 @@ resource "aws_ssm_document" "foo_document" {
 DOC
 }
 
-resource "aws_ssm_association" "foo" {
-  name = "${aws_ssm_document.foo_document.name}"
+resource "aws_ssm_association" "test" {
+  name = "${aws_ssm_document.test.name}"
   %s
 }
 `, rName, targetsStr)
@@ -587,7 +653,7 @@ resource "aws_subnet" "first" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
 }
 
-resource "aws_security_group" "tf_test_foo" {
+resource "aws_security_group" "test" {
   name        = "${var.name}"
   description = "foo"
   vpc_id      = "${aws_vpc.main.id}"
@@ -600,11 +666,11 @@ resource "aws_security_group" "tf_test_foo" {
   }
 }
 
-resource "aws_instance" "foo" {
+resource "aws_instance" "test" {
   ami                    = "${data.aws_ami.amzn.image_id}"
   availability_zone      = "${data.aws_availability_zones.available.names[0]}"
   instance_type          = "t2.micro"
-  vpc_security_group_ids = ["${aws_security_group.tf_test_foo.id}"]
+  vpc_security_group_ids = ["${aws_security_group.test.id}"]
   subnet_id              = "${aws_subnet.first.id}"
 
   tags = {
@@ -612,7 +678,7 @@ resource "aws_instance" "foo" {
   }
 }
 
-resource "aws_ssm_document" "foo_document" {
+resource "aws_ssm_document" "test" {
   name          = "${var.name}"
   document_type = "Command"
 
@@ -637,16 +703,16 @@ resource "aws_ssm_document" "foo_document" {
 DOC
 }
 
-resource "aws_ssm_association" "foo" {
+resource "aws_ssm_association" "test" {
   name        = "${var.name}"
-  instance_id = "${aws_instance.foo.id}"
+  instance_id = "${aws_instance.test.id}"
 }
 `, rName)
 }
 
 func testAccAWSSSMAssociationBasicConfigWithDocumentVersion(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_ssm_document" "foo_document" {
+resource "aws_ssm_document" "test" {
   name          = "test_document_association-%s"
   document_type = "Command"
 
@@ -671,9 +737,9 @@ resource "aws_ssm_document" "foo_document" {
 DOC
 }
 
-resource "aws_ssm_association" "foo" {
+resource "aws_ssm_association" "test" {
   name             = "test_document_association-%s"
-  document_version = "${aws_ssm_document.foo_document.latest_version}"
+  document_version = "${aws_ssm_document.test.latest_version}"
 
   targets {
     key    = "tag:Name"
@@ -685,7 +751,7 @@ resource "aws_ssm_association" "foo" {
 
 func testAccAWSSSMAssociationBasicConfigWithScheduleExpression(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_ssm_document" "foo_document" {
+resource "aws_ssm_document" "test" {
   name          = "test_document_association-%s"
   document_type = "Command"
 
@@ -710,8 +776,8 @@ resource "aws_ssm_document" "foo_document" {
 DOC
 }
 
-resource "aws_ssm_association" "foo" {
-  name                = "${aws_ssm_document.foo_document.name}"
+resource "aws_ssm_association" "test" {
+  name                = "${aws_ssm_document.test.name}"
   schedule_expression = "cron(0 16 ? * TUE *)"
 
   targets {
@@ -724,7 +790,7 @@ resource "aws_ssm_association" "foo" {
 
 func testAccAWSSSMAssociationBasicConfigWithScheduleExpressionUpdated(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_ssm_document" "foo_document" {
+resource "aws_ssm_document" "test" {
   name          = "test_document_association-%s"
   document_type = "Command"
 
@@ -749,8 +815,8 @@ resource "aws_ssm_document" "foo_document" {
 DOC
 }
 
-resource "aws_ssm_association" "foo" {
-  name                = "${aws_ssm_document.foo_document.name}"
+resource "aws_ssm_association" "test" {
+  name                = "${aws_ssm_document.test.name}"
   schedule_expression = "cron(0 16 ? * WED *)"
 
   targets {
@@ -768,7 +834,7 @@ resource "aws_s3_bucket" "output_location" {
   force_destroy = true
 }
 
-resource "aws_ssm_document" "foo_document" {
+resource "aws_ssm_document" "test" {
   name          = "test_document_association-%s"
   document_type = "Command"
 
@@ -793,8 +859,8 @@ resource "aws_ssm_document" "foo_document" {
 DOC
 }
 
-resource "aws_ssm_association" "foo" {
-  name = "${aws_ssm_document.foo_document.name}"
+resource "aws_ssm_association" "test" {
+  name = "${aws_ssm_document.test.name}"
 
   targets {
     key    = "tag:Name"
@@ -821,7 +887,7 @@ resource "aws_s3_bucket" "output_location_updated" {
   force_destroy = true
 }
 
-resource "aws_ssm_document" "foo_document" {
+resource "aws_ssm_document" "test" {
   name          = "test_document_association-%s"
   document_type = "Command"
 
@@ -846,8 +912,8 @@ resource "aws_ssm_document" "foo_document" {
 DOC
 }
 
-resource "aws_ssm_association" "foo" {
-  name = "${aws_ssm_document.foo_document.name}"
+resource "aws_ssm_association" "test" {
+  name = "${aws_ssm_document.test.name}"
 
   targets {
     key    = "tag:Name"
@@ -874,7 +940,7 @@ resource "aws_s3_bucket" "output_location_updated" {
   force_destroy = true
 }
 
-resource "aws_ssm_document" "foo_document" {
+resource "aws_ssm_document" "test" {
   name          = "test_document_association-%s"
   document_type = "Command"
 
@@ -899,8 +965,8 @@ resource "aws_ssm_document" "foo_document" {
 DOC
 }
 
-resource "aws_ssm_association" "foo" {
-  name = "${aws_ssm_document.foo_document.name}"
+resource "aws_ssm_association" "test" {
+  name = "${aws_ssm_document.test.name}"
 
   targets {
     key    = "tag:Name"
@@ -917,7 +983,7 @@ resource "aws_ssm_association" "foo" {
 
 func testAccAWSSSMAssociationBasicConfigWithAssociationName(rName, assocName string) string {
 	return fmt.Sprintf(`
-resource "aws_ssm_document" "foo_document" {
+resource "aws_ssm_document" "test" {
   name          = "test_document_association-%s"
   document_type = "Command"
 
@@ -941,8 +1007,8 @@ resource "aws_ssm_document" "foo_document" {
 DOC
 }
 
-resource "aws_ssm_association" "foo" {
-  name             = "${aws_ssm_document.foo_document.name}"
+resource "aws_ssm_association" "test" {
+  name             = "${aws_ssm_document.test.name}"
   association_name = "%s"
 
   targets {
@@ -994,7 +1060,7 @@ resource "aws_ssm_association" "test" {
 
 func testAccAWSSSMAssociationBasicConfigWithComplianceSeverity(compSeverity, rName, assocName string) string {
 	return fmt.Sprintf(`
-resource "aws_ssm_document" "foo_document" {
+resource "aws_ssm_document" "test" {
   name          = "test_document_association-%s"
   document_type = "Command"
 
@@ -1018,8 +1084,8 @@ resource "aws_ssm_document" "foo_document" {
 DOC
 }
 
-resource "aws_ssm_association" "foo" {
-  name                = "${aws_ssm_document.foo_document.name}"
+resource "aws_ssm_association" "test" {
+  name                = "${aws_ssm_document.test.name}"
   association_name    = "%s"
   compliance_severity = "%s"
 
@@ -1033,7 +1099,7 @@ resource "aws_ssm_association" "foo" {
 
 func testAccAWSSSMAssociationRateControlConfig(rName, rate string) string {
 	return fmt.Sprintf(`
-resource "aws_ssm_document" "foo_document" {
+resource "aws_ssm_document" "test" {
   name          = "tf-test-ssm-document-%s"
   document_type = "Command"
 
@@ -1057,8 +1123,8 @@ resource "aws_ssm_document" "foo_document" {
 DOC
 }
 
-resource "aws_ssm_association" "foo" {
-  name            = "${aws_ssm_document.foo_document.name}"
+resource "aws_ssm_association" "test" {
+  name            = "${aws_ssm_document.test.name}"
   max_concurrency = "%s"
   max_errors      = "%s"
 

--- a/website/docs/r/ssm_association.html.markdown
+++ b/website/docs/r/ssm_association.html.markdown
@@ -53,6 +53,15 @@ Targets specify what instance IDs or tags to apply the document to and has these
 
 In addition to all arguments above, the following attributes are exported:
 
-* `name` - The name of the SSM document to apply.
+* `association_id` - The ID of the SSM association.
 * `instance_ids` - The instance id that the SSM document was applied to.
+* `name` - The name of the SSM document to apply.
 * `parameters` - Additional parameters passed to the SSM document.
+
+## Import
+
+SSM associations can be imported using the `association_id`, e.g.
+
+```
+$ terraform import aws_ssm_association.test-association 10abcdef-0abc-1234-5678-90abcdef123456
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9981

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
ENHANCEMENTS:
* resource/aws_ssm_association: Add import support
```

Output from acceptance testing:

```
$  make testacc TESTARGS="-run=TestAccAWSSSMAssociation_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSSSMAssociation_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSSSMAssociation_basic
=== PAUSE TestAccAWSSSMAssociation_basic
=== RUN   TestAccAWSSSMAssociation_withTargets
=== PAUSE TestAccAWSSSMAssociation_withTargets
=== RUN   TestAccAWSSSMAssociation_withParameters
=== PAUSE TestAccAWSSSMAssociation_withParameters
=== RUN   TestAccAWSSSMAssociation_withAssociationName
=== PAUSE TestAccAWSSSMAssociation_withAssociationName
=== RUN   TestAccAWSSSMAssociation_withAssociationNameAndScheduleExpression
=== PAUSE TestAccAWSSSMAssociation_withAssociationNameAndScheduleExpression
=== RUN   TestAccAWSSSMAssociation_withDocumentVersion
=== PAUSE TestAccAWSSSMAssociation_withDocumentVersion
=== RUN   TestAccAWSSSMAssociation_withOutputLocation
=== PAUSE TestAccAWSSSMAssociation_withOutputLocation
=== RUN   TestAccAWSSSMAssociation_withScheduleExpression
=== PAUSE TestAccAWSSSMAssociation_withScheduleExpression
=== RUN   TestAccAWSSSMAssociation_withComplianceSeverity
=== PAUSE TestAccAWSSSMAssociation_withComplianceSeverity
=== RUN   TestAccAWSSSMAssociation_rateControl
=== PAUSE TestAccAWSSSMAssociation_rateControl
=== CONT  TestAccAWSSSMAssociation_basic
=== CONT  TestAccAWSSSMAssociation_rateControl
=== CONT  TestAccAWSSSMAssociation_withScheduleExpression
=== CONT  TestAccAWSSSMAssociation_withAssociationNameAndScheduleExpression
=== CONT  TestAccAWSSSMAssociation_withComplianceSeverity
=== CONT  TestAccAWSSSMAssociation_withParameters
=== CONT  TestAccAWSSSMAssociation_withAssociationName
=== CONT  TestAccAWSSSMAssociation_withOutputLocation
=== CONT  TestAccAWSSSMAssociation_withTargets
=== CONT  TestAccAWSSSMAssociation_withDocumentVersion
--- PASS: TestAccAWSSSMAssociation_withDocumentVersion (40.39s)
--- PASS: TestAccAWSSSMAssociation_withAssociationName (65.57s)
--- PASS: TestAccAWSSSMAssociation_withComplianceSeverity (65.59s)
--- PASS: TestAccAWSSSMAssociation_withAssociationNameAndScheduleExpression (65.60s)
--- PASS: TestAccAWSSSMAssociation_withScheduleExpression (65.65s)
--- PASS: TestAccAWSSSMAssociation_withParameters (68.74s)
--- PASS: TestAccAWSSSMAssociation_rateControl (70.42s)
--- PASS: TestAccAWSSSMAssociation_withTargets (90.95s)
--- PASS: TestAccAWSSSMAssociation_withOutputLocation (154.03s)
--- PASS: TestAccAWSSSMAssociation_basic (192.84s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       199.581s
```

Local screenshot of docs changes:
![Screenshot 2019-09-10 at 11 44 57](https://user-images.githubusercontent.com/397565/64604188-02774d80-d3c2-11e9-9200-d550cab707aa.png)
