### PR TITLE
Import test refactor for elasticache resources

### DIFF
--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -58,14 +58,14 @@ func testSweepElasticacheReplicationGroups(region string) error {
 	return nil
 }
 
-func TestAccAWSElasticacheReplicationGroup_importBasic(t *testing.T) {
+func TestAccAWSElasticacheReplicationGroup_basic(t *testing.T) {
 	oldvar := os.Getenv("AWS_DEFAULT_REGION")
 	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
 	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
 
+	var rg elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-
-	resourceName := "aws_elasticache_replication_group.bar"
+	resourceName := "aws_elasticache_replication_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -74,8 +74,18 @@ func TestAccAWSElasticacheReplicationGroup_importBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSElasticacheReplicationGroupConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.test", &rg),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_replication_group.test", "cluster_mode.#", "0"),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_replication_group.test", "number_cache_clusters", "2"),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_replication_group.test", "member_clusters.#", "2"),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_replication_group.test", "auto_minor_version_upgrade", "false"),
+				),
 			},
-
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
@@ -86,36 +96,15 @@ func TestAccAWSElasticacheReplicationGroup_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccAWSElasticacheReplicationGroup_basic(t *testing.T) {
-	var rg elasticache.ReplicationGroup
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSElasticacheReplicationGroupConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
-					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "cluster_mode.#", "0"),
-					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "number_cache_clusters", "2"),
-					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "member_clusters.#", "2"),
-					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "auto_minor_version_upgrade", "false"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAWSElasticacheReplicationGroup_Uppercase(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
 	var rg elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_elasticache_replication_group.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -124,18 +113,30 @@ func TestAccAWSElasticacheReplicationGroup_Uppercase(t *testing.T) {
 			{
 				Config: testAccAWSElasticacheReplicationGroupConfig_Uppercase(strings.ToUpper(rName)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
+					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.test", &rg),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "replication_group_id", rName),
+						"aws_elasticache_replication_group.test", "replication_group_id", rName),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
 			},
 		},
 	})
 }
 
 func TestAccAWSElasticacheReplicationGroup_updateDescription(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
 	var rg elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_elasticache_replication_group.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -144,26 +145,31 @@ func TestAccAWSElasticacheReplicationGroup_updateDescription(t *testing.T) {
 			{
 				Config: testAccAWSElasticacheReplicationGroupConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
+					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.test", &rg),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "number_cache_clusters", "2"),
+						"aws_elasticache_replication_group.test", "number_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "replication_group_description", "test description"),
+						"aws_elasticache_replication_group.test", "replication_group_description", "test description"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "auto_minor_version_upgrade", "false"),
+						"aws_elasticache_replication_group.test", "auto_minor_version_upgrade", "false"),
 				),
 			},
-
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
 			{
 				Config: testAccAWSElasticacheReplicationGroupConfigUpdatedDescription(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
+					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.test", &rg),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "number_cache_clusters", "2"),
+						"aws_elasticache_replication_group.test", "number_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "replication_group_description", "updated description"),
+						"aws_elasticache_replication_group.test", "replication_group_description", "updated description"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "auto_minor_version_upgrade", "true"),
+						"aws_elasticache_replication_group.test", "auto_minor_version_upgrade", "true"),
 				),
 			},
 		},
@@ -171,8 +177,14 @@ func TestAccAWSElasticacheReplicationGroup_updateDescription(t *testing.T) {
 }
 
 func TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
 	var rg elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_elasticache_replication_group.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -181,17 +193,23 @@ func TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow(t *testing.T)
 			{
 				Config: testAccAWSElasticacheReplicationGroupConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
+					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.test", &rg),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "maintenance_window", "tue:06:30-tue:07:30"),
+						"aws_elasticache_replication_group.test", "maintenance_window", "tue:06:30-tue:07:30"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
 			},
 			{
 				Config: testAccAWSElasticacheReplicationGroupConfigUpdatedMaintenanceWindow(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
+					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.test", &rg),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "maintenance_window", "wed:03:00-wed:06:00"),
+						"aws_elasticache_replication_group.test", "maintenance_window", "wed:03:00-wed:06:00"),
 				),
 			},
 		},
@@ -199,8 +217,14 @@ func TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow(t *testing.T)
 }
 
 func TestAccAWSElasticacheReplicationGroup_updateNodeSize(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
 	var rg elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_elasticache_replication_group.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -209,22 +233,27 @@ func TestAccAWSElasticacheReplicationGroup_updateNodeSize(t *testing.T) {
 			{
 				Config: testAccAWSElasticacheReplicationGroupConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
+					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.test", &rg),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "number_cache_clusters", "2"),
+						"aws_elasticache_replication_group.test", "number_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "node_type", "cache.m1.small"),
+						"aws_elasticache_replication_group.test", "node_type", "cache.m1.small"),
 				),
 			},
-
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
 			{
 				Config: testAccAWSElasticacheReplicationGroupConfigUpdatedNodeSize(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
+					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.test", &rg),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "number_cache_clusters", "2"),
+						"aws_elasticache_replication_group.test", "number_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "node_type", "cache.m1.medium"),
+						"aws_elasticache_replication_group.test", "node_type", "cache.m1.medium"),
 				),
 			},
 		},
@@ -233,6 +262,10 @@ func TestAccAWSElasticacheReplicationGroup_updateNodeSize(t *testing.T) {
 
 //This is a test to prove that we panic we get in https://github.com/hashicorp/terraform/issues/9097
 func TestAccAWSElasticacheReplicationGroup_updateParameterGroup(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
 	var rg elasticache.ReplicationGroup
 	parameterGroupResourceName1 := "aws_elasticache_parameter_group.test.0"
 	parameterGroupResourceName2 := "aws_elasticache_parameter_group.test.1"
@@ -251,7 +284,12 @@ func TestAccAWSElasticacheReplicationGroup_updateParameterGroup(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "parameter_group_name", parameterGroupResourceName1, "name"),
 				),
 			},
-
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
 			{
 				Config: testAccAWSElasticacheReplicationGroupConfigParameterGroupName(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
@@ -264,7 +302,13 @@ func TestAccAWSElasticacheReplicationGroup_updateParameterGroup(t *testing.T) {
 }
 
 func TestAccAWSElasticacheReplicationGroup_vpc(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
 	var rg elasticache.ReplicationGroup
+	resourceName := "aws_elasticache_replication_group.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -273,19 +317,31 @@ func TestAccAWSElasticacheReplicationGroup_vpc(t *testing.T) {
 			{
 				Config: testAccAWSElasticacheReplicationGroupInVPCConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
+					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.test", &rg),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "number_cache_clusters", "1"),
+						"aws_elasticache_replication_group.test", "number_cache_clusters", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "auto_minor_version_upgrade", "false"),
+						"aws_elasticache_replication_group.test", "auto_minor_version_upgrade", "false"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately", "availability_zones"},
 			},
 		},
 	})
 }
 
 func TestAccAWSElasticacheReplicationGroup_multiAzInVpc(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
 	var rg elasticache.ReplicationGroup
+	resourceName := "aws_elasticache_replication_group.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -294,25 +350,37 @@ func TestAccAWSElasticacheReplicationGroup_multiAzInVpc(t *testing.T) {
 			{
 				Config: testAccAWSElasticacheReplicationGroupMultiAZInVPCConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
+					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.test", &rg),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "number_cache_clusters", "2"),
+						"aws_elasticache_replication_group.test", "number_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "automatic_failover_enabled", "true"),
+						"aws_elasticache_replication_group.test", "automatic_failover_enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "snapshot_window", "02:00-03:00"),
+						"aws_elasticache_replication_group.test", "snapshot_window", "02:00-03:00"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "snapshot_retention_limit", "7"),
+						"aws_elasticache_replication_group.test", "snapshot_retention_limit", "7"),
 					resource.TestCheckResourceAttrSet(
-						"aws_elasticache_replication_group.bar", "primary_endpoint_address"),
+						"aws_elasticache_replication_group.test", "primary_endpoint_address"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately", "availability_zones"},
 			},
 		},
 	})
 }
 
 func TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
 	var rg elasticache.ReplicationGroup
+	resourceName := "aws_elasticache_replication_group.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -321,27 +389,37 @@ func TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2(t *testing.T) {
 			{
 				Config: testAccAWSElasticacheReplicationGroupRedisClusterInVPCConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
+					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.test", &rg),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "number_cache_clusters", "2"),
+						"aws_elasticache_replication_group.test", "number_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "automatic_failover_enabled", "false"),
+						"aws_elasticache_replication_group.test", "automatic_failover_enabled", "false"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "snapshot_window", "02:00-03:00"),
+						"aws_elasticache_replication_group.test", "snapshot_window", "02:00-03:00"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "snapshot_retention_limit", "7"),
+						"aws_elasticache_replication_group.test", "snapshot_retention_limit", "7"),
 					resource.TestCheckResourceAttrSet(
-						"aws_elasticache_replication_group.bar", "primary_endpoint_address"),
+						"aws_elasticache_replication_group.test", "primary_endpoint_address"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately", "availability_zones"},
 			},
 		},
 	})
 }
 
 func TestAccAWSElasticacheReplicationGroup_ClusterMode_Basic(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
 	var rg elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_elasticache_replication_group.bar"
+	resourceName := "aws_elasticache_replication_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -360,14 +438,24 @@ func TestAccAWSElasticacheReplicationGroup_ClusterMode_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "configuration_endpoint_address"),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
 		},
 	})
 }
 
 func TestAccAWSElasticacheReplicationGroup_ClusterMode_NumNodeGroups(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
 	var rg elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_elasticache_replication_group.bar"
+	resourceName := "aws_elasticache_replication_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -383,6 +471,12 @@ func TestAccAWSElasticacheReplicationGroup_ClusterMode_NumNodeGroups(t *testing.
 					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.num_node_groups", "3"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.replicas_per_node_group", "1"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
 			},
 			{
 				Config: testAccAWSElasticacheReplicationGroupNativeRedisClusterConfig(rName, 1, 1),
@@ -409,6 +503,10 @@ func TestAccAWSElasticacheReplicationGroup_ClusterMode_NumNodeGroups(t *testing.
 }
 
 func TestAccAWSElasticacheReplicationGroup_clusteringAndCacheNodesCausesError(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
 	rInt := acctest.RandInt()
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
@@ -426,8 +524,13 @@ func TestAccAWSElasticacheReplicationGroup_clusteringAndCacheNodesCausesError(t 
 }
 
 func TestAccAWSElasticacheReplicationGroup_enableSnapshotting(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
 	var rg elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_elasticache_replication_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -437,18 +540,23 @@ func TestAccAWSElasticacheReplicationGroup_enableSnapshotting(t *testing.T) {
 			{
 				Config: testAccAWSElasticacheReplicationGroupConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
+					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.test", &rg),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "snapshot_retention_limit", "0"),
+						"aws_elasticache_replication_group.test", "snapshot_retention_limit", "0"),
 				),
 			},
-
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
 			{
 				Config: testAccAWSElasticacheReplicationGroupConfigEnableSnapshotting(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
+					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.test", &rg),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "snapshot_retention_limit", "2"),
+						"aws_elasticache_replication_group.test", "snapshot_retention_limit", "2"),
 				),
 			},
 		},
@@ -456,7 +564,13 @@ func TestAccAWSElasticacheReplicationGroup_enableSnapshotting(t *testing.T) {
 }
 
 func TestAccAWSElasticacheReplicationGroup_enableAuthTokenTransitEncryption(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
 	var rg elasticache.ReplicationGroup
+	resourceName := "aws_elasticache_replication_group.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -465,17 +579,29 @@ func TestAccAWSElasticacheReplicationGroup_enableAuthTokenTransitEncryption(t *t
 			{
 				Config: testAccAWSElasticacheReplicationGroup_EnableAuthTokenTransitEncryptionConfig(acctest.RandInt(), acctest.RandString(10), acctest.RandString(16)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
+					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.test", &rg),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "transit_encryption_enabled", "true"),
+						"aws_elasticache_replication_group.test", "transit_encryption_enabled", "true"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately", "auth_token", "availability_zones"},
 			},
 		},
 	})
 }
 
 func TestAccAWSElasticacheReplicationGroup_enableAtRestEncryption(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
 	var rg elasticache.ReplicationGroup
+	resourceName := "aws_elasticache_replication_group.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -484,16 +610,26 @@ func TestAccAWSElasticacheReplicationGroup_enableAtRestEncryption(t *testing.T) 
 			{
 				Config: testAccAWSElasticacheReplicationGroup_EnableAtRestEncryptionConfig(acctest.RandInt(), acctest.RandString(10)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
+					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.test", &rg),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "at_rest_encryption_enabled", "true"),
+						"aws_elasticache_replication_group.test", "at_rest_encryption_enabled", "true"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately", "availability_zones"},
 			},
 		},
 	})
 }
 
 func TestAccAWSElasticacheReplicationGroup_NumberCacheClusters(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
 	var replicationGroup elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_replication_group.test"
@@ -510,6 +646,12 @@ func TestAccAWSElasticacheReplicationGroup_NumberCacheClusters(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "2"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
 			},
 			{
 				Config: testAccAWSElasticacheReplicationGroupConfig_NumberCacheClusters(rName, 4, false),
@@ -532,6 +674,10 @@ func TestAccAWSElasticacheReplicationGroup_NumberCacheClusters(t *testing.T) {
 }
 
 func TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverDisabled(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
 	var replicationGroup elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_replication_group.test"
@@ -548,6 +694,12 @@ func TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFail
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "3"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
 			},
 			{
 				PreConfig: func() {
@@ -577,6 +729,10 @@ func TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFail
 }
 
 func TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverEnabled(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
 	var replicationGroup elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_replication_group.test"
@@ -736,7 +892,7 @@ provider "aws" {
   region = "us-east-1"
 }
 
-resource "aws_security_group" "bar" {
+resource "aws_security_group" "test" {
   name        = %[1]q
   description = "tf-test-security-group-descr"
 
@@ -748,19 +904,19 @@ resource "aws_security_group" "bar" {
   }
 }
 
-resource "aws_elasticache_security_group" "bar" {
+resource "aws_elasticache_security_group" "test" {
   name                 = %[1]q
   description          = "tf-test-security-group-descr"
-  security_group_names = ["${aws_security_group.bar.name}"]
+  security_group_names = ["${aws_security_group.test.name}"]
 }
 
-resource "aws_elasticache_replication_group" "bar" {
+resource "aws_elasticache_replication_group" "test" {
   replication_group_id          = %[1]q
   replication_group_description = "test description"
   node_type                     = "cache.m1.small"
   number_cache_clusters         = 2
   port                          = 6379
-  security_group_names          = ["${aws_elasticache_security_group.bar.name}"]
+  security_group_names          = ["${aws_elasticache_security_group.test.name}"]
   apply_immediately             = true
   auto_minor_version_upgrade    = false
   maintenance_window            = "tue:06:30-tue:07:30"
@@ -800,7 +956,7 @@ resource "aws_elasticache_subnet_group" "test" {
   subnet_ids = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
 }
 
-resource "aws_elasticache_replication_group" "bar" {
+resource "aws_elasticache_replication_group" "test" {
   node_type                     = "cache.t2.micro"
   number_cache_clusters         = 1
   port                          = 6379
@@ -817,7 +973,7 @@ provider "aws" {
   region = "us-east-1"
 }
 
-resource "aws_security_group" "bar" {
+resource "aws_security_group" "test" {
   name        = %[1]q
   description = "tf-test-security-group-descr"
 
@@ -829,19 +985,19 @@ resource "aws_security_group" "bar" {
   }
 }
 
-resource "aws_elasticache_security_group" "bar" {
+resource "aws_elasticache_security_group" "test" {
   name                 = %[1]q
   description          = "tf-test-security-group-descr"
-  security_group_names = ["${aws_security_group.bar.name}"]
+  security_group_names = ["${aws_security_group.test.name}"]
 }
 
-resource "aws_elasticache_replication_group" "bar" {
+resource "aws_elasticache_replication_group" "test" {
   replication_group_id          = %[1]q
   replication_group_description = "test description"
   node_type                     = "cache.m1.small"
   number_cache_clusters         = 2
   port                          = 6379
-  security_group_names          = ["${aws_elasticache_security_group.bar.name}"]
+  security_group_names          = ["${aws_elasticache_security_group.test.name}"]
   apply_immediately             = true
   auto_minor_version_upgrade    = false
   maintenance_window            = "tue:06:30-tue:07:30"
@@ -885,7 +1041,7 @@ provider "aws" {
   region = "us-east-1"
 }
 
-resource "aws_security_group" "bar" {
+resource "aws_security_group" "test" {
   name        = %[1]q
   description = "tf-test-security-group-descr"
 
@@ -897,19 +1053,19 @@ resource "aws_security_group" "bar" {
   }
 }
 
-resource "aws_elasticache_security_group" "bar" {
+resource "aws_elasticache_security_group" "test" {
   name                 = %[1]q
   description          = "tf-test-security-group-descr"
-  security_group_names = ["${aws_security_group.bar.name}"]
+  security_group_names = ["${aws_security_group.test.name}"]
 }
 
-resource "aws_elasticache_replication_group" "bar" {
+resource "aws_elasticache_replication_group" "test" {
   replication_group_id          = %[1]q
   replication_group_description = "updated description"
   node_type                     = "cache.m1.small"
   number_cache_clusters         = 2
   port                          = 6379
-  security_group_names          = ["${aws_elasticache_security_group.bar.name}"]
+  security_group_names          = ["${aws_elasticache_security_group.test.name}"]
   apply_immediately             = true
   auto_minor_version_upgrade    = true
 }
@@ -922,7 +1078,7 @@ provider "aws" {
   region = "us-east-1"
 }
 
-resource "aws_security_group" "bar" {
+resource "aws_security_group" "test" {
   name        = %[1]q
   description = "tf-test-security-group-descr"
 
@@ -934,19 +1090,19 @@ resource "aws_security_group" "bar" {
   }
 }
 
-resource "aws_elasticache_security_group" "bar" {
+resource "aws_elasticache_security_group" "test" {
   name                 = %[1]q
   description          = "tf-test-security-group-descr"
-  security_group_names = ["${aws_security_group.bar.name}"]
+  security_group_names = ["${aws_security_group.test.name}"]
 }
 
-resource "aws_elasticache_replication_group" "bar" {
+resource "aws_elasticache_replication_group" "test" {
   replication_group_id          = %[1]q
   replication_group_description = "updated description"
   node_type                     = "cache.m1.small"
   number_cache_clusters         = 2
   port                          = 6379
-  security_group_names          = ["${aws_elasticache_security_group.bar.name}"]
+  security_group_names          = ["${aws_elasticache_security_group.test.name}"]
   apply_immediately             = true
   auto_minor_version_upgrade    = true
   maintenance_window            = "wed:03:00-wed:06:00"
@@ -961,7 +1117,7 @@ provider "aws" {
   region = "us-east-1"
 }
 
-resource "aws_security_group" "bar" {
+resource "aws_security_group" "test" {
   name        = %[1]q
   description = "tf-test-security-group-descr"
 
@@ -973,19 +1129,19 @@ resource "aws_security_group" "bar" {
   }
 }
 
-resource "aws_elasticache_security_group" "bar" {
+resource "aws_elasticache_security_group" "test" {
   name                 = %[1]q
   description          = "tf-test-security-group-descr"
-  security_group_names = ["${aws_security_group.bar.name}"]
+  security_group_names = ["${aws_security_group.test.name}"]
 }
 
-resource "aws_elasticache_replication_group" "bar" {
+resource "aws_elasticache_replication_group" "test" {
   replication_group_id          = %[1]q
   replication_group_description = "updated description"
   node_type                     = "cache.m1.medium"
   number_cache_clusters         = 2
   port                          = 6379
-  security_group_names          = ["${aws_elasticache_security_group.bar.name}"]
+  security_group_names          = ["${aws_elasticache_security_group.test.name}"]
   apply_immediately             = true
 }
 `, rName)
@@ -998,15 +1154,15 @@ data "aws_availability_zones" "available" {
   state                = "available"
 }
 
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
     cidr_block = "192.168.0.0/16"
   tags = {
         Name = "terraform-testacc-elasticache-replication-group-in-vpc"
     }
 }
 
-resource "aws_subnet" "foo" {
-    vpc_id = "${aws_vpc.foo.id}"
+resource "aws_subnet" "test" {
+    vpc_id = "${aws_vpc.test.id}"
     cidr_block = "192.168.0.0/20"
     availability_zone = "${data.aws_availability_zones.available.names[0]}"
   tags = {
@@ -1014,16 +1170,16 @@ resource "aws_subnet" "foo" {
     }
 }
 
-resource "aws_elasticache_subnet_group" "bar" {
+resource "aws_elasticache_subnet_group" "test" {
     name = "tf-test-cache-subnet-%03d"
     description = "tf-test-cache-subnet-group-descr"
-    subnet_ids = ["${aws_subnet.foo.id}"]
+    subnet_ids = ["${aws_subnet.test.id}"]
 }
 
-resource "aws_security_group" "bar" {
+resource "aws_security_group" "test" {
     name = "tf-test-security-group-%03d"
     description = "tf-test-security-group-descr"
-    vpc_id = "${aws_vpc.foo.id}"
+    vpc_id = "${aws_vpc.test.id}"
     ingress {
         from_port = -1
         to_port = -1
@@ -1032,14 +1188,14 @@ resource "aws_security_group" "bar" {
     }
 }
 
-resource "aws_elasticache_replication_group" "bar" {
+resource "aws_elasticache_replication_group" "test" {
     replication_group_id = "tf-%s"
     replication_group_description = "test description"
     node_type = "cache.m1.small"
     number_cache_clusters = 1
     port = 6379
-    subnet_group_name = "${aws_elasticache_subnet_group.bar.name}"
-    security_group_ids = ["${aws_security_group.bar.id}"]
+    subnet_group_name = "${aws_elasticache_subnet_group.test.name}"
+    security_group_ids = ["${aws_security_group.test.id}"]
     availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
     auto_minor_version_upgrade = false
 }
@@ -1051,45 +1207,40 @@ data "aws_availability_zones" "available" {
   blacklisted_zone_ids = ["use1-az1"]
   state                = "available"
 }
-
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
     cidr_block = "192.168.0.0/16"
   tags = {
         Name = "terraform-testacc-elasticache-replication-group-multi-az-in-vpc"
     }
 }
-
-resource "aws_subnet" "foo" {
-    vpc_id = "${aws_vpc.foo.id}"
+resource "aws_subnet" "test" {
+    vpc_id = "${aws_vpc.test.id}"
     cidr_block = "192.168.0.0/20"
     availability_zone = "${data.aws_availability_zones.available.names[0]}"
   tags = {
         Name = "tf-acc-elasticache-replication-group-multi-az-in-vpc-foo"
     }
 }
-
-resource "aws_subnet" "bar" {
-    vpc_id = "${aws_vpc.foo.id}"
+resource "aws_subnet" "test2" {
+    vpc_id = "${aws_vpc.test.id}"
     cidr_block = "192.168.16.0/20"
     availability_zone = "${data.aws_availability_zones.available.names[1]}"
   tags = {
         Name = "tf-acc-elasticache-replication-group-multi-az-in-vpc-bar"
     }
 }
-
-resource "aws_elasticache_subnet_group" "bar" {
+resource "aws_elasticache_subnet_group" "test" {
     name = "tf-test-cache-subnet-%03d"
     description = "tf-test-cache-subnet-group-descr"
     subnet_ids = [
-        "${aws_subnet.foo.id}",
-        "${aws_subnet.bar.id}"
+        "${aws_subnet.test.id}",
+        "${aws_subnet.test2.id}"
     ]
 }
-
-resource "aws_security_group" "bar" {
+resource "aws_security_group" "test" {
     name = "tf-test-security-group-%03d"
     description = "tf-test-security-group-descr"
-    vpc_id = "${aws_vpc.foo.id}"
+    vpc_id = "${aws_vpc.test.id}"
     ingress {
         from_port = -1
         to_port = -1
@@ -1097,15 +1248,14 @@ resource "aws_security_group" "bar" {
         cidr_blocks = ["0.0.0.0/0"]
     }
 }
-
-resource "aws_elasticache_replication_group" "bar" {
+resource "aws_elasticache_replication_group" "test" {
     replication_group_id = "tf-%s"
     replication_group_description = "test description"
     node_type = "cache.m1.small"
     number_cache_clusters = 2
     port = 6379
-    subnet_group_name = "${aws_elasticache_subnet_group.bar.name}"
-    security_group_ids = ["${aws_security_group.bar.id}"]
+    subnet_group_name = "${aws_elasticache_subnet_group.test.name}"
+    security_group_ids = ["${aws_security_group.test.id}"]
     availability_zones = ["${data.aws_availability_zones.available.names[0]}","${data.aws_availability_zones.available.names[1]}"]
     automatic_failover_enabled = true
     snapshot_window = "02:00-03:00"
@@ -1115,73 +1265,67 @@ resource "aws_elasticache_replication_group" "bar" {
 
 var testAccAWSElasticacheReplicationGroupRedisClusterInVPCConfig = fmt.Sprintf(`
 data "aws_availability_zones" "available" {
-  # InvalidParameterValue: Specified node type cache.m3.medium is not available in AZ us-east-1b.
-  blacklisted_zone_ids = ["use1-az1"]
-  state                = "available"
-}
-
-resource "aws_vpc" "foo" {
-    cidr_block = "192.168.0.0/16"
-  tags = {
-        Name = "terraform-testacc-elasticache-replication-group-redis-cluster-in-vpc"
-    }
-}
-
-resource "aws_subnet" "foo" {
-    vpc_id = "${aws_vpc.foo.id}"
-    cidr_block = "192.168.0.0/20"
-    availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  tags = {
-        Name = "tf-acc-elasticache-replication-group-redis-cluster-in-vpc-foo"
-    }
-}
-
-resource "aws_subnet" "bar" {
-    vpc_id = "${aws_vpc.foo.id}"
-    cidr_block = "192.168.16.0/20"
-    availability_zone = "${data.aws_availability_zones.available.names[1]}"
-  tags = {
-        Name = "tf-acc-elasticache-replication-group-redis-cluster-in-vpc-bar"
-    }
-}
-
-resource "aws_elasticache_subnet_group" "bar" {
-    name = "tf-test-cache-subnet-%03d"
-    description = "tf-test-cache-subnet-group-descr"
-    subnet_ids = [
-        "${aws_subnet.foo.id}",
-        "${aws_subnet.bar.id}"
-    ]
-}
-
-resource "aws_security_group" "bar" {
-    name = "tf-test-security-group-%03d"
-    description = "tf-test-security-group-descr"
-    vpc_id = "${aws_vpc.foo.id}"
-    ingress {
-        from_port = -1
-        to_port = -1
-        protocol = "icmp"
-        cidr_blocks = ["0.0.0.0/0"]
-    }
-}
-
-resource "aws_elasticache_replication_group" "bar" {
-    replication_group_id = "tf-%s"
-    replication_group_description = "test description"
-    node_type = "cache.m3.medium"
-    number_cache_clusters = "2"
-    port = 6379
-    subnet_group_name = "${aws_elasticache_subnet_group.bar.name}"
-    security_group_ids = ["${aws_security_group.bar.id}"]
-    availability_zones = ["${data.aws_availability_zones.available.names[0]}","${data.aws_availability_zones.available.names[1]}"]
-    automatic_failover_enabled = false
-    snapshot_window = "02:00-03:00"
-    snapshot_retention_limit = 7
-    engine_version = "3.2.4"
-    maintenance_window = "thu:03:00-thu:04:00"
-}
-`, acctest.RandInt(), acctest.RandInt(), acctest.RandString(10))
+	# InvalidParameterValue: Specified node type cache.m3.medium is not available in AZ us-east-1b.
+	blacklisted_zone_ids = ["use1-az1"]
+	state                = "available"
+  }
+  resource "aws_vpc" "test" {
+	  cidr_block = "192.168.0.0/16"
+	tags = {
+		  Name = "terraform-testacc-elasticache-replication-group-redis-cluster-in-vpc"
+	  }
+  }
+  resource "aws_subnet" "test" {
+	  vpc_id = "${aws_vpc.test.id}"
+	  cidr_block = "192.168.0.0/20"
+	  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+	tags = {
+		  Name = "tf-acc-elasticache-replication-group-redis-cluster-in-vpc-foo"
+	  }
+  }
+  resource "aws_subnet" "test2" {
+	  vpc_id = "${aws_vpc.test.id}"
+	  cidr_block = "192.168.16.0/20"
+	  availability_zone = "${data.aws_availability_zones.available.names[1]}"
+	tags = {
+		  Name = "tf-acc-elasticache-replication-group-redis-cluster-in-vpc-bar"
+	  }
+  }
+  resource "aws_elasticache_subnet_group" "test" {
+	  name = "tf-test-cache-subnet-%03d"
+	  description = "tf-test-cache-subnet-group-descr"
+	  subnet_ids = [
+		  "${aws_subnet.test.id}",
+		  "${aws_subnet.test2.id}"
+	  ]
+  }
+  resource "aws_security_group" "test" {
+	  name = "tf-test-security-group-%03d"
+	  description = "tf-test-security-group-descr"
+	  vpc_id = "${aws_vpc.test.id}"
+	  ingress {
+		  from_port = -1
+		  to_port = -1
+		  protocol = "icmp"
+		  cidr_blocks = ["0.0.0.0/0"]
+	  }
+  }
+  resource "aws_elasticache_replication_group" "test" {
+	  replication_group_id = "tf-%s"
+	  replication_group_description = "test description"
+	  node_type = "cache.m3.medium"
+	  number_cache_clusters = "2"
+	  port = 6379
+	  subnet_group_name = "${aws_elasticache_subnet_group.test.name}"
+	  security_group_ids = ["${aws_security_group.test.id}"]
+	  availability_zones = ["${data.aws_availability_zones.available.names[0]}","${data.aws_availability_zones.available.names[1]}"]
+	  automatic_failover_enabled = false
+	  snapshot_window = "02:00-03:00"
+	  snapshot_retention_limit = 7
+	  engine_version = "3.2.4"
+	  maintenance_window = "thu:03:00-thu:04:00"
+  }
+  `, acctest.RandInt(), acctest.RandInt(), acctest.RandString(10))
 
 func testAccAWSElasticacheReplicationGroupNativeRedisClusterErrorConfig(rInt int, rName string) string {
 	return fmt.Sprintf(`
@@ -1189,7 +1333,7 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
   cidr_block = "192.168.0.0/16"
 
   tags = {
@@ -1197,40 +1341,40 @@ resource "aws_vpc" "foo" {
   }
 }
 
-resource "aws_subnet" "foo" {
-  vpc_id            = "${aws_vpc.foo.id}"
+resource "aws_subnet" "test" {
+  vpc_id            = "${aws_vpc.test.id}"
   cidr_block        = "192.168.0.0/20"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
 
   tags = {
-    Name = "tf-acc-elasticache-replication-group-native-redis-cluster-err-foo"
+    Name = "tf-acc-elasticache-replication-group-native-redis-cluster-err-test"
   }
 }
 
-resource "aws_subnet" "bar" {
-  vpc_id            = "${aws_vpc.foo.id}"
+resource "aws_subnet" "test2" {
+  vpc_id            = "${aws_vpc.test.id}"
   cidr_block        = "192.168.16.0/20"
   availability_zone = "${data.aws_availability_zones.available.names[1]}"
 
   tags = {
-    Name = "tf-acc-elasticache-replication-group-native-redis-cluster-err-bar"
+    Name = "tf-acc-elasticache-replication-group-native-redis-cluster-err-test"
   }
 }
 
-resource "aws_elasticache_subnet_group" "bar" {
+resource "aws_elasticache_subnet_group" "test" {
   name        = "tf-test-cache-subnet-%03d"
   description = "tf-test-cache-subnet-group-descr"
 
   subnet_ids = [
-    "${aws_subnet.foo.id}",
-    "${aws_subnet.bar.id}",
+    "${aws_subnet.test.id}",
+    "${aws_subnet.test.id}",
   ]
 }
 
-resource "aws_security_group" "bar" {
+resource "aws_security_group" "test" {
   name        = "tf-test-security-group-%03d"
   description = "tf-test-security-group-descr"
-  vpc_id      = "${aws_vpc.foo.id}"
+  vpc_id      = "${aws_vpc.test.id}"
 
   ingress {
     from_port   = -1
@@ -1240,13 +1384,13 @@ resource "aws_security_group" "bar" {
   }
 }
 
-resource "aws_elasticache_replication_group" "bar" {
+resource "aws_elasticache_replication_group" "test" {
   replication_group_id          = "tf-%s"
   replication_group_description = "test description"
   node_type                     = "cache.t2.micro"
   port                          = 6379
-  subnet_group_name             = "${aws_elasticache_subnet_group.bar.name}"
-  security_group_ids            = ["${aws_security_group.bar.id}"]
+  subnet_group_name             = "${aws_elasticache_subnet_group.test.name}"
+  security_group_ids            = ["${aws_security_group.test.id}"]
   automatic_failover_enabled    = true
 
   cluster_mode {
@@ -1265,7 +1409,7 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
   cidr_block = "192.168.0.0/16"
 
   tags = {
@@ -1273,40 +1417,40 @@ resource "aws_vpc" "foo" {
   }
 }
 
-resource "aws_subnet" "foo" {
-  vpc_id            = "${aws_vpc.foo.id}"
+resource "aws_subnet" "test" {
+  vpc_id            = "${aws_vpc.test.id}"
   cidr_block        = "192.168.0.0/20"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
 
   tags = {
-    Name = "tf-acc-elasticache-replication-group-native-redis-cluster-foo"
+    Name = "tf-acc-elasticache-replication-group-native-redis-cluster-test"
   }
 }
 
-resource "aws_subnet" "bar" {
-  vpc_id            = "${aws_vpc.foo.id}"
+resource "aws_subnet" "test2" {
+  vpc_id            = "${aws_vpc.test.id}"
   cidr_block        = "192.168.16.0/20"
   availability_zone = "${data.aws_availability_zones.available.names[1]}"
 
   tags = {
-    Name = "tf-acc-elasticache-replication-group-native-redis-cluster-bar"
+    Name = "tf-acc-elasticache-replication-group-native-redis-cluster-test"
   }
 }
 
-resource "aws_elasticache_subnet_group" "bar" {
+resource "aws_elasticache_subnet_group" "test" {
   name        = "tf-test-%[1]s"
   description = "tf-test-cache-subnet-group-descr"
 
   subnet_ids = [
-    "${aws_subnet.foo.id}",
-    "${aws_subnet.bar.id}",
+    "${aws_subnet.test.id}",
+    "${aws_subnet.test.id}",
   ]
 }
 
-resource "aws_security_group" "bar" {
+resource "aws_security_group" "test" {
   name        = "tf-test-%[1]s"
   description = "tf-test-security-group-descr"
-  vpc_id      = "${aws_vpc.foo.id}"
+  vpc_id      = "${aws_vpc.test.id}"
 
   ingress {
     from_port   = -1
@@ -1316,13 +1460,13 @@ resource "aws_security_group" "bar" {
   }
 }
 
-resource "aws_elasticache_replication_group" "bar" {
+resource "aws_elasticache_replication_group" "test" {
   replication_group_id          = "tf-%[1]s"
   replication_group_description = "test description"
   node_type                     = "cache.t2.micro"
   port                          = 6379
-  subnet_group_name             = "${aws_elasticache_subnet_group.bar.name}"
-  security_group_ids            = ["${aws_security_group.bar.id}"]
+  subnet_group_name             = "${aws_elasticache_subnet_group.test.name}"
+  security_group_ids            = ["${aws_security_group.test.id}"]
   automatic_failover_enabled    = true
 
   cluster_mode {
@@ -1339,7 +1483,7 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
   cidr_block = "192.168.0.0/16"
 
   tags = {
@@ -1347,8 +1491,8 @@ resource "aws_vpc" "foo" {
   }
 }
 
-resource "aws_subnet" "foo" {
-  vpc_id            = "${aws_vpc.foo.id}"
+resource "aws_subnet" "test" {
+  vpc_id            = "${aws_vpc.test.id}"
   cidr_block        = "192.168.0.0/20"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
 
@@ -1357,19 +1501,19 @@ resource "aws_subnet" "foo" {
   }
 }
 
-resource "aws_elasticache_subnet_group" "bar" {
+resource "aws_elasticache_subnet_group" "test" {
   name        = "tf-test-cache-subnet-%03d"
   description = "tf-test-cache-subnet-group-descr"
 
   subnet_ids = [
-    "${aws_subnet.foo.id}",
+    "${aws_subnet.test.id}",
   ]
 }
 
-resource "aws_security_group" "bar" {
+resource "aws_security_group" "test" {
   name        = "tf-test-security-group-%03d"
   description = "tf-test-security-group-descr"
-  vpc_id      = "${aws_vpc.foo.id}"
+  vpc_id      = "${aws_vpc.test.id}"
 
   ingress {
     from_port   = -1
@@ -1379,14 +1523,14 @@ resource "aws_security_group" "bar" {
   }
 }
 
-resource "aws_elasticache_replication_group" "bar" {
+resource "aws_elasticache_replication_group" "test" {
   replication_group_id          = "tf-%s"
   replication_group_description = "test description"
   node_type                     = "cache.t2.micro"
   number_cache_clusters         = "1"
   port                          = 6379
-  subnet_group_name             = "${aws_elasticache_subnet_group.bar.name}"
-  security_group_ids            = ["${aws_security_group.bar.id}"]
+  subnet_group_name             = "${aws_elasticache_subnet_group.test.name}"
+  security_group_ids            = ["${aws_security_group.test.id}"]
   parameter_group_name          = "default.redis3.2"
   availability_zones            = ["${data.aws_availability_zones.available.names[0]}"]
   engine_version                = "3.2.6"
@@ -1401,7 +1545,7 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
   cidr_block = "192.168.0.0/16"
 
   tags = {
@@ -1409,8 +1553,8 @@ resource "aws_vpc" "foo" {
   }
 }
 
-resource "aws_subnet" "foo" {
-  vpc_id            = "${aws_vpc.foo.id}"
+resource "aws_subnet" "test" {
+  vpc_id            = "${aws_vpc.test.id}"
   cidr_block        = "192.168.0.0/20"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
 
@@ -1419,19 +1563,19 @@ resource "aws_subnet" "foo" {
   }
 }
 
-resource "aws_elasticache_subnet_group" "bar" {
+resource "aws_elasticache_subnet_group" "test" {
   name        = "tf-test-cache-subnet-%03d"
   description = "tf-test-cache-subnet-group-descr"
 
   subnet_ids = [
-    "${aws_subnet.foo.id}",
+    "${aws_subnet.test.id}",
   ]
 }
 
-resource "aws_security_group" "bar" {
+resource "aws_security_group" "test" {
   name        = "tf-test-security-group-%03d"
   description = "tf-test-security-group-descr"
-  vpc_id      = "${aws_vpc.foo.id}"
+  vpc_id      = "${aws_vpc.test.id}"
 
   ingress {
     from_port   = -1
@@ -1441,14 +1585,14 @@ resource "aws_security_group" "bar" {
   }
 }
 
-resource "aws_elasticache_replication_group" "bar" {
+resource "aws_elasticache_replication_group" "test" {
   replication_group_id          = "tf-%s"
   replication_group_description = "test description"
   node_type                     = "cache.t2.micro"
   number_cache_clusters         = "1"
   port                          = 6379
-  subnet_group_name             = "${aws_elasticache_subnet_group.bar.name}"
-  security_group_ids            = ["${aws_security_group.bar.id}"]
+  subnet_group_name             = "${aws_elasticache_subnet_group.test.name}"
+  security_group_ids            = ["${aws_security_group.test.id}"]
   parameter_group_name          = "default.redis3.2"
   availability_zones            = ["${data.aws_availability_zones.available.names[0]}"]
   engine_version                = "3.2.6"

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -58,6 +59,10 @@ func testSweepElasticacheReplicationGroups(region string) error {
 }
 
 func TestAccAWSElasticacheReplicationGroup_basic(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
 	var rg elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_replication_group.test"
@@ -120,6 +125,10 @@ func TestAccAWSElasticacheReplicationGroup_Uppercase(t *testing.T) {
 }
 
 func TestAccAWSElasticacheReplicationGroup_updateDescription(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
 	var rg elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_replication_group.test"
@@ -164,6 +173,10 @@ func TestAccAWSElasticacheReplicationGroup_updateDescription(t *testing.T) {
 }
 
 func TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
 	var rg elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_replication_group.test"
@@ -200,6 +213,10 @@ func TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow(t *testing.T)
 }
 
 func TestAccAWSElasticacheReplicationGroup_updateNodeSize(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
 	var rg elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_replication_group.test"
@@ -475,6 +492,10 @@ func TestAccAWSElasticacheReplicationGroup_clusteringAndCacheNodesCausesError(t 
 }
 
 func TestAccAWSElasticacheReplicationGroup_enableSnapshotting(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
 	var rg elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_replication_group.test"

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -59,10 +58,6 @@ func testSweepElasticacheReplicationGroups(region string) error {
 }
 
 func TestAccAWSElasticacheReplicationGroup_basic(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	var rg elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_replication_group.test"
@@ -97,10 +92,6 @@ func TestAccAWSElasticacheReplicationGroup_basic(t *testing.T) {
 }
 
 func TestAccAWSElasticacheReplicationGroup_Uppercase(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	var rg elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_replication_group.test"
@@ -129,10 +120,6 @@ func TestAccAWSElasticacheReplicationGroup_Uppercase(t *testing.T) {
 }
 
 func TestAccAWSElasticacheReplicationGroup_updateDescription(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	var rg elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_replication_group.test"
@@ -177,10 +164,6 @@ func TestAccAWSElasticacheReplicationGroup_updateDescription(t *testing.T) {
 }
 
 func TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	var rg elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_replication_group.test"
@@ -217,10 +200,6 @@ func TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow(t *testing.T)
 }
 
 func TestAccAWSElasticacheReplicationGroup_updateNodeSize(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	var rg elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_replication_group.test"
@@ -262,10 +241,6 @@ func TestAccAWSElasticacheReplicationGroup_updateNodeSize(t *testing.T) {
 
 //This is a test to prove that we panic we get in https://github.com/hashicorp/terraform/issues/9097
 func TestAccAWSElasticacheReplicationGroup_updateParameterGroup(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	var rg elasticache.ReplicationGroup
 	parameterGroupResourceName1 := "aws_elasticache_parameter_group.test.0"
 	parameterGroupResourceName2 := "aws_elasticache_parameter_group.test.1"
@@ -302,10 +277,6 @@ func TestAccAWSElasticacheReplicationGroup_updateParameterGroup(t *testing.T) {
 }
 
 func TestAccAWSElasticacheReplicationGroup_vpc(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	var rg elasticache.ReplicationGroup
 	resourceName := "aws_elasticache_replication_group.test"
 
@@ -335,10 +306,6 @@ func TestAccAWSElasticacheReplicationGroup_vpc(t *testing.T) {
 }
 
 func TestAccAWSElasticacheReplicationGroup_multiAzInVpc(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	var rg elasticache.ReplicationGroup
 	resourceName := "aws_elasticache_replication_group.test"
 
@@ -374,10 +341,6 @@ func TestAccAWSElasticacheReplicationGroup_multiAzInVpc(t *testing.T) {
 }
 
 func TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	var rg elasticache.ReplicationGroup
 	resourceName := "aws_elasticache_replication_group.test"
 
@@ -413,10 +376,6 @@ func TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2(t *testing.T) {
 }
 
 func TestAccAWSElasticacheReplicationGroup_ClusterMode_Basic(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	var rg elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_replication_group.test"
@@ -449,10 +408,6 @@ func TestAccAWSElasticacheReplicationGroup_ClusterMode_Basic(t *testing.T) {
 }
 
 func TestAccAWSElasticacheReplicationGroup_ClusterMode_NumNodeGroups(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	var rg elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_replication_group.test"
@@ -503,10 +458,6 @@ func TestAccAWSElasticacheReplicationGroup_ClusterMode_NumNodeGroups(t *testing.
 }
 
 func TestAccAWSElasticacheReplicationGroup_clusteringAndCacheNodesCausesError(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	rInt := acctest.RandInt()
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
@@ -524,10 +475,6 @@ func TestAccAWSElasticacheReplicationGroup_clusteringAndCacheNodesCausesError(t 
 }
 
 func TestAccAWSElasticacheReplicationGroup_enableSnapshotting(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	var rg elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_replication_group.test"
@@ -564,10 +511,6 @@ func TestAccAWSElasticacheReplicationGroup_enableSnapshotting(t *testing.T) {
 }
 
 func TestAccAWSElasticacheReplicationGroup_enableAuthTokenTransitEncryption(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	var rg elasticache.ReplicationGroup
 	resourceName := "aws_elasticache_replication_group.test"
 
@@ -595,10 +538,6 @@ func TestAccAWSElasticacheReplicationGroup_enableAuthTokenTransitEncryption(t *t
 }
 
 func TestAccAWSElasticacheReplicationGroup_enableAtRestEncryption(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	var rg elasticache.ReplicationGroup
 	resourceName := "aws_elasticache_replication_group.test"
 
@@ -626,10 +565,6 @@ func TestAccAWSElasticacheReplicationGroup_enableAtRestEncryption(t *testing.T) 
 }
 
 func TestAccAWSElasticacheReplicationGroup_NumberCacheClusters(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	var replicationGroup elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_replication_group.test"
@@ -674,10 +609,6 @@ func TestAccAWSElasticacheReplicationGroup_NumberCacheClusters(t *testing.T) {
 }
 
 func TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverDisabled(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	var replicationGroup elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_replication_group.test"
@@ -729,10 +660,6 @@ func TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFail
 }
 
 func TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverEnabled(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	var replicationGroup elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_replication_group.test"

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -75,15 +75,15 @@ func TestAccAWSElasticacheReplicationGroup_basic(t *testing.T) {
 			{
 				Config: testAccAWSElasticacheReplicationGroupConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.test", &rg),
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.test", "cluster_mode.#", "0"),
+						resourceName, "cluster_mode.#", "0"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.test", "number_cache_clusters", "2"),
+						resourceName, "number_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.test", "member_clusters.#", "2"),
+						resourceName, "member_clusters.#", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.test", "auto_minor_version_upgrade", "false"),
+						resourceName, "auto_minor_version_upgrade", "false"),
 				),
 			},
 			{
@@ -109,9 +109,9 @@ func TestAccAWSElasticacheReplicationGroup_Uppercase(t *testing.T) {
 			{
 				Config: testAccAWSElasticacheReplicationGroupConfig_Uppercase(strings.ToUpper(rName)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.test", &rg),
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.test", "replication_group_id", rName),
+						resourceName, "replication_group_id", rName),
 				),
 			},
 			{
@@ -141,13 +141,13 @@ func TestAccAWSElasticacheReplicationGroup_updateDescription(t *testing.T) {
 			{
 				Config: testAccAWSElasticacheReplicationGroupConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.test", &rg),
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.test", "number_cache_clusters", "2"),
+						resourceName, "number_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.test", "replication_group_description", "test description"),
+						resourceName, "replication_group_description", "test description"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.test", "auto_minor_version_upgrade", "false"),
+						resourceName, "auto_minor_version_upgrade", "false"),
 				),
 			},
 			{
@@ -159,13 +159,13 @@ func TestAccAWSElasticacheReplicationGroup_updateDescription(t *testing.T) {
 			{
 				Config: testAccAWSElasticacheReplicationGroupConfigUpdatedDescription(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.test", &rg),
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.test", "number_cache_clusters", "2"),
+						resourceName, "number_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.test", "replication_group_description", "updated description"),
+						resourceName, "replication_group_description", "updated description"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.test", "auto_minor_version_upgrade", "true"),
+						resourceName, "auto_minor_version_upgrade", "true"),
 				),
 			},
 		},
@@ -189,9 +189,9 @@ func TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow(t *testing.T)
 			{
 				Config: testAccAWSElasticacheReplicationGroupConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.test", &rg),
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.test", "maintenance_window", "tue:06:30-tue:07:30"),
+						resourceName, "maintenance_window", "tue:06:30-tue:07:30"),
 				),
 			},
 			{
@@ -203,9 +203,9 @@ func TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow(t *testing.T)
 			{
 				Config: testAccAWSElasticacheReplicationGroupConfigUpdatedMaintenanceWindow(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.test", &rg),
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.test", "maintenance_window", "wed:03:00-wed:06:00"),
+						resourceName, "maintenance_window", "wed:03:00-wed:06:00"),
 				),
 			},
 		},
@@ -229,11 +229,11 @@ func TestAccAWSElasticacheReplicationGroup_updateNodeSize(t *testing.T) {
 			{
 				Config: testAccAWSElasticacheReplicationGroupConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.test", &rg),
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.test", "number_cache_clusters", "2"),
+						resourceName, "number_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.test", "node_type", "cache.m1.small"),
+						resourceName, "node_type", "cache.m1.small"),
 				),
 			},
 			{
@@ -245,11 +245,11 @@ func TestAccAWSElasticacheReplicationGroup_updateNodeSize(t *testing.T) {
 			{
 				Config: testAccAWSElasticacheReplicationGroupConfigUpdatedNodeSize(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.test", &rg),
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.test", "number_cache_clusters", "2"),
+						resourceName, "number_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.test", "node_type", "cache.m1.medium"),
+						resourceName, "node_type", "cache.m1.medium"),
 				),
 			},
 		},
@@ -305,11 +305,11 @@ func TestAccAWSElasticacheReplicationGroup_vpc(t *testing.T) {
 			{
 				Config: testAccAWSElasticacheReplicationGroupInVPCConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.test", &rg),
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.test", "number_cache_clusters", "1"),
+						resourceName, "number_cache_clusters", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.test", "auto_minor_version_upgrade", "false"),
+						resourceName, "auto_minor_version_upgrade", "false"),
 				),
 			},
 			{
@@ -334,17 +334,17 @@ func TestAccAWSElasticacheReplicationGroup_multiAzInVpc(t *testing.T) {
 			{
 				Config: testAccAWSElasticacheReplicationGroupMultiAZInVPCConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.test", &rg),
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.test", "number_cache_clusters", "2"),
+						resourceName, "number_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.test", "automatic_failover_enabled", "true"),
+						resourceName, "automatic_failover_enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.test", "snapshot_window", "02:00-03:00"),
+						resourceName, "snapshot_window", "02:00-03:00"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.test", "snapshot_retention_limit", "7"),
+						resourceName, "snapshot_retention_limit", "7"),
 					resource.TestCheckResourceAttrSet(
-						"aws_elasticache_replication_group.test", "primary_endpoint_address"),
+						resourceName, "primary_endpoint_address"),
 				),
 			},
 			{
@@ -369,17 +369,17 @@ func TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2(t *testing.T) {
 			{
 				Config: testAccAWSElasticacheReplicationGroupRedisClusterInVPCConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.test", &rg),
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.test", "number_cache_clusters", "2"),
+						resourceName, "number_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.test", "automatic_failover_enabled", "false"),
+						resourceName, "automatic_failover_enabled", "false"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.test", "snapshot_window", "02:00-03:00"),
+						resourceName, "snapshot_window", "02:00-03:00"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.test", "snapshot_retention_limit", "7"),
+						resourceName, "snapshot_retention_limit", "7"),
 					resource.TestCheckResourceAttrSet(
-						"aws_elasticache_replication_group.test", "primary_endpoint_address"),
+						resourceName, "primary_endpoint_address"),
 				),
 			},
 			{
@@ -508,9 +508,9 @@ func TestAccAWSElasticacheReplicationGroup_enableSnapshotting(t *testing.T) {
 			{
 				Config: testAccAWSElasticacheReplicationGroupConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.test", &rg),
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.test", "snapshot_retention_limit", "0"),
+						resourceName, "snapshot_retention_limit", "0"),
 				),
 			},
 			{
@@ -522,9 +522,9 @@ func TestAccAWSElasticacheReplicationGroup_enableSnapshotting(t *testing.T) {
 			{
 				Config: testAccAWSElasticacheReplicationGroupConfigEnableSnapshotting(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.test", &rg),
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.test", "snapshot_retention_limit", "2"),
+						resourceName, "snapshot_retention_limit", "2"),
 				),
 			},
 		},
@@ -543,9 +543,9 @@ func TestAccAWSElasticacheReplicationGroup_enableAuthTokenTransitEncryption(t *t
 			{
 				Config: testAccAWSElasticacheReplicationGroup_EnableAuthTokenTransitEncryptionConfig(acctest.RandInt(), acctest.RandString(10), acctest.RandString(16)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.test", &rg),
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.test", "transit_encryption_enabled", "true"),
+						resourceName, "transit_encryption_enabled", "true"),
 				),
 			},
 			{
@@ -570,9 +570,9 @@ func TestAccAWSElasticacheReplicationGroup_enableAtRestEncryption(t *testing.T) 
 			{
 				Config: testAccAWSElasticacheReplicationGroup_EnableAtRestEncryptionConfig(acctest.RandInt(), acctest.RandString(10)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.test", &rg),
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.test", "at_rest_encryption_enabled", "true"),
+						resourceName, "at_rest_encryption_enabled", "true"),
 				),
 			},
 			{

--- a/aws/resource_aws_elasticache_security_group_test.go
+++ b/aws/resource_aws_elasticache_security_group_test.go
@@ -67,6 +67,13 @@ func testSweepElasticacheCacheSecurityGroups(region string) error {
 }
 
 func TestAccAWSElasticacheSecurityGroup_basic(t *testing.T) {
+	// Use EC2-Classic enabled us-east-1 for testing
+	oldRegion := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldRegion)
+
+	resourceName := "aws_elasticache_security_group.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -75,32 +82,13 @@ func TestAccAWSElasticacheSecurityGroup_basic(t *testing.T) {
 			{
 				Config: testAccAWSElasticacheSecurityGroupConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheSecurityGroupExists("aws_elasticache_security_group.bar"),
+					testAccCheckAWSElasticacheSecurityGroupExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_security_group.bar", "description", "Managed by Terraform"),
+						resourceName, "description", "Managed by Terraform"),
 				),
 			},
-		},
-	})
-}
-
-func TestAccAWSElasticacheSecurityGroup_Import(t *testing.T) {
-	// Use EC2-Classic enabled us-east-1 for testing
-	oldRegion := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldRegion)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSElasticacheSecurityGroupDestroy,
-		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSElasticacheSecurityGroupConfig,
-			},
-
-			{
-				ResourceName:      "aws_elasticache_security_group.bar",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -157,7 +145,7 @@ provider "aws" {
   region = "us-east-1"
 }
 
-resource "aws_security_group" "bar" {
+resource "aws_security_group" "test" {
   name = "tf-test-security-group-%03d"
 
   ingress {
@@ -168,8 +156,8 @@ resource "aws_security_group" "bar" {
   }
 }
 
-resource "aws_elasticache_security_group" "bar" {
+resource "aws_elasticache_security_group" "test" {
   name                 = "tf-test-security-group-%03d"
-  security_group_names = ["${aws_security_group.bar.name}"]
+  security_group_names = ["${aws_security_group.test.name}"]
 }
 `, acctest.RandInt(), acctest.RandInt())

--- a/aws/resource_aws_elasticache_subnet_group_test.go
+++ b/aws/resource_aws_elasticache_subnet_group_test.go
@@ -12,9 +12,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSElasticacheSubnetGroup_importBasic(t *testing.T) {
-	resourceName := "aws_elasticache_subnet_group.bar"
+func TestAccAWSElasticacheSubnetGroup_basic(t *testing.T) {
+	var csg elasticache.CacheSubnetGroup
 	config := fmt.Sprintf(testAccAWSElasticacheSubnetGroupConfig, acctest.RandInt())
+	resourceName := "aws_elasticache_subnet_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -23,8 +24,12 @@ func TestAccAWSElasticacheSubnetGroup_importBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheSubnetGroupExists(resourceName, &csg),
+					resource.TestCheckResourceAttr(
+						resourceName, "description", "Managed by Terraform"),
+				),
 			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
@@ -36,33 +41,12 @@ func TestAccAWSElasticacheSubnetGroup_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccAWSElasticacheSubnetGroup_basic(t *testing.T) {
-	var csg elasticache.CacheSubnetGroup
-	config := fmt.Sprintf(testAccAWSElasticacheSubnetGroupConfig, acctest.RandInt())
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSElasticacheSubnetGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheSubnetGroupExists("aws_elasticache_subnet_group.bar", &csg),
-					resource.TestCheckResourceAttr(
-						"aws_elasticache_subnet_group.bar", "description", "Managed by Terraform"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAWSElasticacheSubnetGroup_update(t *testing.T) {
 	var csg elasticache.CacheSubnetGroup
-	rn := "aws_elasticache_subnet_group.bar"
-	ri := acctest.RandInt()
-	preConfig := fmt.Sprintf(testAccAWSElasticacheSubnetGroupUpdateConfigPre, ri)
-	postConfig := fmt.Sprintf(testAccAWSElasticacheSubnetGroupUpdateConfigPost, ri)
+	resourceName := "aws_elasticache_subnet_group.test"
+	rInt := acctest.RandInt()
+	preConfig := fmt.Sprintf(testAccAWSElasticacheSubnetGroupUpdateConfigPre, rInt)
+	postConfig := fmt.Sprintf(testAccAWSElasticacheSubnetGroupUpdateConfigPost, rInt)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -72,16 +56,22 @@ func TestAccAWSElasticacheSubnetGroup_update(t *testing.T) {
 			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheSubnetGroupExists(rn, &csg),
-					testAccCheckAWSElastiCacheSubnetGroupAttrs(&csg, rn, 1),
+					testAccCheckAWSElasticacheSubnetGroupExists(resourceName, &csg),
+					testAccCheckAWSElastiCacheSubnetGroupAttrs(&csg, resourceName, 1),
 				),
 			},
-
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"description"},
+			},
 			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheSubnetGroupExists(rn, &csg),
-					testAccCheckAWSElastiCacheSubnetGroupAttrs(&csg, rn, 2),
+					testAccCheckAWSElasticacheSubnetGroupExists(resourceName, &csg),
+					testAccCheckAWSElastiCacheSubnetGroupAttrs(&csg, resourceName, 2),
 				),
 			},
 		},
@@ -181,7 +171,7 @@ resource "aws_subnet" "foo" {
     }
 }
 
-resource "aws_elasticache_subnet_group" "bar" {
+resource "aws_elasticache_subnet_group" "test" {
     // Including uppercase letters in this name to ensure
     // that we correctly handle the fact that the API
     // normalizes names to lowercase.
@@ -206,7 +196,7 @@ resource "aws_subnet" "foo" {
     }
 }
 
-resource "aws_elasticache_subnet_group" "bar" {
+resource "aws_elasticache_subnet_group" "test" {
     name = "tf-test-cache-subnet-%03d"
     description = "tf-test-cache-subnet-group-descr"
     subnet_ids = ["${aws_subnet.foo.id}"]
@@ -230,21 +220,21 @@ resource "aws_subnet" "foo" {
     }
 }
 
-resource "aws_subnet" "bar" {
+resource "aws_subnet" "test" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "10.0.2.0/24"
     availability_zone = "us-west-2a"
   tags = {
-        Name = "tf-acc-elasticache-subnet-group-update-bar"
+        Name = "tf-acc-elasticache-subnet-group-update-test"
     }
 }
 
-resource "aws_elasticache_subnet_group" "bar" {
+resource "aws_elasticache_subnet_group" "test" {
     name = "tf-test-cache-subnet-%03d"
     description = "tf-test-cache-subnet-group-descr-edited"
     subnet_ids = [
 			"${aws_subnet.foo.id}",
-			"${aws_subnet.bar.id}",
+			"${aws_subnet.test.id}",
 		]
 }
 `


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8944

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSElasticacheSubnetGroup_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSElasticacheSubnetGroup_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSElasticacheSubnetGroup_basic
=== PAUSE TestAccAWSElasticacheSubnetGroup_basic
=== RUN   TestAccAWSElasticacheSubnetGroup_update
=== PAUSE TestAccAWSElasticacheSubnetGroup_update
=== CONT  TestAccAWSElasticacheSubnetGroup_basic
=== CONT  TestAccAWSElasticacheSubnetGroup_update
--- PASS: TestAccAWSElasticacheSubnetGroup_basic (60.82s)
--- PASS: TestAccAWSElasticacheSubnetGroup_update (100.57s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       101.693s

 make testacc TESTARGS="-run=TestAccAWSElasticacheSecurityGroup_" ==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSElasticacheSecurityGroup_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSElasticacheSecurityGroup_basic
=== PAUSE TestAccAWSElasticacheSecurityGroup_basic
=== CONT  TestAccAWSElasticacheSecurityGroup_basic
--- PASS: TestAccAWSElasticacheSecurityGroup_basic (30.65s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       32.110s

make testacc TESTARGS="-run=TestAccAWSElasticacheReplicationGroup_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSElasticacheReplicationGroup_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSElasticacheReplicationGroup_basic
=== PAUSE TestAccAWSElasticacheReplicationGroup_basic
=== RUN   TestAccAWSElasticacheReplicationGroup_Uppercase
=== PAUSE TestAccAWSElasticacheReplicationGroup_Uppercase
=== RUN   TestAccAWSElasticacheReplicationGroup_updateDescription
=== PAUSE TestAccAWSElasticacheReplicationGroup_updateDescription
=== RUN   TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow
=== PAUSE TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow
=== RUN   TestAccAWSElasticacheReplicationGroup_updateNodeSize
=== PAUSE TestAccAWSElasticacheReplicationGroup_updateNodeSize
=== RUN   TestAccAWSElasticacheReplicationGroup_updateParameterGroup
=== PAUSE TestAccAWSElasticacheReplicationGroup_updateParameterGroup
=== RUN   TestAccAWSElasticacheReplicationGroup_vpc
=== PAUSE TestAccAWSElasticacheReplicationGroup_vpc
=== RUN   TestAccAWSElasticacheReplicationGroup_multiAzInVpc
=== PAUSE TestAccAWSElasticacheReplicationGroup_multiAzInVpc
=== RUN   TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2
=== PAUSE TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2
=== RUN   TestAccAWSElasticacheReplicationGroup_ClusterMode_Basic
=== PAUSE TestAccAWSElasticacheReplicationGroup_ClusterMode_Basic
=== RUN   TestAccAWSElasticacheReplicationGroup_ClusterMode_NumNodeGroups
=== PAUSE TestAccAWSElasticacheReplicationGroup_ClusterMode_NumNodeGroups
=== RUN   TestAccAWSElasticacheReplicationGroup_clusteringAndCacheNodesCausesError
=== PAUSE TestAccAWSElasticacheReplicationGroup_clusteringAndCacheNodesCausesError
=== RUN   TestAccAWSElasticacheReplicationGroup_enableSnapshotting
=== PAUSE TestAccAWSElasticacheReplicationGroup_enableSnapshotting
=== RUN   TestAccAWSElasticacheReplicationGroup_enableAuthTokenTransitEncryption
=== PAUSE TestAccAWSElasticacheReplicationGroup_enableAuthTokenTransitEncryption
=== RUN   TestAccAWSElasticacheReplicationGroup_enableAtRestEncryption
=== PAUSE TestAccAWSElasticacheReplicationGroup_enableAtRestEncryption
=== RUN   TestAccAWSElasticacheReplicationGroup_NumberCacheClusters
=== PAUSE TestAccAWSElasticacheReplicationGroup_NumberCacheClusters
=== RUN   TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverDisabled
=== PAUSE TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverDisabled
=== RUN   TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverEnabled
=== PAUSE TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverEnabled
=== CONT  TestAccAWSElasticacheReplicationGroup_basic
=== CONT  TestAccAWSElasticacheReplicationGroup_ClusterMode_Basic
=== CONT  TestAccAWSElasticacheReplicationGroup_updateParameterGroup
=== CONT  TestAccAWSElasticacheReplicationGroup_clusteringAndCacheNodesCausesError
=== CONT  TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverDisabled
=== CONT  TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverEnabled
=== CONT  TestAccAWSElasticacheReplicationGroup_ClusterMode_NumNodeGroups
=== CONT  TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2
=== CONT  TestAccAWSElasticacheReplicationGroup_enableAtRestEncryption
=== CONT  TestAccAWSElasticacheReplicationGroup_NumberCacheClusters
=== CONT  TestAccAWSElasticacheReplicationGroup_enableAuthTokenTransitEncryption
=== CONT  TestAccAWSElasticacheReplicationGroup_enableSnapshotting
=== CONT  TestAccAWSElasticacheReplicationGroup_vpc
=== CONT  TestAccAWSElasticacheReplicationGroup_multiAzInVpc
=== CONT  TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow
=== CONT  TestAccAWSElasticacheReplicationGroup_updateDescription
=== CONT  TestAccAWSElasticacheReplicationGroup_Uppercase
=== CONT  TestAccAWSElasticacheReplicationGroup_updateNodeSize
--- PASS: TestAccAWSElasticacheReplicationGroup_clusteringAndCacheNodesCausesError (34.95s)
--- PASS: TestAccAWSElasticacheReplicationGroup_enableAuthTokenTransitEncryption (768.76s)
--- PASS: TestAccAWSElasticacheReplicationGroup_enableAtRestEncryption (830.76s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateParameterGroup (942.71s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverDisabled (1198.03s)
--- PASS: TestAccAWSElasticacheReplicationGroup_Uppercase (1214.21s)
--- PASS: TestAccAWSElasticacheReplicationGroup_enableSnapshotting (1326.27s)
--- PASS: TestAccAWSElasticacheReplicationGroup_vpc (1326.94s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateDescription (1524.49s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateNodeSize (1654.44s)
--- PASS: TestAccAWSElasticacheReplicationGroup_basic (1813.96s)
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_Basic (1823.14s)
--- PASS: TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2 (1888.82s)
--- PASS: TestAccAWSElasticacheReplicationGroup_multiAzInVpc (2043.80s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow (2337.05s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters (2521.89s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverEnabled (3155.02s)
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_NumNodeGroups (3831.39s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       3832.449s
```
