### PR TITLE
r/aws_appmesh_route: Add support for HTTP header-based routing and route priorities

### DIFF
--- a/aws/resource_aws_appmesh_route.go
+++ b/aws/resource_aws_appmesh_route.go
@@ -90,7 +90,7 @@ func resourceAwsAppmeshRoute() *schema.Resource {
 															},
 														},
 													},
-													Set: appmeshRouteWeightedTargetHash,
+													Set: appmeshWeightedTargetHash,
 												},
 											},
 										},
@@ -103,16 +103,124 @@ func resourceAwsAppmeshRoute() *schema.Resource {
 										MaxItems: 1,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
+												"header": {
+													Type:     schema.TypeSet,
+													Optional: true,
+													MinItems: 0,
+													MaxItems: 10,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"invert": {
+																Type:     schema.TypeBool,
+																Optional: true,
+																Default:  false,
+															},
+
+															"match": {
+																Type:     schema.TypeList,
+																Optional: true,
+																MinItems: 0,
+																MaxItems: 1,
+																Elem: &schema.Resource{
+																	Schema: map[string]*schema.Schema{
+																		"exact": {
+																			Type:         schema.TypeString,
+																			Optional:     true,
+																			ValidateFunc: validation.StringLenBetween(1, 255),
+																		},
+
+																		"prefix": {
+																			Type:         schema.TypeString,
+																			Optional:     true,
+																			ValidateFunc: validation.StringLenBetween(1, 255),
+																		},
+
+																		"range": {
+																			Type:     schema.TypeList,
+																			Optional: true,
+																			MinItems: 0,
+																			MaxItems: 1,
+																			Elem: &schema.Resource{
+																				Schema: map[string]*schema.Schema{
+																					"end": {
+																						Type:     schema.TypeInt,
+																						Required: true,
+																					},
+
+																					"start": {
+																						Type:     schema.TypeInt,
+																						Required: true,
+																					},
+																				},
+																			},
+																		},
+
+																		"regex": {
+																			Type:         schema.TypeString,
+																			Optional:     true,
+																			ValidateFunc: validation.StringLenBetween(1, 255),
+																		},
+
+																		"suffix": {
+																			Type:         schema.TypeString,
+																			Optional:     true,
+																			ValidateFunc: validation.StringLenBetween(1, 255),
+																		},
+																	},
+																},
+															},
+
+															"name": {
+																Type:         schema.TypeString,
+																Required:     true,
+																ValidateFunc: validation.StringLenBetween(1, 50),
+															},
+														},
+													},
+													Set: appmeshHttpRouteHeaderHash,
+												},
+
+												"method": {
+													Type:     schema.TypeString,
+													Optional: true,
+													ValidateFunc: validation.StringInSlice([]string{
+														appmesh.HttpMethodConnect,
+														appmesh.HttpMethodDelete,
+														appmesh.HttpMethodGet,
+														appmesh.HttpMethodHead,
+														appmesh.HttpMethodOptions,
+														appmesh.HttpMethodPatch,
+														appmesh.HttpMethodPost,
+														appmesh.HttpMethodPut,
+														appmesh.HttpMethodTrace,
+													}, false),
+												},
+
 												"prefix": {
 													Type:         schema.TypeString,
 													Required:     true,
 													ValidateFunc: validation.StringMatch(regexp.MustCompile(`^/`), "must start with /"),
+												},
+
+												"scheme": {
+													Type:     schema.TypeString,
+													Optional: true,
+													ValidateFunc: validation.StringInSlice([]string{
+														appmesh.HttpSchemeHttp,
+														appmesh.HttpSchemeHttps,
+													}, false),
 												},
 											},
 										},
 									},
 								},
 							},
+						},
+
+						"priority": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(0, 1000),
 						},
 
 						"tcp_route": {
@@ -150,7 +258,7 @@ func resourceAwsAppmeshRoute() *schema.Resource {
 															},
 														},
 													},
-													Set: appmeshRouteWeightedTargetHash,
+													Set: appmeshWeightedTargetHash,
 												},
 											},
 										},
@@ -331,7 +439,43 @@ func resourceAwsAppmeshRouteImport(d *schema.ResourceData, meta interface{}) ([]
 	return []*schema.ResourceData{d}, nil
 }
 
-func appmeshRouteWeightedTargetHash(v interface{}) int {
+func appmeshHttpRouteHeaderHash(vHttpRouteHeader interface{}) int {
+	var buf bytes.Buffer
+	mHttpRouteHeader := vHttpRouteHeader.(map[string]interface{})
+	if v, ok := mHttpRouteHeader["invert"].(bool); ok {
+		buf.WriteString(fmt.Sprintf("%t-", v))
+	}
+	if vMatch, ok := mHttpRouteHeader["match"].([]interface{}); ok && len(vMatch) > 0 && vMatch[0] != nil {
+		mMatch := vMatch[0].(map[string]interface{})
+		if v, ok := mMatch["exact"].(string); ok {
+			buf.WriteString(fmt.Sprintf("%s-", v))
+		}
+		if v, ok := mMatch["prefix"].(string); ok {
+			buf.WriteString(fmt.Sprintf("%s-", v))
+		}
+		if vRange, ok := mMatch["range"].([]interface{}); ok && len(vRange) > 0 && vRange[0] != nil {
+			mRange := vRange[0].(map[string]interface{})
+			if v, ok := mRange["end"].(int); ok {
+				buf.WriteString(fmt.Sprintf("%d-", v))
+			}
+			if v, ok := mRange["start"].(int); ok {
+				buf.WriteString(fmt.Sprintf("%d-", v))
+			}
+		}
+		if v, ok := mMatch["regex"].(string); ok {
+			buf.WriteString(fmt.Sprintf("%s-", v))
+		}
+		if v, ok := mMatch["suffix"].(string); ok {
+			buf.WriteString(fmt.Sprintf("%s-", v))
+		}
+	}
+	if v, ok := mHttpRouteHeader["name"].(string); ok {
+		buf.WriteString(fmt.Sprintf("%s-", v))
+	}
+	return hashcode.String(buf.String())
+}
+
+func appmeshWeightedTargetHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 	if v, ok := m["virtual_node"].(string); ok {

--- a/aws/resource_aws_appmesh_route_test.go
+++ b/aws/resource_aws_appmesh_route_test.go
@@ -125,7 +125,12 @@ func testAccAwsAppmeshRoute_httpRoute(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.action.0.weighted_target.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.header.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.method", ""),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.prefix", "/"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.scheme", ""),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.priority", "0"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.tcp_route.#", "0"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_date"),
 					resource.TestCheckResourceAttrSet(resourceName, "last_updated_date"),
 					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "appmesh", fmt.Sprintf("mesh/%s/virtualRouter/%s/route/%s", meshName, vrName, rName)),
@@ -143,7 +148,12 @@ func testAccAwsAppmeshRoute_httpRoute(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.action.0.weighted_target.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.header.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.method", ""),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.prefix", "/path"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.scheme", ""),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.priority", "0"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.tcp_route.#", "0"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_date"),
 					resource.TestCheckResourceAttrSet(resourceName, "last_updated_date"),
 					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "appmesh", fmt.Sprintf("mesh/%s/virtualRouter/%s/route/%s", meshName, vrName, rName)),
@@ -151,7 +161,7 @@ func testAccAwsAppmeshRoute_httpRoute(t *testing.T) {
 			},
 			{
 				ResourceName:      resourceName,
-				ImportStateId:     fmt.Sprintf("%s/%s/%s", meshName, vrName, rName),
+				ImportStateIdFunc: testAccAwsAppmeshRouteImportStateIdFunc(resourceName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -181,6 +191,8 @@ func testAccAwsAppmeshRoute_tcpRoute(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					resource.TestCheckResourceAttr(resourceName, "virtual_router_name", vrName),
 					resource.TestCheckResourceAttr(resourceName, "spec.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.priority", "0"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.tcp_route.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.tcp_route.0.action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.tcp_route.0.action.0.weighted_target.#", "1"),
@@ -197,6 +209,8 @@ func testAccAwsAppmeshRoute_tcpRoute(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
 					resource.TestCheckResourceAttr(resourceName, "virtual_router_name", vrName),
 					resource.TestCheckResourceAttr(resourceName, "spec.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.priority", "0"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.tcp_route.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.tcp_route.0.action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.tcp_route.0.action.0.weighted_target.#", "2"),
@@ -207,7 +221,7 @@ func testAccAwsAppmeshRoute_tcpRoute(t *testing.T) {
 			},
 			{
 				ResourceName:      resourceName,
-				ImportStateId:     fmt.Sprintf("%s/%s/%s", meshName, vrName, rName),
+				ImportStateIdFunc: testAccAwsAppmeshRouteImportStateIdFunc(resourceName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -263,12 +277,179 @@ func testAccAwsAppmeshRoute_tags(t *testing.T) {
 			},
 			{
 				ResourceName:      resourceName,
-				ImportStateId:     fmt.Sprintf("%s/%s/%s", meshName, vrName, rName),
+				ImportStateIdFunc: testAccAwsAppmeshRouteImportStateIdFunc(resourceName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 		},
 	})
+}
+
+func testAccAwsAppmeshRoute_httpHeader(t *testing.T) {
+	var r appmesh.RouteData
+	resourceName := "aws_appmesh_route.test"
+	meshName := acctest.RandomWithPrefix("tf-acc-test")
+	vrName := acctest.RandomWithPrefix("tf-acc-test")
+	vn1Name := acctest.RandomWithPrefix("tf-acc-test")
+	vn2Name := acctest.RandomWithPrefix("tf-acc-test")
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAppmeshRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsAppmeshRouteConfig_httpHeader(meshName, vrName, vn1Name, vn2Name, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAppmeshRouteExists(resourceName, &r),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
+					resource.TestCheckResourceAttr(resourceName, "virtual_router_name", vrName),
+					resource.TestCheckResourceAttr(resourceName, "spec.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.action.0.weighted_target.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.header.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.header.2366200004.invert", "false"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.header.2366200004.match.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.header.2366200004.name", "X-Testing1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.method", "POST"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.prefix", "/"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.scheme", "http"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.priority", "0"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.tcp_route.#", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_date"),
+					resource.TestCheckResourceAttrSet(resourceName, "last_updated_date"),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "appmesh", fmt.Sprintf("mesh/%s/virtualRouter/%s/route/%s", meshName, vrName, rName)),
+				),
+			},
+			{
+				Config: testAccAwsAppmeshRouteConfig_httpHeaderUpdated(meshName, vrName, vn1Name, vn2Name, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAppmeshRouteExists(resourceName, &r),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
+					resource.TestCheckResourceAttr(resourceName, "virtual_router_name", vrName),
+					resource.TestCheckResourceAttr(resourceName, "spec.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.action.0.weighted_target.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.header.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.header.2971741486.invert", "true"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.header.2971741486.match.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.header.2971741486.name", "X-Testing1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.header.3147536248.invert", "false"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.header.3147536248.match.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.header.3147536248.match.0.exact", ""),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.header.3147536248.match.0.prefix", ""),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.header.3147536248.match.0.range.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.header.3147536248.match.0.range.0.end", "7"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.header.3147536248.match.0.range.0.start", "2"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.header.3147536248.match.0.regex", ""),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.header.3147536248.match.0.suffix", ""),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.header.3147536248.name", "X-Testing2"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.method", "PUT"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.prefix", "/path"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.scheme", "https"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.priority", "0"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.tcp_route.#", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_date"),
+					resource.TestCheckResourceAttrSet(resourceName, "last_updated_date"),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "appmesh", fmt.Sprintf("mesh/%s/virtualRouter/%s/route/%s", meshName, vrName, rName)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccAwsAppmeshRouteImportStateIdFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAwsAppmeshRoute_routePriority(t *testing.T) {
+	var r appmesh.RouteData
+	resourceName := "aws_appmesh_route.test"
+	meshName := acctest.RandomWithPrefix("tf-acc-test")
+	vrName := acctest.RandomWithPrefix("tf-acc-test")
+	vn1Name := acctest.RandomWithPrefix("tf-acc-test")
+	vn2Name := acctest.RandomWithPrefix("tf-acc-test")
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAppmeshRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsAppmeshRouteConfig_routePriority(meshName, vrName, vn1Name, vn2Name, rName, 42),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAppmeshRouteExists(resourceName, &r),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
+					resource.TestCheckResourceAttr(resourceName, "virtual_router_name", vrName),
+					resource.TestCheckResourceAttr(resourceName, "spec.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.action.0.weighted_target.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.header.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.method", ""),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.prefix", "/"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.scheme", ""),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.priority", "42"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.tcp_route.#", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_date"),
+					resource.TestCheckResourceAttrSet(resourceName, "last_updated_date"),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "appmesh", fmt.Sprintf("mesh/%s/virtualRouter/%s/route/%s", meshName, vrName, rName)),
+				),
+			},
+			{
+				Config: testAccAwsAppmeshRouteConfig_routePriority(meshName, vrName, vn1Name, vn2Name, rName, 1000),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAppmeshRouteExists(resourceName, &r),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
+					resource.TestCheckResourceAttr(resourceName, "virtual_router_name", vrName),
+					resource.TestCheckResourceAttr(resourceName, "spec.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.action.0.weighted_target.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.header.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.method", ""),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.prefix", "/"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.scheme", ""),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.priority", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.tcp_route.#", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_date"),
+					resource.TestCheckResourceAttrSet(resourceName, "last_updated_date"),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "appmesh", fmt.Sprintf("mesh/%s/virtualRouter/%s/route/%s", meshName, vrName, rName)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccAwsAppmeshRouteImportStateIdFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAwsAppmeshRouteImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not Found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s/%s/%s", rs.Primary.Attributes["mesh_name"], rs.Primary.Attributes["virtual_router_name"], rs.Primary.Attributes["name"]), nil
+	}
 }
 
 func testAccCheckAppmeshRouteDestroy(s *terraform.State) error {
@@ -326,42 +507,41 @@ func testAccCheckAppmeshRouteExists(name string, v *appmesh.RouteData) resource.
 func testAccAppmeshRouteConfigBase(meshName, vrName, vn1Name, vn2Name string) string {
 	return fmt.Sprintf(`
 resource "aws_appmesh_mesh" "test" {
-	name = %[1]q
+  name = %[1]q
 }
 
 resource "aws_appmesh_virtual_router" "test" {
-	name      = %[2]q
-	mesh_name = "${aws_appmesh_mesh.test.id}"
+  name      = %[2]q
+  mesh_name = "${aws_appmesh_mesh.test.id}"
 
-	spec {
-		listener {
-			port_mapping {
-				port     = 8080
-				protocol = "http"
-			}
-		}
-	}
+  spec {
+    listener {
+      port_mapping {
+        port     = 8080
+        protocol = "http"
+      }
+    }
+  }
 }
 
 resource "aws_appmesh_virtual_node" "foo" {
-	name      = %[3]q
-	mesh_name = "${aws_appmesh_mesh.test.id}"
+  name      = %[3]q
+  mesh_name = "${aws_appmesh_mesh.test.id}"
 
-	spec {}
+  spec {}
 }
 
 resource "aws_appmesh_virtual_node" "bar" {
-	name      = %[4]q
-	mesh_name = "${aws_appmesh_mesh.test.id}"
+  name      = %[4]q
+  mesh_name = "${aws_appmesh_mesh.test.id}"
 
-	spec {}
+  spec {}
 }
 `, meshName, vrName, vn1Name, vn2Name)
 }
 
 func testAccAppmeshRouteConfig_httpRoute(meshName, vrName, vn1Name, vn2Name, rName string) string {
 	return testAccAppmeshRouteConfigBase(meshName, vrName, vn1Name, vn2Name) + fmt.Sprintf(`
-
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = "${aws_appmesh_mesh.test.id}"
@@ -387,7 +567,6 @@ resource "aws_appmesh_route" "test" {
 
 func testAccAppmeshRouteConfig_httpRouteUpdated(meshName, vrName, vn1Name, vn2Name, rName string) string {
 	return testAccAppmeshRouteConfigBase(meshName, vrName, vn1Name, vn2Name) + fmt.Sprintf(`
-
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = "${aws_appmesh_mesh.test.id}"
@@ -418,7 +597,6 @@ resource "aws_appmesh_route" "test" {
 
 func testAccAppmeshRouteConfig_tcpRoute(meshName, vrName, vn1Name, vn2Name, rName string) string {
 	return testAccAppmeshRouteConfigBase(meshName, vrName, vn1Name, vn2Name) + fmt.Sprintf(`
-
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = "${aws_appmesh_mesh.test.id}"
@@ -440,7 +618,6 @@ resource "aws_appmesh_route" "test" {
 
 func testAccAppmeshRouteConfig_tcpRouteUpdated(meshName, vrName, vn1Name, vn2Name, rName string) string {
 	return testAccAppmeshRouteConfigBase(meshName, vrName, vn1Name, vn2Name) + fmt.Sprintf(`
-
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = "${aws_appmesh_mesh.test.id}"
@@ -467,7 +644,6 @@ resource "aws_appmesh_route" "test" {
 
 func testAccAppmeshRouteConfigWithTags(meshName, vrName, vn1Name, vn2Name, rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return testAccAppmeshRouteConfigBase(meshName, vrName, vn1Name, vn2Name) + fmt.Sprintf(`
-
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
   mesh_name           = "${aws_appmesh_mesh.test.id}"
@@ -489,9 +665,111 @@ resource "aws_appmesh_route" "test" {
   }
 
   tags = {
-	%[2]s = %[3]q
-	%[4]s = %[5]q
+    %[2]s = %[3]q
+    %[4]s = %[5]q
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}
+
+func testAccAwsAppmeshRouteConfig_httpHeader(meshName, vrName, vn1Name, vn2Name, rName string) string {
+	return testAccAppmeshRouteConfigBase(meshName, vrName, vn1Name, vn2Name) + fmt.Sprintf(`
+resource "aws_appmesh_route" "test" {
+  name                = %[1]q
+  mesh_name           = "${aws_appmesh_mesh.test.id}"
+  virtual_router_name = "${aws_appmesh_virtual_router.test.name}"
+
+  spec {
+    http_route {
+      match {
+        prefix = "/"
+        method = "POST"
+        scheme = "http"
+
+        header {
+          name = "X-Testing1"
+        }
+      }
+
+      action {
+        weighted_target {
+          virtual_node = "${aws_appmesh_virtual_node.foo.name}"
+          weight       = 100
+        }
+      }
+    }
+  }
+}
+`, rName)
+}
+
+func testAccAwsAppmeshRouteConfig_httpHeaderUpdated(meshName, vrName, vn1Name, vn2Name, rName string) string {
+	return testAccAppmeshRouteConfigBase(meshName, vrName, vn1Name, vn2Name) + fmt.Sprintf(`
+resource "aws_appmesh_route" "test" {
+  name                = %[1]q
+  mesh_name           = "${aws_appmesh_mesh.test.id}"
+  virtual_router_name = "${aws_appmesh_virtual_router.test.name}"
+
+  spec {
+    http_route {
+      match {
+        prefix = "/path"
+        method = "PUT"
+        scheme = "https"
+
+        header {
+          name   = "X-Testing1"
+          invert = true
+        }
+
+        header {
+          name   = "X-Testing2"
+          invert = false
+
+          match {
+            range {
+              start = 2
+              end   = 7
+            }
+          }
+        }
+      }
+
+      action {
+        weighted_target {
+          virtual_node = "${aws_appmesh_virtual_node.foo.name}"
+          weight       = 100
+        }
+      }
+    }
+  }
+}
+`, rName)
+}
+
+func testAccAwsAppmeshRouteConfig_routePriority(meshName, vrName, vn1Name, vn2Name, rName string, priority int) string {
+	return testAccAppmeshRouteConfigBase(meshName, vrName, vn1Name, vn2Name) + fmt.Sprintf(`
+resource "aws_appmesh_route" "test" {
+  name                = %[1]q
+  mesh_name           = "${aws_appmesh_mesh.test.id}"
+  virtual_router_name = "${aws_appmesh_virtual_router.test.name}"
+
+  spec {
+    http_route {
+      match {
+        prefix = "/"
+      }
+
+      action {
+        weighted_target {
+          virtual_node = "${aws_appmesh_virtual_node.foo.name}"
+          weight       = 100
+        }
+      }
+    }
+
+    priority = %[2]d
+  }
+}
+`, rName, priority)
 }

--- a/aws/resource_aws_appmesh_test.go
+++ b/aws/resource_aws_appmesh_test.go
@@ -12,9 +12,11 @@ func TestAccAWSAppmesh(t *testing.T) {
 			"tags":         testAccAwsAppmeshMesh_tags,
 		},
 		"Route": {
-			"httpRoute": testAccAwsAppmeshRoute_httpRoute,
-			"tcpRoute":  testAccAwsAppmeshRoute_tcpRoute,
-			"tags":      testAccAwsAppmeshRoute_tags,
+			"httpHeader":    testAccAwsAppmeshRoute_httpHeader,
+			"httpRoute":     testAccAwsAppmeshRoute_httpRoute,
+			"tcpRoute":      testAccAwsAppmeshRoute_tcpRoute,
+			"routePriority": testAccAwsAppmeshRoute_routePriority,
+			"tags":          testAccAwsAppmeshRoute_tags,
 		},
 		"VirtualNode": {
 			"basic":                    testAccAwsAppmeshVirtualNode_basic,

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -5261,6 +5261,10 @@ func expandAppmeshRouteSpec(vSpec []interface{}) *appmesh.RouteSpec {
 	}
 	mSpec := vSpec[0].(map[string]interface{})
 
+	if vPriority, ok := mSpec["priority"].(int); ok && vPriority > 0 {
+		spec.Priority = aws.Int64(int64(vPriority))
+	}
+
 	if vHttpRoute, ok := mSpec["http_route"].([]interface{}); ok && len(vHttpRoute) > 0 && vHttpRoute[0] != nil {
 		mHttpRoute := vHttpRoute[0].(map[string]interface{})
 
@@ -5280,7 +5284,7 @@ func expandAppmeshRouteSpec(vSpec []interface{}) *appmesh.RouteSpec {
 					if vVirtualNode, ok := mWeightedTarget["virtual_node"].(string); ok && vVirtualNode != "" {
 						weightedTarget.VirtualNode = aws.String(vVirtualNode)
 					}
-					if vWeight, ok := mWeightedTarget["weight"].(int); ok {
+					if vWeight, ok := mWeightedTarget["weight"].(int); ok && vWeight > 0 {
 						weightedTarget.Weight = aws.Int64(int64(vWeight))
 					}
 
@@ -5294,13 +5298,74 @@ func expandAppmeshRouteSpec(vSpec []interface{}) *appmesh.RouteSpec {
 		}
 
 		if vHttpRouteMatch, ok := mHttpRoute["match"].([]interface{}); ok && len(vHttpRouteMatch) > 0 && vHttpRouteMatch[0] != nil {
+			httpRouteMatch := &appmesh.HttpRouteMatch{}
+
 			mHttpRouteMatch := vHttpRouteMatch[0].(map[string]interface{})
 
-			if vPrefix, ok := mHttpRouteMatch["prefix"].(string); ok && vPrefix != "" {
-				spec.HttpRoute.Match = &appmesh.HttpRouteMatch{
-					Prefix: aws.String(vPrefix),
-				}
+			if vMethod, ok := mHttpRouteMatch["method"].(string); ok && vMethod != "" {
+				httpRouteMatch.Method = aws.String(vMethod)
 			}
+			if vPrefix, ok := mHttpRouteMatch["prefix"].(string); ok && vPrefix != "" {
+				httpRouteMatch.Prefix = aws.String(vPrefix)
+			}
+			if vScheme, ok := mHttpRouteMatch["scheme"].(string); ok && vScheme != "" {
+				httpRouteMatch.Scheme = aws.String(vScheme)
+			}
+
+			if vHttpRouteHeaders, ok := mHttpRouteMatch["header"].(*schema.Set); ok && vHttpRouteHeaders.Len() > 0 {
+				httpRouteHeaders := []*appmesh.HttpRouteHeader{}
+
+				for _, vHttpRouteHeader := range vHttpRouteHeaders.List() {
+					httpRouteHeader := &appmesh.HttpRouteHeader{}
+
+					mHttpRouteHeader := vHttpRouteHeader.(map[string]interface{})
+
+					if vInvert, ok := mHttpRouteHeader["invert"].(bool); ok {
+						httpRouteHeader.Invert = aws.Bool(vInvert)
+					}
+					if vName, ok := mHttpRouteHeader["name"].(string); ok && vName != "" {
+						httpRouteHeader.Name = aws.String(vName)
+					}
+
+					if vMatch, ok := mHttpRouteHeader["match"].([]interface{}); ok && len(vMatch) > 0 && vMatch[0] != nil {
+						httpRouteHeader.Match = &appmesh.HeaderMatchMethod{}
+
+						mMatch := vMatch[0].(map[string]interface{})
+
+						if vExact, ok := mMatch["exact"].(string); ok && vExact != "" {
+							httpRouteHeader.Match.Exact = aws.String(vExact)
+						}
+						if vPrefix, ok := mMatch["prefix"].(string); ok && vPrefix != "" {
+							httpRouteHeader.Match.Prefix = aws.String(vPrefix)
+						}
+						if vRegex, ok := mMatch["regex"].(string); ok && vRegex != "" {
+							httpRouteHeader.Match.Regex = aws.String(vRegex)
+						}
+						if vSuffix, ok := mMatch["suffix"].(string); ok && vSuffix != "" {
+							httpRouteHeader.Match.Suffix = aws.String(vSuffix)
+						}
+
+						if vRange, ok := mMatch["range"].([]interface{}); ok && len(vRange) > 0 && vRange[0] != nil {
+							httpRouteHeader.Match.Range = &appmesh.MatchRange{}
+
+							mRange := vRange[0].(map[string]interface{})
+
+							if vEnd, ok := mRange["end"].(int); ok && vEnd > 0 {
+								httpRouteHeader.Match.Range.End = aws.Int64(int64(vEnd))
+							}
+							if vStart, ok := mRange["start"].(int); ok && vStart > 0 {
+								httpRouteHeader.Match.Range.Start = aws.Int64(int64(vStart))
+							}
+						}
+					}
+
+					httpRouteHeaders = append(httpRouteHeaders, httpRouteHeader)
+				}
+
+				httpRouteMatch.Headers = httpRouteHeaders
+			}
+
+			spec.HttpRoute.Match = httpRouteMatch
 		}
 	}
 
@@ -5323,7 +5388,7 @@ func expandAppmeshRouteSpec(vSpec []interface{}) *appmesh.RouteSpec {
 					if vVirtualNode, ok := mWeightedTarget["virtual_node"].(string); ok && vVirtualNode != "" {
 						weightedTarget.VirtualNode = aws.String(vVirtualNode)
 					}
-					if vWeight, ok := mWeightedTarget["weight"].(int); ok {
+					if vWeight, ok := mWeightedTarget["weight"].(int); ok && vWeight > 0 {
 						weightedTarget.Weight = aws.Int64(int64(vWeight))
 					}
 
@@ -5345,34 +5410,72 @@ func flattenAppmeshRouteSpec(spec *appmesh.RouteSpec) []interface{} {
 		return []interface{}{}
 	}
 
-	mSpec := map[string]interface{}{}
+	mSpec := map[string]interface{}{
+		"priority": int(aws.Int64Value(spec.Priority)),
+	}
 
-	if spec.HttpRoute != nil {
+	if httpRoute := spec.HttpRoute; httpRoute != nil {
 		mHttpRoute := map[string]interface{}{}
 
-		if spec.HttpRoute.Action != nil && spec.HttpRoute.Action.WeightedTargets != nil {
-			vWeightedTargets := []interface{}{}
+		if action := httpRoute.Action; action != nil {
+			if weightedTargets := action.WeightedTargets; weightedTargets != nil {
+				vWeightedTargets := []interface{}{}
 
-			for _, weightedTarget := range spec.HttpRoute.Action.WeightedTargets {
-				mWeightedTarget := map[string]interface{}{
-					"virtual_node": aws.StringValue(weightedTarget.VirtualNode),
-					"weight":       int(aws.Int64Value(weightedTarget.Weight)),
+				for _, weightedTarget := range weightedTargets {
+					mWeightedTarget := map[string]interface{}{
+						"virtual_node": aws.StringValue(weightedTarget.VirtualNode),
+						"weight":       int(aws.Int64Value(weightedTarget.Weight)),
+					}
+
+					vWeightedTargets = append(vWeightedTargets, mWeightedTarget)
 				}
 
-				vWeightedTargets = append(vWeightedTargets, mWeightedTarget)
-			}
-
-			mHttpRoute["action"] = []interface{}{
-				map[string]interface{}{
-					"weighted_target": schema.NewSet(appmeshRouteWeightedTargetHash, vWeightedTargets),
-				},
+				mHttpRoute["action"] = []interface{}{
+					map[string]interface{}{
+						"weighted_target": schema.NewSet(appmeshWeightedTargetHash, vWeightedTargets),
+					},
+				}
 			}
 		}
 
-		if spec.HttpRoute.Match != nil {
+		if httpRouteMatch := httpRoute.Match; httpRouteMatch != nil {
+			vHttpRouteHeaders := []interface{}{}
+
+			for _, httpRouteHeader := range httpRouteMatch.Headers {
+				mHttpRouteHeader := map[string]interface{}{
+					"invert": aws.BoolValue(httpRouteHeader.Invert),
+					"name":   aws.StringValue(httpRouteHeader.Name),
+				}
+
+				if match := httpRouteHeader.Match; match != nil {
+					mMatch := map[string]interface{}{
+						"exact":  aws.StringValue(match.Exact),
+						"prefix": aws.StringValue(match.Prefix),
+						"regex":  aws.StringValue(match.Regex),
+						"suffix": aws.StringValue(match.Suffix),
+					}
+
+					if r := match.Range; r != nil {
+						mRange := map[string]interface{}{
+							"end":   int(aws.Int64Value(r.End)),
+							"start": int(aws.Int64Value(r.Start)),
+						}
+
+						mMatch["range"] = []interface{}{mRange}
+					}
+
+					mHttpRouteHeader["match"] = []interface{}{mMatch}
+				}
+
+				vHttpRouteHeaders = append(vHttpRouteHeaders, mHttpRouteHeader)
+			}
+
 			mHttpRoute["match"] = []interface{}{
 				map[string]interface{}{
-					"prefix": aws.StringValue(spec.HttpRoute.Match.Prefix),
+					"header": schema.NewSet(appmeshHttpRouteHeaderHash, vHttpRouteHeaders),
+					"method": aws.StringValue(httpRouteMatch.Method),
+					"prefix": aws.StringValue(httpRouteMatch.Prefix),
+					"scheme": aws.StringValue(httpRouteMatch.Scheme),
 				},
 			}
 		}
@@ -5380,25 +5483,27 @@ func flattenAppmeshRouteSpec(spec *appmesh.RouteSpec) []interface{} {
 		mSpec["http_route"] = []interface{}{mHttpRoute}
 	}
 
-	if spec.TcpRoute != nil {
+	if tcpRoute := spec.TcpRoute; tcpRoute != nil {
 		mTcpRoute := map[string]interface{}{}
 
-		if spec.TcpRoute.Action != nil && spec.TcpRoute.Action.WeightedTargets != nil {
-			vWeightedTargets := []interface{}{}
+		if action := tcpRoute.Action; action != nil {
+			if weightedTargets := action.WeightedTargets; weightedTargets != nil {
+				vWeightedTargets := []interface{}{}
 
-			for _, weightedTarget := range spec.TcpRoute.Action.WeightedTargets {
-				mWeightedTarget := map[string]interface{}{
-					"virtual_node": aws.StringValue(weightedTarget.VirtualNode),
-					"weight":       int(aws.Int64Value(weightedTarget.Weight)),
+				for _, weightedTarget := range weightedTargets {
+					mWeightedTarget := map[string]interface{}{
+						"virtual_node": aws.StringValue(weightedTarget.VirtualNode),
+						"weight":       int(aws.Int64Value(weightedTarget.Weight)),
+					}
+
+					vWeightedTargets = append(vWeightedTargets, mWeightedTarget)
 				}
 
-				vWeightedTargets = append(vWeightedTargets, mWeightedTarget)
-			}
-
-			mTcpRoute["action"] = []interface{}{
-				map[string]interface{}{
-					"weighted_target": schema.NewSet(appmeshRouteWeightedTargetHash, vWeightedTargets),
-				},
+				mTcpRoute["action"] = []interface{}{
+					map[string]interface{}{
+						"weighted_target": schema.NewSet(appmeshWeightedTargetHash, vWeightedTargets),
+					},
+				}
 			}
 		}
 

--- a/website/docs/r/appmesh_route.html.markdown
+++ b/website/docs/r/appmesh_route.html.markdown
@@ -42,6 +42,41 @@ resource "aws_appmesh_route" "serviceb" {
 }
 ```
 
+### HTTP Header Routing
+
+```hcl
+resource "aws_appmesh_route" "serviceb" {
+  name                = "serviceB-route"
+  mesh_name           = "${aws_appmesh_mesh.simple.id}"
+  virtual_router_name = "${aws_appmesh_virtual_router.serviceb.name}"
+
+  spec {
+    http_route {
+      match {
+        method = "POST"
+        prefix = "/"
+        scheme = "https"
+
+        header {
+          name = "clientRequestId"
+
+          match {
+            prefix = "123"
+          }
+        }
+      }
+
+      action {
+        weighted_target {
+          virtual_node = "${aws_appmesh_virtual_node.serviceb.name}"
+          weight       = 100
+        }
+      }
+    }
+  }
+}
+```
+
 ### TCP Routing
 
 ```hcl
@@ -76,6 +111,8 @@ The following arguments are supported:
 The `spec` object supports the following:
 
 * `http_route` - (Optional) The HTTP routing information for the route.
+* `priority` - (Optional) The priority for the route, between `0` and `1000`.
+Routes are matched based on the specified value, where `0` is the highest priority.
 * `tcp_route` - (Optional) The TCP routing information for the route.
 
 The `http_route` object supports the following:
@@ -92,15 +129,37 @@ The `action` object supports the following:
 * `weighted_target` - (Required) The targets that traffic is routed to when a request matches the route.
 You can specify one or more targets and their relative weights with which to distribute traffic.
 
-The `match` object supports the following:
+The `http_route`'s `match` object supports the following:
 
 * `prefix` - (Required) Specifies the path with which to match requests.
 This parameter must always start with /, which by itself matches all requests to the virtual router service name.
+* `header` - (Optional) The client request headers to match on.
+* `method` - (Optional) The client request header method to match on. Valid values: `GET`, `HEAD`, `POST`, `PUT`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`, `PATCH`.
+* `scheme` - (Optional) The client request header scheme to match on. Valid values: `http`, `https`.
 
 The `weighted_target` object supports the following:
 
 * `virtual_node` - (Required) The virtual node to associate with the weighted target.
 * `weight` - (Required) The relative weight of the weighted target. An integer between 0 and 100.
+
+The `header` object supports the following:
+
+* `name` - (Required) A name for the HTTP header in the client request that will be matched on.
+* `invert` - (Optional) If `true`, the match is on the opposite of the `match` method and value. Default is `false`.
+* `match` - (Optional) The method and value to match the header value sent with a request. Specify one match method.
+
+The `header`'s `match` object supports the following:
+
+* `exact` - (Optional) The header value sent by the client must match the specified value exactly.
+* `prefix` - (Optional) The header value sent by the client must begin with the specified characters.
+* `range`- (Optional) The object that specifies the range of numbers that the header value sent by the client must be included in.
+* `regex` - (Optional) The header value sent by the client must include the specified characters.
+* `suffix` - (Optional) The header value sent by the client must end with the specified characters.
+
+The `range` object supports the following:
+
+* `end` - (Required) The end of the range.
+* `start` - (Requited) The start of the range.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9802.
Replaces #9803, #9964.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_appmesh_route: Add `priority` and `header` attributes to support route priorities and HTTP header-based routing
```

Output from acceptance testing:

```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAppmesh'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAppmesh -timeout 120m
go: finding github.com/terraform-providers/terraform-provider-tls v2.1.1+incompatible
go: finding github.com/terraform-providers/terraform-provider-tls v2.1.1+incompatible
=== RUN   TestAccAWSAppmesh
=== RUN   TestAccAWSAppmesh/VirtualRouter
=== RUN   TestAccAWSAppmesh/VirtualRouter/basic
=== RUN   TestAccAWSAppmesh/VirtualRouter/tags
=== RUN   TestAccAWSAppmesh/VirtualService
=== RUN   TestAccAWSAppmesh/VirtualService/virtualNode
=== RUN   TestAccAWSAppmesh/VirtualService/virtualRouter
=== RUN   TestAccAWSAppmesh/VirtualService/tags
=== RUN   TestAccAWSAppmesh/Mesh
=== RUN   TestAccAWSAppmesh/Mesh/basic
=== RUN   TestAccAWSAppmesh/Mesh/egressFilter
=== RUN   TestAccAWSAppmesh/Mesh/tags
=== RUN   TestAccAWSAppmesh/Route
=== RUN   TestAccAWSAppmesh/Route/routePriority
=== RUN   TestAccAWSAppmesh/Route/tags
=== RUN   TestAccAWSAppmesh/Route/httpHeader
=== RUN   TestAccAWSAppmesh/Route/httpRoute
=== RUN   TestAccAWSAppmesh/Route/tcpRoute
=== RUN   TestAccAWSAppmesh/VirtualNode
=== RUN   TestAccAWSAppmesh/VirtualNode/basic
=== RUN   TestAccAWSAppmesh/VirtualNode/cloudMapServiceDiscovery
=== RUN   TestAccAWSAppmesh/VirtualNode/listenerHealthChecks
=== RUN   TestAccAWSAppmesh/VirtualNode/logging
=== RUN   TestAccAWSAppmesh/VirtualNode/tags
--- PASS: TestAccAWSAppmesh (752.19s)
    --- PASS: TestAccAWSAppmesh/VirtualRouter (83.46s)
        --- PASS: TestAccAWSAppmesh/VirtualRouter/basic (34.89s)
        --- PASS: TestAccAWSAppmesh/VirtualRouter/tags (48.57s)
    --- PASS: TestAccAWSAppmesh/VirtualService (130.40s)
        --- PASS: TestAccAWSAppmesh/VirtualService/virtualNode (39.33s)
        --- PASS: TestAccAWSAppmesh/VirtualService/virtualRouter (36.55s)
        --- PASS: TestAccAWSAppmesh/VirtualService/tags (54.52s)
    --- PASS: TestAccAWSAppmesh/Mesh (95.06s)
        --- PASS: TestAccAWSAppmesh/Mesh/basic (17.70s)
        --- PASS: TestAccAWSAppmesh/Mesh/egressFilter (36.11s)
        --- PASS: TestAccAWSAppmesh/Mesh/tags (41.25s)
    --- PASS: TestAccAWSAppmesh/Route (198.89s)
        --- PASS: TestAccAWSAppmesh/Route/routePriority (39.47s)
        --- PASS: TestAccAWSAppmesh/Route/tags (40.73s)
        --- PASS: TestAccAWSAppmesh/Route/httpHeader (39.52s)
        --- PASS: TestAccAWSAppmesh/Route/httpRoute (39.84s)
        --- PASS: TestAccAWSAppmesh/Route/tcpRoute (39.34s)
    --- PASS: TestAccAWSAppmesh/VirtualNode (244.38s)
        --- PASS: TestAccAWSAppmesh/VirtualNode/basic (20.96s)
        --- PASS: TestAccAWSAppmesh/VirtualNode/cloudMapServiceDiscovery (106.20s)
        --- PASS: TestAccAWSAppmesh/VirtualNode/listenerHealthChecks (34.43s)
        --- PASS: TestAccAWSAppmesh/VirtualNode/logging (34.27s)
        --- PASS: TestAccAWSAppmesh/VirtualNode/tags (48.51s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	752.208s
```
