### PR TITLE
resource/aws_wafregional_web_acl_association: Ensure missing resource triggers state removal

### DIFF
--- a/aws/resource_aws_wafregional_web_acl_association.go
+++ b/aws/resource_aws_wafregional_web_acl_association.go
@@ -94,7 +94,9 @@ func resourceAwsWafRegionalWebAclAssociationRead(d *schema.ResourceData, meta in
 	}
 
 	if output == nil || output.WebACLSummary == nil {
-		return fmt.Errorf("error getting WAF Regional Web ACL for resource (%s): empty response", resourceArn)
+		log.Printf("[WARN] WAF Regional Web ACL for resource (%s) not found, removing from state", resourceArn)
+		d.SetId("")
+		return nil
 	}
 
 	d.Set("resource_arn", resourceArn)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9203

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_wafregional_web_acl_association: Ensure missing resource triggers state removal
```

Previous to code change:

```
--- FAIL: TestAccAWSWafRegionalWebAclAssociation_disappears (175.64s)
    testing.go:569: Step 0 error: errors during follow-up refresh:

        Error: error getting WAF Regional Web ACL for resource (arn:aws:elasticloadbalancing:us-west-2:--OMITTED--:loadbalancer/app/tf-lb-20190924095723723200000001/e2739f0d448dc712): empty response
```

Output from acceptance testing:

```
--- PASS: TestAccAWSWafRegionalWebAclAssociation_disappears (207.92s)
```
