### PR TITLE
Correct match to don't-match in default_action block of web acl

### DIFF
--- a/website/docs/r/waf_web_acl.html.markdown
+++ b/website/docs/r/waf_web_acl.html.markdown
@@ -91,7 +91,7 @@ The following arguments are supported:
 
 ### `default_action` Configuration Block
 
-* `type` - (Required) Specifies how you want AWS WAF to respond to requests that match the settings in a rule.
+* `type` - (Required) Specifies how you want AWS WAF to respond to requests that don't match the criteria in any of the `rules`.
   e.g. `ALLOW`, `BLOCK` or `COUNT`
 
 ### `logging_configuration` Configuration Block


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
