### PR TITLE
Feature/add enabled boolean to stage aws codepipeline resource

### DIFF
--- a/aws/resource_aws_codepipeline.go
+++ b/aws/resource_aws_codepipeline.go
@@ -94,6 +94,11 @@ func resourceAwsCodePipeline() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
+						"enable": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+						},
 						"action": {
 							Type:     schema.TypeList,
 							Required: true,
@@ -211,6 +216,7 @@ func expandAwsCodePipeline(d *schema.ResourceData) *codepipeline.PipelineDeclara
 	}
 	return &pipeline
 }
+
 func expandAwsCodePipelineArtifactStore(d *schema.ResourceData) *codepipeline.ArtifactStore {
 	configs := d.Get("artifact_store").([]interface{})
 	data := configs[0].(map[string]interface{})
@@ -263,13 +269,14 @@ func expandAwsCodePipelineStages(d *schema.ResourceData) []*codepipeline.StageDe
 func flattenAwsCodePipelineStages(stages []*codepipeline.StageDeclaration) []interface{} {
 	stagesList := []interface{}{}
 	for _, stage := range stages {
-		values := map[string]interface{}{}
-		values["name"] = *stage.Name
-		values["action"] = flattenAwsCodePipelineStageActions(stage.Actions)
-		stagesList = append(stagesList, values)
+		if *stage.Enable == true {
+			values := map[string]interface{}{}
+			values["name"] = *stage.Name
+			values["action"] = flattenAwsCodePipelineStageActions(stage.Actions)
+			stagesList = append(stagesList, values)
+		}
 	}
 	return stagesList
-
 }
 
 func expandAwsCodePipelineActions(s []interface{}) []*codepipeline.ActionDeclaration {
@@ -283,7 +290,6 @@ func expandAwsCodePipelineActions(s []interface{}) []*codepipeline.ActionDeclara
 			if githubToken != "" {
 				conf["OAuthToken"] = aws.String(githubToken)
 			}
-
 		}
 
 		action := codepipeline.ActionDeclaration{

--- a/aws/resource_aws_codepipeline.go
+++ b/aws/resource_aws_codepipeline.go
@@ -269,8 +269,8 @@ func expandAwsCodePipelineStages(d *schema.ResourceData) []*codepipeline.StageDe
 func flattenAwsCodePipelineStages(stages []*codepipeline.StageDeclaration) []interface{} {
 	stagesList := []interface{}{}
 	for _, stage := range stages {
-		if *stage.Enable == true {
-			values := map[string]interface{}{}
+		values := map[string]interface{}{}
+		if values["enable"] == true {
 			values["name"] = *stage.Name
 			values["action"] = flattenAwsCodePipelineStageActions(stage.Actions)
 			stagesList = append(stagesList, values)

--- a/aws/resource_aws_codepipeline_test.go
+++ b/aws/resource_aws_codepipeline_test.go
@@ -903,7 +903,7 @@ resource "aws_codepipeline" "bar" {
 `, rName, tag1, tag2)
 }
 
-func testAccAWSCodePipelineConfig_disabledStage(rName) string {
+func testAccAWSCodePipelineConfig_disabledStage(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "foo" {
   bucket = "tf-test-pipeline-%[1]s"

--- a/aws/resource_aws_codepipeline_test.go
+++ b/aws/resource_aws_codepipeline_test.go
@@ -1026,5 +1026,5 @@ resource "aws_codepipeline" "bar" {
     }
   }
 }
-`, rName)
+`, rName, rName, rName)
 }

--- a/aws/resource_aws_codepipeline_test.go
+++ b/aws/resource_aws_codepipeline_test.go
@@ -184,6 +184,30 @@ func TestAccAWSCodePipeline_tags(t *testing.T) {
 	})
 }
 
+func TestAccAWSCodePipeline_disabledStage(t *testing.T) {
+	if os.Getenv("GITHUB_TOKEN") == "" {
+		t.Skip("Environment variable GITHUB_TOKEN is not set")
+	}
+
+	name := acctest.RandString(10)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCodePipeline(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodePipelineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodePipelineConfig_disabledStage(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodePipelineExists("aws_codepipeline.bar"),
+					resource.TestCheckResourceAttr("aws_codepipeline.bar", "stage.2.name", "Build"),
+					resource.TestCheckResourceAttr("aws_codepipeline.bar", "stage.2.action.0.category", "Build"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSCodePipelineExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -874,6 +898,132 @@ resource "aws_codepipeline" "bar" {
     Name = "test-pipeline-%[1]s"
     tag1 = %[2]q
     tag2 = %[3]q
+  }
+}
+`, rName, tag1, tag2)
+}
+
+func testAccAWSCodePipelineConfig_disabledStage(rName, tag1, tag2 string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "foo" {
+  bucket = "tf-test-pipeline-%[1]s"
+  acl    = "private"
+}
+
+resource "aws_iam_role" "codepipeline_role" {
+  name = "codepipeline-role-%[1]s"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "codepipeline.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "codepipeline_policy" {
+  name = "codepipeline_policy"
+  role = "${aws_iam_role.codepipeline_role.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect":"Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:GetObjectVersion",
+        "s3:GetBucketVersioning"
+      ],
+      "Resource": [
+        "${aws_s3_bucket.foo.arn}",
+        "${aws_s3_bucket.foo.arn}/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "codebuild:BatchGetBuilds",
+        "codebuild:StartBuild"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_codepipeline" "bar" {
+  name     = "test-pipeline-%[1]s"
+  role_arn = "${aws_iam_role.codepipeline_role.arn}"
+
+  artifact_store {
+    location = "${aws_s3_bucket.foo.bucket}"
+    type     = "S3"
+
+    encryption_key {
+      id   = "1234"
+      type = "KMS"
+    }
+  }
+
+  stage {
+    name = "Source"
+
+    action {
+      name             = "Source"
+      category         = "Source"
+      owner            = "ThirdParty"
+      provider         = "GitHub"
+      version          = "1"
+      output_artifacts = ["test"]
+
+      configuration = {
+        Owner  = "lifesum-terraform"
+        Repo   = "test"
+        Branch = "master"
+      }
+    }
+  }
+
+  stage {
+    name = "Approval"
+		enable = false
+
+    action {
+      name            = "Approval"
+      category        = "Approval"
+      owner           = "AWS"
+      provider        = "Manual"
+      version         = "1"
+    }
+  }
+
+  stage {
+    name = "Build"
+		enable = true
+
+    action {
+      name            = "Build"
+      category        = "Build"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      input_artifacts = ["test"]
+      version         = "1"
+
+      configuration = {
+        ProjectName = "test"
+      }
+    }
   }
 }
 `, rName, tag1, tag2)

--- a/aws/resource_aws_codepipeline_test.go
+++ b/aws/resource_aws_codepipeline_test.go
@@ -997,7 +997,7 @@ resource "aws_codepipeline" "bar" {
 
   stage {
     name = "Approval"
-		enable = false
+    enable = false
 
     action {
       name            = "Approval"
@@ -1010,7 +1010,7 @@ resource "aws_codepipeline" "bar" {
 
   stage {
     name = "Build"
-		enable = true
+    enable = true
 
     action {
       name            = "Build"

--- a/aws/resource_aws_codepipeline_test.go
+++ b/aws/resource_aws_codepipeline_test.go
@@ -1026,5 +1026,5 @@ resource "aws_codepipeline" "bar" {
     }
   }
 }
-`, rName, tag1, tag2)
+`, rName)
 }

--- a/aws/resource_aws_codepipeline_test.go
+++ b/aws/resource_aws_codepipeline_test.go
@@ -903,7 +903,7 @@ resource "aws_codepipeline" "bar" {
 `, rName, tag1, tag2)
 }
 
-func testAccAWSCodePipelineConfig_disabledStage(rName, tag1, tag2 string) string {
+func testAccAWSCodePipelineConfig_disabledStage(rName) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "foo" {
   bucket = "tf-test-pipeline-%[1]s"

--- a/website/docs/r/codepipeline.markdown
+++ b/website/docs/r/codepipeline.markdown
@@ -176,6 +176,7 @@ An `encryption_key` block supports the following arguments:
 A `stage` block supports the following arguments:
 
 * `name` - (Required) The name of the stage.
+* `enable` - (Optional) Whether this stage is enabled or not. Defaults to `true`.
 * `action` - (Required) The action(s) to include in the stage. Defined as an `action` block below
 
 A `action` block supports the following arguments:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #924

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_codepipeline: Add `enable` boolean flag to CodePipeline stage
```

Output from acceptance testing:

The test currently times out when I attempt to run it. Will update when I can successfully run a test.

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCodePipeline_disbaledStage'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSCodePipeline_disbaledStage -timeout 120m
go: finding git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999
...

currently times out at:
go: finding git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999
```
