### PR TITLE
Import test refactor for glacier vault

### DIFF
--- a/aws/resource_aws_glacier_vault_test.go
+++ b/aws/resource_aws_glacier_vault_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSGlacierVault_importBasic(t *testing.T) {
-	resourceName := "aws_glacier_vault.full"
+func TestAccAWSGlacierVault_basic(t *testing.T) {
 	rInt := acctest.RandInt()
+	resourceName := "aws_glacier_vault.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -24,9 +24,11 @@ func TestAccAWSGlacierVault_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckGlacierVaultDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGlacierVault_full(rInt),
+				Config: testAccGlacierVault_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlacierVaultExists(resourceName),
+				),
 			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
@@ -36,25 +38,10 @@ func TestAccAWSGlacierVault_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccAWSGlacierVault_basic(t *testing.T) {
-	rInt := acctest.RandInt()
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckGlacierVaultDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccGlacierVault_basic(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGlacierVaultExists("aws_glacier_vault.test"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAWSGlacierVault_full(t *testing.T) {
 	rInt := acctest.RandInt()
+	resourceName := "aws_glacier_vault.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -63,8 +50,13 @@ func TestAccAWSGlacierVault_full(t *testing.T) {
 			{
 				Config: testAccGlacierVault_full(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGlacierVaultExists("aws_glacier_vault.full"),
+					testAccCheckGlacierVaultExists(resourceName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -72,6 +64,8 @@ func TestAccAWSGlacierVault_full(t *testing.T) {
 
 func TestAccAWSGlacierVault_RemoveNotifications(t *testing.T) {
 	rInt := acctest.RandInt()
+	resourceName := "aws_glacier_vault.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -80,14 +74,19 @@ func TestAccAWSGlacierVault_RemoveNotifications(t *testing.T) {
 			{
 				Config: testAccGlacierVault_full(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGlacierVaultExists("aws_glacier_vault.full"),
+					testAccCheckGlacierVaultExists(resourceName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccGlacierVault_withoutNotification(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGlacierVaultExists("aws_glacier_vault.full"),
-					testAccCheckVaultNotificationsMissing("aws_glacier_vault.full"),
+					testAccCheckGlacierVaultExists(resourceName),
+					testAccCheckVaultNotificationsMissing(resourceName),
 				),
 			},
 		},
@@ -245,7 +244,7 @@ resource "aws_sns_topic" "aws_sns_topic" {
   name = "glacier-sns-topic-%d"
 }
 
-resource "aws_glacier_vault" "full" {
+resource "aws_glacier_vault" "test" {
   name = "my_test_vault_%d"
 
   notification {
@@ -266,7 +265,7 @@ resource "aws_sns_topic" "aws_sns_topic" {
   name = "glacier-sns-topic-%d"
 }
 
-resource "aws_glacier_vault" "full" {
+resource "aws_glacier_vault" "test" {
   name = "my_test_vault_%d"
 
   tags = {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8944

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSGlacierVault_"     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSGlacierVault_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSGlacierVault_basic
=== PAUSE TestAccAWSGlacierVault_basic
=== RUN   TestAccAWSGlacierVault_full
=== PAUSE TestAccAWSGlacierVault_full
=== RUN   TestAccAWSGlacierVault_RemoveNotifications
=== PAUSE TestAccAWSGlacierVault_RemoveNotifications
=== CONT  TestAccAWSGlacierVault_basic
=== CONT  TestAccAWSGlacierVault_RemoveNotifications
=== CONT  TestAccAWSGlacierVault_full
--- PASS: TestAccAWSGlacierVault_basic (37.84s)
--- PASS: TestAccAWSGlacierVault_full (45.04s)
--- PASS: TestAccAWSGlacierVault_RemoveNotifications (66.85s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       67.995s
```
