### PR TITLE
resource/aws_cloudhsm_v2_cluster: Ensure multiple tag configurations are applied and perform drift detection of tags

### DIFF
--- a/aws/resource_aws_cloudhsm2_cluster.go
+++ b/aws/resource_aws_cloudhsm2_cluster.go
@@ -2,15 +2,15 @@ package aws
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/validation"
 	"log"
 	"time"
-
-	"github.com/hashicorp/terraform/helper/schema"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudhsmv2"
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsCloudHsm2Cluster() *schema.Resource {
@@ -212,16 +212,19 @@ func resourceAwsCloudHsm2ClusterCreate(d *schema.ResourceData, meta interface{})
 		}
 	}
 
-	if err := setTagsAwsCloudHsm2Cluster(cloudhsm2, d); err != nil {
-		return err
+	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
+		if err := keyvaluetags.Cloudhsmv2UpdateTags(cloudhsm2, d.Id(), nil, v); err != nil {
+			return fmt.Errorf("error updating tags: %s", err)
+		}
 	}
 
 	return resourceAwsCloudHsm2ClusterRead(d, meta)
 }
 
 func resourceAwsCloudHsm2ClusterRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudhsmv2conn
 
-	cluster, err := describeCloudHsm2Cluster(meta.(*AWSClient).cloudhsmv2conn, d.Id())
+	cluster, err := describeCloudHsm2Cluster(conn, d.Id())
 
 	if cluster == nil {
 		log.Printf("[WARN] CloudHSMv2 Cluster (%s) not found", d.Id())
@@ -249,14 +252,27 @@ func resourceAwsCloudHsm2ClusterRead(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error saving Subnet IDs to state for CloudHSMv2 Cluster (%s): %s", d.Id(), err)
 	}
 
+	tags, err := keyvaluetags.Cloudhsmv2ListTags(conn, d.Id())
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for resource (%s): %s", d.Id(), err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
 	return nil
 }
 
 func resourceAwsCloudHsm2ClusterUpdate(d *schema.ResourceData, meta interface{}) error {
-	cloudhsm2 := meta.(*AWSClient).cloudhsmv2conn
+	conn := meta.(*AWSClient).cloudhsmv2conn
 
-	if err := setTagsAwsCloudHsm2Cluster(cloudhsm2, d); err != nil {
-		return err
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+		if err := keyvaluetags.Cloudhsmv2UpdateTags(conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("error updating tags: %s", err)
+		}
 	}
 
 	return resourceAwsCloudHsm2ClusterRead(d, meta)
@@ -291,48 +307,6 @@ func resourceAwsCloudHsm2ClusterDelete(d *schema.ResourceData, meta interface{})
 
 	if err := waitForCloudhsmv2ClusterDeletion(cloudhsm2, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
 		return fmt.Errorf("error waiting for CloudHSMv2 Cluster (%s) deletion: %s", d.Id(), err)
-	}
-
-	return nil
-}
-
-func setTagsAwsCloudHsm2Cluster(conn *cloudhsmv2.CloudHSMV2, d *schema.ResourceData) error {
-	if d.HasChange("tags") {
-		oraw, nraw := d.GetChange("tags")
-		create, remove := diffTagsGeneric(oraw.(map[string]interface{}), nraw.(map[string]interface{}))
-
-		if len(remove) > 0 {
-			log.Printf("[DEBUG] Removing tags: %#v", remove)
-			keys := make([]*string, 0, len(remove))
-			for k := range remove {
-				keys = append(keys, aws.String(k))
-			}
-
-			_, err := conn.UntagResource(&cloudhsmv2.UntagResourceInput{
-				ResourceId: aws.String(d.Id()),
-				TagKeyList: keys,
-			})
-			if err != nil {
-				return err
-			}
-		}
-		if len(create) > 0 {
-			log.Printf("[DEBUG] Creating tags: %#v", create)
-			tagList := make([]*cloudhsmv2.Tag, 0, len(create))
-			for k, v := range create {
-				tagList = append(tagList, &cloudhsmv2.Tag{
-					Key:   aws.String(k),
-					Value: v,
-				})
-			}
-			_, err := conn.TagResource(&cloudhsmv2.TagResourceInput{
-				ResourceId: aws.String(d.Id()),
-				TagList:    tagList,
-			})
-			if err != nil {
-				return err
-			}
-		}
 	}
 
 	return nil

--- a/aws/resource_aws_cloudhsm2_cluster_test.go
+++ b/aws/resource_aws_cloudhsm2_cluster_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudhsmv2"
-	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -85,32 +84,77 @@ func testSweepCloudhsmv2Clusters(region string) error {
 }
 
 func TestAccAWSCloudHsm2Cluster_basic(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudHsm2ClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudHsm2Cluster(),
+				Config: testAccAWSCloudHsm2ClusterConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCloudHsm2ClusterExists("aws_cloudhsm_v2_cluster.cluster"),
 					resource.TestCheckResourceAttrSet("aws_cloudhsm_v2_cluster.cluster", "cluster_id"),
 					resource.TestCheckResourceAttrSet("aws_cloudhsm_v2_cluster.cluster", "vpc_id"),
 					resource.TestCheckResourceAttrSet("aws_cloudhsm_v2_cluster.cluster", "security_group_id"),
 					resource.TestCheckResourceAttrSet("aws_cloudhsm_v2_cluster.cluster", "cluster_state"),
+					resource.TestCheckResourceAttr("aws_cloudhsm_v2_cluster.cluster", "tags.%", "0"),
 				),
 			},
 			{
 				ResourceName:            "aws_cloudhsm_v2_cluster.cluster",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"cluster_certificates", "tags"},
+				ImportStateVerifyIgnore: []string{"cluster_certificates"},
 			},
 		},
 	})
 }
 
-func testAccAWSCloudHsm2Cluster() string {
+func TestAccAWSCloudHsm2Cluster_Tags(t *testing.T) {
+	resourceName := "aws_cloudhsm_v2_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudHsm2ClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudHsm2ClusterConfigTags2("key1", "value1", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCloudHsm2ClusterExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"cluster_certificates"},
+			},
+			{
+				Config: testAccAWSCloudHsm2ClusterConfigTags1("key1", "value1updated"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCloudHsm2ClusterExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+				),
+			},
+			{
+				Config: testAccAWSCloudHsm2ClusterConfigTags2("key1", "value1updated", "key3", "value3"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCloudHsm2ClusterExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key3", "value3"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSCloudHsm2ClusterConfigBase() string {
 	return fmt.Sprintf(`
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
@@ -138,16 +182,43 @@ resource "aws_subnet" "cloudhsm2_test_subnets" {
     Name = "tf-acc-aws_cloudhsm_v2_cluster-resource-basic"
   }
 }
+`)
+}
 
+func testAccAWSCloudHsm2ClusterConfig() string {
+	return testAccAWSCloudHsm2ClusterConfigBase() + fmt.Sprintf(`
 resource "aws_cloudhsm_v2_cluster" "cluster" {
+  hsm_type   = "hsm1.medium"
+  subnet_ids = ["${aws_subnet.cloudhsm2_test_subnets.*.id[0]}", "${aws_subnet.cloudhsm2_test_subnets.*.id[1]}"]
+}
+`)
+}
+
+func testAccAWSCloudHsm2ClusterConfigTags1(tagKey1, tagValue1 string) string {
+	return testAccAWSCloudHsm2ClusterConfigBase() + fmt.Sprintf(`
+resource "aws_cloudhsm_v2_cluster" "test" {
   hsm_type   = "hsm1.medium"
   subnet_ids = ["${aws_subnet.cloudhsm2_test_subnets.*.id[0]}", "${aws_subnet.cloudhsm2_test_subnets.*.id[1]}"]
 
   tags = {
-    Name = "tf-acc-aws_cloudhsm_v2_cluster-resource-basic-%d"
+    %[1]q = %[2]q
   }
 }
-`, acctest.RandInt())
+`, tagKey1, tagValue1)
+}
+
+func testAccAWSCloudHsm2ClusterConfigTags2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return testAccAWSCloudHsm2ClusterConfigBase() + fmt.Sprintf(`
+resource "aws_cloudhsm_v2_cluster" "test" {
+  hsm_type   = "hsm1.medium"
+  subnet_ids = ["${aws_subnet.cloudhsm2_test_subnets.*.id[0]}", "${aws_subnet.cloudhsm2_test_subnets.*.id[1]}"]
+
+  tags = {
+    %[1]q = %[2]q
+    %[3]q = %[4]q
+  }
+}
+`, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
 func testAccCheckAWSCloudHsm2ClusterDestroy(s *terraform.State) error {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9871
Includes and supersedes #9741 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_cloudhsm_v2_cluster: Ensure multiple tag configurations are applied
* resource/aws_cloudhsm_v2_cluster: Perform drift detection with tags
```

Output from acceptance testing:

```
--- PASS: TestAccAWSCloudHsm2Cluster_Tags (281.94s)
--- PASS: TestAccAWSCloudHsm2Cluster_basic (286.25s)
```
