### PR TITLE
[WIP] Experiment on allowed secondary artifact types

### DIFF
--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -380,6 +380,8 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 							ValidateFunc: validation.StringInSlice([]string{
+								codebuild.ArtifactsTypeCodepipeline,
+								codebuild.ArtifactsTypeNoArtifacts,
 								codebuild.ArtifactsTypeS3,
 							}, false),
 						},

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -1575,13 +1575,77 @@ func TestAccAWSCodeBuildProject_SecondaryArtifacts_Path(t *testing.T) {
 	})
 }
 
-func TestAccAWSCodeBuildProject_SecondaryArtifacts_Type(t *testing.T) {
+func TestAccAWSCodeBuildProject_SecondaryArtifacts_Type_S3(t *testing.T) {
 	var project codebuild.Project
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	bName := acctest.RandomWithPrefix("tf-acc-test-bucket")
 	resourceName := "aws_codebuild_project.test"
 
 	type1 := codebuild.ArtifactsTypeS3
+
+	hash1 := artifactHash("secondaryArtifact1", "false", bName, codebuild.ArtifactNamespaceNone, "false", codebuild.ArtifactPackagingNone, "", type1)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCodeBuild(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeBuildProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodebuildProjectConfig_SecondaryArtifacts_Type(rName, bName, type1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
+					resource.TestCheckResourceAttr(resourceName, "secondary_artifacts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, fmt.Sprintf("secondary_artifacts.%d.type", hash1), type1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeBuildProject_SecondaryArtifacts_Type_Codepipeline(t *testing.T) {
+	var project codebuild.Project
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	bName := acctest.RandomWithPrefix("tf-acc-test-bucket")
+	resourceName := "aws_codebuild_project.test"
+
+	type1 := codebuild.ArtifactsTypeCodepipeline
+
+	hash1 := artifactHash("secondaryArtifact1", "false", bName, codebuild.ArtifactNamespaceNone, "false", codebuild.ArtifactPackagingNone, "", type1)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCodeBuild(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeBuildProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodebuildProjectConfig_SecondaryArtifacts_Type(rName, bName, type1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
+					resource.TestCheckResourceAttr(resourceName, "secondary_artifacts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, fmt.Sprintf("secondary_artifacts.%d.type", hash1), type1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeBuildProject_SecondaryArtifacts_Type_NoArtifacts(t *testing.T) {
+	var project codebuild.Project
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	bName := acctest.RandomWithPrefix("tf-acc-test-bucket")
+	resourceName := "aws_codebuild_project.test"
+
+	type1 := codebuild.ArtifactsTypeNoArtifacts
 
 	hash1 := artifactHash("secondaryArtifact1", "false", bName, codebuild.ArtifactNamespaceNone, "false", codebuild.ArtifactPackagingNone, "", type1)
 


### PR DESCRIPTION
See https://github.com/terraform-providers/terraform-provider-aws/pull/9652#issuecomment-533340651

This is are two tests (**do not merge**), to validate which types are allowed for `secondary_artifacts` in the `aws_codebuild_project`: 

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSCodeBuildProject_SecondaryArtifacts_Type_* -timeout 120m
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_Type_S3
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_Type_S3
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_Type_Codepipeline
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_Type_Codepipeline
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_Type_NoArtifacts
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_Type_NoArtifacts
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_Type_S3
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_Type_Codepipeline
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_Type_NoArtifacts
--- FAIL: TestAccAWSCodeBuildProject_SecondaryArtifacts_Type_Codepipeline (42.30s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating CodeBuild project: InvalidInputException: Invalid input: artifactType CODEPIPELINE is not allowed for secondaryArtifacts
        	status code: 400, request id: 37d70abf-ef59-4c93-bbdd-7887fea18761
        
          on /tmp/tf-test835885072/main.tf line 69:
          (source code not available)
        
        
--- FAIL: TestAccAWSCodeBuildProject_SecondaryArtifacts_Type_NoArtifacts (50.22s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating CodeBuild project: InvalidInputException: Invalid input: artifactType NO_ARTIFACTS is not allowed for secondaryArtifacts
        	status code: 400, request id: eda4699b-2ddc-4483-90aa-8129be3d8aa2
        
          on /tmp/tf-test461337647/main.tf line 69:
          (source code not available)
        
        
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Type_S3 (71.69s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	71.713s
FAIL
```
