### PR TITLE
Import test refactor for EIP resources

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -218,6 +218,16 @@ func testAccEC2ClassicPreCheck(t *testing.T) {
 	}
 }
 
+func testAccEC2VPCOnlyPreCheck(t *testing.T) {
+	client := testAccProvider.Meta().(*AWSClient)
+	platforms := client.supportedplatforms
+	region := client.region
+	if hasEc2Classic(platforms) {
+		t.Skipf("This test can only in regions without EC2 Classic, platforms available in %s: %q",
+			region, platforms)
+	}
+}
+
 func testAccHasServicePreCheck(service string, t *testing.T) {
 	if partition, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), testAccGetRegion()); ok {
 		if _, ok := partition.Services()[service]; !ok {

--- a/aws/resource_aws_eip_test.go
+++ b/aws/resource_aws_eip_test.go
@@ -85,12 +85,13 @@ func testSweepEc2Eips(region string) error {
 	return nil
 }
 
-func TestAccAWSEIP_importEc2Classic(t *testing.T) {
+func TestAccAWSEIP_Ec2Classic(t *testing.T) {
 	oldvar := os.Getenv("AWS_DEFAULT_REGION")
 	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
 	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
 
-	resourceName := "aws_eip.bar"
+	resourceName := "aws_eip.test"
+	var conf ec2.Address
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
@@ -99,26 +100,11 @@ func TestAccAWSEIP_importEc2Classic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSEIPInstanceEc2Classic,
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSEIP_importVpc(t *testing.T) {
-	resourceName := "aws_eip.bar"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSEIPDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSEIPNetworkInterfaceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEIPExists(resourceName, &conf),
+					testAccCheckAWSEIPAttributes(&conf),
+					testAccCheckAWSEIPPublicDNS(resourceName),
+				),
 			},
 			{
 				ResourceName:      resourceName,
@@ -131,20 +117,26 @@ func TestAccAWSEIP_importVpc(t *testing.T) {
 
 func TestAccAWSEIP_basic(t *testing.T) {
 	var conf ec2.Address
+	resourceName := "aws_eip.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_eip.bar",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSEIPDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSEIPConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists("aws_eip.bar", &conf),
+					testAccCheckAWSEIPExists(resourceName, &conf),
 					testAccCheckAWSEIPAttributes(&conf),
-					testAccCheckAWSEIPPublicDNS("aws_eip.bar"),
+					testAccCheckAWSEIPPublicDNS(resourceName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -152,25 +144,30 @@ func TestAccAWSEIP_basic(t *testing.T) {
 
 func TestAccAWSEIP_instance(t *testing.T) {
 	var conf ec2.Address
+	resourceName := "aws_eip.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_eip.bar",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSEIPDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSEIPInstanceConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists("aws_eip.bar", &conf),
+					testAccCheckAWSEIPExists(resourceName, &conf),
 					testAccCheckAWSEIPAttributes(&conf),
 				),
 			},
-
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 			{
 				Config: testAccAWSEIPInstanceConfig2,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists("aws_eip.bar", &conf),
+					testAccCheckAWSEIPExists(resourceName, &conf),
 					testAccCheckAWSEIPAttributes(&conf),
 				),
 			},
@@ -178,23 +175,29 @@ func TestAccAWSEIP_instance(t *testing.T) {
 	})
 }
 
-func TestAccAWSEIP_network_interface(t *testing.T) {
+func TestAccAWSEIP_networkInterface(t *testing.T) {
 	var conf ec2.Address
+	resourceName := "aws_eip.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_eip.bar",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSEIPDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSEIPNetworkInterfaceConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists("aws_eip.bar", &conf),
+					testAccCheckAWSEIPExists(resourceName, &conf),
 					testAccCheckAWSEIPAttributes(&conf),
 					testAccCheckAWSEIPAssociated(&conf),
-					testAccCheckAWSEIPPrivateDNS("aws_eip.bar"),
+					testAccCheckAWSEIPPrivateDNS(resourceName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -202,23 +205,31 @@ func TestAccAWSEIP_network_interface(t *testing.T) {
 
 func TestAccAWSEIP_twoEIPsOneNetworkInterface(t *testing.T) {
 	var one, two ec2.Address
+	resourceName := "aws_eip.test"
+	resourceName2 := "aws_eip.test2"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_eip.one",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSEIPDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSEIPMultiNetworkInterfaceConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists("aws_eip.one", &one),
+					testAccCheckAWSEIPExists(resourceName, &one),
 					testAccCheckAWSEIPAttributes(&one),
 					testAccCheckAWSEIPAssociated(&one),
-					testAccCheckAWSEIPExists("aws_eip.two", &two),
+					testAccCheckAWSEIPExists(resourceName2, &two),
 					testAccCheckAWSEIPAttributes(&two),
 					testAccCheckAWSEIPAssociated(&two),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"associate_with_private_ip"},
 			},
 		},
 	})
@@ -228,26 +239,32 @@ func TestAccAWSEIP_twoEIPsOneNetworkInterface(t *testing.T) {
 // associated Private EIPs of two instances
 func TestAccAWSEIP_associated_user_private_ip(t *testing.T) {
 	var one ec2.Address
+	resourceName := "aws_eip.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_eip.bar",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSEIPDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSEIPInstanceConfig_associated,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists("aws_eip.bar", &one),
+					testAccCheckAWSEIPExists(resourceName, &one),
 					testAccCheckAWSEIPAttributes(&one),
 					testAccCheckAWSEIPAssociated(&one),
 				),
 			},
-
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"associate_with_private_ip"},
+			},
 			{
 				Config: testAccAWSEIPInstanceConfig_associated_switch,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists("aws_eip.bar", &one),
+					testAccCheckAWSEIPExists(resourceName, &one),
 					testAccCheckAWSEIPAttributes(&one),
 					testAccCheckAWSEIPAssociated(&one),
 				),
@@ -272,10 +289,10 @@ func TestAccAWSEIP_classic_disassociate(t *testing.T) {
 				Config: testAccAWSEIP_classic_disassociate("instance-store"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(
-						"aws_eip.ip.0",
+						"aws_eip.test.0",
 						"instance"),
 					resource.TestCheckResourceAttrSet(
-						"aws_eip.ip.1",
+						"aws_eip.test.1",
 						"instance"),
 				),
 			},
@@ -283,10 +300,10 @@ func TestAccAWSEIP_classic_disassociate(t *testing.T) {
 				Config: testAccAWSEIP_classic_disassociate("ebs"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(
-						"aws_eip.ip.0",
+						"aws_eip.test.0",
 						"instance"),
 					resource.TestCheckResourceAttrSet(
-						"aws_eip.ip.1",
+						"aws_eip.test.1",
 						"instance"),
 				),
 			},
@@ -296,6 +313,7 @@ func TestAccAWSEIP_classic_disassociate(t *testing.T) {
 
 func TestAccAWSEIP_disappears(t *testing.T) {
 	var conf ec2.Address
+	resourceName := "aws_eip.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -305,7 +323,7 @@ func TestAccAWSEIP_disappears(t *testing.T) {
 			{
 				Config: testAccAWSEIPConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists("aws_eip.bar", &conf),
+					testAccCheckAWSEIPExists(resourceName, &conf),
 					testAccCheckAWSEIPDisappears(&conf),
 				),
 				ExpectNonEmptyPlan: true,
@@ -314,27 +332,32 @@ func TestAccAWSEIP_disappears(t *testing.T) {
 	})
 }
 
-func TestAccAWSEIPAssociate_not_associated(t *testing.T) {
+func TestAccAWSEIPAssociate_notAssociated(t *testing.T) {
 	var conf ec2.Address
+	resourceName := "aws_eip.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_eip.bar",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSEIPDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSEIPAssociate_not_associated,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists("aws_eip.bar", &conf),
+					testAccCheckAWSEIPExists(resourceName, &conf),
 					testAccCheckAWSEIPAttributes(&conf),
 				),
 			},
-
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 			{
 				Config: testAccAWSEIPAssociate_associated,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEIPExists("aws_eip.bar", &conf),
+					testAccCheckAWSEIPExists(resourceName, &conf),
 					testAccCheckAWSEIPAttributes(&conf),
 					testAccCheckAWSEIPAssociated(&conf),
 				),
@@ -345,13 +368,13 @@ func TestAccAWSEIPAssociate_not_associated(t *testing.T) {
 
 func TestAccAWSEIP_tags(t *testing.T) {
 	var conf ec2.Address
-	resourceName := "aws_eip.bar"
+	resourceName := "aws_eip.test"
 	rName1 := fmt.Sprintf("%s-%d", t.Name(), acctest.RandInt())
 	rName2 := fmt.Sprintf("%s-%d", t.Name(), acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_eip.bar",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSEIPDestroy,
 		Steps: []resource.TestStep{
@@ -364,6 +387,11 @@ func TestAccAWSEIP_tags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.RandomName", rName1),
 					resource.TestCheckResourceAttr(resourceName, "tags.TestName", t.Name()),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSEIPConfig_tags(rName2, t.Name()),
@@ -381,7 +409,7 @@ func TestAccAWSEIP_tags(t *testing.T) {
 
 func TestAccAWSEIP_PublicIpv4Pool_default(t *testing.T) {
 	var conf ec2.Address
-	resourceName := "aws_eip.bar"
+	resourceName := "aws_eip.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -397,6 +425,11 @@ func TestAccAWSEIP_PublicIpv4Pool_default(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "public_ipv4_pool", "amazon"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -407,7 +440,7 @@ func TestAccAWSEIP_PublicIpv4Pool_custom(t *testing.T) {
 	}
 
 	var conf ec2.Address
-	resourceName := "aws_eip.bar"
+	resourceName := "aws_eip.test"
 
 	poolName := os.Getenv("AWS_EC2_EIP_PUBLIC_IPV4_POOL")
 
@@ -424,6 +457,11 @@ func TestAccAWSEIP_PublicIpv4Pool_custom(t *testing.T) {
 					testAccCheckAWSEIPAttributes(&conf),
 					resource.TestCheckResourceAttr(resourceName, "public_ipv4_pool", poolName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -608,13 +646,13 @@ func testAccCheckAWSEIPPublicDNS(resourceName string) resource.TestCheckFunc {
 }
 
 const testAccAWSEIPConfig = `
-resource "aws_eip" "bar" {
+resource "aws_eip" "test" {
 }
 `
 
 func testAccAWSEIPConfig_tags(rName, testName string) string {
 	return fmt.Sprintf(`
-resource "aws_eip" "bar" {
+resource "aws_eip" "test" {
   tags = {
     RandomName = "%[1]s"
     TestName   = "%[2]s"
@@ -624,14 +662,14 @@ resource "aws_eip" "bar" {
 }
 
 const testAccAWSEIPConfig_PublicIpv4Pool_default = `
-resource "aws_eip" "bar" {
+resource "aws_eip" "test" {
    vpc = true
 }
 `
 
 func testAccAWSEIPConfig_PublicIpv4Pool_custom(poolName string) string {
 	return fmt.Sprintf(`
-resource "aws_eip" "bar" {
+resource "aws_eip" "test" {
   vpc              = true
   public_ipv4_pool = "%s"
 }
@@ -657,7 +695,7 @@ data "aws_ami" "amzn-ami-minimal-pv" {
   }
 }
 
-resource "aws_instance" "foo" {
+resource "aws_instance" "test" {
 	ami = "${data.aws_ami.amzn-ami-minimal-pv.id}"
 	instance_type = "m1.small"
 	tags = {
@@ -665,8 +703,8 @@ resource "aws_instance" "foo" {
 	}
 }
 
-resource "aws_eip" "bar" {
-	instance = "${aws_instance.foo.id}"
+resource "aws_eip" "test" {
+	instance = "${aws_instance.test.id}"
 }
 `
 
@@ -685,13 +723,13 @@ data "aws_ami" "amzn-ami-minimal-pv" {
   }
 }
 
-resource "aws_instance" "foo" {
+resource "aws_instance" "test" {
 	ami = "${data.aws_ami.amzn-ami-minimal-pv.id}"
 	instance_type = "m1.small"
 }
 
-resource "aws_eip" "bar" {
-	instance = "${aws_instance.foo.id}"
+resource "aws_eip" "test" {
+	instance = "${aws_instance.test.id}"
 }
 `
 
@@ -710,13 +748,13 @@ data "aws_ami" "amzn-ami-minimal-pv" {
   }
 }
 
-resource "aws_instance" "bar" {
+resource "aws_instance" "test" {
 	ami = "${data.aws_ami.amzn-ami-minimal-pv.id}"
 	instance_type = "m1.small"
 }
 
-resource "aws_eip" "bar" {
-	instance = "${aws_instance.bar.id}"
+resource "aws_eip" "test" {
+	instance = "${aws_instance.test.id}"
 }
 `
 
@@ -764,7 +802,7 @@ resource "aws_subnet" "tf_test_subnet" {
   }
 }
 
-resource "aws_instance" "foo" {
+resource "aws_instance" "test" {
   ami           = "${data.aws_ami.amzn-ami-minimal-hvm.id}"
   instance_type = "t2.micro"
 
@@ -772,11 +810,11 @@ resource "aws_instance" "foo" {
   subnet_id  = "${aws_subnet.tf_test_subnet.id}"
 
   tags = {
-    Name = "foo instance"
+    Name = "test instance"
   }
 }
 
-resource "aws_instance" "bar" {
+resource "aws_instance" "test2" {
   ami = "${data.aws_ami.amzn-ami-minimal-hvm.id}"
 
   instance_type = "t2.micro"
@@ -785,14 +823,14 @@ resource "aws_instance" "bar" {
   subnet_id  = "${aws_subnet.tf_test_subnet.id}"
 
   tags = {
-    Name = "bar instance"
+    Name = "test2 instance"
   }
 }
 
-resource "aws_eip" "bar" {
+resource "aws_eip" "test" {
   vpc = true
 
-  instance                  = "${aws_instance.bar.id}"
+  instance                  = "${aws_instance.test2.id}"
   associate_with_private_ip = "10.0.0.19"
 }
 `
@@ -840,7 +878,7 @@ resource "aws_subnet" "tf_test_subnet" {
   }
 }
 
-resource "aws_instance" "foo" {
+resource "aws_instance" "test" {
   ami           = "${data.aws_ami.amzn-ami-minimal-hvm.id}"
   instance_type = "t2.micro"
 
@@ -848,11 +886,11 @@ resource "aws_instance" "foo" {
   subnet_id  = "${aws_subnet.tf_test_subnet.id}"
 
   tags = {
-    Name = "foo instance"
+    Name = "test instance"
   }
 }
 
-resource "aws_instance" "bar" {
+resource "aws_instance" "test2" {
   ami = "${data.aws_ami.amzn-ami-minimal-hvm.id}"
 
   instance_type = "t2.micro"
@@ -861,32 +899,32 @@ resource "aws_instance" "bar" {
   subnet_id  = "${aws_subnet.tf_test_subnet.id}"
 
   tags = {
-    Name = "bar instance"
+    Name = "test2 instance"
   }
 }
 
-resource "aws_eip" "bar" {
+resource "aws_eip" "test" {
   vpc = true
 
-  instance                  = "${aws_instance.foo.id}"
+  instance                  = "${aws_instance.test.id}"
   associate_with_private_ip = "10.0.0.12"
 }
 `
 
 const testAccAWSEIPNetworkInterfaceConfig = `
-resource "aws_vpc" "bar" {
+resource "aws_vpc" "test" {
 	cidr_block = "10.0.0.0/24"
 	tags = {
 		Name = "terraform-testacc-eip-network-interface"
 	}
 }
 
-resource "aws_internet_gateway" "bar" {
-	vpc_id = "${aws_vpc.bar.id}"
+resource "aws_internet_gateway" "test" {
+	vpc_id = "${aws_vpc.test.id}"
 }
 
-resource "aws_subnet" "bar" {
-  vpc_id = "${aws_vpc.bar.id}"
+resource "aws_subnet" "test" {
+  vpc_id = "${aws_vpc.test.id}"
   availability_zone = "us-west-2a"
   cidr_block = "10.0.0.0/24"
   tags = {
@@ -894,33 +932,33 @@ resource "aws_subnet" "bar" {
   }
 }
 
-resource "aws_network_interface" "bar" {
-  subnet_id = "${aws_subnet.bar.id}"
+resource "aws_network_interface" "test" {
+  subnet_id = "${aws_subnet.test.id}"
 	private_ips = ["10.0.0.10"]
-  security_groups = [ "${aws_vpc.bar.default_security_group_id}" ]
+  security_groups = [ "${aws_vpc.test.default_security_group_id}" ]
 }
 
-resource "aws_eip" "bar" {
+resource "aws_eip" "test" {
 	vpc = "true"
-	network_interface = "${aws_network_interface.bar.id}"
-	depends_on = ["aws_internet_gateway.bar"]
+	network_interface = "${aws_network_interface.test.id}"
+	depends_on = ["aws_internet_gateway.test"]
 }
 `
 
 const testAccAWSEIPMultiNetworkInterfaceConfig = `
-resource "aws_vpc" "bar" {
+resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/24"
 	tags = {
 		Name = "terraform-testacc-eip-multi-network-interface"
 	}
 }
 
-resource "aws_internet_gateway" "bar" {
-  vpc_id = "${aws_vpc.bar.id}"
+resource "aws_internet_gateway" "test" {
+  vpc_id = "${aws_vpc.test.id}"
 }
 
-resource "aws_subnet" "bar" {
-  vpc_id            = "${aws_vpc.bar.id}"
+resource "aws_subnet" "test" {
+  vpc_id            = "${aws_vpc.test.id}"
   availability_zone = "us-west-2a"
   cidr_block        = "10.0.0.0/24"
   tags = {
@@ -928,24 +966,24 @@ resource "aws_subnet" "bar" {
   }
 }
 
-resource "aws_network_interface" "bar" {
-  subnet_id       = "${aws_subnet.bar.id}"
+resource "aws_network_interface" "test" {
+  subnet_id       = "${aws_subnet.test.id}"
   private_ips     = ["10.0.0.10", "10.0.0.11"]
-  security_groups = ["${aws_vpc.bar.default_security_group_id}"]
+  security_groups = ["${aws_vpc.test.default_security_group_id}"]
 }
 
-resource "aws_eip" "one" {
+resource "aws_eip" "test" {
   vpc                       = "true"
-  network_interface         = "${aws_network_interface.bar.id}"
+  network_interface         = "${aws_network_interface.test.id}"
   associate_with_private_ip = "10.0.0.10"
-  depends_on                = ["aws_internet_gateway.bar"]
+  depends_on                = ["aws_internet_gateway.test"]
 }
 
-resource "aws_eip" "two" {
+resource "aws_eip" "test2" {
   vpc                       = "true"
-  network_interface         = "${aws_network_interface.bar.id}"
+  network_interface         = "${aws_network_interface.test.id}"
   associate_with_private_ip = "10.0.0.11"
-  depends_on                = ["aws_internet_gateway.bar"]
+  depends_on                = ["aws_internet_gateway.test"]
 }
 `
 
@@ -973,7 +1011,7 @@ data "aws_ami" "amzn-ami-minimal-pv" {
   }
 }
 
-resource "aws_eip" "ip" {
+resource "aws_eip" "test" {
   count    = "${var.server_count}"
   instance = "${element(aws_instance.example.*.id, count.index)}"
   vpc      = true
@@ -1049,12 +1087,12 @@ data "aws_ami" "amzn-ami-minimal-pv" {
   }
 }
 
-resource "aws_instance" "foo" {
+resource "aws_instance" "test" {
 	ami = "${data.aws_ami.amzn-ami-minimal-pv.id}"
 	instance_type = "m1.small"
 }
 
-resource "aws_eip" "bar" {
+resource "aws_eip" "test" {
 }
 `
 
@@ -1073,12 +1111,12 @@ data "aws_ami" "amzn-ami-minimal-pv" {
   }
 }
 
-resource "aws_instance" "foo" {
+resource "aws_instance" "test" {
 	ami = "${data.aws_ami.amzn-ami-minimal-pv.id}"
 	instance_type = "m1.small"
 }
 
-resource "aws_eip" "bar" {
-	instance = "${aws_instance.foo.id}"
+resource "aws_eip" "test" {
+	instance = "${aws_instance.test.id}"
 }
 `


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8944

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$  make testacc TESTARGS="-run=TestAccAWSEIP_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSEIP_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEIP_Ec2Classic
=== PAUSE TestAccAWSEIP_Ec2Classic
=== RUN   TestAccAWSEIP_basic
=== PAUSE TestAccAWSEIP_basic
=== RUN   TestAccAWSEIP_instance
=== PAUSE TestAccAWSEIP_instance
=== RUN   TestAccAWSEIP_networkInterface
=== PAUSE TestAccAWSEIP_networkInterface
=== RUN   TestAccAWSEIP_twoEIPsOneNetworkInterface
=== PAUSE TestAccAWSEIP_twoEIPsOneNetworkInterface
=== RUN   TestAccAWSEIP_associated_user_private_ip
=== PAUSE TestAccAWSEIP_associated_user_private_ip
=== RUN   TestAccAWSEIP_classic_disassociate
=== PAUSE TestAccAWSEIP_classic_disassociate
=== RUN   TestAccAWSEIP_disappears
=== PAUSE TestAccAWSEIP_disappears
=== RUN   TestAccAWSEIP_tags
=== PAUSE TestAccAWSEIP_tags
=== RUN   TestAccAWSEIP_PublicIpv4Pool_default
=== PAUSE TestAccAWSEIP_PublicIpv4Pool_default
=== RUN   TestAccAWSEIP_PublicIpv4Pool_custom
--- SKIP: TestAccAWSEIP_PublicIpv4Pool_custom (0.00s)
    resource_aws_eip_test.go:444: Environment variable AWS_EC2_EIP_PUBLIC_IPV4_POOL is not set
=== CONT  TestAccAWSEIP_Ec2Classic
=== CONT  TestAccAWSEIP_tags
=== CONT  TestAccAWSEIP_networkInterface
=== CONT  TestAccAWSEIP_instance
=== CONT  TestAccAWSEIP_classic_disassociate
=== CONT  TestAccAWSEIP_disappears
=== CONT  TestAccAWSEIP_basic
=== CONT  TestAccAWSEIP_associated_user_private_ip
=== CONT  TestAccAWSEIP_PublicIpv4Pool_default
=== CONT  TestAccAWSEIP_twoEIPsOneNetworkInterface
--- PASS: TestAccAWSEIP_tags (46.31s)
--- PASS: TestAccAWSEIP_disappears (19.81s)
--- PASS: TestAccAWSEIP_PublicIpv4Pool_default (23.26s)
--- PASS: TestAccAWSEIP_basic (24.40s)
--- PASS: TestAccAWSEIP_twoEIPsOneNetworkInterface (80.02s)   
--- PASS: TestAccAWSEIP_networkInterface (78.03s) 
--- PASS: TestAccAWSEIP_classic_disassociate (295.36s)
--- PASS: TestAccAWSEIP_associated_user_private_ip (193.47s)
--- PASS: TestAccAWSEIP_Ec2Classic (218.82s)
--- PASS: TestAccAWSEIP_instance (183.63s)

make testacc TESTARGS="-run=TestAccAWSEIPAssociation_"     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSEIPAssociation_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEIPAssociation_basic
=== PAUSE TestAccAWSEIPAssociation_basic
=== RUN   TestAccAWSEIPAssociation_ec2Classic
=== PAUSE TestAccAWSEIPAssociation_ec2Classic
=== RUN   TestAccAWSEIPAssociation_spotInstance
=== PAUSE TestAccAWSEIPAssociation_spotInstance
=== RUN   TestAccAWSEIPAssociation_disappears
=== PAUSE TestAccAWSEIPAssociation_disappears
=== CONT  TestAccAWSEIPAssociation_basic
=== CONT  TestAccAWSEIPAssociation_disappears
=== CONT  TestAccAWSEIPAssociation_spotInstance
=== CONT  TestAccAWSEIPAssociation_ec2Classic
--- SKIP: TestAccAWSEIPAssociation_ec2Classic (2.69s)
    provider_test.go:216: This test can only run in EC2 Classic, platforms available in us-west-2: ["VPC"]
--- PASS: TestAccAWSEIPAssociation_disappears (129.27s)
--- PASS: TestAccAWSEIPAssociation_spotInstance (177.77s)
--- PASS: TestAccAWSEIPAssociation_basic (187.24s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       188.639s

make testacc TESTARGS="-run=TestAccAWSEIPAssociation_ec2Classic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSEIPAssociation_ec2Classic -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEIPAssociation_ec2Classic
=== PAUSE TestAccAWSEIPAssociation_ec2Classic
=== CONT  TestAccAWSEIPAssociation_ec2Classic
--- PASS: TestAccAWSEIPAssociation_ec2Classic (94.88s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       96.254s
```
