### PR TITLE
tests/resource/aws_sagemaker_notebook_instance: Add sweeper

### DIFF
--- a/aws/resource_aws_sagemaker_notebook_instance_lifecycle_configuration_test.go
+++ b/aws/resource_aws_sagemaker_notebook_instance_lifecycle_configuration_test.go
@@ -21,6 +21,9 @@ func init() {
 	resource.AddTestSweepers("aws_sagemaker_notebook_instance_lifecycle_configuration", &resource.Sweeper{
 		Name: "aws_sagemaker_notebook_instance_lifecycle_configuration",
 		F:    testSweepSagemakerNotebookInstanceLifecycleConfiguration,
+		Dependencies: []string{
+			"aws_sagemaker_notebook_instance",
+		},
 	})
 }
 

--- a/aws/resource_aws_sagemaker_notebook_instance_test.go
+++ b/aws/resource_aws_sagemaker_notebook_instance_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
 	"time"
 
@@ -12,6 +13,70 @@ import (
 )
 
 const sagemakerTestAccSagemakerNotebookInstanceResourceNamePrefix = "terraform-testacc-"
+
+func init() {
+	resource.AddTestSweepers("aws_sagemaker_notebook_instance", &resource.Sweeper{
+		Name: "aws_sagemaker_notebook_instance",
+		F:    testSweepSagemakerNotebookInstances,
+	})
+}
+
+func testSweepSagemakerNotebookInstances(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).sagemakerconn
+
+	err = conn.ListNotebookInstancesPages(&sagemaker.ListNotebookInstancesInput{}, func(page *sagemaker.ListNotebookInstancesOutput, lastPage bool) bool {
+		for _, instance := range page.NotebookInstances {
+			name := aws.StringValue(instance.NotebookInstanceName)
+			status := aws.StringValue(instance.NotebookInstanceStatus)
+
+			input := &sagemaker.DeleteNotebookInstanceInput{
+				NotebookInstanceName: instance.NotebookInstanceName,
+			}
+
+			log.Printf("[INFO] Stopping SageMaker Notebook Instance: %s", name)
+			if status != sagemaker.NotebookInstanceStatusFailed && status != sagemaker.NotebookInstanceStatusStopped {
+				if err := stopSagemakerNotebookInstance(conn, name); err != nil {
+					log.Printf("[ERROR] Error stopping SageMaker Notebook Instance (%s): %s", name, err)
+					continue
+				}
+			}
+
+			log.Printf("[INFO] Deleting SageMaker Notebook Instance: %s", name)
+			if _, err := conn.DeleteNotebookInstance(input); err != nil {
+				log.Printf("[ERROR] Error deleting SageMaker Notebook Instance (%s): %s", name, err)
+				continue
+			}
+
+			stateConf := &resource.StateChangeConf{
+				Pending: []string{sagemaker.NotebookInstanceStatusDeleting},
+				Target:  []string{""},
+				Refresh: sagemakerNotebookInstanceStateRefreshFunc(conn, name),
+				Timeout: 10 * time.Minute,
+			}
+
+			if _, err := stateConf.WaitForState(); err != nil {
+				log.Printf("[ERROR] Error waiting for SageMaker Notebook Instance (%s) deletion: %s", name, err)
+			}
+		}
+
+		return !lastPage
+	})
+
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping SageMaker Notebook Instance sweep for %s: %s", region, err)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("Error retrieving SageMaker Notebook Instances: %s", err)
+	}
+
+	return nil
+}
 
 func TestAccAWSSagemakerNotebookInstance_basic(t *testing.T) {
 	var notebook sagemaker.DescribeNotebookInstanceOutput

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -43,6 +43,7 @@ func init() {
 			"aws_network_interface",
 			"aws_redshift_cluster",
 			"aws_route53_resolver_endpoint",
+			"aws_sagemaker_notebook_instance",
 			"aws_spot_fleet_request",
 			"aws_vpc_endpoint",
 		},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Some of these expensive resources were being left, making our monthly bill much higher than it should be.

Output from sweeper in AWS Commercial:

```console
$ go test ./aws -v -sweep=us-east-1,us-west-2 -sweep-run=aws_sagemaker_notebook_instance -timeout 10h
2019/10/02 10:40:51 [DEBUG] Running Sweepers for region (us-east-1):
...
2019/10/02 10:40:55 [INFO] No SageMaker Notebook Instance Lifecycle Configuration to sweep
2019/10/02 10:40:55 Sweeper Tests ran:
  - aws_sagemaker_notebook_instance
  - aws_sagemaker_notebook_instance_lifecycle_configuration
2019/10/02 10:40:55 [DEBUG] Running Sweepers for region (us-west-2):
...
2019/10/02 10:40:57 [INFO] Stopping SageMaker Notebook Instance: terraform-testacc-20190111204137989200000001
2019/10/02 10:42:15 [INFO] Deleting SageMaker Notebook Instance: terraform-testacc-20190111204137989200000001
2019/10/02 10:43:22 [INFO] Stopping SageMaker Notebook Instance: terraform-testacc-20190111203020262800000001
2019/10/02 10:44:30 [INFO] Deleting SageMaker Notebook Instance: terraform-testacc-20190111203020262800000001
2019/10/02 10:45:37 [INFO] Stopping SageMaker Notebook Instance: terraform-testacc-20181107160450462100000002
2019/10/02 10:45:37 [INFO] Deleting SageMaker Notebook Instance: terraform-testacc-20181107160450462100000002
2019/10/02 10:45:42 [INFO] Stopping SageMaker Notebook Instance: terraform-testacc-20181106174217513800000002
2019/10/02 10:45:42 [INFO] Deleting SageMaker Notebook Instance: terraform-testacc-20181106174217513800000002
2019/10/02 10:45:45 [INFO] Stopping SageMaker Notebook Instance: terraform-testacc-20181102155400054000000002
2019/10/02 10:45:45 [INFO] Deleting SageMaker Notebook Instance: terraform-testacc-20181102155400054000000002
2019/10/02 10:45:48 [INFO] Stopping SageMaker Notebook Instance: terraform-testacc-20181102135150793100000002
2019/10/02 10:45:48 [INFO] Deleting SageMaker Notebook Instance: terraform-testacc-20181102135150793100000002
2019/10/02 10:45:53 [INFO] No SageMaker Notebook Instance Lifecycle Configuration to sweep
2019/10/02 10:45:53 Sweeper Tests ran:
  - aws_sagemaker_notebook_instance
  - aws_sagemaker_notebook_instance_lifecycle_configuration
ok    github.com/terraform-providers/terraform-provider-aws/aws 303.047s
```

Output from sweeper in AWS GovCloud (US):

```console
$  go test ./aws -v -sweep=us-gov-west-1 -sweep-run=aws_sagemaker_notebook_instance -timeout 10h
2019/10/02 10:40:56 [DEBUG] Running Sweepers for region (us-gov-west-1):
...
2019/10/02 10:41:00 [INFO] No SageMaker Notebook Instance Lifecycle Configuration to sweep
2019/10/02 10:41:00 Sweeper Tests ran:
	- aws_sagemaker_notebook_instance_lifecycle_configuration
	- aws_sagemaker_notebook_instance
ok  	github.com/terraform-providers/terraform-provider-aws/aws	5.196s
```
