### PR TITLE
Add ip_address attribute to aws_lightsail_static_ip_attachment resource

### DIFF
--- a/aws/resource_aws_lightsail_static_ip_attachment.go
+++ b/aws/resource_aws_lightsail_static_ip_attachment.go
@@ -26,6 +26,10 @@ func resourceAwsLightsailStaticIpAttachment() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"ip_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -76,6 +80,7 @@ func resourceAwsLightsailStaticIpAttachmentRead(d *schema.ResourceData, meta int
 	log.Printf("[INFO] Received Lightsail Static IP: %s", *out)
 
 	d.Set("instance_name", out.StaticIp.AttachedTo)
+	d.Set("ip_address", out.StaticIp.IpAddress)
 
 	return nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
No issues opened for this feature—please let me know if one is necessary.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Adds support for the documented ip_address attribute to aws_lightsail_static_ip_attachment resource.
```

Output from acceptance testing: **Not included** 

I don't have the skill set to write terraform provider acceptance tests. I can only really report that this patch functions as described.