### PR TITLE
Added the creation of the aws_route53_record to the Custom Cognito Domain example

### DIFF
--- a/website/docs/r/cognito_user_pool_domain.markdown
+++ b/website/docs/r/cognito_user_pool_domain.markdown
@@ -42,7 +42,7 @@ data "aws_route53_zone" "example" {
 resource "aws_route53_record" "auth-cognito-A" {
   name    = "${aws_cognito_user_pool_domain.main.domain}"
   type    = "A"
-  zone_id = "${aws_route53_zone.example.zone_id}"
+  zone_id = "${data.aws_route53_zone.example.zone_id}"
   alias {
     evaluate_target_health = false
     name                   = "${aws_cognito_user_pool_domain.main.cloudfront_distribution_arn}"

--- a/website/docs/r/cognito_user_pool_domain.markdown
+++ b/website/docs/r/cognito_user_pool_domain.markdown
@@ -34,9 +34,23 @@ resource "aws_cognito_user_pool_domain" "main" {
 resource "aws_cognito_user_pool" "example" {
   name = "example-pool"
 }
+
+data "aws_route53_zone" "example" {
+  name = "example.com"
+}
+
+resource "aws_route53_record" "auth-cognito-A" {
+  name    = "${aws_cognito_user_pool_domain.domain}"
+  type    = "A"
+  zone_id = "${data.aws_route53_zone.example.id}"
+  alias {
+    evaluate_target_health = false
+    name                   = "${aws_cognito_user_pool_domain.main.cloudfront_distribution_arn}"
+    // This zone_id is fixed
+    zone_id                = "Z2FDTNDATAQYW2"
+  }
+}
 ```
-
-
 
 ## Argument Reference
 
@@ -51,7 +65,7 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `aws_account_id` - The AWS account ID for the user pool owner.
-* `cloudfront_distribution_arn` - The ARN of the CloudFront distribution.
+* `cloudfront_distribution_arn` - The URL of the CloudFront distribution. This is required to generate the ALIAS `aws_route53_record` 
 * `s3_bucket` - The S3 bucket where the static files for this domain are stored.
 * `version` - The app version.
 

--- a/website/docs/r/cognito_user_pool_domain.markdown
+++ b/website/docs/r/cognito_user_pool_domain.markdown
@@ -40,9 +40,9 @@ data "aws_route53_zone" "example" {
 }
 
 resource "aws_route53_record" "auth-cognito-A" {
-  name    = "${aws_cognito_user_pool_domain.domain}"
+  name    = "${aws_cognito_user_pool_domain.main.domain}"
   type    = "A"
-  zone_id = "${data.aws_route53_zone.example.id}"
+  zone_id = "${aws_route53_zone.example.zone_id}"
   alias {
     evaluate_target_health = false
     name                   = "${aws_cognito_user_pool_domain.main.cloudfront_distribution_arn}"


### PR DESCRIPTION
This is for clarification of the `aws_cognito_user_pool_domain` resource and how to generate the correct ALIAS `aws_route53_record`.
This belongs to https://github.com/hashicorp/terraform/issues/22860

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #22860

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
...
```
