### PR TITLE
tests/resource/aws_lb_ssl_negotiation_policy: Use internal implementation for TLS key/certificate

### DIFF
--- a/aws/resource_aws_lb_ssl_negotiation_policy_test.go
+++ b/aws/resource_aws_lb_ssl_negotiation_policy_test.go
@@ -14,60 +14,51 @@ import (
 )
 
 func TestAccAWSLBSSLNegotiationPolicy_basic(t *testing.T) {
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(8)) // ELB name cannot be longer than 32 characters
+	elbResourceName := "aws_elb.test"
+	resourceName := "aws_lb_ssl_negotiation_policy.test"
+
+	key := tlsRsaPrivateKeyPem(2048)
+	certificate := tlsRsaX509SelfSignedCertificatePem(key, "example.com")
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProvidersWithTLS,
+		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckLBSSLNegotiationPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSslNegotiationPolicyConfig(
-					fmt.Sprintf("tf-acctest-%s", acctest.RandString(10)), fmt.Sprintf("tf-test-lb-%s", acctest.RandString(5))),
+				Config: testAccSslNegotiationPolicyConfig(rName, key, certificate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLBSSLNegotiationPolicy(
-						"aws_elb.lb",
-						"aws_lb_ssl_negotiation_policy.foo",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_lb_ssl_negotiation_policy.foo", "attribute.#", "7"),
+					testAccCheckLBSSLNegotiationPolicy(elbResourceName, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "attribute.#", "7"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAWSLBSSLNegotiationPolicy_missingLB(t *testing.T) {
-	lbName := fmt.Sprintf("tf-test-lb-%s", acctest.RandString(5))
+func TestAccAWSLBSSLNegotiationPolicy_disappears(t *testing.T) {
+	var loadBalancer elb.LoadBalancerDescription
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(8)) // ELB name cannot be longer than 32 characters
+	elbResourceName := "aws_elb.test"
+	resourceName := "aws_lb_ssl_negotiation_policy.test"
 
-	// check that we can destroy the policy if the LB is missing
-	removeLB := func() {
-		conn := testAccProvider.Meta().(*AWSClient).elbconn
-		deleteElbOpts := elb.DeleteLoadBalancerInput{
-			LoadBalancerName: aws.String(lbName),
-		}
-		if _, err := conn.DeleteLoadBalancer(&deleteElbOpts); err != nil {
-			t.Fatalf("Error deleting ELB: %s", err)
-		}
-	}
+	key := tlsRsaPrivateKeyPem(2048)
+	certificate := tlsRsaX509SelfSignedCertificatePem(key, "example.com")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProvidersWithTLS,
+		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckLBSSLNegotiationPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSslNegotiationPolicyConfig(fmt.Sprintf("tf-acctest-%s", acctest.RandString(10)), lbName),
+				Config: testAccSslNegotiationPolicyConfig(rName, key, certificate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLBSSLNegotiationPolicy(
-						"aws_elb.lb",
-						"aws_lb_ssl_negotiation_policy.foo",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_lb_ssl_negotiation_policy.foo", "attribute.#", "7"),
+					testAccCheckLBSSLNegotiationPolicy(elbResourceName, resourceName),
+					testAccCheckAWSELBExists(elbResourceName, &loadBalancer),
+					testAccCheckAWSELBDisappears(&loadBalancer),
 				),
-			},
-			{
-				PreConfig: removeLB,
-				Config:    testAccSslNegotiationPolicyConfig(fmt.Sprintf("tf-acctest-%s", acctest.RandString(10)), lbName),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -191,52 +182,34 @@ func policyAttributesToMap(attributes *[]*elb.PolicyAttributeDescription) map[st
 }
 
 // Sets the SSL Negotiation policy with attributes.
-func testAccSslNegotiationPolicyConfig(certName string, lbName string) string {
+func testAccSslNegotiationPolicyConfig(rName, key, certificate string) string {
 	return fmt.Sprintf(`
-resource "tls_private_key" "example" {
-  algorithm = "RSA"
+data "aws_availability_zones" "available" {
+  state = "available"
 }
 
-resource "tls_self_signed_cert" "example" {
-  key_algorithm   = "RSA"
-  private_key_pem = "${tls_private_key.example.private_key_pem}"
-
-  subject {
-    common_name  = "example.com"
-    organization = "ACME Examples, Inc"
-  }
-
-  validity_period_hours = 12
-
-  allowed_uses = [
-    "key_encipherment",
-    "digital_signature",
-    "server_auth",
-  ]
+resource "aws_iam_server_certificate" "test" {
+  name             = "%[1]s"
+  certificate_body = "%[2]s"
+  private_key      = "%[3]s"
 }
 
-resource "aws_iam_server_certificate" "test_cert" {
-  name             = "%s"
-  certificate_body = "${tls_self_signed_cert.example.cert_pem}"
-  private_key      = "${tls_private_key.example.private_key_pem}"
-}
-
-resource "aws_elb" "lb" {
-  name               = "%s"
-  availability_zones = ["us-west-2a"]
+resource "aws_elb" "test" {
+  name               = "%[1]s"
+  availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
 
   listener {
     instance_port      = 8000
     instance_protocol  = "https"
     lb_port            = 443
     lb_protocol        = "https"
-    ssl_certificate_id = "${aws_iam_server_certificate.test_cert.arn}"
+    ssl_certificate_id = "${aws_iam_server_certificate.test.arn}"
   }
 }
 
-resource "aws_lb_ssl_negotiation_policy" "foo" {
+resource "aws_lb_ssl_negotiation_policy" "test" {
   name          = "foo-policy"
-  load_balancer = "${aws_elb.lb.id}"
+  load_balancer = "${aws_elb.test.id}"
   lb_port       = 443
 
   attribute {
@@ -274,5 +247,5 @@ resource "aws_lb_ssl_negotiation_policy" "foo" {
     value = "false"
   }
 }
-`, certName, lbName)
+`, rName, tlsPemEscapeNewlines(certificate), tlsPemEscapeNewlines(key))
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/10023

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
--- PASS: TestAccAWSLBSSLNegotiationPolicy_disappears (33.49s)
--- PASS: TestAccAWSLBSSLNegotiationPolicy_basic (40.18s)
```