### PR TITLE
tests/resource/aws_ebs_snapshot_copy: Refactoring to remove inconsistent ProviderFactories usage and make region agnostic

### DIFF
--- a/aws/resource_aws_ebs_snapshot_copy_test.go
+++ b/aws/resource_aws_ebs_snapshot_copy_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -13,7 +12,9 @@ import (
 )
 
 func TestAccAWSEbsSnapshotCopy_basic(t *testing.T) {
-	var v ec2.Snapshot
+	var snapshot ec2.Snapshot
+	resourceName := "aws_ebs_snapshot_copy.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -22,8 +23,8 @@ func TestAccAWSEbsSnapshotCopy_basic(t *testing.T) {
 			{
 				Config: testAccAwsEbsSnapshotCopyConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEbsSnapshotCopyExists("aws_ebs_snapshot_copy.test", &v),
-					testAccCheckTags(&v.Tags, "Name", "testAccAwsEbsSnapshotCopyConfig"),
+					testAccCheckEbsSnapshotCopyExists(resourceName, &snapshot),
+					testAccCheckTags(&snapshot.Tags, "Name", "testAccAwsEbsSnapshotCopyConfig"),
 				),
 			},
 		},
@@ -31,7 +32,9 @@ func TestAccAWSEbsSnapshotCopy_basic(t *testing.T) {
 }
 
 func TestAccAWSEbsSnapshotCopy_withDescription(t *testing.T) {
-	var v ec2.Snapshot
+	var snapshot ec2.Snapshot
+	resourceName := "aws_ebs_snapshot_copy.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -40,8 +43,8 @@ func TestAccAWSEbsSnapshotCopy_withDescription(t *testing.T) {
 			{
 				Config: testAccAwsEbsSnapshotCopyConfigWithDescription,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEbsSnapshotCopyExists("aws_ebs_snapshot_copy.description_test", &v),
-					resource.TestCheckResourceAttr("aws_ebs_snapshot_copy.description_test", "description", "Copy Snapshot Acceptance Test"),
+					testAccCheckEbsSnapshotCopyExists(resourceName, &snapshot),
+					resource.TestCheckResourceAttr(resourceName, "description", "Copy Snapshot Acceptance Test"),
 				),
 			},
 		},
@@ -49,28 +52,23 @@ func TestAccAWSEbsSnapshotCopy_withDescription(t *testing.T) {
 }
 
 func TestAccAWSEbsSnapshotCopy_withRegions(t *testing.T) {
-	var v ec2.Snapshot
-
-	// record the initialized providers so that we can use them to
-	// check for the instances in each region
 	var providers []*schema.Provider
-	providerFactories := map[string]terraform.ResourceProviderFactory{
-		"aws": func() (terraform.ResourceProvider, error) {
-			p := Provider()
-			providers = append(providers, p.(*schema.Provider))
-			return p, nil
-		},
-	}
+	var snapshot ec2.Snapshot
+	resourceName := "aws_ebs_snapshot_copy.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: providerFactories,
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccMultipleRegionsPreCheck(t)
+			testAccAlternateRegionPreCheck(t)
+		},
+		ProviderFactories: testAccProviderFactories(&providers),
 		CheckDestroy:      testAccCheckEbsSnapshotCopyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAwsEbsSnapshotCopyConfigWithRegions,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEbsSnapshotCopyExistsWithProviders("aws_ebs_snapshot_copy.region_test", &v, &providers),
+					testAccCheckEbsSnapshotCopyExists(resourceName, &snapshot),
 				),
 			},
 		},
@@ -79,7 +77,10 @@ func TestAccAWSEbsSnapshotCopy_withRegions(t *testing.T) {
 }
 
 func TestAccAWSEbsSnapshotCopy_withKms(t *testing.T) {
-	var v ec2.Snapshot
+	var snapshot ec2.Snapshot
+	kmsKeyResourceName := "aws_kms_key.test"
+	resourceName := "aws_ebs_snapshot_copy.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -88,9 +89,8 @@ func TestAccAWSEbsSnapshotCopy_withKms(t *testing.T) {
 			{
 				Config: testAccAwsEbsSnapshotCopyConfigWithKms,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEbsSnapshotCopyExists("aws_ebs_snapshot_copy.kms_test", &v),
-					resource.TestMatchResourceAttr("aws_ebs_snapshot_copy.kms_test", "kms_key_id",
-						regexp.MustCompile(`^arn:aws:kms:[a-z]{2}-[a-z]+-\d{1}:[0-9]{12}:key/[a-z0-9-]{36}$`)),
+					testAccCheckEbsSnapshotCopyExists(resourceName, &snapshot),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", kmsKeyResourceName, "arn"),
 				),
 			},
 		},
@@ -98,7 +98,9 @@ func TestAccAWSEbsSnapshotCopy_withKms(t *testing.T) {
 }
 
 func TestAccAWSEbsSnapshotCopy_disappears(t *testing.T) {
-	var v ec2.Snapshot
+	var snapshot ec2.Snapshot
+	resourceName := "aws_ebs_snapshot_copy.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -107,8 +109,8 @@ func TestAccAWSEbsSnapshotCopy_disappears(t *testing.T) {
 			{
 				Config: testAccAwsEbsSnapshotCopyConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEbsSnapshotCopyExists("aws_ebs_snapshot_copy.test", &v),
-					testAccCheckEbsSnapshotCopyDisappears(&v),
+					testAccCheckEbsSnapshotCopyExists(resourceName, &snapshot),
+					testAccCheckEbsSnapshotCopyDisappears(&snapshot),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -159,11 +161,6 @@ func testAccCheckEbsSnapshotCopyDisappears(snapshot *ec2.Snapshot) resource.Test
 }
 
 func testAccCheckEbsSnapshotCopyExists(n string, v *ec2.Snapshot) resource.TestCheckFunc {
-	providers := []*schema.Provider{testAccProvider}
-	return testAccCheckEbsSnapshotCopyExistsWithProviders(n, v, &providers)
-}
-
-func testAccCheckEbsSnapshotCopyExistsWithProviders(n string, v *ec2.Snapshot, providers *[]*schema.Provider) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -174,33 +171,37 @@ func testAccCheckEbsSnapshotCopyExistsWithProviders(n string, v *ec2.Snapshot, p
 			return fmt.Errorf("No ID is set")
 		}
 
-		for _, provider := range *providers {
-			// Ignore if Meta is empty, this can happen for validation providers
-			if provider.Meta() == nil {
-				continue
-			}
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
 
-			conn := provider.Meta().(*AWSClient).ec2conn
-
-			request := &ec2.DescribeSnapshotsInput{
-				SnapshotIds: []*string{aws.String(rs.Primary.ID)},
-			}
-
-			response, err := conn.DescribeSnapshots(request)
-			if err == nil {
-				if response.Snapshots != nil && len(response.Snapshots) > 0 {
-					*v = *response.Snapshots[0]
-					return nil
-				}
-			}
+		input := &ec2.DescribeSnapshotsInput{
+			SnapshotIds: []*string{aws.String(rs.Primary.ID)},
 		}
-		return fmt.Errorf("Error finding EC2 Snapshot %s", rs.Primary.ID)
+
+		output, err := conn.DescribeSnapshots(input)
+
+		if err != nil {
+			return err
+		}
+
+		if output == nil || len(output.Snapshots) == 0 {
+			return fmt.Errorf("Error finding EC2 Snapshot %s", rs.Primary.ID)
+		}
+
+		*v = *output.Snapshots[0]
+
+		return nil
 	}
 }
 
 const testAccAwsEbsSnapshotCopyConfig = `
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+data "aws_region" "current" {}
+
 resource "aws_ebs_volume" "test" {
-  availability_zone = "us-west-2a"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
   size              = 1
 }
 
@@ -214,7 +215,7 @@ resource "aws_ebs_snapshot" "test" {
 
 resource "aws_ebs_snapshot_copy" "test" {
   source_snapshot_id = "${aws_ebs_snapshot.test.id}"
-	source_region      = "us-west-2"
+  source_region      = "${data.aws_region.current.name}"
 
   tags = {
     Name = "testAccAwsEbsSnapshotCopyConfig"
@@ -223,28 +224,34 @@ resource "aws_ebs_snapshot_copy" "test" {
 `
 
 const testAccAwsEbsSnapshotCopyConfigWithDescription = `
-resource "aws_ebs_volume" "description_test" {
-	availability_zone = "us-west-2a"
-	size              = 1
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+data "aws_region" "current" {}
+
+resource "aws_ebs_volume" "test" {
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  size              = 1
 
   tags = {
     Name = "testAccAwsEbsSnapshotCopyConfigWithDescription"
   }
 }
 
-resource "aws_ebs_snapshot" "description_test" {
-	volume_id   = "${aws_ebs_volume.description_test.id}"
-	description = "EBS Snapshot Acceptance Test"
+resource "aws_ebs_snapshot" "test" {
+  volume_id   = "${aws_ebs_volume.test.id}"
+  description = "EBS Snapshot Acceptance Test"
 
   tags = {
     Name = "testAccAwsEbsSnapshotCopyConfigWithDescription"
   }
 }
 
-resource "aws_ebs_snapshot_copy" "description_test" {
-	description        = "Copy Snapshot Acceptance Test"
-  source_snapshot_id = "${aws_ebs_snapshot.description_test.id}"
-	source_region      = "us-west-2"
+resource "aws_ebs_snapshot_copy" "test" {
+  description        = "Copy Snapshot Acceptance Test"
+  source_snapshot_id = "${aws_ebs_snapshot.test.id}"
+  source_region      = "${data.aws_region.current.name}"
 
   tags = {
     Name = "testAccAwsEbsSnapshotCopyConfigWithDescription"
@@ -252,20 +259,19 @@ resource "aws_ebs_snapshot_copy" "description_test" {
 }
 `
 
-const testAccAwsEbsSnapshotCopyConfigWithRegions = `
-provider "aws" {
-  region = "us-west-2"
-  alias  = "uswest2"
+var testAccAwsEbsSnapshotCopyConfigWithRegions = testAccAlternateRegionProviderConfig() + `
+data "aws_availability_zones" "alternate_available" {
+  provider = "aws.alternate"
+  state    = "available"
 }
 
-provider "aws" {
-  region = "us-east-1"
-  alias  = "useast1"
+data "aws_region" "alternate" {
+  provider = "aws.alternate"
 }
 
-resource "aws_ebs_volume" "region_test" {
-  provider          = "aws.uswest2"
-  availability_zone = "us-west-2a"
+resource "aws_ebs_volume" "test" {
+  provider          = "aws.alternate"
+  availability_zone = "${data.aws_availability_zones.alternate_available.names[0]}"
   size              = 1
 
   tags = {
@@ -273,19 +279,18 @@ resource "aws_ebs_volume" "region_test" {
   }
 }
 
-resource "aws_ebs_snapshot" "region_test" {
-  provider  = "aws.uswest2"
-  volume_id = "${aws_ebs_volume.region_test.id}"
+resource "aws_ebs_snapshot" "test" {
+  provider  = "aws.alternate"
+  volume_id = "${aws_ebs_volume.test.id}"
 
   tags = {
     Name = "testAccAwsEbsSnapshotCopyConfigWithRegions"
   }
 }
 
-resource "aws_ebs_snapshot_copy" "region_test" {
-  provider           = "aws.useast1"
-  source_snapshot_id = "${aws_ebs_snapshot.region_test.id}"
-  source_region      = "us-west-2"
+resource "aws_ebs_snapshot_copy" "test" {
+  source_snapshot_id = "${aws_ebs_snapshot.test.id}"
+  source_region      = "${data.aws_region.alternate.name}"
 
   tags = {
     Name = "testAccAwsEbsSnapshotCopyConfigWithRegions"
@@ -294,17 +299,19 @@ resource "aws_ebs_snapshot_copy" "region_test" {
 `
 
 const testAccAwsEbsSnapshotCopyConfigWithKms = `
-provider "aws" {
-  region = "us-west-2"
+data "aws_availability_zones" "available" {
+  state = "available"
 }
 
-resource "aws_kms_key" "kms_test" {
+data "aws_region" "current" {}
+
+resource "aws_kms_key" "test" {
   description             = "testAccAwsEbsSnapshotCopyConfigWithKms"
   deletion_window_in_days = 7
 }
 
-resource "aws_ebs_volume" "kms_test" {
-  availability_zone = "us-west-2a"
+resource "aws_ebs_volume" "test" {
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
   size              = 1
 
   tags = {
@@ -312,19 +319,19 @@ resource "aws_ebs_volume" "kms_test" {
   }
 }
 
-resource "aws_ebs_snapshot" "kms_test" {
-  volume_id = "${aws_ebs_volume.kms_test.id}"
+resource "aws_ebs_snapshot" "test" {
+  volume_id = "${aws_ebs_volume.test.id}"
 
   tags = {
     Name = "testAccAwsEbsSnapshotCopyConfigWithKms"
   }
 }
 
-resource "aws_ebs_snapshot_copy" "kms_test" {
-  source_snapshot_id = "${aws_ebs_snapshot.kms_test.id}"
-  source_region      = "us-west-2"
+resource "aws_ebs_snapshot_copy" "test" {
+  source_snapshot_id = "${aws_ebs_snapshot.test.id}"
+  source_region      = "${data.aws_region.current.name}"
   encrypted          = true
-  kms_key_id         = "${aws_kms_key.kms_test.arn}"
+  kms_key_id         = "${aws_kms_key.test.arn}"
 
   tags = {
     Name = "testAccAwsEbsSnapshotCopyConfigWithKms"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Noticed this was the only testing left in the provider using the direct `map[string]terraform.ResourceProviderFactory{}` setup instead of `testAccProviderFactories()`. While here, also refactored the testing to make it region agnostic and use consistent test resource naming.

Output from acceptance testing:

```
--- PASS: TestAccAWSEbsSnapshotCopy_disappears (61.46s)
--- PASS: TestAccAWSEbsSnapshotCopy_basic (62.02s)
--- PASS: TestAccAWSEbsSnapshotCopy_withDescription (62.38s)
--- PASS: TestAccAWSEbsSnapshotCopy_withKms (70.19s)
--- PASS: TestAccAWSEbsSnapshotCopy_withRegions (74.09s)
```
