### PR TITLE
tests/service/apigateway: Use internal implementation for TLS key/certificate

### DIFF
--- a/aws/resource_aws_api_gateway_base_path_mapping_test.go
+++ b/aws/resource_aws_api_gateway_base_path_mapping_test.go
@@ -67,16 +67,18 @@ func TestDecodeApiGatewayBasePathMappingId(t *testing.T) {
 func TestAccAWSAPIGatewayBasePathMapping_basic(t *testing.T) {
 	var conf apigateway.BasePathMapping
 
-	// Our test cert is for a wildcard on this domain
 	name := fmt.Sprintf("tf-acc-%s.terraformtest.com", acctest.RandString(8))
+
+	key := tlsRsaPrivateKeyPem(2048)
+	certificate := tlsRsaX509SelfSignedCertificatePem(key, name)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProvidersWithTLS,
+		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayBasePathDestroy(name),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSAPIGatewayBasePathConfig(name),
+				Config: testAccAWSAPIGatewayBasePathConfigBasePath(name, key, certificate, "tf-acc-test"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayBasePathExists("aws_api_gateway_base_path_mapping.test", name, &conf),
 				),
@@ -94,16 +96,18 @@ func TestAccAWSAPIGatewayBasePathMapping_basic(t *testing.T) {
 func TestAccAWSAPIGatewayBasePathMapping_BasePath_Empty(t *testing.T) {
 	var conf apigateway.BasePathMapping
 
-	// Our test cert is for a wildcard on this domain
 	name := fmt.Sprintf("tf-acc-%s.terraformtest.com", acctest.RandString(8))
+
+	key := tlsRsaPrivateKeyPem(2048)
+	certificate := tlsRsaX509SelfSignedCertificatePem(key, name)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProvidersWithTLS,
+		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayBasePathDestroy(name),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSAPIGatewayEmptyBasePathConfig(name),
+				Config: testAccAWSAPIGatewayBasePathConfigBasePath(name, key, certificate, ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayBasePathExists("aws_api_gateway_base_path_mapping.test", name, &conf),
 				),
@@ -184,11 +188,29 @@ func testAccCheckAWSAPIGatewayBasePathDestroy(name string) resource.TestCheckFun
 	}
 }
 
-func testAccAWSAPIGatewayBasePathConfig(domainName string) string {
+func testAccAWSAPIGatewayBasePathConfigBase(domainName, key, certificate string) string {
 	return fmt.Sprintf(`
+resource "aws_acm_certificate" "test" {
+  certificate_body = "%[2]s"
+  private_key      = "%[3]s"
+}
+
+resource "aws_api_gateway_domain_name" "test" {
+  domain_name              = %[1]q
+  regional_certificate_arn = "${aws_acm_certificate.test.arn}"
+
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
+}
+
 resource "aws_api_gateway_rest_api" "test" {
   name        = "tf-acc-apigateway-base-path-mapping"
   description = "Terraform Acceptance Tests"
+
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
 }
 
 # API gateway won't let us deploy an empty API
@@ -217,70 +239,16 @@ resource "aws_api_gateway_deployment" "test" {
   stage_name  = "test"
   depends_on  = ["aws_api_gateway_integration.test"]
 }
+`, domainName, tlsPemEscapeNewlines(certificate), tlsPemEscapeNewlines(key))
+}
 
+func testAccAWSAPIGatewayBasePathConfigBasePath(domainName, key, certificate, basePath string) string {
+	return testAccAWSAPIGatewayBasePathConfigBase(domainName, key, certificate) + fmt.Sprintf(`
 resource "aws_api_gateway_base_path_mapping" "test" {
   api_id      = "${aws_api_gateway_rest_api.test.id}"
-  base_path   = "tf-acc"
+  base_path   = %[1]q
   stage_name  = "${aws_api_gateway_deployment.test.stage_name}"
   domain_name = "${aws_api_gateway_domain_name.test.domain_name}"
 }
-
-resource "aws_api_gateway_domain_name" "test" {
-  domain_name             = "%s"
-  certificate_name        = "tf-apigateway-base-path-mapping-test"
-  certificate_body        = "${tls_locally_signed_cert.leaf.cert_pem}"
-  certificate_chain       = "${tls_self_signed_cert.ca.cert_pem}"
-  certificate_private_key = "${tls_private_key.test.private_key_pem}"
-}
-
-%s
-
-`, domainName, testAccAWSAPIGatewayCerts(domainName))
-}
-
-func testAccAWSAPIGatewayEmptyBasePathConfig(domainName string) string {
-	return fmt.Sprintf(`
-resource "aws_api_gateway_rest_api" "test" {
-  name        = "tf-acc-apigateway-base-path-mapping"
-  description = "Terraform Acceptance Tests"
-}
-
-resource "aws_api_gateway_method" "test" {
-  rest_api_id   = "${aws_api_gateway_rest_api.test.id}"
-  resource_id   = "${aws_api_gateway_rest_api.test.root_resource_id}"
-  http_method   = "GET"
-  authorization = "NONE"
-}
-
-resource "aws_api_gateway_integration" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_rest_api.test.root_resource_id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
-  type        = "MOCK"
-}
-
-resource "aws_api_gateway_deployment" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  stage_name  = "test"
-  depends_on  = ["aws_api_gateway_integration.test"]
-}
-
-resource "aws_api_gateway_base_path_mapping" "test" {
-  api_id      = "${aws_api_gateway_rest_api.test.id}"
-  base_path   = ""
-  stage_name  = "${aws_api_gateway_deployment.test.stage_name}"
-  domain_name = "${aws_api_gateway_domain_name.test.domain_name}"
-}
-
-resource "aws_api_gateway_domain_name" "test" {
-  domain_name             = "%s"
-  certificate_name        = "tf-apigateway-base-path-mapping-test"
-  certificate_body        = "${tls_locally_signed_cert.leaf.cert_pem}"
-  certificate_chain       = "${tls_self_signed_cert.ca.cert_pem}"
-  certificate_private_key = "${tls_private_key.test.private_key_pem}"
-}
-
-%s
-
-`, domainName, testAccAWSAPIGatewayCerts(domainName))
+`, basePath)
 }

--- a/aws/tls.go
+++ b/aws/tls.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha1"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -61,6 +62,122 @@ func tlsRsaPublicKeyPem(keyPem string) string {
 	}
 
 	return string(pem.EncodeToMemory(block))
+}
+
+// tlsRsaX509LocallySignedCertificatePem generates a local CA x509 certificate PEM string.
+// Wrap with tlsPemEscapeNewlines() to allow simple fmt.Sprintf()
+// configurations such as: certificate_pem = "%[1]s"
+func tlsRsaX509LocallySignedCertificatePem(caKeyPem, caCertificatePem, keyPem, commonName string) string {
+	caCertificateBlock, _ := pem.Decode([]byte(caCertificatePem))
+
+	caCertificate, err := x509.ParseCertificate(caCertificateBlock.Bytes)
+
+	if err != nil {
+		panic(err)
+	}
+
+	caKeyBlock, _ := pem.Decode([]byte(caKeyPem))
+
+	caKey, err := x509.ParsePKCS1PrivateKey(caKeyBlock.Bytes)
+
+	if err != nil {
+		panic(err)
+	}
+
+	keyBlock, _ := pem.Decode([]byte(keyPem))
+
+	key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+
+	if err != nil {
+		panic(err)
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, tlsX509CertificateSerialNumberLimit)
+
+	if err != nil {
+		panic(err)
+	}
+
+	certificate := &x509.Certificate{
+		BasicConstraintsValid: true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		NotBefore:             time.Now(),
+		SerialNumber:          serialNumber,
+		Subject: pkix.Name{
+			CommonName:   commonName,
+			Organization: []string{"ACME Examples, Inc"},
+		},
+	}
+
+	certificateBytes, err := x509.CreateCertificate(rand.Reader, certificate, caCertificate, &key.PublicKey, caKey)
+
+	if err != nil {
+		panic(err)
+	}
+
+	certificateBlock := &pem.Block{
+		Bytes: certificateBytes,
+		Type:  pemBlockTypeCertificate,
+	}
+
+	return string(pem.EncodeToMemory(certificateBlock))
+}
+
+// tlsRsaX509SelfSignedCaCertificatePem generates a x509 CA certificate PEM string.
+// Wrap with tlsPemEscapeNewlines() to allow simple fmt.Sprintf()
+// configurations such as: root_certificate_pem = "%[1]s"
+func tlsRsaX509SelfSignedCaCertificatePem(keyPem string) string {
+	keyBlock, _ := pem.Decode([]byte(keyPem))
+
+	key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+
+	if err != nil {
+		panic(err)
+	}
+
+	publicKeyBytes, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+
+	if err != nil {
+		panic(err)
+	}
+
+	publicKeyBytesSha1 := sha1.Sum(publicKeyBytes)
+
+	serialNumber, err := rand.Int(rand.Reader, tlsX509CertificateSerialNumberLimit)
+
+	if err != nil {
+		panic(err)
+	}
+
+	certificate := &x509.Certificate{
+		BasicConstraintsValid: true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		NotBefore:             time.Now(),
+		SerialNumber:          serialNumber,
+		Subject: pkix.Name{
+			CommonName:   "ACME Root CA",
+			Organization: []string{"ACME Examples, Inc"},
+		},
+		SubjectKeyId: publicKeyBytesSha1[:],
+	}
+
+	certificateBytes, err := x509.CreateCertificate(rand.Reader, certificate, certificate, &key.PublicKey, key)
+
+	if err != nil {
+		panic(err)
+	}
+
+	certificateBlock := &pem.Block{
+		Bytes: certificateBytes,
+		Type:  pemBlockTypeCertificate,
+	}
+
+	return string(pem.EncodeToMemory(certificateBlock))
 }
 
 // tlsRsaX509SelfSignedCertificatePem generates a x509 certificate PEM string.

--- a/aws/tls_test.go
+++ b/aws/tls_test.go
@@ -22,11 +22,31 @@ func TestTlsRsaPublicKeyPem(t *testing.T) {
 	}
 }
 
-func TestTlsRsaX509CertificatePem(t *testing.T) {
+func TestTlsRsaX509LocallySignedCertificatePem(t *testing.T) {
+	caKey := tlsRsaPrivateKeyPem(2048)
+	caCertificate := tlsRsaX509SelfSignedCaCertificatePem(caKey)
+	key := tlsRsaPrivateKeyPem(2048)
+	certificate := tlsRsaX509LocallySignedCertificatePem(caKey, caCertificate, key, "example.com")
+
+	if !strings.Contains(certificate, pemBlockTypeCertificate) {
+		t.Errorf("certificate does not contain CERTIFICATE: %s", certificate)
+	}
+}
+
+func TestTlsRsaX509SelfSignedCaCertificatePem(t *testing.T) {
+	caKey := tlsRsaPrivateKeyPem(2048)
+	caCertificate := tlsRsaX509SelfSignedCaCertificatePem(caKey)
+
+	if !strings.Contains(caCertificate, pemBlockTypeCertificate) {
+		t.Errorf("CA certificate does not contain CERTIFICATE: %s", caCertificate)
+	}
+}
+
+func TestTlsRsaX509SelfSignedCertificatePem(t *testing.T) {
 	key := tlsRsaPrivateKeyPem(2048)
 	certificate := tlsRsaX509SelfSignedCertificatePem(key, "example.com")
 
 	if !strings.Contains(certificate, pemBlockTypeCertificate) {
-		t.Errorf("key does not contain CERTIFICATE: %s", certificate)
+		t.Errorf("certificate does not contain CERTIFICATE: %s", certificate)
 	}
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/10023

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Switches `aws_api_gateway_base_path_mapping` testing to the simplest `aws_api_gateway_domain_name` configuration with `regional_certificate_arn`. Requires new environment variables for `certificate_name` testing as CloudFront now strictly requires a publicly trusted key/certificate:

```
--- FAIL: TestAccAWSAPIGatewayDomainName_CertificateName (5.58s)
    testing.go:569: Step 0 error: errors during apply:

        Error: Error creating API Gateway Domain Name: BadRequestException: The certificate that is attached to your distribution was not issued by a trusted Certificate Authority. For more details, see: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html#alternate-domain-names-requirements (Service: AmazonCloudFront; Status Code: 400; Error Code: InvalidViewerCertificate; Request ID: e052f947-e261-11e9-a70c-b3beead7f798)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSAPIGatewayBasePathMapping_basic (103.50s)
--- PASS: TestAccAWSAPIGatewayBasePathMapping_BasePath_Empty (61.24s)

--- SKIP: TestAccAWSAPIGatewayDomainName_CertificateArn (0.00s)
--- SKIP: TestAccAWSAPIGatewayDomainName_CertificateName (0.00s)
--- SKIP: TestAccAWSAPIGatewayDomainName_RegionalCertificateName (0.00s)
--- PASS: TestAccAWSAPIGatewayDomainName_RegionalCertificateArn (20.45s)
--- PASS: TestAccAWSAPIGatewayDomainName_SecurityPolicy (104.68s)
```
