### PR TITLE
Refactor: use acctest.RandStringFromCharSet() instead of randomString in resource_aws_redshift_cluster_test

### DIFF
--- a/aws/resource_aws_redshift_cluster_test.go
+++ b/aws/resource_aws_redshift_cluster_test.go
@@ -84,7 +84,7 @@ func TestValidateRedshiftClusterDbName(t *testing.T) {
 		"/slash-at-the-beginning",
 		"slash-at-the-end/",
 		"",
-		randomString(100),
+		acctest.RandStringFromCharSet(100, acctest.CharSetAlpha),
 		"TestDBname",
 	}
 	for _, v := range invalidNames {
@@ -801,7 +801,7 @@ func TestResourceAWSRedshiftClusterFinalSnapshotIdentifierValidation(t *testing.
 			ErrCount: 1,
 		},
 		{
-			Value:    randomString(256),
+			Value:    acctest.RandStringFromCharSet(256, acctest.CharSetAlpha),
 			ErrCount: 1,
 		},
 	}
@@ -829,7 +829,7 @@ func TestResourceAWSRedshiftClusterMasterUsernameValidation(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    randomString(129),
+			Value:    acctest.RandStringFromCharSet(129, acctest.CharSetAlpha),
 			ErrCount: 1,
 		},
 		{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10040

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestValidateRedshiftClusterDbName'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestValidateRedshiftClusterDbName -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestValidateRedshiftClusterDbName
--- PASS: TestValidateRedshiftClusterDbName (0.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       0.054s
$ make testacc TESTARGS='-run=TestResourceAWSRedshiftClusterFinalSnapshotIdentifierValidation'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestResourceAWSRedshiftClusterFinalSnapshotIdentifierValidation -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestResourceAWSRedshiftClusterFinalSnapshotIdentifierValidation
--- PASS: TestResourceAWSRedshiftClusterFinalSnapshotIdentifierValidation (0.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       0.049s

$ make testacc TESTARGS='-run=TestResourceAWSRedshiftClusterMasterUsernameValidation'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestResourceAWSRedshiftClusterMasterUsernameValidation -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestResourceAWSRedshiftClusterMasterUsernameValidation
--- PASS: TestResourceAWSRedshiftClusterMasterUsernameValidation (0.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       0.048s
```
