### PR TITLE
resource/aws_s3_bucket: Prevent infinite deletion recursion with force_destroy argument and object keys with empty "directory" prefixes

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -1256,6 +1256,11 @@ func resourceAwsS3BucketDelete(d *schema.ResourceData, meta interface{}) error {
 
 	if isAWSErr(err, "BucketNotEmpty", "") {
 		if d.Get("force_destroy").(bool) {
+			// Use a S3 service client that can handle multiple slashes in URIs.
+			// While aws_s3_bucket_object resources cannot create these object
+			// keys, other AWS services and applications using the S3 Bucket can.
+			s3conn = meta.(*AWSClient).s3connUriCleaningDisabled
+
 			// bucket may have things delete them
 			log.Printf("[DEBUG] S3 Bucket attempting to forceDestroy %+v", err)
 

--- a/aws/resource_aws_s3_bucket_object_test.go
+++ b/aws/resource_aws_s3_bucket_object_test.go
@@ -33,7 +33,7 @@ func testSweepS3BucketObjects(region string) error {
 		return fmt.Errorf("error getting client: %s", err)
 	}
 
-	conn := client.(*AWSClient).s3conn
+	conn := client.(*AWSClient).s3connUriCleaningDisabled
 	input := &s3.ListBucketsInput{}
 
 	output, err := conn.ListBuckets(input)

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -1923,6 +1923,32 @@ func TestAccAWSS3Bucket_forceDestroy(t *testing.T) {
 	})
 }
 
+// By default, the AWS Go SDK cleans up URIs by removing extra slashes
+// when the service API requests use the URI as part of making a request.
+// While the aws_s3_bucket_object resource automatically cleans the key
+// to not contain these extra slashes, out-of-band handling and other AWS
+// services may create keys with extra slashes (empty "directory" prefixes).
+func TestAccAWSS3Bucket_forceDestroyWithEmptyPrefixes(t *testing.T) {
+	resourceName := "aws_s3_bucket.bucket"
+	rInt := acctest.RandInt()
+	bucketName := fmt.Sprintf("tf-test-bucket-%d", rInt)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSS3BucketConfig_forceDestroy(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketExists(resourceName),
+					testAccCheckAWSS3BucketAddObjects(resourceName, "data.txt", "/extraleadingslash.txt"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSS3Bucket_forceDestroyWithObjectLockEnabled(t *testing.T) {
 	resourceName := "aws_s3_bucket.bucket"
 	rInt := acctest.RandInt()
@@ -2161,7 +2187,7 @@ func testAccCheckAWSS3DestroyBucket(n string) resource.TestCheckFunc {
 func testAccCheckAWSS3BucketAddObjects(n string, keys ...string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs := s.RootModule().Resources[n]
-		conn := testAccProvider.Meta().(*AWSClient).s3conn
+		conn := testAccProvider.Meta().(*AWSClient).s3connUriCleaningDisabled
 
 		for _, key := range keys {
 			_, err := conn.PutObject(&s3.PutObjectInput{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/9942

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_s3_bucket: Prevent infinite deletion recursion with `force_destroy` argument and object keys with empty "directory" prefixes present since version 2.29.0
```

While aws_s3_bucket_object resources cannot create object keys with extra slashes (empty "directory" prefixes, e.g. `//extraleadingslash.txt`), other AWS services and applications using the S3 Bucket can. This problem seems related to the refactoring in #9942, which switched from using the `DeleteObjects` API call (`Key` parameters in request body) to the `DeleteObject` (`Key` parameter in request URI).

We may want to reconsider changing `deleteAllS3ObjectVersions()` back to using `DeleteObjects` for efficiency, catching the returned `Errors` from the response to handle any `PutObjectLegalHold` changes necessary, but I think that is out of scope of this fix.

The previous failing behavior from the new accceptance test was that it would always just run until the testing timeout (never actually able to delete the S3 Bucket).

Output from acceptance testing (`TestAccAWSCloudTrail/Trail/basic` originally displayed this issue before the new acceptance testing):

```
--- PASS: TestAccAWSCloudTrail/Trail/basic (61.14s)

--- PASS: TestAccAWSS3Bucket_acceleration (60.47s)
--- PASS: TestAccAWSS3Bucket_basic (30.85s)
--- PASS: TestAccAWSS3Bucket_Bucket_EmptyString (31.39s)
--- PASS: TestAccAWSS3Bucket_Cors_Delete (28.55s)
--- PASS: TestAccAWSS3Bucket_Cors_EmptyOrigin (32.60s)
--- PASS: TestAccAWSS3Bucket_Cors_Update (51.53s)
--- PASS: TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled (49.39s)
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed (31.37s)
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical (57.21s)
--- PASS: TestAccAWSS3Bucket_forceDestroy (25.84s)
--- PASS: TestAccAWSS3Bucket_forceDestroyWithEmptyPrefixes (26.06s)
--- PASS: TestAccAWSS3Bucket_forceDestroyWithObjectLockEnabled (30.31s)
--- PASS: TestAccAWSS3Bucket_generatedName (28.75s)
--- PASS: TestAccAWSS3Bucket_LifecycleBasic (70.74s)
--- PASS: TestAccAWSS3Bucket_LifecycleExpireMarkerOnly (52.23s)
--- PASS: TestAccAWSS3Bucket_Logging (45.53s)
--- PASS: TestAccAWSS3Bucket_namePrefix (36.83s)
--- PASS: TestAccAWSS3Bucket_objectLock (50.36s)
--- PASS: TestAccAWSS3Bucket_Policy (68.41s)
--- PASS: TestAccAWSS3Bucket_region (29.66s)
--- PASS: TestAccAWSS3Bucket_Replication (209.69s)
--- PASS: TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation (136.24s)
--- PASS: TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError (33.68s)
--- PASS: TestAccAWSS3Bucket_ReplicationSchemaV2 (205.78s)
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutPrefix (63.72s)
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutStorageClass (66.43s)
--- PASS: TestAccAWSS3Bucket_RequestPayer (52.27s)
--- PASS: TestAccAWSS3Bucket_shouldFailNotFound (13.76s)
--- PASS: TestAccAWSS3Bucket_tagsWithNoSystemTags (91.66s)
--- PASS: TestAccAWSS3Bucket_tagsWithSystemTags (126.69s)
--- PASS: TestAccAWSS3Bucket_UpdateAcl (49.76s)
--- PASS: TestAccAWSS3Bucket_Versioning (71.84s)
--- PASS: TestAccAWSS3Bucket_Website_Simple (71.35s)
--- PASS: TestAccAWSS3Bucket_WebsiteRedirect (71.47s)
--- PASS: TestAccAWSS3Bucket_WebsiteRoutingRules (51.40s)
```
