### PR TITLE
Refactor: Use acctest.RandString instead of randomString on worklink tests

### DIFF
--- a/aws/resource_aws_worklink_fleet_test.go
+++ b/aws/resource_aws_worklink_fleet_test.go
@@ -9,12 +9,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/worklink"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func TestAccAWSWorkLinkFleet_Basic(t *testing.T) {
-	suffix := randomString(20)
+	suffix := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
 	resourceName := "aws_worklink_fleet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -41,7 +42,7 @@ func TestAccAWSWorkLinkFleet_Basic(t *testing.T) {
 }
 
 func TestAccAWSWorkLinkFleet_DisplayName(t *testing.T) {
-	suffix := randomString(20)
+	suffix := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
 	resourceName := "aws_worklink_fleet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -73,7 +74,7 @@ func TestAccAWSWorkLinkFleet_DisplayName(t *testing.T) {
 }
 
 func TestAccAWSWorkLinkFleet_OptimizeForEndUserLocation(t *testing.T) {
-	suffix := randomString(20)
+	suffix := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
 	resourceName := "aws_worklink_fleet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -105,7 +106,7 @@ func TestAccAWSWorkLinkFleet_OptimizeForEndUserLocation(t *testing.T) {
 }
 
 func TestAccAWSWorkLinkFleet_AuditStreamArn(t *testing.T) {
-	rName := randomString(20)
+	rName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
 	resourceName := "aws_worklink_fleet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -130,7 +131,7 @@ func TestAccAWSWorkLinkFleet_AuditStreamArn(t *testing.T) {
 }
 
 func TestAccAWSWorkLinkFleet_Network(t *testing.T) {
-	rName := randomString(20)
+	rName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
 	resourceName := "aws_worklink_fleet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -172,7 +173,7 @@ func TestAccAWSWorkLinkFleet_Network(t *testing.T) {
 }
 
 func TestAccAWSWorkLinkFleet_DeviceCaCertificate(t *testing.T) {
-	rName := randomString(20)
+	rName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
 	resourceName := "aws_worklink_fleet.test"
 	fName := "test-fixtures/worklink-device-ca-certificate.pem"
 
@@ -205,7 +206,7 @@ func TestAccAWSWorkLinkFleet_DeviceCaCertificate(t *testing.T) {
 }
 
 func TestAccAWSWorkLinkFleet_IdentityProvider(t *testing.T) {
-	rName := randomString(20)
+	rName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
 	resourceName := "aws_worklink_fleet.test"
 	fName := "test-fixtures/saml-metadata.xml"
 
@@ -236,7 +237,7 @@ func TestAccAWSWorkLinkFleet_IdentityProvider(t *testing.T) {
 }
 
 func TestAccAWSWorkLinkFleet_Disappears(t *testing.T) {
-	rName := randomString(20)
+	rName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
 	resourceName := "aws_worklink_fleet.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/aws/resource_aws_worklink_website_certificate_authority_association_test.go
+++ b/aws/resource_aws_worklink_website_certificate_authority_association_test.go
@@ -9,12 +9,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/worklink"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_Basic(t *testing.T) {
-	suffix := randomString(20)
+	suffix := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
 	resourceName := "aws_worklink_website_certificate_authority_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -42,10 +43,10 @@ func TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_Basic(t *t
 }
 
 func TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_DisplayName(t *testing.T) {
-	suffix := randomString(20)
+	suffix := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
 	resourceName := "aws_worklink_website_certificate_authority_association.test"
-	displayName1 := fmt.Sprintf("tf-website-certificate-%s", randomString(5))
-	displayName2 := fmt.Sprintf("tf-website-certificate-%s", randomString(5))
+	displayName1 := fmt.Sprintf("tf-website-certificate-%s", acctest.RandStringFromCharSet(5, acctest.CharSetAlpha))
+	displayName2 := fmt.Sprintf("tf-website-certificate-%s", acctest.RandStringFromCharSet(5, acctest.CharSetAlpha))
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWorkLink(t) },
 		Providers:    testAccProviders,
@@ -75,7 +76,7 @@ func TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_DisplayNam
 }
 
 func TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_Disappears(t *testing.T) {
-	suffix := randomString(20)
+	suffix := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
 	resourceName := "aws_worklink_website_certificate_authority_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10040 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
N/A - code refactor
```
**Note:** TestAccAWSWorkLinkFleet_AuditStreamArn is failing both on this branch and on master with the output below. I'll open a separate issue/PR to fix that.
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSWorkLinkFleet_AuditStreamArn'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSWorkLinkFleet_AuditStreamArn -timeout 120m
=== RUN   TestAccAWSWorkLinkFleet_AuditStreamArn
=== PAUSE TestAccAWSWorkLinkFleet_AuditStreamArn
=== CONT  TestAccAWSWorkLinkFleet_AuditStreamArn
--- FAIL: TestAccAWSWorkLinkFleet_AuditStreamArn (82.60s)
    testing.go:569: Step 0 error: errors during apply:

        Error: Error Updating Worklink Audit Stream Configuration: InvalidRequestException: Invalid request body
        	status code: 400, request id: $some-request-id

          on /var/folders/hx/m9sbgjpn4r542dd3v7058z_m0000gn/T/tf-test052068388/main.tf line 7:
          (source code not available)


FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	82.656s
FAIL
make: *** [testacc] Error 1
```
Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSWorkLinkFleet_Basic\|TestAccAWSWorkLinkFleet_DisplayName\|TestAccAWSWorkLinkFleet_OptimizeForEndUserLocation\|TestAccAWSWorkLinkFleet_Network\|TestAccAWSWorkLinkFleet_DeviceCaCertificate\|TestAccAWSWorkLinkFleet_IdentityProvider\|TestAccAWSWorkLinkFleet_Disappears\|TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_Basic\|TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_DisplayName\|TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_Disappears'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSWorkLinkFleet_Basic\|TestAccAWSWorkLinkFleet_DisplayName\|TestAccAWSWorkLinkFleet_OptimizeForEndUserLocation\|TestAccAWSWorkLinkFleet_Network\|TestAccAWSWorkLinkFleet_DeviceCaCertificate\|TestAccAWSWorkLinkFleet_IdentityProvider\|TestAccAWSWorkLinkFleet_Disappears\|TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_Basic\|TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_DisplayName\|TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_Disappears -timeout 120m
=== RUN   TestAccAWSWorkLinkFleet_Basic
=== PAUSE TestAccAWSWorkLinkFleet_Basic
=== RUN   TestAccAWSWorkLinkFleet_DisplayName
=== PAUSE TestAccAWSWorkLinkFleet_DisplayName
=== RUN   TestAccAWSWorkLinkFleet_OptimizeForEndUserLocation
=== PAUSE TestAccAWSWorkLinkFleet_OptimizeForEndUserLocation
=== RUN   TestAccAWSWorkLinkFleet_Network
=== PAUSE TestAccAWSWorkLinkFleet_Network
=== RUN   TestAccAWSWorkLinkFleet_DeviceCaCertificate
=== PAUSE TestAccAWSWorkLinkFleet_DeviceCaCertificate
=== RUN   TestAccAWSWorkLinkFleet_IdentityProvider
=== PAUSE TestAccAWSWorkLinkFleet_IdentityProvider
=== RUN   TestAccAWSWorkLinkFleet_Disappears
=== PAUSE TestAccAWSWorkLinkFleet_Disappears
=== RUN   TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_Basic
=== PAUSE TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_Basic
=== RUN   TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_DisplayName
=== PAUSE TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_DisplayName
=== RUN   TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_Disappears
=== PAUSE TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_Disappears
=== CONT  TestAccAWSWorkLinkFleet_Basic
=== CONT  TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_Basic
=== CONT  TestAccAWSWorkLinkFleet_DisplayName
=== CONT  TestAccAWSWorkLinkFleet_DeviceCaCertificate
=== CONT  TestAccAWSWorkLinkFleet_Disappears
=== CONT  TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_Disappears
=== CONT  TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_DisplayName
=== CONT  TestAccAWSWorkLinkFleet_OptimizeForEndUserLocation
=== CONT  TestAccAWSWorkLinkFleet_Network
=== CONT  TestAccAWSWorkLinkFleet_IdentityProvider
--- PASS: TestAccAWSWorkLinkFleet_Disappears (29.29s)
--- PASS: TestAccAWSWorkLinkFleet_Basic (47.68s)
--- PASS: TestAccAWSWorkLinkFleet_IdentityProvider (52.56s)
--- PASS: TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_Disappears (53.84s)
--- PASS: TestAccAWSWorkLinkFleet_DeviceCaCertificate (61.34s)
--- PASS: TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_Basic (63.19s)
--- PASS: TestAccAWSWorkLinkFleet_DisplayName (63.53s)
--- PASS: TestAccAWSWorkLinkFleet_OptimizeForEndUserLocation (68.61s)
--- PASS: TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_DisplayName (79.40s)
--- PASS: TestAccAWSWorkLinkFleet_Network (90.97s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	91.034s

...
```
