### PR TITLE
resource/aws_s3_bucket_object: Fix object deletion for non-versioned objects

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -470,8 +470,7 @@ func TestAccAWSProvider_Endpoints_Deprecated(t *testing.T) {
 			{
 				Config: testAccAWSProviderConfigEndpoints(endpointsDeprecated.String()),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSProviderEndpointsDeprecated(&providers),
-				),
+					testAccCheckAWSProviderEndpointsDeprecated(&providers)),
 			},
 		},
 	})
@@ -749,4 +748,22 @@ data "aws_arn" "test" {
   arn = "arn:aws:s3:::test"
 }
 `, region)
+}
+
+func testAccAssumeRoleARNPreCheck(t *testing.T) {
+	v := os.Getenv("TF_ACC_ASSUME_ROLE_ARN")
+	if v == "" {
+		t.Skip("skipping tests; TF_ACC_ASSUME_ROLE_ARN must be set")
+	}
+}
+
+func testAccProviderConfigAssumeRolePolicy(policy string) string {
+	return fmt.Sprintf(`
+provider "aws" {
+	assume_role {
+		role_arn = %q
+		policy   = %q
+	}
+}
+`, os.Getenv("TF_ACC_ASSUME_ROLE_ARN"), policy)
 }

--- a/aws/resource_aws_s3_bucket_object.go
+++ b/aws/resource_aws_s3_bucket_object.go
@@ -487,7 +487,14 @@ func resourceAwsS3BucketObjectDelete(d *schema.ResourceData, meta interface{}) e
 	// We are effectively ignoring any leading '/' in the key name as aws.Config.DisableRestProtocolURICleaning is false
 	key = strings.TrimPrefix(key, "/")
 
-	if err := deleteAllS3ObjectVersions(s3conn, bucket, key, d.Get("force_destroy").(bool), false); err != nil {
+	var err error
+	if _, ok := d.GetOk("version_id"); ok {
+		err = deleteAllS3ObjectVersions(s3conn, bucket, key, d.Get("force_destroy").(bool), false)
+	} else {
+		err = deleteS3ObjectVersion(s3conn, bucket, key, "", false)
+	}
+
+	if err != nil {
 		return fmt.Errorf("error deleting S3 Bucket (%s) Object (%s): %s", bucket, key, err)
 	}
 
@@ -656,10 +663,14 @@ func deleteAllS3ObjectVersions(conn *s3.S3, bucketName, key string, force, ignor
 // Set force to true to override any S3 object lock protections.
 func deleteS3ObjectVersion(conn *s3.S3, b, k, v string, force bool) error {
 	input := &s3.DeleteObjectInput{
-		Bucket:    aws.String(b),
-		Key:       aws.String(k),
-		VersionId: aws.String(v),
+		Bucket: aws.String(b),
+		Key:    aws.String(k),
 	}
+
+	if v != "" {
+		input.VersionId = aws.String(v)
+	}
+
 	if force {
 		input.BypassGovernanceRetention = aws.Bool(true)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10191

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_s3_bucket_object: Fix object deletion for non-versioned objects

```

 Acceptance test before change
 ```
 --- FAIL: TestAccAWSS3BucketObject_NonVersioned (32.38s)
    testing.go:630: Error destroying resource! WARNING: Dangling
    resources may exist. The full state and error is shown below.

     Error: errors during apply: Failed listing S3 object versions:
 AccessDenied: Access Denied
 ```

 Acceptance test after change
 ```
 --- PASS: TestAccAWSS3BucketObject_NonVersioned (32.16s)
 ```

 The test case for S3 is only reproducible for IAM users that have restricted permissions on bucket objects. This change introduces a simple test Provider configuration that can be used for assuming a restricted policy at runtime. This change introduces a testAccAssumeRoleARNPreCheck function that can be used for validating that a TF_ACC_ASSUME_ROLE_ARN environment variable is set for any tests using the testAccProviderConfigAssumeRolePolicy provider configuration block.

 testAccAssumeRoleARNPreCheck unset
 ```
 > make testacc TEST=./aws
 TESTARGS='-run=TestAccAWSS3BucketObject_NonVersioned'
 --- SKIP: TestAccAWSS3BucketObject_NonVersioned (1.56s)
    provider_test.go:756: skipping tests; TF_ACC_ASSUME_ROLE_ARN must be
 ```

 testAccAssumeRoleARNPreCheck set
 ``` TF_ACC_ASSUME_ROLE_ARN=...  make testacc TEST=./aws
 TESTARGS='-run=TestAccAWSS3BucketObject_NonVersioned'
 --- PASS: TestAccAWSS3BucketObject_NonVersioned (32.47s)
 ```

 Acceptance tests after change
 ```
 --- SKIP: TestAccAWSS3BucketObject_NonVersioned (2.03s)
    provider_test.go:756: skipping tests; TF_ACC_ASSUME_ROLE_ARN must be set
 === CONT  TestAccAWSS3BucketObject_tagsLeadingSlash
 --- PASS: TestAccAWSS3BucketObject_noNameNoKey (3.53s)
 --- PASS: TestAccAWSS3BucketObject_empty (32.55s)
 --- PASS: TestAccAWSS3BucketObject_source (36.75s)
 --- PASS: TestAccAWSS3BucketObject_withContentCharacteristics (37.46s)
 --- PASS: TestAccAWSS3BucketObject_content (37.75s)
 --- PASS: TestAccAWSS3BucketObject_etagEncryption (37.78s)
 --- PASS: TestAccAWSS3BucketObject_sse (37.78s)
 --- PASS: TestAccAWSS3BucketObject_contentBase64 (37.90s)
 --- PASS: TestAccAWSS3BucketObject_kms (61.81s)
 --- PASS: TestAccAWSS3BucketObject_updates (61.91s)
 --- PASS: TestAccAWSS3BucketObject_updatesWithVersioning (62.52s)
 --- PASS: TestAccAWSS3BucketObject_updateSameFile (62.80s)
 --- PASS: TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithOn (63.18s)
 --- PASS: TestAccAWSS3BucketObject_metadata (82.99s)
 --- PASS: TestAccAWSS3BucketObject_acl (86.10s)
 --- PASS: TestAccAWSS3BucketObject_ObjectLockRetentionStartWithNone (86.15s)
 --- PASS: TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithNone (87.09s)
 --- PASS: TestAccAWSS3BucketObject_ObjectLockRetentionStartWithSet (105.55s)
 --- PASS: TestAccAWSS3BucketObject_tagsLeadingSlash (105.43s)
 --- PASS: TestAccAWSS3BucketObject_tags (107.64s)
 --- PASS: TestAccAWSS3BucketObject_storageClass (127.35s)
 ```