### PR TITLE
Add aws.StringValue wrapper to prevent crash on missing environment name

### DIFF
--- a/aws/ecs_task_definition_equivalency.go
+++ b/aws/ecs_task_definition_equivalency.go
@@ -78,7 +78,7 @@ func (cd containerDefinitions) Reduce(isAWSVPC bool) error {
 
 		// Deal with fields which may be re-ordered in the API
 		sort.Slice(def.Environment, func(i, j int) bool {
-			return *def.Environment[i].Name < *def.Environment[j].Name
+			return aws.StringValue(def.Environment[i].Name) < aws.StringValue(def.Environment[j].Name)
 		})
 
 		// Create a mutable copy

--- a/aws/ecs_task_definition_equivalency_test.go
+++ b/aws/ecs_task_definition_equivalency_test.go
@@ -474,3 +474,90 @@ func TestAwsEcsContainerDefinitionsAreEquivalent_negative(t *testing.T) {
 		t.Fatal("Expected definitions to differ.")
 	}
 }
+
+func TestAwsEcsContainerDefinitionsAreEquivalent_missingEnvironmentName(t *testing.T) {
+	cfgRepresention := `
+[
+    {
+      "name": "wordpress",
+      "links": [
+        "mysql"
+      ],
+      "image": "wordpress",
+      "essential": true,
+      "portMappings": [
+        {
+          "containerPort": 80,
+          "hostPort": 80
+        }
+      ],
+      "memory": 500,
+      "cpu": 10
+    },
+    {
+      "environment": [
+        {
+          "value": "password"
+        },
+        {
+          "value": "password2"
+        }
+      ],
+      "name": "mysql",
+      "image": "mysql",
+      "cpu": 10,
+      "memory": 500,
+      "essential": true
+    }
+]`
+
+	apiRepresentation := `
+[
+    {
+        "name": "wordpress",
+        "image": "wordpress",
+        "cpu": 10,
+        "memory": 500,
+        "links": [
+            "mysql"
+        ],
+        "portMappings": [
+            {
+                "containerPort": 80,
+                "hostPort": 80,
+                "protocol": "tcp"
+            }
+        ],
+        "essential": true,
+        "environment": [],
+        "mountPoints": [],
+        "volumesFrom": []
+    },
+    {
+        "name": "mysql",
+        "image": "mysql",
+        "cpu": 10,
+        "memory": 500,
+        "portMappings": [],
+        "essential": true,
+        "environment": [
+          {
+            "value": "password"
+          },
+          {
+            "value": "password2"
+          }
+        ],
+        "mountPoints": [],
+        "volumesFrom": []
+    }
+]`
+
+	equal, err := EcsContainerDefinitionsAreEquivalent(cfgRepresention, apiRepresentation, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !equal {
+		t.Fatal("Expected definitions to be equal.")
+	}
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10065

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* ecs_task_definition_equivalency: Fix a crash if environment name is missing
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAwsEcsContainerDefinitionsAreEquivalent_"
==> Fixing source code with gofmt...
gofmt -s -w ./aws
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAwsEcsContainerDefinitionsAreEquivalent_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAwsEcsContainerDefinitionsAreEquivalent_basic
--- PASS: TestAwsEcsContainerDefinitionsAreEquivalent_basic (0.00s)
=== RUN   TestAwsEcsContainerDefinitionsAreEquivalent_portMappings
--- PASS: TestAwsEcsContainerDefinitionsAreEquivalent_portMappings (0.00s)
=== RUN   TestAwsEcsContainerDefinitionsAreEquivalent_portMappingsIgnoreHostPort
2019/09/11 13:53:20 [DEBUG] Canonical definitions are not equal.
First: [{"essential":true,"image":"wordpress","name":"wordpress","portMappings":[{"containerPort":80,"hostPort":80}]}]
Second: [{"essential":true,"image":"wordpress","name":"wordpress","portMappings":[{"containerPort":80}]}]
--- PASS: TestAwsEcsContainerDefinitionsAreEquivalent_portMappingsIgnoreHostPort (0.00s)
=== RUN   TestAwsEcsContainerDefinitionsAreEquivalent_arrays
--- PASS: TestAwsEcsContainerDefinitionsAreEquivalent_arrays (0.00s)
=== RUN   TestAwsEcsContainerDefinitionsAreEquivalent_negative
2019/09/11 13:53:20 [DEBUG] Canonical definitions are not equal.
First: [{"cpu":10,"environment":[{"name":"EXAMPLE_NAME","value":"foobar"}],"essential":true,"image":"wordpress","memory":500,"name":"wordpress"}]
Second: [{"cpu":10,"essential":true,"image":"wordpress","memory":500,"name":"wordpress"}]
--- PASS: TestAwsEcsContainerDefinitionsAreEquivalent_negative (0.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws
```
