### PR TITLE
Change description regex after aws lambda eni enhancement rollout

### DIFF
--- a/aws/resource_aws_security_group.go
+++ b/aws/resource_aws_security_group.go
@@ -1412,7 +1412,7 @@ func deleteLingeringLambdaENIs(conn *ec2.EC2, d *schema.ResourceData, filterName
 			},
 			{
 				Name:   aws.String("description"),
-				Values: []*string{aws.String("AWS Lambda VPC ENI: *")},
+				Values: []*string{aws.String("AWS Lambda VPC ENI*")},
 			},
 		},
 	}


### PR DESCRIPTION
* aws/resource_aws_security_group.go: As part of this AWS
  announcement (https://aws.amazon.com/blogs/compute/announcing-improved-vpc-networking-for-aws-lambda-functions/),
  eni's created by lambda will now have a different description. This is not explicitly
  documented, but was found in region 'eu-west-1', and will affect more regions over the next
  few months as AWS rolls out this change. This description, which used to be a string of the
  form "AWS Lambda VPC ENI: .*", now will look like this: "AWS Lambda VPC
  ENI-xxx-xxxxxxx-xxxxx-xxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx". As such, the regex used
  to determine lingering lambda eni's no longer works in all regions, and in the future, when
  this rollout is completed, will not work at all. This will appear to the user as a dependency
  error, if they have any security groups attached to a lambda eni. For example:

```
Error: Error deleting security group: DependencyViolation: resource sg-xxxxxxxxxxxxxxxxx has a dependent object
	status code: 400, request id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
```

Signed-off-by: Collin J. Doering <collin@rekahsoft.ca>

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes https://github.com/terraform-providers/terraform-provider-aws/issues/10044

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Allow vpc enabled lambda's automatically provisioned enis to be removed without dependency errors
```

Output from acceptance testing:

```
➜ make testacc TESTARGS='-run=TestAccAWSLambdaFunction_VPCRemoval'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSLambdaFunction_VPCRemoval -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSLambdaFunction_VPCRemoval
=== PAUSE TestAccAWSLambdaFunction_VPCRemoval
=== CONT  TestAccAWSLambdaFunction_VPCRemoval
--- PASS: TestAccAWSLambdaFunction_VPCRemoval (101.85s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       101.875s
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap      0.008s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags 0.006s [no tests to run]
```