### PR TITLE
Fix small typo in aws_route_table doc

### DIFF
--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -65,7 +65,7 @@ The following arguments are supported:
 One of the following destination arguments must be supplied:
 
 * `cidr_block` - (Required) The CIDR block of the route.
-* `ipv6_cidr_block` - (Optional) The Ipv6 CIDR block of the route
+* `ipv6_cidr_block` - (Optional) The Ipv6 CIDR block of the route.
 
 One of the following target arguments must be supplied:
 
@@ -82,11 +82,12 @@ Note that the default route, mapping the VPC's CIDR block to "local", is created
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
+
 ~> **NOTE:** Only the target that is entered is exported as a readable
 attribute once the route resource is created.
 
-* `id` - The ID of the routing table
-* `owner_id` - The ID of the AWS account that owns the route table
+* `id` - The ID of the routing table.
+* `owner_id` - The ID of the AWS account that owns the route table.
 
 ## Import
 


### PR DESCRIPTION
Just fix small typos.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

```release-note
NONE
```

