### PR TITLE
Supply tags in the Creating EFS resource at creation time

### DIFF
--- a/aws/resource_aws_efs_file_system.go
+++ b/aws/resource_aws_efs_file_system.go
@@ -128,10 +128,12 @@ func resourceAwsEfsFileSystemCreate(d *schema.ResourceData, meta interface{}) er
 		creationToken = resource.UniqueId()
 	}
 	throughputMode := d.Get("throughput_mode").(string)
+	tags := tagsFromMapEFS(d.Get("tags").(map[string]interface{}))
 
 	createOpts := &efs.CreateFileSystemInput{
 		CreationToken:  aws.String(creationToken),
 		ThroughputMode: aws.String(throughputMode),
+		Tags: tags,
 	}
 
 	if v, ok := d.GetOk("performance_mode"); ok {
@@ -191,11 +193,6 @@ func resourceAwsEfsFileSystemCreate(d *schema.ResourceData, meta interface{}) er
 			return fmt.Errorf("Error creating lifecycle policy for EFS file system %q: %s",
 				d.Id(), err.Error())
 		}
-	}
-
-	err = setTagsEFS(conn, d)
-	if err != nil {
-		return fmt.Errorf("error setting tags for EFS file system (%q): %s", d.Id(), err)
 	}
 
 	return resourceAwsEfsFileSystemRead(d, meta)

--- a/aws/resource_aws_efs_file_system_test.go
+++ b/aws/resource_aws_efs_file_system_test.go
@@ -86,7 +86,7 @@ func TestAccAWSEFSFileSystem_basic(t *testing.T) {
 					resource.TestMatchResourceAttr(
 						"aws_efs_file_system.foo",
 						"dns_name",
-						regexp.MustCompile("^[^.]+.efs.us-west-2.amazonaws.com$"),
+						regexp.MustCompile("^[^.]+.efs.([0-9A-Za-z]+-[0-9A-Za-z]+-[0-9]).amazonaws.com$"),
 					),
 				),
 			},

--- a/aws/resource_aws_efs_file_system_test.go
+++ b/aws/resource_aws_efs_file_system_test.go
@@ -86,7 +86,7 @@ func TestAccAWSEFSFileSystem_basic(t *testing.T) {
 					resource.TestMatchResourceAttr(
 						"aws_efs_file_system.foo",
 						"dns_name",
-						regexp.MustCompile("^[^.]+.efs.([0-9A-Za-z]+-[0-9A-Za-z]+-[0-9]).amazonaws.com$"),
+						regexp.MustCompile("^[^.]+.efs.([a-z]+-[a-z]+-[0-9]).amazonaws.com$"),
 					),
 				),
 			},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #10278

This pull request supplies the tags at `conn.CreateFileSystem(createOpts)` instead of apply the `TAGS` after the resource is created.
This should make it possible to create EFS resource when control IAM access by `tags conditions`

`PR` include a fix in the tests so it possible to run the TEST against different AWS regions then `us-west-2` and not failing 

Output from acceptance testing:

```
TF_ACC=1 go test ./aws -v -run=TestAccAWSEFSFileSystem -timeout 120m
go: finding github.com/terraform-providers/terraform-provider-tls v2.1.0+incompatible
go: finding github.com/terraform-providers/terraform-provider-tls v2.1.0+incompatible
=== RUN   TestAccAWSEFSFileSystem_importBasic
=== PAUSE TestAccAWSEFSFileSystem_importBasic
=== RUN   TestAccAWSEFSFileSystem_basic
=== PAUSE TestAccAWSEFSFileSystem_basic
=== RUN   TestAccAWSEFSFileSystem_pagedTags
=== PAUSE TestAccAWSEFSFileSystem_pagedTags
=== RUN   TestAccAWSEFSFileSystem_kmsKey
=== PAUSE TestAccAWSEFSFileSystem_kmsKey
=== RUN   TestAccAWSEFSFileSystem_kmsConfigurationWithoutEncryption
=== PAUSE TestAccAWSEFSFileSystem_kmsConfigurationWithoutEncryption
=== RUN   TestAccAWSEFSFileSystem_ProvisionedThroughputInMibps
=== PAUSE TestAccAWSEFSFileSystem_ProvisionedThroughputInMibps
=== RUN   TestAccAWSEFSFileSystem_ThroughputMode
=== PAUSE TestAccAWSEFSFileSystem_ThroughputMode
=== RUN   TestAccAWSEFSFileSystem_lifecyclePolicy
=== PAUSE TestAccAWSEFSFileSystem_lifecyclePolicy
=== RUN   TestAccAWSEFSFileSystem_lifecyclePolicy_update
=== PAUSE TestAccAWSEFSFileSystem_lifecyclePolicy_update
=== RUN   TestAccAWSEFSFileSystem_lifecyclePolicy_removal
=== PAUSE TestAccAWSEFSFileSystem_lifecyclePolicy_removal
=== CONT  TestAccAWSEFSFileSystem_importBasic
=== CONT  TestAccAWSEFSFileSystem_lifecyclePolicy_removal
=== CONT  TestAccAWSEFSFileSystem_kmsConfigurationWithoutEncryption
=== CONT  TestAccAWSEFSFileSystem_ProvisionedThroughputInMibps
=== CONT  TestAccAWSEFSFileSystem_lifecyclePolicy_update
=== CONT  TestAccAWSEFSFileSystem_lifecyclePolicy
=== CONT  TestAccAWSEFSFileSystem_ThroughputMode
=== CONT  TestAccAWSEFSFileSystem_kmsKey
--- PASS: TestAccAWSEFSFileSystem_kmsConfigurationWithoutEncryption (44.25s)
=== CONT  TestAccAWSEFSFileSystem_pagedTags
--- PASS: TestAccAWSEFSFileSystem_importBasic (59.50s)
=== CONT  TestAccAWSEFSFileSystem_basic
--- PASS: TestAccAWSEFSFileSystem_lifecyclePolicy (62.48s)
--- PASS: TestAccAWSEFSFileSystem_lifecyclePolicy_removal (65.30s)
--- PASS: TestAccAWSEFSFileSystem_lifecyclePolicy_update (78.28s)
--- PASS: TestAccAWSEFSFileSystem_pagedTags (34.99s)
--- PASS: TestAccAWSEFSFileSystem_kmsKey (86.41s)
--- PASS: TestAccAWSEFSFileSystem_ThroughputMode (96.07s)
--- PASS: TestAccAWSEFSFileSystem_ProvisionedThroughputInMibps (115.94s)
--- PASS: TestAccAWSEFSFileSystem_basic (75.91s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       136.670s

```
