### PR TITLE
Automatically run make fmt if the tests need a make fmt

### DIFF
--- a/scripts/gofmtcheck.sh
+++ b/scripts/gofmtcheck.sh
@@ -6,8 +6,8 @@ gofmt_files=$(find . -name '*.go' | grep -v vendor | xargs gofmt -l -s)
 if [[ -n ${gofmt_files} ]]; then
     echo 'gofmt needs running on the following files:'
     echo "${gofmt_files}"
-    echo "You can use the command: \`make fmt\` to reformat code."
-    exit 1
+    echo "Running \`make fmt\`..."
+    make fmt
 fi
 
 exit 0


### PR DESCRIPTION
If we have to run `make fmt` anyways, let's do it automatically!

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ NONE
```
