### PR TITLE
aws_datasync_location_smb addition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ ENHANCEMENTS:
 
 * resource/aws_emr_instance_group: Add `configurations_json` argument ([#10426](https://github.com/terraform-providers/terraform-provider-aws/issues/10426))
 
+FEATURES:
+
+* **New Resource:** `aws_quicksight_users`
+
 BUG FIXES:
 
 * provider: Fix session handling to correctly validate and use assume_role credentials ([#10379](https://github.com/terraform-providers/terraform-provider-aws/issues/10379))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,6 @@ ENHANCEMENTS:
 
 * resource/aws_emr_instance_group: Add `configurations_json` argument ([#10426](https://github.com/terraform-providers/terraform-provider-aws/issues/10426))
 
-FEATURES:
-
-* **New Resource:** `aws_quicksight_users`
-
 BUG FIXES:
 
 * provider: Fix session handling to correctly validate and use assume_role credentials ([#10379](https://github.com/terraform-providers/terraform-provider-aws/issues/10379))

--- a/aws/datasync.go
+++ b/aws/datasync.go
@@ -33,6 +33,20 @@ func expandDataSyncEc2Config(l []interface{}) *datasync.Ec2Config {
 	return ec2Config
 }
 
+func expandDataSyncSmbMountOptions(l []interface{}) *datasync.SmbMountOptions {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	smbMountOptions := &datasync.SmbMountOptions{
+		Version: aws.String(m["version"].(string)),
+	}
+
+	return smbMountOptions
+}
+
 func expandDataSyncOnPremConfig(l []interface{}) *datasync.OnPremConfig {
 	if len(l) == 0 || l[0] == nil {
 		return nil
@@ -94,6 +108,18 @@ func flattenDataSyncEc2Config(ec2Config *datasync.Ec2Config) []interface{} {
 	m := map[string]interface{}{
 		"security_group_arns": schema.NewSet(schema.HashString, flattenStringList(ec2Config.SecurityGroupArns)),
 		"subnet_arn":          aws.StringValue(ec2Config.SubnetArn),
+	}
+
+	return []interface{}{m}
+}
+
+func flattenDataSyncSmbMountOptions(mountOptions *datasync.SmbMountOptions) []interface{} {
+	if mountOptions == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"version": aws.StringValue(mountOptions.Version),
 	}
 
 	return []interface{}{m}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -409,6 +409,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_datasync_location_efs":                               resourceAwsDataSyncLocationEfs(),
 			"aws_datasync_location_nfs":                               resourceAwsDataSyncLocationNfs(),
 			"aws_datasync_location_s3":                                resourceAwsDataSyncLocationS3(),
+			"aws_datasync_location_smb":                               resourceAwsDataSyncLocationSmb(),
 			"aws_datasync_task":                                       resourceAwsDataSyncTask(),
 			"aws_dax_cluster":                                         resourceAwsDaxCluster(),
 			"aws_dax_parameter_group":                                 resourceAwsDaxParameterGroup(),

--- a/aws/resource_aws_datasync_location_smb.go
+++ b/aws/resource_aws_datasync_location_smb.go
@@ -36,6 +36,7 @@ func resourceAwsDataSyncLocationSmb() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 				Optional: true,
+				ForceNew: true,
 			},
 			"mount_options": {
 				Type:             schema.TypeList,
@@ -63,10 +64,12 @@ func resourceAwsDataSyncLocationSmb() *schema.Resource {
 				Type:      schema.TypeString,
 				Required:  true,
 				Sensitive: true,
+				ForceNew:  true,
 			},
 			"server_hostname": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"subdirectory": {
 				Type:     schema.TypeString,
@@ -92,6 +95,7 @@ func resourceAwsDataSyncLocationSmb() *schema.Resource {
 			"user": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 		},
 	}

--- a/aws/resource_aws_datasync_location_smb.go
+++ b/aws/resource_aws_datasync_location_smb.go
@@ -1,0 +1,247 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/datasync"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func resourceAwsDataSyncLocationSmb() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsDataSyncLocationSmbCreate,
+		Read:   resourceAwsDataSyncLocationSmbRead,
+		Update: resourceAwsDataSyncLocationSmbUpdate,
+		Delete: resourceAwsDataSyncLocationSmbDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"agent_arns": {
+				Type:     schema.TypeSet,
+				Required: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"domain": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			"mount_options": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				// Ignore missing config block (stolen from aws_ecs_service)
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if old == "1" && new == "0" {
+						return true
+					}
+					return false
+				},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"version": {
+							Type:         schema.TypeString,
+							Default:      "AUTOMATIC",
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.NoZeroValues,
+						},
+					},
+				},
+			},
+			"password": {
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+			},
+			"server_hostname": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"subdirectory": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				/*// Ignore missing trailing slash
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if new == "/" {
+						return false
+					}
+					if strings.TrimSuffix(old, "/") == strings.TrimSuffix(new, "/") {
+						return true
+					}
+					return false
+				},
+				*/
+			},
+			"tags": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"uri": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"user": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceAwsDataSyncLocationSmbCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).datasyncconn
+
+	input := &datasync.CreateLocationSmbInput{
+		AgentArns:      expandStringSet(d.Get("agent_arns").(*schema.Set)),
+		MountOptions:   expandDataSyncSmbMountOptions(d.Get("mount_options").([]interface{})),
+		Password:       aws.String(d.Get("password").(string)),
+		ServerHostname: aws.String(d.Get("server_hostname").(string)),
+		Subdirectory:   aws.String(d.Get("subdirectory").(string)),
+		Tags:           expandDataSyncTagListEntry(d.Get("tags").(map[string]interface{})),
+		User:           aws.String(d.Get("user").(string)),
+	}
+
+	if v, ok := d.GetOk("domain"); ok {
+		input.Domain = aws.String(v.(string))
+	}
+
+	log.Printf("[DEBUG] Creating DataSync Location SMB: %s", input)
+	output, err := conn.CreateLocationSmb(input)
+	if err != nil {
+		return fmt.Errorf("error creating DataSync Location SMB: %s", err)
+	}
+
+	d.SetId(aws.StringValue(output.LocationArn))
+
+	return resourceAwsDataSyncLocationSmbRead(d, meta)
+}
+
+func resourceAwsDataSyncLocationSmbRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).datasyncconn
+
+	input := &datasync.DescribeLocationSmbInput{
+		LocationArn: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Reading DataSync Location SMB: %s", input)
+	output, err := conn.DescribeLocationSmb(input)
+
+	if isAWSErr(err, "InvalidRequestException", "not found") {
+		log.Printf("[WARN] DataSync Location SMB %q not found - removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading DataSync Location SMB (%s): %s", d.Id(), err)
+	}
+
+	tagsInput := &datasync.ListTagsForResourceInput{
+		ResourceArn: output.LocationArn,
+	}
+
+	log.Printf("[DEBUG] Reading DataSync Location SMB tags: %s", tagsInput)
+	tagsOutput, err := conn.ListTagsForResource(tagsInput)
+
+	if err != nil {
+		return fmt.Errorf("error reading DataSync Location SMB (%s) tags: %s", d.Id(), err)
+	}
+
+	subdirectory, err := dataSyncParseLocationURI(aws.StringValue(output.LocationUri))
+
+	if err != nil {
+		return fmt.Errorf("error parsing Location SMB (%s) URI (%s): %s", d.Id(), aws.StringValue(output.LocationUri), err)
+	}
+
+	d.Set("agent_arns", schema.NewSet(schema.HashString, flattenStringList(output.AgentArns)))
+
+	d.Set("arn", output.LocationArn)
+
+	d.Set("domain", output.Domain)
+
+	if err := d.Set("mount_options", flattenDataSyncSmbMountOptions(output.MountOptions)); err != nil {
+		return fmt.Errorf("error setting mount_options: %s", err)
+	}
+
+	d.Set("subdirectory", subdirectory)
+
+	if err := d.Set("tags", flattenDataSyncTagListEntry(tagsOutput.Tags)); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	d.Set("user", output.User)
+
+	d.Set("uri", output.LocationUri)
+
+	return nil
+}
+
+func resourceAwsDataSyncLocationSmbUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).datasyncconn
+
+	if d.HasChange("tags") {
+		oldRaw, newRaw := d.GetChange("tags")
+		createTags, removeTags := dataSyncTagsDiff(expandDataSyncTagListEntry(oldRaw.(map[string]interface{})), expandDataSyncTagListEntry(newRaw.(map[string]interface{})))
+
+		if len(removeTags) > 0 {
+			input := &datasync.UntagResourceInput{
+				Keys:        dataSyncTagsKeys(removeTags),
+				ResourceArn: aws.String(d.Id()),
+			}
+
+			log.Printf("[DEBUG] Untagging DataSync Location SMB: %s", input)
+			if _, err := conn.UntagResource(input); err != nil {
+				return fmt.Errorf("error untagging DataSync Location SMB (%s): %s", d.Id(), err)
+			}
+		}
+
+		if len(createTags) > 0 {
+			input := &datasync.TagResourceInput{
+				ResourceArn: aws.String(d.Id()),
+				Tags:        createTags,
+			}
+
+			log.Printf("[DEBUG] Tagging DataSync Location SMB: %s", input)
+			if _, err := conn.TagResource(input); err != nil {
+				return fmt.Errorf("error tagging DataSync Location SMB (%s): %s", d.Id(), err)
+			}
+		}
+	}
+
+	return resourceAwsDataSyncLocationSmbRead(d, meta)
+}
+
+func resourceAwsDataSyncLocationSmbDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).datasyncconn
+
+	input := &datasync.DeleteLocationInput{
+		LocationArn: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Deleting DataSync Location SMB: %s", input)
+	_, err := conn.DeleteLocation(input)
+
+	if isAWSErr(err, "InvalidRequestException", "not found") {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting DataSync Location SMB (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_datasync_location_smb_test.go
+++ b/aws/resource_aws_datasync_location_smb_test.go
@@ -1,0 +1,533 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/datasync"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_datasync_location_smb", &resource.Sweeper{
+		Name: "aws_datasync_location_smb",
+		F:    testSweepDataSyncLocationSmbs,
+	})
+}
+
+func testSweepDataSyncLocationSmbs(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).datasyncconn
+
+	input := &datasync.ListLocationsInput{}
+	for {
+		output, err := conn.ListLocations(input)
+
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping DataSync Location SMB sweep for %s: %s", region, err)
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("Error retrieving DataSync Location SMBs: %s", err)
+		}
+
+		if len(output.Locations) == 0 {
+			log.Print("[DEBUG] No DataSync Location SMBs to sweep")
+			return nil
+		}
+
+		for _, location := range output.Locations {
+			uri := aws.StringValue(location.LocationUri)
+			if !strings.HasPrefix(uri, "smb://") {
+				log.Printf("[INFO] Skipping DataSync Location SMB: %s", uri)
+				continue
+			}
+			log.Printf("[INFO] Deleting DataSync Location SMB: %s", uri)
+			input := &datasync.DeleteLocationInput{
+				LocationArn: location.LocationArn,
+			}
+
+			_, err := conn.DeleteLocation(input)
+
+			if isAWSErr(err, "InvalidRequestException", "not found") {
+				continue
+			}
+
+			if err != nil {
+				log.Printf("[ERROR] Failed to delete DataSync Location SMB (%s): %s", uri, err)
+			}
+		}
+
+		if aws.StringValue(output.NextToken) == "" {
+			break
+		}
+
+		input.NextToken = output.NextToken
+	}
+
+	return nil
+}
+
+func TestAccAWSDataSyncLocationSmb_basic(t *testing.T) {
+	var locationSmb1 datasync.DescribeLocationSmbOutput
+
+	resourceName := "aws_datasync_location_smb.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSDataSync(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDataSyncLocationSmbDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDataSyncLocationSmbConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataSyncLocationSmbExists(resourceName, &locationSmb1),
+
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "datasync", regexp.MustCompile(`location/loc-.+`)),
+					resource.TestCheckResourceAttr(resourceName, "agent_arns.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mount_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mount_options.0.version", "AUTOMATIC"),
+					resource.TestCheckResourceAttr(resourceName, "user", "Guest"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestMatchResourceAttr(resourceName, "uri", regexp.MustCompile(`^smb://.+/`)),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password", "server_hostname"},
+			},
+		},
+	})
+}
+
+func TestAccAWSDataSyncLocationSmb_disappears(t *testing.T) {
+	var locationSmb1 datasync.DescribeLocationSmbOutput
+	resourceName := "aws_datasync_location_smb.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSDataSync(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDataSyncLocationSmbDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDataSyncLocationSmbConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataSyncLocationSmbExists(resourceName, &locationSmb1),
+					testAccCheckAWSDataSyncLocationSmbDisappears(&locationSmb1),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSDataSyncLocationSmb_Tags(t *testing.T) {
+	var locationSmb1, locationSmb2, locationSmb3 datasync.DescribeLocationSmbOutput
+	resourceName := "aws_datasync_location_smb.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSDataSync(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDataSyncLocationSmbDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDataSyncLocationSmbConfigTags1("key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataSyncLocationSmbExists(resourceName, &locationSmb1),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password", "server_hostname"},
+			},
+			{
+				Config: testAccAWSDataSyncLocationSmbConfigTags2("key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataSyncLocationSmbExists(resourceName, &locationSmb2),
+					testAccCheckAWSDataSyncLocationSmbNotRecreated(&locationSmb1, &locationSmb2),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSDataSyncLocationSmbConfigTags1("key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataSyncLocationSmbExists(resourceName, &locationSmb3),
+					testAccCheckAWSDataSyncLocationSmbNotRecreated(&locationSmb2, &locationSmb3),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSDataSyncLocationSmbDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).datasyncconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_datasync_location_smb" {
+			continue
+		}
+
+		input := &datasync.DescribeLocationSmbInput{
+			LocationArn: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.DescribeLocationSmb(input)
+
+		if isAWSErr(err, "InvalidRequestException", "not found") {
+			return nil
+		}
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAWSDataSyncLocationSmbExists(resourceName string, locationSmb *datasync.DescribeLocationSmbOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).datasyncconn
+		input := &datasync.DescribeLocationSmbInput{
+			LocationArn: aws.String(rs.Primary.ID),
+		}
+
+		output, err := conn.DescribeLocationSmb(input)
+
+		if err != nil {
+			return err
+		}
+
+		if output == nil {
+			return fmt.Errorf("Location %q does not exist", rs.Primary.ID)
+		}
+
+		*locationSmb = *output
+
+		return nil
+	}
+}
+
+func testAccCheckAWSDataSyncLocationSmbDisappears(location *datasync.DescribeLocationSmbOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).datasyncconn
+
+		input := &datasync.DeleteLocationInput{
+			LocationArn: location.LocationArn,
+		}
+
+		_, err := conn.DeleteLocation(input)
+
+		return err
+	}
+}
+
+func testAccCheckAWSDataSyncLocationSmbNotRecreated(i, j *datasync.DescribeLocationSmbOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if aws.TimeValue(i.CreationTime) != aws.TimeValue(j.CreationTime) {
+			return errors.New("DataSync Location SMB was recreated")
+		}
+
+		return nil
+	}
+}
+
+func testAccAWSDataSyncLocationSmbConfigBase() string {
+	gatewayUid := acctest.RandString(5)
+
+	return fmt.Sprintf(`
+data "aws_ami" "aws_thinstaller" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["aws-thinstaller-*"]
+  }
+}
+
+data "aws_ami" "aws_datasync" {
+  most_recent = true
+	# I do not know why, but only in us-west-2 
+	# does the datasync ami _not_ have the amazon-alias.
+	# Reverting to amazon-owner id.
+  owners      = ["633936118553"]
+
+  filter {
+    name   = "name"
+    values = ["aws-datasync-*"]
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "tf-acc-test-datasync-location-smb"
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block = "10.0.0.0/24"
+  vpc_id     = "${aws_vpc.test.id}"
+
+  tags = {
+    Name = "tf-acc-test-datasync-location-smb"
+  }
+}
+
+resource "aws_internet_gateway" "test" {
+  vpc_id = "${aws_vpc.test.id}"
+
+  tags = {
+    Name = "tf-acc-test-datasync-location-smb"
+  }
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = "${aws_vpc.test.id}"
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${aws_internet_gateway.test.id}"
+  }
+
+  tags = {
+    Name = "tf-acc-test-datasync-location-smb"
+  }
+}
+
+resource "aws_route_table_association" "test" {
+  subnet_id      = "${aws_subnet.test.id}"
+  route_table_id = "${aws_route_table.test.id}"
+}
+
+resource "aws_iam_role" "test" {
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "storagegateway.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy" "test" {
+  role = "${aws_iam_role.test.name}"
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:*"
+      ],
+      "Resource": [
+        "${aws_s3_bucket.test.arn}",
+        "${aws_s3_bucket.test.arn}/*"
+      ],
+      "Effect": "Allow"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_s3_bucket" "test" {
+  force_destroy = true
+
+  tags = {
+    Name = "tf-acc-test-datasync-location-smb"
+  }
+}
+
+resource "aws_security_group" "test" {
+  vpc_id = "${aws_vpc.test.id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "tf-acc-test-datasync-smb"
+  }
+}
+
+
+resource "aws_instance" "test_gateway" {
+	depends_on = ["aws_internet_gateway.test"]
+
+  ami                         = "${data.aws_ami.aws_thinstaller.id}"
+  associate_public_ip_address = true
+
+  instance_type          = "c5.2xlarge"
+  vpc_security_group_ids = ["${aws_security_group.test.id}"]
+  subnet_id              = "${aws_subnet.test.id}"
+
+  ebs_block_device {
+    device_name = "/dev/sdf"
+    volume_size = "150"
+  }
+
+  tags = {
+    Name = "tf-acc-test-datasync-smb"
+  }
+}
+
+resource "aws_storagegateway_gateway" "test" {
+  gateway_ip_address = "${aws_instance.test_gateway.public_ip}"
+  gateway_name       = "datasyncsmb-%s"
+  gateway_timezone   = "GMT"
+  gateway_type       = "FILE_S3"
+  smb_guest_password = "ZaphodBeeblebroxPW"
+}
+
+data "aws_storagegateway_local_disk" "test" {
+  disk_path   = "/dev/nvme1n1"
+  gateway_arn = "${aws_storagegateway_gateway.test.arn}"
+}
+
+resource "aws_storagegateway_cache" "test" {
+  # ACCEPTANCE TESTING WORKAROUND:
+	# (Shamelessly stolen from:
+	# https://github.com/terraform-providers/terraform-provider-aws/
+	# blob/1647a5ba13c5abaf5cf65ecdeb7c5fdf0107e56f/aws
+	# /resource_aws_storagegateway_cache_test.go#L219 )
+  # Data sources are not refreshed before plan after apply in TestStep
+  # Step 0 error: After applying this step, the plan was not empty:
+  #   disk_id:     "0b68f77a-709b-4c79-ad9d-d7728014b291" => "/dev/xvdc" (forces new resource)
+  # We expect this data source value to change due to how Storage Gateway works.
+  lifecycle {
+    ignore_changes = ["disk_id"]
+  }
+
+  disk_id     = "${data.aws_storagegateway_local_disk.test.id}"
+  gateway_arn = "${aws_storagegateway_gateway.test.arn}"
+}
+
+resource "aws_storagegateway_smb_file_share" "test" {
+  # Use GuestAccess to simplify testing
+  authentication = "GuestAccess"
+  gateway_arn    = "${aws_storagegateway_gateway.test.arn}"
+  location_arn   = "${aws_s3_bucket.test.arn}"
+  role_arn       = "${aws_iam_role.test.arn}"
+
+	# I'm not super sure why this depends_on sadness is required in
+	# the test framework but not the binary so... yolo!
+	depends_on = ["aws_storagegateway_cache.test"]
+}
+
+resource "aws_instance" "test_datasync" {
+  depends_on = ["aws_internet_gateway.test"]
+
+  ami                         = "${data.aws_ami.aws_datasync.id}"
+  associate_public_ip_address = true
+
+  instance_type          = "c5.large"
+  vpc_security_group_ids = ["${aws_security_group.test.id}"]
+  subnet_id              = "${aws_subnet.test.id}"
+
+  tags = {
+    Name = "tf-acc-test-datasync-smb"
+  }
+}
+
+resource "aws_datasync_agent" "test" {
+  ip_address = "${aws_instance.test_datasync.public_ip}"
+  name       = "datasyncsmb-%s"
+}
+`, gatewayUid, gatewayUid)
+}
+
+func testAccAWSDataSyncLocationSmbConfig() string {
+	return testAccAWSDataSyncLocationSmbConfigBase() + fmt.Sprintf(`
+resource "aws_datasync_location_smb" "test" {
+	user               = "Guest"
+	password           = "ZaphodBeeblebroxPW"
+	subdirectory       = "/${aws_s3_bucket.test.id}/"
+
+	server_hostname  = "${aws_instance.test_datasync.public_ip}"
+	agent_arns       = ["${aws_datasync_agent.test.arn}"]
+}
+`)
+}
+
+func testAccAWSDataSyncLocationSmbConfigTags1(key1, value1 string) string {
+	return testAccAWSDataSyncLocationSmbConfigBase() + fmt.Sprintf(`
+resource "aws_datasync_location_smb" "test" {
+	user               = "Guest"
+	password           = "ZaphodBeeblebroxPW"
+	subdirectory       = "/${aws_s3_bucket.test.id}/"
+
+	server_hostname  = "${aws_instance.test_datasync.public_ip}"
+	agent_arns       = ["${aws_datasync_agent.test.arn}"]
+
+  tags = {
+    %q = %q
+  }
+}
+`, key1, value1)
+}
+
+func testAccAWSDataSyncLocationSmbConfigTags2(key1, value1, key2, value2 string) string {
+	return testAccAWSDataSyncLocationSmbConfigBase() + fmt.Sprintf(`
+resource "aws_datasync_location_smb" "test" {
+	user               = "Guest"
+	password           = "ZaphodBeeblebroxPW"
+	subdirectory       = "/${aws_s3_bucket.test.id}/"
+
+	server_hostname  = "${aws_instance.test_datasync.public_ip}"
+	agent_arns       = ["${aws_datasync_agent.test.arn}"]
+
+  tags = {
+    %q = %q
+    %q = %q
+  }
+}
+`, key1, value1, key2, value2)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -794,6 +794,9 @@
                                     <a href="/docs/providers/aws/r/datasync_location_s3.html">aws_datasync_location_s3</a>
                                 </li>
                                 <li>
+                                    <a href="/docs/providers/aws/r/datasync_location_smb.html">aws_datasync_location_smb</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/aws/r/datasync_task.html">aws_datasync_task</a>
                                 </li>
                             </ul>

--- a/website/docs/r/datasync_location_smb.html.markdown
+++ b/website/docs/r/datasync_location_smb.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Manages an AWS DataSync SMB Location
 ---
 
-# Resource: aws_datasync_location_SMB
+# Resource: aws_datasync_location_smb
 
 Manages a SMB Location within AWS DataSync.
 
@@ -32,7 +32,7 @@ The following arguments are supported:
 
 * `agent_arns` - (Required) A list of DataSync Agent ARNs with which this location will be associated.
 * `domain` - (Optional) The name of the Windows domain the SMB server belongs to.
-* `mount_options` - (Optional) The mount options used by DataSync to access the SMB Server. Can be `AUTOMATIC`, `SMB2`, or `SMB3`.
+* `mount_options` - (Optional) Configuration block containing mount options used by DataSync to access the SMB Server. Can be `AUTOMATIC`, `SMB2`, or `SMB3`.
 * `password` - (Required) The password of the user who can mount the share and has file permissions in the SMB.
 * `server_hostname` - (Required) Specifies the IP address or DNS name of the SMB server. The DataSync Agent(s) use this to mount the SMB share.
 * `subdirectory` - (Required) Subdirectory to perform actions as source or destination. Should be exported by the NFS server.
@@ -41,9 +41,9 @@ The following arguments are supported:
 
 ### mount_options Argument Reference
 
-The following arguments are supported inside the `on_prem_config` configuration block:
+The following arguments are supported inside the `mount_options` configuration block:
 
-* `version` - (Optional) The specific SMB version that you want DataSync to use mounting your SMB share. Default: `AUTOMATIC`
+* `version` - (Optional) The specific SMB version that you want DataSync to use for mounting your SMB share. Valid values: `AUTOMATIC`, `SMB2`, and `SMB3`. Default: `AUTOMATIC`
 
 ## Attribute Reference
 
@@ -53,7 +53,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-`aws_datasync_location_smb` can be imported by using the DataSync Task Amazon Resource Name (ARN), e.g.
+`aws_datasync_location_smb` can be imported by using the Amazon Resource Name (ARN), e.g.
 
 ```
 $ terraform import aws_datasync_location_smb.example arn:aws:datasync:us-east-1:123456789012:location/loc-12345678901234567

--- a/website/docs/r/datasync_location_smb.html.markdown
+++ b/website/docs/r/datasync_location_smb.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "DataSync"
 layout: "aws"
 page_title: "AWS: aws_datasync_location_smb"
 description: |-

--- a/website/docs/r/datasync_location_smb.html.markdown
+++ b/website/docs/r/datasync_location_smb.html.markdown
@@ -18,7 +18,7 @@ Manages a SMB Location within AWS DataSync.
 resource "aws_datasync_location_smb" "example" {
   server_hostname = "smb.example.com"
   subdirectory    = "/exported/path"
-  
+
   user     = "Guest"
   password = "ANotGreatPassword"
 
@@ -37,7 +37,7 @@ The following arguments are supported:
 * `server_hostname` - (Required) Specifies the IP address or DNS name of the SMB server. The DataSync Agent(s) use this to mount the SMB share.
 * `subdirectory` - (Required) Subdirectory to perform actions as source or destination. Should be exported by the NFS server.
 * `tags` - (Optional) Key-value pairs of resource tags to assign to the DataSync Location.
-* `user` - (Required) The user who can mount the share and has file permissions in the SMB.
+* `user` - (Required) The user who can mount the share and has file and folder permissions in the SMB share.
 
 ### mount_options Argument Reference
 

--- a/website/docs/r/datasync_location_smb.html.markdown
+++ b/website/docs/r/datasync_location_smb.html.markdown
@@ -1,0 +1,59 @@
+---
+layout: "aws"
+page_title: "AWS: aws_datasync_location_smb"
+description: |-
+  Manages an AWS DataSync SMB Location
+---
+
+# Resource: aws_datasync_location_SMB
+
+Manages a SMB Location within AWS DataSync.
+
+~> **NOTE:** The DataSync Agents must be available before creating this resource.
+
+## Example Usage
+
+```hcl
+resource "aws_datasync_location_smb" "example" {
+  server_hostname = "smb.example.com"
+  subdirectory    = "/exported/path"
+  
+  user     = "Guest"
+  password = "ANotGreatPassword"
+
+  agent_arns = ["${aws_datasync_agent.example.arn}"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `agent_arns` - (Required) A list of DataSync Agent ARNs with which this location will be associated.
+* `domain` - (Optional) The name of the Windows domain the SMB server belongs to.
+* `mount_options` - (Optional)
+* `password` - (Required) The password of the user who can mount the share and has file permissions in the SMB.
+* `server_hostname` - (Required) Specifies the IP address or DNS name of the SMB server. The DataSync Agent(s) use this to mount the SMB share.
+* `subdirectory` - (Required) Subdirectory to perform actions as source or destination. Should be exported by the NFS server.
+* `tags` - (Optional) Key-value pairs of resource tags to assign to the DataSync Location.
+* `user` - (Required) The user who can mount the share and has file permissions in the SMB.
+
+### mount_options Argument Reference
+
+The following arguments are supported inside the `on_prem_config` configuration block:
+
+* `version` - (Optional) The specific SMB version that you want DataSync to use mounting your SMB share. Default: `AUTOMATIC`
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - Amazon Resource Name (ARN) of the DataSync Location.
+
+## Import
+
+`aws_datasync_location_smb` can be imported by using the DataSync Task Amazon Resource Name (ARN), e.g.
+
+```
+$ terraform import aws_datasync_location_smb.example arn:aws:datasync:us-east-1:123456789012:location/loc-12345678901234567
+```

--- a/website/docs/r/datasync_location_smb.html.markdown
+++ b/website/docs/r/datasync_location_smb.html.markdown
@@ -31,7 +31,7 @@ The following arguments are supported:
 
 * `agent_arns` - (Required) A list of DataSync Agent ARNs with which this location will be associated.
 * `domain` - (Optional) The name of the Windows domain the SMB server belongs to.
-* `mount_options` - (Optional)
+* `mount_options` - (Optional) The mount options used by DataSync to access the SMB Server. Can be `AUTOMATIC`, `SMB2`, or `SMB3`.
 * `password` - (Required) The password of the user who can mount the share and has file permissions in the SMB.
 * `server_hostname` - (Required) Specifies the IP address or DNS name of the SMB server. The DataSync Agent(s) use this to mount the SMB share.
 * `subdirectory` - (Required) Subdirectory to perform actions as source or destination. Should be exported by the NFS server.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9868

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* **New Resource:** `aws_datasync_location_smb` [GH-10381]
```

Output from acceptance testing:

```
root@46bfb2c125b3:/go/src/github.com/terraform-providers/terraform-provider-aws# AWS_PROFILE=default  make testacc TEST=./aws TESTARGS='-run=TestAccAWSDataSyncLocationSmb'
\==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDataSyncLocationSmb -timeout 120m
go: finding github.com/terraform-providers/terraform-provider-tls v2.1.1+incompatible
go: finding github.com/terraform-providers/terraform-provider-tls v2.1.1+incompatible
=== RUN   TestAccAWSDataSyncLocationSmb_basic
=== PAUSE TestAccAWSDataSyncLocationSmb_basic
=== RUN   TestAccAWSDataSyncLocationSmb_disappears
=== PAUSE TestAccAWSDataSyncLocationSmb_disappears
=== RUN   TestAccAWSDataSyncLocationSmb_Tags
=== PAUSE TestAccAWSDataSyncLocationSmb_Tags
=== CONT  TestAccAWSDataSyncLocationSmb_basic
=== CONT  TestAccAWSDataSyncLocationSmb_Tags
=== CONT  TestAccAWSDataSyncLocationSmb_disappears
--- PASS: TestAccAWSDataSyncLocationSmb_disappears (289.55s)
--- PASS: TestAccAWSDataSyncLocationSmb_basic (354.49s)
--- PASS: TestAccAWSDataSyncLocationSmb_Tags (448.62s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	448.666s
```
