### PR TITLE
Provide a working example in docs for data ecs-task-definition

### DIFF
--- a/website/docs/d/ecs_task_definition.html.markdown
+++ b/website/docs/d/ecs_task_definition.html.markdown
@@ -17,7 +17,7 @@ a specific AWS ECS task definition.
 ```hcl
 # Simply specify the family to find the latest ACTIVE revision in that family.
 data "aws_ecs_task_definition" "mongo" {
-  task_definition = "${aws_ecs_task_definition.mongo.family}"
+  task_definition = "${aws_ecs_task_definition.mongo.revision ? "${aws_ecs_task_definition.mongo.family}" : "${aws_ecs_task_definition.mongo.family}"}"
 }
 
 resource "aws_ecs_cluster" "foo" {


### PR DESCRIPTION
This is working around the issue of not having a task definition when the resources are initially rolled out.

Background:

The documetation example of directly referecing "task_family" doesn't work and exits with an error when initially applying it. See also this issue https://github.com/terraform-providers/terraform-provider-aws/issues/1274

The reason is, that data sources don't handle missing data gracefully. Unfortunately, that's not gonna be addressed, as stated here: https://github.com/hashicorp/terraform/issues/16380#issuecomment-517282340
One of the suggested workarounds is, to add an explict `depends_on`. However, this causes a potential change in the terraform plan output, even though it's not actually going to change. Furthermore, it's discourage by the Terraform documentation itself.

This thread mentions a few other workarounds, but none of them seem to be suitable https://github.com/hashicorp/terraform/issues/16380

`aws_ecs_task_definition.self.revision` can only be referenced, once the resource is created (in contrast to family, which is already present in code)
Apparently, this allows Terraform to correctly resolve the dependencies and makes the data source behave as expected.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

```release-note
NONE
```
