### PR TITLE
tests/service/iam: Use internal implementation for TLS key/certificate

### DIFF
--- a/aws/data_source_aws_iam_server_certificate_test.go
+++ b/aws/data_source_aws_iam_server_certificate_test.go
@@ -39,15 +39,18 @@ func TestResourceSortByExpirationDate(t *testing.T) {
 }
 
 func TestAccAWSDataSourceIAMServerCertificate_basic(t *testing.T) {
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	key := tlsRsaPrivateKeyPem(2048)
+	certificate := tlsRsaX509SelfSignedCertificatePem(key, "example.com")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProvidersWithTLS,
+		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckIAMServerCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsDataIAMServerCertConfig(rInt),
+				Config: testAccAwsDataIAMServerCertConfig(rName, key, certificate),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("aws_iam_server_certificate.test_cert", "arn"),
 					resource.TestCheckResourceAttrSet("data.aws_iam_server_certificate.test", "arn"),
@@ -78,17 +81,20 @@ func TestAccAWSDataSourceIAMServerCertificate_matchNamePrefix(t *testing.T) {
 }
 
 func TestAccAWSDataSourceIAMServerCertificate_path(t *testing.T) {
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	path := "/test-path/"
 	pathPrefix := "/test-path/"
 
+	key := tlsRsaPrivateKeyPem(2048)
+	certificate := tlsRsaX509SelfSignedCertificatePem(key, "example.com")
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProvidersWithTLS,
+		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckIAMServerCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsDataIAMServerCertConfigPath(rInt, path, pathPrefix),
+				Config: testAccAwsDataIAMServerCertConfigPath(rName, path, pathPrefix, key, certificate),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_iam_server_certificate.test", "path", path),
 				),
@@ -97,27 +103,36 @@ func TestAccAWSDataSourceIAMServerCertificate_path(t *testing.T) {
 	})
 }
 
-func testAccAwsDataIAMServerCertConfig(rInt int) string {
+func testAccAwsDataIAMServerCertConfig(rName, key, certificate string) string {
 	return fmt.Sprintf(`
-%s
+resource "aws_iam_server_certificate" "test_cert" {
+  name             = "%[1]s"
+  certificate_body = "%[2]s"
+  private_key      = "%[3]s"
+}
 
 data "aws_iam_server_certificate" "test" {
   name   = "${aws_iam_server_certificate.test_cert.name}"
   latest = true
 }
-`, testAccIAMServerCertConfig(rInt))
+`, rName, tlsPemEscapeNewlines(certificate), tlsPemEscapeNewlines(key))
 }
 
-func testAccAwsDataIAMServerCertConfigPath(rInt int, path, pathPrefix string) string {
+func testAccAwsDataIAMServerCertConfigPath(rName, path, pathPrefix, key, certificate string) string {
 	return fmt.Sprintf(`
-%s
+resource "aws_iam_server_certificate" "test_cert" {
+  name             = "%[1]s"
+  path             = "%[2]s"
+  certificate_body = "%[3]s"
+  private_key      = "%[4]s"
+}
 
 data "aws_iam_server_certificate" "test" {
   name        = "${aws_iam_server_certificate.test_cert.name}"
-  path_prefix = "%s"
+  path_prefix = "%[5]s"
   latest      = true
 }
-`, testAccIAMServerCertConfig_path(rInt, path), pathPrefix)
+`, rName, path, tlsPemEscapeNewlines(certificate), tlsPemEscapeNewlines(key), pathPrefix)
 }
 
 var testAccAwsDataIAMServerCertConfigMatchNamePrefix = `

--- a/aws/resource_aws_iam_server_certificate_test.go
+++ b/aws/resource_aws_iam_server_certificate_test.go
@@ -55,29 +55,30 @@ func testSweepIamServerCertificates(region string) error {
 
 func TestAccAWSIAMServerCertificate_basic(t *testing.T) {
 	var cert iam.ServerCertificate
-	rInt := acctest.RandInt()
-	var certBody string
+
 	resourceName := "aws_iam_server_certificate.test_cert"
-	resourceId := fmt.Sprintf("terraform-test-cert-%d", rInt)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	key := tlsRsaPrivateKeyPem(2048)
+	certificate := tlsRsaX509SelfSignedCertificatePem(key, "example.com")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProvidersWithTLS,
+		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckIAMServerCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIAMServerCertConfig(rInt),
+				Config: testAccIAMServerCertConfig(rName, key, certificate),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCertExists(resourceName, &cert),
-					getCertBody(&certBody),
-					testAccCheckAWSServerCertAttributes(&cert, &certBody),
+					testAccCheckAWSServerCertAttributes(&cert, &certificate),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateId:     resourceId,
+				ImportStateId:     rName,
 				ImportStateVerifyIgnore: []string{
 					"private_key"},
 			},
@@ -87,20 +88,22 @@ func TestAccAWSIAMServerCertificate_basic(t *testing.T) {
 
 func TestAccAWSIAMServerCertificate_name_prefix(t *testing.T) {
 	var cert iam.ServerCertificate
-	var certBody string
+
 	resourceName := "aws_iam_server_certificate.test_cert"
+
+	key := tlsRsaPrivateKeyPem(2048)
+	certificate := tlsRsaX509SelfSignedCertificatePem(key, "example.com")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProvidersWithTLS,
+		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckIAMServerCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIAMServerCertConfig_random(),
+				Config: testAccIAMServerCertConfig_random(key, certificate),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCertExists(resourceName, &cert),
-					getCertBody(&certBody),
-					testAccCheckAWSServerCertAttributes(&cert, &certBody),
+					testAccCheckAWSServerCertAttributes(&cert, &certificate),
 				),
 			},
 		},
@@ -110,6 +113,9 @@ func TestAccAWSIAMServerCertificate_name_prefix(t *testing.T) {
 func TestAccAWSIAMServerCertificate_disappears(t *testing.T) {
 	var cert iam.ServerCertificate
 	resourceName := "aws_iam_server_certificate.test_cert"
+
+	key := tlsRsaPrivateKeyPem(2048)
+	certificate := tlsRsaX509SelfSignedCertificatePem(key, "example.com")
 
 	testDestroyCert := func(*terraform.State) error {
 		// reach out and DELETE the Cert
@@ -127,11 +133,11 @@ func TestAccAWSIAMServerCertificate_disappears(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProvidersWithTLS,
+		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckIAMServerCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIAMServerCertConfig_random(),
+				Config: testAccIAMServerCertConfig_random(key, certificate),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCertExists(resourceName, &cert),
 					testDestroyCert,
@@ -206,22 +212,9 @@ func testAccCheckCertExists(n string, cert *iam.ServerCertificate) resource.Test
 	}
 }
 
-func getCertBody(body *string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		for _, rs := range s.RootModule().Resources {
-			if rs.Type != "tls_self_signed_cert" {
-				continue
-			}
-
-			*body = rs.Primary.Attributes["cert_pem"]
-		}
-		return nil
-	}
-}
-
 func testAccCheckAWSServerCertAttributes(cert *iam.ServerCertificate, certBody *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if !strings.Contains(*cert.ServerCertificateMetadata.ServerCertificateName, "terraform-test-cert") {
+		if !strings.Contains(*cert.ServerCertificateMetadata.ServerCertificateName, "tf-acc-test") {
 			return fmt.Errorf("Bad Server Cert Name: %s", *cert.ServerCertificateMetadata.ServerCertificateName)
 		}
 
@@ -258,65 +251,35 @@ func testAccCheckIAMServerCertificateDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccTLSServerCert = `
-resource "tls_private_key" "example" {
-  algorithm = "RSA"
-}
-
-resource "tls_self_signed_cert" "example" {
-  key_algorithm   = "RSA"
-  private_key_pem = "${tls_private_key.example.private_key_pem}"
-
-  subject {
-    common_name  = "example.com"
-    organization = "ACME Examples, Inc"
-  }
-
-  validity_period_hours = 12
-
-  allowed_uses = [
-    "key_encipherment",
-    "digital_signature",
-    "server_auth",
-  ]
-}
-`
-
-func testAccIAMServerCertConfig(rInt int) string {
+func testAccIAMServerCertConfig(rName, key, certificate string) string {
 	return fmt.Sprintf(`
-%s
-
 resource "aws_iam_server_certificate" "test_cert" {
-  name             = "terraform-test-cert-%d"
-  certificate_body = "${tls_self_signed_cert.example.cert_pem}"
-  private_key      = "${tls_private_key.example.private_key_pem}"
+  name             = "%[1]s"
+  certificate_body = "%[2]s"
+  private_key      = "%[3]s"
 }
-`, testAccTLSServerCert, rInt)
+`, rName, tlsPemEscapeNewlines(certificate), tlsPemEscapeNewlines(key))
 }
 
-func testAccIAMServerCertConfig_random() string {
+func testAccIAMServerCertConfig_random(key, certificate string) string {
 	return fmt.Sprintf(`
-%s 
-
 resource "aws_iam_server_certificate" "test_cert" {
-  name_prefix = "terraform-test-cert"
-  certificate_body = "${tls_self_signed_cert.example.cert_pem}"
-  private_key      = "${tls_private_key.example.private_key_pem}"
+  name_prefix      = "tf-acc-test"
+  certificate_body = "%[1]s"
+  private_key      = "%[2]s"
 }
-`, testAccTLSServerCert)
+`, tlsPemEscapeNewlines(certificate), tlsPemEscapeNewlines(key))
 }
 
-func testAccIAMServerCertConfig_path(rInt int, path string) string {
+func testAccIAMServerCertConfig_path(rName, path, key, certificate string) string {
 	return fmt.Sprintf(`
-%s
-
 resource "aws_iam_server_certificate" "test_cert" {
-  name             = "terraform-test-cert-%d"
-  path             = "%s"
-  certificate_body = "${tls_self_signed_cert.example.cert_pem}"
-  private_key      = "${tls_private_key.example.private_key_pem}"
+  name             = "%[1]s"
+  path             = "%[2]s"
+  certificate_body = "%[3]s"
+  private_key      = "%[4]s"
 }
-`, testAccTLSServerCert, rInt, path)
+`, rName, path, tlsPemEscapeNewlines(certificate), tlsPemEscapeNewlines(key))
 }
 
 // iam-ssl-unix-line-endings


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/10023

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
--- PASS: TestAccAWSDataSourceIAMServerCertificate_matchNamePrefix (3.55s)
--- PASS: TestAccAWSIAMServerCertificate_disappears (9.30s)
--- PASS: TestAccAWSIAMServerCertificate_name_prefix (10.17s)
--- PASS: TestAccAWSIAMServerCertificate_basic (11.28s)
--- PASS: TestAccAWSDataSourceIAMServerCertificate_basic (12.65s)
--- PASS: TestAccAWSDataSourceIAMServerCertificate_path (12.71s)
--- PASS: TestAccAWSIAMServerCertificate_file (17.00s)
```