### PR TITLE
Update the minimum allowed rate for waf_rate_based_rules

### DIFF
--- a/aws/resource_aws_waf_rate_based_rule.go
+++ b/aws/resource_aws_waf_rate_based_rule.go
@@ -59,7 +59,7 @@ func resourceAwsWafRateBasedRule() *schema.Resource {
 			"rate_limit": {
 				Type:         schema.TypeInt,
 				Required:     true,
-				ValidateFunc: validation.IntAtLeast(2000),
+				ValidateFunc: validation.IntAtLeast(100),
 			},
 		},
 	}

--- a/aws/resource_aws_wafregional_rate_based_rule.go
+++ b/aws/resource_aws_wafregional_rate_based_rule.go
@@ -62,7 +62,7 @@ func resourceAwsWafRegionalRateBasedRule() *schema.Resource {
 			"rate_limit": {
 				Type:         schema.TypeInt,
 				Required:     true,
-				ValidateFunc: validation.IntAtLeast(2000),
+				ValidateFunc: validation.IntAtLeast(100),
 			},
 		},
 	}

--- a/website/docs/r/waf_rate_based_rule.html.markdown
+++ b/website/docs/r/waf_rate_based_rule.html.markdown
@@ -45,7 +45,7 @@ The following arguments are supported:
 * `metric_name` - (Required) The name or description for the Amazon CloudWatch metric of this rule.
 * `name` - (Required) The name or description of the rule.
 * `rate_key` - (Required) Valid value is IP.
-* `rate_limit` - (Required) The maximum number of requests, which have an identical value in the field specified by the RateKey, allowed in a five-minute period. Minimum value is 2000.
+* `rate_limit` - (Required) The maximum number of requests, which have an identical value in the field specified by the RateKey, allowed in a five-minute period. Minimum value is 100.
 * `predicates` - (Optional) The objects to include in a rule (documented below).
 
 ## Nested Blocks

--- a/website/docs/r/wafregional_rate_based_rule.html.markdown
+++ b/website/docs/r/wafregional_rate_based_rule.html.markdown
@@ -45,7 +45,7 @@ The following arguments are supported:
 * `metric_name` - (Required) The name or description for the Amazon CloudWatch metric of this rule.
 * `name` - (Required) The name or description of the rule.
 * `rate_key` - (Required) Valid value is IP.
-* `rate_limit` - (Required) The maximum number of requests, which have an identical value in the field specified by the RateKey, allowed in a five-minute period. Minimum value is 2000.
+* `rate_limit` - (Required) The maximum number of requests, which have an identical value in the field specified by the RateKey, allowed in a five-minute period. Minimum value is 100.
 * `predicate` - (Optional) The objects to include in a rule (documented below).
 
 ## Nested Blocks


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Relates OR Closes #10058

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
Updates the rate_limit minimum amount on `aws_wafregional_rate_based_rule` and `aws_waf_rate_based_rule` resource to match the current AWS minimum, 100 / 5 minutes.
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSWafRegionalRateBasedRule'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 1 -run=TestAccAWSWafRegionalRateBasedRule -timeout 120m
=== RUN   TestAccAWSWafRegionalRateBasedRule_basic
=== PAUSE TestAccAWSWafRegionalRateBasedRule_basic
=== RUN   TestAccAWSWafRegionalRateBasedRule_changeNameForceNew
=== PAUSE TestAccAWSWafRegionalRateBasedRule_changeNameForceNew
=== RUN   TestAccAWSWafRegionalRateBasedRule_disappears
=== PAUSE TestAccAWSWafRegionalRateBasedRule_disappears
=== RUN   TestAccAWSWafRegionalRateBasedRule_changePredicates
=== PAUSE TestAccAWSWafRegionalRateBasedRule_changePredicates
=== RUN   TestAccAWSWafRegionalRateBasedRule_changeRateLimit
=== PAUSE TestAccAWSWafRegionalRateBasedRule_changeRateLimit
=== RUN   TestAccAWSWafRegionalRateBasedRule_noPredicates
=== PAUSE TestAccAWSWafRegionalRateBasedRule_noPredicates
=== CONT  TestAccAWSWafRegionalRateBasedRule_basic
--- PASS: TestAccAWSWafRegionalRateBasedRule_basic (24.33s)
=== CONT  TestAccAWSWafRegionalRateBasedRule_changeRateLimit
--- PASS: TestAccAWSWafRegionalRateBasedRule_changeRateLimit (28.28s)
=== CONT  TestAccAWSWafRegionalRateBasedRule_disappears
--- PASS: TestAccAWSWafRegionalRateBasedRule_disappears (22.22s)
=== CONT  TestAccAWSWafRegionalRateBasedRule_changePredicates
--- PASS: TestAccAWSWafRegionalRateBasedRule_changePredicates (40.83s)
=== CONT  TestAccAWSWafRegionalRateBasedRule_changeNameForceNew
--- PASS: TestAccAWSWafRegionalRateBasedRule_changeNameForceNew (45.33s)
=== CONT  TestAccAWSWafRegionalRateBasedRule_noPredicates
--- PASS: TestAccAWSWafRegionalRateBasedRule_noPredicates (18.14s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	179.151s

$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSWafRateBasedRule'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 1 -run=TestAccAWSWafRateBasedRule -timeout 120m
=== RUN   TestAccAWSWafRateBasedRule_basic
=== PAUSE TestAccAWSWafRateBasedRule_basic
=== RUN   TestAccAWSWafRateBasedRule_changeNameForceNew
=== PAUSE TestAccAWSWafRateBasedRule_changeNameForceNew
=== RUN   TestAccAWSWafRateBasedRule_disappears
=== PAUSE TestAccAWSWafRateBasedRule_disappears
=== RUN   TestAccAWSWafRateBasedRule_changePredicates
=== PAUSE TestAccAWSWafRateBasedRule_changePredicates
=== RUN   TestAccAWSWafRateBasedRule_noPredicates
=== PAUSE TestAccAWSWafRateBasedRule_noPredicates
=== CONT  TestAccAWSWafRateBasedRule_basic
--- PASS: TestAccAWSWafRateBasedRule_basic (17.67s)
=== CONT  TestAccAWSWafRateBasedRule_changePredicates
--- PASS: TestAccAWSWafRateBasedRule_changePredicates (30.54s)
=== CONT  TestAccAWSWafRateBasedRule_noPredicates
--- PASS: TestAccAWSWafRateBasedRule_noPredicates (13.40s)
=== CONT  TestAccAWSWafRateBasedRule_disappears
--- PASS: TestAccAWSWafRateBasedRule_disappears (17.97s)
=== CONT  TestAccAWSWafRateBasedRule_changeNameForceNew
--- PASS: TestAccAWSWafRateBasedRule_changeNameForceNew (33.50s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	113.099s
```
