### PR TITLE
Revert retry logic change that's apparently causing policy not found …

### DIFF
--- a/aws/resource_aws_iam_policy_attachment.go
+++ b/aws/resource_aws_iam_policy_attachment.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 )
@@ -215,26 +217,36 @@ func attachPolicyToRoles(conn *iam.IAM, roles []*string, arn string) error {
 			return err
 		}
 
-		input := iam.ListRolePoliciesInput{
-			RoleName: r,
-		}
-		attachedPolicies, err := conn.ListRolePolicies(&input)
-		if err != nil {
-			return fmt.Errorf("Error listing role policies: %s", err)
-		}
+		var attachmentErr = resource.Retry(2*time.Minute, func() *resource.RetryError {
 
-		if len(attachedPolicies.PolicyNames) > 0 {
-			var foundPolicy bool
-			for _, policyName := range attachedPolicies.PolicyNames {
-				if strings.HasSuffix(arn, *policyName) {
-					foundPolicy = true
-					break
+			input := iam.ListRolePoliciesInput{
+				RoleName: r,
+			}
+
+			attachedPolicies, err := conn.ListRolePolicies(&input)
+			if err != nil {
+				return resource.NonRetryableError(err)
+			}
+
+			if len(attachedPolicies.PolicyNames) > 0 {
+				var foundPolicy bool
+				for _, policyName := range attachedPolicies.PolicyNames {
+					if strings.HasSuffix(arn, *policyName) {
+						foundPolicy = true
+						break
+					}
+				}
+
+				if !foundPolicy {
+					return resource.NonRetryableError(err)
 				}
 			}
 
-			if !foundPolicy {
-				return fmt.Errorf("Error: Attached policy not found")
-			}
+			return nil
+		})
+
+		if attachmentErr != nil {
+			return attachmentErr
 		}
 
 	}


### PR DESCRIPTION
…errors

The timing of the regression (v2.25.0) noted in #9918 points to the changes made in #9766 being at fault here. I've been unable to reproduce the error, but given the number of 👍 on it, it seems prudent to revert for now.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #9918

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_iam_policy_attachment: Revert a change causing errors with policies not being found during attachment
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSRolePolicyAttachment_"     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSRolePolicyAttachment_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSRolePolicyAttachment_basic
=== PAUSE TestAccAWSRolePolicyAttachment_basic
=== RUN   TestAccAWSRolePolicyAttachment_disappears
=== PAUSE TestAccAWSRolePolicyAttachment_disappears
=== RUN   TestAccAWSRolePolicyAttachment_disappears_Role
=== PAUSE TestAccAWSRolePolicyAttachment_disappears_Role
=== CONT  TestAccAWSRolePolicyAttachment_basic
=== CONT  TestAccAWSRolePolicyAttachment_disappears_Role
=== CONT  TestAccAWSRolePolicyAttachment_disappears
--- PASS: TestAccAWSRolePolicyAttachment_disappears_Role (28.15s)
--- PASS: TestAccAWSRolePolicyAttachment_disappears (28.27s)
--- PASS: TestAccAWSRolePolicyAttachment_basic (52.93s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       53.797s
```
