### PR TITLE
Add resource aws_cloudwatch_event_bus

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -383,6 +383,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_cloudfront_origin_access_identity":                   resourceAwsCloudFrontOriginAccessIdentity(),
 			"aws_cloudfront_public_key":                               resourceAwsCloudFrontPublicKey(),
 			"aws_cloudtrail":                                          resourceAwsCloudTrail(),
+			"aws_cloudwatch_event_bus":                                resourceAwsCloudWatchEventBus(),
 			"aws_cloudwatch_event_permission":                         resourceAwsCloudWatchEventPermission(),
 			"aws_cloudwatch_event_rule":                               resourceAwsCloudWatchEventRule(),
 			"aws_cloudwatch_event_target":                             resourceAwsCloudWatchEventTarget(),

--- a/aws/resource_aws_cloudwatch_event_bus.go
+++ b/aws/resource_aws_cloudwatch_event_bus.go
@@ -1,0 +1,100 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudwatchevents"
+)
+
+func resourceAwsCloudWatchEventBus() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsCloudWatchEventBusCreate,
+		Read:   resourceAwsCloudWatchEventBusRead,
+		Delete: resourceAwsCloudWatchEventBusDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateCloudWatchEventBusName,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsCloudWatchEventBusCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudwatcheventsconn
+
+	eventBusName := d.Get("name").(string)
+	params := &cloudwatchevents.CreateEventBusInput{
+		Name: aws.String(eventBusName),
+	}
+
+	log.Printf("[DEBUG] Creating CloudWatch Event Bus: %v", params)
+
+	_, err := conn.CreateEventBus(params)
+	if err != nil {
+		return fmt.Errorf("Creating CloudWatch Event Bus %v failed: %v", eventBusName, err)
+	}
+
+	d.SetId(eventBusName)
+
+	log.Printf("[INFO] CloudWatch Event Bus %v created", d.Id())
+
+	return resourceAwsCloudWatchEventBusRead(d, meta)
+}
+
+func resourceAwsCloudWatchEventBusRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudwatcheventsconn
+	log.Printf("[DEBUG] Reading CloudWatch Event Bus: %v", d.Id())
+
+	input := &cloudwatchevents.DescribeEventBusInput{
+		Name: aws.String(d.Id()),
+	}
+
+	output, err := conn.DescribeEventBus(input)
+	if isAWSErr(err, cloudwatchevents.ErrCodeResourceNotFoundException, "") {
+		log.Printf("[WARN] CloudWatch Event Bus (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error reading CloudWatch Event Bus: %s", err)
+	}
+
+	log.Printf("[DEBUG] Found CloudWatch Event bus: %#v", *output)
+
+	d.Set("arn", output.Arn)
+	d.Set("name", output.Name)
+
+	return nil
+}
+
+func resourceAwsCloudWatchEventBusDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudwatcheventsconn
+	log.Printf("[INFO] Deleting CloudWatch Event Bus: %v", d.Id())
+	_, err := conn.DeleteEventBus(&cloudwatchevents.DeleteEventBusInput{
+		Name: aws.String(d.Id()),
+	})
+	if isAWSErr(err, cloudwatchevents.ErrCodeResourceNotFoundException, "") {
+		log.Printf("[WARN] CloudWatch Event Bus (%s) not found", d.Id())
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error deleting CloudWatch Event Bus %v: %v", d.Id(), err)
+	}
+	log.Printf("[INFO] CloudWatch Event Bus %v deleted", d.Id())
+
+	return nil
+}

--- a/aws/resource_aws_cloudwatch_event_bus_test.go
+++ b/aws/resource_aws_cloudwatch_event_bus_test.go
@@ -1,0 +1,186 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"log"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudwatchevents"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_cloudwatch_event_bus", &resource.Sweeper{
+		Name: "aws_cloudwatch_event_bus",
+		F:    testSweepCloudWatchEventBuses,
+		Dependencies: []string{
+			"aws_cloudwatch_event_rule",
+			"aws_cloudwatch_event_target",
+		},
+	})
+}
+
+func testSweepCloudWatchEventBuses(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("Error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).cloudwatcheventsconn
+
+	input := &cloudwatchevents.ListEventBusesInput{}
+
+	for {
+		output, err := conn.ListEventBuses(input)
+		if err != nil {
+			if testSweepSkipSweepError(err) {
+				log.Printf("[WARN] Skipping CloudWatch Event Bus sweep for %s: %s", region, err)
+				return nil
+			}
+			return fmt.Errorf("Error retrieving CloudWatch Event Buses: %s", err)
+		}
+
+		if len(output.EventBuses) == 0 {
+			log.Print("[DEBUG] No CloudWatch Event Buses to sweep")
+			return nil
+		}
+
+		for _, eventBus := range output.EventBuses {
+			name := aws.StringValue(eventBus.Name)
+			if name == "default" {
+				continue
+			}
+
+			log.Printf("[INFO] Deleting CloudWatch Event Bus %s", name)
+			_, err := conn.DeleteEventBus(&cloudwatchevents.DeleteEventBusInput{
+				Name: aws.String(name),
+			})
+			if err != nil {
+				return fmt.Errorf("Error deleting CloudWatch Event Bus %s: %s", name, err)
+			}
+		}
+
+		if output.NextToken == nil {
+			break
+		}
+		input.NextToken = output.NextToken
+	}
+
+	return nil
+}
+
+func TestAccAWSCloudWatchEventBus_basic(t *testing.T) {
+	var eventBusOutput cloudwatchevents.DescribeEventBusOutput
+	busName := acctest.RandomWithPrefix("tf-acc-test")
+	busNameModified := acctest.RandomWithPrefix("tf-acc-test")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudWatchEventBusDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudWatchEventBusConfig(busName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchEventBusExists("aws_cloudwatch_event_bus.foo", &eventBusOutput),
+					resource.TestCheckResourceAttr("aws_cloudwatch_event_bus.foo", "name", busName),
+				),
+			},
+			{
+				Config: testAccAWSCloudWatchEventBusConfig(busNameModified),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchEventBusExists("aws_cloudwatch_event_bus.foo", &eventBusOutput),
+					resource.TestCheckResourceAttr("aws_cloudwatch_event_bus.foo", "name", busNameModified),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudWatchEventBus_disappears(t *testing.T) {
+	var eventBusOutput cloudwatchevents.DescribeEventBusOutput
+	busName := acctest.RandomWithPrefix("tf-acc-test")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudWatchEventBusDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudWatchEventBusConfig(busName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchEventBusExists("aws_cloudwatch_event_bus.foo", &eventBusOutput),
+					testAccCheckCloudWatchEventBusDisappears(&eventBusOutput),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSCloudWatchEventBusDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).cloudwatcheventsconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_cloudwatch_event_bus" {
+			continue
+		}
+
+		params := cloudwatchevents.DescribeEventBusInput{
+			Name: aws.String(rs.Primary.ID),
+		}
+
+		resp, err := conn.DescribeEventBus(&params)
+
+		if err == nil {
+			return fmt.Errorf("CloudWatch Event Bus %q still exists: %s",
+				rs.Primary.ID, resp)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckCloudWatchEventBusExists(n string, v *cloudwatchevents.DescribeEventBusOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).cloudwatcheventsconn
+		params := cloudwatchevents.DescribeEventBusInput{
+			Name: aws.String(rs.Primary.ID),
+		}
+		resp, err := conn.DescribeEventBus(&params)
+		if err != nil {
+			return err
+		}
+		if resp == nil {
+			return fmt.Errorf("Event Bus not found")
+		}
+
+		*v = *resp
+
+		return nil
+	}
+}
+
+func testAccCheckCloudWatchEventBusDisappears(v *cloudwatchevents.DescribeEventBusOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).cloudwatcheventsconn
+		opts := &cloudwatchevents.DeleteEventBusInput{
+			Name: v.Name,
+		}
+		_, err := conn.DeleteEventBus(opts)
+		return err
+	}
+}
+
+func testAccAWSCloudWatchEventBusConfig(name string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_event_bus" "foo" {
+    name = "%s"
+}
+`, name)
+}

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -2407,3 +2407,9 @@ func validateRoute53ResolverName(v interface{}, k string) (ws []string, errors [
 
 	return
 }
+
+var validateCloudWatchEventBusName = validation.All(
+	validation.StringLenBetween(1, 256),
+	validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9._\-]+$`), ""),
+	validation.StringDoesNotMatch(regexp.MustCompile(`^default$`), ""),
+)

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2985,3 +2985,42 @@ func TestValidateRoute53ResolverName(t *testing.T) {
 		}
 	}
 }
+
+func TestCloudWatchEventBusName(t *testing.T) {
+	cases := []struct {
+		Value   string
+		IsValid bool
+	}{
+		{
+			Value:   "",
+			IsValid: false,
+		},
+		{
+			Value:   acctest.RandStringFromCharSet(256, acctest.CharSetAlpha),
+			IsValid: true,
+		},
+		{
+			Value:   acctest.RandStringFromCharSet(257, acctest.CharSetAlpha),
+			IsValid: false,
+		},
+		{
+			Value:   "aws.partner/test/test",
+			IsValid: false,
+		},
+		{
+			Value:   "/test0._1-",
+			IsValid: false,
+		},
+		{
+			Value:   "test0._1-",
+			IsValid: true,
+		},
+	}
+	for _, tc := range cases {
+		_, errors := validateCloudWatchEventBusName(tc.Value, "aws_cloudwatch_event_bus")
+		isValid := len(errors) == 0
+		if tc.IsValid != isValid {
+			t.Fatalf("Expected the AWS CloudWatch Event Bus Name to not trigger a validation error for %q", tc.Value)
+		}
+	}
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -526,6 +526,9 @@
                                     <a href="/docs/providers/aws/r/cloudwatch_dashboard.html">aws_cloudwatch_dashboard</a>
                                 </li>
                                 <li>
+                                    <a href="/docs/providers/aws/r/cloudwatch_event_bus.html">aws_cloudwatch_event_bus</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/aws/r/cloudwatch_event_permission.html">aws_cloudwatch_event_permission</a>
                                 </li>
                                 <li>

--- a/website/docs/r/cloudwatch_event_bus.html.markdown
+++ b/website/docs/r/cloudwatch_event_bus.html.markdown
@@ -1,0 +1,42 @@
+---
+subcategory: "CloudWatch"
+layout: "aws"
+page_title: "AWS: aws_cloudwatch_event_bus"
+description: |-
+  Provides a CloudWatch Event Bus resource.
+---
+
+# Resource: aws_cloudwatch_event_bus
+
+Provides a CloudWatch Event Bus resource.
+
+## Example Usage
+
+```hcl
+resource "aws_cloudwatch_event_bus" "messenger" {
+  name = "chat-messages"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the new event bus.
+	The names of custom event buses can't contain the / character.
+	Please note that a partner event bus is not supported at the moment.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The Amazon Resource Name (ARN) of the event bus.
+
+
+## Import
+
+Cloudwatch Event Buses can be imported using the `name`, e.g.
+
+```
+$ terraform import aws_cloudwatch_event_bus.messenger chat-messages
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #9330

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* **New Resource:** `aws_cloudwatch_event_bus`
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudWatchEventBus'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudWatchEventBus -timeout 120m
=== RUN   TestAccAWSCloudWatchEventBus_basic
=== PAUSE TestAccAWSCloudWatchEventBus_basic
=== RUN   TestAccAWSCloudWatchEventBus_disappears
=== PAUSE TestAccAWSCloudWatchEventBus_disappears
=== CONT  TestAccAWSCloudWatchEventBus_basic
=== CONT  TestAccAWSCloudWatchEventBus_disappears
--- PASS: TestAccAWSCloudWatchEventBus_disappears (33.66s)
--- PASS: TestAccAWSCloudWatchEventBus_basic (72.56s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	72.599s

$ make testacc TEST=./aws TESTARGS='-run=TestCloudWatchEventBusName'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestCloudWatchEventBusName -timeout 120m
=== RUN   TestCloudWatchEventBusName
--- PASS: TestCloudWatchEventBusName (0.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	0.027s
```
