### PR TITLE
deps: Override renovate semanticCommits auto-detection by always disabling

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,5 +17,6 @@
   ],
   "labels": [
     "dependencies"
-  ]
+  ],
+  "semanticCommits": false
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

This project contains both non-semantic and semantic commit messages. Renovate tries to auto-detect which style it should use when submitting dependency update pull requests, however the mixture of the two seems to lead to renovate pull requests that start without the `chore(deps)` titles, then flip-flop to including it and not including it. This leads to confusing and duplicate pull requests.

Here we just force disable the semantic commit messaging to prevent the changing auto-detection behavior.

References:

- https://docs.renovatebot.com/configuration-options/#semanticcommits
- https://github.com/terraform-providers/terraform-provider-aws/pull/10255 and https://github.com/terraform-providers/terraform-provider-aws/pull/10262
- https://github.com/terraform-providers/terraform-provider-aws/pull/10248 and https://github.com/terraform-providers/terraform-provider-aws/pull/10264
- https://github.com/terraform-providers/terraform-provider-aws/pull/9991 and https://github.com/terraform-providers/terraform-provider-aws/pull/10263
- https://github.com/terraform-providers/terraform-provider-aws/pull/10011#event-2655384146

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing: N/A
