### PR TITLE
provider: Remove hashibot pull request labeling of old tags filenames

### DIFF
--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -456,13 +456,11 @@ behavior "pull_request_path_labeler" "service_labels" {
     # label services
     "service/acm" = [
       "**/*_acm_*",
-      "**/acm_*",
-      "aws/tagsACM*"
+      "**/acm_*"
     ]
     "service/acmpca" = [
       "**/*_acmpca_*",
-      "**/acmpca_*",
-      "aws/tagsACMPCA*"
+      "**/acmpca_*"
     ]
     "service/alexaforbusiness" = [
       "**/*_alexaforbusiness_*",
@@ -474,13 +472,11 @@ behavior "pull_request_path_labeler" "service_labels" {
     ]
     "service/apigateway" = [
       "**/*_api_gateway_[^v][^2][^_]*",
-      "**/api_gateway_[^v][^2][^_]*",
-      "aws/tags_apigateway[^v][^2]*"
+      "**/api_gateway_[^v][^2][^_]*"
     ]
     "service/apigatewayv2" = [
       "**/*_api_gateway_v2_*",
-      "**/api_gateway_v2_*",
-      "aws/tags_apigatewayv2*"
+      "**/api_gateway_v2_*"
     ]
     "service/applicationautoscaling" = [
       "**/*_appautoscaling_*",
@@ -542,8 +538,7 @@ behavior "pull_request_path_labeler" "service_labels" {
     ]
     "service/cloudfront" = [
       "**/*_cloudfront_*",
-      "**/cloudfront_*",
-      "aws/tagsCloudFront*"
+      "**/cloudfront_*"
     ]
     "service/cloudhsmv2" = [
       "**/*_cloudhsm_v2_*",
@@ -555,8 +550,7 @@ behavior "pull_request_path_labeler" "service_labels" {
     ]
     "service/cloudtrail" = [
       "**/*_cloudtrail_*",
-      "**/cloudtrail_*",
-      "aws/tagsCloudtrail*"
+      "**/cloudtrail_*"
     ]
     "service/cloudwatch" = [
       "**/*_cloudwatch_dashboard*",
@@ -574,8 +568,7 @@ behavior "pull_request_path_labeler" "service_labels" {
     ]
     "service/codebuild" = [
       "**/*_codebuild_*",
-      "**/codebuild_*",
-      "aws/tagsCodeBuild*"
+      "**/codebuild_*"
     ]
     "service/codecommit" = [
       "**/*_codecommit_*",
@@ -603,8 +596,7 @@ behavior "pull_request_path_labeler" "service_labels" {
     ]
     "service/databasemigrationservice" = [
       "**/*_dms_*",
-      "**/dms_*",
-      "aws/tags_dms*"
+      "**/dms_*"
     ]
     "service/datapipeline" = [
       "**/*_datapipeline_*",
@@ -616,8 +608,7 @@ behavior "pull_request_path_labeler" "service_labels" {
     ]
     "service/dax" = [
       "**/*_dax_*",
-      "**/dax_*",
-      "aws/tagsDAX*"
+      "**/dax_*"
     ]
     "service/devicefarm" = [
       "**/*_devicefarm_*",
@@ -625,13 +616,11 @@ behavior "pull_request_path_labeler" "service_labels" {
     ]
     "service/directconnect" = [
       "**/*_dx_*",
-      "**/dx_*",
-      "aws/tagsDX*"
+      "**/dx_*"
     ]
     "service/directoryservice" = [
       "**/*_directory_service_*",
-      "**/directory_service_*",
-      "aws/tagsDS*"
+      "**/directory_service_*"
     ]
     "service/dlm" = [
       "**/*_dlm_*",
@@ -711,8 +700,7 @@ behavior "pull_request_path_labeler" "service_labels" {
     ]
     "service/efs" = [
       "**/*_efs_*",
-      "**/efs_*",
-      "aws/tagsEFS*"
+      "**/efs_*"
     ]
     "service/eks" = [
       "**/*_eks_*",
@@ -724,13 +712,11 @@ behavior "pull_request_path_labeler" "service_labels" {
     ]
     "service/elasticache" = [
       "**/*_elasticache_*",
-      "**/elasticache_*",
-      "aws/tagsEC*"
+      "**/elasticache_*"
     ]
     "service/elasticbeanstalk" = [
       "**/*_elastic_beanstalk_*",
-      "**/elastic_beanstalk_*",
-      "aws/tagsBeanstalk*"
+      "**/elastic_beanstalk_*"
     ]
     "service/elasticsearch" = [
       "**/*_elasticsearch_*",
@@ -744,7 +730,6 @@ behavior "pull_request_path_labeler" "service_labels" {
       "aws/*_aws_lb_ssl_negotiation_policy*",
       "aws/*_aws_load_balancer*",
       "aws/*_aws_proxy_protocol_policy*",
-      "aws/tagsELB*",
       "website/**/app_cookie_stickiness_policy*",
       "website/**/elb*",
       "website/**/lb_cookie_stickiness_policy*",
@@ -806,8 +791,7 @@ behavior "pull_request_path_labeler" "service_labels" {
     ]
     "service/inspector" = [
       "**/*_inspector_*",
-      "**/inspector_*",
-      "aws/tagsInspector*"
+      "**/inspector_*"
     ]
     "service/iot" = [
       "**/*_iot_*",
@@ -819,7 +803,6 @@ behavior "pull_request_path_labeler" "service_labels" {
     ]
     "service/kinesis" = [
       "aws/*_aws_kinesis_stream*",
-      "aws/tags_kinesis*",
       "website/kinesis_stream*"
     ]
     "service/kinesisanalytics" = [
@@ -828,13 +811,11 @@ behavior "pull_request_path_labeler" "service_labels" {
     ]
     "service/kms" = [
       "**/*_kms_*",
-      "**/kms_*",
-      "aws/tagsKMS*"
+      "**/kms_*"
     ]
     "service/lambda" = [
       "**/*_lambda_*",
-      "**/lambda_*",
-      "aws/tagsLambda*"
+      "**/lambda_*"
     ]
     "service/lexmodelbuildingservice" = [
       "**/*_lex_*",
@@ -890,13 +871,11 @@ behavior "pull_request_path_labeler" "service_labels" {
     ]
     "service/neptune" = [
       "**/*_neptune_*",
-      "**/neptune_*",
-      "aws/tagsNeptune*"
+      "**/neptune_*"
     ]
     "service/opsworks" = [
       "**/*_opsworks_*",
-      "**/opsworks_*",
-      "aws/tagsOpsworks*"
+      "**/opsworks_*"
     ]
     "service/organizations" = [
       "**/*_organizations_*",
@@ -921,14 +900,12 @@ behavior "pull_request_path_labeler" "service_labels" {
     "service/rds" = [
       "aws/*_aws_db_*",
       "aws/*_aws_rds_*",
-      "aws/tagsRDS*",
       "website/**/db_*",
       "website/**/rds_*"
     ]
     "service/redshift" = [
       "**/*_redshift_*",
-      "**/redshift_*",
-      "aws/tagsRedshift*"
+      "**/redshift_*"
     ]
     "service/resourcegroups" = [
       "**/*_resourcegroups_*",
@@ -944,8 +921,7 @@ behavior "pull_request_path_labeler" "service_labels" {
       "**/route53_health_check*",
       "**/route53_query_log*",
       "**/route53_record*",
-      "**/route53_zone*",
-      "aws/tags_route53*"
+      "**/route53_zone*"
     ]
     "service/robomaker" = [
       "**/*_robomaker_*",
@@ -971,8 +947,7 @@ behavior "pull_request_path_labeler" "service_labels" {
     ]
     "service/secretsmanager" = [
       "**/*_secretsmanager_*",
-      "**/secretsmanager_*",
-      "aws/tagsSecretsManager*"
+      "**/secretsmanager_*"
     ]
     "service/securityhub" = [
       "**/*_securityhub_*",
@@ -992,8 +967,7 @@ behavior "pull_request_path_labeler" "service_labels" {
     ]
     "service/ses" = [
       "**/*_ses_*",
-      "**/ses_*",
-      "aws/tagsSSM*"
+      "**/ses_*"
     ]
     "service/sfn" = [
       "**/*_sfn_*",


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/10325#event-2677341915

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Since the file naming and implementation of these files was inconsistent, the labeling was sometimes inconsistent. We won't be accepting changes to these files anymore in preference of replacing them with the auto-generated `keyvaluetags` library, so removing the hashibot labeling of them.

Output from acceptance testing: N/A