### PR TITLE
Add support for `source_configuration` parameter of EB config template

### DIFF
--- a/aws/resource_aws_elastic_beanstalk_configuration_template.go
+++ b/aws/resource_aws_elastic_beanstalk_configuration_template.go
@@ -51,6 +51,11 @@ func resourceAwsElasticBeanstalkConfigurationTemplate() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"source_configuration": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -80,6 +85,13 @@ func resourceAwsElasticBeanstalkConfigurationTemplateCreate(d *schema.ResourceDa
 
 	if attr, ok := d.GetOk("solution_stack_name"); ok {
 		opts.SolutionStackName = aws.String(attr.(string))
+	}
+
+	if attr, ok := d.GetOk("source_configuration"); ok {
+		opts.SourceConfiguration = &elasticbeanstalk.SourceConfiguration{
+			ApplicationName: aws.String(appName),
+			TemplateName: aws.String(attr.(string)),
+		}
 	}
 
 	log.Printf("[DEBUG] Elastic Beanstalk configuration template create opts: %s", opts)

--- a/website/docs/r/elastic_beanstalk_configuration_template.html.markdown
+++ b/website/docs/r/elastic_beanstalk_configuration_template.html.markdown
@@ -40,6 +40,7 @@ The following arguments are supported:
   below in [Option Settings](#option-settings)
 * `solution_stack_name` – (Optional) A solution stack to base your Template
 off of. Example stacks can be found in the [Amazon API documentation][1]
+* `source_configuration` - (Optional) A configuration template that this resource will inherit from
 
 
 ## Option Settings


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add support for `source_configuration` parameter to `aws_elastic_beanstalk_configuration_template` resource
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSBeanstalkConfigurationTemplate_SourceConfiguration'
=== RUN   TestAccAWSBeanstalkConfigurationTemplate_SourceConfiguration
=== PAUSE TestAccAWSBeanstalkConfigurationTemplate_SourceConfiguration
=== CONT  TestAccAWSBeanstalkConfigurationTemplate_SourceConfiguration
--- PASS: TestAccAWSBeanstalkConfigurationTemplate_SourceConfiguration (26.51s)
PASS
```
