### PR TITLE
provider: Ensure hashibot performs issue labeling with backup, docdb, forecast, personalize, qldb, quicksight, and worklink services

### DIFF
--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -93,6 +93,9 @@ behavior "regexp_issue_labeler_v2" "service_labels" {
     "service/autoscalingplans" = [
       "aws_autoscalingplans_",
     ],
+    "service/backup" = [
+      "aws_backup_",
+    ],
     "service/batch" = [
       "aws_batch_",
     ],
@@ -174,6 +177,9 @@ behavior "regexp_issue_labeler_v2" "service_labels" {
     "service/dlm" = [
       "aws_dlm_",
     ],
+    "service/docdb" = [
+      "aws_docdb_",
+    ],
     "service/dynamodb" = [
       "aws_dynamodb_",
     ],
@@ -242,6 +248,9 @@ behavior "regexp_issue_labeler_v2" "service_labels" {
     ],
     "service/fms" = [
       "aws_fms_",
+    ],
+    "service/forecast" = [
+      "aws_forecast_",
     ],
     "service/fsx" = [
       "aws_fsx_",
@@ -337,6 +346,9 @@ behavior "regexp_issue_labeler_v2" "service_labels" {
     "service/organizations" = [
       "aws_organizations_",
     ],
+    "service/personalize" = [
+      "aws_personalize_",
+    ],
     "service/pinpoint" = [
       "aws_pinpoint_",
     ],
@@ -345,6 +357,12 @@ behavior "regexp_issue_labeler_v2" "service_labels" {
     ],
     "service/pricing" = [
       "aws_pricing_",
+    ],
+    "service/qldb" = [
+      "aws_qldb_",
+    ],
+    "service/quicksight" = [
+      "aws_quicksight_",
     ],
     "service/ram" = [
       "aws_ram_",
@@ -439,6 +457,9 @@ behavior "regexp_issue_labeler_v2" "service_labels" {
     ],
     "service/workdocs" = [
       "aws_workdocs_",
+    ],
+    "service/worklink" = [
+      "aws_worklink_",
     ],
     "service/workmail" = [
       "aws_workmail_",


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/10392

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Some of these were likely missed because they live in the GitHub Actions pull request labeling instead of hashibot (where the original list of copy-pasted from), but others are just newer GA services.

Output from acceptance testing: N/A