### PR TITLE
d/aws_route53_resolver_rule: Don't retrieve tags for rules 'SHARED_WITH_ME'

### DIFF
--- a/aws/data_source_aws_route53_resolver_rule.go
+++ b/aws/data_source_aws_route53_resolver_rule.go
@@ -125,9 +125,13 @@ func dataSourceAwsRoute53ResolverRuleRead(d *schema.ResourceData, meta interface
 	d.Set("resolver_endpoint_id", rule.ResolverEndpointId)
 	d.Set("resolver_rule_id", rule.Id)
 	d.Set("rule_type", rule.RuleType)
-	d.Set("share_status", rule.ShareStatus)
-	if err := getTagsRoute53Resolver(conn, d); err != nil {
-		return fmt.Errorf("error reading Route 53 Resolver rule (%s) tags: %s", d.Id(), err)
+	shareStatus := aws.StringValue(rule.ShareStatus)
+	d.Set("share_status", shareStatus)
+	// https://github.com/terraform-providers/terraform-provider-aws/issues/10211
+	if shareStatus != route53resolver.ShareStatusSharedWithMe {
+		if err := getTagsRoute53Resolver(conn, d); err != nil {
+			return fmt.Errorf("error reading Route 53 Resolver rule (%s) tags: %s", d.Id(), err)
+		}
 	}
 
 	return nil

--- a/aws/data_source_aws_route53_resolver_rule_test.go
+++ b/aws/data_source_aws_route53_resolver_rule_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func TestAccDataSourceAwsRoute53ResolverRule_basic(t *testing.T) {
@@ -91,6 +92,78 @@ func TestAccDataSourceAwsRoute53ResolverRule_ResolverEndpointIdWithTags(t *testi
 	})
 }
 
+func TestAccDataSourceAwsRoute53ResolverRule_SharedByMe(t *testing.T) {
+	var providers []*schema.Provider
+	rName := fmt.Sprintf("tf-testacc-r53-resolver-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum))
+	resourceName := "aws_route53_resolver_rule.example"
+	ds1ResourceName := "data.aws_route53_resolver_rule.by_resolver_endpoint_id"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccAlternateAccountPreCheck(t)
+			testAccPreCheckAWSRoute53Resolver(t)
+		},
+		ProviderFactories: testAccProviderFactories(&providers),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsRoute53ResolverRule_sharedByMe(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "domain_name", resourceName, "domain_name"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "owner_id", resourceName, "owner_id"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "resolver_endpoint_id", resourceName, "resolver_endpoint_id"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "resolver_rule_id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "rule_type", resourceName, "rule_type"),
+					resource.TestCheckResourceAttr(ds1ResourceName, "share_status", "SHARED_BY_ME"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "tags.%", resourceName, "tags.%"),
+					resource.TestCheckResourceAttr(ds1ResourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "tags.Key1", resourceName, "tags.Key1"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "tags.Key2", resourceName, "tags.Key2"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsRoute53ResolverRule_SharedWithMe(t *testing.T) {
+	var providers []*schema.Provider
+	rName := fmt.Sprintf("tf-testacc-r53-resolver-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum))
+	resourceName := "aws_route53_resolver_rule.example"
+	ds1ResourceName := "data.aws_route53_resolver_rule.by_resolver_endpoint_id"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccAlternateAccountPreCheck(t)
+			testAccPreCheckAWSRoute53Resolver(t)
+		},
+		ProviderFactories: testAccProviderFactories(&providers),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsRoute53ResolverRule_sharedWithMe(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "domain_name", resourceName, "domain_name"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "owner_id", resourceName, "owner_id"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "resolver_endpoint_id", resourceName, "resolver_endpoint_id"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "resolver_rule_id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "rule_type", resourceName, "rule_type"),
+					resource.TestCheckResourceAttr(ds1ResourceName, "share_status", "SHARED_WITH_ME"),
+					// Tags cannot be retrieved for rules shared with us.
+					resource.TestCheckResourceAttr(ds1ResourceName, "tags.%", "0"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccDataSourceAwsRoute53ResolverRule_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_route53_resolver_rule" "example" {
@@ -135,6 +208,96 @@ resource "aws_route53_resolver_rule" "example" {
 
 data "aws_route53_resolver_rule" "by_resolver_endpoint_id" {
   resolver_endpoint_id = "${aws_route53_resolver_rule.example.resolver_endpoint_id}"
+}
+`, rName)
+}
+
+func testAccDataSourceAwsRoute53ResolverRule_sharedByMe(rName string) string {
+	return testAccAlternateAccountProviderConfig() + testAccRoute53ResolverRuleConfig_resolverEndpoint(rName) + fmt.Sprintf(`
+resource "aws_route53_resolver_rule" "example" {
+  domain_name = "%[1]s.example.com"
+  rule_type   = "FORWARD"
+  name        = %[1]q
+
+  resolver_endpoint_id = "${aws_route53_resolver_endpoint.bar.id}"
+
+  target_ip {
+    ip = "192.0.2.7"
+  }
+
+  tags = {
+    "Key1" = "Value1"
+    "Key2" = "Value2"
+  }
+}
+
+resource "aws_ram_resource_share" "test" {
+  name                      = %[1]q
+  allow_external_principals = true
+}
+
+resource "aws_ram_resource_association" "test" {
+  resource_arn       = "${aws_route53_resolver_rule.example.arn}"
+  resource_share_arn = "${aws_ram_resource_share.test.arn}"
+}
+
+data "aws_organizations_organization" "test" {}
+
+resource "aws_ram_principal_association" "test" {
+  principal          = "${data.aws_organizations_organization.test.arn}"
+  resource_share_arn = "${aws_ram_resource_share.test.arn}"
+}
+
+data "aws_route53_resolver_rule" "by_resolver_endpoint_id" {
+  resolver_endpoint_id = "${aws_route53_resolver_rule.example.resolver_endpoint_id}"
+
+  depends_on = ["aws_ram_resource_association.test", "aws_ram_principal_association.test"]
+}
+`, rName)
+}
+
+func testAccDataSourceAwsRoute53ResolverRule_sharedWithMe(rName string) string {
+	return testAccAlternateAccountProviderConfig() + testAccRoute53ResolverRuleConfig_resolverEndpoint(rName) + fmt.Sprintf(`
+resource "aws_route53_resolver_rule" "example" {
+  domain_name = "%[1]s.example.com"
+  rule_type   = "FORWARD"
+  name        = %[1]q
+
+  resolver_endpoint_id = "${aws_route53_resolver_endpoint.bar.id}"
+
+  target_ip {
+    ip = "192.0.2.7"
+  }
+
+  tags = {
+    "Key1" = "Value1"
+    "Key2" = "Value2"
+  }
+}
+
+resource "aws_ram_resource_share" "test" {
+  name                      = %[1]q
+  allow_external_principals = true
+}
+
+resource "aws_ram_resource_association" "test" {
+  resource_arn       = "${aws_route53_resolver_rule.example.arn}"
+  resource_share_arn = "${aws_ram_resource_share.test.arn}"
+}
+
+data "aws_organizations_organization" "test" {}
+
+resource "aws_ram_principal_association" "test" {
+  principal          = "${data.aws_organizations_organization.test.arn}"
+  resource_share_arn = "${aws_ram_resource_share.test.arn}"
+}
+
+data "aws_route53_resolver_rule" "by_resolver_endpoint_id" {
+  provider = "aws.alternate"
+
+  resolver_endpoint_id = "${aws_route53_resolver_rule.example.resolver_endpoint_id}"
+
+  depends_on = ["aws_ram_resource_association.test", "aws_ram_principal_association.test"]
 }
 `, rName)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/10211

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data-source/aws_route53_resolver_rule: Don't retrieve tags for rules shared with the AWS account that owns the data source
```

Output from acceptance testing:

```console
$ AWS_ALTERNATE_ACCESS_KEY_ID=AAAAAAAAAAAAAAAAAAAA AWS_ALTERNATE_SECRET_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx make testacc TEST=./aws/ TESTARGS='-run=TestAccDataSourceAwsRoute53ResolverRule_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 1 -run=TestAccDataSourceAwsRoute53ResolverRule_ -timeout 120m
go: finding github.com/terraform-providers/terraform-provider-tls v2.1.1+incompatible
go: finding github.com/terraform-providers/terraform-provider-tls v2.1.1+incompatible
=== RUN   TestAccDataSourceAwsRoute53ResolverRule_basic
=== PAUSE TestAccDataSourceAwsRoute53ResolverRule_basic
=== RUN   TestAccDataSourceAwsRoute53ResolverRule_ResolverEndpointIdWithTags
=== PAUSE TestAccDataSourceAwsRoute53ResolverRule_ResolverEndpointIdWithTags
=== RUN   TestAccDataSourceAwsRoute53ResolverRule_SharedByMe
=== PAUSE TestAccDataSourceAwsRoute53ResolverRule_SharedByMe
=== RUN   TestAccDataSourceAwsRoute53ResolverRule_SharedWithMe
=== PAUSE TestAccDataSourceAwsRoute53ResolverRule_SharedWithMe
=== CONT  TestAccDataSourceAwsRoute53ResolverRule_basic
--- PASS: TestAccDataSourceAwsRoute53ResolverRule_basic (41.90s)
=== CONT  TestAccDataSourceAwsRoute53ResolverRule_SharedWithMe
--- PASS: TestAccDataSourceAwsRoute53ResolverRule_SharedWithMe (218.40s)
=== CONT  TestAccDataSourceAwsRoute53ResolverRule_SharedByMe
--- PASS: TestAccDataSourceAwsRoute53ResolverRule_SharedByMe (227.76s)
=== CONT  TestAccDataSourceAwsRoute53ResolverRule_ResolverEndpointIdWithTags
--- PASS: TestAccDataSourceAwsRoute53ResolverRule_ResolverEndpointIdWithTags (244.33s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	732.452s
```
