### PR TITLE
Ignore lint complaints for valid fsx lustre fs tests

### DIFF
--- a/aws/resource_aws_fsx_lustre_file_system_test.go
+++ b/aws/resource_aws_fsx_lustre_file_system_test.go
@@ -162,6 +162,7 @@ func TestAccAWSFsxLustreFileSystem_ExportPath(t *testing.T) {
 	})
 }
 
+// lintignore: AT002
 func TestAccAWSFsxLustreFileSystem_ImportPath(t *testing.T) {
 	var filesystem1, filesystem2 fsx.FileSystem
 	resourceName := "aws_fsx_lustre_file_system.test"
@@ -197,6 +198,7 @@ func TestAccAWSFsxLustreFileSystem_ImportPath(t *testing.T) {
 	})
 }
 
+// lintignore: AT002
 func TestAccAWSFsxLustreFileSystem_ImportedFileChunkSize(t *testing.T) {
 	var filesystem1, filesystem2 fsx.FileSystem
 	resourceName := "aws_fsx_lustre_file_system.test"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8944

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSFsxLustreFileSystem_"          
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSFsxLustreFileSystem_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSFsxLustreFileSystem_basic
=== PAUSE TestAccAWSFsxLustreFileSystem_basic
=== RUN   TestAccAWSFsxLustreFileSystem_disappears
=== PAUSE TestAccAWSFsxLustreFileSystem_disappears
=== RUN   TestAccAWSFsxLustreFileSystem_ExportPath
=== PAUSE TestAccAWSFsxLustreFileSystem_ExportPath
=== RUN   TestAccAWSFsxLustreFileSystem_ImportPath
=== PAUSE TestAccAWSFsxLustreFileSystem_ImportPath
=== RUN   TestAccAWSFsxLustreFileSystem_ImportedFileChunkSize
=== PAUSE TestAccAWSFsxLustreFileSystem_ImportedFileChunkSize
=== RUN   TestAccAWSFsxLustreFileSystem_SecurityGroupIds
=== PAUSE TestAccAWSFsxLustreFileSystem_SecurityGroupIds
=== RUN   TestAccAWSFsxLustreFileSystem_StorageCapacity
=== PAUSE TestAccAWSFsxLustreFileSystem_StorageCapacity
=== RUN   TestAccAWSFsxLustreFileSystem_Tags
=== PAUSE TestAccAWSFsxLustreFileSystem_Tags
=== RUN   TestAccAWSFsxLustreFileSystem_WeeklyMaintenanceStartTime
=== PAUSE TestAccAWSFsxLustreFileSystem_WeeklyMaintenanceStartTime
=== CONT  TestAccAWSFsxLustreFileSystem_basic
=== CONT  TestAccAWSFsxLustreFileSystem_WeeklyMaintenanceStartTime
=== CONT  TestAccAWSFsxLustreFileSystem_disappears
=== CONT  TestAccAWSFsxLustreFileSystem_ImportedFileChunkSize
=== CONT  TestAccAWSFsxLustreFileSystem_Tags
=== CONT  TestAccAWSFsxLustreFileSystem_StorageCapacity
=== CONT  TestAccAWSFsxLustreFileSystem_SecurityGroupIds
=== CONT  TestAccAWSFsxLustreFileSystem_ImportPath
=== CONT  TestAccAWSFsxLustreFileSystem_ExportPath
--- PASS: TestAccAWSFsxLustreFileSystem_disappears (449.44s)
--- PASS: TestAccAWSFsxLustreFileSystem_basic (482.43s)
--- PASS: TestAccAWSFsxLustreFileSystem_WeeklyMaintenanceStartTime (549.72s)
--- PASS: TestAccAWSFsxLustreFileSystem_Tags (608.41s)
--- PASS: TestAccAWSFsxLustreFileSystem_SecurityGroupIds (969.75s)
--- PASS: TestAccAWSFsxLustreFileSystem_StorageCapacity (971.78s)
--- PASS: TestAccAWSFsxLustreFileSystem_ImportedFileChunkSize (1110.86s)
--- PASS: TestAccAWSFsxLustreFileSystem_ImportPath (1124.92s)
--- PASS: TestAccAWSFsxLustreFileSystem_ExportPath (1252.05s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       1254.359s
```
