### PR TITLE
Use placement group in spot fleet requests when it is specified

### DIFF
--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -406,6 +406,14 @@ func buildSpotFleetLaunchSpecification(d map[string]interface{}, meta interface{
 		opts.Placement = placement
 	}
 
+	if v, ok := d["placement_group"]; ok {
+		if v.(string) != "" {
+			// If instanceInterruptionBehavior is set to STOP, this can't be set at all, even to an empty string, so check for "" to avoid those errors
+			placement.GroupName = aws.String(v.(string))
+			opts.Placement = placement
+		}
+	}
+
 	if v, ok := d["ebs_optimized"]; ok {
 		opts.EbsOptimized = aws.Bool(v.(bool))
 	}

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -620,7 +620,7 @@ func TestAccAWSSpotFleetRequest_withTags(t *testing.T) {
 	})
 }
 
-func TestAccAWSSpotFleetRequest_placementTenancy(t *testing.T) {
+func TestAccAWSSpotFleetRequest_placementTenancyAndGroup(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
 	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
@@ -631,11 +631,11 @@ func TestAccAWSSpotFleetRequest_placementTenancy(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestTenancyConfig(rName, rInt),
+				Config: testAccAWSSpotFleetRequestTenancyGroupConfig(rName, rInt),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists("aws_spot_fleet_request.foo", &sfr),
 					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					testAccCheckAWSSpotFleetRequest_PlacementAttributes(&sfr),
+					testAccCheckAWSSpotFleetRequest_PlacementAttributes(&sfr, rName),
 				),
 			},
 		},
@@ -780,7 +780,7 @@ func testAccCheckAWSSpotFleetRequest_EBSAttributes(
 }
 
 func testAccCheckAWSSpotFleetRequest_PlacementAttributes(
-	sfr *ec2.SpotFleetRequestConfig) resource.TestCheckFunc {
+	sfr *ec2.SpotFleetRequestConfig, rName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if len(sfr.SpotFleetRequestConfig.LaunchSpecifications) == 0 {
 			return errors.New("Missing launch specification")
@@ -794,6 +794,9 @@ func testAccCheckAWSSpotFleetRequest_PlacementAttributes(
 		}
 		if *placement.Tenancy != "dedicated" {
 			return fmt.Errorf("Expected placement tenancy to be %q, got %q", "dedicated", *placement.Tenancy)
+		}
+		if aws.StringValue(placement.GroupName) != fmt.Sprintf("test-pg-%s", rName) {
+			return fmt.Errorf("Expected placement group to be %q, got %q", fmt.Sprintf("test-pg-%s", rName), aws.StringValue(placement.GroupName))
 		}
 
 		return nil
@@ -1646,8 +1649,13 @@ resource "aws_spot_fleet_request" "foo" {
 `)
 }
 
-func testAccAWSSpotFleetRequestTenancyConfig(rName string, rInt int) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprint(`
+func testAccAWSSpotFleetRequestTenancyGroupConfig(rName string, rInt int) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+resource "aws_placement_group" "test" {
+	name     = "test-pg-%s"
+	strategy = "cluster"
+}
+
 resource "aws_spot_fleet_request" "foo" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
     spot_price = "0.005"
@@ -1658,9 +1666,10 @@ resource "aws_spot_fleet_request" "foo" {
         instance_type = "m1.small"
         ami = "ami-d06a90b0"
         key_name = "${aws_key_pair.debugging.key_name}"
-        placement_tenancy = "dedicated"
+		placement_tenancy = "dedicated"
+		placement_group = "${aws_placement_group.test.name}"
     }
     depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
-`)
+`, rName)
 }


### PR DESCRIPTION
Looking at [the API](https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#SpotPlacement), this probably should get set if it is present in the schema.  

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #6713

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_spot_fleet_request: Placement group names in launch specifications no longer get ignored
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSSpotFleetRequest_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSSpotFleetRequest_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSSpotFleetRequest_basic
=== PAUSE TestAccAWSSpotFleetRequest_basic
=== RUN   TestAccAWSSpotFleetRequest_associatePublicIpAddress
=== PAUSE TestAccAWSSpotFleetRequest_associatePublicIpAddress
=== RUN   TestAccAWSSpotFleetRequest_instanceInterruptionBehavior
=== PAUSE TestAccAWSSpotFleetRequest_instanceInterruptionBehavior
=== RUN   TestAccAWSSpotFleetRequest_fleetType
=== PAUSE TestAccAWSSpotFleetRequest_fleetType
=== RUN   TestAccAWSSpotFleetRequest_iamInstanceProfileArn
=== PAUSE TestAccAWSSpotFleetRequest_iamInstanceProfileArn
=== RUN   TestAccAWSSpotFleetRequest_changePriceForcesNewRequest
=== PAUSE TestAccAWSSpotFleetRequest_changePriceForcesNewRequest
=== RUN   TestAccAWSSpotFleetRequest_updateTargetCapacity
=== PAUSE TestAccAWSSpotFleetRequest_updateTargetCapacity
=== RUN   TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy
=== PAUSE TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy
=== RUN   TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion
=== PAUSE TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion
=== RUN   TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList
=== PAUSE TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList
=== RUN   TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList
=== PAUSE TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList
=== RUN   TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz
=== PAUSE TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz
=== RUN   TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet
=== PAUSE TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet
=== RUN   TestAccAWSSpotFleetRequest_overriddingSpotPrice
=== PAUSE TestAccAWSSpotFleetRequest_overriddingSpotPrice
=== RUN   TestAccAWSSpotFleetRequest_withoutSpotPrice
=== PAUSE TestAccAWSSpotFleetRequest_withoutSpotPrice
=== RUN   TestAccAWSSpotFleetRequest_diversifiedAllocation
=== PAUSE TestAccAWSSpotFleetRequest_diversifiedAllocation
=== RUN   TestAccAWSSpotFleetRequest_multipleInstancePools
=== PAUSE TestAccAWSSpotFleetRequest_multipleInstancePools
=== RUN   TestAccAWSSpotFleetRequest_withWeightedCapacity
=== PAUSE TestAccAWSSpotFleetRequest_withWeightedCapacity
=== RUN   TestAccAWSSpotFleetRequest_withEBSDisk
=== PAUSE TestAccAWSSpotFleetRequest_withEBSDisk
=== RUN   TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDevice_KmsKeyId
=== PAUSE TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDevice_KmsKeyId
=== RUN   TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDevice_KmsKeyId
=== PAUSE TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDevice_KmsKeyId
=== RUN   TestAccAWSSpotFleetRequest_withTags
=== PAUSE TestAccAWSSpotFleetRequest_withTags
=== RUN   TestAccAWSSpotFleetRequest_placementTenancyAndGroup
=== PAUSE TestAccAWSSpotFleetRequest_placementTenancyAndGroup
=== RUN   TestAccAWSSpotFleetRequest_WithELBs
=== PAUSE TestAccAWSSpotFleetRequest_WithELBs
=== RUN   TestAccAWSSpotFleetRequest_WithTargetGroups
=== PAUSE TestAccAWSSpotFleetRequest_WithTargetGroups
=== CONT  TestAccAWSSpotFleetRequest_basic
=== CONT  TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet
=== CONT  TestAccAWSSpotFleetRequest_overriddingSpotPrice
=== CONT  TestAccAWSSpotFleetRequest_WithTargetGroups
=== CONT  TestAccAWSSpotFleetRequest_WithELBs
=== CONT  TestAccAWSSpotFleetRequest_placementTenancyAndGroup
=== CONT  TestAccAWSSpotFleetRequest_withTags
=== CONT  TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDevice_KmsKeyId
=== CONT  TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDevice_KmsKeyId
=== CONT  TestAccAWSSpotFleetRequest_withEBSDisk
=== CONT  TestAccAWSSpotFleetRequest_withWeightedCapacity
=== CONT  TestAccAWSSpotFleetRequest_multipleInstancePools
=== CONT  TestAccAWSSpotFleetRequest_diversifiedAllocation
=== CONT  TestAccAWSSpotFleetRequest_updateTargetCapacity
=== CONT  TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz
=== CONT  TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList
=== CONT  TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList
=== CONT  TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion
=== CONT  TestAccAWSSpotFleetRequest_changePriceForcesNewRequest
=== CONT  TestAccAWSSpotFleetRequest_withoutSpotPrice
--- PASS: TestAccAWSSpotFleetRequest_placementTenancyAndGroup (78.75s)
=== CONT  TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDevice_KmsKeyId (160.24s)
=== CONT  TestAccAWSSpotFleetRequest_fleetType
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDevice_KmsKeyId (161.63s)
=== CONT  TestAccAWSSpotFleetRequest_associatePublicIpAddress
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList (274.85s)
=== CONT  TestAccAWSSpotFleetRequest_iamInstanceProfileArn
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet (274.91s)
=== CONT  TestAccAWSSpotFleetRequest_instanceInterruptionBehavior
--- PASS: TestAccAWSSpotFleetRequest_WithELBs (320.21s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion (332.26s)
--- PASS: TestAccAWSSpotFleetRequest_withWeightedCapacity (334.06s)
--- PASS: TestAccAWSSpotFleetRequest_withoutSpotPrice (335.68s)
--- PASS: TestAccAWSSpotFleetRequest_withTags (337.31s)
--- PASS: TestAccAWSSpotFleetRequest_diversifiedAllocation (406.59s)
--- PASS: TestAccAWSSpotFleetRequest_fleetType (249.62s)
--- PASS: TestAccAWSSpotFleetRequest_associatePublicIpAddress (250.12s)
--- PASS: TestAccAWSSpotFleetRequest_withEBSDisk (413.81s)
--- PASS: TestAccAWSSpotFleetRequest_overriddingSpotPrice (414.89s)    
--- PASS: TestAccAWSSpotFleetRequest_changePriceForcesNewRequest (465.94s)
--- PASS: TestAccAWSSpotFleetRequest_WithTargetGroups (451.52s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstancePools (477.37s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList (479.62s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz (480.14s)
--- PASS: TestAccAWSSpotFleetRequest_basic (487.09s)
--- PASS: TestAccAWSSpotFleetRequest_iamInstanceProfileArn (267.28s)
--- PASS: TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy (465.85s)
--- PASS: TestAccAWSSpotFleetRequest_instanceInterruptionBehavior (270.67s)
--- PASS: TestAccAWSSpotFleetRequest_updateTargetCapacity (882.71s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       883.867s
```
