### PR TITLE
Add Sweeper for cleaning up CloudWatch Log Resource Policies

### DIFF
--- a/aws/resource_aws_cloudwatch_log_resource_policy_test.go
+++ b/aws/resource_aws_cloudwatch_log_resource_policy_test.go
@@ -2,14 +2,62 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_cloudwatch_log_resource_policy", &resource.Sweeper{
+		Name: "aws_cloudwatch_log_resource_policy",
+		F:    testSweepCloudWatchLogResourcePolicys,
+	})
+}
+
+func testSweepCloudWatchLogResourcePolicys(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).cloudwatchlogsconn
+
+	input := &cloudwatchlogs.DescribeResourcePoliciesInput{}
+
+	for {
+		output, err := conn.DescribeResourcePolicies(input)
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping CloudWatchLog Resource Policy sweep for %s: %s", region, err)
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("error describing CloudWatchLog Resource Policy: %s", err)
+		}
+
+		for _, resourcePolicy := range output.ResourcePolicies {
+			deleteInput := &cloudwatchlogs.DeleteResourcePolicyInput{
+				PolicyName: resourcePolicy.PolicyName,
+			}
+			if _, err := conn.DeleteResourcePolicy(deleteInput); err != nil {
+				return fmt.Errorf("error deleting CloudWatch log resource policy (%s): %s", aws.StringValue(resourcePolicy.PolicyName), err)
+			}
+		}
+
+		if output.NextToken == nil {
+			break
+		}
+
+		input.NextToken = output.NextToken
+	}
+
+	return nil
+}
 
 func TestAccAWSCloudWatchLogResourcePolicy_Basic(t *testing.T) {
 	name := acctest.RandString(5)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10032

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$  go test ./aws -v -sweep=us-east-1,us-west-2 -sweep-run=aws_cloudwatch_log_resource_policy -timeout 10h
2019/09/16 08:10:57 [DEBUG] Running Sweepers for region (us-east-1):
2019/09/16 08:10:57 [INFO] Building AWS auth structure
2019/09/16 08:10:57 [INFO] Setting AWS metadata API timeout to 100ms
2019/09/16 08:10:58 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2019/09/16 08:10:58 [INFO] AWS Auth provider used: "EnvProvider"
2019/09/16 08:10:58 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/09/16 08:10:59 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/09/16 08:11:02 Sweeper Tests ran:
	- aws_cloudwatch_log_resource_policy
2019/09/16 08:11:02 [DEBUG] Running Sweepers for region (us-west-2):
2019/09/16 08:11:02 [INFO] Building AWS auth structure
2019/09/16 08:11:02 [INFO] Setting AWS metadata API timeout to 100ms
2019/09/16 08:11:02 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2019/09/16 08:11:02 [INFO] AWS Auth provider used: "EnvProvider"
2019/09/16 08:11:02 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/09/16 08:11:03 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/09/16 08:11:06 Sweeper Tests ran:
	- aws_cloudwatch_log_resource_policy
ok  	github.com/terraform-providers/terraform-provider-aws/aws	9.541s
```
