### PR TITLE
provider: Add hashibot deprecated_import_commenter for terraform-plugin-sdk migration

### DIFF
--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -8,6 +8,30 @@ queued_behavior "release_commenter" "releases" {
   EOF
 }
 
+behavior "deprecated_import_commenter" "hashicorp_terraform" {
+  import_regexp = "github.com/hashicorp/terraform/"
+  marker_label  = "terraform-plugin-sdk-migration"
+
+  message = <<-EOF
+    Hello, and thank you for your contribution!
+
+    This project recently migrated to the [standalone Terraform Plugin SDK](https://www.terraform.io/docs/extend/plugin-sdk.html). While this will help speed up future feature requests and bug fixes with Terraform AWS Provider's interface with Terraform itself, it also has the unfortunate consequence of requiring some minor changes to pull requests created before the migration.
+
+    This pull request appears to include the Go import path `${var.import_path}`, which was from the older SDK. The newer SDK uses import paths beginning with `github.com/hashicorp/terraform-plugin-sdk/`.
+
+    To resolve this situation without losing any existing work, you may be able to Git rebase your branch against the current master branch (example below), then replacing any remaining old import paths with the newer ones.
+
+    ```console
+    $ git fetch --all
+    $ git rebase origin/master
+    ```
+
+    Another option is to create a new branch from the current master with the same code changes (replacing the import paths), submit a new pull request, and close this existing pull request.
+
+    We apologize for this inconvenience and appreciate your effort. Thank you for contributing and helping make the Terraform AWS Provider better for everyone.
+  EOF
+}
+
 # Catch the following in issues:
 # *aws_XXX
 # * aws_XXX


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/10367

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing: N/A
