### PR TITLE
WIP: Sort bootstrap_brokers for kafka

### DIFF
--- a/aws/resource_aws_msk_cluster.go
+++ b/aws/resource_aws_msk_cluster.go
@@ -3,6 +3,8 @@ package aws
 import (
 	"fmt"
 	"log"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -310,9 +312,17 @@ func resourceAwsMskClusterRead(d *schema.ResourceData, meta interface{}) error {
 
 	cluster := out.ClusterInfo
 
+	bootstrapBrokersSorted := strings.Split(*brokerOut.BootstrapBrokerString, ",")
+	sort.Strings(bootstrapBrokersSorted)
+	bootstrapBrokersSortedJoined := strings.Join(bootstrapBrokersSorted, ",")
+
+	bootstrapBrokersTlsSorted := strings.Split(*brokerOut.BootstrapBrokerStringTls, ",")
+	sort.Strings(bootstrapBrokersTlsSorted)
+	bootstrapBrokersTlsSortedJoined := strings.Join(bootstrapBrokersTlsSorted, ",")
+
 	d.Set("arn", aws.StringValue(cluster.ClusterArn))
-	d.Set("bootstrap_brokers", aws.StringValue(brokerOut.BootstrapBrokerString))
-	d.Set("bootstrap_brokers_tls", aws.StringValue(brokerOut.BootstrapBrokerStringTls))
+	d.Set("bootstrap_brokers", aws.StringValue(&bootstrapBrokersSortedJoined))
+	d.Set("bootstrap_brokers_tls", aws.StringValue(&bootstrapBrokersTlsSortedJoined))
 
 	if err := d.Set("broker_node_group_info", flattenMskBrokerNodeGroupInfo(cluster.BrokerNodeGroupInfo)); err != nil {
 		return fmt.Errorf("error setting broker_node_group_info: %s", err)


### PR DESCRIPTION
This is still very much a WIP, I'm just opening it to notice my current activity on this. I never worked with go so I'm still in the process of figuring out how to build/test the code. stuck at `go: finding git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999` right now.

The issue: The provider (or kafka, idk which one) returns the brokers in no particular order. That's annoying because to kafka, these are now different values and it keeps updating resources. 

Solution: Split on `,`, sort, concat with `,`. 
 

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request



<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_msk_cluster: sort broker urls string
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
