### PR TITLE
Fix docs for aws_subnet_ids

### DIFF
--- a/website/docs/d/subnet_ids.html.markdown
+++ b/website/docs/d/subnet_ids.html.markdown
@@ -22,7 +22,7 @@ data "aws_subnet_ids" "example" {
 
 data "aws_subnet" "example" {
   count = "${length(data.aws_subnet_ids.example.ids)}"
-  id    = "${data.aws_subnet_ids.example.ids[count.index]}"
+  id    = "${tolist(data.aws_subnet_ids.example.ids)[count.index]}"
 }
 
 output "subnet_cidr_blocks" {


### PR DESCRIPTION
The type of `data.aws_subnet_ids.example.ids.ids` is not a list and so its items cannot be referenced by index. It must be converted to a list first.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/7522

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:
N/A
