### PR TITLE
r/aws_globalaccelerator_endpoint_group: Fix import command on doc

### DIFF
--- a/website/docs/r/globalaccelerator_endpoint_group.html.markdown
+++ b/website/docs/r/globalaccelerator_endpoint_group.html.markdown
@@ -52,5 +52,5 @@ In addition to all arguments above, the following attributes are exported:
 Global Accelerator endpoint groups can be imported using the `id`, e.g.
 
 ```
-$ terraform import globalaccelerator_endpoint_group.example arn:aws:globalaccelerator::111111111111:accelerator/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/listener/xxxxxxx/endpoint-group/xxxxxxxx
+$ terraform import aws_globalaccelerator_endpoint_group.example arn:aws:globalaccelerator::111111111111:accelerator/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/listener/xxxxxxx/endpoint-group/xxxxxxxx
 ```


### PR DESCRIPTION
Just a tiny fix on the resource name for terraform import command.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
NONE
```
