### PR TITLE
Refactor: Use acctest.RandStringFromCharSet() instead of randomString()

### DIFF
--- a/aws/resource_aws_redshift_parameter_group_test.go
+++ b/aws/resource_aws_redshift_parameter_group_test.go
@@ -185,7 +185,7 @@ func TestResourceAWSRedshiftParameterGroupNameValidation(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    randomString(256),
+			Value:    acctest.RandStringFromCharSet(256, acctest.CharSetAlpha),
 			ErrCount: 1,
 		},
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10040

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
N/a - code refactor 
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestResourceAWSRedshiftParameterGroupNameValidation'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestResourceAWSRedshiftParameterGroupNameValidation -timeout 120m
=== RUN   TestResourceAWSRedshiftParameterGroupNameValidation
--- PASS: TestResourceAWSRedshiftParameterGroupNameValidation (0.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	0.050s

...
```
