### PR TITLE
WIP: Datasync private link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ ENHANCEMENTS:
 
 * resource_aws_efs_filesystem: Support tag-on-create [GH-10254]
 * resource/aws_mq_broker: Add `encryption_options` configuration block (support AWS and customer managed KMS CMKs) [GH-10276]
+* resource/aws_datasync_agent: Add `private_link_ip` and `vpc_endpoint_id` to support private datasync configuration. [GH-9755]
 
 BUG FIXES:
 

--- a/aws/resource_aws_datasync_agent.go
+++ b/aws/resource_aws_datasync_agent.go
@@ -92,9 +92,8 @@ func resourceAwsDataSyncAgentCreate(d *schema.ResourceData, meta interface{}) er
 
 		requestURL := fmt.Sprintf("http://%s/?gatewayType=SYNC&activationRegion=%s", agentIpAddress, region)
 
-		privateLinkIp := d.Get("private_link_ip").(string)
-		if privateLinkIp != "" {
-			requestURL := fmt.Sprintf("http://%s/?gatewayType=SYNC&activationRegion=%s&endpointType=PRIVATE_LINK&privateLinkEndpoint=%s", agentIpAddress, region, privateLinkIp)
+		if v, ok := d.GetOk("private_link_ip"); ok {
+			requestURL = fmt.Sprintf("http://%s/?gatewayType=SYNC&activationRegion=%s&endpointType=PRIVATE_LINK&privateLinkEndpoint=%s", agentIpAddress, region, v.(string))
 		}
 
 		log.Printf("[DEBUG] Creating HTTP request: %s", requestURL)
@@ -149,9 +148,8 @@ func resourceAwsDataSyncAgentCreate(d *schema.ResourceData, meta interface{}) er
 		Tags:          expandDataSyncTagListEntry(d.Get("tags").(map[string]interface{})),
 	}
 
-	vpc_endpoint_id = d.Get("vpc_endpoint_id").(string)
-	if vpc_endpoint_id != "" {
-		input.SetVpcEndpointId(vpc_endpoint_id)
+	if v, ok := d.GetOk("vpc_endpoint_id"); ok {
+		input.VpcEndpointId = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("name"); ok {

--- a/aws/resource_aws_datasync_agent_test.go
+++ b/aws/resource_aws_datasync_agent_test.go
@@ -420,3 +420,21 @@ resource "aws_datasync_agent" "test" {
 }
 `, key1, value1, key2, value2)
 }
+
+func testAccAWSDataSyncAgentPrivateLink(rName string) string {
+	return testAccAWSDataSyncAgentConfigAgentBase() + fmt.Sprintf(`
+resource "aws_vpc_endpoint" "interface" {
+  security_group_ids = ["${aws_security_group.test.id}"]
+  service_name       = "tf-acc-test-datasync-vpce"
+  subnet_ids         = [${aws_subnet.test.id}]
+  vpc_endpoint_type  = "Interface"
+  vpc_id             = "${aws_vpc.test.id}"
+}
+	  
+resource "aws_datasync_agent" "test" {
+  private_link_ip = "${aws_instance.test.private_ip}"
+  vpc_endpoint_id = "${aws_vpc_endpoint.interface.id}"
+  name       = %q
+}
+`, rName)
+}

--- a/website/docs/r/datasync_agent.html.markdown
+++ b/website/docs/r/datasync_agent.html.markdown
@@ -27,6 +27,8 @@ The following arguments are supported:
 * `name` - (Required) Name of the DataSync Agent.
 * `activation_key` - (Optional) DataSync Agent activation key during resource creation. Conflicts with `ip_address`. If an `ip_address` is provided instead, Terraform will retrieve the `activation_key` as part of the resource creation.
 * `ip_address` - (Optional) DataSync Agent IP address to retrieve activation key during resource creation. Conflicts with `activation_key`. DataSync Agent must be accessible on port 80 from where Terraform is running.
+* `private_link_ip` - (Optional) The IP of the VPC endpoint you connected to our service with via PrivateLink
+* `vpc_endpoint_id` - (Optional) The ARN of the VPC endpoint.
 * `tags` - (Optional) Key-value pairs of resource tags to assign to the DataSync Agent.
 
 ## Attribute Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9755

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_datasync_agent: Add `private_link_ip` and `vpc_endpoint_id` to support private datasync configuration.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=testAccAWSDataSyncAgentPrivateLink'

(Unable to test on my account)
```
