### PR TITLE
resource/ses_receipt_rule: Set recipients to be lowercase in state

### DIFF
--- a/aws/resource_aws_ses_receipt_rule.go
+++ b/aws/resource_aws_ses_receipt_rule.go
@@ -50,8 +50,13 @@ func resourceAwsSesReceiptRule() *schema.Resource {
 			},
 
 			"recipients": {
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					StateFunc: func(val interface{}) string {
+						return strings.ToLower(val.(string))
+					},
+				},
 				Optional: true,
 				Set:      schema.HashString,
 			},

--- a/aws/resource_aws_ses_receipt_rule_test.go
+++ b/aws/resource_aws_ses_receipt_rule_test.go
@@ -38,6 +38,28 @@ func TestAccAWSSESReceiptRule_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSSESReceiptRule_caseInsensitive(t *testing.T) {
+	rInt := acctest.RandInt()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSSES(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSESReceiptRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSESReceiptRuleCaseInsensitiveConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsSESReceiptRuleExists("aws_ses_receipt_rule.basic"),
+					resource.TestCheckResourceAttr("aws_ses_receipt_rule.basic", "recipients.#", "1"),
+					resource.TestCheckResourceAttr("aws_ses_receipt_rule.basic", "recipients.2533918602", "test@example.com"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSSESReceiptRule_s3Action(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.ParallelTest(t, resource.TestCase{
@@ -295,6 +317,23 @@ resource "aws_ses_receipt_rule" "basic" {
   name          = "basic"
   rule_set_name = "${aws_ses_receipt_rule_set.test.rule_set_name}"
   recipients    = ["test@example.com"]
+  enabled       = true
+  scan_enabled  = true
+  tls_policy    = "Require"
+}
+`, rInt)
+}
+
+func testAccAWSSESReceiptRuleCaseInsensitiveConfig(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_ses_receipt_rule_set" "test" {
+  rule_set_name = "test-me-%d"
+}
+
+resource "aws_ses_receipt_rule" "basic" {
+  name          = "basic"
+  rule_set_name = "${aws_ses_receipt_rule_set.test.rule_set_name}"
+  recipients    = ["Test@example.com"]
   enabled       = true
   scan_enabled  = true
   tls_policy    = "Require"


### PR DESCRIPTION
When a person supplies a recipient that isn't lower case, AWS will
normalise this to lowercase and we get a perpetual diff (see image)

This commit introduces a StateFunc that makes the members of recipients
to be lowercase to ensure that no perpetual diffs are found

```
$ acctests aws TestAccAWSSESReceiptRule_
=== RUN   TestAccAWSSESReceiptRule_basic
=== PAUSE TestAccAWSSESReceiptRule_basic
=== RUN   TestAccAWSSESReceiptRule_caseInsensitive
=== PAUSE TestAccAWSSESReceiptRule_caseInsensitive
=== RUN   TestAccAWSSESReceiptRule_s3Action
=== PAUSE TestAccAWSSESReceiptRule_s3Action
=== RUN   TestAccAWSSESReceiptRule_order
=== PAUSE TestAccAWSSESReceiptRule_order
=== RUN   TestAccAWSSESReceiptRule_actions
=== PAUSE TestAccAWSSESReceiptRule_actions
=== CONT  TestAccAWSSESReceiptRule_basic
=== CONT  TestAccAWSSESReceiptRule_order
=== CONT  TestAccAWSSESReceiptRule_s3Action
=== CONT  TestAccAWSSESReceiptRule_caseInsensitive
=== CONT  TestAccAWSSESReceiptRule_actions
--- PASS: TestAccAWSSESReceiptRule_caseInsensitive (31.85s)
--- PASS: TestAccAWSSESReceiptRule_actions (34.86s)
--- PASS: TestAccAWSSESReceiptRule_basic (35.62s)
--- PASS: TestAccAWSSESReceiptRule_order (41.28s)
--- PASS: TestAccAWSSESReceiptRule_s3Action (73.22s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	73.280s
```

With the following config, I got a perpetual diff:

```
resource "aws_ses_receipt_rule_set" "main" {
  rule_set_name = "default-rule-set"
}

resource "aws_ses_receipt_rule" "store" {
  name          = "store"
  rule_set_name = "${aws_ses_receipt_rule_set.main.rule_set_name}"
  recipients    = ["Karen@example.com"]
  enabled       = true
  scan_enabled  = true

  add_header_action {
    header_name  = "Custom-Header"
    header_value = "Added by SES"
    position     = 1
  }
}
```

<img width="714" alt="Screenshot 2019-09-28 at 13 12 18" src="https://user-images.githubusercontent.com/227823/65818003-01de1400-e216-11e9-8339-3998c72035be.png">

After adding the StateFunc in the PR, I didn't get the diff anymore:

<img width="888" alt="Screenshot 2019-09-28 at 17 13 06" src="https://user-images.githubusercontent.com/227823/65818013-16baa780-e216-11e9-92be-e2873d26c0c9.png">
