### PR TITLE
resource/aws_instance: Prevent panic when updating `credit_specification` to empty configuration block

### DIFF
--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -1204,7 +1204,7 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("credit_specification") && !d.IsNewResource() {
-		if v, ok := d.GetOk("credit_specification"); ok {
+		if v, ok := d.GetOk("credit_specification"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 			creditSpecification := v.([]interface{})[0].(map[string]interface{})
 			log.Printf("[DEBUG] Modifying credit specification for Instance (%s)", d.Id())
 			_, err := conn.ModifyInstanceCreditSpecification(&ec2.ModifyInstanceCreditSpecificationInput{


### PR DESCRIPTION

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10203

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_instance: Prevent panic when updating `credit_specification` to empty configuration block
```

Previously before code fix:

```
=== CONT  TestAccAWSInstance_CreditSpecification_UnspecifiedToEmpty_NonBurstable
panic: interface conversion: interface {} is nil, not map[string]interface {}

goroutine 1291 [running]:
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsInstanceUpdate(0xc0004b2460, 0x524ba00, 0xc000b8e480, 0x0, 0x0)
	/Users/bflad/src/github.com/terraform-providers/terraform-provider-aws-deux/aws/resource_aws_instance.go:1208 +0x485b
```

Output from acceptance testing:

```
--- PASS: TestAccAWSInstance_CreditSpecification_UnspecifiedToEmpty_NonBurstable (135.98s)
```

