### PR TITLE
Import test refactor for IAM resources

### DIFF
--- a/aws/resource_aws_iam_account_password_policy_test.go
+++ b/aws/resource_aws_iam_account_password_policy_test.go
@@ -10,8 +10,9 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSIAMAccountPasswordPolicy_importBasic(t *testing.T) {
-	resourceName := "aws_iam_account_password_policy.default"
+func TestAccAWSIAMAccountPasswordPolicy_basic(t *testing.T) {
+	var policy iam.GetAccountPasswordPolicyOutput
+	resourceName := "aws_iam_account_password_policy.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -20,37 +21,21 @@ func TestAccAWSIAMAccountPasswordPolicy_importBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSIAMAccountPasswordPolicy,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSIAMAccountPasswordPolicyExists(resourceName, &policy),
+					resource.TestCheckResourceAttr(resourceName, "minimum_password_length", "8"),
+				),
 			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-		},
-	})
-}
-
-func TestAccAWSIAMAccountPasswordPolicy_basic(t *testing.T) {
-	var policy iam.GetAccountPasswordPolicyOutput
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSIAMAccountPasswordPolicyDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSIAMAccountPasswordPolicy,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSIAMAccountPasswordPolicyExists("aws_iam_account_password_policy.default", &policy),
-					resource.TestCheckResourceAttr("aws_iam_account_password_policy.default", "minimum_password_length", "8"),
-				),
-			},
 			{
 				Config: testAccAWSIAMAccountPasswordPolicy_modified,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSIAMAccountPasswordPolicyExists("aws_iam_account_password_policy.default", &policy),
-					resource.TestCheckResourceAttr("aws_iam_account_password_policy.default", "minimum_password_length", "7"),
+					testAccCheckAWSIAMAccountPasswordPolicyExists(resourceName, &policy),
+					resource.TestCheckResourceAttr(resourceName, "minimum_password_length", "7"),
 				),
 			},
 		},
@@ -109,14 +94,14 @@ func testAccCheckAWSIAMAccountPasswordPolicyExists(n string, res *iam.GetAccount
 }
 
 const testAccAWSIAMAccountPasswordPolicy = `
-resource "aws_iam_account_password_policy" "default" {
+resource "aws_iam_account_password_policy" "test" {
 	allow_users_to_change_password = true
 	minimum_password_length = 8
 	require_numbers = true
 }
 `
 const testAccAWSIAMAccountPasswordPolicy_modified = `
-resource "aws_iam_account_password_policy" "default" {
+resource "aws_iam_account_password_policy" "test" {
 	allow_users_to_change_password = true
 	minimum_password_length = 7
 	require_numbers = false

--- a/aws/resource_aws_iam_group_test.go
+++ b/aws/resource_aws_iam_group_test.go
@@ -50,33 +50,10 @@ func TestValidateIamGroupName(t *testing.T) {
 	}
 }
 
-func TestAccAWSIAMGroup_importBasic(t *testing.T) {
-	resourceName := "aws_iam_group.group"
-
-	rString := acctest.RandString(8)
-	groupName := fmt.Sprintf("tf-acc-group-import-%s", rString)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSGroupConfig(groupName),
-			},
-
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAWSIAMGroup_basic(t *testing.T) {
 	var conf iam.GetGroupOutput
-
+	resourceName := "aws_iam_group.test"
+	resourceName2 := "aws_iam_group.test2"
 	rString := acctest.RandString(8)
 	groupName := fmt.Sprintf("tf-acc-group-basic-%s", rString)
 	groupName2 := fmt.Sprintf("tf-acc-group-basic-2-%s", rString)
@@ -89,14 +66,19 @@ func TestAccAWSIAMGroup_basic(t *testing.T) {
 			{
 				Config: testAccAWSGroupConfig(groupName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSGroupExists("aws_iam_group.group", &conf),
+					testAccCheckAWSGroupExists(resourceName, &conf),
 					testAccCheckAWSGroupAttributes(&conf, groupName, "/"),
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAWSGroupConfig2(groupName2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSGroupExists("aws_iam_group.group2", &conf),
+					testAccCheckAWSGroupExists(resourceName2, &conf),
 					testAccCheckAWSGroupAttributes(&conf, groupName2, "/funnypath/"),
 				),
 			},
@@ -106,7 +88,7 @@ func TestAccAWSIAMGroup_basic(t *testing.T) {
 
 func TestAccAWSIAMGroup_nameChange(t *testing.T) {
 	var conf iam.GetGroupOutput
-
+	resourceName := "aws_iam_group.test"
 	rString := acctest.RandString(8)
 	groupName := fmt.Sprintf("tf-acc-group-basic-%s", rString)
 	groupName2 := fmt.Sprintf("tf-acc-group-basic-2-%s", rString)
@@ -119,14 +101,14 @@ func TestAccAWSIAMGroup_nameChange(t *testing.T) {
 			{
 				Config: testAccAWSGroupConfig(groupName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSGroupExists("aws_iam_group.group", &conf),
+					testAccCheckAWSGroupExists(resourceName, &conf),
 					testAccCheckAWSGroupAttributes(&conf, groupName, "/"),
 				),
 			},
 			{
 				Config: testAccAWSGroupConfig(groupName2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSGroupExists("aws_iam_group.group", &conf),
+					testAccCheckAWSGroupExists(resourceName, &conf),
 					testAccCheckAWSGroupAttributes(&conf, groupName2, "/"),
 				),
 			},
@@ -205,7 +187,7 @@ func testAccCheckAWSGroupAttributes(group *iam.GetGroupOutput, name string, path
 
 func testAccAWSGroupConfig(groupName string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_group" "group" {
+resource "aws_iam_group" "test" {
   name = "%s"
   path = "/"
 }
@@ -214,7 +196,7 @@ resource "aws_iam_group" "group" {
 
 func testAccAWSGroupConfig2(groupName string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_group" "group2" {
+resource "aws_iam_group" "test2" {
   name = "%s"
   path = "/funnypath/"
 }

--- a/aws/resource_aws_iam_instance_profile_test.go
+++ b/aws/resource_aws_iam_instance_profile_test.go
@@ -13,7 +13,8 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSIAMInstanceProfile_importBasic(t *testing.T) {
+func TestAccAWSIAMInstanceProfile_basic(t *testing.T) {
+	var conf iam.GetInstanceProfileOutput
 	resourceName := "aws_iam_instance_profile.test"
 	rName := acctest.RandString(5)
 
@@ -23,33 +24,15 @@ func TestAccAWSIAMInstanceProfile_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSInstanceProfileDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSInstanceProfilePrefixNameConfig(rName),
-			},
-
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"name_prefix"},
-			},
-		},
-	})
-}
-
-func TestAccAWSIAMInstanceProfile_basic(t *testing.T) {
-	var conf iam.GetInstanceProfileOutput
-
-	rName := acctest.RandString(5)
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSInstanceProfileDestroy,
-		Steps: []resource.TestStep{
-			{
 				Config: testAccAwsIamInstanceProfileConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSInstanceProfileExists("aws_iam_instance_profile.test", &conf),
+					testAccCheckAWSInstanceProfileExists(resourceName, &conf),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -57,6 +40,7 @@ func TestAccAWSIAMInstanceProfile_basic(t *testing.T) {
 
 func TestAccAWSIAMInstanceProfile_withRoleNotRoles(t *testing.T) {
 	var conf iam.GetInstanceProfileOutput
+	resourceName := "aws_iam_instance_profile.test"
 
 	rName := acctest.RandString(5)
 	resource.ParallelTest(t, resource.TestCase{
@@ -67,8 +51,14 @@ func TestAccAWSIAMInstanceProfile_withRoleNotRoles(t *testing.T) {
 			{
 				Config: testAccAWSInstanceProfileWithRoleSpecified(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSInstanceProfileExists("aws_iam_instance_profile.test", &conf),
+					testAccCheckAWSInstanceProfileExists(resourceName, &conf),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name_prefix"},
 			},
 		},
 	})
@@ -92,10 +82,11 @@ func TestAccAWSIAMInstanceProfile_missingRoleThrowsError(t *testing.T) {
 func TestAccAWSIAMInstanceProfile_namePrefix(t *testing.T) {
 	var conf iam.GetInstanceProfileOutput
 	rName := acctest.RandString(5)
+	resourceName := "aws_iam_instance_profile.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
-		IDRefreshName:   "aws_iam_instance_profile.test",
+		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"name_prefix"},
 		Providers:       testAccProviders,
 		CheckDestroy:    testAccCheckAWSInstanceProfileDestroy,
@@ -103,10 +94,16 @@ func TestAccAWSIAMInstanceProfile_namePrefix(t *testing.T) {
 			{
 				Config: testAccAWSInstanceProfilePrefixNameConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSInstanceProfileExists("aws_iam_instance_profile.test", &conf),
+					testAccCheckAWSInstanceProfileExists(resourceName, &conf),
 					testAccCheckAWSInstanceProfileGeneratedNamePrefix(
-						"aws_iam_instance_profile.test", "test-"),
+						resourceName, "test-"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name_prefix"},
 			},
 		},
 	})

--- a/aws/resource_aws_iam_openid_connect_provider_test.go
+++ b/aws/resource_aws_iam_openid_connect_provider_test.go
@@ -14,7 +14,8 @@ import (
 
 func TestAccAWSIAMOpenIDConnectProvider_basic(t *testing.T) {
 	rString := acctest.RandString(5)
-	url := "accounts.google.com/" + rString
+	url := "accounts.testle.com/" + rString
+	resourceName := "aws_iam_openid_connect_provider.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -24,48 +25,31 @@ func TestAccAWSIAMOpenIDConnectProvider_basic(t *testing.T) {
 			{
 				Config: testAccIAMOpenIDConnectProviderConfig(rString),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIAMOpenIDConnectProvider("aws_iam_openid_connect_provider.goog"),
-					resource.TestCheckResourceAttr("aws_iam_openid_connect_provider.goog", "url", url),
-					resource.TestCheckResourceAttr("aws_iam_openid_connect_provider.goog", "client_id_list.#", "1"),
-					resource.TestCheckResourceAttr("aws_iam_openid_connect_provider.goog", "client_id_list.0",
-						"266362248691-re108qaeld573ia0l6clj2i5ac7r7291.apps.googleusercontent.com"),
-					resource.TestCheckResourceAttr("aws_iam_openid_connect_provider.goog", "thumbprint_list.#", "0"),
+					testAccCheckIAMOpenIDConnectProvider(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "url", url),
+					resource.TestCheckResourceAttr(resourceName, "client_id_list.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "client_id_list.0",
+						"266362248691-re108qaeld573ia0l6clj2i5ac7r7291.apps.testleusercontent.com"),
+					resource.TestCheckResourceAttr(resourceName, "thumbprint_list.#", "0"),
 				),
 			},
-			{
-				Config: testAccIAMOpenIDConnectProviderConfig_modified(rString),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIAMOpenIDConnectProvider("aws_iam_openid_connect_provider.goog"),
-					resource.TestCheckResourceAttr("aws_iam_openid_connect_provider.goog", "url", url),
-					resource.TestCheckResourceAttr("aws_iam_openid_connect_provider.goog", "client_id_list.#", "1"),
-					resource.TestCheckResourceAttr("aws_iam_openid_connect_provider.goog", "client_id_list.0",
-						"266362248691-re108qaeld573ia0l6clj2i5ac7r7291.apps.googleusercontent.com"),
-					resource.TestCheckResourceAttr("aws_iam_openid_connect_provider.goog", "thumbprint_list.#", "2"),
-					resource.TestCheckResourceAttr("aws_iam_openid_connect_provider.goog", "thumbprint_list.0", "cf23df2207d99a74fbe169e3eba035e633b65d94"),
-					resource.TestCheckResourceAttr("aws_iam_openid_connect_provider.goog", "thumbprint_list.1", "c784713d6f9cb67b55dd84f4e4af7832d42b8f55"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSIAMOpenIDConnectProvider_importBasic(t *testing.T) {
-	resourceName := "aws_iam_openid_connect_provider.goog"
-	rString := acctest.RandString(5)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckIAMOpenIDConnectProviderDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccIAMOpenIDConnectProviderConfig_modified(rString),
-			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccIAMOpenIDConnectProviderConfig_modified(rString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIAMOpenIDConnectProvider(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "url", url),
+					resource.TestCheckResourceAttr(resourceName, "client_id_list.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "client_id_list.0",
+						"266362248691-re108qaeld573ia0l6clj2i5ac7r7291.apps.testleusercontent.com"),
+					resource.TestCheckResourceAttr(resourceName, "thumbprint_list.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "thumbprint_list.0", "cf23df2207d99a74fbe169e3eba035e633b65d94"),
+					resource.TestCheckResourceAttr(resourceName, "thumbprint_list.1", "c784713d6f9cb67b55dd84f4e4af7832d42b8f55"),
+				),
 			},
 		},
 	})
@@ -73,6 +57,7 @@ func TestAccAWSIAMOpenIDConnectProvider_importBasic(t *testing.T) {
 
 func TestAccAWSIAMOpenIDConnectProvider_disappears(t *testing.T) {
 	rString := acctest.RandString(5)
+	resourceName := "aws_iam_openid_connect_provider.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -82,8 +67,8 @@ func TestAccAWSIAMOpenIDConnectProvider_disappears(t *testing.T) {
 			{
 				Config: testAccIAMOpenIDConnectProviderConfig(rString),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIAMOpenIDConnectProvider("aws_iam_openid_connect_provider.goog"),
-					testAccCheckIAMOpenIDConnectProviderDisappears("aws_iam_openid_connect_provider.goog"),
+					testAccCheckIAMOpenIDConnectProvider(resourceName),
+					testAccCheckIAMOpenIDConnectProviderDisappears(resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -160,11 +145,11 @@ func testAccCheckIAMOpenIDConnectProvider(id string) resource.TestCheckFunc {
 
 func testAccIAMOpenIDConnectProviderConfig(rString string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_openid_connect_provider" "goog" {
-  url = "https://accounts.google.com/%s"
+resource "aws_iam_openid_connect_provider" "test" {
+  url = "https://accounts.testle.com/%s"
 
   client_id_list = [
-    "266362248691-re108qaeld573ia0l6clj2i5ac7r7291.apps.googleusercontent.com",
+    "266362248691-re108qaeld573ia0l6clj2i5ac7r7291.apps.testleusercontent.com",
   ]
 
   thumbprint_list = []
@@ -174,11 +159,11 @@ resource "aws_iam_openid_connect_provider" "goog" {
 
 func testAccIAMOpenIDConnectProviderConfig_modified(rString string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_openid_connect_provider" "goog" {
-  url = "https://accounts.google.com/%s"
+resource "aws_iam_openid_connect_provider" "test" {
+  url = "https://accounts.testle.com/%s"
 
   client_id_list = [
-    "266362248691-re108qaeld573ia0l6clj2i5ac7r7291.apps.googleusercontent.com",
+    "266362248691-re108qaeld573ia0l6clj2i5ac7r7291.apps.testleusercontent.com",
   ]
 
   thumbprint_list = ["cf23df2207d99a74fbe169e3eba035e633b65d94", "c784713d6f9cb67b55dd84f4e4af7832d42b8f55"]

--- a/aws/resource_aws_iam_role_policy_test.go
+++ b/aws/resource_aws_iam_role_policy_test.go
@@ -14,33 +14,14 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSIAMRolePolicy_importBasic(t *testing.T) {
-	suffix := randomString(10)
-	resourceName := fmt.Sprintf("aws_iam_role_policy.foo_%s", suffix)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckIAMRolePolicyDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAwsIamRolePolicyConfig(suffix),
-			},
-
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAWSIAMRolePolicy_basic(t *testing.T) {
 	var rolePolicy1, rolePolicy2, rolePolicy3 iam.GetRolePolicyOutput
 	role := acctest.RandString(10)
 	policy1 := acctest.RandString(10)
 	policy2 := acctest.RandString(10)
+	resourceName := "aws_iam_role_policy.test"
+	resourceName2 := "aws_iam_role_policy.test2"
+	roleName := "aws_iam_role.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -51,23 +32,28 @@ func TestAccAWSIAMRolePolicy_basic(t *testing.T) {
 				Config: testAccIAMRolePolicyConfig(role, policy1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMRolePolicyExists(
-						"aws_iam_role.role",
-						"aws_iam_role_policy.foo",
+						roleName,
+						resourceName,
 						&rolePolicy1,
 					),
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccIAMRolePolicyConfigUpdate(role, policy1, policy2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMRolePolicyExists(
-						"aws_iam_role.role",
-						"aws_iam_role_policy.foo",
+						roleName,
+						resourceName,
 						&rolePolicy2,
 					),
 					testAccCheckIAMRolePolicyExists(
-						"aws_iam_role.role",
-						"aws_iam_role_policy.bar",
+						roleName,
+						resourceName2,
 						&rolePolicy3,
 					),
 					testAccCheckAWSIAMRolePolicyNameMatches(&rolePolicy1, &rolePolicy2),
@@ -82,7 +68,7 @@ func TestAccAWSIAMRolePolicy_disappears(t *testing.T) {
 	var out iam.GetRolePolicyOutput
 	suffix := randomString(10)
 	roleResourceName := fmt.Sprintf("aws_iam_role.role_%s", suffix)
-	rolePolicyResourceName := fmt.Sprintf("aws_iam_role_policy.foo_%s", suffix)
+	rolePolicyResourceName := fmt.Sprintf("aws_iam_role_policy.test_%s", suffix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -108,10 +94,12 @@ func TestAccAWSIAMRolePolicy_disappears(t *testing.T) {
 func TestAccAWSIAMRolePolicy_namePrefix(t *testing.T) {
 	var rolePolicy1, rolePolicy2 iam.GetRolePolicyOutput
 	role := acctest.RandString(10)
+	resourceName := "aws_iam_role_policy.test"
+	roleName := "aws_iam_role.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_iam_role_policy.test",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckIAMRolePolicyDestroy,
 		Steps: []resource.TestStep{
@@ -119,23 +107,29 @@ func TestAccAWSIAMRolePolicy_namePrefix(t *testing.T) {
 				Config: testAccIAMRolePolicyConfig_namePrefix(role, "*"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMRolePolicyExists(
-						"aws_iam_role.test",
-						"aws_iam_role_policy.test",
+						roleName,
+						resourceName,
 						&rolePolicy1,
 					),
-					resource.TestCheckResourceAttrSet("aws_iam_role_policy.test", "name"),
+					resource.TestCheckResourceAttrSet(resourceName, "name"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name_prefix"},
 			},
 			{
 				Config: testAccIAMRolePolicyConfig_namePrefix(role, "ec2:*"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMRolePolicyExists(
-						"aws_iam_role.test",
-						"aws_iam_role_policy.test",
+						roleName,
+						resourceName,
 						&rolePolicy2,
 					),
 					testAccCheckAWSIAMRolePolicyNameMatches(&rolePolicy1, &rolePolicy2),
-					resource.TestCheckResourceAttrSet("aws_iam_role_policy.test", "name"),
+					resource.TestCheckResourceAttrSet(resourceName, "name"),
 				),
 			},
 		},
@@ -145,10 +139,12 @@ func TestAccAWSIAMRolePolicy_namePrefix(t *testing.T) {
 func TestAccAWSIAMRolePolicy_generatedName(t *testing.T) {
 	var rolePolicy1, rolePolicy2 iam.GetRolePolicyOutput
 	role := acctest.RandString(10)
+	resourceName := "aws_iam_role_policy.test"
+	roleName := "aws_iam_role.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_iam_role_policy.test",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckIAMRolePolicyDestroy,
 		Steps: []resource.TestStep{
@@ -156,23 +152,28 @@ func TestAccAWSIAMRolePolicy_generatedName(t *testing.T) {
 				Config: testAccIAMRolePolicyConfig_generatedName(role, "*"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMRolePolicyExists(
-						"aws_iam_role.test",
-						"aws_iam_role_policy.test",
+						roleName,
+						resourceName,
 						&rolePolicy1,
 					),
-					resource.TestCheckResourceAttrSet("aws_iam_role_policy.test", "name"),
+					resource.TestCheckResourceAttrSet(resourceName, "name"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccIAMRolePolicyConfig_generatedName(role, "ec2:*"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMRolePolicyExists(
-						"aws_iam_role.test",
-						"aws_iam_role_policy.test",
+						roleName,
+						resourceName,
 						&rolePolicy2,
 					),
 					testAccCheckAWSIAMRolePolicyNameMatches(&rolePolicy1, &rolePolicy2),
-					resource.TestCheckResourceAttrSet("aws_iam_role_policy.test", "name"),
+					resource.TestCheckResourceAttrSet(resourceName, "name"),
 				),
 			},
 		},
@@ -311,7 +312,7 @@ resource "aws_iam_role" "role_%[1]s" {
   assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}"
 }
 
-resource "aws_iam_role_policy" "foo_%[1]s" {
+resource "aws_iam_role_policy" "test_%[1]s" {
   name = "tf_test_policy_test_%[1]s"
   role = "${aws_iam_role.role_%[1]s.name}"
 
@@ -331,7 +332,7 @@ EOF
 
 func testAccIAMRolePolicyConfig(role, policy1 string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_role" "role" {
+resource "aws_iam_role" "test" {
   name = "tf_test_role_%s"
   path = "/"
 
@@ -352,9 +353,9 @@ resource "aws_iam_role" "role" {
 EOF
 }
 
-resource "aws_iam_role_policy" "foo" {
+resource "aws_iam_role_policy" "test" {
   name = "tf_test_policy_%s"
-  role = "${aws_iam_role.role.name}"
+  role = "${aws_iam_role.test.name}"
 
   policy = <<EOF
 {
@@ -453,7 +454,7 @@ EOF
 
 func testAccIAMRolePolicyConfigUpdate(role, policy1, policy2 string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_role" "role" {
+resource "aws_iam_role" "test" {
   name = "tf_test_role_%s"
   path = "/"
 
@@ -474,9 +475,9 @@ resource "aws_iam_role" "role" {
 EOF
 }
 
-resource "aws_iam_role_policy" "foo" {
+resource "aws_iam_role_policy" "test" {
   name = "tf_test_policy_%s"
-  role = "${aws_iam_role.role.name}"
+  role = "${aws_iam_role.test.name}"
 
   policy = <<EOF
 {
@@ -490,9 +491,9 @@ resource "aws_iam_role_policy" "foo" {
 EOF
 }
 
-resource "aws_iam_role_policy" "bar" {
+resource "aws_iam_role_policy" "test2" {
   name = "tf_test_policy_2_%s"
-  role = "${aws_iam_role.role.name}"
+  role = "${aws_iam_role.test.name}"
 
   policy = <<EOF
 {
@@ -510,7 +511,7 @@ EOF
 
 func testAccIAMRolePolicyConfig_invalidJSON(role string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_role" "role" {
+resource "aws_iam_role" "test" {
   name = "tf_test_role_%s"
   path = "/"
 
@@ -531,9 +532,9 @@ resource "aws_iam_role" "role" {
 EOF
 }
 
-resource "aws_iam_role_policy" "foo" {
+resource "aws_iam_role_policy" "test" {
   name = "tf_test_policy_%s"
-  role = "${aws_iam_role.role.name}"
+  role = "${aws_iam_role.test.name}"
 
   policy = <<EOF
   {

--- a/aws/resource_aws_iam_role_test.go
+++ b/aws/resource_aws_iam_role_test.go
@@ -121,9 +121,10 @@ func testSweepIamRoles(region string) error {
 	return nil
 }
 
-func TestAccAWSIAMRole_importBasic(t *testing.T) {
-	resourceName := "aws_iam_role.role"
+func TestAccAWSIAMRole_basic(t *testing.T) {
+	var conf iam.GetRoleOutput
 	rName := acctest.RandString(10)
+	resourceName := "aws_iam_role.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -132,8 +133,12 @@ func TestAccAWSIAMRole_importBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSIAMRoleConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRoleExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "path", "/"),
+					resource.TestCheckResourceAttrSet(resourceName, "create_date"),
+				),
 			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
@@ -143,30 +148,10 @@ func TestAccAWSIAMRole_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccAWSIAMRole_basic(t *testing.T) {
-	var conf iam.GetRoleOutput
-	rName := acctest.RandString(10)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSRoleDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSIAMRoleConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRoleExists("aws_iam_role.role", &conf),
-					resource.TestCheckResourceAttr("aws_iam_role.role", "path", "/"),
-					resource.TestCheckResourceAttrSet("aws_iam_role.role", "create_date"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAWSIAMRole_basicWithDescription(t *testing.T) {
 	var conf iam.GetRoleOutput
 	rName := acctest.RandString(10)
+	resourceName := "aws_iam_role.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -176,25 +161,30 @@ func TestAccAWSIAMRole_basicWithDescription(t *testing.T) {
 			{
 				Config: testAccAWSIAMRoleConfigWithDescription(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRoleExists("aws_iam_role.role", &conf),
-					resource.TestCheckResourceAttr("aws_iam_role.role", "path", "/"),
-					resource.TestCheckResourceAttr("aws_iam_role.role", "description", "This 1s a D3scr!pti0n with weird content: &@90ë“‘{«¡Çø}"),
+					testAccCheckAWSRoleExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "path", "/"),
+					resource.TestCheckResourceAttr(resourceName, "description", "This 1s a D3scr!pti0n with weird content: &@90ë“‘{«¡Çø}"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSIAMRoleConfigWithUpdatedDescription(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRoleExists("aws_iam_role.role", &conf),
-					resource.TestCheckResourceAttr("aws_iam_role.role", "path", "/"),
-					resource.TestCheckResourceAttr("aws_iam_role.role", "description", "This 1s an Upd@ted D3scr!pti0n with weird content: &90ë“‘{«¡Çø}"),
+					testAccCheckAWSRoleExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "path", "/"),
+					resource.TestCheckResourceAttr(resourceName, "description", "This 1s an Upd@ted D3scr!pti0n with weird content: &90ë“‘{«¡Çø}"),
 				),
 			},
 			{
 				Config: testAccAWSIAMRoleConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRoleExists("aws_iam_role.role", &conf),
-					resource.TestCheckResourceAttrSet("aws_iam_role.role", "create_date"),
-					resource.TestCheckResourceAttr("aws_iam_role.role", "description", ""),
+					testAccCheckAWSRoleExists(resourceName, &conf),
+					resource.TestCheckResourceAttrSet(resourceName, "create_date"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
 				),
 			},
 		},
@@ -204,10 +194,11 @@ func TestAccAWSIAMRole_basicWithDescription(t *testing.T) {
 func TestAccAWSIAMRole_namePrefix(t *testing.T) {
 	var conf iam.GetRoleOutput
 	rName := acctest.RandString(10)
+	resourceName := "aws_iam_role.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
-		IDRefreshName:   "aws_iam_role.role",
+		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"name_prefix"},
 		Providers:       testAccProviders,
 		CheckDestroy:    testAccCheckAWSRoleDestroy,
@@ -215,10 +206,16 @@ func TestAccAWSIAMRole_namePrefix(t *testing.T) {
 			{
 				Config: testAccAWSIAMRolePrefixNameConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRoleExists("aws_iam_role.role", &conf),
+					testAccCheckAWSRoleExists(resourceName, &conf),
 					testAccCheckAWSRoleGeneratedNamePrefix(
-						"aws_iam_role.role", "test-role-"),
+						resourceName, "test-role-"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name_prefix"},
 			},
 		},
 	})
@@ -227,6 +224,7 @@ func TestAccAWSIAMRole_namePrefix(t *testing.T) {
 func TestAccAWSIAMRole_testNameChange(t *testing.T) {
 	var conf iam.GetRoleOutput
 	rName := acctest.RandString(10)
+	resourceName := "aws_iam_role.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -236,14 +234,18 @@ func TestAccAWSIAMRole_testNameChange(t *testing.T) {
 			{
 				Config: testAccAWSIAMRolePre(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRoleExists("aws_iam_role.role_update_test", &conf),
+					testAccCheckAWSRoleExists(resourceName, &conf),
 				),
 			},
-
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 			{
 				Config: testAccAWSIAMRolePost(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRoleExists("aws_iam_role.role_update_test", &conf),
+					testAccCheckAWSRoleExists(resourceName, &conf),
 				),
 			},
 		},
@@ -270,7 +272,7 @@ func TestAccAWSIAMRole_disappears(t *testing.T) {
 	var role iam.GetRoleOutput
 
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_iam_role.role"
+	resourceName := "aws_iam_role.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -292,6 +294,7 @@ func TestAccAWSIAMRole_disappears(t *testing.T) {
 func TestAccAWSIAMRole_force_detach_policies(t *testing.T) {
 	var conf iam.GetRoleOutput
 	rName := acctest.RandString(10)
+	resourceName := "aws_iam_role.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -301,9 +304,15 @@ func TestAccAWSIAMRole_force_detach_policies(t *testing.T) {
 			{
 				Config: testAccAWSIAMRoleConfig_force_detach_policies(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRoleExists("aws_iam_role.test", &conf),
-					testAccAddAwsIAMRolePolicy("aws_iam_role.test"),
+					testAccCheckAWSRoleExists(resourceName, &conf),
+					testAccAddAwsIAMRolePolicy(resourceName),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_detach_policies"},
 			},
 		},
 	})
@@ -335,6 +344,11 @@ func TestAccAWSIAMRole_MaxSessionDuration(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccCheckIAMRoleConfig_MaxSessionDuration(rName, 3701),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRoleExists(resourceName, &conf),
@@ -354,7 +368,7 @@ func TestAccAWSIAMRole_PermissionsBoundary(t *testing.T) {
 	var role iam.GetRoleOutput
 
 	rName := acctest.RandString(10)
-	resourceName := "aws_iam_role.role"
+	resourceName := "aws_iam_role.test"
 
 	permissionsBoundary1 := fmt.Sprintf("arn:%s:iam::aws:policy/AdministratorAccess", testAccGetPartition())
 	permissionsBoundary2 := fmt.Sprintf("arn:%s:iam::aws:policy/ReadOnlyAccess", testAccGetPartition())
@@ -438,6 +452,11 @@ func TestAccAWSIAMRole_tags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.tag1", "test-value1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.tag2", "test-value2"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSIAMRoleConfig_tagsUpdate(rName),
@@ -600,7 +619,7 @@ resource "aws_iam_role" "test" {
 
 func testAccCheckIAMRoleConfig_PermissionsBoundary(rName, permissionsBoundary string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_role" "role" {
+resource "aws_iam_role" "test" {
   assume_role_policy   = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"ec2.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
   name                 = "test-role-%s"
   path                 = "/"
@@ -611,7 +630,7 @@ resource "aws_iam_role" "role" {
 
 func testAccAWSIAMRoleConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_role" "role" {
+resource "aws_iam_role" "test" {
   name               = "test-role-%s"
   path               = "/"
   assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"ec2.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
@@ -621,7 +640,7 @@ resource "aws_iam_role" "role" {
 
 func testAccAWSIAMRoleConfigWithDescription(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_role" "role" {
+resource "aws_iam_role" "test" {
   name               = "test-role-%s"
   description        = "This 1s a D3scr!pti0n with weird content: &@90ë“‘{«¡Çø}"
   path               = "/"
@@ -632,7 +651,7 @@ resource "aws_iam_role" "role" {
 
 func testAccAWSIAMRoleConfigWithUpdatedDescription(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_role" "role" {
+resource "aws_iam_role" "test" {
   name               = "test-role-%s"
   description        = "This 1s an Upd@ted D3scr!pti0n with weird content: &90ë“‘{«¡Çø}"
   path               = "/"
@@ -643,7 +662,7 @@ resource "aws_iam_role" "role" {
 
 func testAccAWSIAMRolePrefixNameConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_role" "role" {
+resource "aws_iam_role" "test" {
   name_prefix        = "test-role-%s"
   path               = "/"
   assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"ec2.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
@@ -655,7 +674,7 @@ func testAccAWSIAMRolePre(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
-resource "aws_iam_role" "role_update_test" {
+resource "aws_iam_role" "test" {
   name = "tf_old_name_%s"
   path = "/test/"
 
@@ -678,7 +697,7 @@ EOF
 
 resource "aws_iam_role_policy" "role_update_test" {
   name = "role_update_test_%s"
-  role = "${aws_iam_role.role_update_test.id}"
+  role = "${aws_iam_role.test.id}"
 
   policy = <<EOF
 {
@@ -700,7 +719,7 @@ EOF
 resource "aws_iam_instance_profile" "role_update_test" {
   name  = "role_update_test_%s"
   path  = "/test/"
-  roles = ["${aws_iam_role.role_update_test.name}"]
+  roles = ["${aws_iam_role.test.name}"]
 }
 `, rName, rName, rName)
 }
@@ -709,7 +728,7 @@ func testAccAWSIAMRolePost(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
-resource "aws_iam_role" "role_update_test" {
+resource "aws_iam_role" "test" {
   name = "tf_new_name_%s"
   path = "/test/"
 
@@ -732,7 +751,7 @@ EOF
 
 resource "aws_iam_role_policy" "role_update_test" {
   name = "role_update_test_%s"
-  role = "${aws_iam_role.role_update_test.id}"
+  role = "${aws_iam_role.test.id}"
 
   policy = <<EOF
 {
@@ -754,14 +773,14 @@ EOF
 resource "aws_iam_instance_profile" "role_update_test" {
   name  = "role_update_test_%s"
   path  = "/test/"
-  roles = ["${aws_iam_role.role_update_test.name}"]
+  roles = ["${aws_iam_role.test.name}"]
 }
 `, rName, rName, rName)
 }
 
 func testAccAWSIAMRoleConfig_badJson(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_role" "my_instance_role" {
+resource "aws_iam_role" "test" {
   name = "test-role-%s"
 
   assume_role_policy = <<POLICY

--- a/aws/resource_aws_iam_server_certificate_test.go
+++ b/aws/resource_aws_iam_server_certificate_test.go
@@ -53,9 +53,11 @@ func testSweepIamServerCertificates(region string) error {
 	return nil
 }
 
-func TestAccAWSIAMServerCertificate_importBasic(t *testing.T) {
-	resourceName := "aws_iam_server_certificate.test_cert"
+func TestAccAWSIAMServerCertificate_basic(t *testing.T) {
+	var cert iam.ServerCertificate
 	rInt := acctest.RandInt()
+	var certBody string
+	resourceName := "aws_iam_server_certificate.test_cert"
 	resourceId := fmt.Sprintf("terraform-test-cert-%d", rInt)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -65,6 +67,11 @@ func TestAccAWSIAMServerCertificate_importBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIAMServerCertConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCertExists(resourceName, &cert),
+					getCertBody(&certBody),
+					testAccCheckAWSServerCertAttributes(&cert, &certBody),
+				),
 			},
 			{
 				ResourceName:      resourceName,
@@ -78,32 +85,10 @@ func TestAccAWSIAMServerCertificate_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccAWSIAMServerCertificate_basic(t *testing.T) {
-	var cert iam.ServerCertificate
-	rInt := acctest.RandInt()
-	var certBody string
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProvidersWithTLS,
-		CheckDestroy: testAccCheckIAMServerCertificateDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccIAMServerCertConfig(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCertExists("aws_iam_server_certificate.test_cert", &cert),
-					getCertBody(&certBody),
-					testAccCheckAWSServerCertAttributes(&cert, &certBody),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAWSIAMServerCertificate_name_prefix(t *testing.T) {
 	var cert iam.ServerCertificate
 	var certBody string
-	rInt := acctest.RandInt()
+	resourceName := "aws_iam_server_certificate.test_cert"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -111,9 +96,9 @@ func TestAccAWSIAMServerCertificate_name_prefix(t *testing.T) {
 		CheckDestroy: testAccCheckIAMServerCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIAMServerCertConfig_random(rInt),
+				Config: testAccIAMServerCertConfig_random(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCertExists("aws_iam_server_certificate.test_cert", &cert),
+					testAccCheckCertExists(resourceName, &cert),
 					getCertBody(&certBody),
 					testAccCheckAWSServerCertAttributes(&cert, &certBody),
 				),
@@ -124,7 +109,7 @@ func TestAccAWSIAMServerCertificate_name_prefix(t *testing.T) {
 
 func TestAccAWSIAMServerCertificate_disappears(t *testing.T) {
 	var cert iam.ServerCertificate
-	rInt := acctest.RandInt()
+	resourceName := "aws_iam_server_certificate.test_cert"
 
 	testDestroyCert := func(*terraform.State) error {
 		// reach out and DELETE the Cert
@@ -146,9 +131,9 @@ func TestAccAWSIAMServerCertificate_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckIAMServerCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIAMServerCertConfig_random(rInt),
+				Config: testAccIAMServerCertConfig_random(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCertExists("aws_iam_server_certificate.test_cert", &cert),
+					testAccCheckCertExists(resourceName, &cert),
 					testDestroyCert,
 				),
 				ExpectNonEmptyPlan: true,
@@ -163,6 +148,8 @@ func TestAccAWSIAMServerCertificate_file(t *testing.T) {
 	rInt := acctest.RandInt()
 	unixFile := "test-fixtures/iam-ssl-unix-line-endings.pem"
 	winFile := "test-fixtures/iam-ssl-windows-line-endings.pem.winfile"
+	resourceName := "aws_iam_server_certificate.test_cert"
+	resourceId := fmt.Sprintf("terraform-test-cert-%d", rInt)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -172,13 +159,21 @@ func TestAccAWSIAMServerCertificate_file(t *testing.T) {
 			{
 				Config: testAccIAMServerCertConfig_file(rInt, unixFile),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCertExists("aws_iam_server_certificate.test_cert", &cert),
+					testAccCheckCertExists(resourceName, &cert),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     resourceId,
+				ImportStateVerifyIgnore: []string{
+					"private_key"},
 			},
 			{
 				Config: testAccIAMServerCertConfig_file(rInt, winFile),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCertExists("aws_iam_server_certificate.test_cert", &cert),
+					testAccCheckCertExists(resourceName, &cert),
 				),
 			},
 		},
@@ -299,7 +294,7 @@ resource "aws_iam_server_certificate" "test_cert" {
 `, testAccTLSServerCert, rInt)
 }
 
-func testAccIAMServerCertConfig_random(rInt int) string {
+func testAccIAMServerCertConfig_random() string {
 	return fmt.Sprintf(`
 %s 
 

--- a/aws/resource_aws_iam_user_policy_test.go
+++ b/aws/resource_aws_iam_user_policy_test.go
@@ -14,28 +14,6 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSIAMUserPolicy_importBasic(t *testing.T) {
-	suffix := randomString(10)
-	resourceName := fmt.Sprintf("aws_iam_user_policy.foo_%s", suffix)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckIAMUserPolicyDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAwsIamUserPolicyConfig(suffix),
-			},
-
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAWSIAMUserPolicy_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 	policy1 := `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"*","Resource":"*"}}`
@@ -64,6 +42,11 @@ func TestAccAWSIAMUserPolicy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(policyResourceName, "policy", policy1),
 					resource.TestCheckResourceAttr(policyResourceName, "user", userName),
 				),
+			},
+			{
+				ResourceName:      policyResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccIAMUserPolicyConfig_name(rInt, strconv.Quote(policy2)),
@@ -125,6 +108,12 @@ func TestAccAWSIAMUserPolicy_namePrefix(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:            policyResourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name_prefix"},
+			},
+			{
 				Config: testAccIAMUserPolicyConfig_namePrefix(rInt, strconv.Quote(policy2)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMUserPolicy(userResourceName, policyResourceName),
@@ -158,6 +147,11 @@ func TestAccAWSIAMUserPolicy_generatedName(t *testing.T) {
 					resource.TestMatchResourceAttr(policyResourceName, "id", regexp.MustCompile(fmt.Sprintf("^%s:.+$", userName))),
 					resource.TestCheckResourceAttr(policyResourceName, "policy", policy1),
 				),
+			},
+			{
+				ResourceName:      policyResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccIAMUserPolicyConfig_generatedName(rInt, strconv.Quote(policy2)),
@@ -194,6 +188,11 @@ func TestAccAWSIAMUserPolicy_multiplePolicies(t *testing.T) {
 					resource.TestCheckResourceAttr(policyResourceName1, "name", policyName1),
 					resource.TestCheckResourceAttr(policyResourceName1, "policy", policy1),
 				),
+			},
+			{
+				ResourceName:      policyResourceName1,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccIAMUserPolicyConfig_multiplePolicies(rInt, strconv.Quote(policy1), strconv.Quote(policy2)),

--- a/aws/resource_aws_iam_user_test.go
+++ b/aws/resource_aws_iam_user_test.go
@@ -165,31 +165,6 @@ func testSweepIamUsers(region string) error {
 	return nil
 }
 
-func TestAccAWSUser_importBasic(t *testing.T) {
-	resourceName := "aws_iam_user.user"
-
-	n := fmt.Sprintf("test-user-%d", acctest.RandInt())
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSUserDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSUserConfig(n, "/"),
-			},
-
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"force_destroy"},
-			},
-		},
-	})
-}
-
 func TestAccAWSUser_basic(t *testing.T) {
 	var conf iam.GetUserOutput
 
@@ -197,6 +172,7 @@ func TestAccAWSUser_basic(t *testing.T) {
 	name2 := fmt.Sprintf("test-user-%d", acctest.RandInt())
 	path1 := "/"
 	path2 := "/path2/"
+	resourceName := "aws_iam_user.user"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -209,6 +185,13 @@ func TestAccAWSUser_basic(t *testing.T) {
 					testAccCheckAWSUserExists("aws_iam_user.user", &conf),
 					testAccCheckAWSUserAttributes(&conf, name1, "/"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy"},
 			},
 			{
 				Config: testAccAWSUserConfig(name2, path2),
@@ -262,6 +245,13 @@ func TestAccAWSUser_ForceDestroy_AccessKey(t *testing.T) {
 					testAccCheckAWSUserCreatesAccessKey(&user),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy"},
+			},
 		},
 	})
 }
@@ -283,6 +273,13 @@ func TestAccAWSUser_ForceDestroy_LoginProfile(t *testing.T) {
 					testAccCheckAWSUserExists(resourceName, &user),
 					testAccCheckAWSUserCreatesLoginProfile(&user),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy"},
 			},
 		},
 	})
@@ -306,6 +303,13 @@ func TestAccAWSUser_ForceDestroy_MFADevice(t *testing.T) {
 					testAccCheckAWSUserCreatesMFADevice(&user),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy"},
+			},
 		},
 	})
 }
@@ -328,6 +332,13 @@ func TestAccAWSUser_ForceDestroy_SSHKey(t *testing.T) {
 					testAccCheckAWSUserUploadsSSHKey(&user),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy"},
+			},
 		},
 	})
 }
@@ -338,6 +349,7 @@ func TestAccAWSUser_nameChange(t *testing.T) {
 	name1 := fmt.Sprintf("test-user-%d", acctest.RandInt())
 	name2 := fmt.Sprintf("test-user-%d", acctest.RandInt())
 	path := "/"
+	resourceName := "aws_iam_user.user"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -349,6 +361,13 @@ func TestAccAWSUser_nameChange(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSUserExists("aws_iam_user.user", &conf),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy"},
 			},
 			{
 				Config: testAccAWSUserConfig(name2, path),
@@ -366,6 +385,7 @@ func TestAccAWSUser_pathChange(t *testing.T) {
 	name := fmt.Sprintf("test-user-%d", acctest.RandInt())
 	path1 := "/"
 	path2 := "/updated/"
+	resourceName := "aws_iam_user.user"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -377,6 +397,13 @@ func TestAccAWSUser_pathChange(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSUserExists("aws_iam_user.user", &conf),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy"},
 			},
 			{
 				Config: testAccAWSUserConfig(name, path2),
@@ -410,6 +437,13 @@ func TestAccAWSUser_permissionsBoundary(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "permissions_boundary", permissionsBoundary1),
 					testAccCheckAWSUserPermissionsBoundary(&user, permissionsBoundary1),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy"},
 			},
 			// Test update
 			{
@@ -477,6 +511,13 @@ func TestAccAWSUser_tags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.Name", "test-Name"),
 					resource.TestCheckResourceAttr(resourceName, "tags.tag2", "test-tag2"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy"},
 			},
 			{
 				Config: testAccAWSUserConfig_tagsUpdate(rName),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8944

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSUser_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSUser_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSUser_basic
=== PAUSE TestAccAWSUser_basic
=== RUN   TestAccAWSUser_disappears
=== PAUSE TestAccAWSUser_disappears
=== RUN   TestAccAWSUser_ForceDestroy_AccessKey
=== PAUSE TestAccAWSUser_ForceDestroy_AccessKey
=== RUN   TestAccAWSUser_ForceDestroy_LoginProfile
=== PAUSE TestAccAWSUser_ForceDestroy_LoginProfile
=== RUN   TestAccAWSUser_ForceDestroy_MFADevice
=== PAUSE TestAccAWSUser_ForceDestroy_MFADevice
=== RUN   TestAccAWSUser_ForceDestroy_SSHKey
=== PAUSE TestAccAWSUser_ForceDestroy_SSHKey
=== RUN   TestAccAWSUser_nameChange
=== PAUSE TestAccAWSUser_nameChange
=== RUN   TestAccAWSUser_pathChange
=== PAUSE TestAccAWSUser_pathChange
=== RUN   TestAccAWSUser_permissionsBoundary
=== PAUSE TestAccAWSUser_permissionsBoundary
=== RUN   TestAccAWSUser_tags
=== PAUSE TestAccAWSUser_tags
=== CONT  TestAccAWSUser_basic
=== CONT  TestAccAWSUser_tags
=== CONT  TestAccAWSUser_ForceDestroy_AccessKey
=== CONT  TestAccAWSUser_ForceDestroy_SSHKey
=== CONT  TestAccAWSUser_permissionsBoundary
=== CONT  TestAccAWSUser_pathChange
=== CONT  TestAccAWSUser_ForceDestroy_LoginProfile
=== CONT  TestAccAWSUser_nameChange
=== CONT  TestAccAWSUser_ForceDestroy_MFADevice
=== CONT  TestAccAWSUser_disappears
--- PASS: TestAccAWSUser_disappears (18.76s)
--- PASS: TestAccAWSUser_ForceDestroy_LoginProfile (27.67s)
--- PASS: TestAccAWSUser_ForceDestroy_AccessKey (27.92s)
--- PASS: TestAccAWSUser_ForceDestroy_MFADevice (28.40s)
--- PASS: TestAccAWSUser_ForceDestroy_SSHKey (33.63s)
--- PASS: TestAccAWSUser_basic (42.30s)
--- PASS: TestAccAWSUser_nameChange (42.47s)
--- PASS: TestAccAWSUser_pathChange (42.73s)
--- PASS: TestAccAWSUser_tags (42.94s)
--- PASS: TestAccAWSUser_permissionsBoundary (91.53s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       93.334s

make testacc TESTARGS="-run=TestAccAWSIAMUserPolicy_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSIAMUserPolicy_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSIAMUserPolicy_basic
=== PAUSE TestAccAWSIAMUserPolicy_basic
=== RUN   TestAccAWSIAMUserPolicy_disappears
=== PAUSE TestAccAWSIAMUserPolicy_disappears
=== RUN   TestAccAWSIAMUserPolicy_namePrefix
=== PAUSE TestAccAWSIAMUserPolicy_namePrefix
=== RUN   TestAccAWSIAMUserPolicy_generatedName
=== PAUSE TestAccAWSIAMUserPolicy_generatedName
=== RUN   TestAccAWSIAMUserPolicy_multiplePolicies
=== PAUSE TestAccAWSIAMUserPolicy_multiplePolicies
=== CONT  TestAccAWSIAMUserPolicy_basic
=== CONT  TestAccAWSIAMUserPolicy_multiplePolicies
=== CONT  TestAccAWSIAMUserPolicy_disappears
=== CONT  TestAccAWSIAMUserPolicy_namePrefix
=== CONT  TestAccAWSIAMUserPolicy_generatedName
--- PASS: TestAccAWSIAMUserPolicy_disappears (26.45s)
--- PASS: TestAccAWSIAMUserPolicy_namePrefix (44.01s)
--- PASS: TestAccAWSIAMUserPolicy_basic (44.41s)
--- PASS: TestAccAWSIAMUserPolicy_generatedName (44.87s)
--- PASS: TestAccAWSIAMUserPolicy_multiplePolicies (79.28s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       80.381s

make testacc TESTARGS="-run=TestAccAWSIAMServerCertificate_" ==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSIAMServerCertificate_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSIAMServerCertificate_basic
=== PAUSE TestAccAWSIAMServerCertificate_basic
=== RUN   TestAccAWSIAMServerCertificate_name_prefix
=== PAUSE TestAccAWSIAMServerCertificate_name_prefix
=== RUN   TestAccAWSIAMServerCertificate_disappears
=== PAUSE TestAccAWSIAMServerCertificate_disappears
=== RUN   TestAccAWSIAMServerCertificate_file
=== PAUSE TestAccAWSIAMServerCertificate_file
=== CONT  TestAccAWSIAMServerCertificate_basic
=== CONT  TestAccAWSIAMServerCertificate_file
=== CONT  TestAccAWSIAMServerCertificate_name_prefix
=== CONT  TestAccAWSIAMServerCertificate_disappears
--- PASS: TestAccAWSIAMServerCertificate_disappears (20.22s)
--- PASS: TestAccAWSIAMServerCertificate_name_prefix (21.15s)
--- PASS: TestAccAWSIAMServerCertificate_basic (23.97s)
--- PASS: TestAccAWSIAMServerCertificate_file (38.59s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       40.011s

make testacc TESTARGS="-run=TestAccAWSIAMRole_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSIAMRole_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSIAMRole_basic
=== PAUSE TestAccAWSIAMRole_basic
=== RUN   TestAccAWSIAMRole_basicWithDescription
=== PAUSE TestAccAWSIAMRole_basicWithDescription
=== RUN   TestAccAWSIAMRole_namePrefix
=== PAUSE TestAccAWSIAMRole_namePrefix
=== RUN   TestAccAWSIAMRole_testNameChange
=== PAUSE TestAccAWSIAMRole_testNameChange
=== RUN   TestAccAWSIAMRole_badJSON
=== PAUSE TestAccAWSIAMRole_badJSON
=== RUN   TestAccAWSIAMRole_disappears
=== PAUSE TestAccAWSIAMRole_disappears
=== RUN   TestAccAWSIAMRole_force_detach_policies
=== PAUSE TestAccAWSIAMRole_force_detach_policies
=== RUN   TestAccAWSIAMRole_MaxSessionDuration
=== PAUSE TestAccAWSIAMRole_MaxSessionDuration
=== RUN   TestAccAWSIAMRole_PermissionsBoundary
=== PAUSE TestAccAWSIAMRole_PermissionsBoundary
=== RUN   TestAccAWSIAMRole_tags
=== PAUSE TestAccAWSIAMRole_tags
=== CONT  TestAccAWSIAMRole_basic
=== CONT  TestAccAWSIAMRole_force_detach_policies
=== CONT  TestAccAWSIAMRole_disappears
=== CONT  TestAccAWSIAMRole_badJSON
=== CONT  TestAccAWSIAMRole_basicWithDescription
=== CONT  TestAccAWSIAMRole_tags
=== CONT  TestAccAWSIAMRole_PermissionsBoundary
=== CONT  TestAccAWSIAMRole_testNameChange
=== CONT  TestAccAWSIAMRole_MaxSessionDuration
=== CONT  TestAccAWSIAMRole_namePrefix
--- PASS: TestAccAWSIAMRole_badJSON (3.03s)
--- PASS: TestAccAWSIAMRole_disappears (18.96s)
--- PASS: TestAccAWSIAMRole_basic (24.94s)
--- PASS: TestAccAWSIAMRole_namePrefix (25.17s)
--- PASS: TestAccAWSIAMRole_force_detach_policies (31.24s)
--- PASS: TestAccAWSIAMRole_tags (41.10s)
--- PASS: TestAccAWSIAMRole_MaxSessionDuration (45.57s)
--- PASS: TestAccAWSIAMRole_testNameChange (54.21s)
--- PASS: TestAccAWSIAMRole_basicWithDescription (57.17s)
--- PASS: TestAccAWSIAMRole_PermissionsBoundary (88.47s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       92.394s

make testacc TESTARGS="-run=TestAccAWSIAMRolePolicy_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSIAMRolePolicy_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSIAMRolePolicy_basic
=== PAUSE TestAccAWSIAMRolePolicy_basic
=== RUN   TestAccAWSIAMRolePolicy_disappears
=== PAUSE TestAccAWSIAMRolePolicy_disappears
=== RUN   TestAccAWSIAMRolePolicy_namePrefix
=== PAUSE TestAccAWSIAMRolePolicy_namePrefix
=== RUN   TestAccAWSIAMRolePolicy_generatedName
=== PAUSE TestAccAWSIAMRolePolicy_generatedName
=== RUN   TestAccAWSIAMRolePolicy_invalidJSON
=== PAUSE TestAccAWSIAMRolePolicy_invalidJSON
=== CONT  TestAccAWSIAMRolePolicy_basic
=== CONT  TestAccAWSIAMRolePolicy_invalidJSON
=== CONT  TestAccAWSIAMRolePolicy_disappears
=== CONT  TestAccAWSIAMRolePolicy_namePrefix
=== CONT  TestAccAWSIAMRolePolicy_generatedName
--- PASS: TestAccAWSIAMRolePolicy_invalidJSON (2.78s)
--- PASS: TestAccAWSIAMRolePolicy_disappears (24.79s)
--- PASS: TestAccAWSIAMRolePolicy_basic (45.10s)
--- PASS: TestAccAWSIAMRolePolicy_namePrefix (46.68s)
--- PASS: TestAccAWSIAMRolePolicy_generatedName (47.12s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       49.333s

make testacc TESTARGS="-run=TestAccAWSIAMOpenIDConnectProvider_" ==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSIAMOpenIDConnectProvider_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSIAMOpenIDConnectProvider_basic
=== PAUSE TestAccAWSIAMOpenIDConnectProvider_basic
=== RUN   TestAccAWSIAMOpenIDConnectProvider_disappears
=== PAUSE TestAccAWSIAMOpenIDConnectProvider_disappears
=== CONT  TestAccAWSIAMOpenIDConnectProvider_basic
=== CONT  TestAccAWSIAMOpenIDConnectProvider_disappears
--- PASS: TestAccAWSIAMOpenIDConnectProvider_disappears (18.53s)
--- PASS: TestAccAWSIAMOpenIDConnectProvider_basic (42.72s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       44.148s

make testacc TESTARGS="-run=TestAccAWSIAMInstanceProfile_"
==> Fixing source code with gofmt...
gofmt -s -w ./aws
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSIAMInstanceProfile_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSIAMInstanceProfile_basic
=== PAUSE TestAccAWSIAMInstanceProfile_basic
=== RUN   TestAccAWSIAMInstanceProfile_withRoleNotRoles
=== PAUSE TestAccAWSIAMInstanceProfile_withRoleNotRoles
=== RUN   TestAccAWSIAMInstanceProfile_missingRoleThrowsError
=== PAUSE TestAccAWSIAMInstanceProfile_missingRoleThrowsError
=== RUN   TestAccAWSIAMInstanceProfile_namePrefix
=== PAUSE TestAccAWSIAMInstanceProfile_namePrefix
=== CONT  TestAccAWSIAMInstanceProfile_basic
=== CONT  TestAccAWSIAMInstanceProfile_namePrefix
=== CONT  TestAccAWSIAMInstanceProfile_missingRoleThrowsError
=== CONT  TestAccAWSIAMInstanceProfile_withRoleNotRoles
--- PASS: TestAccAWSIAMInstanceProfile_missingRoleThrowsError (9.67s)
--- PASS: TestAccAWSIAMInstanceProfile_basic (28.59s)
--- PASS: TestAccAWSIAMInstanceProfile_withRoleNotRoles (28.70s)
--- PASS: TestAccAWSIAMInstanceProfile_namePrefix (30.78s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       32.187s

make testacc TESTARGS="-run=TestAccAWSIAMGroup_"
==> Fixing source code with gofmt...
gofmt -s -w ./aws
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSIAMGroup_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSIAMGroup_basic
=== PAUSE TestAccAWSIAMGroup_basic
=== RUN   TestAccAWSIAMGroup_nameChange
=== PAUSE TestAccAWSIAMGroup_nameChange
=== CONT  TestAccAWSIAMGroup_basic
=== CONT  TestAccAWSIAMGroup_nameChange
--- PASS: TestAccAWSIAMGroup_nameChange (37.89s)
--- PASS: TestAccAWSIAMGroup_basic (40.42s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       42.576s

make testacc TESTARGS="-run=TestAccAWSIAMAccountPasswordPolicy_" ==> Fixing source code with gofmt...
gofmt -s -w ./aws
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSIAMAccountPasswordPolicy_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSIAMAccountPasswordPolicy_basic
=== PAUSE TestAccAWSIAMAccountPasswordPolicy_basic
=== CONT  TestAccAWSIAMAccountPasswordPolicy_basic
--- PASS: TestAccAWSIAMAccountPasswordPolicy_basic (40.84s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       41.965s
```
