### PR TITLE
Acmpca private cert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ FEATURES:
 
 * **New Data Source:** `aws_acmpca_private_certificate` ([#10183](https://github.com/terraform-providers/terraform-provider-aws/issues/10183))
 * **New Resource:** `aws_acmpca_private_certificate` ([#10183](https://github.com/terraform-providers/terraform-provider-aws/issues/10183))
-*
+
+
 ## 2.29.0 (September 20, 2019)
 
 ENHANCEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## 2.30.0 (Unreleased)
+
+FEATURES:
+
+* **New Data Source:** `aws_acmpca_private_certificate` ([#10183](https://github.com/terraform-providers/terraform-provider-aws/issues/10183))
+* **New Resource:** `aws_acmpca_private_certificate` ([#10183](https://github.com/terraform-providers/terraform-provider-aws/issues/10183))
+*
 ## 2.29.0 (September 20, 2019)
 
 ENHANCEMENTS:

--- a/aws/data_source_aws_acmpca_private_certificate.go
+++ b/aws/data_source_aws_acmpca_private_certificate.go
@@ -1,0 +1,58 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/acmpca"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsAcmpcaPrivateCertificate() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsAcmpcaPrivateCertificateRead,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"certificate_authority_arn": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"certificate": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"certificate_chain": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsAcmpcaPrivateCertificateRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).acmpcaconn
+	certificateArn := d.Get("arn").(string)
+
+	getCertificateInput := &acmpca.GetCertificateInput{
+		CertificateArn:          aws.String(certificateArn),
+		CertificateAuthorityArn: aws.String(d.Get("certificate_authority_arn").(string)),
+	}
+
+	log.Printf("[DEBUG] Reading ACMPCA Certificate: %s", getCertificateInput)
+
+	certificateOutput, err := conn.GetCertificate(getCertificateInput)
+	if err != nil {
+		return fmt.Errorf("error reading ACMPCA Certificate: %s", err)
+	}
+
+	d.SetId(certificateArn)
+	d.Set("certificate", aws.StringValue(certificateOutput.Certificate))
+	d.Set("certificate_chain", aws.StringValue(certificateOutput.CertificateChain))
+
+	return nil
+}

--- a/aws/data_source_aws_acmpca_private_certificate_test.go
+++ b/aws/data_source_aws_acmpca_private_certificate_test.go
@@ -1,0 +1,103 @@
+package aws
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAwsAcmpcaPrivateCertificate_Basic(t *testing.T) {
+	resourceName := "aws_acmpca_private_certificate.test"
+	datasourceName := "data.aws_acmpca_private_certificate.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProvidersWithTLS,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSourceAwsAcmpcaPrivateCertificateConfig_NonExistent,
+				ExpectError: regexp.MustCompile(`(AccessDeniedException|ResourceNotFoundException)`),
+			},
+			{
+				Config: testAccDataSourceAwsAcmpcaPrivateCertificateConfig_ARN,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "certificate", resourceName, "certificate"),
+					resource.TestCheckResourceAttrPair(datasourceName, "certificate_chain", resourceName, "certificate_chain"),
+					resource.TestCheckResourceAttrPair(datasourceName, "certificate_authority_arn", resourceName, "certificate_authority_arn"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceAwsAcmpcaPrivateCertificateConfig_ARN = `
+resource "tls_private_key" "key_1" {
+  algorithm = "RSA"
+}
+
+resource "tls_cert_request" "csr_1" {
+  key_algorithm   = "RSA"
+  private_key_pem = tls_private_key.key_1.private_key_pem
+
+  subject {
+    common_name = "wrong"
+  }
+}
+
+resource "tls_private_key" "key_2" {
+  algorithm = "RSA"
+}
+
+resource "tls_cert_request" "csr_2" {
+  key_algorithm   = "RSA"
+  private_key_pem = tls_private_key.key_2.private_key_pem
+
+  subject {
+    common_name = "testing"
+  }
+}
+
+resource "aws_acmpca_certificate_authority" "test" {
+  permanent_deletion_time_in_days = 7
+  type                            = "ROOT"
+
+  certificate_authority_configuration {
+    key_algorithm     = "RSA_4096"
+    signing_algorithm = "SHA512WITHRSA"
+
+    subject {
+      common_name = "terraformtesting.com"
+    }
+  }
+}
+
+resource "aws_acmpca_private_certificate" "wrong" {
+	certificate_authority_arn = aws_acmpca_certificate_authority.test.arn
+	certificate_signing_request = tls_cert_request.csr_1.cert_request_pem
+	signing_algorithm = "SHA256WITHRSA"
+	validity_length = 1
+	validity_unit = "YEARS"
+}
+
+resource "aws_acmpca_private_certificate" "test" {
+	certificate_authority_arn = aws_acmpca_certificate_authority.test.arn
+	certificate_signing_request = tls_cert_request.csr_2.cert_request_pem
+	signing_algorithm = "SHA256WITHRSA"
+	validity_length = 1
+	validity_unit = "YEARS"
+}
+
+data "aws_acmpca_private_certificate" "test" {
+	arn = aws_acmpca_private_certificate.test.arn
+	certificate_authority_arn = aws_acmpca_certificate_authority.test.arn
+}
+`
+
+const testAccDataSourceAwsAcmpcaPrivateCertificateConfig_NonExistent = `
+data "aws_acmpca_private_certificate" "test" {
+	arn = "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/does-not-exist/certificate/does-not-exist"
+	certificate_authority_arn = "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/does-not-exist"
+}
+`

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -143,6 +143,7 @@ func Provider() terraform.ResourceProvider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"aws_acm_certificate":                           dataSourceAwsAcmCertificate(),
 			"aws_acmpca_certificate_authority":              dataSourceAwsAcmpcaCertificateAuthority(),
+			"aws_acmpca_private_certificate":                dataSourceAwsAcmpcaPrivateCertificate(),
 			"aws_ami":                                       dataSourceAwsAmi(),
 			"aws_ami_ids":                                   dataSourceAwsAmiIds(),
 			"aws_api_gateway_api_key":                       dataSourceAwsApiGatewayApiKey(),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -298,6 +298,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_acm_certificate":                                     resourceAwsAcmCertificate(),
 			"aws_acm_certificate_validation":                          resourceAwsAcmCertificateValidation(),
 			"aws_acmpca_certificate_authority":                        resourceAwsAcmpcaCertificateAuthority(),
+			"aws_acmpca_private_certificate":                          resourceAwsAcmpcaPrivateCertificate(),
 			"aws_ami":                                                 resourceAwsAmi(),
 			"aws_ami_copy":                                            resourceAwsAmiCopy(),
 			"aws_ami_from_instance":                                   resourceAwsAmiFromInstance(),

--- a/aws/resource_aws_acmpca_private_certificate.go
+++ b/aws/resource_aws_acmpca_private_certificate.go
@@ -1,0 +1,206 @@
+package aws
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/acmpca"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceAwsAcmpcaPrivateCertificate() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsAcmpcaPrivateCertificateCreate,
+		Read:   resourceAwsAcmpcaPrivateCertificateRead,
+		Delete: resourceAwsAcmpcaPrivateCertificateRevoke,
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+		},
+		SchemaVersion: 1,
+
+		Schema: map[string]*schema.Schema{
+			"certificate_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"certificate": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				StateFunc: normalizeCert,
+			},
+			"certificate_chain": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				StateFunc: normalizeCert,
+			},
+			"certificate_authority_arn": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"certificate_signing_request": {
+				Type:      schema.TypeString,
+				Required:  true,
+				StateFunc: normalizeCert,
+			},
+			"signing_algorithm": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					acmpca.SigningAlgorithmSha256withecdsa,
+					acmpca.SigningAlgorithmSha256withrsa,
+					acmpca.SigningAlgorithmSha384withecdsa,
+					acmpca.SigningAlgorithmSha384withrsa,
+					acmpca.SigningAlgorithmSha512withecdsa,
+					acmpca.SigningAlgorithmSha512withrsa,
+				}, false),
+			},
+			"validity_length": {
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+			"validity_unit": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					acmpca.ValidityPeriodTypeAbsolute,
+					acmpca.ValidityPeriodTypeDays,
+					acmpca.ValidityPeriodTypeEndDate,
+					acmpca.ValidityPeriodTypeMonths,
+					acmpca.ValidityPeriodTypeYears,
+				}, false),
+			},
+			"template_arn": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"arn:aws:acm-pca:::template/EndEntityCertificate/V1",
+					"arn:aws:acm-pca:::template/SubordinateCACertificate_PathLen0/V1",
+					"arn:aws:acm-pca:::template/SubordinateCACertificate_PathLen1/V1",
+					"arn:aws:acm-pca:::template/SubordinateCACertificate_PathLen2/V1",
+					"arn:aws:acm-pca:::template/SubordinateCACertificate_PathLen3/V1",
+					"arn:aws:acm-pca:::template/RootCACertificate/V1",
+				}, false),
+				Default: "arn:aws:acm-pca:::template/EndEntityCertificate/V1",
+			},
+		},
+	}
+}
+
+func resourceAwsAcmpcaPrivateCertificateCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).acmpcaconn
+
+	input := &acmpca.IssueCertificateInput{
+		CertificateAuthorityArn: aws.String(d.Get("certificate_authority_arn").(string)),
+		Csr:                     []byte(d.Get("certificate_signing_request").(string)),
+		IdempotencyToken:        aws.String(resource.UniqueId()),
+		SigningAlgorithm:        aws.String(d.Get("signing_algorithm").(string)),
+		TemplateArn:             aws.String(d.Get("template_arn").(string)),
+		Validity: &acmpca.Validity{
+			Type:  aws.String(d.Get("validity_unit").(string)),
+			Value: aws.Int64(d.Get("validity_length").(int64)),
+		},
+	}
+
+	log.Printf("[DEBUG] ACMPCA Issue Certificate: %s", input)
+	var output *acmpca.IssueCertificateOutput
+	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+		var err error
+		output, err = conn.IssueCertificate(input)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if isResourceTimeoutError(err) {
+		output, err = conn.IssueCertificate(input)
+	}
+	if err != nil {
+		return fmt.Errorf("error issuing ACMPCA Certificate: %s", err)
+	}
+
+	d.SetId(aws.StringValue(output.CertificateArn))
+	d.Set("certificate_arn", aws.StringValue(output.CertificateArn))
+
+	getCertificateInput := &acmpca.GetCertificateInput{
+		CertificateArn:          output.CertificateArn,
+		CertificateAuthorityArn: aws.String(d.Get("certificate_authority_arn").(string)),
+	}
+
+	err = conn.WaitUntilCertificateIssued(getCertificateInput)
+	if err != nil {
+		return fmt.Errorf("error waiting for ACMPCA to issue Certificate %q, error: %s", d.Id(), err)
+	}
+
+	return resourceAwsAcmpcaPrivateCertificateRead(d, meta)
+}
+
+func resourceAwsAcmpcaPrivateCertificateRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).acmpcaconn
+
+	getCertificateInput := &acmpca.GetCertificateInput{
+		CertificateArn:          aws.String(d.Id()),
+		CertificateAuthorityArn: aws.String(d.Get("certificate_authority_arn").(string)),
+	}
+
+	log.Printf("[DEBUG] Reading ACMPCA Certificate: %s", getCertificateInput)
+
+	certificateOutput, err := conn.GetCertificate(getCertificateInput)
+	if err != nil {
+		if isAWSErr(err, acmpca.ErrCodeResourceNotFoundException, "") {
+			log.Printf("[WARN] ACMPCA Certificate %q not found - removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("error reading ACMPCA Certificate: %s", err)
+	}
+
+	d.Set("certificate_arn", d.Id())
+	d.Set("certificate", aws.StringValue(certificateOutput.Certificate))
+	d.Set("certificate_chain", aws.StringValue(certificateOutput.CertificateChain))
+
+	return nil
+}
+
+func resourceAwsAcmpcaPrivateCertificateRevoke(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).acmpcaconn
+
+	block, _ := pem.Decode([]byte(d.Get("certificate").(string)))
+	if block == nil {
+		log.Printf("[WARN] Failed to parse certificate %q", d.Id())
+		return nil
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		fmt.Errorf("Failed to parse ACMPCA Certificate: %s", err)
+	}
+
+	input := &acmpca.RevokeCertificateInput{
+		CertificateAuthorityArn: aws.String(d.Get("certificate_authority_arn").(string)),
+		CertificateSerial:       aws.String(fmt.Sprintf("%x", cert.SerialNumber)),
+		RevocationReason:        aws.String("Terraform Delete"),
+	}
+
+	log.Printf("[DEBUG] Revoking ACMPCA Certificate: %s", input)
+	_, err = conn.RevokeCertificate(input)
+	if err != nil {
+		if isAWSErr(err, acmpca.ErrCodeResourceNotFoundException, "") ||
+			isAWSErr(err, acmpca.ErrCodeRequestAlreadyProcessedException, "") ||
+			isAWSErr(err, acmpca.ErrCodeRequestInProgressException, "") {
+			return nil
+		}
+		return fmt.Errorf("error revoking ACMPCA Certificate: %s", err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_acmpca_private_certificate_test.go
+++ b/aws/resource_aws_acmpca_private_certificate_test.go
@@ -82,7 +82,6 @@ resource "tls_cert_request" "csr" {
   subject {
     common_name = "testing"
   }
-
 }
 
 resource "aws_acmpca_certificate_authority" "test" {

--- a/aws/resource_aws_acmpca_private_certificate_test.go
+++ b/aws/resource_aws_acmpca_private_certificate_test.go
@@ -1,0 +1,109 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/acmpca"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAwsAcmpcaPrivateCertificate_Basic(t *testing.T) {
+	resourceName := "aws_acmpca_private_certificate.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProvidersWithTLS,
+		CheckDestroy: testAccCheckAwsAcmpcaPrivateCertificateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsAcmpcaPrivateCertificateConfig_Required,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAcmpcaPrivateCertificateExists(resourceName),
+					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(`^arn:[^:]+:acm-pca:[^:]+:[^:]+:certificate-authority/.+/certificate/.+$`)),
+					resource.TestCheckResourceAttrSet(resourceName, "certificate"),
+					resource.TestCheckResourceAttrSet(resourceName, "certificate_chain"),
+					resource.TestCheckResourceAttrSet(resourceName, "certificate_signing_request"),
+					resource.TestCheckResourceAttr(resourceName, "validity_length", "1"),
+					resource.TestCheckResourceAttr(resourceName, "validity_unit", "YEARS"),
+					resource.TestCheckResourceAttr(resourceName, "signing_algorithm", "SHA256WITHRSA"),
+					resource.TestCheckResourceAttr(resourceName, "template_arn", "arn:aws:acm-pca:::template/EndEntityCertificate/V1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsAcmpcaPrivateCertificateDestroy(s *terraform.State) error {
+	// unfortunately aws pca does not have an API to determine if a cert has been revoked.
+	// see: https://docs.aws.amazon.com/acm-pca/latest/userguide/PcaRevokeCert.html
+	return nil
+}
+
+func testAccCheckAwsAcmpcaPrivateCertificateExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).acmpcaconn
+		input := &acmpca.GetCertificateInput{
+			CertificateArn:          aws.String(rs.Primary.ID),
+			CertificateAuthorityArn: aws.String(rs.Primary.Attributes["certificate_authority_arn"]),
+		}
+
+		output, err := conn.GetCertificate(input)
+
+		if err != nil {
+			return err
+		}
+
+		if output == nil || output.Certificate == nil {
+			return fmt.Errorf("ACMPCA Certificate %q does not exist", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+const testAccAwsAcmpcaPrivateCertificateConfig_Required = `
+resource "tls_private_key" "key" {
+  algorithm = "RSA"
+}
+
+resource "tls_cert_request" "csr" {
+  key_algorithm   = "RSA"
+  private_key_pem = tls_private_key.key.private_key_pem
+
+  subject {
+    common_name = "testing"
+  }
+
+}
+
+resource "aws_acmpca_certificate_authority" "test" {
+  permanent_deletion_time_in_days = 7
+  type                            = "ROOT"
+
+  certificate_authority_configuration {
+    key_algorithm     = "RSA_4096"
+    signing_algorithm = "SHA512WITHRSA"
+
+    subject {
+      common_name = "terraformtesting.com"
+    }
+  }
+}
+
+resource "aws_acmpca_private_certificate" "test" {
+	certificate_authority_arn = aws_acmpca_certificate_authority.test.arn
+	certificate_signing_request = tls_cert_request.csr.cert_request_pem
+	signing_algorithm = "SHA256WITHRSA"
+	validity_length = 1
+	validity_unit = "YEARS"
+}
+`

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -87,6 +87,7 @@
                             <ul class="nav nav-auto-expand">
                                 <li>
                                     <a href="/docs/providers/aws/d/acmpca_certificate_authority.html">aws_acmpca_certificate_authority</a>
+                                    <a href="/docs/providers/aws/d/acmpca_private_certificate.html">aws_acmpca_private_certificate</a>
                                 </li>
                             </ul>
                         </li>
@@ -95,6 +96,7 @@
                             <ul class="nav nav-auto-expand">
                                 <li>
                                     <a href="/docs/providers/aws/r/acmpca_certificate_authority.html">aws_acmpca_certificate_authority</a>
+                                    <a href="/docs/providers/aws/r/acmpca_private_certificate.html">aws_acmpca_private_certificate</a>
                                 </li>
                             </ul>
                         </li>

--- a/website/docs/d/acmpca_private_certificate.html.markdown
+++ b/website/docs/d/acmpca_private_certificate.html.markdown
@@ -1,0 +1,35 @@
+---
+layout: "aws"
+page_title: "AWS: aws_acmpca_private_certificate"
+sidebar_current: "docs-aws-datasource-acmpca-private-certificate"
+description: |-
+  Get information on a AWS Certificate Manager Private Certificate Issuing
+---
+
+# Data Source: aws_acmpca_private_certificate
+
+Get information on a AWS Certificate Manager Private Certificate Authority (ACM PCA Certificate Authority).
+
+## Example Usage
+
+```hcl
+data "aws_acmpca_private_certificate" "example" {
+  arn = "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/12345678-1234-1234-1234-123456789012/certificate/1234b4a0d73e2056789bdbe77d5b1a23"
+  certificate_authority_arn = "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/12345678-1234-1234-1234-123456789012"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `arn` - (Required) Amazon Resource Name (ARN) of the certificate issued by the private certificate authority.
+* `certificate_authority_arn` - (Required) Amazon Resource Name (ARN) of the certificate authority.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Amazon Resource Name (ARN) of the certificate authority.
+* `certificate` - Base64-encoded certificate authority (CA) certificate. Only available after the certificate authority certificate has been imported.
+* `certificate_chain` - Base64-encoded certificate chain that includes any intermediate certificates and chains up to root on-premises certificate that you used to sign your private CA certificate. The chain does not include your private CA certificate. Only available after the certificate authority certificate has been imported.

--- a/website/docs/r/acmpca_private_certificate.html.markdown
+++ b/website/docs/r/acmpca_private_certificate.html.markdown
@@ -1,0 +1,83 @@
+---
+layout: "aws"
+page_title: "AWS: aws_acmpca_private_certificate"
+sidebar_current: "docs-aws-resource-acmpca-certificate-authority"
+description: |-
+  Provides a resource to manage AWS Certificate Manager Private Certificate Issuing
+---
+
+# Resource: aws_acmpca_private_certificate
+
+Provides a resource to manage AWS Certificate Manager Private Certificate Issuing (ACM PCA Certificate Issuing). It is to be used when signing a certificate that was generated outside AWS and have `aws_acmpca_certificate_authority` as the CA.
+
+## Example Usage
+
+### Basic
+
+```hcl
+resource "aws_acmpca_certificate_authority" "example" {
+  private_certificate_configuration {
+    key_algorithm     = "RSA_4096"
+    signing_algorithm = "SHA512WITHRSA"
+
+    subject {
+      common_name = "example.com"
+    }
+  }
+
+  permanent_deletion_time_in_days = 7
+}
+
+resource "tls_private_key" "key" {
+  algorithm = "RSA"
+}
+
+resource "tls_cert_request" "csr" {
+  key_algorithm   = "RSA"
+  private_key_pem = tls_private_key.key.private_key_pem
+
+  subject {
+    common_name = "example"
+  }
+}
+
+resource "aws_acmpca_private_certificate" "example" {
+	certificate_authority_arn = aws_acmpca_certificate_authority.example.arn
+	certificate_signing_request = tls_cert_request.csr.cert_request_pem
+	signing_algorithm = "SHA256WITHRSA"
+	validity_length = 1
+	validity_unit = "YEARS"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `certificate_authority_arn` - (Required) Amazon Resource Name (ARN) of the certificate authority.
+* `certificate_signing_request` - (Required) Certificate Signing Request in PEM format.
+* `signing_algorithm` - (Required) Algorithm to use to sign certificate requests. Valid values: `SHA256WITHRSA`, `SHA256WITHECDSA`, `SHA384WITHRSA`, `SHA384WITHECDSA`, `SHA512WITHRSA`, `SHA512WITHECDSA`
+* `validity_length` - (Required) Used with `validity_unit` as the number to apply with the unit
+* `validity_unit` - (Required) The unit of time for certificate validity. Cannot be set to a value higher than the validity of the Certficate Authority. Valid values: `DAYS`, `MONTHS`, `YEARS`, `ABSOLUTE`, `END_DATE`.
+* `template_arn` - (Optional) The template to use when issueing a certificate. See [ACM PCA Documentation](https://docs.aws.amazon.com/acm-pca/latest/userguide/UsingTemplates.html) for more information.
+
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Amazon Resource Name (ARN) of the certificate.
+* `arn` - Amazon Resource Name (ARN) of the certificate.
+* `certificate` - Certificate PEM.
+* `certificate_chain` - Certificate chain that includes any intermediate certificates and chains up to root CA that you used to sign your private certificate.
+
+## Timeouts
+
+`aws_acmpca_private_certificate` provides the following [Timeouts](/docs/configuration/resources.html#timeouts)
+configuration options:
+
+* `create` - (Default `5m`) How long to wait for a certificate authority to issue a certificate.
+
+## Import
+
+`aws_acmpca_private_certificate` can not be imported at this time.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10183 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
FEATURES:

* **New Data Source:** `aws_acmpca_private_certificate` ([#10183](https://github.com/terraform-providers/terraform-provider-aws/issues/10183))
* **New Resource:** `aws_acmpca_private_certificate` ([#10183](https://github.com/terraform-providers/terraform-provider-aws/issues/10183))
```

Output from acceptance testing:

```
make testacc TEST=./aws TESTARGS='-run=TestAccAwsAcmpcaPrivateCertificate_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAwsAcmpcaPrivateCertificate_Basic -timeout 120m
=== RUN   TestAccAwsAcmpcaPrivateCertificate_Basic
=== PAUSE TestAccAwsAcmpcaPrivateCertificate_Basic
=== CONT  TestAccAwsAcmpcaPrivateCertificate_Basic
--- PASS: TestAccAwsAcmpcaPrivateCertificate_Basic (19.08s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	19.124s

make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsAcmpcaPrivateCertificate_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccDataSourceAwsAcmpcaPrivateCertificate_Basic -timeout 120m
=== RUN   TestAccDataSourceAwsAcmpcaPrivateCertificate_Basic
=== PAUSE TestAccDataSourceAwsAcmpcaPrivateCertificate_Basic
=== CONT  TestAccDataSourceAwsAcmpcaPrivateCertificate_Basic
--- PASS: TestAccDataSourceAwsAcmpcaPrivateCertificate_Basic (23.57s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	23.621s
```
