### PR TITLE
[WIP] Wait for Hyperplane-attached ENIs for lambdas to move to 'available' state before detaching

### DIFF
--- a/aws/resource_aws_network_interface.go
+++ b/aws/resource_aws_network_interface.go
@@ -529,11 +529,11 @@ func networkInterfaceAttachmentStateRefresh(conn *ec2.EC2, eniId string) resourc
 			return "", ec2.AttachmentStatusDetached, nil
 
 		case 1:
-			eni := resp.NetworkInterfaces[0]
-			if eni.Attachment == nil {
-				return eni, ec2.AttachmentStatusDetached, nil
+			attachment := resp.NetworkInterfaces[0].Attachment
+			if attachment == nil {
+				return "", ec2.AttachmentStatusDetached, nil
 			}
-			return eni, aws.StringValue(eni.Attachment.Status), nil
+			return attachment, aws.StringValue(attachment.Status), nil
 
 		default:
 			return nil, "", fmt.Errorf("found %d ENIs for %s, expected 1", n, eniId)

--- a/aws/resource_aws_security_group.go
+++ b/aws/resource_aws_security_group.go
@@ -1435,11 +1435,13 @@ func deleteLingeringLambdaENIs(conn *ec2.EC2, filterName, resourceId string, tim
 				ContinuousTargetOccurence: 10,
 			}
 
-			_, err = stateConf.WaitForState()
+			eniRaw, err := stateConf.WaitForState()
 
 			if err != nil {
 				return fmt.Errorf("error waiting for ENI (%s) to become available: %s", eniId, err)
 			}
+
+			eni = eniRaw.(*ec2.NetworkInterface)
 		}
 
 		err = detachNetworkInterface(conn, eni, timeout)

--- a/aws/resource_aws_subnet.go
+++ b/aws/resource_aws_subnet.go
@@ -24,7 +24,7 @@ func resourceAwsSubnet() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
-			Delete: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
 		SchemaVersion: 1,
@@ -319,8 +319,8 @@ func resourceAwsSubnetDelete(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[INFO] Deleting subnet: %s", d.Id())
 
-	if err := deleteLingeringLambdaENIs(conn, d, "subnet-id"); err != nil {
-		return fmt.Errorf("Failed to delete Lambda ENIs: %s", err)
+	if err := deleteLingeringLambdaENIs(conn, "subnet-id", d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
+		return fmt.Errorf("error deleting Lambda ENIs using subnet (%s): %s", d.Id(), err)
 	}
 
 	req := &ec2.DeleteSubnetInput{

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -186,7 +186,7 @@ In addition to all arguments above, the following attributes are exported:
 configuration options:
 
 - `create` - (Default `10 minutes`) How long to wait for a security group to be created.
-- `delete` - (Default `10 minutes`) How long to wait for a security group to be deleted.
+- `delete` - (Default `30 minutes`) How long to wait for a security group to be deleted.
 
 ## Import
 

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -69,6 +69,14 @@ In addition to all arguments above, the following attributes are exported:
 * `ipv6_cidr_block_association_id` - The association ID for the IPv6 CIDR block.
 * `owner_id` - The ID of the AWS account that owns the subnet.
 
+## Timeouts
+
+`aws_subnet` provides the following [Timeouts](/docs/configuration/resources.html#timeouts)
+configuration options:
+
+- `create` - (Default `10 minutes`) How long to wait for a subnet to be created.
+- `delete` - (Default `30 minutes`) How long to wait for a subnet to be deleted.
+
 ## Import
 
 Subnets can be imported using the `subnet id`, e.g.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/10044

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resources/aws_security_group: Increase default delete timeout to 30 minutes. Wait for Hyperplane-attached ENIs for lambdas to move to 'available' state before attempting to delete lingering ENIs.
resources/aws_subnet: Increase default delete timeout to 30 minutes. Wait for Hyperplane-attached ENIs for lambdas to move to 'available' state before attempting to delete lingering ENIs.
```

Output from acceptance testing:

```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSLambdaFunction_VPC_withInvocation'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSLambdaFunction_VPC_withInvocation -timeout 120m
=== RUN   TestAccAWSLambdaFunction_VPC_withInvocation
=== PAUSE TestAccAWSLambdaFunction_VPC_withInvocation
=== CONT  TestAccAWSLambdaFunction_VPC_withInvocation
--- PASS: TestAccAWSLambdaFunction_VPC_withInvocation (195.10s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	195.166s
$ AWS_DEFAULT_REGION=eu-west-1 make testacc TEST=./aws TESTARGS='-run=TestAccAWSLambdaFunction_VPC_withInvocation'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSLambdaFunction_VPC_withInvocation -timeout 120m
=== RUN   TestAccAWSLambdaFunction_VPC_withInvocation
=== PAUSE TestAccAWSLambdaFunction_VPC_withInvocation
=== CONT  TestAccAWSLambdaFunction_VPC_withInvocation
--- FAIL: TestAccAWSLambdaFunction_VPC_withInvocation (1288.36s)
    testing.go:630: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: errors during apply: 2 problems:
        
        - error deleting Lambda ENIs using subnet (subnet-0fae3a7fbe012c060): error waiting for ENI (eni-0606e238685023d8f) to become available: timeout while waiting for state to become 'available, deleted' (last state: 'available', timeout: 20m0s)
        - error deleting Lambda ENIs using Security Group (sg-0f12870b552344394): error waiting for ENI (eni-0606e238685023d8f) to become available: timeout while waiting for state to become 'available, deleted' (last state: 'available', timeout: 20m0s)
...
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	1288.465s
make: *** [testacc] Error 1
```

For some reason the new delete timeout of 30 minutes for both security groups and subnets is not being respected and even though the ENI has entered `available` state we are still ensuring that we get a number of `available`s in a row to work around any API consistency issues and hit the default 20 minute timeout.
Maybe a Terraform 0.12 issue with [`Timeout` blocks](https://github.com/hashicorp/terraform/pull/19222) and `MigrateState` functions?