### PR TITLE
Retrieve server certificate thumbprint for embedded eks OIDC provider

### DIFF
--- a/aws/data_source_aws_eks_cluster.go
+++ b/aws/data_source_aws_eks_cluster.go
@@ -60,6 +60,13 @@ func dataSourceAwsEksCluster() *schema.Resource {
 										Type:     schema.TypeString,
 										Computed: true,
 									},
+									"thumbprint_list": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+									},
 								},
 							},
 						},
@@ -155,7 +162,11 @@ func dataSourceAwsEksClusterRead(d *schema.ResourceData, meta interface{}) error
 	}
 	d.Set("endpoint", cluster.Endpoint)
 
-	if err := d.Set("identity", flattenEksIdentity(cluster.Identity)); err != nil {
+	eksIdentity, err := flattenEksIdentity(cluster.Identity)
+	if err != nil {
+		return fmt.Errorf("error obtaining eks cluster identity: %s", err)
+	}
+	if err := d.Set("identity", eksIdentity); err != nil {
 		return fmt.Errorf("error setting identity: %s", err)
 	}
 

--- a/aws/data_source_aws_eks_cluster_test.go
+++ b/aws/data_source_aws_eks_cluster_test.go
@@ -33,6 +33,7 @@ func TestAccAWSEksClusterDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "identity.#", dataSourceResourceName, "identity.#"),
 					resource.TestCheckResourceAttrPair(resourceName, "identity.0.oidc.#", dataSourceResourceName, "identity.0.oidc.#"),
 					resource.TestCheckResourceAttrPair(resourceName, "identity.0.oidc.0.issuer", dataSourceResourceName, "identity.0.oidc.0.issuer"),
+					resource.TestCheckResourceAttrPair(resourceName, "identity.0.oidc.0.thumbprint_list.0", dataSourceResourceName, "identity.0.oidc.0.thumbprint_list.0"),
 					resource.TestMatchResourceAttr(dataSourceResourceName, "platform_version", regexp.MustCompile(`^eks\.\d+$`)),
 					resource.TestCheckResourceAttrPair(resourceName, "role_arn", dataSourceResourceName, "role_arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "status", dataSourceResourceName, "status"),

--- a/aws/resource_aws_eks_cluster_test.go
+++ b/aws/resource_aws_eks_cluster_test.go
@@ -93,6 +93,7 @@ func TestAccAWSEksCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "identity.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "identity.0.oidc.#", "1"),
 					resource.TestMatchResourceAttr(resourceName, "identity.0.oidc.0.issuer", regexp.MustCompile(`^https://`)),
+					resource.TestMatchResourceAttr(resourceName, "identity.0.oidc.0.thumbprint_list.0", regexp.MustCompile(`^[0-9a-f]{40}$`)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestMatchResourceAttr(resourceName, "platform_version", regexp.MustCompile(`^eks\.\d+$`)),
 					resource.TestMatchResourceAttr(resourceName, "role_arn", regexp.MustCompile(fmt.Sprintf("%s$", rName))),

--- a/website/docs/d/eks_cluster.html.markdown
+++ b/website/docs/d/eks_cluster.html.markdown
@@ -47,6 +47,7 @@ output "identity-oidc-issuer" {
 * `identity` - Nested attribute containing identity provider information for your cluster. Only available on Kubernetes version 1.13 and 1.14 clusters created or upgraded on or after September 3, 2019. For an example using this information to enable IAM Roles for Service Accounts, see the [`aws_eks_cluster` resource documentation](/docs/providers/aws/r/eks_cluster.html).
   * `oidc` - Nested attribute containing [OpenID Connect](https://openid.net/connect/) identity provider information for the cluster.
     * `issuer` - Issuer URL for the OpenID Connect identity provider.
+    * `thumbprint_list` - A list of server certificate thumbprints for the OpenID Connect (OIDC) identity provider's server certificate(s)
 * `platform_version` - The platform version for the cluster.
 * `role_arn` - The Amazon Resource Name (ARN) of the IAM role that provides permissions for the Kubernetes control plane to make calls to AWS API operations on your behalf.
 * `status` - The status of the EKS cluster. One of `CREATING`, `ACTIVE`, `DELETING`, `FAILED`.

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -134,6 +134,7 @@ In addition to all arguments above, the following attributes are exported:
 * `identity` - Nested attribute containing identity provider information for your cluster. Only available on Kubernetes version 1.13 and 1.14 clusters created or upgraded on or after September 3, 2019.
   * `oidc` - Nested attribute containing [OpenID Connect](https://openid.net/connect/) identity provider information for the cluster.
     * `issuer` - Issuer URL for the OpenID Connect identity provider.
+    * `thumbprint_list` - A list of server certificate thumbprints for the OpenID Connect (OIDC) identity provider's server certificate(s)
 * `platform_version` - The platform version for the cluster.
 * `status` - The status of the EKS cluster. One of `CREATING`, `ACTIVE`, `DELETING`, `FAILED`. 
 * `version` - The Kubernetes server version for the cluster.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

### Issue
The server certificate thumbprint is not automatically populated when creating an OIDC provider through terraform.

Closes terraform-providers/terraform-provider-aws#10104

### Description
This adds a list of server certificate thumbprints as a computed attribute
to both the aws_eks_cluster resource and aws_eks_cluster data source.
It implements the instructions from https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html
in go.

After the change, the oidc portion of an eks_cluster state looks as follows

```
data "aws_eks_cluster" "test_cluster" {
    identity = [
        {
            oidc = [
                {
                    issuer = "https://oidc.eks.us-east-2.amazonaws.com/id/ABCDEFGHI"
                    thumbprint_list = [
                        "9e99a48a9960b14926bb7f3b02e22da2b0ab7280",
                    ]
                },
            ]
        },
    ]
}
```

The happy path acceptance tests have been updated.

### Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
ENHANCEMENTS
* resource/aws_eks_cluster: Added thumbprint_list attribute to embedded OIDC provider
* data-source/aws_eks_cluster: Added thumbprint_list attribute to embedded OIDC provider
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSEksCluster_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSEksCluster_basic -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEksCluster_basic
=== PAUSE TestAccAWSEksCluster_basic
=== CONT  TestAccAWSEksCluster_basic
--- PASS: TestAccAWSEksCluster_basic (1119.64s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       1119.678s
```

```
$ make testacc TESTARGS='-run=TestAccAWSEksClusterDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSEksClusterDataSource_basic -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEksClusterDataSource_basic
=== PAUSE TestAccAWSEksClusterDataSource_basic
=== CONT  TestAccAWSEksClusterDataSource_basic
--- PASS: TestAccAWSEksClusterDataSource_basic (1133.96s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       1133.998s
```