### PR TITLE
Fix for missing return statement

### DIFF
--- a/aws/resource_aws_security_group.go
+++ b/aws/resource_aws_security_group.go
@@ -471,7 +471,7 @@ func resourceAwsSecurityGroupDelete(d *schema.ResourceData, meta interface{}) er
 				// If it is a dependency violation, we want to retry
 				return resource.RetryableError(err)
 			}
-			resource.NonRetryableError(err)
+			return resource.NonRetryableError(err)
 		}
 		return nil
 	})


### PR DESCRIPTION
Without this fix, there are most probably
some cases where errors will not be risen
properly

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
fix missing return statement for errors to raise properly when deleting security groups
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```