### PR TITLE
Add WAF rate based rule data source

### DIFF
--- a/aws/data_source_aws_waf_rate_based_rule.go
+++ b/aws/data_source_aws_waf_rate_based_rule.go
@@ -1,0 +1,60 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsWafRateBasedRule() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsWafRateBasedRuleRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsWafRateBasedRuleRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafconn
+	name := d.Get("name").(string)
+
+	rules := make([]*waf.RuleSummary, 0)
+	// ListRulesInput does not have a name parameter for filtering
+	input := &waf.ListRateBasedRulesInput{}
+	for {
+		output, err := conn.ListRateBasedRules(input)
+		if err != nil {
+			return fmt.Errorf("error reading WAF Rate Based Rules: %s", err)
+		}
+		for _, rule := range output.Rules {
+			if aws.StringValue(rule.Name) == name {
+				rules = append(rules, rule)
+			}
+		}
+
+		if output.NextMarker == nil {
+			break
+		}
+		input.NextMarker = output.NextMarker
+	}
+
+	if len(rules) == 0 {
+		return fmt.Errorf("WAF Rate Based Rules not found for name: %s", name)
+	}
+
+	if len(rules) > 1 {
+		return fmt.Errorf("multiple WAF Rate Based Rules found for name: %s", name)
+	}
+
+	rule := rules[0]
+
+	d.SetId(aws.StringValue(rule.RuleId))
+
+	return nil
+}

--- a/aws/data_source_aws_waf_rate_based_rule.go
+++ b/aws/data_source_aws_waf_rate_based_rule.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/waf"
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func dataSourceAwsWafRateBasedRule() *schema.Resource {

--- a/aws/data_source_aws_waf_rate_based_rule_test.go
+++ b/aws/data_source_aws_waf_rate_based_rule_test.go
@@ -2,11 +2,11 @@ package aws
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
 func TestAccDataSourceAwsWafRateBasedRule_Basic(t *testing.T) {

--- a/aws/data_source_aws_waf_rate_based_rule_test.go
+++ b/aws/data_source_aws_waf_rate_based_rule_test.go
@@ -1,0 +1,55 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAwsWafRateBasedRule_Basic(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_waf_rate_based_rule.wafrule"
+	datasourceName := "data.aws_waf_rate_based_rule.wafrule"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSourceAwsWafRateBasedRuleConfig_NonExistent,
+				ExpectError: regexp.MustCompile(`WAF Rate Based Rules not found`),
+			},
+			{
+				Config: testAccDataSourceAwsWafRateBasedRuleConfig_Name(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsWafRateBasedRuleConfig_Name(name string) string {
+	return fmt.Sprintf(`
+resource "aws_waf_rate_based_rule" "wafrule" {
+  name        = %[1]q
+  metric_name = "WafruleTest"
+  rate_key    = "IP"
+  rate_limit  = 2000
+}
+
+data "aws_waf_rate_based_rule" "wafrule" {
+  name = "${aws_waf_rate_based_rule.wafrule.name}"
+}
+`, name)
+}
+
+const testAccDataSourceAwsWafRateBasedRuleConfig_NonExistent = `
+data "aws_waf_rate_based_rule" "wafrule" {
+  name = "tf-acc-test-does-not-exist"
+}
+`

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -279,6 +279,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_vpn_gateway":                               dataSourceAwsVpnGateway(),
 			"aws_waf_ipset":                                 dataSourceAwsWafIpSet(),
 			"aws_waf_rule":                                  dataSourceAwsWafRule(),
+			"aws_waf_rate_based_rule":                       dataSourceAwsWafRateBasedRule(),
 			"aws_waf_web_acl":                               dataSourceAwsWafWebAcl(),
 			"aws_wafregional_ipset":                         dataSourceAwsWafRegionalIpSet(),
 			"aws_wafregional_rule":                          dataSourceAwsWafRegionalRule(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -3147,9 +3147,6 @@
                             <a href="#">Data Sources</a>
                             <ul class="nav nav-auto-expand">
                                 <li>
-                                    <a href="/docs/providers/aws/d/waf_rule.html">aws_waf_rule</a>
-                                </li>
-                                <li>
                                     <a href="/docs/providers/aws/d/waf_web_acl.html">aws_waf_web_acl</a>
                                 </li>
                                 <li>

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -3155,6 +3155,9 @@
                                 <li>
                                     <a href="/docs/providers/aws/d/waf_rule.html">aws_waf_rule</a>
                                 </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/waf_rate_based_rule.html">aws_waf_rate_based_rule</a>
+                                </li>
                             </ul>
                         </li>
                         <li>

--- a/website/docs/d/waf_rate_based_rule.html.markdown
+++ b/website/docs/d/waf_rate_based_rule.html.markdown
@@ -1,0 +1,31 @@
+---
+layout: "aws"
+page_title: "AWS: aws_waf_rate_based_rule"
+sidebar_current: "docs-aws-datasource-waf-rate-based-rule"
+description: |-
+  Retrieves an AWS WAF rate based rule id.
+---
+
+# Data Source: aws_waf_rate_based_rule
+
+`aws_waf_rate_based_rule` Retrieves a WAF Rate Based Rule Resource Id.
+
+## Example Usage
+
+```hcl
+data "aws_waf_rate_based_rule" "example" {
+  name = "tfWAFRateBasedRule"
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the WAF rate based rule.
+
+## Attributes Reference
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the WAF rate based rule.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
Add the `aws_waf_rate_based_rule` data source.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccDataSourceAwsWafRateBasedRule_Basic'
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccDataSourceAwsWafRateBasedRule_Basic -timeout 120m
=== RUN   TestAccDataSourceAwsWafRateBasedRule_Basic
=== PAUSE TestAccDataSourceAwsWafRateBasedRule_Basic
=== CONT  TestAccDataSourceAwsWafRateBasedRule_Basic
--- PASS: TestAccDataSourceAwsWafRateBasedRule_Basic (46.95s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	47.002s
```