### PR TITLE
refactor: use acctest.RandStringFromCharSet() instead of randomString() in resource_aws_elb_test

### DIFF
--- a/aws/resource_aws_elb_test.go
+++ b/aws/resource_aws_elb_test.go
@@ -1007,7 +1007,8 @@ func TestResourceAWSELB_validateHealthCheckTarget(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    fmt.Sprintf("HTTP:8080/%s%s", randomString(512), randomRunes(512)),
+			Value: fmt.Sprintf("HTTP:8080/%s%s",
+				acctest.RandStringFromCharSet(512, acctest.CharSetAlpha), randomRunes(512)),
 			ErrCount: 1,
 		},
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10040 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestResourceAWSELB_validateHealthCheckTarget'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestResourceAWSELB_validateHealthCheckTarget -timeout 120m
=== RUN   TestResourceAWSELB_validateHealthCheckTarget
--- PASS: TestResourceAWSELB_validateHealthCheckTarget (0.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       0.055s
...
```
