### PR TITLE
Import test refactor for ELBs

### DIFF
--- a/aws/resource_aws_elb_test.go
+++ b/aws/resource_aws_elb_test.go
@@ -64,18 +64,38 @@ func testSweepELBs(region string) error {
 	return nil
 }
 
-func TestAccAWSELB_importBasic(t *testing.T) {
-	resourceName := "aws_elb.bar"
+func TestAccAWSELB_basic(t *testing.T) {
+	var conf elb.LoadBalancerDescription
+	resourceName := "aws_elb.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSELBDestroy,
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSELBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSELBConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSELBExists(resourceName, &conf),
+					testAccCheckAWSELBAttributes(&conf),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(
+						resourceName, "availability_zones.#", "3"),
+					resource.TestCheckResourceAttr(
+						resourceName, "subnets.#", "3"),
+					resource.TestCheckResourceAttr(
+						resourceName, "listener.206423021.instance_port", "8000"),
+					resource.TestCheckResourceAttr(
+						resourceName, "listener.206423021.instance_protocol", "http"),
+					resource.TestCheckResourceAttr(
+						resourceName, "listener.206423021.lb_port", "80"),
+					resource.TestCheckResourceAttr(
+						resourceName, "listener.206423021.lb_protocol", "http"),
+					resource.TestCheckResourceAttr(
+						resourceName, "cross_zone_load_balancing", "true"),
+				),
 			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
@@ -85,44 +105,9 @@ func TestAccAWSELB_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccAWSELB_basic(t *testing.T) {
-	var conf elb.LoadBalancerDescription
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_elb.bar",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSELBDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSELBConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSELBExists("aws_elb.bar", &conf),
-					testAccCheckAWSELBAttributes(&conf),
-					resource.TestCheckResourceAttrSet("aws_elb.bar", "arn"),
-					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "availability_zones.#", "3"),
-					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "subnets.#", "3"),
-					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "listener.206423021.instance_port", "8000"),
-					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "listener.206423021.instance_protocol", "http"),
-					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "listener.206423021.lb_port", "80"),
-					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "listener.206423021.lb_protocol", "http"),
-					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "cross_zone_load_balancing", "true"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAWSELB_disappears(t *testing.T) {
 	var loadBalancer elb.LoadBalancerDescription
-	resourceName := "aws_elb.bar"
+	resourceName := "aws_elb.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -143,21 +128,21 @@ func TestAccAWSELB_disappears(t *testing.T) {
 
 func TestAccAWSELB_fullCharacterRange(t *testing.T) {
 	var conf elb.LoadBalancerDescription
-
+	resourceName := "aws_elb.test"
 	lbName := fmt.Sprintf("Tf-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_elb.foo",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSELBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(testAccAWSELBFullRangeOfCharacters, lbName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSELBExists("aws_elb.foo", &conf),
+					testAccCheckAWSELBExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(
-						"aws_elb.foo", "name", lbName),
+						resourceName, "name", lbName),
 				),
 			},
 		},
@@ -166,43 +151,43 @@ func TestAccAWSELB_fullCharacterRange(t *testing.T) {
 
 func TestAccAWSELB_AccessLogs_enabled(t *testing.T) {
 	var conf elb.LoadBalancerDescription
-
+	resourceName := "aws_elb.test"
 	rName := fmt.Sprintf("terraform-access-logs-bucket-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_elb.foo",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSELBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSELBAccessLogs,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSELBExists("aws_elb.foo", &conf),
+					testAccCheckAWSELBExists(resourceName, &conf),
 				),
 			},
 
 			{
 				Config: testAccAWSELBAccessLogsOn(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSELBExists("aws_elb.foo", &conf),
+					testAccCheckAWSELBExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(
-						"aws_elb.foo", "access_logs.#", "1"),
+						resourceName, "access_logs.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_elb.foo", "access_logs.0.bucket", rName),
+						resourceName, "access_logs.0.bucket", rName),
 					resource.TestCheckResourceAttr(
-						"aws_elb.foo", "access_logs.0.interval", "5"),
+						resourceName, "access_logs.0.interval", "5"),
 					resource.TestCheckResourceAttr(
-						"aws_elb.foo", "access_logs.0.enabled", "true"),
+						resourceName, "access_logs.0.enabled", "true"),
 				),
 			},
 
 			{
 				Config: testAccAWSELBAccessLogs,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSELBExists("aws_elb.foo", &conf),
+					testAccCheckAWSELBExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(
-						"aws_elb.foo", "access_logs.#", "0"),
+						resourceName, "access_logs.#", "0"),
 				),
 			},
 		},
@@ -211,43 +196,43 @@ func TestAccAWSELB_AccessLogs_enabled(t *testing.T) {
 
 func TestAccAWSELB_AccessLogs_disabled(t *testing.T) {
 	var conf elb.LoadBalancerDescription
-
+	resourceName := "aws_elb.test"
 	rName := fmt.Sprintf("terraform-access-logs-bucket-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_elb.foo",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSELBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSELBAccessLogs,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSELBExists("aws_elb.foo", &conf),
+					testAccCheckAWSELBExists(resourceName, &conf),
 				),
 			},
 
 			{
 				Config: testAccAWSELBAccessLogsDisabled(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSELBExists("aws_elb.foo", &conf),
+					testAccCheckAWSELBExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(
-						"aws_elb.foo", "access_logs.#", "1"),
+						resourceName, "access_logs.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_elb.foo", "access_logs.0.bucket", rName),
+						resourceName, "access_logs.0.bucket", rName),
 					resource.TestCheckResourceAttr(
-						"aws_elb.foo", "access_logs.0.interval", "5"),
+						resourceName, "access_logs.0.interval", "5"),
 					resource.TestCheckResourceAttr(
-						"aws_elb.foo", "access_logs.0.enabled", "false"),
+						resourceName, "access_logs.0.enabled", "false"),
 				),
 			},
 
 			{
 				Config: testAccAWSELBAccessLogs,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSELBExists("aws_elb.foo", &conf),
+					testAccCheckAWSELBExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(
-						"aws_elb.foo", "access_logs.#", "0"),
+						resourceName, "access_logs.#", "0"),
 				),
 			},
 		},
@@ -257,19 +242,20 @@ func TestAccAWSELB_AccessLogs_disabled(t *testing.T) {
 func TestAccAWSELB_namePrefix(t *testing.T) {
 	var conf elb.LoadBalancerDescription
 	nameRegex := regexp.MustCompile("^test-")
+	resourceName := "aws_elb.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_elb.test",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSELBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSELB_namePrefix,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSELBExists("aws_elb.test", &conf),
+					testAccCheckAWSELBExists(resourceName, &conf),
 					resource.TestMatchResourceAttr(
-						"aws_elb.test", "name", nameRegex),
+						resourceName, "name", nameRegex),
 				),
 			},
 		},
@@ -279,19 +265,20 @@ func TestAccAWSELB_namePrefix(t *testing.T) {
 func TestAccAWSELB_generatedName(t *testing.T) {
 	var conf elb.LoadBalancerDescription
 	generatedNameRegexp := regexp.MustCompile("^tf-lb-")
+	resourceName := "aws_elb.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_elb.foo",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSELBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSELBGeneratedName,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSELBExists("aws_elb.foo", &conf),
+					testAccCheckAWSELBExists(resourceName, &conf),
 					resource.TestMatchResourceAttr(
-						"aws_elb.foo", "name", generatedNameRegexp),
+						resourceName, "name", generatedNameRegexp),
 				),
 			},
 		},
@@ -301,19 +288,20 @@ func TestAccAWSELB_generatedName(t *testing.T) {
 func TestAccAWSELB_generatesNameForZeroValue(t *testing.T) {
 	var conf elb.LoadBalancerDescription
 	generatedNameRegexp := regexp.MustCompile("^tf-lb-")
+	resourceName := "aws_elb.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_elb.foo",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSELBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSELB_zeroValueName,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSELBExists("aws_elb.foo", &conf),
+					testAccCheckAWSELBExists(resourceName, &conf),
 					resource.TestMatchResourceAttr(
-						"aws_elb.foo", "name", generatedNameRegexp),
+						resourceName, "name", generatedNameRegexp),
 				),
 			},
 		},
@@ -322,28 +310,29 @@ func TestAccAWSELB_generatesNameForZeroValue(t *testing.T) {
 
 func TestAccAWSELB_availabilityZones(t *testing.T) {
 	var conf elb.LoadBalancerDescription
+	resourceName := "aws_elb.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_elb.bar",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSELBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSELBConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSELBExists("aws_elb.bar", &conf),
+					testAccCheckAWSELBExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "availability_zones.#", "3"),
+						resourceName, "availability_zones.#", "3"),
 				),
 			},
 
 			{
 				Config: testAccAWSELBConfig_AvailabilityZonesUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSELBExists("aws_elb.bar", &conf),
+					testAccCheckAWSELBExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "availability_zones.#", "2"),
+						resourceName, "availability_zones.#", "2"),
 				),
 			},
 		},
@@ -353,30 +342,31 @@ func TestAccAWSELB_availabilityZones(t *testing.T) {
 func TestAccAWSELB_tags(t *testing.T) {
 	var conf elb.LoadBalancerDescription
 	var td elb.TagDescription
+	resourceName := "aws_elb.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_elb.bar",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSELBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSELBConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSELBExists("aws_elb.bar", &conf),
+					testAccCheckAWSELBExists(resourceName, &conf),
 					testAccCheckAWSELBAttributes(&conf),
 					testAccLoadTags(&conf, &td),
-					testAccCheckELBTags(&td.Tags, "bar", "baz"),
+					testAccCheckELBTags(&td.Tags, "test", "test2"),
 				),
 			},
 
 			{
 				Config: testAccAWSELBConfig_TagUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSELBExists("aws_elb.bar", &conf),
+					testAccCheckAWSELBExists(resourceName, &conf),
 					testAccCheckAWSELBAttributes(&conf),
 					testAccLoadTags(&conf, &td),
-					testAccCheckELBTags(&td.Tags, "foo", "bar"),
+					testAccCheckELBTags(&td.Tags, "test", "test"),
 					testAccCheckELBTags(&td.Tags, "new", "type"),
 				),
 			},
@@ -387,7 +377,7 @@ func TestAccAWSELB_tags(t *testing.T) {
 func TestAccAWSELB_Listener_SSLCertificateID_IAMServerCertificate(t *testing.T) {
 	var conf elb.LoadBalancerDescription
 	rName := fmt.Sprintf("tf-acctest-%s", acctest.RandString(10))
-	resourceName := "aws_elb.bar"
+	resourceName := "aws_elb.test"
 
 	testCheck := func(*terraform.State) error {
 		if len(conf.ListenerDescriptions) != 1 {
@@ -424,54 +414,38 @@ func TestAccAWSELB_Listener_SSLCertificateID_IAMServerCertificate(t *testing.T) 
 
 func TestAccAWSELB_swap_subnets(t *testing.T) {
 	var conf elb.LoadBalancerDescription
+	resourceName := "aws_elb.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_elb.ourapp",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSELBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSELBConfig_subnets,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSELBExists("aws_elb.ourapp", &conf),
+					testAccCheckAWSELBExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(
-						"aws_elb.ourapp", "subnets.#", "2"),
+						resourceName, "subnets.#", "2"),
 				),
 			},
 
 			{
 				Config: testAccAWSELBConfig_subnet_swap,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSELBExists("aws_elb.ourapp", &conf),
+					testAccCheckAWSELBExists("aws_elb.test", &conf),
 					resource.TestCheckResourceAttr(
-						"aws_elb.ourapp", "subnets.#", "2"),
+						"aws_elb.test", "subnets.#", "2"),
 				),
 			},
 		},
 	})
 }
 
-func testAccLoadTags(conf *elb.LoadBalancerDescription, td *elb.TagDescription) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).elbconn
-
-		describe, err := conn.DescribeTags(&elb.DescribeTagsInput{
-			LoadBalancerNames: []*string{conf.LoadBalancerName},
-		})
-
-		if err != nil {
-			return err
-		}
-		if len(describe.TagDescriptions) > 0 {
-			*td = *describe.TagDescriptions[0]
-		}
-		return nil
-	}
-}
-
 func TestAccAWSELB_InstanceAttaching(t *testing.T) {
 	var conf elb.LoadBalancerDescription
+	resourceName := "aws_elb.test"
 
 	testCheckInstanceAttached := func(count int) resource.TestCheckFunc {
 		return func(*terraform.State) error {
@@ -484,14 +458,14 @@ func TestAccAWSELB_InstanceAttaching(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_elb.bar",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSELBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSELBConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSELBExists("aws_elb.bar", &conf),
+					testAccCheckAWSELBExists(resourceName, &conf),
 					testAccCheckAWSELBAttributes(&conf),
 				),
 			},
@@ -499,7 +473,7 @@ func TestAccAWSELB_InstanceAttaching(t *testing.T) {
 			{
 				Config: testAccAWSELBConfigNewInstance,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSELBExists("aws_elb.bar", &conf),
+					testAccCheckAWSELBExists(resourceName, &conf),
 					testCheckInstanceAttached(1),
 				),
 			},
@@ -509,7 +483,7 @@ func TestAccAWSELB_InstanceAttaching(t *testing.T) {
 
 func TestAccAWSELB_listener(t *testing.T) {
 	var conf elb.LoadBalancerDescription
-	resourceName := "aws_elb.bar"
+	resourceName := "aws_elb.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -622,28 +596,29 @@ func TestAccAWSELB_listener(t *testing.T) {
 
 func TestAccAWSELB_HealthCheck(t *testing.T) {
 	var conf elb.LoadBalancerDescription
+	resourceName := "aws_elb.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_elb.bar",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSELBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSELBConfigHealthCheck,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSELBExists("aws_elb.bar", &conf),
+					testAccCheckAWSELBExists(resourceName, &conf),
 					testAccCheckAWSELBAttributesHealthCheck(&conf),
 					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "health_check.0.healthy_threshold", "5"),
+						resourceName, "health_check.0.healthy_threshold", "5"),
 					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "health_check.0.unhealthy_threshold", "5"),
+						resourceName, "health_check.0.unhealthy_threshold", "5"),
 					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "health_check.0.target", "HTTP:8000/"),
+						resourceName, "health_check.0.target", "HTTP:8000/"),
 					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "health_check.0.timeout", "30"),
+						resourceName, "health_check.0.timeout", "30"),
 					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "health_check.0.interval", "60"),
+						resourceName, "health_check.0.interval", "60"),
 				),
 			},
 		},
@@ -651,9 +626,11 @@ func TestAccAWSELB_HealthCheck(t *testing.T) {
 }
 
 func TestAccAWSELBUpdate_HealthCheck(t *testing.T) {
+	resourceName := "aws_elb.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_elb.bar",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSELBDestroy,
 		Steps: []resource.TestStep{
@@ -661,14 +638,14 @@ func TestAccAWSELBUpdate_HealthCheck(t *testing.T) {
 				Config: testAccAWSELBConfigHealthCheck,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "health_check.0.healthy_threshold", "5"),
+						resourceName, "health_check.0.healthy_threshold", "5"),
 				),
 			},
 			{
 				Config: testAccAWSELBConfigHealthCheck_update,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "health_check.0.healthy_threshold", "10"),
+						resourceName, "health_check.0.healthy_threshold", "10"),
 				),
 			},
 		},
@@ -677,19 +654,20 @@ func TestAccAWSELBUpdate_HealthCheck(t *testing.T) {
 
 func TestAccAWSELB_Timeout(t *testing.T) {
 	var conf elb.LoadBalancerDescription
+	resourceName := "aws_elb.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_elb.bar",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSELBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSELBConfigIdleTimeout,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSELBExists("aws_elb.bar", &conf),
+					testAccCheckAWSELBExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "idle_timeout", "200",
+						resourceName, "idle_timeout", "200",
 					),
 				),
 			},
@@ -698,9 +676,11 @@ func TestAccAWSELB_Timeout(t *testing.T) {
 }
 
 func TestAccAWSELBUpdate_Timeout(t *testing.T) {
+	resourceName := "aws_elb.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_elb.bar",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSELBDestroy,
 		Steps: []resource.TestStep{
@@ -708,7 +688,7 @@ func TestAccAWSELBUpdate_Timeout(t *testing.T) {
 				Config: testAccAWSELBConfigIdleTimeout,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "idle_timeout", "200",
+						resourceName, "idle_timeout", "200",
 					),
 				),
 			},
@@ -716,7 +696,7 @@ func TestAccAWSELBUpdate_Timeout(t *testing.T) {
 				Config: testAccAWSELBConfigIdleTimeout_update,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "idle_timeout", "400",
+						resourceName, "idle_timeout", "400",
 					),
 				),
 			},
@@ -725,9 +705,11 @@ func TestAccAWSELBUpdate_Timeout(t *testing.T) {
 }
 
 func TestAccAWSELB_ConnectionDraining(t *testing.T) {
+	resourceName := "aws_elb.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_elb.bar",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSELBDestroy,
 		Steps: []resource.TestStep{
@@ -735,10 +717,10 @@ func TestAccAWSELB_ConnectionDraining(t *testing.T) {
 				Config: testAccAWSELBConfigConnectionDraining,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "connection_draining", "true",
+						resourceName, "connection_draining", "true",
 					),
 					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "connection_draining_timeout", "400",
+						resourceName, "connection_draining_timeout", "400",
 					),
 				),
 			},
@@ -747,9 +729,11 @@ func TestAccAWSELB_ConnectionDraining(t *testing.T) {
 }
 
 func TestAccAWSELBUpdate_ConnectionDraining(t *testing.T) {
+	resourceName := "aws_elb.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_elb.bar",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSELBDestroy,
 		Steps: []resource.TestStep{
@@ -757,10 +741,10 @@ func TestAccAWSELBUpdate_ConnectionDraining(t *testing.T) {
 				Config: testAccAWSELBConfigConnectionDraining,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "connection_draining", "true",
+						resourceName, "connection_draining", "true",
 					),
 					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "connection_draining_timeout", "400",
+						resourceName, "connection_draining_timeout", "400",
 					),
 				),
 			},
@@ -768,10 +752,10 @@ func TestAccAWSELBUpdate_ConnectionDraining(t *testing.T) {
 				Config: testAccAWSELBConfigConnectionDraining_update_timeout,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "connection_draining", "true",
+						resourceName, "connection_draining", "true",
 					),
 					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "connection_draining_timeout", "600",
+						resourceName, "connection_draining_timeout", "600",
 					),
 				),
 			},
@@ -779,7 +763,7 @@ func TestAccAWSELBUpdate_ConnectionDraining(t *testing.T) {
 				Config: testAccAWSELBConfigConnectionDraining_update_disable,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "connection_draining", "false",
+						resourceName, "connection_draining", "false",
 					),
 				),
 			},
@@ -788,9 +772,11 @@ func TestAccAWSELBUpdate_ConnectionDraining(t *testing.T) {
 }
 
 func TestAccAWSELB_SecurityGroups(t *testing.T) {
+	resourceName := "aws_elb.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_elb.bar",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSELBDestroy,
 		Steps: []resource.TestStep{
@@ -799,7 +785,7 @@ func TestAccAWSELB_SecurityGroups(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					// ELBs get a default security group
 					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "security_groups.#", "1",
+						resourceName, "security_groups.#", "1",
 					),
 				),
 			},
@@ -808,12 +794,30 @@ func TestAccAWSELB_SecurityGroups(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					// Count should still be one as we swap in a custom security group
 					resource.TestCheckResourceAttr(
-						"aws_elb.bar", "security_groups.#", "1",
+						resourceName, "security_groups.#", "1",
 					),
 				),
 			},
 		},
 	})
+}
+
+func testAccLoadTags(conf *elb.LoadBalancerDescription, td *elb.TagDescription) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).elbconn
+
+		describe, err := conn.DescribeTags(&elb.DescribeTagsInput{
+			LoadBalancerNames: []*string{conf.LoadBalancerName},
+		})
+
+		if err != nil {
+			return err
+		}
+		if len(describe.TagDescriptions) > 0 {
+			*td = *describe.TagDescriptions[0]
+		}
+		return nil
+	}
 }
 
 // Unit test for listeners hash
@@ -1161,7 +1165,7 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
-resource "aws_elb" "bar" {
+resource "aws_elb" "test" {
   availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
   listener {
@@ -1172,7 +1176,7 @@ resource "aws_elb" "bar" {
   }
 
 	tags = {
-		bar = "baz"
+		test = "test2"
 	}
 
   cross_zone_load_balancing = true
@@ -1184,7 +1188,7 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
-resource "aws_elb" "foo" {
+resource "aws_elb" "test" {
   name = "%s"
   availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
@@ -1202,7 +1206,7 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
-resource "aws_elb" "foo" {
+resource "aws_elb" "test" {
   availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
   listener {
@@ -1248,7 +1252,7 @@ resource "aws_s3_bucket" "acceslogs_bucket" {
 EOF
 }
 
-resource "aws_elb" "foo" {
+resource "aws_elb" "test" {
   availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
   listener {
@@ -1300,7 +1304,7 @@ resource "aws_s3_bucket" "acceslogs_bucket" {
 EOF
 }
 
-resource "aws_elb" "foo" {
+resource "aws_elb" "test" {
   availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
   listener {
@@ -1342,7 +1346,7 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
-resource "aws_elb" "foo" {
+resource "aws_elb" "test" {
   availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
   listener {
@@ -1359,7 +1363,7 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
-resource "aws_elb" "foo" {
+resource "aws_elb" "test" {
   name               = ""
   availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
@@ -1373,7 +1377,7 @@ resource "aws_elb" "foo" {
 
 # See https://github.com/terraform-providers/terraform-provider-aws/issues/2498
 output "lb_name" {
-  value = "${aws_elb.foo.name}"
+  value = "${aws_elb.test.name}"
 }
 `
 
@@ -1382,7 +1386,7 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
-resource "aws_elb" "bar" {
+resource "aws_elb" "test" {
   availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}"]
 
   listener {
@@ -1399,7 +1403,7 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
-resource "aws_elb" "bar" {
+resource "aws_elb" "test" {
   availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
   listener {
@@ -1410,7 +1414,7 @@ resource "aws_elb" "bar" {
   }
 
 	tags = {
-		foo = "bar"
+		test = "test"
 		new = "type"
 	}
 
@@ -1438,7 +1442,7 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
-resource "aws_elb" "bar" {
+resource "aws_elb" "test" {
   availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
   listener {
@@ -1448,10 +1452,10 @@ resource "aws_elb" "bar" {
     lb_protocol = "http"
   }
 
-  instances = ["${aws_instance.foo.id}"]
+  instances = ["${aws_instance.test.id}"]
 }
 
-resource "aws_instance" "foo" {
+resource "aws_instance" "test" {
   ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   instance_type = "t3.micro"
 }
@@ -1462,7 +1466,7 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
-resource "aws_elb" "bar" {
+resource "aws_elb" "test" {
   availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
   listener {
@@ -1487,7 +1491,7 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
-resource "aws_elb" "bar" {
+resource "aws_elb" "test" {
   availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
 
   listener {
@@ -1512,7 +1516,7 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
-resource "aws_elb" "bar" {
+resource "aws_elb" "test" {
   availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
   listener {
@@ -1529,7 +1533,7 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
-resource "aws_elb" "bar" {
+resource "aws_elb" "test" {
   availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
   listener {
@@ -1553,7 +1557,7 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
-resource "aws_elb" "bar" {
+resource "aws_elb" "test" {
 	availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
 
 	listener {
@@ -1572,7 +1576,7 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
-resource "aws_elb" "bar" {
+resource "aws_elb" "test" {
 	availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
 
 	listener {
@@ -1591,7 +1595,7 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
-resource "aws_elb" "bar" {
+resource "aws_elb" "test" {
 	availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
 
 	listener {
@@ -1611,7 +1615,7 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
-resource "aws_elb" "bar" {
+resource "aws_elb" "test" {
 	availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
 
 	listener {
@@ -1631,7 +1635,7 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
-resource "aws_elb" "bar" {
+resource "aws_elb" "test" {
 	availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
 
 	listener {
@@ -1650,7 +1654,7 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
-resource "aws_elb" "bar" {
+resource "aws_elb" "test" {
   availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
 
   listener {
@@ -1660,10 +1664,10 @@ resource "aws_elb" "bar" {
     lb_protocol = "http"
   }
 
-  security_groups = ["${aws_security_group.bar.id}"]
+  security_groups = ["${aws_security_group.test.id}"]
 }
 
-resource "aws_security_group" "bar" {
+resource "aws_security_group" "test" {
   ingress {
     protocol = "tcp"
     from_port = 80
@@ -1689,7 +1693,7 @@ resource "aws_iam_server_certificate" "test_cert" {
   private_key      = "${tls_private_key.example.private_key_pem}"
 }
 
-resource "aws_elb" "bar" {
+resource "aws_elb" "test" {
   availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
 
   listener {
@@ -1715,7 +1719,7 @@ resource "aws_iam_server_certificate" "test_cert" {
   private_key      = "${tls_private_key.example.private_key_pem}"
 }
 
-resource "aws_elb" "bar" {
+resource "aws_elb" "test" {
   availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
 
   listener {
@@ -1782,7 +1786,7 @@ resource "aws_subnet" "public_a_two" {
   }
 }
 
-resource "aws_elb" "ourapp" {
+resource "aws_elb" "test" {
   name = "terraform-asg-deployment-example"
 
   subnets = [
@@ -1853,7 +1857,7 @@ resource "aws_subnet" "public_a_two" {
   }
 }
 
-resource "aws_elb" "ourapp" {
+resource "aws_elb" "test" {
   name = "terraform-asg-deployment-example"
 
   subnets = [


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8944

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSELB_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSELB_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSELB_basic
=== PAUSE TestAccAWSELB_basic
=== RUN   TestAccAWSELB_disappears
=== PAUSE TestAccAWSELB_disappears
=== RUN   TestAccAWSELB_fullCharacterRange
=== PAUSE TestAccAWSELB_fullCharacterRange
=== RUN   TestAccAWSELB_AccessLogs_enabled
=== PAUSE TestAccAWSELB_AccessLogs_enabled
=== RUN   TestAccAWSELB_AccessLogs_disabled
=== PAUSE TestAccAWSELB_AccessLogs_disabled
=== RUN   TestAccAWSELB_namePrefix
=== PAUSE TestAccAWSELB_namePrefix
=== RUN   TestAccAWSELB_generatedName
=== PAUSE TestAccAWSELB_generatedName
=== RUN   TestAccAWSELB_generatesNameForZeroValue
=== PAUSE TestAccAWSELB_generatesNameForZeroValue
=== RUN   TestAccAWSELB_availabilityZones
=== PAUSE TestAccAWSELB_availabilityZones
=== RUN   TestAccAWSELB_tags
=== PAUSE TestAccAWSELB_tags
=== RUN   TestAccAWSELB_Listener_SSLCertificateID_IAMServerCertificate
=== PAUSE TestAccAWSELB_Listener_SSLCertificateID_IAMServerCertificate
=== RUN   TestAccAWSELB_swap_subnets
=== PAUSE TestAccAWSELB_swap_subnets
=== RUN   TestAccAWSELB_InstanceAttaching
=== PAUSE TestAccAWSELB_InstanceAttaching
=== RUN   TestAccAWSELB_listener
=== PAUSE TestAccAWSELB_listener
=== RUN   TestAccAWSELB_HealthCheck
=== PAUSE TestAccAWSELB_HealthCheck
=== RUN   TestAccAWSELB_Timeout
=== PAUSE TestAccAWSELB_Timeout
=== RUN   TestAccAWSELB_ConnectionDraining
=== PAUSE TestAccAWSELB_ConnectionDraining
=== RUN   TestAccAWSELB_SecurityGroups
=== PAUSE TestAccAWSELB_SecurityGroups
=== CONT  TestAccAWSELB_basic
=== CONT  TestAccAWSELB_SecurityGroups
=== CONT  TestAccAWSELB_listener
=== CONT  TestAccAWSELB_swap_subnets
=== CONT  TestAccAWSELB_availabilityZones
=== CONT  TestAccAWSELB_ConnectionDraining
=== CONT  TestAccAWSELB_Timeout
=== CONT  TestAccAWSELB_HealthCheck
=== CONT  TestAccAWSELB_generatesNameForZeroValue
=== CONT  TestAccAWSELB_generatedName
=== CONT  TestAccAWSELB_fullCharacterRange
=== CONT  TestAccAWSELB_AccessLogs_enabled
=== CONT  TestAccAWSELB_namePrefix
=== CONT  TestAccAWSELB_tags
=== CONT  TestAccAWSELB_InstanceAttaching
=== CONT  TestAccAWSELB_AccessLogs_disabled
=== CONT  TestAccAWSELB_Listener_SSLCertificateID_IAMServerCertificate
=== CONT  TestAccAWSELB_disappears
--- PASS: TestAccAWSELB_generatesNameForZeroValue (79.85s)
--- PASS: TestAccAWSELB_fullCharacterRange (105.80s)
--- PASS: TestAccAWSELB_Listener_SSLCertificateID_IAMServerCertificate (128.88s)
--- PASS: TestAccAWSELB_availabilityZones (129.99s)
--- PASS: TestAccAWSELB_namePrefix (137.65s)
--- PASS: TestAccAWSELB_HealthCheck (145.50s)
--- PASS: TestAccAWSELB_generatedName (147.76s)
--- PASS: TestAccAWSELB_disappears (155.81s)
--- PASS: TestAccAWSELB_basic (165.76s)
--- PASS: TestAccAWSELB_AccessLogs_disabled (174.79s)
--- PASS: TestAccAWSELB_tags (183.41s)
--- PASS: TestAccAWSELB_swap_subnets (226.78s)
--- PASS: TestAccAWSELB_InstanceAttaching (233.38s)
--- PASS: TestAccAWSELB_Timeout (241.29s)
--- PASS: TestAccAWSELB_ConnectionDraining (271.05s)
--- PASS: TestAccAWSELB_SecurityGroups (305.51s)
--- PASS: TestAccAWSELB_AccessLogs_enabled (325.23s)
--- PASS: TestAccAWSELB_listener (401.58s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       402.470s
```
