### PR TITLE
Import test refactor for internet gateway

### DIFF
--- a/aws/resource_aws_internet_gateway_test.go
+++ b/aws/resource_aws_internet_gateway_test.go
@@ -118,29 +118,9 @@ func testSweepInternetGateways(region string) error {
 	return nil
 }
 
-func TestAccAWSInternetGateway_importBasic(t *testing.T) {
-	resourceName := "aws_internet_gateway.foo"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInternetGatewayDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccInternetGatewayConfig,
-			},
-
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAWSInternetGateway_basic(t *testing.T) {
 	var v, v2 ec2.InternetGateway
+	resourceName := "aws_internet_gateway.test"
 
 	testNotEqual := func(*terraform.State) error {
 		if len(v.Attachments) == 0 {
@@ -161,7 +141,7 @@ func TestAccAWSInternetGateway_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_internet_gateway.foo",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckInternetGatewayDestroy,
 		Steps: []resource.TestStep{
@@ -169,18 +149,22 @@ func TestAccAWSInternetGateway_basic(t *testing.T) {
 				Config: testAccInternetGatewayConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInternetGatewayExists(
-						"aws_internet_gateway.foo", &v),
-					testAccCheckResourceAttrAccountID("aws_internet_gateway.foo", "owner_id"),
+						resourceName, &v),
+					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 				),
 			},
-
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 			{
 				Config: testAccInternetGatewayConfigChangeVPC,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInternetGatewayExists(
-						"aws_internet_gateway.foo", &v2),
+						resourceName, &v2),
 					testNotEqual,
-					testAccCheckResourceAttrAccountID("aws_internet_gateway.foo", "owner_id"),
+					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 				),
 			},
 		},
@@ -189,6 +173,7 @@ func TestAccAWSInternetGateway_basic(t *testing.T) {
 
 func TestAccAWSInternetGateway_delete(t *testing.T) {
 	var ig ec2.InternetGateway
+	resourceName := "aws_internet_gateway.test"
 
 	testDeleted := func(r string) resource.TestCheckFunc {
 		return func(s *terraform.State) error {
@@ -202,18 +187,18 @@ func TestAccAWSInternetGateway_delete(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_internet_gateway.foo",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckInternetGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInternetGatewayConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInternetGatewayExists("aws_internet_gateway.foo", &ig)),
+					testAccCheckInternetGatewayExists(resourceName, &ig)),
 			},
 			{
 				Config: testAccNoInternetGatewayConfig,
-				Check:  resource.ComposeTestCheckFunc(testDeleted("aws_internet_gateway.foo")),
+				Check:  resource.ComposeTestCheckFunc(testDeleted(resourceName)),
 			},
 		},
 	})
@@ -221,31 +206,36 @@ func TestAccAWSInternetGateway_delete(t *testing.T) {
 
 func TestAccAWSInternetGateway_tags(t *testing.T) {
 	var v ec2.InternetGateway
+	resourceName := "aws_internet_gateway.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_internet_gateway.foo",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckInternetGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckInternetGatewayConfigTags,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInternetGatewayExists("aws_internet_gateway.foo", &v),
+					testAccCheckInternetGatewayExists(resourceName, &v),
 					testAccCheckTags(&v.Tags, "Name", "terraform-testacc-internet-gateway-tags"),
-					testAccCheckTags(&v.Tags, "foo", "bar"),
-					testAccCheckResourceAttrAccountID("aws_internet_gateway.foo", "owner_id"),
+					testAccCheckTags(&v.Tags, "test", "bar"),
+					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 				),
 			},
-
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 			{
 				Config: testAccCheckInternetGatewayConfigTagsUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInternetGatewayExists("aws_internet_gateway.foo", &v),
+					testAccCheckInternetGatewayExists(resourceName, &v),
 					testAccCheckTags(&v.Tags, "Name", "terraform-testacc-internet-gateway-tags"),
-					testAccCheckTags(&v.Tags, "foo", ""),
+					testAccCheckTags(&v.Tags, "test", ""),
 					testAccCheckTags(&v.Tags, "bar", "baz"),
-					testAccCheckResourceAttrAccountID("aws_internet_gateway.foo", "owner_id"),
+					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 				),
 			},
 		},
@@ -314,7 +304,7 @@ func testAccCheckInternetGatewayExists(n string, ig *ec2.InternetGateway) resour
 }
 
 const testAccNoInternetGatewayConfig = `
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
 	cidr_block = "10.1.0.0/16"
 	tags = {
 		Name = "terraform-testacc-no-internet-gateway"
@@ -323,15 +313,15 @@ resource "aws_vpc" "foo" {
 `
 
 const testAccInternetGatewayConfig = `
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
 	cidr_block = "10.1.0.0/16"
 	tags = {
 		Name = "terraform-testacc-internet-gateway"
 	}
 }
 
-resource "aws_internet_gateway" "foo" {
-	vpc_id = "${aws_vpc.foo.id}"
+resource "aws_internet_gateway" "test" {
+	vpc_id = "${aws_vpc.test.id}"
 	tags = {
 		Name = "terraform-testacc-internet-gateway"
 	}
@@ -339,7 +329,7 @@ resource "aws_internet_gateway" "foo" {
 `
 
 const testAccInternetGatewayConfigChangeVPC = `
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
 	cidr_block = "10.1.0.0/16"
 	tags = {
 		Name = "terraform-testacc-internet-gateway-change-vpc"
@@ -353,7 +343,7 @@ resource "aws_vpc" "bar" {
 	}
 }
 
-resource "aws_internet_gateway" "foo" {
+resource "aws_internet_gateway" "test" {
 	vpc_id = "${aws_vpc.bar.id}"
 	tags = {
 		Name = "terraform-testacc-internet-gateway-change-vpc-other"
@@ -362,32 +352,32 @@ resource "aws_internet_gateway" "foo" {
 `
 
 const testAccCheckInternetGatewayConfigTags = `
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
 	cidr_block = "10.1.0.0/16"
 	tags = {
 		Name = "terraform-testacc-internet-gateway-tags"
 	}
 }
 
-resource "aws_internet_gateway" "foo" {
-	vpc_id = "${aws_vpc.foo.id}"
+resource "aws_internet_gateway" "test" {
+	vpc_id = "${aws_vpc.test.id}"
 	tags = {
 		Name = "terraform-testacc-internet-gateway-tags"
-		foo = "bar"
+		test = "bar"
 	}
 }
 `
 
 const testAccCheckInternetGatewayConfigTagsUpdate = `
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
 	cidr_block = "10.1.0.0/16"
 	tags = {
 		Name = "terraform-testacc-internet-gateway-tags"
 	}
 }
 
-resource "aws_internet_gateway" "foo" {
-	vpc_id = "${aws_vpc.foo.id}"
+resource "aws_internet_gateway" "test" {
+	vpc_id = "${aws_vpc.test.id}"
 	tags = {
 		Name = "terraform-testacc-internet-gateway-tags"
 		bar = "baz"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8944

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSInternetGateway_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSInternetGateway_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSInternetGateway_basic
=== PAUSE TestAccAWSInternetGateway_basic
=== RUN   TestAccAWSInternetGateway_delete
=== PAUSE TestAccAWSInternetGateway_delete
=== RUN   TestAccAWSInternetGateway_tags
=== PAUSE TestAccAWSInternetGateway_tags
=== CONT  TestAccAWSInternetGateway_basic
=== CONT  TestAccAWSInternetGateway_tags
=== CONT  TestAccAWSInternetGateway_delete
--- PASS: TestAccAWSInternetGateway_delete (92.04s)
--- PASS: TestAccAWSInternetGateway_tags (99.24s)
--- PASS: TestAccAWSInternetGateway_basic (125.27s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       126.155s
```
