### PR TITLE
Add support for glue_version to resource aws_glue_job

### DIFF
--- a/aws/resource_aws_glue_job.go
+++ b/aws/resource_aws_glue_job.go
@@ -66,6 +66,10 @@ func resourceAwsGlueJob() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"glue_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"execution_property": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -155,6 +159,10 @@ func resourceAwsGlueJobCreate(d *schema.ResourceData, meta interface{}) error {
 		input.Description = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("glue_version"); ok {
+		input.GlueVersion = aws.String(v.(string))
+	}
+
 	if v, ok := d.GetOk("execution_property"); ok {
 		input.ExecutionProperty = expandGlueExecutionProperty(v.([]interface{}))
 	}
@@ -213,6 +221,7 @@ func resourceAwsGlueJobRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error setting default_arguments: %s", err)
 	}
 	d.Set("description", job.Description)
+	d.Set("glue_version", job.GlueVersion)
 	if err := d.Set("execution_property", flattenGlueExecutionProperty(job.ExecutionProperty)); err != nil {
 		return fmt.Errorf("error setting execution_property: %s", err)
 	}
@@ -265,6 +274,10 @@ func resourceAwsGlueJobUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("description"); ok {
 		jobUpdate.Description = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("glue_version"); ok {
+		jobUpdate.GlueVersion = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("execution_property"); ok {

--- a/aws/resource_aws_glue_job_test.go
+++ b/aws/resource_aws_glue_job_test.go
@@ -233,6 +233,40 @@ func TestAccAWSGlueJob_Description(t *testing.T) {
 	})
 }
 
+func TestAccAWSGlueJob_GlueVersion(t *testing.T) {
+	var job glue.Job
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "aws_glue_job.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGlueJobConfig_GlueVersion(rName, "0.9"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueJobExists(resourceName, &job),
+					resource.TestCheckResourceAttr(resourceName, "glue_version", "0.9"),
+				),
+			},
+			{
+				Config: testAccAWSGlueJobConfig_GlueVersion(rName, "1.0"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueJobExists(resourceName, &job),
+					resource.TestCheckResourceAttr(resourceName, "glue_version", "1.0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSGlueJob_ExecutionProperty(t *testing.T) {
 	var job glue.Job
 
@@ -643,6 +677,25 @@ resource "aws_glue_job" "test" {
   depends_on = ["aws_iam_role_policy_attachment.test"]
 }
 `, testAccAWSGlueJobConfig_Base(rName), description, rName)
+}
+
+func testAccAWSGlueJobConfig_GlueVersion(rName, glueVersion string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "aws_glue_job" "test" {
+  glue_version       = "%s"
+  name               = "%s"
+  role_arn           = "${aws_iam_role.test.arn}"
+  allocated_capacity = 10
+
+  command {
+    script_location = "testscriptlocation"
+  }
+
+  depends_on = ["aws_iam_role_policy_attachment.test"]
+}
+`, testAccAWSGlueJobConfig_Base(rName), glueVersion, rName)
 }
 
 func testAccAWSGlueJobConfig_ExecutionProperty(rName string, maxConcurrentRuns int) string {

--- a/website/docs/r/glue_job.html.markdown
+++ b/website/docs/r/glue_job.html.markdown
@@ -61,7 +61,8 @@ be removed in future releases, please use `max_capacity` instead.
 * `role_arn` – (Required) The ARN of the IAM role associated with this job.
 * `timeout` – (Optional) The job timeout in minutes. The default is 2880 minutes (48 hours).
 * `security_configuration` - (Optional) The name of the Security Configuration to be associated with the job.
-
+* `glue_version` - (Optional) The version of glue to use, for example "1.0".  For information about available versionse see [AWS Glue Release Notes](https://docs.aws.amazon.com/glue/latest/dg/release-notes.html).
+  
 ### command Argument Reference
 
 * `name` - (Optional) The name of the job command. Defaults to `glueetl`


### PR DESCRIPTION
Closes #9524 , python_version support is already resolved. 

This will enable you to use a newer versions of AWS Glue, also python 3 and Spark 2.4.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
- Added support to change glue version in resource aws_glue_job
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSGlueJob_GlueVersion'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSGlueJob_GlueVersion -timeout 120m
=== RUN   TestAccAWSGlueJob_GlueVersion
=== PAUSE TestAccAWSGlueJob_GlueVersion
=== CONT  TestAccAWSGlueJob_GlueVersion

--- PASS: TestAccAWSGlueJob_GlueVersion (66.90s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	66.922s

...
```
