### PR TITLE
resource_aws_efs_filesystem: create tags when resource is created

### DIFF
--- a/aws/resource_aws_efs_file_system.go
+++ b/aws/resource_aws_efs_file_system.go
@@ -132,6 +132,7 @@ func resourceAwsEfsFileSystemCreate(d *schema.ResourceData, meta interface{}) er
 	createOpts := &efs.CreateFileSystemInput{
 		CreationToken:  aws.String(creationToken),
 		ThroughputMode: aws.String(throughputMode),
+		Tags:           tagsFromMapEFS(d.Get("tags").(map[string]interface{})),
 	}
 
 	if v, ok := d.GetOk("performance_mode"); ok {
@@ -191,11 +192,6 @@ func resourceAwsEfsFileSystemCreate(d *schema.ResourceData, meta interface{}) er
 			return fmt.Errorf("Error creating lifecycle policy for EFS file system %q: %s",
 				d.Id(), err.Error())
 		}
-	}
-
-	err = setTagsEFS(conn, d)
-	if err != nil {
-		return fmt.Errorf("error setting tags for EFS file system (%q): %s", d.Id(), err)
 	}
 
 	return resourceAwsEfsFileSystemRead(d, meta)


### PR DESCRIPTION
The tags for the efs filesystems were being attached after the resource
was created. AWS has since updated their API so that tags can be
specificed at create time.

Fixes #7662

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #7662

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_efs_file_system: add tags at create time
```

Output from acceptance testing:

```
AWS_PROFILE=testacc TF_ACC=1 go test -v ./aws/ -run TestAccAWSEFSFileSystem
=== RUN   TestAccAWSEFSFileSystem_importBasic
=== PAUSE TestAccAWSEFSFileSystem_importBasic
=== RUN   TestAccAWSEFSFileSystem_basic
=== PAUSE TestAccAWSEFSFileSystem_basic
=== RUN   TestAccAWSEFSFileSystem_pagedTags
=== PAUSE TestAccAWSEFSFileSystem_pagedTags
=== RUN   TestAccAWSEFSFileSystem_kmsKey
=== PAUSE TestAccAWSEFSFileSystem_kmsKey
=== RUN   TestAccAWSEFSFileSystem_kmsConfigurationWithoutEncryption
=== PAUSE TestAccAWSEFSFileSystem_kmsConfigurationWithoutEncryption
=== RUN   TestAccAWSEFSFileSystem_ProvisionedThroughputInMibps
=== PAUSE TestAccAWSEFSFileSystem_ProvisionedThroughputInMibps
=== RUN   TestAccAWSEFSFileSystem_ThroughputMode
=== PAUSE TestAccAWSEFSFileSystem_ThroughputMode
=== RUN   TestAccAWSEFSFileSystem_lifecyclePolicy
=== PAUSE TestAccAWSEFSFileSystem_lifecyclePolicy
=== RUN   TestAccAWSEFSFileSystem_lifecyclePolicy_update
=== PAUSE TestAccAWSEFSFileSystem_lifecyclePolicy_update
=== RUN   TestAccAWSEFSFileSystem_lifecyclePolicy_removal
=== PAUSE TestAccAWSEFSFileSystem_lifecyclePolicy_removal
=== CONT  TestAccAWSEFSFileSystem_importBasic
=== CONT  TestAccAWSEFSFileSystem_ThroughputMode
=== CONT  TestAccAWSEFSFileSystem_ProvisionedThroughputInMibps
=== CONT  TestAccAWSEFSFileSystem_kmsConfigurationWithoutEncryption
--- PASS: TestAccAWSEFSFileSystem_importBasic (29.44s)
=== CONT  TestAccAWSEFSFileSystem_kmsKey
--- PASS: TestAccAWSEFSFileSystem_kmsConfigurationWithoutEncryption (36.99s)
=== CONT  TestAccAWSEFSFileSystem_pagedTags
--- PASS: TestAccAWSEFSFileSystem_ThroughputMode (44.96s)
=== CONT  TestAccAWSEFSFileSystem_basic
--- PASS: TestAccAWSEFSFileSystem_ProvisionedThroughputInMibps (45.47s)
=== CONT  TestAccAWSEFSFileSystem_lifecyclePolicy_update
--- PASS: TestAccAWSEFSFileSystem_pagedTags (25.57s)
=== CONT  TestAccAWSEFSFileSystem_lifecyclePolicy
--- PASS: TestAccAWSEFSFileSystem_kmsKey (56.22s)
=== CONT  TestAccAWSEFSFileSystem_lifecyclePolicy_removal
--- PASS: TestAccAWSEFSFileSystem_lifecyclePolicy_update (43.64s)
--- PASS: TestAccAWSEFSFileSystem_lifecyclePolicy (37.87s)
--- PASS: TestAccAWSEFSFileSystem_basic (62.46s)
--- PASS: TestAccAWSEFSFileSystem_lifecyclePolicy_removal (39.58s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	126.953s
```
