### PR TITLE
tests/service/kafka: Update removed Kafka version

### DIFF
--- a/aws/data_source_aws_msk_cluster_test.go
+++ b/aws/data_source_aws_msk_cluster_test.go
@@ -39,7 +39,7 @@ func testAccMskClusterDataSourceConfigName(rName string) string {
 	return testAccMskClusterBaseConfig() + fmt.Sprintf(`
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
-  kafka_version          = "2.1.0"
+  kafka_version          = "2.2.1"
   number_of_broker_nodes = 3
 
   broker_node_group_info {

--- a/aws/resource_aws_msk_cluster_test.go
+++ b/aws/resource_aws_msk_cluster_test.go
@@ -91,7 +91,7 @@ func TestAccAWSMskCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "encryption_info.0.encryption_in_transit.0.client_broker", "TLS_PLAINTEXT"),
 					resource.TestCheckResourceAttr(resourceName, "encryption_info.0.encryption_in_transit.0.in_cluster", "true"),
 					resource.TestCheckResourceAttr(resourceName, "enhanced_monitoring", kafka.EnhancedMonitoringDefault),
-					resource.TestCheckResourceAttr(resourceName, "kafka_version", "2.1.0"),
+					resource.TestCheckResourceAttr(resourceName, "kafka_version", "2.2.1"),
 					resource.TestCheckResourceAttr(resourceName, "number_of_broker_nodes", "3"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestMatchResourceAttr(resourceName, "zookeeper_connect_string", regexp.MustCompile(`^\d+\.\d+\.\d+\.\d+:\d+,\d+\.\d+\.\d+\.\d+:\d+,\d+\.\d+\.\d+\.\d+:\d+$`)),
@@ -595,7 +595,7 @@ func testAccMskClusterConfig_basic(rName string) string {
 	return testAccMskClusterBaseConfig() + fmt.Sprintf(`
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
-  kafka_version          = "2.1.0"
+  kafka_version          = "2.2.1"
   number_of_broker_nodes = 3
 
   broker_node_group_info {
@@ -612,7 +612,7 @@ func testAccMskClusterConfigBrokerNodeGroupInfoEbsVolumeSize(rName string, ebsVo
 	return testAccMskClusterBaseConfig() + fmt.Sprintf(`
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
-  kafka_version          = "2.1.0"
+  kafka_version          = "2.2.1"
   number_of_broker_nodes = 3
 
   broker_node_group_info {
@@ -640,7 +640,7 @@ resource "aws_acmpca_certificate_authority" "test" {
 
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
-  kafka_version          = "2.1.0"
+  kafka_version          = "2.2.1"
   number_of_broker_nodes = 3
 
   broker_node_group_info {
@@ -668,7 +668,7 @@ resource "aws_msk_cluster" "test" {
 func testAccMskClusterConfigConfigurationInfoRevision1(rName string) string {
 	return testAccMskClusterBaseConfig() + fmt.Sprintf(`
 resource "aws_msk_configuration" "test" {
-  kafka_versions = ["2.1.0"]
+  kafka_versions = ["2.2.1"]
   name           = "%[1]s-1"
 
   server_properties = <<PROPERTIES
@@ -678,7 +678,7 @@ PROPERTIES
 
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
-  kafka_version          = "2.1.0"
+  kafka_version          = "2.2.1"
   number_of_broker_nodes = 3
 
   broker_node_group_info {
@@ -699,7 +699,7 @@ resource "aws_msk_cluster" "test" {
 func testAccMskClusterConfigConfigurationInfoRevision2(rName string) string {
 	return testAccMskClusterBaseConfig() + fmt.Sprintf(`
 resource "aws_msk_configuration" "test" {
-  kafka_versions = ["2.1.0"]
+  kafka_versions = ["2.2.1"]
   name           = "%[1]s-2"
 
   server_properties = <<PROPERTIES
@@ -709,7 +709,7 @@ PROPERTIES
 
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
-  kafka_version          = "2.1.0"
+  kafka_version          = "2.2.1"
   number_of_broker_nodes = 3
 
   broker_node_group_info {
@@ -739,7 +739,7 @@ resource "aws_kms_key" "example_key" {
 
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
-  kafka_version          = "2.1.0"
+  kafka_version          = "2.2.1"
   number_of_broker_nodes = 3
 
   broker_node_group_info {
@@ -761,7 +761,7 @@ func testAccMskClusterConfigEncryptionInfoEncryptionInTransitClientBroker(rName,
 	return testAccMskClusterBaseConfig() + fmt.Sprintf(`
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
-  kafka_version          = "2.1.0"
+  kafka_version          = "2.2.1"
   number_of_broker_nodes = 3
 
   broker_node_group_info {
@@ -784,7 +784,7 @@ func testAccMskClusterConfigEncryptionInfoEncryptionInTransitInCluster(rName str
 	return testAccMskClusterBaseConfig() + fmt.Sprintf(`
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
-  kafka_version          = "2.1.0"
+  kafka_version          = "2.2.1"
   number_of_broker_nodes = 3
 
   broker_node_group_info {
@@ -808,7 +808,7 @@ func testAccMskClusterConfigEnhancedMonitoring(rName, enhancedMonitoring string)
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
   enhanced_monitoring    = %[2]q
-  kafka_version          = "2.1.0"
+  kafka_version          = "2.2.1"
   number_of_broker_nodes = 3
 
   broker_node_group_info {
@@ -826,7 +826,7 @@ func testAccMskClusterConfigNumberOfBrokerNodes(rName string) string {
 	return testAccMskClusterBaseConfig() + fmt.Sprintf(`
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
-  kafka_version          = "2.1.0"
+  kafka_version          = "2.2.1"
   number_of_broker_nodes = 6
 
   broker_node_group_info {
@@ -844,7 +844,7 @@ func testAccMskClusterConfigTags1(rName string) string {
 	return testAccMskClusterBaseConfig() + fmt.Sprintf(`
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
-  kafka_version          = "2.1.0"
+  kafka_version          = "2.2.1"
   number_of_broker_nodes = 3
 
   broker_node_group_info {
@@ -865,7 +865,7 @@ func testAccMskClusterConfigTags2(rName string) string {
 	return testAccMskClusterBaseConfig() + fmt.Sprintf(`
 resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
-  kafka_version          = "2.1.0"
+  kafka_version          = "2.2.1"
   number_of_broker_nodes = 3
 
   broker_node_group_info {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

There is no API for fetching available versions, so manually updating the test configurations. This API removal was not included in the [2.2.1 announcement](https://aws.amazon.com/about-aws/whats-new/2019/07/amazon-msk-adds-support-apache-kafka-version-221-expands-availability-stockholm-mumbai-seoul/).

Previously:

```
--- FAIL: TestAccAWSMskCluster_basic (8.39s)
    testing.go:569: Step 0 error: errors during apply:

        Error: error creating MSK cluster: BadRequestException: Unsupported KafkaVersion [2.1.0]. Valid values: [1.1.1, 2.2.1]
```

Output from acceptance testing in AWS Commercial (in an account that hasn't reached the MSK Configuration quota and now correctly shows failures relating to the default client broker encryption changing from TLS_PLAINTEXT to TLS after launch):

```
--- FAIL: TestAccAWSMskCluster_basic (756.44s)
    testing.go:569: Step 0 error: Check failed: Check 3/27 error: aws_msk_cluster.test: Attribute 'bootstrap_brokers' didn't match "^(([-\\w]+\\.){1,}[\\w]+:\\d+,){2,}([-\\w]+\\.){1,}[\\w]+:\\d+$", got ""
```

Which can/should be addressed separately.