### PR TITLE
tests/resource/aws_waf_web_acl: Add sweeper

### DIFF
--- a/aws/resource_aws_waf_rule_group_test.go
+++ b/aws/resource_aws_waf_rule_group_test.go
@@ -17,6 +17,9 @@ func init() {
 	resource.AddTestSweepers("aws_waf_rule_group", &resource.Sweeper{
 		Name: "aws_waf_rule_group",
 		F:    testSweepWafRuleGroups,
+		Dependencies: []string{
+			"aws_waf_web_acl",
+		},
 	})
 }
 

--- a/aws/resource_aws_waf_web_acl_test.go
+++ b/aws/resource_aws_waf_web_acl_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"testing"
 
@@ -11,6 +12,106 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_waf_web_acl", &resource.Sweeper{
+		Name: "aws_waf_web_acl",
+		F:    testSweepWafWebAcls,
+	})
+}
+
+func testSweepWafWebAcls(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).wafconn
+
+	input := &waf.ListWebACLsInput{}
+
+	for {
+		output, err := conn.ListWebACLs(input)
+
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping WAF Regional Web ACL sweep for %s: %s", region, err)
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("error listing WAF Regional Web ACLs: %s", err)
+		}
+
+		for _, webACL := range output.WebACLs {
+			deleteInput := &waf.DeleteWebACLInput{
+				WebACLId: webACL.WebACLId,
+			}
+			id := aws.StringValue(webACL.WebACLId)
+			wr := newWafRetryer(conn)
+
+			_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+				deleteInput.ChangeToken = token
+				log.Printf("[INFO] Deleting WAF Regional Web ACL: %s", id)
+				return conn.DeleteWebACL(deleteInput)
+			})
+
+			if isAWSErr(err, waf.ErrCodeNonEmptyEntityException, "") {
+				getWebACLInput := &waf.GetWebACLInput{
+					WebACLId: webACL.WebACLId,
+				}
+
+				getWebACLOutput, getWebACLErr := conn.GetWebACL(getWebACLInput)
+
+				if getWebACLErr != nil {
+					return fmt.Errorf("error getting WAF Regional Web ACL (%s): %s", id, getWebACLErr)
+				}
+
+				var updates []*waf.WebACLUpdate
+				updateWebACLInput := &waf.UpdateWebACLInput{
+					DefaultAction: getWebACLOutput.WebACL.DefaultAction,
+					Updates:       updates,
+					WebACLId:      webACL.WebACLId,
+				}
+
+				for _, rule := range getWebACLOutput.WebACL.Rules {
+					update := &waf.WebACLUpdate{
+						Action:        aws.String(waf.ChangeActionDelete),
+						ActivatedRule: rule,
+					}
+
+					updateWebACLInput.Updates = append(updateWebACLInput.Updates, update)
+				}
+
+				_, updateWebACLErr := wr.RetryWithToken(func(token *string) (interface{}, error) {
+					updateWebACLInput.ChangeToken = token
+					log.Printf("[INFO] Removing Rules from WAF Regional Web ACL: %s", id)
+					return conn.UpdateWebACL(updateWebACLInput)
+				})
+
+				if updateWebACLErr != nil {
+					return fmt.Errorf("error removing rules from WAF Regional Web ACL (%s): %s", id, updateWebACLErr)
+				}
+
+				_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
+					deleteInput.ChangeToken = token
+					log.Printf("[INFO] Deleting WAF Regional Web ACL: %s", id)
+					return conn.DeleteWebACL(deleteInput)
+				})
+			}
+
+			if err != nil {
+				return fmt.Errorf("error deleting WAF Regional Web ACL (%s): %s", id, err)
+			}
+		}
+
+		if aws.StringValue(output.NextMarker) == "" {
+			break
+		}
+
+		input.NextMarker = output.NextMarker
+	}
+
+	return nil
+}
 
 func TestAccAWSWafWebAcl_basic(t *testing.T) {
 	var webACL waf.WebACL


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Prevent sweeper errors such as the following:

```
[02:06:51][Step 2/4] 2019/10/01 02:06:51 [ERR] error running (aws_waf_rule_group): Error deleting WAF Rule Group: WAFReferencedItemException: This entity is still referenced by other entities.
```

Output from sweeper in AWS Commercial:

```console
$ go test ./aws -v -sweep=us-east-1,us-west-2 -sweep-run=aws_waf_web_acl -timeout 10h
...
2019/10/01 08:34:32 [INFO] Deleting WAF Regional Web ACL: 0a403434-d93a-4aab-a77e-eb4233d18782
2019/10/01 08:34:33 [INFO] Removing Rules from WAF Regional Web ACL: 0a403434-d93a-4aab-a77e-eb4233d18782
2019/10/01 08:34:33 [INFO] Deleting WAF Regional Web ACL: 0a403434-d93a-4aab-a77e-eb4233d18782
2019/10/01 08:34:34 [INFO] Deleting WAF Regional Web ACL: 5337406c-99fd-49dc-9ff5-0dfdf5c197c0
2019/10/01 08:34:34 [INFO] Deleting WAF Regional Web ACL: 544a93f3-7729-48ad-850a-a52e4b135c69
2019/10/01 08:34:35 [INFO] Removing Rules from WAF Regional Web ACL: 544a93f3-7729-48ad-850a-a52e4b135c69
2019/10/01 08:34:35 [INFO] Deleting WAF Regional Web ACL: 544a93f3-7729-48ad-850a-a52e4b135c69
2019/10/01 08:34:36 [INFO] Deleting WAF Regional Web ACL: 8029c8ef-ace5-43c6-ae41-83097c17a319
2019/10/01 08:34:36 [INFO] Deleting WAF Regional Web ACL: f5afc502-250b-4256-9b0c-585e399a124c
2019/10/01 08:34:37 Sweeper Tests ran:
	- aws_waf_web_acl

$ go test ./aws -v -sweep=us-east-1,us-west-2 -sweep-run=aws_waf_rule_group -timeout 10h
...
2019/10/01 08:36:47 [INFO] Deleting WAF Rule Group
2019/10/01 08:36:48 Sweeper Tests ran:
	- aws_waf_web_acl
	- aws_waf_rule_group
```

Output from sweeper in AWS GovCloud (US):

```console
$ go test ./aws -v -sweep=us-gov-west-1 -sweep-run=aws_waf_web_acl -timeout 10h
...
2019/10/01 08:34:36 [WARN] Skipping WAF Regional Web ACL sweep for us-gov-west-1: RequestError: send request failed
caused by: Post https://waf.us-gov-west-1.amazonaws.com/: dial tcp: lookup waf.us-gov-west-1.amazonaws.com: no such host
2019/10/01 08:34:36 Sweeper Tests ran:
	- aws_waf_web_acl
ok  	github.com/terraform-providers/terraform-provider-aws/aws	4.366s
```
