### PR TITLE
KmsKeyId support for aws_elasticache_replication_group

### DIFF
--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -229,6 +229,11 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 				Default:  false,
 				ForceNew: true,
 			},
+			"kms_key_id": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+			},
 		},
 		SchemaVersion: 1,
 
@@ -304,6 +309,10 @@ func resourceAwsElasticacheReplicationGroupCreate(d *schema.ResourceData, meta i
 
 	if v, ok := d.GetOk("notification_topic_arn"); ok {
 		params.NotificationTopicArn = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("kms_key_id"); ok {
+		params.KmsKeyId = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("snapshot_retention_limit"); ok {
@@ -426,6 +435,8 @@ func resourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta int
 			log.Printf("Unknown AutomaticFailover state %s", *rgp.AutomaticFailover)
 		}
 	}
+
+	d.Set("kms_key_id", rgp.KmsKeyId)
 
 	d.Set("replication_group_description", rgp.Description)
 	d.Set("number_cache_clusters", len(rgp.MemberClusters))

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -108,6 +108,7 @@ The following arguments are supported:
 * `at_rest_encryption_enabled` - (Optional) Whether to enable encryption at rest.
 * `transit_encryption_enabled` - (Optional) Whether to enable encryption in transit.
 * `auth_token` - (Optional) The password used to access a password protected server. Can be specified only if `transit_encryption_enabled = true`.
+* `kms_key_id` - (Optional) The ARN of the key that you wish to use if encrypting at rest. If not supplied, uses service managed encryption. Can be specified only if `at_rest_encryption_enabled = true`.
 * `engine_version` - (Optional) The version number of the cache engine to be used for the cache clusters in this replication group.
 * `parameter_group_name` - (Optional) The name of the parameter group to associate with this replication group. If this argument is omitted, the default cache parameter group for the specified engine is used.
 * `port` – (Optional) The port number on which each of the cache nodes will accept connections. For Memcache the default is 11211, and for Redis the default port is 6379.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9939 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
ENHANCEMENTS
* resource/aws_elasticache_replication_group: Support for KmsKeyId
```
