### PR TITLE
Only set associate_public_ip_address if it's explicitly set

### DIFF
--- a/aws/resource_aws_ec2_fleet_test.go
+++ b/aws/resource_aws_ec2_fleet_test.go
@@ -4,9 +4,12 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	//"strings"
 	"testing"
+	//"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	//"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -985,6 +988,183 @@ func TestAccAWSEc2Fleet_Type(t *testing.T) {
 		},
 	})
 }
+
+// Test for the bug described in https://github.com/terraform-providers/terraform-provider-aws/issues/6777
+// For various reasons that don't seem trivially fixable, this test infrastructure doesn't get destroyed cleanly
+// when the testAccCheckAWSEc2FleetHistory check passes. Leaving it commented out for now.
+/*
+func TestAccAWSEc2Fleet_TemplateMultipleNetworkInterfaces(t *testing.T) {
+	var fleet1 ec2.FleetData
+	resourceName := "aws_ec2_fleet.test"
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2Fleet(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEc2FleetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEc2FleetConfig_multipleNetworkInterfaces(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEc2FleetExists(resourceName, &fleet1),
+					resource.TestCheckResourceAttr(resourceName, "type", "maintain"),
+					testAccCheckAWSEc2FleetHistory(resourceName, "The associatePublicIPAddress parameter cannot be specified when launching with multiple network interfaces"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSEc2FleetConfig_multipleNetworkInterfaces(rInt int) string {
+	return fmt.Sprintf(`
+data "aws_ami" "test" {
+	most_recent = true
+
+	filter {
+		name   = "name"
+		values = ["ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*"]
+	}
+
+	filter {
+		name   = "virtualization-type"
+		values = ["hvm"]
+	}
+
+	owners = ["099720109477"] # Canonical
+}
+
+resource "aws_vpc" "test" {
+	cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_internet_gateway" "test" {
+	vpc_id = "${aws_vpc.test.id}"
+}
+
+resource "aws_subnet" "test" {
+	cidr_block = "10.1.0.0/24"
+	vpc_id     = "${aws_vpc.test.id}"
+}
+
+resource "aws_security_group" "test" {
+	name = "security-group-%d"
+	description = "Testacc SSH security group"
+	vpc_id = "${aws_vpc.test.id}"
+
+	ingress {
+		protocol = "tcp"
+		from_port = 22
+		to_port = 22
+		cidr_blocks = ["0.0.0.0/0"]
+	}
+	egress {
+		protocol = "-1"
+		from_port = 0
+		to_port = 0
+		cidr_blocks = ["0.0.0.0/0"]
+	}
+}
+
+resource "aws_network_interface" "test" {
+	subnet_id = "${aws_subnet.test.id}"
+	security_groups = ["${aws_security_group.test.id}"]
+}
+
+resource "aws_launch_template" "test" {
+	name     = "testacc-lt-%d"
+	image_id = "${data.aws_ami.test.id}"
+
+	instance_market_options {
+		spot_options {
+		spot_instance_type = "persistent"
+		}
+		market_type="spot"
+	}
+
+	network_interfaces {
+		device_index = 0
+		network_interface_id = "${aws_network_interface.test.id}"
+	}
+	network_interfaces {
+		device_index = 1
+		subnet_id = "${aws_subnet.test.id}"
+	}
+
+}
+
+resource "aws_ec2_fleet" "test" {
+	launch_template_config {
+		launch_template_specification {
+		launch_template_id = "${aws_launch_template.test.id}"
+		version            = "${aws_launch_template.test.latest_version}"
+		}
+		# allow to choose from several instance types if there is no spot capacity for some type
+		override {
+		instance_type = "t2.micro"
+		}
+		override {
+		instance_type = "t3.micro"
+		}
+		override {
+		instance_type = "t3.small"
+		}
+	}
+
+	target_capacity_specification {
+		default_target_capacity_type = "spot"
+		total_target_capacity = 1
+	}
+}
+`, rInt, rInt)
+}
+
+func testAccCheckAWSEc2FleetHistory(resourceName string, errorMsg string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		time.Sleep(time.Minute * 2) // We have to wait a bit for the history to get populated.
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No EC2 Fleet ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+		input := &ec2.DescribeFleetHistoryInput{
+			FleetId:   aws.String(rs.Primary.ID),
+			StartTime: aws.Time(time.Now().Add(time.Hour * -2)),
+		}
+
+		output, err := conn.DescribeFleetHistory(input)
+
+		if err != nil {
+			return err
+		}
+
+		if output == nil {
+			return fmt.Errorf("EC2 Fleet history not found")
+		}
+
+		if output.HistoryRecords == nil {
+			return fmt.Errorf("No fleet history records found for fleet %s", rs.Primary.ID)
+		}
+
+		for _, record := range output.HistoryRecords {
+			if record == nil {
+				continue
+			}
+			if strings.Contains(aws.StringValue(record.EventInformation.EventDescription), errorMsg) {
+				return fmt.Errorf("Error %s found in fleet history event", errorMsg)
+			}
+		}
+
+		return nil
+	}
+}
+*/
 
 func testAccCheckAWSEc2FleetExists(resourceName string, fleet *ec2.FleetData) resource.TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/aws/resource_aws_ec2_fleet_test.go
+++ b/aws/resource_aws_ec2_fleet_test.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	//"strings"
+	"strings"
 	"testing"
-	//"time"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	//"github.com/aws/aws-sdk-go/aws/awserr"
@@ -990,9 +990,6 @@ func TestAccAWSEc2Fleet_Type(t *testing.T) {
 }
 
 // Test for the bug described in https://github.com/terraform-providers/terraform-provider-aws/issues/6777
-// For various reasons that don't seem trivially fixable, this test infrastructure doesn't get destroyed cleanly
-// when the testAccCheckAWSEc2FleetHistory check passes. Leaving it commented out for now.
-/*
 func TestAccAWSEc2Fleet_TemplateMultipleNetworkInterfaces(t *testing.T) {
 	var fleet1 ec2.FleetData
 	resourceName := "aws_ec2_fleet.test"
@@ -1083,20 +1080,24 @@ resource "aws_launch_template" "test" {
 
 	network_interfaces {
 		device_index = 0
+		delete_on_termination = true
 		network_interface_id = "${aws_network_interface.test.id}"
 	}
 	network_interfaces {
 		device_index = 1
+		delete_on_termination = true
 		subnet_id = "${aws_subnet.test.id}"
 	}
 
 }
 
 resource "aws_ec2_fleet" "test" {
+	terminate_instances = true
+
 	launch_template_config {
 		launch_template_specification {
-		launch_template_id = "${aws_launch_template.test.id}"
-		version            = "${aws_launch_template.test.latest_version}"
+			launch_template_id = "${aws_launch_template.test.id}"
+			version            = "${aws_launch_template.test.latest_version}"
 		}
 		# allow to choose from several instance types if there is no spot capacity for some type
 		override {
@@ -1164,7 +1165,6 @@ func testAccCheckAWSEc2FleetHistory(resourceName string, errorMsg string) resour
 		return nil
 	}
 }
-*/
 
 func testAccCheckAWSEc2FleetExists(resourceName string, fleet *ec2.FleetData) resource.TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/aws/resource_aws_ec2_fleet_test.go
+++ b/aws/resource_aws_ec2_fleet_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	//"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -357,8 +357,10 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"associate_public_ip_address": {
-							Type:     schema.TypeBool,
-							Optional: true,
+							Type:             schema.TypeString,
+							Optional:         true,
+							DiffSuppressFunc: suppressEquivalentTypeStringBoolean,
+							ValidateFunc:     validateTypeStringNullableBoolean,
 						},
 						"delete_on_termination": {
 							Type:     schema.TypeBool,
@@ -921,15 +923,17 @@ func getNetworkInterfaces(n []*ec2.LaunchTemplateInstanceNetworkInterfaceSpecifi
 		var ipv4Addresses []string
 
 		networkInterface := map[string]interface{}{
-			"associate_public_ip_address": aws.BoolValue(v.AssociatePublicIpAddress),
-			"delete_on_termination":       aws.BoolValue(v.DeleteOnTermination),
-			"description":                 aws.StringValue(v.Description),
-			"device_index":                aws.Int64Value(v.DeviceIndex),
-			"ipv4_address_count":          aws.Int64Value(v.SecondaryPrivateIpAddressCount),
-			"ipv6_address_count":          aws.Int64Value(v.Ipv6AddressCount),
-			"network_interface_id":        aws.StringValue(v.NetworkInterfaceId),
-			"private_ip_address":          aws.StringValue(v.PrivateIpAddress),
-			"subnet_id":                   aws.StringValue(v.SubnetId),
+			"delete_on_termination": aws.BoolValue(v.DeleteOnTermination),
+			"description":           aws.StringValue(v.Description),
+			"device_index":          aws.Int64Value(v.DeviceIndex),
+			"ipv4_address_count":    aws.Int64Value(v.SecondaryPrivateIpAddressCount),
+			"ipv6_address_count":    aws.Int64Value(v.Ipv6AddressCount),
+			"network_interface_id":  aws.StringValue(v.NetworkInterfaceId),
+			"private_ip_address":    aws.StringValue(v.PrivateIpAddress),
+			"subnet_id":             aws.StringValue(v.SubnetId),
+		}
+		if v.AssociatePublicIpAddress != nil {
+			networkInterface["associate_public_ip_address"] = strconv.FormatBool(aws.BoolValue(v.AssociatePublicIpAddress))
 		}
 
 		if len(v.Ipv6Addresses) > 0 {
@@ -1149,7 +1153,10 @@ func buildLaunchTemplateData(d *schema.ResourceData) (*ec2.RequestLaunchTemplate
 				continue
 			}
 			niData := ni.(map[string]interface{})
-			networkInterface := readNetworkInterfacesFromConfig(niData)
+			networkInterface, err := readNetworkInterfacesFromConfig(niData)
+			if err != nil {
+				return nil, err
+			}
 			networkInterfaces = append(networkInterfaces, networkInterface)
 		}
 		opts.NetworkInterfaces = networkInterfaces
@@ -1256,7 +1263,7 @@ func readEbsBlockDeviceFromConfig(ebs map[string]interface{}) (*ec2.LaunchTempla
 	return ebsDevice, nil
 }
 
-func readNetworkInterfacesFromConfig(ni map[string]interface{}) *ec2.LaunchTemplateInstanceNetworkInterfaceSpecificationRequest {
+func readNetworkInterfacesFromConfig(ni map[string]interface{}) (*ec2.LaunchTemplateInstanceNetworkInterfaceSpecificationRequest, error) {
 	var ipv4Addresses []*ec2.PrivateIpAddressSpecification
 	var ipv6Addresses []*ec2.InstanceIpv6AddressRequest
 	var privateIpAddress string
@@ -1276,13 +1283,14 @@ func readNetworkInterfacesFromConfig(ni map[string]interface{}) *ec2.LaunchTempl
 
 	if v, ok := ni["network_interface_id"].(string); ok && v != "" {
 		networkInterface.NetworkInterfaceId = aws.String(v)
-	} else if v, ok := ni["associate_public_ip_address"]; ok {
-		if ni["associate_public_ip_address"] == true {
-			// If there are multiple network interfaces, having this be explicitly set, even to false, will cause problems
-			// so don't set it unless we actually need to
-			networkInterface.AssociatePublicIpAddress = aws.Bool(v.(bool))
-		}
+	}
 
+	if v, ok := ni["associate_public_ip_address"]; ok && v.(string) != "" {
+		vBool, err := strconv.ParseBool(v.(string))
+		if err != nil {
+			return nil, fmt.Errorf("error converting associate_public_ip_address %q from string to boolean: %s", v.(string), err)
+		}
+		networkInterface.AssociatePublicIpAddress = aws.Bool(vBool)
 	}
 
 	if v, ok := ni["private_ip_address"].(string); ok && v != "" {
@@ -1325,7 +1333,7 @@ func readNetworkInterfacesFromConfig(ni map[string]interface{}) *ec2.LaunchTempl
 		networkInterface.PrivateIpAddresses = ipv4Addresses
 	}
 
-	return networkInterface
+	return networkInterface, nil
 }
 
 func readIamInstanceProfileFromConfig(iip map[string]interface{}) *ec2.LaunchTemplateIamInstanceProfileSpecificationRequest {

--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -1277,7 +1277,12 @@ func readNetworkInterfacesFromConfig(ni map[string]interface{}) *ec2.LaunchTempl
 	if v, ok := ni["network_interface_id"].(string); ok && v != "" {
 		networkInterface.NetworkInterfaceId = aws.String(v)
 	} else if v, ok := ni["associate_public_ip_address"]; ok {
-		networkInterface.AssociatePublicIpAddress = aws.Bool(v.(bool))
+		if ni["associate_public_ip_address"] == true {
+			// If there are multiple network interfaces, having this be explicitly set, even to false, will cause problems
+			// so don't set it unless we actually need to
+			networkInterface.AssociatePublicIpAddress = aws.Bool(v.(bool))
+		}
+
 	}
 
 	if v, ok := ni["private_ip_address"].(string); ok && v != "" {

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -554,6 +554,54 @@ func TestAccAWSLaunchTemplate_networkInterface(t *testing.T) {
 	})
 }
 
+func TestAccAWSLaunchTemplate_associatePublicIPAddress(t *testing.T) {
+	var template ec2.LaunchTemplate
+	resourceName := "aws_launch_template.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchTemplateConfig_associatePublicIpAddressTrue,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "network_interfaces.0.network_interface_id"),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.associate_public_ip_address", "true"),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.ipv4_address_count", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSLaunchTemplateConfig_associatePublicIpAddressFalse,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "network_interfaces.0.network_interface_id"),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.associate_public_ip_address", "false"),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.ipv4_address_count", "2"),
+				),
+			},
+			{
+				Config: testAccAWSLaunchTemplateConfig_associatePublicIpAddressMissing,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "network_interfaces.0.network_interface_id"),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.associate_public_ip_address", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.ipv4_address_count", "2"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses(t *testing.T) {
 	var template ec2.LaunchTemplate
 	resourceName := "aws_launch_template.test"

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -541,7 +541,7 @@ func TestAccAWSLaunchTemplate_networkInterface(t *testing.T) {
 					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "network_interfaces.0.network_interface_id"),
-					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.associate_public_ip_address", "false"),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.associate_public_ip_address", ""),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.ipv4_address_count", "2"),
 				),
 			},
@@ -1072,6 +1072,80 @@ resource "aws_launch_template" "test" {
 
   network_interfaces {
     network_interface_id = "${aws_network_interface.test.id}"
+    ipv4_address_count = 2
+  }
+}
+`
+
+const testAccAWSLaunchTemplateConfig_associatePublicIpAddressTrue = `
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_subnet" "test" {
+  vpc_id = "${aws_vpc.test.id}"
+  cidr_block = "10.1.0.0/24"
+}
+
+resource "aws_network_interface" "test" {
+  subnet_id = "${aws_subnet.test.id}"
+}
+
+resource "aws_launch_template" "test" {
+  name = "network-interface-launch-template"
+
+  network_interfaces {
+	network_interface_id = "${aws_network_interface.test.id}"
+	associate_public_ip_address = true
+    ipv4_address_count = 2
+  }
+}
+`
+
+const testAccAWSLaunchTemplateConfig_associatePublicIpAddressFalse = `
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_subnet" "test" {
+  vpc_id = "${aws_vpc.test.id}"
+  cidr_block = "10.1.0.0/24"
+}
+
+resource "aws_network_interface" "test" {
+  subnet_id = "${aws_subnet.test.id}"
+}
+
+resource "aws_launch_template" "test" {
+  name = "network-interface-launch-template"
+
+  network_interfaces {
+	network_interface_id = "${aws_network_interface.test.id}"
+	associate_public_ip_address = false
+    ipv4_address_count = 2
+  }
+}
+`
+
+const testAccAWSLaunchTemplateConfig_associatePublicIpAddressMissing = `
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_subnet" "test" {
+  vpc_id = "${aws_vpc.test.id}"
+  cidr_block = "10.1.0.0/24"
+}
+
+resource "aws_network_interface" "test" {
+  subnet_id = "${aws_subnet.test.id}"
+}
+
+resource "aws_launch_template" "test" {
+  name = "network-interface-launch-template"
+
+  network_interfaces {
+	network_interface_id = "${aws_network_interface.test.id}"
     ipv4_address_count = 2
   }
 }

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -556,6 +556,7 @@ func TestAccAWSLaunchTemplate_networkInterface(t *testing.T) {
 
 func TestAccAWSLaunchTemplate_associatePublicIPAddress(t *testing.T) {
 	var template ec2.LaunchTemplate
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_launch_template.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -564,7 +565,7 @@ func TestAccAWSLaunchTemplate_associatePublicIPAddress(t *testing.T) {
 		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLaunchTemplateConfig_associatePublicIpAddressTrue,
+				Config: testAccAWSLaunchTemplateConfig_associatePublicIpAddress(rName, "true"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.#", "1"),
@@ -579,7 +580,7 @@ func TestAccAWSLaunchTemplate_associatePublicIPAddress(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSLaunchTemplateConfig_associatePublicIpAddressFalse,
+				Config: testAccAWSLaunchTemplateConfig_associatePublicIpAddress(rName, "false"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.#", "1"),
@@ -589,7 +590,7 @@ func TestAccAWSLaunchTemplate_associatePublicIPAddress(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSLaunchTemplateConfig_associatePublicIpAddressMissing,
+				Config: testAccAWSLaunchTemplateConfig_associatePublicIpAddress(rName, "null"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.#", "1"),
@@ -1125,7 +1126,8 @@ resource "aws_launch_template" "test" {
 }
 `
 
-const testAccAWSLaunchTemplateConfig_associatePublicIpAddressTrue = `
+func testAccAWSLaunchTemplateConfig_associatePublicIpAddress(rName, associatePublicIPAddress string) string {
+	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 }
@@ -1140,64 +1142,16 @@ resource "aws_network_interface" "test" {
 }
 
 resource "aws_launch_template" "test" {
-  name = "network-interface-launch-template"
+  name = %[1]q
 
   network_interfaces {
 	network_interface_id = "${aws_network_interface.test.id}"
-	associate_public_ip_address = true
+	associate_public_ip_address = %[2]s
     ipv4_address_count = 2
   }
 }
-`
-
-const testAccAWSLaunchTemplateConfig_associatePublicIpAddressFalse = `
-resource "aws_vpc" "test" {
-  cidr_block = "10.1.0.0/16"
+`, rName, associatePublicIPAddress)
 }
-
-resource "aws_subnet" "test" {
-  vpc_id = "${aws_vpc.test.id}"
-  cidr_block = "10.1.0.0/24"
-}
-
-resource "aws_network_interface" "test" {
-  subnet_id = "${aws_subnet.test.id}"
-}
-
-resource "aws_launch_template" "test" {
-  name = "network-interface-launch-template"
-
-  network_interfaces {
-	network_interface_id = "${aws_network_interface.test.id}"
-	associate_public_ip_address = false
-    ipv4_address_count = 2
-  }
-}
-`
-
-const testAccAWSLaunchTemplateConfig_associatePublicIpAddressMissing = `
-resource "aws_vpc" "test" {
-  cidr_block = "10.1.0.0/16"
-}
-
-resource "aws_subnet" "test" {
-  vpc_id = "${aws_vpc.test.id}"
-  cidr_block = "10.1.0.0/24"
-}
-
-resource "aws_network_interface" "test" {
-  subnet_id = "${aws_subnet.test.id}"
-}
-
-resource "aws_launch_template" "test" {
-  name = "network-interface-launch-template"
-
-  network_interfaces {
-	network_interface_id = "${aws_network_interface.test.id}"
-    ipv4_address_count = 2
-  }
-}
-`
 
 const testAccAWSLaunchTemplateConfig_networkInterface_ipv6Addresses = `
 resource "aws_launch_template" "test" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #6777 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_launch_template: Only set associate_public_ip_address on network interfaces if it's explicitly set to avoid problems with multiple network interfaces
```

Output from acceptance testing:

```
Test to catch this problem - commented out because of problems with TF destroy when it passes

$ make testacc TESTARGS="-run=TestAccAWSEc2Fleet_TemplateMultipleNetworkInterfaces"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSEc2Fleet_TemplateMultipleNetworkInterfaces -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEc2Fleet_TemplateMultipleNetworkInterfaces
=== PAUSE TestAccAWSEc2Fleet_TemplateMultipleNetworkInterfaces
=== CONT  TestAccAWSEc2Fleet_TemplateMultipleNetworkInterfaces
fleet id: fleet-b7d98d6c-bc90-4ef2-b246-70449d1a395b
--- FAIL: TestAccAWSEc2Fleet_TemplateMultipleNetworkInterfaces (203.10s)
    testing.go:569: Step 0 error: Check failed: Check 3/3 error: Error The associatePublicIPAddress parameter cannot be specified when launching with multiple network interfaces found in fleet history event
FAIL
FAIL    github.com/terraform-providers/terraform-provider-aws/aws       204.383s
make: *** [testacc] Error 1

All other tests with the new code:

make testacc TESTARGS="-run=TestAccAWSEc2Fleet_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSEc2Fleet_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEc2Fleet_basic
=== PAUSE TestAccAWSEc2Fleet_basic
=== RUN   TestAccAWSEc2Fleet_disappears
=== PAUSE TestAccAWSEc2Fleet_disappears
=== RUN   TestAccAWSEc2Fleet_ExcessCapacityTerminationPolicy
=== PAUSE TestAccAWSEc2Fleet_ExcessCapacityTerminationPolicy
=== RUN   TestAccAWSEc2Fleet_LaunchTemplateConfig_LaunchTemplateSpecification_LaunchTemplateId
=== PAUSE TestAccAWSEc2Fleet_LaunchTemplateConfig_LaunchTemplateSpecification_LaunchTemplateId
=== RUN   TestAccAWSEc2Fleet_LaunchTemplateConfig_LaunchTemplateSpecification_LaunchTemplateName
=== PAUSE TestAccAWSEc2Fleet_LaunchTemplateConfig_LaunchTemplateSpecification_LaunchTemplateName
=== RUN   TestAccAWSEc2Fleet_LaunchTemplateConfig_LaunchTemplateSpecification_Version
=== PAUSE TestAccAWSEc2Fleet_LaunchTemplateConfig_LaunchTemplateSpecification_Version
=== RUN   TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_AvailabilityZone
=== PAUSE TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_AvailabilityZone
=== RUN   TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_InstanceType
=== PAUSE TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_InstanceType
=== RUN   TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_MaxPrice
--- SKIP: TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_MaxPrice (0.00s)
    resource_aws_ec2_fleet_test.go:337: EC2 API is not correctly returning MaxPrice override
=== RUN   TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_Priority
=== PAUSE TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_Priority
=== RUN   TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_Priority_Multiple
=== PAUSE TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_Priority_Multiple
=== RUN   TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_SubnetId
=== PAUSE TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_SubnetId
=== RUN   TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_WeightedCapacity
=== PAUSE TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_WeightedCapacity
=== RUN   TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_WeightedCapacity_Multiple
=== PAUSE TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_WeightedCapacity_Multiple
=== RUN   TestAccAWSEc2Fleet_OnDemandOptions_AllocationStrategy
=== PAUSE TestAccAWSEc2Fleet_OnDemandOptions_AllocationStrategy
=== RUN   TestAccAWSEc2Fleet_ReplaceUnhealthyInstances
=== PAUSE TestAccAWSEc2Fleet_ReplaceUnhealthyInstances
=== RUN   TestAccAWSEc2Fleet_SpotOptions_AllocationStrategy
=== PAUSE TestAccAWSEc2Fleet_SpotOptions_AllocationStrategy
=== RUN   TestAccAWSEc2Fleet_SpotOptions_InstanceInterruptionBehavior
=== PAUSE TestAccAWSEc2Fleet_SpotOptions_InstanceInterruptionBehavior
=== RUN   TestAccAWSEc2Fleet_SpotOptions_InstancePoolsToUseCount
=== PAUSE TestAccAWSEc2Fleet_SpotOptions_InstancePoolsToUseCount
=== RUN   TestAccAWSEc2Fleet_Tags
=== PAUSE TestAccAWSEc2Fleet_Tags
=== RUN   TestAccAWSEc2Fleet_TargetCapacitySpecification_DefaultTargetCapacityType
=== PAUSE TestAccAWSEc2Fleet_TargetCapacitySpecification_DefaultTargetCapacityType
=== RUN   TestAccAWSEc2Fleet_TargetCapacitySpecification_DefaultTargetCapacityType_OnDemand
=== PAUSE TestAccAWSEc2Fleet_TargetCapacitySpecification_DefaultTargetCapacityType_OnDemand
=== RUN   TestAccAWSEc2Fleet_TargetCapacitySpecification_DefaultTargetCapacityType_Spot
=== PAUSE TestAccAWSEc2Fleet_TargetCapacitySpecification_DefaultTargetCapacityType_Spot
=== RUN   TestAccAWSEc2Fleet_TargetCapacitySpecification_TotalTargetCapacity
=== PAUSE TestAccAWSEc2Fleet_TargetCapacitySpecification_TotalTargetCapacity
=== RUN   TestAccAWSEc2Fleet_TerminateInstancesWithExpiration
=== PAUSE TestAccAWSEc2Fleet_TerminateInstancesWithExpiration
=== RUN   TestAccAWSEc2Fleet_Type
=== PAUSE TestAccAWSEc2Fleet_Type
=== CONT  TestAccAWSEc2Fleet_basic
=== CONT  TestAccAWSEc2Fleet_OnDemandOptions_AllocationStrategy
=== CONT  TestAccAWSEc2Fleet_TargetCapacitySpecification_DefaultTargetCapacityType
=== CONT  TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_WeightedCapacity_Multiple
=== CONT  TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_WeightedCapacity
=== CONT  TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_SubnetId
=== CONT  TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_Priority_Multiple
=== CONT  TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_Priority
=== CONT  TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_InstanceType
=== CONT  TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_AvailabilityZone
=== CONT  TestAccAWSEc2Fleet_TargetCapacitySpecification_DefaultTargetCapacityType_OnDemand
=== CONT  TestAccAWSEc2Fleet_LaunchTemplateConfig_LaunchTemplateSpecification_Version
=== CONT  TestAccAWSEc2Fleet_LaunchTemplateConfig_LaunchTemplateSpecification_LaunchTemplateName
=== CONT  TestAccAWSEc2Fleet_LaunchTemplateConfig_LaunchTemplateSpecification_LaunchTemplateId
=== CONT  TestAccAWSEc2Fleet_ExcessCapacityTerminationPolicy
=== CONT  TestAccAWSEc2Fleet_Type
=== CONT  TestAccAWSEc2Fleet_TerminateInstancesWithExpiration
=== CONT  TestAccAWSEc2Fleet_TargetCapacitySpecification_TotalTargetCapacity
=== CONT  TestAccAWSEc2Fleet_disappears
=== CONT  TestAccAWSEc2Fleet_TargetCapacitySpecification_DefaultTargetCapacityType_Spot
--- PASS: TestAccAWSEc2Fleet_disappears (52.44s)
=== CONT  TestAccAWSEc2Fleet_SpotOptions_AllocationStrategy
--- PASS: TestAccAWSEc2Fleet_Type (52.68s)
=== CONT  TestAccAWSEc2Fleet_Tags
--- PASS: TestAccAWSEc2Fleet_TargetCapacitySpecification_DefaultTargetCapacityType_OnDemand (53.23s)
=== CONT  TestAccAWSEc2Fleet_ReplaceUnhealthyInstances
--- PASS: TestAccAWSEc2Fleet_basic (53.27s)
=== CONT  TestAccAWSEc2Fleet_SpotOptions_InstancePoolsToUseCount
--- PASS: TestAccAWSEc2Fleet_TargetCapacitySpecification_DefaultTargetCapacityType_Spot (53.37s)
=== CONT  TestAccAWSEc2Fleet_SpotOptions_InstanceInterruptionBehavior
--- PASS: TestAccAWSEc2Fleet_TargetCapacitySpecification_DefaultTargetCapacityType (92.85s)
--- PASS: TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_InstanceType (94.09s)
--- PASS: TestAccAWSEc2Fleet_LaunchTemplateConfig_LaunchTemplateSpecification_LaunchTemplateName (94.43s)
--- PASS: TestAccAWSEc2Fleet_TerminateInstancesWithExpiration (94.54s)
--- PASS: TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_Priority_Multiple (94.68s)
--- PASS: TestAccAWSEc2Fleet_LaunchTemplateConfig_LaunchTemplateSpecification_LaunchTemplateId (95.14s)
--- PASS: TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_WeightedCapacity (95.57s)
--- PASS: TestAccAWSEc2Fleet_OnDemandOptions_AllocationStrategy (95.57s)
--- PASS: TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_WeightedCapacity_Multiple (95.58s)
--- PASS: TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_AvailabilityZone (95.63s)
--- PASS: TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_Priority (96.97s)
--- PASS: TestAccAWSEc2Fleet_LaunchTemplateConfig_LaunchTemplateSpecification_Version (97.10s)
--- PASS: TestAccAWSEc2Fleet_ExcessCapacityTerminationPolicy (124.79s)
--- PASS: TestAccAWSEc2Fleet_LaunchTemplateConfig_Override_SubnetId (130.06s)
--- PASS: TestAccAWSEc2Fleet_Tags (93.38s)
--- PASS: TestAccAWSEc2Fleet_SpotOptions_AllocationStrategy (94.62s)
--- PASS: TestAccAWSEc2Fleet_SpotOptions_InstancePoolsToUseCount (93.88s)
--- PASS: TestAccAWSEc2Fleet_SpotOptions_InstanceInterruptionBehavior (93.79s)
--- PASS: TestAccAWSEc2Fleet_ReplaceUnhealthyInstances (94.10s)
--- PASS: TestAccAWSEc2Fleet_TargetCapacitySpecification_TotalTargetCapacity (497.61s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       499.024s

make testacc TESTARGS="-run=TestAccAWSLaunchTemplate_"   ==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSLaunchTemplate_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSLaunchTemplate_importBasic
=== PAUSE TestAccAWSLaunchTemplate_importBasic
=== RUN   TestAccAWSLaunchTemplate_importData
=== PAUSE TestAccAWSLaunchTemplate_importData
=== RUN   TestAccAWSLaunchTemplate_basic
=== PAUSE TestAccAWSLaunchTemplate_basic
=== RUN   TestAccAWSLaunchTemplate_disappears
=== PAUSE TestAccAWSLaunchTemplate_disappears
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
=== PAUSE TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
=== PAUSE TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
=== RUN   TestAccAWSLaunchTemplate_EbsOptimized
=== PAUSE TestAccAWSLaunchTemplate_EbsOptimized
=== RUN   TestAccAWSLaunchTemplate_ElasticInferenceAccelerator
=== PAUSE TestAccAWSLaunchTemplate_ElasticInferenceAccelerator
=== RUN   TestAccAWSLaunchTemplate_data
=== PAUSE TestAccAWSLaunchTemplate_data
=== RUN   TestAccAWSLaunchTemplate_description
=== PAUSE TestAccAWSLaunchTemplate_description
=== RUN   TestAccAWSLaunchTemplate_update
=== PAUSE TestAccAWSLaunchTemplate_update
=== RUN   TestAccAWSLaunchTemplate_tags
=== PAUSE TestAccAWSLaunchTemplate_tags
=== RUN   TestAccAWSLaunchTemplate_capacityReservation_preference
=== PAUSE TestAccAWSLaunchTemplate_capacityReservation_preference
=== RUN   TestAccAWSLaunchTemplate_capacityReservation_target
=== PAUSE TestAccAWSLaunchTemplate_capacityReservation_target
=== RUN   TestAccAWSLaunchTemplate_creditSpecification_nonBurstable
=== PAUSE TestAccAWSLaunchTemplate_creditSpecification_nonBurstable
=== RUN   TestAccAWSLaunchTemplate_creditSpecification_t2
=== PAUSE TestAccAWSLaunchTemplate_creditSpecification_t2
=== RUN   TestAccAWSLaunchTemplate_creditSpecification_t3
=== PAUSE TestAccAWSLaunchTemplate_creditSpecification_t3
=== RUN   TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock
=== PAUSE TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock
=== RUN   TestAccAWSLaunchTemplate_networkInterface
=== PAUSE TestAccAWSLaunchTemplate_networkInterface
=== RUN   TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses
=== PAUSE TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses
=== RUN   TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount
=== PAUSE TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount
=== RUN   TestAccAWSLaunchTemplate_instanceMarketOptions
=== PAUSE TestAccAWSLaunchTemplate_instanceMarketOptions
=== RUN   TestAccAWSLaunchTemplate_licenseSpecification
=== PAUSE TestAccAWSLaunchTemplate_licenseSpecification
=== CONT  TestAccAWSLaunchTemplate_importBasic
=== CONT  TestAccAWSLaunchTemplate_licenseSpecification
=== CONT  TestAccAWSLaunchTemplate_update
=== CONT  TestAccAWSLaunchTemplate_tags
=== CONT  TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock
=== CONT  TestAccAWSLaunchTemplate_creditSpecification_t3
=== CONT  TestAccAWSLaunchTemplate_instanceMarketOptions
=== CONT  TestAccAWSLaunchTemplate_creditSpecification_t2
=== CONT  TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount
=== CONT  TestAccAWSLaunchTemplate_creditSpecification_nonBurstable
=== CONT  TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses
=== CONT  TestAccAWSLaunchTemplate_capacityReservation_target
=== CONT  TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
=== CONT  TestAccAWSLaunchTemplate_description
=== CONT  TestAccAWSLaunchTemplate_data
=== CONT  TestAccAWSLaunchTemplate_capacityReservation_preference
=== CONT  TestAccAWSLaunchTemplate_EbsOptimized
=== CONT  TestAccAWSLaunchTemplate_disappears
=== CONT  TestAccAWSLaunchTemplate_networkInterface
=== CONT  TestAccAWSLaunchTemplate_ElasticInferenceAccelerator
--- PASS: TestAccAWSLaunchTemplate_disappears (21.94s)
=== CONT  TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount (26.70s)
=== CONT  TestAccAWSLaunchTemplate_basic
--- PASS: TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock (26.82s)
=== CONT  TestAccAWSLaunchTemplate_importData
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t2 (26.94s)
--- PASS: TestAccAWSLaunchTemplate_data (27.11s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t3 (27.13s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses (27.13s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_nonBurstable (27.35s)
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_preference (27.38s)
--- PASS: TestAccAWSLaunchTemplate_licenseSpecification (30.62s)
--- PASS: TestAccAWSLaunchTemplate_importBasic (31.55s)
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_target (37.52s)
--- PASS: TestAccAWSLaunchTemplate_description (45.69s)
--- PASS: TestAccAWSLaunchTemplate_ElasticInferenceAccelerator (49.20s)
--- PASS: TestAccAWSLaunchTemplate_tags (49.21s)
--- PASS: TestAccAWSLaunchTemplate_basic (26.33s)
--- PASS: TestAccAWSLaunchTemplate_importData (27.91s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface (61.59s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS (51.53s)
--- PASS: TestAccAWSLaunchTemplate_update (82.10s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination (83.31s)
--- PASS: TestAccAWSLaunchTemplate_instanceMarketOptions (92.07s)
--- PASS: TestAccAWSLaunchTemplate_EbsOptimized (109.33s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       110.236s
```
