### PR TITLE
Address cloudtrail error when no event selectors defined in config

### DIFF
--- a/aws/resource_aws_cloudtrail.go
+++ b/aws/resource_aws_cloudtrail.go
@@ -450,6 +450,11 @@ func cloudTrailSetEventSelectors(conn *cloudtrail.CloudTrail, d *schema.Resource
 	}
 
 	eventSelectors := expandAwsCloudTrailEventSelector(d.Get("event_selector").([]interface{}))
+	if len(eventSelectors) == 0 {
+		es := &cloudtrail.EventSelector{}
+		eventSelectors = append(eventSelectors, es)
+	}
+
 	input.EventSelectors = eventSelectors
 
 	if err := input.Validate(); err != nil {


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Closes #6628
Also fixes failing cloudtrail acc test on master due to '/' in S3 key prefix.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):


```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSCloudTrail''
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSCloudTrail -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSCloudTrailServiceAccount_basic
=== PAUSE TestAccAWSCloudTrailServiceAccount_basic
=== RUN   TestAccAWSCloudTrailServiceAccount_Region
=== PAUSE TestAccAWSCloudTrailServiceAccount_Region
=== RUN   TestAccAWSCloudTrail
=== RUN   TestAccAWSCloudTrail/Trail
=== RUN   TestAccAWSCloudTrail/Trail/basic
=== RUN   TestAccAWSCloudTrail/Trail/cloudwatch
=== RUN   TestAccAWSCloudTrail/Trail/includeGlobalServiceEvents
=== RUN   TestAccAWSCloudTrail/Trail/deleteEventSelector
=== RUN   TestAccAWSCloudTrail/Trail/enableLogging
=== RUN   TestAccAWSCloudTrail/Trail/isMultiRegion
=== RUN   TestAccAWSCloudTrail/Trail/isOrganization
=== RUN   TestAccAWSCloudTrail/Trail/logValidation
=== RUN   TestAccAWSCloudTrail/Trail/kmsKey
=== RUN   TestAccAWSCloudTrail/Trail/tags
=== RUN   TestAccAWSCloudTrail/Trail/eventSelector
--- PASS: TestAccAWSCloudTrail (744.55s)
    --- PASS: TestAccAWSCloudTrail/Trail (744.55s)
        --- PASS: TestAccAWSCloudTrail/Trail/basic (66.50s)
        --- PASS: TestAccAWSCloudTrail/Trail/cloudwatch (80.80s)
        --- PASS: TestAccAWSCloudTrail/Trail/includeGlobalServiceEvents (41.54s)
        --- PASS: TestAccAWSCloudTrail/Trail/deleteEventSelector (85.66s)
        --- PASS: TestAccAWSCloudTrail/Trail/enableLogging (91.61s)
        --- PASS: TestAccAWSCloudTrail/Trail/isMultiRegion (87.32s)
        --- SKIP: TestAccAWSCloudTrail/Trail/isOrganization (1.38s)
            provider_test.go:255: skipping tests; this AWS account must not be an existing member of an AWS Organization
        --- PASS: TestAccAWSCloudTrail/Trail/logValidation (66.99s)
        --- PASS: TestAccAWSCloudTrail/Trail/kmsKey (60.49s)
        --- PASS: TestAccAWSCloudTrail/Trail/tags (89.40s)
        --- PASS: TestAccAWSCloudTrail/Trail/eventSelector (72.87s)
=== CONT  TestAccAWSCloudTrailServiceAccount_basic
=== CONT  TestAccAWSCloudTrailServiceAccount_Region
--- PASS: TestAccAWSCloudTrailServiceAccount_basic (10.79s)
--- PASS: TestAccAWSCloudTrailServiceAccount_Region (10.93s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	755.540s

```
