### PR TITLE
Add force_destroy attribute for aws_athena_workgroup resource

### DIFF
--- a/aws/resource_aws_athena_workgroup_test.go
+++ b/aws/resource_aws_athena_workgroup_test.go
@@ -37,9 +37,10 @@ func TestAccAWSAthenaWorkGroup_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 		},
 	})
@@ -86,9 +87,10 @@ func TestAccAWSAthenaWorkGroup_Configuration_BytesScannedCutoffPerQuery(t *testi
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 			{
 				Config: testAccAthenaWorkGroupConfigConfigurationBytesScannedCutoffPerQuery(rName, 10485760),
@@ -121,9 +123,10 @@ func TestAccAWSAthenaWorkGroup_Configuration_EnforceWorkgroupConfiguration(t *te
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 			{
 				Config: testAccAthenaWorkGroupConfigConfigurationEnforceWorkgroupConfiguration(rName, true),
@@ -156,9 +159,10 @@ func TestAccAWSAthenaWorkGroup_Configuration_PublishCloudWatchMetricsEnabled(t *
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 			{
 				Config: testAccAthenaWorkGroupConfigConfigurationPublishCloudWatchMetricsEnabled(rName, true),
@@ -193,9 +197,10 @@ func TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_EncryptionConfi
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 		},
 	})
@@ -224,9 +229,10 @@ func TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_EncryptionConfi
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 			{
 				Config: testAccAthenaWorkGroupConfigConfigurationResultConfigurationEncryptionConfigurationEncryptionOptionWithKms(rName, rEncryption2),
@@ -264,9 +270,10 @@ func TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_OutputLocation(
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 			{
 				Config: testAccAthenaWorkGroupConfigConfigurationResultConfigurationOutputLocation(rName, rOutputLocation2),
@@ -301,9 +308,10 @@ func TestAccAWSAthenaWorkGroup_Description(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 			{
 				Config: testAccAthenaWorkGroupConfigDescription(rName, rDescriptionUpdate),
@@ -334,9 +342,10 @@ func TestAccAWSAthenaWorkGroup_State(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 			{
 				Config: testAccAthenaWorkGroupConfigState(rName, athena.WorkGroupStateEnabled),
@@ -375,9 +384,10 @@ func TestAccAWSAthenaWorkGroup_Tags(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 			{
 				Config: testAccAthenaWorkGroupConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
@@ -395,6 +405,37 @@ func TestAccAWSAthenaWorkGroup_Tags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAthenaWorkGroup_ForceDestroy(t *testing.T) {
+	var workgroup athena.WorkGroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	dbName := acctest.RandString(5)
+	queryName1 := acctest.RandomWithPrefix("tf-athena-named-query-")
+	queryName2 := acctest.RandomWithPrefix("tf-athena-named-query-")
+	resourceName := "aws_athena_workgroup.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAthenaWorkGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAthenaWorkGroupConfigForceDestroy(rName, dbName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaWorkGroupExists(resourceName, &workgroup),
+					testAccCheckAWSAthenaCreateNamedQuery(&workgroup, dbName, queryName1, fmt.Sprintf("SELECT * FROM %s limit 10;", rName)),
+					testAccCheckAWSAthenaCreateNamedQuery(&workgroup, dbName, queryName2, fmt.Sprintf("SELECT * FROM %s limit 100;", rName)),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 		},
 	})
@@ -464,6 +505,26 @@ func testAccCheckAWSAthenaWorkGroupDisappears(workgroup *athena.WorkGroup) resou
 		_, err := conn.DeleteWorkGroup(input)
 
 		return err
+	}
+}
+
+func testAccCheckAWSAthenaCreateNamedQuery(workGroup *athena.WorkGroup, databaseName, queryName, query string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).athenaconn
+
+		input := &athena.CreateNamedQueryInput{
+			Name:        aws.String(queryName),
+			WorkGroup:   workGroup.Name,
+			Database:    aws.String(databaseName),
+			QueryString: aws.String(query),
+			Description: aws.String("tf test"),
+		}
+
+		if _, err := conn.CreateNamedQuery(input); err != nil {
+			return fmt.Errorf("error creating Named Query (%s) on Workgroup (%s): %s", queryName, aws.StringValue(workGroup.Name), err)
+		}
+
+		return nil
 	}
 }
 
@@ -609,4 +670,25 @@ resource "aws_athena_workgroup" "test" {
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}
+
+func testAccAthenaWorkGroupConfigForceDestroy(rName, dbName string) string {
+	return fmt.Sprintf(`
+resource "aws_athena_workgroup" "test" {
+  name          = %[1]q
+  force_destroy = true
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket        = %[1]q
+  force_destroy = true
+}
+  
+resource "aws_athena_database" "test" {
+  name          = %[2]q
+  bucket        = "${aws_s3_bucket.test.bucket}"
+  force_destroy = true
+}
+
+`, rName, dbName)
 }

--- a/website/docs/r/athena_workgroup.html.markdown
+++ b/website/docs/r/athena_workgroup.html.markdown
@@ -41,6 +41,7 @@ The following arguments are supported:
 * `description` - (Optional) Description of the workgroup.
 * `state` - (Optional) State of the workgroup. Valid values are `DISABLED` or `ENABLED`. Defaults to `ENABLED`.
 * `tags` - (Optional) Key-value mapping of resource tags for the workgroup.
+* `force_destroy` - (Optional, Default: false) A boolean that indicates all named query should be deleted from the workgroup so that the workgroup can be destroyed without error.
 
 ### configuration Argument Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10085 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
r/aws_athena_workgroup: add support `force_destroy` attribute
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAthenaWorkGroup_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSAthenaWorkGroup_ -timeout 120m
=== RUN   TestAccAWSAthenaWorkGroup_basic
=== PAUSE TestAccAWSAthenaWorkGroup_basic
=== RUN   TestAccAWSAthenaWorkGroup_disappears
=== PAUSE TestAccAWSAthenaWorkGroup_disappears
=== RUN   TestAccAWSAthenaWorkGroup_Configuration_BytesScannedCutoffPerQuery
=== PAUSE TestAccAWSAthenaWorkGroup_Configuration_BytesScannedCutoffPerQuery
=== RUN   TestAccAWSAthenaWorkGroup_Configuration_EnforceWorkgroupConfiguration
=== PAUSE TestAccAWSAthenaWorkGroup_Configuration_EnforceWorkgroupConfiguration
=== RUN   TestAccAWSAthenaWorkGroup_Configuration_PublishCloudWatchMetricsEnabled
=== PAUSE TestAccAWSAthenaWorkGroup_Configuration_PublishCloudWatchMetricsEnabled
=== RUN   TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_EncryptionConfiguration_SseS3
=== PAUSE TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_EncryptionConfiguration_SseS3
=== RUN   TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_EncryptionConfiguration_Kms
=== PAUSE TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_EncryptionConfiguration_Kms
=== RUN   TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_OutputLocation
=== PAUSE TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_OutputLocation
=== RUN   TestAccAWSAthenaWorkGroup_Description
=== PAUSE TestAccAWSAthenaWorkGroup_Description
=== RUN   TestAccAWSAthenaWorkGroup_State
=== PAUSE TestAccAWSAthenaWorkGroup_State
=== RUN   TestAccAWSAthenaWorkGroup_Tags
=== PAUSE TestAccAWSAthenaWorkGroup_Tags
=== RUN   TestAccAWSAthenaWorkGroup_ForceDestroy
=== PAUSE TestAccAWSAthenaWorkGroup_ForceDestroy
=== CONT  TestAccAWSAthenaWorkGroup_basic
=== CONT  TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_OutputLocation
=== CONT  TestAccAWSAthenaWorkGroup_ForceDestroy
=== CONT  TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_EncryptionConfiguration_Kms
=== CONT  TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_EncryptionConfiguration_SseS3
=== CONT  TestAccAWSAthenaWorkGroup_Configuration_PublishCloudWatchMetricsEnabled
=== CONT  TestAccAWSAthenaWorkGroup_Configuration_EnforceWorkgroupConfiguration
=== CONT  TestAccAWSAthenaWorkGroup_Configuration_BytesScannedCutoffPerQuery
=== CONT  TestAccAWSAthenaWorkGroup_disappears
=== CONT  TestAccAWSAthenaWorkGroup_State
=== CONT  TestAccAWSAthenaWorkGroup_Tags
=== CONT  TestAccAWSAthenaWorkGroup_Description
--- PASS: TestAccAWSAthenaWorkGroup_disappears (32.81s)
--- PASS: TestAccAWSAthenaWorkGroup_basic (43.70s)
--- PASS: TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_EncryptionConfiguration_SseS3 (44.15s)
--- PASS: TestAccAWSAthenaWorkGroup_Configuration_BytesScannedCutoffPerQuery (64.24s)
--- PASS: TestAccAWSAthenaWorkGroup_Configuration_EnforceWorkgroupConfiguration (64.43s)
--- PASS: TestAccAWSAthenaWorkGroup_Configuration_PublishCloudWatchMetricsEnabled (64.85s)
--- PASS: TestAccAWSAthenaWorkGroup_Description (65.17s)
--- PASS: TestAccAWSAthenaWorkGroup_Tags (85.72s)
--- PASS: TestAccAWSAthenaWorkGroup_State (85.81s)
--- PASS: TestAccAWSAthenaWorkGroup_ForceDestroy (89.67s)
--- PASS: TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_EncryptionConfiguration_Kms (103.44s)
--- PASS: TestAccAWSAthenaWorkGroup_Configuration_ResultConfiguration_OutputLocation (112.91s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	114.051s
```
