### PR TITLE
tests/resource/aws_cloudtrail: Remove troublesome slash prefix

### DIFF
--- a/aws/resource_aws_cloudtrail_test.go
+++ b/aws/resource_aws_cloudtrail_test.go
@@ -71,7 +71,7 @@ func testAccAWSCloudTrail_basic(t *testing.T) {
 				Config: testAccAWSCloudTrailConfigModified(cloudTrailRandInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists("aws_cloudtrail.foobar", &trail),
-					resource.TestCheckResourceAttr("aws_cloudtrail.foobar", "s3_key_prefix", "/prefix"),
+					resource.TestCheckResourceAttr("aws_cloudtrail.foobar", "s3_key_prefix", "prefix"),
 					resource.TestCheckResourceAttr("aws_cloudtrail.foobar", "include_global_service_events", "false"),
 					testAccCheckCloudTrailLogValidationEnabled("aws_cloudtrail.foobar", false, &trail),
 					testAccCheckCloudTrailKmsKeyIdEquals("aws_cloudtrail.foobar", "", &trail),
@@ -647,7 +647,7 @@ func testAccAWSCloudTrailConfigModified(cloudTrailRandInt int) string {
 resource "aws_cloudtrail" "foobar" {
   name                          = "tf-trail-foobar-%d"
   s3_bucket_name                = "${aws_s3_bucket.foo.id}"
-  s3_key_prefix                 = "/prefix"
+  s3_key_prefix                 = "prefix"
   include_global_service_events = false
   enable_logging                = false
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
none
```

During testing of the S3 bucket sweeper it was found that the test changed in the PR was creating a S3 key that had an extra slash at the beginning. This key causes issues when when trying to delete the bucket object "nothing gets deleted" causing the `s3_bucket` sweeper to error out.

Acceptance test after change
```
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSCloudTrail/Trail/basic -timeout 120m
=== RUN   TestAccAWSCloudTrailServiceAccount_basic
=== PAUSE TestAccAWSCloudTrailServiceAccount_basic
=== RUN   TestAccAWSCloudTrailServiceAccount_Region
=== PAUSE TestAccAWSCloudTrailServiceAccount_Region
=== RUN   TestAccAWSCloudTrail
=== RUN   TestAccAWSCloudTrail/Trail
=== RUN   TestAccAWSCloudTrail/Trail/basic
--- PASS: TestAccAWSCloudTrail (72.62s)
    --- PASS: TestAccAWSCloudTrail/Trail (72.62s)
        --- PASS: TestAccAWSCloudTrail/Trail/basic (72.62s)
=== CONT  TestAccAWSCloudTrailServiceAccount_basic
=== CONT  TestAccAWSCloudTrailServiceAccount_Region
--- PASS: TestAccAWSCloudTrailServiceAccount_Region (15.04s)
--- PASS: TestAccAWSCloudTrailServiceAccount_basic (15.12s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       87.776s
```