### PR TITLE
tests/resource/aws_load_balancer_backend_server_policy: Use internal implementation for TLS key/certificate

### DIFF
--- a/aws/resource_aws_load_balancer_backend_server_policy_test.go
+++ b/aws/resource_aws_load_balancer_backend_server_policy_test.go
@@ -10,23 +10,24 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	tlsprovider "github.com/terraform-providers/terraform-provider-tls/tls"
 )
 
 func TestAccAWSLoadBalancerBackendServerPolicy_basic(t *testing.T) {
+	privateKey1 := tlsRsaPrivateKeyPem(2048)
+	privateKey2 := tlsRsaPrivateKeyPem(2048)
+	publicKey1 := tlsRsaPublicKeyPem(privateKey1)
+	publicKey2 := tlsRsaPublicKeyPem(privateKey2)
+	certificate1 := tlsRsaX509SelfSignedCertificatePem(privateKey1, "example.com")
 	rString := acctest.RandString(8)
 	lbName := fmt.Sprintf("tf-acc-lb-bsp-basic-%s", rString)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() { testAccPreCheck(t) },
-		Providers: map[string]terraform.ResourceProvider{
-			"aws": testAccProvider,
-			"tls": tlsprovider.Provider(),
-		},
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSLoadBalancerBackendServerPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLoadBalancerBackendServerPolicyConfig_basic0(lbName),
+				Config: testAccAWSLoadBalancerBackendServerPolicyConfig_basic0(lbName, privateKey1, publicKey1, certificate1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLoadBalancerPolicyState("aws_elb.test-lb", "aws_load_balancer_policy.test-pubkey-policy0"),
 					testAccCheckAWSLoadBalancerPolicyState("aws_elb.test-lb", "aws_load_balancer_policy.test-backend-auth-policy0"),
@@ -34,7 +35,7 @@ func TestAccAWSLoadBalancerBackendServerPolicy_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSLoadBalancerBackendServerPolicyConfig_basic1(lbName),
+				Config: testAccAWSLoadBalancerBackendServerPolicyConfig_basic1(lbName, privateKey1, publicKey1, certificate1, publicKey2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLoadBalancerPolicyState("aws_elb.test-lb", "aws_load_balancer_policy.test-pubkey-policy0"),
 					testAccCheckAWSLoadBalancerPolicyState("aws_elb.test-lb", "aws_load_balancer_policy.test-pubkey-policy1"),
@@ -43,7 +44,7 @@ func TestAccAWSLoadBalancerBackendServerPolicy_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSLoadBalancerBackendServerPolicyConfig_basic2(lbName),
+				Config: testAccAWSLoadBalancerBackendServerPolicyConfig_basic2(lbName, privateKey1, certificate1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLoadBalancerBackendServerPolicyState(lbName, "test-backend-auth-policy0", false),
 				),
@@ -139,39 +140,21 @@ func testAccCheckAWSLoadBalancerBackendServerPolicyState(loadBalancerName string
 	}
 }
 
-func testAccAWSLoadBalancerBackendServerPolicyConfig_basic0(lbName string) string {
+func testAccAWSLoadBalancerBackendServerPolicyConfig_basic0(rName, privateKey, publicKey, certificate string) string {
 	return fmt.Sprintf(`
-resource "tls_private_key" "example0" {
-  algorithm = "RSA"
-}
-
-resource "tls_self_signed_cert" "test-cert0" {
-  key_algorithm   = "RSA"
-  private_key_pem = "${tls_private_key.example0.private_key_pem}"
-
-  subject {
-    common_name  = "example.com"
-    organization = "ACME Examples, Inc"
-  }
-
-  validity_period_hours = 12
-
-  allowed_uses = [
-    "key_encipherment",
-    "digital_signature",
-    "server_auth",
-  ]
+data "aws_availability_zones" "available" {
+  state = "available"
 }
 
 resource "aws_iam_server_certificate" "test-iam-cert0" {
   name_prefix      = "test_cert_"
-  certificate_body = "${tls_self_signed_cert.test-cert0.cert_pem}"
-  private_key      = "${tls_private_key.example0.private_key_pem}"
+  certificate_body = "%[2]s"
+  private_key      = "%[3]s"
 }
 
 resource "aws_elb" "test-lb" {
-  name               = "%s"
-  availability_zones = ["us-west-2a"]
+  name               = "%[1]s"
+  availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
 
   listener {
     instance_port      = 443
@@ -193,7 +176,7 @@ resource "aws_load_balancer_policy" "test-pubkey-policy0" {
 
   policy_attribute {
     name  = "PublicKey"
-    value = "${replace(replace(replace(tls_private_key.example0.public_key_pem, "\n", ""), "-----BEGIN PUBLIC KEY-----", ""), "-----END PUBLIC KEY-----", "")}"
+    value = "${replace(replace(replace("%[4]s", "\n", ""), "-----BEGIN PUBLIC KEY-----", ""), "-----END PUBLIC KEY-----", "")}"
   }
 }
 
@@ -216,64 +199,24 @@ resource "aws_load_balancer_backend_server_policy" "test-backend-auth-policies-4
     "${aws_load_balancer_policy.test-backend-auth-policy0.policy_name}",
   ]
 }
-`, lbName)
+`, rName, tlsPemEscapeNewlines(certificate), tlsPemEscapeNewlines(privateKey), tlsPemEscapeNewlines(publicKey))
 }
 
-func testAccAWSLoadBalancerBackendServerPolicyConfig_basic1(lbName string) string {
+func testAccAWSLoadBalancerBackendServerPolicyConfig_basic1(rName, privateKey1, publicKey1, certificate1, publicKey2 string) string {
 	return fmt.Sprintf(`
-resource "tls_private_key" "example0" {
-  algorithm = "RSA"
-}
-
-resource "tls_self_signed_cert" "test-cert0" {
-  key_algorithm   = "RSA"
-  private_key_pem = "${tls_private_key.example0.private_key_pem}"
-
-  subject {
-    common_name  = "example.com"
-    organization = "ACME Examples, Inc"
-  }
-
-  validity_period_hours = 12
-
-  allowed_uses = [
-    "key_encipherment",
-    "digital_signature",
-    "server_auth",
-  ]
-}
-
-resource "tls_private_key" "example1" {
-  algorithm = "RSA"
-}
-
-resource "tls_self_signed_cert" "test-cert1" {
-  key_algorithm   = "RSA"
-  private_key_pem = "${tls_private_key.example1.private_key_pem}"
-
-  subject {
-    common_name  = "example.com"
-    organization = "ACME Examples, Inc"
-  }
-
-  validity_period_hours = 12
-
-  allowed_uses = [
-    "key_encipherment",
-    "digital_signature",
-    "server_auth",
-  ]
+data "aws_availability_zones" "available" {
+  state = "available"
 }
 
 resource "aws_iam_server_certificate" "test-iam-cert0" {
   name_prefix      = "test_cert_"
-  certificate_body = "${tls_self_signed_cert.test-cert0.cert_pem}"
-  private_key      = "${tls_private_key.example0.private_key_pem}"
+  certificate_body = "%[2]s"
+  private_key      = "%[3]s"
 }
 
 resource "aws_elb" "test-lb" {
-  name               = "%s"
-  availability_zones = ["us-west-2a"]
+  name               = "%[1]s"
+  availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
 
   listener {
     instance_port      = 443
@@ -295,7 +238,7 @@ resource "aws_load_balancer_policy" "test-pubkey-policy0" {
 
   policy_attribute {
     name  = "PublicKey"
-    value = "${replace(replace(replace(tls_private_key.example0.public_key_pem, "\n", ""), "-----BEGIN PUBLIC KEY-----", ""), "-----END PUBLIC KEY-----", "")}"
+    value = "${replace(replace(replace("%[4]s", "\n", ""), "-----BEGIN PUBLIC KEY-----", ""), "-----END PUBLIC KEY-----", "")}"
   }
 }
 
@@ -306,7 +249,7 @@ resource "aws_load_balancer_policy" "test-pubkey-policy1" {
 
   policy_attribute {
     name  = "PublicKey"
-    value = "${replace(replace(replace(tls_private_key.example1.public_key_pem, "\n", ""), "-----BEGIN PUBLIC KEY-----", ""), "-----END PUBLIC KEY-----", "")}"
+    value = "${replace(replace(replace("%[5]s", "\n", ""), "-----BEGIN PUBLIC KEY-----", ""), "-----END PUBLIC KEY-----", "")}"
   }
 }
 
@@ -329,64 +272,24 @@ resource "aws_load_balancer_backend_server_policy" "test-backend-auth-policies-4
     "${aws_load_balancer_policy.test-backend-auth-policy0.policy_name}",
   ]
 }
-`, lbName)
+`, rName, tlsPemEscapeNewlines(certificate1), tlsPemEscapeNewlines(privateKey1), tlsPemEscapeNewlines(publicKey1), tlsPemEscapeNewlines(publicKey2))
 }
 
-func testAccAWSLoadBalancerBackendServerPolicyConfig_basic2(lbName string) string {
+func testAccAWSLoadBalancerBackendServerPolicyConfig_basic2(rName, privateKey, certificate string) string {
 	return fmt.Sprintf(`
-resource "tls_private_key" "example0" {
-  algorithm = "RSA"
-}
-
-resource "tls_self_signed_cert" "test-cert0" {
-  key_algorithm   = "RSA"
-  private_key_pem = "${tls_private_key.example0.private_key_pem}"
-
-  subject {
-    common_name  = "example.com"
-    organization = "ACME Examples, Inc"
-  }
-
-  validity_period_hours = 12
-
-  allowed_uses = [
-    "key_encipherment",
-    "digital_signature",
-    "server_auth",
-  ]
-}
-
-resource "tls_private_key" "example1" {
-  algorithm = "RSA"
-}
-
-resource "tls_self_signed_cert" "test-cert1" {
-  key_algorithm   = "RSA"
-  private_key_pem = "${tls_private_key.example1.private_key_pem}"
-
-  subject {
-    common_name  = "example.com"
-    organization = "ACME Examples, Inc"
-  }
-
-  validity_period_hours = 12
-
-  allowed_uses = [
-    "key_encipherment",
-    "digital_signature",
-    "server_auth",
-  ]
+data "aws_availability_zones" "available" {
+  state = "available"
 }
 
 resource "aws_iam_server_certificate" "test-iam-cert0" {
   name_prefix      = "test_cert_"
-  certificate_body = "${tls_self_signed_cert.test-cert0.cert_pem}"
-  private_key      = "${tls_private_key.example0.private_key_pem}"
+  certificate_body = "%[2]s"
+  private_key      = "%[3]s"
 }
 
 resource "aws_elb" "test-lb" {
-  name               = "%s"
-  availability_zones = ["us-west-2a"]
+  name               = "%[1]s"
+  availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
 
   listener {
     instance_port      = 443
@@ -400,5 +303,5 @@ resource "aws_elb" "test-lb" {
     Name = "tf-acc-test"
   }
 }
-`, lbName)
+`, rName, tlsPemEscapeNewlines(certificate), tlsPemEscapeNewlines(privateKey))
 }

--- a/aws/tls.go
+++ b/aws/tls.go
@@ -14,6 +14,7 @@ import (
 const (
 	pemBlockTypeCertificate   = `CERTIFICATE`
 	pemBlockTypeRsaPrivateKey = `RSA PRIVATE KEY`
+	pemBlockTypePublicKey     = `PUBLIC KEY`
 )
 
 var tlsX509CertificateSerialNumberLimit = new(big.Int).Lsh(big.NewInt(1), 128)
@@ -31,6 +32,32 @@ func tlsRsaPrivateKeyPem(bits int) string {
 	block := &pem.Block{
 		Bytes: x509.MarshalPKCS1PrivateKey(key),
 		Type:  pemBlockTypeRsaPrivateKey,
+	}
+
+	return string(pem.EncodeToMemory(block))
+}
+
+// tlsRsaPublicKeyPem generates a RSA public key PEM string.
+// Wrap with tlsPemEscapeNewlines() to allow simple fmt.Sprintf()
+// configurations such as: public_key_pem = "%[1]s"
+func tlsRsaPublicKeyPem(keyPem string) string {
+	keyBlock, _ := pem.Decode([]byte(keyPem))
+
+	key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+
+	if err != nil {
+		panic(err)
+	}
+
+	publicKeyBytes, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+
+	if err != nil {
+		panic(err)
+	}
+
+	block := &pem.Block{
+		Bytes: publicKeyBytes,
+		Type:  pemBlockTypePublicKey,
 	}
 
 	return string(pem.EncodeToMemory(block))

--- a/aws/tls_test.go
+++ b/aws/tls_test.go
@@ -13,6 +13,15 @@ func TestTlsRsaPrivateKeyPem(t *testing.T) {
 	}
 }
 
+func TestTlsRsaPublicKeyPem(t *testing.T) {
+	privateKey := tlsRsaPrivateKeyPem(2048)
+	publicKey := tlsRsaPublicKeyPem(privateKey)
+
+	if !strings.Contains(publicKey, pemBlockTypePublicKey) {
+		t.Errorf("key does not contain PUBLIC KEY: %s", publicKey)
+	}
+}
+
 func TestTlsRsaX509CertificatePem(t *testing.T) {
 	key := tlsRsaPrivateKeyPem(2048)
 	certificate := tlsRsaX509SelfSignedCertificatePem(key, "example.com")


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/10023

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
--- PASS: TestAccAWSLoadBalancerBackendServerPolicy_basic (70.37s)
```
