### PR TITLE
Import test refactor for IOT resources

### DIFF
--- a/aws/resource_aws_iot_thing_test.go
+++ b/aws/resource_aws_iot_thing_test.go
@@ -15,6 +15,7 @@ func TestAccAWSIotThing_basic(t *testing.T) {
 	var thing iot.DescribeThingOutput
 	rString := acctest.RandString(8)
 	thingName := fmt.Sprintf("tf_acc_thing_%s", rString)
+	resourceName := "aws_iot_thing.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -24,14 +25,19 @@ func TestAccAWSIotThing_basic(t *testing.T) {
 			{
 				Config: testAccAWSIotThingConfig_basic(thingName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIotThingExists("aws_iot_thing.test", &thing),
-					resource.TestCheckResourceAttr("aws_iot_thing.test", "name", thingName),
-					resource.TestCheckResourceAttr("aws_iot_thing.test", "attributes.%", "0"),
-					resource.TestCheckResourceAttr("aws_iot_thing.test", "thing_type_name", ""),
-					resource.TestCheckResourceAttrSet("aws_iot_thing.test", "arn"),
-					resource.TestCheckResourceAttrSet("aws_iot_thing.test", "default_client_id"),
-					resource.TestCheckResourceAttrSet("aws_iot_thing.test", "version"),
+					testAccCheckIotThingExists(resourceName, &thing),
+					resource.TestCheckResourceAttr(resourceName, "name", thingName),
+					resource.TestCheckResourceAttr(resourceName, "attributes.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "thing_type_name", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "default_client_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "version"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -42,6 +48,7 @@ func TestAccAWSIotThing_full(t *testing.T) {
 	rString := acctest.RandString(8)
 	thingName := fmt.Sprintf("tf_acc_thing_%s", rString)
 	typeName := fmt.Sprintf("tf_acc_type_%s", rString)
+	resourceName := "aws_iot_thing.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -51,66 +58,49 @@ func TestAccAWSIotThing_full(t *testing.T) {
 			{
 				Config: testAccAWSIotThingConfig_full(thingName, typeName, "42"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIotThingExists("aws_iot_thing.test", &thing),
-					resource.TestCheckResourceAttr("aws_iot_thing.test", "name", thingName),
-					resource.TestCheckResourceAttr("aws_iot_thing.test", "thing_type_name", typeName),
-					resource.TestCheckResourceAttr("aws_iot_thing.test", "attributes.%", "3"),
-					resource.TestCheckResourceAttr("aws_iot_thing.test", "attributes.One", "11111"),
-					resource.TestCheckResourceAttr("aws_iot_thing.test", "attributes.Two", "TwoTwo"),
-					resource.TestCheckResourceAttr("aws_iot_thing.test", "attributes.Answer", "42"),
-					resource.TestCheckResourceAttrSet("aws_iot_thing.test", "arn"),
-					resource.TestCheckResourceAttrSet("aws_iot_thing.test", "default_client_id"),
-					resource.TestCheckResourceAttrSet("aws_iot_thing.test", "version"),
+					testAccCheckIotThingExists(resourceName, &thing),
+					resource.TestCheckResourceAttr(resourceName, "name", thingName),
+					resource.TestCheckResourceAttr(resourceName, "thing_type_name", typeName),
+					resource.TestCheckResourceAttr(resourceName, "attributes.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "attributes.One", "11111"),
+					resource.TestCheckResourceAttr(resourceName, "attributes.Two", "TwoTwo"),
+					resource.TestCheckResourceAttr(resourceName, "attributes.Answer", "42"),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "default_client_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "version"),
 				),
-			},
-			{ // Update attribute
-				Config: testAccAWSIotThingConfig_full(thingName, typeName, "differentOne"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIotThingExists("aws_iot_thing.test", &thing),
-					resource.TestCheckResourceAttr("aws_iot_thing.test", "name", thingName),
-					resource.TestCheckResourceAttr("aws_iot_thing.test", "thing_type_name", typeName),
-					resource.TestCheckResourceAttr("aws_iot_thing.test", "attributes.%", "3"),
-					resource.TestCheckResourceAttr("aws_iot_thing.test", "attributes.One", "11111"),
-					resource.TestCheckResourceAttr("aws_iot_thing.test", "attributes.Two", "TwoTwo"),
-					resource.TestCheckResourceAttr("aws_iot_thing.test", "attributes.Answer", "differentOne"),
-					resource.TestCheckResourceAttrSet("aws_iot_thing.test", "arn"),
-					resource.TestCheckResourceAttrSet("aws_iot_thing.test", "default_client_id"),
-					resource.TestCheckResourceAttrSet("aws_iot_thing.test", "version"),
-				),
-			},
-			{ // Remove thing type association
-				Config: testAccAWSIotThingConfig_basic(thingName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIotThingExists("aws_iot_thing.test", &thing),
-					resource.TestCheckResourceAttr("aws_iot_thing.test", "name", thingName),
-					resource.TestCheckResourceAttr("aws_iot_thing.test", "attributes.%", "0"),
-					resource.TestCheckResourceAttr("aws_iot_thing.test", "thing_type_name", ""),
-					resource.TestCheckResourceAttrSet("aws_iot_thing.test", "arn"),
-					resource.TestCheckResourceAttrSet("aws_iot_thing.test", "default_client_id"),
-					resource.TestCheckResourceAttrSet("aws_iot_thing.test", "version"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSIotThing_importBasic(t *testing.T) {
-	resourceName := "aws_iot_thing.test"
-	rString := acctest.RandString(8)
-	thingName := fmt.Sprintf("tf_acc_thing_%s", rString)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSIotThingTypeDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSIotThingConfig_basic(thingName),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{ // Update attribute
+				Config: testAccAWSIotThingConfig_full(thingName, typeName, "differentOne"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIotThingExists(resourceName, &thing),
+					resource.TestCheckResourceAttr(resourceName, "name", thingName),
+					resource.TestCheckResourceAttr(resourceName, "thing_type_name", typeName),
+					resource.TestCheckResourceAttr(resourceName, "attributes.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "attributes.One", "11111"),
+					resource.TestCheckResourceAttr(resourceName, "attributes.Two", "TwoTwo"),
+					resource.TestCheckResourceAttr(resourceName, "attributes.Answer", "differentOne"),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "default_client_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "version"),
+				),
+			},
+			{ // Remove thing type association
+				Config: testAccAWSIotThingConfig_basic(thingName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIotThingExists(resourceName, &thing),
+					resource.TestCheckResourceAttr(resourceName, "name", thingName),
+					resource.TestCheckResourceAttr(resourceName, "attributes.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "thing_type_name", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "default_client_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "version"),
+				),
 			},
 		},
 	})

--- a/aws/resource_aws_iot_topic_rule_test.go
+++ b/aws/resource_aws_iot_topic_rule_test.go
@@ -10,29 +10,9 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSIoTTopicRule_importbasic(t *testing.T) {
-	resourceName := "aws_iot_topic_rule.rule"
-	rName := acctest.RandString(5)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSIoTTopicRuleDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSIoTTopicRule_basic(rName),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAWSIoTTopicRule_basic(t *testing.T) {
 	rName := acctest.RandString(5)
+	resourceName := "aws_iot_topic_rule.rule"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -50,12 +30,18 @@ func TestAccAWSIoTTopicRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_iot_topic_rule.rule", "sql_version", "2015-10-08"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
 
 func TestAccAWSIoTTopicRule_cloudwatchalarm(t *testing.T) {
 	rName := acctest.RandString(5)
+	resourceName := "aws_iot_topic_rule.rule"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -68,12 +54,18 @@ func TestAccAWSIoTTopicRule_cloudwatchalarm(t *testing.T) {
 					testAccCheckAWSIoTTopicRuleExists_basic("aws_iot_topic_rule.rule"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
 
 func TestAccAWSIoTTopicRule_cloudwatchmetric(t *testing.T) {
 	rName := acctest.RandString(5)
+	resourceName := "aws_iot_topic_rule.rule"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -86,12 +78,18 @@ func TestAccAWSIoTTopicRule_cloudwatchmetric(t *testing.T) {
 					testAccCheckAWSIoTTopicRuleExists_basic("aws_iot_topic_rule.rule"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
 
 func TestAccAWSIoTTopicRule_dynamodb(t *testing.T) {
 	rName := acctest.RandString(5)
+	resourceName := "aws_iot_topic_rule.rule"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -105,6 +103,11 @@ func TestAccAWSIoTTopicRule_dynamodb(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAWSIoTTopicRule_dynamodb_rangekeys(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSIoTTopicRuleExists_basic("aws_iot_topic_rule.rule"),
@@ -116,6 +119,7 @@ func TestAccAWSIoTTopicRule_dynamodb(t *testing.T) {
 
 func TestAccAWSIoTTopicRule_elasticsearch(t *testing.T) {
 	rName := acctest.RandString(5)
+	resourceName := "aws_iot_topic_rule.rule"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -128,12 +132,18 @@ func TestAccAWSIoTTopicRule_elasticsearch(t *testing.T) {
 					testAccCheckAWSIoTTopicRuleExists_basic("aws_iot_topic_rule.rule"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
 
 func TestAccAWSIoTTopicRule_firehose(t *testing.T) {
 	rName := acctest.RandString(5)
+	resourceName := "aws_iot_topic_rule.rule"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -146,12 +156,18 @@ func TestAccAWSIoTTopicRule_firehose(t *testing.T) {
 					testAccCheckAWSIoTTopicRuleExists_basic("aws_iot_topic_rule.rule"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
 
 func TestAccAWSIoTTopicRule_firehose_separator(t *testing.T) {
 	rName := acctest.RandString(5)
+	resourceName := "aws_iot_topic_rule.rule"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -165,6 +181,11 @@ func TestAccAWSIoTTopicRule_firehose_separator(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAWSIoTTopicRule_firehose_separator(rName, ","),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSIoTTopicRuleExists_basic("aws_iot_topic_rule.rule"),
@@ -176,6 +197,7 @@ func TestAccAWSIoTTopicRule_firehose_separator(t *testing.T) {
 
 func TestAccAWSIoTTopicRule_kinesis(t *testing.T) {
 	rName := acctest.RandString(5)
+	resourceName := "aws_iot_topic_rule.rule"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -188,12 +210,18 @@ func TestAccAWSIoTTopicRule_kinesis(t *testing.T) {
 					testAccCheckAWSIoTTopicRuleExists_basic("aws_iot_topic_rule.rule"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
 
 func TestAccAWSIoTTopicRule_lambda(t *testing.T) {
 	rName := acctest.RandString(5)
+	resourceName := "aws_iot_topic_rule.rule"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -206,12 +234,18 @@ func TestAccAWSIoTTopicRule_lambda(t *testing.T) {
 					testAccCheckAWSIoTTopicRuleExists_basic("aws_iot_topic_rule.rule"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
 
 func TestAccAWSIoTTopicRule_republish(t *testing.T) {
 	rName := acctest.RandString(5)
+	resourceName := "aws_iot_topic_rule.rule"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -224,12 +258,18 @@ func TestAccAWSIoTTopicRule_republish(t *testing.T) {
 					testAccCheckAWSIoTTopicRuleExists_basic("aws_iot_topic_rule.rule"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
 
 func TestAccAWSIoTTopicRule_s3(t *testing.T) {
 	rName := acctest.RandString(5)
+	resourceName := "aws_iot_topic_rule.rule"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -242,12 +282,18 @@ func TestAccAWSIoTTopicRule_s3(t *testing.T) {
 					testAccCheckAWSIoTTopicRuleExists_basic("aws_iot_topic_rule.rule"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
 
 func TestAccAWSIoTTopicRule_sns(t *testing.T) {
 	rName := acctest.RandString(5)
+	resourceName := "aws_iot_topic_rule.rule"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -260,12 +306,18 @@ func TestAccAWSIoTTopicRule_sns(t *testing.T) {
 					testAccCheckAWSIoTTopicRuleExists_basic("aws_iot_topic_rule.rule"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
 
 func TestAccAWSIoTTopicRule_sqs(t *testing.T) {
 	rName := acctest.RandString(5)
+	resourceName := "aws_iot_topic_rule.rule"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -277,6 +329,11 @@ func TestAccAWSIoTTopicRule_sqs(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSIoTTopicRuleExists_basic("aws_iot_topic_rule.rule"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8944
Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSIotThing_"     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSIotThing_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSIotThing_basic
=== PAUSE TestAccAWSIotThing_basic
=== RUN   TestAccAWSIotThing_full
=== PAUSE TestAccAWSIotThing_full
=== CONT  TestAccAWSIotThing_basic
=== CONT  TestAccAWSIotThing_full
--- PASS: TestAccAWSIotThing_basic (26.73s)
--- PASS: TestAccAWSIotThing_full (365.69s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       366.787s

make testacc TESTARGS="-run=TestAccAWSIoTTopicRule"    
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSIoTTopicRule -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSIoTTopicRule_basic
=== PAUSE TestAccAWSIoTTopicRule_basic
=== RUN   TestAccAWSIoTTopicRule_cloudwatchalarm
=== PAUSE TestAccAWSIoTTopicRule_cloudwatchalarm
=== RUN   TestAccAWSIoTTopicRule_cloudwatchmetric
=== PAUSE TestAccAWSIoTTopicRule_cloudwatchmetric
=== RUN   TestAccAWSIoTTopicRule_dynamodb
=== PAUSE TestAccAWSIoTTopicRule_dynamodb
=== RUN   TestAccAWSIoTTopicRule_elasticsearch
=== PAUSE TestAccAWSIoTTopicRule_elasticsearch
=== RUN   TestAccAWSIoTTopicRule_firehose
=== PAUSE TestAccAWSIoTTopicRule_firehose
=== RUN   TestAccAWSIoTTopicRule_firehose_separator
=== PAUSE TestAccAWSIoTTopicRule_firehose_separator
=== RUN   TestAccAWSIoTTopicRule_kinesis
=== PAUSE TestAccAWSIoTTopicRule_kinesis
=== RUN   TestAccAWSIoTTopicRule_lambda
=== PAUSE TestAccAWSIoTTopicRule_lambda
=== RUN   TestAccAWSIoTTopicRule_republish
=== PAUSE TestAccAWSIoTTopicRule_republish
=== RUN   TestAccAWSIoTTopicRule_s3
=== PAUSE TestAccAWSIoTTopicRule_s3
=== RUN   TestAccAWSIoTTopicRule_sns
=== PAUSE TestAccAWSIoTTopicRule_sns
=== RUN   TestAccAWSIoTTopicRule_sqs
=== PAUSE TestAccAWSIoTTopicRule_sqs
=== CONT  TestAccAWSIoTTopicRule_basic
=== CONT  TestAccAWSIoTTopicRule_sqs
=== CONT  TestAccAWSIoTTopicRule_firehose_separator
=== CONT  TestAccAWSIoTTopicRule_firehose
=== CONT  TestAccAWSIoTTopicRule_cloudwatchmetric
=== CONT  TestAccAWSIoTTopicRule_lambda
=== CONT  TestAccAWSIoTTopicRule_republish
=== CONT  TestAccAWSIoTTopicRule_sns
=== CONT  TestAccAWSIoTTopicRule_s3
=== CONT  TestAccAWSIoTTopicRule_dynamodb
=== CONT  TestAccAWSIoTTopicRule_kinesis
=== CONT  TestAccAWSIoTTopicRule_elasticsearch
=== CONT  TestAccAWSIoTTopicRule_cloudwatchalarm
--- PASS: TestAccAWSIoTTopicRule_sqs (31.40s)
--- PASS: TestAccAWSIoTTopicRule_basic (31.49s)
--- PASS: TestAccAWSIoTTopicRule_cloudwatchalarm (31.53s)
--- PASS: TestAccAWSIoTTopicRule_firehose (31.74s)
--- PASS: TestAccAWSIoTTopicRule_cloudwatchmetric (31.79s)
--- PASS: TestAccAWSIoTTopicRule_s3 (31.82s)
--- PASS: TestAccAWSIoTTopicRule_sns (31.93s)
--- PASS: TestAccAWSIoTTopicRule_lambda (31.95s)
--- PASS: TestAccAWSIoTTopicRule_republish (31.97s)
--- PASS: TestAccAWSIoTTopicRule_kinesis (32.29s)
--- PASS: TestAccAWSIoTTopicRule_elasticsearch (32.81s)
--- PASS: TestAccAWSIoTTopicRule_firehose_separator (51.23s)
--- PASS: TestAccAWSIoTTopicRule_dynamodb (52.15s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       53.962s
```
