### PR TITLE
service/waf: Only wrap errors returned by GetChangeToken in RetryWithToken

### DIFF
--- a/aws/waf_token_handlers.go
+++ b/aws/waf_token_handlers.go
@@ -40,12 +40,15 @@ func (t *WafRetryer) RetryWithToken(f withTokenFunc) (interface{}, error) {
 	})
 	if isResourceTimeoutError(err) {
 		tokenOut, err = t.Connection.GetChangeToken(&waf.GetChangeTokenInput{})
-		if err == nil {
-			out, err = f(tokenOut.ChangeToken)
+
+		if err != nil {
+			return nil, fmt.Errorf("error getting WAF change token: %s", err)
 		}
+
+		out, err = f(tokenOut.ChangeToken)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("Error getting WAF change token: %s", err)
+		return nil, err
 	}
 	return out, nil
 }

--- a/aws/wafregionl_token_handlers.go
+++ b/aws/wafregionl_token_handlers.go
@@ -43,12 +43,15 @@ func (t *WafRegionalRetryer) RetryWithToken(f withRegionalTokenFunc) (interface{
 	})
 	if isResourceTimeoutError(err) {
 		tokenOut, err = t.Connection.GetChangeToken(&waf.GetChangeTokenInput{})
-		if err == nil {
-			out, err = f(tokenOut.ChangeToken)
+
+		if err != nil {
+			return nil, fmt.Errorf("error getting WAF Regional change token: %s", err)
 		}
+
+		out, err = f(tokenOut.ChangeToken)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("Error getting WAF regional change token: %s", err)
+		return nil, err
 	}
 	return out, nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/9826

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* service/waf: Prevent incorrect `Error getting WAF change token` errors for API calls that should be retried
* service/wafregional: Prevent incorrect `Error getting WAF regional change token` errors for API calls that should be retried
```

Wrapping the errors of the passed in WAF API functions breaks downstream error checking, e.g. `isAWSErr()`

Previously (failure based on eventual consistency):

```
--- FAIL: TestAccAWSWafWebAcl_Rules (31.87s)
    testing.go:569: Step 2 error: errors during apply:

        Error: Error deleting WAF Rule: Error getting WAF change token: WAFReferencedItemException: This entity is still referenced by other entities.
```

Output from acceptance testing:

```console
$ TF_ACC=1 go test ./aws -v -count=10 -timeout 120m -parallel 20 -run='TestAccAWSWafWebAcl_Rules'
...
--- PASS: TestAccAWSWafWebAcl_Rules (36.99s)
--- PASS: TestAccAWSWafWebAcl_Rules (34.34s)
--- PASS: TestAccAWSWafWebAcl_Rules (34.90s)
--- PASS: TestAccAWSWafWebAcl_Rules (35.58s)
--- PASS: TestAccAWSWafWebAcl_Rules (36.87s)
--- PASS: TestAccAWSWafWebAcl_Rules (33.99s)
--- PASS: TestAccAWSWafWebAcl_Rules (35.01s)
--- PASS: TestAccAWSWafWebAcl_Rules (33.60s)
--- PASS: TestAccAWSWafWebAcl_Rules (33.70s)
--- PASS: TestAccAWSWafWebAcl_Rules (35.82s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	353.338s
```

Also verified by running the stuck sweeper:

```console
$ go test ./aws -v -sweep=us-east-1,us-west-2 -sweep-run=aws_wafregional_web_acl -timeout 10h
...
2019/09/25 11:50:25 [INFO] Deleting WAF Regional Web ACL: dc595176-6e50-488d-a9b0-35df984b672f
...
2019/09/25 11:50:26 [INFO] Removing Rules from WAF Regional Web ACL: dc595176-6e50-488d-a9b0-35df984b672f
...
2019/09/25 11:50:27 [INFO] Deleting WAF Regional Web ACL: dc595176-6e50-488d-a9b0-35df984b672f
...
2019/09/25 11:50:28 Sweeper Tests ran:
	- aws_wafregional_web_acl
ok  	github.com/terraform-providers/terraform-provider-aws/aws	8.119s
```
