### PR TITLE
Import test refactor for emr security config

### DIFF
--- a/aws/resource_aws_emr_security_configuration_test.go
+++ b/aws/resource_aws_emr_security_configuration_test.go
@@ -10,28 +10,9 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSEmrSecurityConfiguration_importBasic(t *testing.T) {
-	resourceName := "aws_emr_security_configuration.foo"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckEmrSecurityConfigurationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccEmrSecurityConfigurationConfig,
-			},
-
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAWSEmrSecurityConfiguration_basic(t *testing.T) {
+	resourceName := "aws_emr_security_configuration.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -40,8 +21,13 @@ func TestAccAWSEmrSecurityConfiguration_basic(t *testing.T) {
 			{
 				Config: testAccEmrSecurityConfigurationConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEmrSecurityConfigurationExists("aws_emr_security_configuration.foo"),
+					testAccCheckEmrSecurityConfigurationExists(resourceName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -109,7 +95,7 @@ func testAccCheckEmrSecurityConfigurationExists(n string) resource.TestCheckFunc
 }
 
 const testAccEmrSecurityConfigurationConfig = `
-resource "aws_emr_security_configuration" "foo" {
+resource "aws_emr_security_configuration" "test" {
 	configuration = <<EOF
 {
   "EncryptionConfiguration": {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8944

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSEmrSecurityConfiguration_" ==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSEmrSecurityConfiguration_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEmrSecurityConfiguration_basic
=== PAUSE TestAccAWSEmrSecurityConfiguration_basic
=== CONT  TestAccAWSEmrSecurityConfiguration_basic
--- PASS: TestAccAWSEmrSecurityConfiguration_basic (27.44s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       28.600s
```
