### PR TITLE
Update LocalStack r53 reference to route53

### DIFF
--- a/website/docs/guides/custom-service-endpoints.html.md
+++ b/website/docs/guides/custom-service-endpoints.html.md
@@ -226,7 +226,7 @@ provider "aws" {
     iam            = "http://localhost:4593"
     kinesis        = "http://localhost:4568"
     lambda         = "http://localhost:4574"
-    r53            = "http://localhost:4580"
+    route53        = "http://localhost:4580"
     redshift       = "http://localhost:4577"
     s3             = "http://localhost:4572"
     secretsmanager = "http://localhost:4584"


### PR DESCRIPTION
`r53` is the deprecated name of `route53`. The following warning is otherwise thrown if copy/pasting the example config:

```
Warning: "endpoints.0.r53": [DEPRECATED] use `endpoints` configuration block `route53` argument instead
```