### PR TITLE
Import test refactor for glue catalog resources

### DIFF
--- a/aws/resource_aws_glue_catalog_database_test.go
+++ b/aws/resource_aws_glue_catalog_database_test.go
@@ -12,29 +12,9 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSGlueCatalogDatabase_importBasic(t *testing.T) {
-	resourceName := "aws_glue_catalog_database.test"
-	rInt := acctest.RandInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckGlueDatabaseDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccGlueCatalogDatabase_full(rInt, "A test catalog from terraform"),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAWSGlueCatalogDatabase_full(t *testing.T) {
 	rInt := acctest.RandInt()
+	resourceName := "aws_glue_catalog_database.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -44,56 +24,61 @@ func TestAccAWSGlueCatalogDatabase_full(t *testing.T) {
 				Config:  testAccGlueCatalogDatabase_basic(rInt),
 				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGlueCatalogDatabaseExists("aws_glue_catalog_database.test"),
+					testAccCheckGlueCatalogDatabaseExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_glue_catalog_database.test",
+						resourceName,
 						"name",
 						fmt.Sprintf("my_test_catalog_database_%d", rInt),
 					),
 					resource.TestCheckResourceAttr(
-						"aws_glue_catalog_database.test",
+						resourceName,
 						"description",
 						"",
 					),
 					resource.TestCheckResourceAttr(
-						"aws_glue_catalog_database.test",
+						resourceName,
 						"location_uri",
 						"",
 					),
 					resource.TestCheckResourceAttr(
-						"aws_glue_catalog_database.test",
+						resourceName,
 						"parameters.%",
 						"0",
 					),
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config:  testAccGlueCatalogDatabase_full(rInt, "A test catalog from terraform"),
 				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGlueCatalogDatabaseExists("aws_glue_catalog_database.test"),
+					testAccCheckGlueCatalogDatabaseExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_glue_catalog_database.test",
+						resourceName,
 						"description",
 						"A test catalog from terraform",
 					),
 					resource.TestCheckResourceAttr(
-						"aws_glue_catalog_database.test",
+						resourceName,
 						"location_uri",
 						"my-location",
 					),
 					resource.TestCheckResourceAttr(
-						"aws_glue_catalog_database.test",
+						resourceName,
 						"parameters.param1",
 						"value1",
 					),
 					resource.TestCheckResourceAttr(
-						"aws_glue_catalog_database.test",
+						resourceName,
 						"parameters.param2",
-						"1",
+						"true",
 					),
 					resource.TestCheckResourceAttr(
-						"aws_glue_catalog_database.test",
+						resourceName,
 						"parameters.param3",
 						"50",
 					),
@@ -102,29 +87,29 @@ func TestAccAWSGlueCatalogDatabase_full(t *testing.T) {
 			{
 				Config: testAccGlueCatalogDatabase_full(rInt, "An updated test catalog from terraform"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGlueCatalogDatabaseExists("aws_glue_catalog_database.test"),
+					testAccCheckGlueCatalogDatabaseExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_glue_catalog_database.test",
+						resourceName,
 						"description",
 						"An updated test catalog from terraform",
 					),
 					resource.TestCheckResourceAttr(
-						"aws_glue_catalog_database.test",
+						resourceName,
 						"location_uri",
 						"my-location",
 					),
 					resource.TestCheckResourceAttr(
-						"aws_glue_catalog_database.test",
+						resourceName,
 						"parameters.param1",
 						"value1",
 					),
 					resource.TestCheckResourceAttr(
-						"aws_glue_catalog_database.test",
+						resourceName,
 						"parameters.param2",
-						"1",
+						"true",
 					),
 					resource.TestCheckResourceAttr(
-						"aws_glue_catalog_database.test",
+						resourceName,
 						"parameters.param3",
 						"50",
 					),

--- a/aws/resource_aws_glue_catalog_table_test.go
+++ b/aws/resource_aws_glue_catalog_table_test.go
@@ -47,9 +47,9 @@ func TestAccAWSGlueCatalogTable_recreates(t *testing.T) {
 	})
 }
 
-func TestAccAWSGlueCatalogTable_importBasic(t *testing.T) {
-	resourceName := "aws_glue_catalog_table.test"
+func TestAccAWSGlueCatalogTable_basic(t *testing.T) {
 	rInt := acctest.RandInt()
+	resourceName := "aws_glue_catalog_table.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -57,7 +57,21 @@ func TestAccAWSGlueCatalogTable_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckGlueTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGlueCatalogTable_full(rInt, "A test table from terraform"),
+				Config:  testAccGlueCatalogTable_basic(rInt),
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlueCatalogTableExists(resourceName),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"name",
+						fmt.Sprintf("my_test_catalog_table_%d", rInt),
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"database_name",
+						fmt.Sprintf("my_test_catalog_database_%d", rInt),
+					),
+				),
 			},
 			{
 				ResourceName:      resourceName,
@@ -68,40 +82,10 @@ func TestAccAWSGlueCatalogTable_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccAWSGlueCatalogTable_basic(t *testing.T) {
-	rInt := acctest.RandInt()
-	tableName := "aws_glue_catalog_table.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckGlueTableDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config:  testAccGlueCatalogTable_basic(rInt),
-				Destroy: false,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGlueCatalogTableExists("aws_glue_catalog_table.test"),
-					resource.TestCheckResourceAttr(
-						"aws_glue_catalog_table.test",
-						"name",
-						fmt.Sprintf("my_test_catalog_table_%d", rInt),
-					),
-					resource.TestCheckResourceAttr(
-						tableName,
-						"database_name",
-						fmt.Sprintf("my_test_catalog_database_%d", rInt),
-					),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAWSGlueCatalogTable_full(t *testing.T) {
 	rInt := acctest.RandInt()
 	description := "A test table from terraform"
-	tableName := "aws_glue_catalog_table.test"
+	resourceName := "aws_glue_catalog_table.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -112,45 +96,50 @@ func TestAccAWSGlueCatalogTable_full(t *testing.T) {
 				Config:  testAccGlueCatalogTable_full(rInt, description),
 				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGlueCatalogTableExists(tableName),
-					resource.TestCheckResourceAttr(tableName, "name", fmt.Sprintf("my_test_catalog_table_%d", rInt)),
-					resource.TestCheckResourceAttr(tableName, "database_name", fmt.Sprintf("my_test_catalog_database_%d", rInt)),
-					resource.TestCheckResourceAttr(tableName, "description", description),
-					resource.TestCheckResourceAttr(tableName, "owner", "my_owner"),
-					resource.TestCheckResourceAttr(tableName, "retention", "1"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.0.name", "my_column_1"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.0.type", "int"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.0.comment", "my_column1_comment"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.1.name", "my_column_2"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.1.type", "string"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.1.comment", "my_column2_comment"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.location", "my_location"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.input_format", "SequenceFileInputFormat"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.output_format", "SequenceFileInputFormat"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.compressed", "false"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.number_of_buckets", "1"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.ser_de_info.0.name", "ser_de_name"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.ser_de_info.0.parameters.param1", "param_val_1"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.ser_de_info.0.serialization_library", "org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.bucket_columns.0", "bucket_column_1"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.sort_columns.0.column", "my_column_1"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.sort_columns.0.sort_order", "1"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.parameters.param1", "param1_val"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.skewed_info.0.skewed_column_names.0", "my_column_1"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.skewed_info.0.skewed_column_value_location_maps.my_column_1", "my_column_1_val_loc_map"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.skewed_info.0.skewed_column_values.0", "skewed_val_1"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.stored_as_sub_directories", "false"),
-					resource.TestCheckResourceAttr(tableName, "partition_keys.0.name", "my_column_1"),
-					resource.TestCheckResourceAttr(tableName, "partition_keys.0.type", "int"),
-					resource.TestCheckResourceAttr(tableName, "partition_keys.0.comment", "my_column_1_comment"),
-					resource.TestCheckResourceAttr(tableName, "partition_keys.1.name", "my_column_2"),
-					resource.TestCheckResourceAttr(tableName, "partition_keys.1.type", "string"),
-					resource.TestCheckResourceAttr(tableName, "partition_keys.1.comment", "my_column_2_comment"),
-					resource.TestCheckResourceAttr(tableName, "view_original_text", "view_original_text_1"),
-					resource.TestCheckResourceAttr(tableName, "view_expanded_text", "view_expanded_text_1"),
-					resource.TestCheckResourceAttr(tableName, "table_type", "VIRTUAL_VIEW"),
-					resource.TestCheckResourceAttr(tableName, "parameters.param1", "param1_val"),
+					testAccCheckGlueCatalogTableExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("my_test_catalog_table_%d", rInt)),
+					resource.TestCheckResourceAttr(resourceName, "database_name", fmt.Sprintf("my_test_catalog_database_%d", rInt)),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, "owner", "my_owner"),
+					resource.TestCheckResourceAttr(resourceName, "retention", "1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.columns.0.name", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.columns.0.type", "int"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.columns.0.comment", "my_column1_comment"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.columns.1.name", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.columns.1.type", "string"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.columns.1.comment", "my_column2_comment"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.location", "my_location"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.input_format", "SequenceFileInputFormat"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.output_format", "SequenceFileInputFormat"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.compressed", "false"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.number_of_buckets", "1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.ser_de_info.0.name", "ser_de_name"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.ser_de_info.0.parameters.param1", "param_val_1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.ser_de_info.0.serialization_library", "org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.bucket_columns.0", "bucket_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.sort_columns.0.column", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.sort_columns.0.sort_order", "1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.parameters.param1", "param1_val"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.skewed_info.0.skewed_column_names.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.skewed_info.0.skewed_column_value_location_maps.my_column_1", "my_column_1_val_loc_map"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.skewed_info.0.skewed_column_values.0", "skewed_val_1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.stored_as_sub_directories", "false"),
+					resource.TestCheckResourceAttr(resourceName, "partition_keys.0.name", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "partition_keys.0.type", "int"),
+					resource.TestCheckResourceAttr(resourceName, "partition_keys.0.comment", "my_column_1_comment"),
+					resource.TestCheckResourceAttr(resourceName, "partition_keys.1.name", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "partition_keys.1.type", "string"),
+					resource.TestCheckResourceAttr(resourceName, "partition_keys.1.comment", "my_column_2_comment"),
+					resource.TestCheckResourceAttr(resourceName, "view_original_text", "view_original_text_1"),
+					resource.TestCheckResourceAttr(resourceName, "view_expanded_text", "view_expanded_text_1"),
+					resource.TestCheckResourceAttr(resourceName, "table_type", "VIRTUAL_VIEW"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.param1", "param1_val"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -159,7 +148,7 @@ func TestAccAWSGlueCatalogTable_full(t *testing.T) {
 func TestAccAWSGlueCatalogTable_update_addValues(t *testing.T) {
 	rInt := acctest.RandInt()
 	description := "A test table from terraform"
-	tableName := "aws_glue_catalog_table.test"
+	resourceName := "aws_glue_catalog_table.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -170,61 +159,66 @@ func TestAccAWSGlueCatalogTable_update_addValues(t *testing.T) {
 				Config:  testAccGlueCatalogTable_basic(rInt),
 				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGlueCatalogTableExists("aws_glue_catalog_table.test"),
+					testAccCheckGlueCatalogTableExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_glue_catalog_table.test",
+						resourceName,
 						"name",
 						fmt.Sprintf("my_test_catalog_table_%d", rInt),
 					),
 					resource.TestCheckResourceAttr(
-						tableName,
+						resourceName,
 						"database_name",
 						fmt.Sprintf("my_test_catalog_database_%d", rInt),
 					),
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config:  testAccGlueCatalogTable_full(rInt, description),
 				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGlueCatalogTableExists(tableName),
-					resource.TestCheckResourceAttr(tableName, "name", fmt.Sprintf("my_test_catalog_table_%d", rInt)),
-					resource.TestCheckResourceAttr(tableName, "database_name", fmt.Sprintf("my_test_catalog_database_%d", rInt)),
-					resource.TestCheckResourceAttr(tableName, "description", description),
-					resource.TestCheckResourceAttr(tableName, "owner", "my_owner"),
-					resource.TestCheckResourceAttr(tableName, "retention", "1"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.0.name", "my_column_1"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.0.type", "int"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.0.comment", "my_column1_comment"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.1.name", "my_column_2"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.1.type", "string"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.1.comment", "my_column2_comment"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.location", "my_location"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.input_format", "SequenceFileInputFormat"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.output_format", "SequenceFileInputFormat"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.compressed", "false"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.number_of_buckets", "1"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.ser_de_info.0.name", "ser_de_name"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.ser_de_info.0.parameters.param1", "param_val_1"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.ser_de_info.0.serialization_library", "org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.bucket_columns.0", "bucket_column_1"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.sort_columns.0.column", "my_column_1"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.sort_columns.0.sort_order", "1"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.parameters.param1", "param1_val"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.skewed_info.0.skewed_column_names.0", "my_column_1"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.skewed_info.0.skewed_column_value_location_maps.my_column_1", "my_column_1_val_loc_map"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.skewed_info.0.skewed_column_values.0", "skewed_val_1"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.stored_as_sub_directories", "false"),
-					resource.TestCheckResourceAttr(tableName, "partition_keys.0.name", "my_column_1"),
-					resource.TestCheckResourceAttr(tableName, "partition_keys.0.type", "int"),
-					resource.TestCheckResourceAttr(tableName, "partition_keys.0.comment", "my_column_1_comment"),
-					resource.TestCheckResourceAttr(tableName, "partition_keys.1.name", "my_column_2"),
-					resource.TestCheckResourceAttr(tableName, "partition_keys.1.type", "string"),
-					resource.TestCheckResourceAttr(tableName, "partition_keys.1.comment", "my_column_2_comment"),
-					resource.TestCheckResourceAttr(tableName, "view_original_text", "view_original_text_1"),
-					resource.TestCheckResourceAttr(tableName, "view_expanded_text", "view_expanded_text_1"),
-					resource.TestCheckResourceAttr(tableName, "table_type", "VIRTUAL_VIEW"),
-					resource.TestCheckResourceAttr(tableName, "parameters.param1", "param1_val"),
+					testAccCheckGlueCatalogTableExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("my_test_catalog_table_%d", rInt)),
+					resource.TestCheckResourceAttr(resourceName, "database_name", fmt.Sprintf("my_test_catalog_database_%d", rInt)),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, "owner", "my_owner"),
+					resource.TestCheckResourceAttr(resourceName, "retention", "1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.columns.0.name", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.columns.0.type", "int"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.columns.0.comment", "my_column1_comment"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.columns.1.name", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.columns.1.type", "string"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.columns.1.comment", "my_column2_comment"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.location", "my_location"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.input_format", "SequenceFileInputFormat"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.output_format", "SequenceFileInputFormat"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.compressed", "false"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.number_of_buckets", "1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.ser_de_info.0.name", "ser_de_name"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.ser_de_info.0.parameters.param1", "param_val_1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.ser_de_info.0.serialization_library", "org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.bucket_columns.0", "bucket_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.sort_columns.0.column", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.sort_columns.0.sort_order", "1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.parameters.param1", "param1_val"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.skewed_info.0.skewed_column_names.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.skewed_info.0.skewed_column_value_location_maps.my_column_1", "my_column_1_val_loc_map"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.skewed_info.0.skewed_column_values.0", "skewed_val_1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.stored_as_sub_directories", "false"),
+					resource.TestCheckResourceAttr(resourceName, "partition_keys.0.name", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "partition_keys.0.type", "int"),
+					resource.TestCheckResourceAttr(resourceName, "partition_keys.0.comment", "my_column_1_comment"),
+					resource.TestCheckResourceAttr(resourceName, "partition_keys.1.name", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "partition_keys.1.type", "string"),
+					resource.TestCheckResourceAttr(resourceName, "partition_keys.1.comment", "my_column_2_comment"),
+					resource.TestCheckResourceAttr(resourceName, "view_original_text", "view_original_text_1"),
+					resource.TestCheckResourceAttr(resourceName, "view_expanded_text", "view_expanded_text_1"),
+					resource.TestCheckResourceAttr(resourceName, "table_type", "VIRTUAL_VIEW"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.param1", "param1_val"),
 				),
 			},
 		},
@@ -234,7 +228,7 @@ func TestAccAWSGlueCatalogTable_update_addValues(t *testing.T) {
 func TestAccAWSGlueCatalogTable_update_replaceValues(t *testing.T) {
 	rInt := acctest.RandInt()
 	description := "A test table from terraform"
-	tableName := "aws_glue_catalog_table.test"
+	resourceName := "aws_glue_catalog_table.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -245,94 +239,99 @@ func TestAccAWSGlueCatalogTable_update_replaceValues(t *testing.T) {
 				Config:  testAccGlueCatalogTable_full(rInt, description),
 				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGlueCatalogTableExists(tableName),
-					resource.TestCheckResourceAttr(tableName, "name", fmt.Sprintf("my_test_catalog_table_%d", rInt)),
-					resource.TestCheckResourceAttr(tableName, "database_name", fmt.Sprintf("my_test_catalog_database_%d", rInt)),
-					resource.TestCheckResourceAttr(tableName, "description", description),
-					resource.TestCheckResourceAttr(tableName, "owner", "my_owner"),
-					resource.TestCheckResourceAttr(tableName, "retention", "1"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.0.name", "my_column_1"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.0.type", "int"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.0.comment", "my_column1_comment"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.1.name", "my_column_2"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.1.type", "string"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.1.comment", "my_column2_comment"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.location", "my_location"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.input_format", "SequenceFileInputFormat"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.output_format", "SequenceFileInputFormat"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.compressed", "false"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.number_of_buckets", "1"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.ser_de_info.0.name", "ser_de_name"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.ser_de_info.0.parameters.param1", "param_val_1"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.ser_de_info.0.serialization_library", "org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.bucket_columns.0", "bucket_column_1"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.sort_columns.0.column", "my_column_1"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.sort_columns.0.sort_order", "1"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.parameters.param1", "param1_val"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.skewed_info.0.skewed_column_names.0", "my_column_1"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.skewed_info.0.skewed_column_value_location_maps.my_column_1", "my_column_1_val_loc_map"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.skewed_info.0.skewed_column_values.0", "skewed_val_1"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.stored_as_sub_directories", "false"),
-					resource.TestCheckResourceAttr(tableName, "partition_keys.0.name", "my_column_1"),
-					resource.TestCheckResourceAttr(tableName, "partition_keys.0.type", "int"),
-					resource.TestCheckResourceAttr(tableName, "partition_keys.0.comment", "my_column_1_comment"),
-					resource.TestCheckResourceAttr(tableName, "partition_keys.1.name", "my_column_2"),
-					resource.TestCheckResourceAttr(tableName, "partition_keys.1.type", "string"),
-					resource.TestCheckResourceAttr(tableName, "partition_keys.1.comment", "my_column_2_comment"),
-					resource.TestCheckResourceAttr(tableName, "view_original_text", "view_original_text_1"),
-					resource.TestCheckResourceAttr(tableName, "view_expanded_text", "view_expanded_text_1"),
-					resource.TestCheckResourceAttr(tableName, "table_type", "VIRTUAL_VIEW"),
-					resource.TestCheckResourceAttr(tableName, "parameters.param1", "param1_val"),
+					testAccCheckGlueCatalogTableExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("my_test_catalog_table_%d", rInt)),
+					resource.TestCheckResourceAttr(resourceName, "database_name", fmt.Sprintf("my_test_catalog_database_%d", rInt)),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, "owner", "my_owner"),
+					resource.TestCheckResourceAttr(resourceName, "retention", "1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.columns.0.name", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.columns.0.type", "int"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.columns.0.comment", "my_column1_comment"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.columns.1.name", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.columns.1.type", "string"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.columns.1.comment", "my_column2_comment"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.location", "my_location"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.input_format", "SequenceFileInputFormat"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.output_format", "SequenceFileInputFormat"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.compressed", "false"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.number_of_buckets", "1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.ser_de_info.0.name", "ser_de_name"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.ser_de_info.0.parameters.param1", "param_val_1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.ser_de_info.0.serialization_library", "org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.bucket_columns.0", "bucket_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.sort_columns.0.column", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.sort_columns.0.sort_order", "1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.parameters.param1", "param1_val"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.skewed_info.0.skewed_column_names.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.skewed_info.0.skewed_column_value_location_maps.my_column_1", "my_column_1_val_loc_map"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.skewed_info.0.skewed_column_values.0", "skewed_val_1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.stored_as_sub_directories", "false"),
+					resource.TestCheckResourceAttr(resourceName, "partition_keys.0.name", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "partition_keys.0.type", "int"),
+					resource.TestCheckResourceAttr(resourceName, "partition_keys.0.comment", "my_column_1_comment"),
+					resource.TestCheckResourceAttr(resourceName, "partition_keys.1.name", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "partition_keys.1.type", "string"),
+					resource.TestCheckResourceAttr(resourceName, "partition_keys.1.comment", "my_column_2_comment"),
+					resource.TestCheckResourceAttr(resourceName, "view_original_text", "view_original_text_1"),
+					resource.TestCheckResourceAttr(resourceName, "view_expanded_text", "view_expanded_text_1"),
+					resource.TestCheckResourceAttr(resourceName, "table_type", "VIRTUAL_VIEW"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.param1", "param1_val"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config:  testAccGlueCatalogTable_full_replacedValues(rInt),
 				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGlueCatalogTableExists(tableName),
-					resource.TestCheckResourceAttr(tableName, "name", fmt.Sprintf("my_test_catalog_table_%d", rInt)),
-					resource.TestCheckResourceAttr(tableName, "database_name", fmt.Sprintf("my_test_catalog_database_%d", rInt)),
-					resource.TestCheckResourceAttr(tableName, "description", "A test table from terraform2"),
-					resource.TestCheckResourceAttr(tableName, "owner", "my_owner2"),
-					resource.TestCheckResourceAttr(tableName, "retention", "2"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.0.name", "my_column_12"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.0.type", "date"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.0.comment", "my_column1_comment2"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.1.name", "my_column_22"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.1.type", "timestamp"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.1.comment", "my_column2_comment2"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.location", "my_location2"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.input_format", "TextInputFormat"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.output_format", "TextInputFormat"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.compressed", "true"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.number_of_buckets", "12"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.ser_de_info.0.name", "ser_de_name2"),
-					resource.TestCheckNoResourceAttr(tableName, "storage_descriptor.0.ser_de_info.0.parameters.param1"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.ser_de_info.0.parameters.param2", "param_val_12"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.ser_de_info.0.serialization_library", "org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe2"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.bucket_columns.0", "bucket_column_12"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.bucket_columns.1", "bucket_column_2"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.sort_columns.0.column", "my_column_12"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.sort_columns.0.sort_order", "0"),
-					resource.TestCheckNoResourceAttr(tableName, "storage_descriptor.0.parameters.param1"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.parameters.param12", "param1_val2"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.skewed_info.0.skewed_column_names.0", "my_column_12"),
-					resource.TestCheckNoResourceAttr(tableName, "storage_descriptor.0.skewed_info.0.skewed_column_value_location_maps.my_column_1"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.skewed_info.0.skewed_column_value_location_maps.my_column_12", "my_column_1_val_loc_map2"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.skewed_info.0.skewed_column_values.0", "skewed_val_12"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.skewed_info.0.skewed_column_values.1", "skewed_val_2"),
-					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.stored_as_sub_directories", "true"),
-					resource.TestCheckResourceAttr(tableName, "partition_keys.0.name", "my_column_12"),
-					resource.TestCheckResourceAttr(tableName, "partition_keys.0.type", "date"),
-					resource.TestCheckResourceAttr(tableName, "partition_keys.0.comment", "my_column_1_comment2"),
-					resource.TestCheckResourceAttr(tableName, "partition_keys.1.name", "my_column_22"),
-					resource.TestCheckResourceAttr(tableName, "partition_keys.1.type", "timestamp"),
-					resource.TestCheckResourceAttr(tableName, "partition_keys.1.comment", "my_column_2_comment2"),
-					resource.TestCheckResourceAttr(tableName, "view_original_text", "view_original_text_12"),
-					resource.TestCheckResourceAttr(tableName, "view_expanded_text", "view_expanded_text_12"),
-					resource.TestCheckResourceAttr(tableName, "table_type", "EXTERNAL_TABLE"),
-					//resource.TestCheckResourceAttr(tableName, "parameters.param1", "param1_val"),
-					resource.TestCheckResourceAttr(tableName, "parameters.param2", "param1_val2"),
+					testAccCheckGlueCatalogTableExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("my_test_catalog_table_%d", rInt)),
+					resource.TestCheckResourceAttr(resourceName, "database_name", fmt.Sprintf("my_test_catalog_database_%d", rInt)),
+					resource.TestCheckResourceAttr(resourceName, "description", "A test table from terraform2"),
+					resource.TestCheckResourceAttr(resourceName, "owner", "my_owner2"),
+					resource.TestCheckResourceAttr(resourceName, "retention", "2"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.columns.0.name", "my_column_12"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.columns.0.type", "date"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.columns.0.comment", "my_column1_comment2"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.columns.1.name", "my_column_22"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.columns.1.type", "timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.columns.1.comment", "my_column2_comment2"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.location", "my_location2"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.input_format", "TextInputFormat"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.output_format", "TextInputFormat"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.compressed", "true"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.number_of_buckets", "12"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.ser_de_info.0.name", "ser_de_name2"),
+					resource.TestCheckNoResourceAttr(resourceName, "storage_descriptor.0.ser_de_info.0.parameters.param1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.ser_de_info.0.parameters.param2", "param_val_12"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.ser_de_info.0.serialization_library", "org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe2"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.bucket_columns.0", "bucket_column_12"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.bucket_columns.1", "bucket_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.sort_columns.0.column", "my_column_12"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.sort_columns.0.sort_order", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "storage_descriptor.0.parameters.param1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.parameters.param12", "param1_val2"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.skewed_info.0.skewed_column_names.0", "my_column_12"),
+					resource.TestCheckNoResourceAttr(resourceName, "storage_descriptor.0.skewed_info.0.skewed_column_value_location_maps.my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.skewed_info.0.skewed_column_value_location_maps.my_column_12", "my_column_1_val_loc_map2"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.skewed_info.0.skewed_column_values.0", "skewed_val_12"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.skewed_info.0.skewed_column_values.1", "skewed_val_2"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.stored_as_sub_directories", "true"),
+					resource.TestCheckResourceAttr(resourceName, "partition_keys.0.name", "my_column_12"),
+					resource.TestCheckResourceAttr(resourceName, "partition_keys.0.type", "date"),
+					resource.TestCheckResourceAttr(resourceName, "partition_keys.0.comment", "my_column_1_comment2"),
+					resource.TestCheckResourceAttr(resourceName, "partition_keys.1.name", "my_column_22"),
+					resource.TestCheckResourceAttr(resourceName, "partition_keys.1.type", "timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "partition_keys.1.comment", "my_column_2_comment2"),
+					resource.TestCheckResourceAttr(resourceName, "view_original_text", "view_original_text_12"),
+					resource.TestCheckResourceAttr(resourceName, "view_expanded_text", "view_expanded_text_12"),
+					resource.TestCheckResourceAttr(resourceName, "table_type", "EXTERNAL_TABLE"),
+					//resource.TestCheckResourceAttr(resourceName, "parameters.param1", "param1_val"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.param2", "param1_val2"),
 				),
 			},
 		},
@@ -545,7 +544,7 @@ func testAccCheckGlueTableDestroy(s *terraform.State) error {
 			continue
 		}
 
-		catalogId, dbName, tableName, err := readAwsGlueTableID(rs.Primary.ID)
+		catalogId, dbName, resourceName, err := readAwsGlueTableID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -553,7 +552,7 @@ func testAccCheckGlueTableDestroy(s *terraform.State) error {
 		input := &glue.GetTableInput{
 			DatabaseName: aws.String(dbName),
 			CatalogId:    aws.String(catalogId),
-			Name:         aws.String(tableName),
+			Name:         aws.String(resourceName),
 		}
 		if _, err := conn.GetTable(input); err != nil {
 			//Verify the error is what we want
@@ -579,7 +578,7 @@ func testAccCheckGlueCatalogTableExists(name string) resource.TestCheckFunc {
 			return fmt.Errorf("No ID is set")
 		}
 
-		catalogId, dbName, tableName, err := readAwsGlueTableID(rs.Primary.ID)
+		catalogId, dbName, resourceName, err := readAwsGlueTableID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -588,7 +587,7 @@ func testAccCheckGlueCatalogTableExists(name string) resource.TestCheckFunc {
 		out, err := glueconn.GetTable(&glue.GetTableInput{
 			CatalogId:    aws.String(catalogId),
 			DatabaseName: aws.String(dbName),
-			Name:         aws.String(tableName),
+			Name:         aws.String(resourceName),
 		})
 
 		if err != nil {
@@ -599,9 +598,9 @@ func testAccCheckGlueCatalogTableExists(name string) resource.TestCheckFunc {
 			return fmt.Errorf("No Glue Table Found")
 		}
 
-		if *out.Table.Name != tableName {
+		if *out.Table.Name != resourceName {
 			return fmt.Errorf("Glue Table Mismatch - existing: %q, state: %q",
-				*out.Table.Name, tableName)
+				*out.Table.Name, resourceName)
 		}
 
 		return nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8944

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSGlueCatalogTable_"
==> Fixing source code with gofmt...
gofmt -s -w ./aws
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSGlueCatalogTable_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSGlueCatalogTable_recreates
=== PAUSE TestAccAWSGlueCatalogTable_recreates
=== RUN   TestAccAWSGlueCatalogTable_basic
=== PAUSE TestAccAWSGlueCatalogTable_basic
=== RUN   TestAccAWSGlueCatalogTable_full
=== PAUSE TestAccAWSGlueCatalogTable_full
=== RUN   TestAccAWSGlueCatalogTable_update_addValues
=== PAUSE TestAccAWSGlueCatalogTable_update_addValues
=== RUN   TestAccAWSGlueCatalogTable_update_replaceValues
=== PAUSE TestAccAWSGlueCatalogTable_update_replaceValues
=== CONT  TestAccAWSGlueCatalogTable_recreates
=== CONT  TestAccAWSGlueCatalogTable_update_addValues
=== CONT  TestAccAWSGlueCatalogTable_update_replaceValues
=== CONT  TestAccAWSGlueCatalogTable_full
=== CONT  TestAccAWSGlueCatalogTable_basic
--- PASS: TestAccAWSGlueCatalogTable_basic (31.78s)
--- PASS: TestAccAWSGlueCatalogTable_full (33.81s)
--- PASS: TestAccAWSGlueCatalogTable_recreates (39.39s)
--- PASS: TestAccAWSGlueCatalogTable_update_replaceValues (50.92s)
--- PASS: TestAccAWSGlueCatalogTable_update_addValues (51.08s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       57.765s

make testacc TESTARGS="-run=TestAccAWSGlueCatalogDatabase_"
==> Fixing source code with gofmt...
gofmt -s -w ./aws
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSGlueCatalogDatabase_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSGlueCatalogDatabase_full
=== PAUSE TestAccAWSGlueCatalogDatabase_full
=== RUN   TestAccAWSGlueCatalogDatabase_recreates
=== PAUSE TestAccAWSGlueCatalogDatabase_recreates
=== CONT  TestAccAWSGlueCatalogDatabase_full
=== CONT  TestAccAWSGlueCatalogDatabase_recreates
--- PASS: TestAccAWSGlueCatalogDatabase_recreates (30.10s)
--- PASS: TestAccAWSGlueCatalogDatabase_full (68.12s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       74.722s
```
