### PR TITLE
Allow to modify ca_cert_identifier

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -424,6 +424,7 @@ func resourceAwsDbInstance() *schema.Resource {
 
 			"ca_cert_identifier": {
 				Type:     schema.TypeString,
+				Optional: true,
 				Computed: true,
 			},
 
@@ -1477,6 +1478,11 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 	if d.HasChange("backup_retention_period") {
 		d.SetPartial("backup_retention_period")
 		req.BackupRetentionPeriod = aws.Int64(int64(d.Get("backup_retention_period").(int)))
+		requestUpdate = true
+	}
+	if d.HasChange("ca_cert_identifier") {
+		d.SetPartial("ca_cert_identifier")
+		req.CACertificateIdentifier = aws.String(d.Get("ca_cert_identifier").(string))
 		requestUpdate = true
 	}
 	if d.HasChange("copy_tags_to_snapshot") {


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

### Description

I'd be happy to add tests, but I can't figure out how to do this as AWS only allows two CA cert identifiers at the moment (`rds-ca-2015` and `rds-ca-2019`). The 2015 one expires in 2020 and I believe AWS will remove it afterwards, same will happen with 2019 one in 2022. Does it make sense to have these hardcoded in acceptance tests, as the test will start failing as soon as AWS removes the CA identifiers.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
Ability to modify `ca_cert_identifier` argument on `aws_db_instance` resource.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSDBInstance'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSDBInstance -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]

=== RUN   TestAccAWSDBInstance_basic
=== PAUSE TestAccAWSDBInstance_basic
=== RUN   TestAccAWSDBInstance_namePrefix
=== PAUSE TestAccAWSDBInstance_namePrefix
=== RUN   TestAccAWSDBInstance_generatedName
=== PAUSE TestAccAWSDBInstance_generatedName
=== RUN   TestAccAWSDBInstance_kmsKey
=== PAUSE TestAccAWSDBInstance_kmsKey
=== RUN   TestAccAWSDBInstance_subnetGroup
=== PAUSE TestAccAWSDBInstance_subnetGroup
=== RUN   TestAccAWSDBInstance_optionGroup
=== PAUSE TestAccAWSDBInstance_optionGroup
=== RUN   TestAccAWSDBInstance_iamAuth
=== PAUSE TestAccAWSDBInstance_iamAuth
=== RUN   TestAccAWSDBInstance_AllowMajorVersionUpgrade
=== PAUSE TestAccAWSDBInstance_AllowMajorVersionUpgrade
=== RUN   TestAccAWSDBInstance_DeletionProtection
=== PAUSE TestAccAWSDBInstance_DeletionProtection
=== RUN   TestAccAWSDBInstance_FinalSnapshotIdentifier
=== PAUSE TestAccAWSDBInstance_FinalSnapshotIdentifier
=== RUN   TestAccAWSDBInstance_FinalSnapshotIdentifier_SkipFinalSnapshot
=== PAUSE TestAccAWSDBInstance_FinalSnapshotIdentifier_SkipFinalSnapshot
=== RUN   TestAccAWSDBInstance_IsAlreadyBeingDeleted
=== PAUSE TestAccAWSDBInstance_IsAlreadyBeingDeleted
=== RUN   TestAccAWSDBInstance_MaxAllocatedStorage
=== PAUSE TestAccAWSDBInstance_MaxAllocatedStorage
=== RUN   TestAccAWSDBInstance_Password
=== PAUSE TestAccAWSDBInstance_Password
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_AllocatedStorage
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_AllocatedStorage
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_AllowMajorVersionUpgrade
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_AllowMajorVersionUpgrade
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_AutoMinorVersionUpgrade
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_AutoMinorVersionUpgrade
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_AvailabilityZone
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_AvailabilityZone
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_BackupRetentionPeriod
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_BackupRetentionPeriod
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_BackupWindow
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_BackupWindow
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_DeletionProtection
--- SKIP: TestAccAWSDBInstance_ReplicateSourceDb_DeletionProtection (0.00s)
    resource_aws_db_instance_test.go:678: CreateDBInstanceReadReplica API currently ignores DeletionProtection=true with SourceDBInstanceIdentifier set
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_IamDatabaseAuthenticationEnabled
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_IamDatabaseAuthenticationEnabled
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_MaintenanceWindow
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_MaintenanceWindow
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_MaxAllocatedStorage
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_MaxAllocatedStorage
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_Monitoring
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_Monitoring
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_MultiAZ
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_MultiAZ
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_ParameterGroupName
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_ParameterGroupName
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_Port
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_Port
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_VpcSecurityGroupIds
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_VpcSecurityGroupIds
=== RUN   TestAccAWSDBInstance_S3Import
=== PAUSE TestAccAWSDBInstance_S3Import
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_AllocatedStorage
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_AllocatedStorage
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_Io1Storage
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_Io1Storage
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_AllowMajorVersionUpgrade
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_AllowMajorVersionUpgrade
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_AutoMinorVersionUpgrade
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_AutoMinorVersionUpgrade
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_AvailabilityZone
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_AvailabilityZone
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod_Unset
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod_Unset
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_BackupWindow
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_BackupWindow
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_DeletionProtection
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_DeletionProtection
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_IamDatabaseAuthenticationEnabled
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_IamDatabaseAuthenticationEnabled
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_MaintenanceWindow
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_MaintenanceWindow
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_MaxAllocatedStorage
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_MaxAllocatedStorage
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_Monitoring
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_Monitoring
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ_SQLServer
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ_SQLServer
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_ParameterGroupName
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_ParameterGroupName
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_Port
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_Port
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_Tags
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_Tags
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_Tags_Unset
--- SKIP: TestAccAWSDBInstance_SnapshotIdentifier_Tags_Unset (0.00s)
    resource_aws_db_instance_test.go:1470: To be fixed: https://github.com/terraform-providers/terraform-provider-aws/issues/5959
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds_Tags
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds_Tags
=== RUN   TestAccAWSDBInstance_MonitoringInterval
=== PAUSE TestAccAWSDBInstance_MonitoringInterval
=== RUN   TestAccAWSDBInstance_MonitoringRoleArn_EnabledToDisabled
=== PAUSE TestAccAWSDBInstance_MonitoringRoleArn_EnabledToDisabled
=== RUN   TestAccAWSDBInstance_MonitoringRoleArn_EnabledToRemoved
=== PAUSE TestAccAWSDBInstance_MonitoringRoleArn_EnabledToRemoved
=== RUN   TestAccAWSDBInstance_MonitoringRoleArn_RemovedToEnabled
=== PAUSE TestAccAWSDBInstance_MonitoringRoleArn_RemovedToEnabled
=== RUN   TestAccAWSDBInstance_separate_iops_update
=== PAUSE TestAccAWSDBInstance_separate_iops_update
=== RUN   TestAccAWSDBInstance_portUpdate
=== PAUSE TestAccAWSDBInstance_portUpdate
=== RUN   TestAccAWSDBInstance_MSSQL_TZ
=== PAUSE TestAccAWSDBInstance_MSSQL_TZ
=== RUN   TestAccAWSDBInstance_MSSQL_Domain
=== PAUSE TestAccAWSDBInstance_MSSQL_Domain
=== RUN   TestAccAWSDBInstance_MSSQL_DomainSnapshotRestore
=== PAUSE TestAccAWSDBInstance_MSSQL_DomainSnapshotRestore
=== RUN   TestAccAWSDBInstance_MySQL_SnapshotRestoreWithEngineVersion
=== PAUSE TestAccAWSDBInstance_MySQL_SnapshotRestoreWithEngineVersion
=== RUN   TestAccAWSDBInstance_MinorVersion
=== PAUSE TestAccAWSDBInstance_MinorVersion
=== RUN   TestAccAWSDBInstance_diffSuppressInitialState
=== PAUSE TestAccAWSDBInstance_diffSuppressInitialState
=== RUN   TestAccAWSDBInstance_ec2Classic
=== PAUSE TestAccAWSDBInstance_ec2Classic
=== RUN   TestAccAWSDBInstance_cloudwatchLogsExportConfiguration
=== PAUSE TestAccAWSDBInstance_cloudwatchLogsExportConfiguration
=== RUN   TestAccAWSDBInstance_cloudwatchLogsExportConfigurationUpdate
=== PAUSE TestAccAWSDBInstance_cloudwatchLogsExportConfigurationUpdate
=== RUN   TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle
=== PAUSE TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle
=== RUN   TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Postgresql
=== PAUSE TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Postgresql
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_PerformanceInsightsEnabled
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_PerformanceInsightsEnabled
=== CONT  TestAccAWSDBInstance_basic
=== CONT  TestAccAWSDBInstance_diffSuppressInitialState
=== CONT  TestAccAWSDBInstance_ec2Classic
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_PerformanceInsightsEnabled
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled
=== CONT  TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Postgresql
=== CONT  TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle
=== CONT  TestAccAWSDBInstance_cloudwatchLogsExportConfigurationUpdate
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_AllocatedStorage
=== CONT  TestAccAWSDBInstance_MinorVersion
=== CONT  TestAccAWSDBInstance_MySQL_SnapshotRestoreWithEngineVersion
=== CONT  TestAccAWSDBInstance_MSSQL_DomainSnapshotRestore
=== CONT  TestAccAWSDBInstance_MSSQL_Domain
=== CONT  TestAccAWSDBInstance_MSSQL_TZ
=== CONT  TestAccAWSDBInstance_portUpdate
=== CONT  TestAccAWSDBInstance_separate_iops_update
=== CONT  TestAccAWSDBInstance_MonitoringRoleArn_RemovedToEnabled
=== CONT  TestAccAWSDBInstance_MonitoringRoleArn_EnabledToRemoved
=== CONT  TestAccAWSDBInstance_MonitoringRoleArn_EnabledToDisabled
=== CONT  TestAccAWSDBInstance_cloudwatchLogsExportConfiguration
--- SKIP: TestAccAWSDBInstance_ec2Classic (17.77s)
    provider_test.go:216: This test can only run in EC2 Classic, platforms available in us-east-1: ["VPC"]
=== CONT  TestAccAWSDBInstance_MonitoringInterval
--- FAIL: TestAccAWSDBInstance_separate_iops_update (34.95s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating DB Instance: InvalidParameterValue: Unable to create the resource. Verify that you have permission to create service linked role. Otherwise wait and try again later
        	status code: 400, request id: d7707652-3a55-4a6f-b1b8-d66a4d913b4f, {
          AllocatedStorage: 200,
          AutoMinorVersionUpgrade: true,
          BackupRetentionPeriod: 0,
          CopyTagsToSnapshot: false,
          DBInstanceClass: "db.t2.micro",
          DBInstanceIdentifier: "mydb-rds-h73h9",
          DBName: "mydb",
          DBParameterGroupName: "default.mysql5.6",
          DeletionProtection: false,
          Engine: "mysql",
          EngineVersion: "5.6.35",
          Iops: 1000,
          MasterUserPassword: "********",
          MasterUsername: "foo",
          PubliclyAccessible: false,
          StorageEncrypted: false,
          StorageType: "io1",
          Tags: []
        }
        
          on /var/folders/md/52wjnhf54x50bjskcyvbpjkm0000gn/T/tf-test704190433/main.tf line 2:
          (source code not available)
        
        
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds_Tags
--- PASS: TestAccAWSDBInstance_basic (467.24s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds
--- PASS: TestAccAWSDBInstance_MinorVersion (519.24s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_Tags
--- PASS: TestAccAWSDBInstance_diffSuppressInitialState (527.92s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_Port
--- PASS: TestAccAWSDBInstance_portUpdate (560.51s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_ParameterGroupName
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Postgresql (608.51s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ_SQLServer
--- PASS: TestAccAWSDBInstance_MonitoringRoleArn_RemovedToEnabled (648.41s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ
--- PASS: TestAccAWSDBInstance_cloudwatchLogsExportConfiguration (676.95s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_Monitoring
--- PASS: TestAccAWSDBInstance_MonitoringRoleArn_EnabledToDisabled (682.42s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_MaxAllocatedStorage
--- PASS: TestAccAWSDBInstance_MonitoringRoleArn_EnabledToRemoved (734.58s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_MaintenanceWindow
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle (949.09s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_IamDatabaseAuthenticationEnabled
--- PASS: TestAccAWSDBInstance_cloudwatchLogsExportConfigurationUpdate (949.48s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_DeletionProtection
--- PASS: TestAccAWSDBInstance_MonitoringInterval (941.55s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_BackupWindow
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_PerformanceInsightsEnabled (1513.03s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod_Unset
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds_Tags (1588.26s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod
--- FAIL: TestAccAWSDBInstance_MSSQL_DomainSnapshotRestore (1686.25s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating DB Instance: InvalidParameterValue: Unable to create the resource. Verify that you have permission to create service linked role. Otherwise wait and try again later
        	status code: 400, request id: 8f250336-6acc-4dc8-be17-0faf25bf4384, {
          AllocatedStorage: 20,
          AutoMinorVersionUpgrade: true,
          BackupRetentionPeriod: 0,
          CopyTagsToSnapshot: false,
          DBInstanceClass: "db.t2.micro",
          DBInstanceIdentifier: "tf-test-mssql-5531586480321844476",
          DBName: "",
          DeletionProtection: false,
          Engine: "sqlserver-ex",
          EngineVersion: "",
          MasterUserPassword: "********",
          MasterUsername: "somecrazyusername",
          PubliclyAccessible: false,
          StorageEncrypted: false,
          Tags: []
        }
        
          on /var/folders/md/52wjnhf54x50bjskcyvbpjkm0000gn/T/tf-test547766621/main.tf line 38:
          (source code not available)
        
        
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_AvailabilityZone
--- PASS: TestAccAWSDBInstance_MSSQL_TZ (1707.77s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_AutoMinorVersionUpgrade
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Port (1191.05s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_AllowMajorVersionUpgrade
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds (1280.37s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_Io1Storage
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AllocatedStorage (1773.54s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_AllowMajorVersionUpgrade
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Tags (1271.39s)
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MaxAllocatedStorage (1159.84s)
=== CONT  TestAccAWSDBInstance_S3Import
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled (1859.81s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_VpcSecurityGroupIds
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_ParameterGroupName (1308.71s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_Port
--- PASS: TestAccAWSDBInstance_MySQL_SnapshotRestoreWithEngineVersion (1938.87s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_ParameterGroupName
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MaintenanceWindow (1378.49s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_MultiAZ
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Monitoring (1462.24s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_Monitoring
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_IamDatabaseAuthenticationEnabled (1291.17s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_MaxAllocatedStorage
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_DeletionProtection (1430.03s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_MaintenanceWindow
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ (1893.47s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_IamDatabaseAuthenticationEnabled
--- FAIL: TestAccAWSDBInstance_S3Import (719.90s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: unexpected state 'incompatible-restore', wanted target 'available, storage-optimization'. last error: %!s(<nil>)
        
          on /var/folders/md/52wjnhf54x50bjskcyvbpjkm0000gn/T/tf-test815858268/main.tf line 103:
          (source code not available)
        
        
    testing.go:630: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: errors during apply: unexpected state 'incompatible-restore', wanted target ''. last error: %!s(<nil>)
        
        State: aws_db_instance.s3:
          ID = tf-acc-s3-import-test-4572482445988535205-db
          provider = provider.aws
          address = tf-acc-s3-import-test-4572482445988535205-db.c1cbvrhiibw5.us-west-2.rds.amazonaws.com
          allocated_storage = 5
          arn = arn:aws:rds:us-west-2:591289824811:db:tf-acc-s3-import-test-4572482445988535205-db
          auto_minor_version_upgrade = true
          availability_zone = us-west-2b
          backup_retention_period = 0
          backup_window = 07:12-07:42
          ca_cert_identifier = rds-ca-2015
          copy_tags_to_snapshot = false
          db_subnet_group_name = tf-acc-s3-import-test-4572482445988535205-subnet-group
          deletion_protection = false
          domain = 
          domain_iam_role_name = 
          enabled_cloudwatch_logs_exports.# = 0
          endpoint = tf-acc-s3-import-test-4572482445988535205-db.c1cbvrhiibw5.us-west-2.rds.amazonaws.com:3306
          engine = mysql
          engine_version = 5.6.41
          hosted_zone_id = Z1PVIF0B656C1W
          iam_database_authentication_enabled = false
          identifier = tf-acc-s3-import-test-4572482445988535205-db
          instance_class = db.t2.small
          iops = 0
          kms_key_id = 
          license_model = general-public-license
          maintenance_window = mon:08:50-mon:09:20
          max_allocated_storage = 0
          monitoring_interval = 0
          monitoring_role_arn = 
          multi_az = false
          name = baz
          option_group_name = default:mysql-5-6
          parameter_group_name = default.mysql5.6
          password = barbarbarbar
          performance_insights_enabled = false
          performance_insights_kms_key_id = 
          performance_insights_retention_period = 0
          port = 3306
          publicly_accessible = false
          replicas.# = 0
          replicate_source_db = 
          resource_id = db-LJA7YY4STMI44UVYCKFO3QOQHE
          s3_import.# = 1
          s3_import.0.bucket_name = tf-acc-test-880793965719664849
          s3_import.0.bucket_prefix = 376qs
          s3_import.0.ingestion_role = arn:aws:iam::591289824811:role/tf-acc-s3-import-test-4572482445988535205-role
          s3_import.0.source_engine = mysql
          s3_import.0.source_engine_version = 5.6
          security_group_names.# = 0
          skip_final_snapshot = true
          status = incompatible-restore
          storage_encrypted = false
          storage_type = gp2
          tags.% = 0
          timezone = 
          username = foo
          vpc_security_group_ids.# = 1
          vpc_security_group_ids.58224892 = sg-0a40086de68ce849f
        aws_db_subnet_group.foo:
          ID = tf-acc-s3-import-test-4572482445988535205-subnet-group
          provider = provider.aws
          arn = arn:aws:rds:us-west-2:591289824811:subgrp:tf-acc-s3-import-test-4572482445988535205-subnet-group
          description = Managed by Terraform
          name = tf-acc-s3-import-test-4572482445988535205-subnet-group
          subnet_ids.# = 2
          subnet_ids.3028696977 = subnet-0bd9612991753c50c
          subnet_ids.3122210889 = subnet-084ea786982efc554
          tags.% = 1
          tags.Name = tf-dbsubnet-group-test
        
          Dependencies:
            aws_subnet.bar
            aws_subnet.foo
        aws_iam_role.rds_s3_access_role:
          ID = tf-acc-s3-import-test-4572482445988535205-role
          provider = provider.aws
          arn = arn:aws:iam::591289824811:role/tf-acc-s3-import-test-4572482445988535205-role
          assume_role_policy = {"Version":"2012-10-17","Statement":[{"Sid":"","Effect":"Allow","Principal":{"Service":"rds.amazonaws.com"},"Action":"sts:AssumeRole"}]}
          create_date = 2019-09-13T08:12:06Z
          description = 
          force_detach_policies = false
          max_session_duration = 3600
          name = tf-acc-s3-import-test-4572482445988535205-role
          path = /
          tags.% = 0
          unique_id = AROAYTK46WYVXNWYCVEUA
        aws_s3_bucket.xtrabackup:
          ID = tf-acc-test-880793965719664849
          provider = provider.aws
          acceleration_status = 
          acl = private
          arn = arn:aws:s3:::tf-acc-test-880793965719664849
          bucket = tf-acc-test-880793965719664849
          bucket_domain_name = tf-acc-test-880793965719664849.s3.amazonaws.com
          bucket_regional_domain_name = tf-acc-test-880793965719664849.s3.us-west-2.amazonaws.com
          cors_rule.# = 0
          force_destroy = false
          hosted_zone_id = Z3BJ6K6RIION7M
          lifecycle_rule.# = 0
          logging.# = 0
          object_lock_configuration.# = 0
          region = us-west-2
          replication_configuration.# = 0
          request_payer = BucketOwner
          server_side_encryption_configuration.# = 0
          tags.% = 0
          versioning.# = 1
          versioning.0.enabled = false
          versioning.0.mfa_delete = false
          website.# = 0
        aws_subnet.bar:
          ID = subnet-0bd9612991753c50c
          provider = provider.aws
          arn = arn:aws:ec2:us-west-2:591289824811:subnet/subnet-0bd9612991753c50c
          assign_ipv6_address_on_creation = false
          availability_zone = us-west-2b
          availability_zone_id = usw2-az2
          cidr_block = 10.1.2.0/24
          ipv6_cidr_block = 
          ipv6_cidr_block_association_id = 
          map_public_ip_on_launch = false
          owner_id = 591289824811
          tags.% = 1
          tags.Name = tf-acc-db-instance-with-subnet-group-2
          vpc_id = vpc-09c77a17665f16468
        
          Dependencies:
            aws_vpc.foo
        aws_subnet.foo:
          ID = subnet-084ea786982efc554
          provider = provider.aws
          arn = arn:aws:ec2:us-west-2:591289824811:subnet/subnet-084ea786982efc554
          assign_ipv6_address_on_creation = false
          availability_zone = us-west-2a
          availability_zone_id = usw2-az1
          cidr_block = 10.1.1.0/24
          ipv6_cidr_block = 
          ipv6_cidr_block_association_id = 
          map_public_ip_on_launch = false
          owner_id = 591289824811
          tags.% = 1
          tags.Name = tf-acc-db-instance-with-subnet-group-1
          vpc_id = vpc-09c77a17665f16468
        
          Dependencies:
            aws_vpc.foo
        aws_vpc.foo:
          ID = vpc-09c77a17665f16468
          provider = provider.aws
          arn = arn:aws:ec2:us-west-2:591289824811:vpc/vpc-09c77a17665f16468
          assign_generated_ipv6_cidr_block = false
          cidr_block = 10.1.0.0/16
          default_network_acl_id = acl-01e19771362bf9cd9
          default_route_table_id = rtb-07376f943a81280fb
          default_security_group_id = sg-0a40086de68ce849f
          dhcp_options_id = dopt-fb68cb83
          enable_classiclink = false
          enable_classiclink_dns_support = false
          enable_dns_hostnames = false
          enable_dns_support = true
          instance_tenancy = default
          ipv6_association_id = 
          ipv6_cidr_block = 
          main_route_table_id = rtb-07376f943a81280fb
          owner_id = 591289824811
          tags.% = 1
          tags.Name = terraform-testacc-db-instance-with-subnet-group
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_BackupWindow
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupWindow (1611.90s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_BackupRetentionPeriod
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AvailabilityZone (1242.63s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_AvailabilityZone
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AutoMinorVersionUpgrade (1302.43s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_AutoMinorVersionUpgrade
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier (1236.20s)
=== CONT  TestAccAWSDBInstance_subnetGroup
--- PASS: TestAccAWSDBInstance_MSSQL_Domain (3174.35s)
=== CONT  TestAccAWSDBInstance_AllowMajorVersionUpgrade
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AllowMajorVersionUpgrade (1416.78s)
=== CONT  TestAccAWSDBInstance_DeletionProtection
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_VpcSecurityGroupIds (1378.57s)
=== CONT  TestAccAWSDBInstance_iamAuth
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod (1662.36s)
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_AllocatedStorage
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Io1Storage (1714.47s)
=== CONT  TestAccAWSDBInstance_optionGroup
--- FAIL: TestAccAWSDBInstance_optionGroup (18.17s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating DB Instance: InvalidParameterCombination: The option group tf-option-test-5897071866805738088 is for mysql 5.6, and your DB instance is mysql 5.7.
        	status code: 400, request id: 14a8fe75-d9e6-4b09-890b-5d75ce6c3b59
        
          on /var/folders/md/52wjnhf54x50bjskcyvbpjkm0000gn/T/tf-test160094616/main.tf line 9:
          (source code not available)
        
        
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod_Unset (1977.63s)
=== CONT  TestAccAWSDBInstance_generatedName
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_Port (1702.55s)
=== CONT  TestAccAWSDBInstance_kmsKey
--- PASS: TestAccAWSDBInstance_AllowMajorVersionUpgrade (463.78s)
=== CONT  TestAccAWSDBInstance_IsAlreadyBeingDeleted
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_ParameterGroupName (1742.86s)
=== CONT  TestAccAWSDBInstance_Password
--- FAIL: TestAccAWSDBInstance_ReplicateSourceDb_AutoMinorVersionUpgrade (693.44s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating DB Instance: InvalidParameterValue: The auto-minor-version-upgrade value is not valid for the Read Replica
        	status code: 400, request id: 8f1ec182-34b9-4c69-aec8-53b3bfc31f96
        
          on /var/folders/md/52wjnhf54x50bjskcyvbpjkm0000gn/T/tf-test672108067/main.tf line 13:
          (source code not available)
        
        
=== CONT  TestAccAWSDBInstance_FinalSnapshotIdentifier_SkipFinalSnapshot
--- PASS: TestAccAWSDBInstance_DeletionProtection (538.75s)
=== CONT  TestAccAWSDBInstance_FinalSnapshotIdentifier
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MaxAllocatedStorage (1514.58s)
=== CONT  TestAccAWSDBInstance_MaxAllocatedStorage
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_Monitoring (1621.46s)
=== CONT  TestAccAWSDBInstance_namePrefix
--- PASS: TestAccAWSDBInstance_iamAuth (525.80s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AllowMajorVersionUpgrade (2195.43s)
--- PASS: TestAccAWSDBInstance_subnetGroup (898.71s)
--- PASS: TestAccAWSDBInstance_generatedName (473.19s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_IamDatabaseAuthenticationEnabled (1429.77s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MaintenanceWindow (1690.12s)
--- PASS: TestAccAWSDBInstance_kmsKey (524.76s)
--- PASS: TestAccAWSDBInstance_IsAlreadyBeingDeleted (475.72s)
--- PASS: TestAccAWSDBInstance_Password (528.90s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MultiAZ (2104.01s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_BackupWindow (1700.10s)
--- PASS: TestAccAWSDBInstance_FinalSnapshotIdentifier_SkipFinalSnapshot (638.89s)
--- PASS: TestAccAWSDBInstance_MaxAllocatedStorage (621.28s)
--- PASS: TestAccAWSDBInstance_namePrefix (636.23s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_BackupRetentionPeriod (1908.23s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AvailabilityZone (1641.91s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ_SQLServer (4002.40s)
--- PASS: TestAccAWSDBInstance_FinalSnapshotIdentifier (959.79s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb (1508.82s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AllocatedStorage (1813.11s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	5098.802s
make: *** [testacc] Error 1
```
