### PR TITLE
Add support Import for aws_sns_topic_policy resource

### DIFF
--- a/aws/resource_aws_sns_topic_policy.go
+++ b/aws/resource_aws_sns_topic_policy.go
@@ -20,6 +20,10 @@ func resourceAwsSnsTopicPolicy() *schema.Resource {
 		Update: resourceAwsSnsTopicPolicyUpsert,
 		Delete: resourceAwsSnsTopicPolicyDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"arn": {
 				Type:     schema.TypeString,
@@ -91,6 +95,7 @@ func resourceAwsSnsTopicPolicyRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	d.Set("policy", policy)
+	d.Set("arn", attrmap["TopicArn"])
 
 	return nil
 }

--- a/aws/resource_aws_sns_topic_policy_test.go
+++ b/aws/resource_aws_sns_topic_policy_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestAccAWSSNSTopicPolicy_basic(t *testing.T) {
 	attributes := make(map[string]string)
+	resourceName := "aws_sns_topic_policy.custom"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -19,9 +20,14 @@ func TestAccAWSSNSTopicPolicy_basic(t *testing.T) {
 				Config: testAccAWSSNSTopicConfig_withPolicy,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSNSTopicExists("aws_sns_topic.test", attributes),
-					resource.TestMatchResourceAttr("aws_sns_topic_policy.custom", "policy",
+					resource.TestMatchResourceAttr(resourceName, "policy",
 						regexp.MustCompile("^{\"Version\":\"2012-10-17\".+")),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/website/docs/r/sns_topic_policy.html.markdown
+++ b/website/docs/r/sns_topic_policy.html.markdown
@@ -72,3 +72,12 @@ The following arguments are supported:
 
 * `arn` - (Required) The ARN of the SNS topic
 * `policy` - (Required) The fully-formed AWS policy as JSON. For more information about building AWS IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](/docs/providers/aws/guides/iam-policy-documents.html).
+
+## Import
+
+SNS Topic Policy can be imported using the topic ARN, e.g.
+
+```
+$ terraform import aws_sns_topic.user_updates arn:aws:sns:us-west-2:0123456789012:my-topic
+```
+


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9578

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
r/aws_sns_topic_policy: add support import
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSSNSTopicPolicy_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSSNSTopicPolicy_basic -timeout 120m
=== RUN   TestAccAWSSNSTopicPolicy_basic
=== PAUSE TestAccAWSSNSTopicPolicy_basic
=== CONT  TestAccAWSSNSTopicPolicy_basic
--- PASS: TestAccAWSSNSTopicPolicy_basic (33.26s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	33.389s
```
