### PR TITLE
Import test refactor for gamelift alias

### DIFF
--- a/aws/resource_aws_gamelift_alias_test.go
+++ b/aws/resource_aws_gamelift_alias_test.go
@@ -80,6 +80,7 @@ func TestAccAWSGameliftAlias_basic(t *testing.T) {
 	var conf gamelift.Alias
 
 	rString := acctest.RandString(8)
+	resourceName := "aws_gamelift_alias.test"
 
 	aliasName := fmt.Sprintf("tf_acc_alias_%s", rString)
 	description := fmt.Sprintf("tf test description %s", rString)
@@ -97,50 +98,31 @@ func TestAccAWSGameliftAlias_basic(t *testing.T) {
 			{
 				Config: testAccAWSGameliftAliasBasicConfig(aliasName, description, message),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSGameliftAliasExists("aws_gamelift_alias.test", &conf),
-					resource.TestCheckResourceAttrSet("aws_gamelift_alias.test", "arn"),
-					resource.TestCheckResourceAttr("aws_gamelift_alias.test", "routing_strategy.#", "1"),
-					resource.TestCheckResourceAttr("aws_gamelift_alias.test", "routing_strategy.0.message", message),
-					resource.TestCheckResourceAttr("aws_gamelift_alias.test", "routing_strategy.0.type", "TERMINAL"),
-					resource.TestCheckResourceAttr("aws_gamelift_alias.test", "name", aliasName),
-					resource.TestCheckResourceAttr("aws_gamelift_alias.test", "description", description),
+					testAccCheckAWSGameliftAliasExists(resourceName, &conf),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "routing_strategy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "routing_strategy.0.message", message),
+					resource.TestCheckResourceAttr(resourceName, "routing_strategy.0.type", "TERMINAL"),
+					resource.TestCheckResourceAttr(resourceName, "name", aliasName),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSGameliftAliasBasicConfig(uAliasName, uDescription, uMessage),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSGameliftAliasExists("aws_gamelift_alias.test", &conf),
-					resource.TestCheckResourceAttrSet("aws_gamelift_alias.test", "arn"),
-					resource.TestCheckResourceAttr("aws_gamelift_alias.test", "routing_strategy.#", "1"),
-					resource.TestCheckResourceAttr("aws_gamelift_alias.test", "routing_strategy.0.message", uMessage),
-					resource.TestCheckResourceAttr("aws_gamelift_alias.test", "routing_strategy.0.type", "TERMINAL"),
-					resource.TestCheckResourceAttr("aws_gamelift_alias.test", "name", uAliasName),
-					resource.TestCheckResourceAttr("aws_gamelift_alias.test", "description", uDescription),
+					testAccCheckAWSGameliftAliasExists(resourceName, &conf),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "routing_strategy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "routing_strategy.0.message", uMessage),
+					resource.TestCheckResourceAttr(resourceName, "routing_strategy.0.type", "TERMINAL"),
+					resource.TestCheckResourceAttr(resourceName, "name", uAliasName),
+					resource.TestCheckResourceAttr(resourceName, "description", uDescription),
 				),
-			},
-		},
-	})
-}
-
-func TestAccAWSGameliftAlias_importBasic(t *testing.T) {
-	rString := acctest.RandString(8)
-
-	aliasName := fmt.Sprintf("tf_acc_alias_%s", rString)
-	description := fmt.Sprintf("tf test description %s", rString)
-	message := fmt.Sprintf("tf test message %s", rString)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSGameliftAliasDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSGameliftAliasBasicConfig(aliasName, description, message),
-			},
-			{
-				ResourceName:      "aws_gamelift_alias.test",
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})
@@ -174,6 +156,7 @@ func TestAccAWSGameliftAlias_fleetRouting(t *testing.T) {
 
 	launchPath := g.LaunchPath
 	params := g.Parameters(33435)
+	resourceName := "aws_gamelift_alias.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
@@ -184,14 +167,19 @@ func TestAccAWSGameliftAlias_fleetRouting(t *testing.T) {
 				Config: testAccAWSGameliftAliasAllFieldsConfig(aliasName, description,
 					fleetName, launchPath, params, buildName, bucketName, key, roleArn),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSGameliftAliasExists("aws_gamelift_alias.test", &conf),
-					resource.TestCheckResourceAttrSet("aws_gamelift_alias.test", "arn"),
-					resource.TestCheckResourceAttr("aws_gamelift_alias.test", "routing_strategy.#", "1"),
-					resource.TestCheckResourceAttrSet("aws_gamelift_alias.test", "routing_strategy.0.fleet_id"),
-					resource.TestCheckResourceAttr("aws_gamelift_alias.test", "routing_strategy.0.type", "SIMPLE"),
-					resource.TestCheckResourceAttr("aws_gamelift_alias.test", "name", aliasName),
-					resource.TestCheckResourceAttr("aws_gamelift_alias.test", "description", description),
+					testAccCheckAWSGameliftAliasExists(resourceName, &conf),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "routing_strategy.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "routing_strategy.0.fleet_id"),
+					resource.TestCheckResourceAttr(resourceName, "routing_strategy.0.type", "SIMPLE"),
+					resource.TestCheckResourceAttr(resourceName, "name", aliasName),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8944

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
NOTE: the timeout is not a new error


$ make testacc TESTARGS="-run=TestAccAWSGameliftAlias_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSGameliftAlias_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSGameliftAlias_basic
=== PAUSE TestAccAWSGameliftAlias_basic
=== RUN   TestAccAWSGameliftAlias_fleetRouting
=== PAUSE TestAccAWSGameliftAlias_fleetRouting
=== CONT  TestAccAWSGameliftAlias_basic
=== CONT  TestAccAWSGameliftAlias_fleetRouting
--- PASS: TestAccAWSGameliftAlias_basic (44.89s)
--- FAIL: TestAccAWSGameliftAlias_fleetRouting (1325.49s)
    testing.go:630: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: errors during apply: timeout while waiting for resource to be gone (last state: 'DELETING', timeout: 5m0s) Recent failures:
        [{
          EventCode: "SERVER_PROCESS_FORCE_TERMINATED",
          EventId: "e24182c0-39f4-4ba1-9eef-34cfaab013b3",
          EventTime: 2019-09-13 12:54:22 +0000 UTC,
          Message: "Server process did not cleanly exit within 30 seconds of OnProcessTerminate(), exitCode(-1), launchPath(C:\\game\\Bin64.Release.Dedicated\\MultiplayerProjectLauncher_Server.exe), arguments(+sv_port 33435 +gamelift_start_server), instanceId(i-0ec34a47f0126686f), publicIP(18.237.213.209), gameSessionId(none)",
          ResourceId: "fleet-1262e5ef-683b-4a79-a2a9-4dc31ad45585"
        }]
        
        State: aws_gamelift_build.test:
          ID = build-5b04cc07-4003-443a-8717-a8ab288cbe7a
          provider = provider.aws
          name = tf_acc_build_suutx38l
          operating_system = WINDOWS_2012
          storage_location.# = 1
          storage_location.0.bucket = gamelift-sample-builds-prod-us-west-2
          storage_location.0.key = v1.2.0.0/server/sample_build_v1.2.0.0
          storage_location.0.role_arn = arn:aws:iam::741061592171:role/sample-build-upload-role-us-west-2
          version = 
        aws_gamelift_fleet.test:
          ID = fleet-1262e5ef-683b-4a79-a2a9-4dc31ad45585
          provider = provider.aws
          arn = arn:aws:gamelift:us-west-2:187416307283:fleet/fleet-1262e5ef-683b-4a79-a2a9-4dc31ad45585
          build_id = build-5b04cc07-4003-443a-8717-a8ab288cbe7a
          description = 
          ec2_inbound_permission.# = 0
          ec2_instance_type = c4.large
          log_paths.# = 0
          metric_groups.# = 1
          metric_groups.0 = default
          name = tf_acc_fleet_suutx38l
          new_game_session_protection_policy = NoProtection
          operating_system = WINDOWS_2012
          resource_creation_limit_policy.# = 0
          runtime_configuration.# = 1
          runtime_configuration.0.game_session_activation_timeout_seconds = 0
          runtime_configuration.0.max_concurrent_game_session_activations = 0
          runtime_configuration.0.server_process.# = 1
          runtime_configuration.0.server_process.0.concurrent_executions = 1
          runtime_configuration.0.server_process.0.launch_path = C:\game\Bin64.Release.Dedicated\MultiplayerProjectLauncher_Server.exe
          runtime_configuration.0.server_process.0.parameters = +sv_port 33435 +gamelift_start_server
FAIL
FAIL    github.com/terraform-providers/terraform-provider-aws/aws       1326.418s
make: *** [testacc] Error 1
```
