### PR TITLE
resource/aws_iot_topic_rule: Fix recreate resource when name change

### DIFF
--- a/aws/resource_aws_iot_topic_rule.go
+++ b/aws/resource_aws_iot_topic_rule.go
@@ -23,6 +23,7 @@ func resourceAwsIotTopicRule() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: validateIoTTopicRuleName,
 			},
 			"description": {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10365

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:

resource/aws_iot_topic_rule: Fix the resource recreation after name change
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSIoTTopicRule_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSIoTTopicRule_basic -timeout 120m
go: finding github.com/terraform-providers/terraform-provider-tls v2.1.0+incompatible
go: finding github.com/terraform-providers/terraform-provider-tls v2.1.0+incompatible
=== RUN   TestAccAWSIoTTopicRule_basic
=== PAUSE TestAccAWSIoTTopicRule_basic
=== CONT  TestAccAWSIoTTopicRule_basic
--- PASS: TestAccAWSIoTTopicRule_basic (32.08s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	32.162s
```
