### PR TITLE
tests/service/elasticsearchservice: Add PreCheck for IAM SLR, use Cognito PreCheck, refactor to be more region/partition agnostic

### DIFF
--- a/aws/data_source_aws_elasticsearch_domain_test.go
+++ b/aws/data_source_aws_elasticsearch_domain_test.go
@@ -14,7 +14,7 @@ func TestAccAWSDataElasticsearchDomain_basic(t *testing.T) {
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckIamServiceLinkedRoleEs(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -44,7 +44,7 @@ func TestAccAWSDataElasticsearchDomain_advanced(t *testing.T) {
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckIamServiceLinkedRoleEs(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/aws/data_source_aws_elasticsearch_domain_test.go
+++ b/aws/data_source_aws_elasticsearch_domain_test.go
@@ -102,7 +102,7 @@ resource "aws_elasticsearch_domain" "test" {
 POLICY
 
   cluster_config {
-    instance_type = "t2.micro.elasticsearch"
+    instance_type = "t2.small.elasticsearch"
     instance_count = 2
 	dedicated_master_enabled = false
 	zone_awareness_config {
@@ -219,7 +219,7 @@ resource "aws_elasticsearch_domain" "test" {
 POLICY
 
   cluster_config {
-    instance_type = "t2.micro.elasticsearch"
+    instance_type = "t2.small.elasticsearch"
     instance_count = 2
     dedicated_master_enabled = false
 	zone_awareness_config {

--- a/aws/data_source_aws_elasticsearch_domain_test.go
+++ b/aws/data_source_aws_elasticsearch_domain_test.go
@@ -72,10 +72,6 @@ func TestAccAWSDataElasticsearchDomain_advanced(t *testing.T) {
 
 func testAccAWSElasticsearchDomainConfigWithDataSource(rInt int) string {
 	return fmt.Sprintf(`
-provider "aws" {
-	region = "us-east-1"
-}
-
 locals {
 	random_name = "test-es-%d"
 }
@@ -132,9 +128,11 @@ data "aws_elasticsearch_domain" "test" {
 
 func testAccAWSElasticsearchDomainConfigAdvancedWithDataSource(rInt int) string {
 	return fmt.Sprintf(`
-provider "aws" {
-	region = "us-east-1"
+data "aws_availability_zones" "available" {
+  state = "available"
 }
+
+data "aws_partition" "current" {}
 
 data "aws_region" "current" {}
 
@@ -157,14 +155,14 @@ resource "aws_cloudwatch_log_resource_policy" "test" {
 		{
 			"Effect": "Allow",
 			"Principal": {
-				"Service": "es.amazonaws.com"
+				"Service": "es.${data.aws_partition.current.dns_suffix}"
 			},
 			"Action": [
 				"logs:PutLogEvents",
 				"logs:PutLogEventsBatch",
 				"logs:CreateLogStream"
 			],
-			"Resource": "arn:aws:logs:*"
+			"Resource": "arn:${data.aws_partition.current.partition}:logs:*"
 		}
 	]
 }
@@ -176,13 +174,15 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-	vpc_id = "${aws_vpc.test.id}"
-	cidr_block = "10.0.0.0/24"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  cidr_block        = "10.0.0.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
 }
 
 resource "aws_subnet" "test2" {
-	vpc_id = "${aws_vpc.test.id}"
-	cidr_block = "10.0.1.0/24"
+  availability_zone = "${data.aws_availability_zones.available.names[1]}"
+  cidr_block        = "10.0.1.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
 }
 
 resource "aws_security_group" "test" {
@@ -212,7 +212,7 @@ resource "aws_elasticsearch_domain" "test" {
 			"Action": "es:*",
 			"Principal": "*",
 			"Effect": "Allow",
-			"Resource": "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${local.random_name}/*"
+			"Resource": "arn:${data.aws_partition.current.partition}:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${local.random_name}/*"
 		}
 	]
 }

--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	elasticsearch "github.com/aws/aws-sdk-go/service/elasticsearchservice"
+	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -60,7 +62,7 @@ func TestAccAWSElasticSearchDomain_basic(t *testing.T) {
 	ri := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckIamServiceLinkedRoleEs(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{
@@ -83,7 +85,7 @@ func TestAccAWSElasticSearchDomain_ClusterConfig_ZoneAwarenessConfig(t *testing.
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckIamServiceLinkedRoleEs(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{
@@ -140,7 +142,7 @@ func TestAccAWSElasticSearchDomain_withDedicatedMaster(t *testing.T) {
 	ri := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckIamServiceLinkedRoleEs(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{
@@ -172,7 +174,7 @@ func TestAccAWSElasticSearchDomain_duplicate(t *testing.T) {
 	name := fmt.Sprintf("tf-test-%d", ri)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckIamServiceLinkedRoleEs(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(s *terraform.State) error {
 			conn := testAccProvider.Meta().(*AWSClient).esconn
@@ -220,7 +222,7 @@ func TestAccAWSElasticSearchDomain_importBasic(t *testing.T) {
 	resourceId := fmt.Sprintf("tf-test-%d", ri)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckIamServiceLinkedRoleEs(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{
@@ -242,7 +244,7 @@ func TestAccAWSElasticSearchDomain_v23(t *testing.T) {
 	ri := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckIamServiceLinkedRoleEs(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{
@@ -263,7 +265,7 @@ func TestAccAWSElasticSearchDomain_complex(t *testing.T) {
 	ri := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckIamServiceLinkedRoleEs(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{
@@ -282,7 +284,7 @@ func TestAccAWSElasticSearchDomain_vpc(t *testing.T) {
 	ri := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckIamServiceLinkedRoleEs(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{
@@ -301,7 +303,7 @@ func TestAccAWSElasticSearchDomain_vpc_update(t *testing.T) {
 	ri := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckIamServiceLinkedRoleEs(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{
@@ -328,7 +330,7 @@ func TestAccAWSElasticSearchDomain_internetToVpcEndpoint(t *testing.T) {
 	ri := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckIamServiceLinkedRoleEs(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{
@@ -351,7 +353,7 @@ func TestAccAWSElasticSearchDomain_internetToVpcEndpoint(t *testing.T) {
 func TestAccAWSElasticSearchDomain_LogPublishingOptions(t *testing.T) {
 	var domain elasticsearch.ElasticsearchDomainStatus
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckIamServiceLinkedRoleEs(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{
@@ -370,7 +372,7 @@ func TestAccAWSElasticSearchDomain_CognitoOptionsCreateAndRemove(t *testing.T) {
 	ri := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckIamServiceLinkedRoleEs(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{
@@ -397,7 +399,7 @@ func TestAccAWSElasticSearchDomain_CognitoOptionsUpdate(t *testing.T) {
 	ri := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckIamServiceLinkedRoleEs(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{
@@ -433,7 +435,7 @@ func TestAccAWSElasticSearchDomain_policy(t *testing.T) {
 	var domain elasticsearch.ElasticsearchDomainStatus
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckIamServiceLinkedRoleEs(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{
@@ -451,7 +453,7 @@ func TestAccAWSElasticSearchDomain_encrypt_at_rest_default_key(t *testing.T) {
 	var domain elasticsearch.ElasticsearchDomainStatus
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckIamServiceLinkedRoleEs(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{
@@ -470,7 +472,7 @@ func TestAccAWSElasticSearchDomain_encrypt_at_rest_specify_key(t *testing.T) {
 	var domain elasticsearch.ElasticsearchDomainStatus
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckIamServiceLinkedRoleEs(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{
@@ -489,7 +491,7 @@ func TestAccAWSElasticSearchDomain_NodeToNodeEncryption(t *testing.T) {
 	var domain elasticsearch.ElasticsearchDomainStatus
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckIamServiceLinkedRoleEs(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{
@@ -510,7 +512,7 @@ func TestAccAWSElasticSearchDomain_tags(t *testing.T) {
 	ri := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckIamServiceLinkedRoleEs(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSELBDestroy,
 		Steps: []resource.TestStep{
@@ -539,7 +541,7 @@ func TestAccAWSElasticSearchDomain_update(t *testing.T) {
 	ri := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckIamServiceLinkedRoleEs(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{
@@ -567,7 +569,7 @@ func TestAccAWSElasticSearchDomain_update_volume_type(t *testing.T) {
 	ri := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckIamServiceLinkedRoleEs(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{
@@ -602,7 +604,7 @@ func TestAccAWSElasticSearchDomain_update_version(t *testing.T) {
 	ri := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckIamServiceLinkedRoleEs(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{
@@ -792,6 +794,38 @@ func testAccCheckESDomainDestroy(s *terraform.State) error {
 		}
 	}
 	return nil
+}
+
+func testAccPreCheckIamServiceLinkedRoleEs(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).iamconn
+	dnsSuffix := testAccProvider.Meta().(*AWSClient).dnsSuffix
+
+	input := &iam.ListRolesInput{
+		PathPrefix: aws.String("/aws-service-role/es."),
+	}
+
+	var role *iam.Role
+	err := conn.ListRolesPages(input, func(page *iam.ListRolesOutput, lastPage bool) bool {
+		for _, r := range page.Roles {
+			if strings.HasPrefix(aws.StringValue(r.Path), "/aws-service-role/es.") {
+				role = r
+			}
+		}
+
+		return !lastPage
+	})
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+
+	if role == nil {
+		t.Fatalf("missing IAM Service Linked Role (es.%s), please create it in the AWS account and retry", dnsSuffix)
+	}
 }
 
 func testAccESDomainConfig(randInt int) string {

--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -372,7 +372,11 @@ func TestAccAWSElasticSearchDomain_CognitoOptionsCreateAndRemove(t *testing.T) {
 	ri := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckIamServiceLinkedRoleEs(t) },
+		PreCheck:     func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSCognitoIdentityProvider(t)
+			testAccPreCheckIamServiceLinkedRoleEs(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{
@@ -399,7 +403,11 @@ func TestAccAWSElasticSearchDomain_CognitoOptionsUpdate(t *testing.T) {
 	ri := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckIamServiceLinkedRoleEs(t) },
+		PreCheck:     func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSCognitoIdentityProvider(t)
+			testAccPreCheckIamServiceLinkedRoleEs(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -372,7 +372,7 @@ func TestAccAWSElasticSearchDomain_CognitoOptionsCreateAndRemove(t *testing.T) {
 	ri := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() {
+		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSCognitoIdentityProvider(t)
 			testAccPreCheckIamServiceLinkedRoleEs(t)
@@ -403,7 +403,7 @@ func TestAccAWSElasticSearchDomain_CognitoOptionsUpdate(t *testing.T) {
 	ri := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() {
+		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSCognitoIdentityProvider(t)
 			testAccPreCheckIamServiceLinkedRoleEs(t)
@@ -855,7 +855,7 @@ resource "aws_elasticsearch_domain" "test" {
   domain_name = %[1]q
 
   cluster_config {
-    instance_type          = "t2.micro.elasticsearch"
+    instance_type          = "t2.small.elasticsearch"
     instance_count         = 6
     zone_awareness_enabled = true
 
@@ -878,7 +878,7 @@ resource "aws_elasticsearch_domain" "test" {
   domain_name = %[1]q
 
   cluster_config {
-    instance_type          = "t2.micro.elasticsearch"
+    instance_type          = "t2.small.elasticsearch"
     instance_count         = 6
     zone_awareness_enabled = %[2]t
   }
@@ -897,11 +897,11 @@ resource "aws_elasticsearch_domain" "example" {
   domain_name = "tf-test-%d"
 
   cluster_config {
-    instance_type            = "t2.micro.elasticsearch"
+    instance_type            = "t2.small.elasticsearch"
     instance_count           = "1"
     dedicated_master_enabled = %t
     dedicated_master_count   = "3"
-    dedicated_master_type    = "t2.micro.elasticsearch"
+    dedicated_master_type    = "t2.small.elasticsearch"
   }
 
   ebs_options {
@@ -929,7 +929,7 @@ resource "aws_elasticsearch_domain" "example" {
   cluster_config {
     instance_count         = %d
     zone_awareness_enabled = true
-    instance_type          = "t2.micro.elasticsearch"
+    instance_type          = "t2.small.elasticsearch"
   }
 
   snapshot_options {
@@ -1161,13 +1161,14 @@ resource "aws_elasticsearch_domain" "example" {
   }
 
   ebs_options {
-    ebs_enabled = false
+    ebs_enabled = true
+    volume_size = 10
   }
 
   cluster_config {
     instance_count         = 2
     zone_awareness_enabled = true
-    instance_type          = "m3.medium.elasticsearch"
+    instance_type          = "t2.small.elasticsearch"
   }
 
   snapshot_options {
@@ -1242,13 +1243,14 @@ resource "aws_elasticsearch_domain" "example" {
   domain_name = "tf-test-%d"
 
   ebs_options {
-    ebs_enabled = false
+    ebs_enabled = true
+    volume_size = 10
   }
 
   cluster_config {
     instance_count         = 2
     zone_awareness_enabled = true
-    instance_type          = "m3.medium.elasticsearch"
+    instance_type          = "t2.small.elasticsearch"
   }
 
   vpc_options {
@@ -1334,13 +1336,14 @@ resource "aws_elasticsearch_domain" "example" {
   domain_name = "tf-test-%d"
 
   ebs_options {
-    ebs_enabled = false
+    ebs_enabled = true
+    volume_size = 10
   }
 
   cluster_config {
     instance_count         = 2
     zone_awareness_enabled = true
-    instance_type          = "m3.medium.elasticsearch"
+    instance_type          = "t2.small.elasticsearch"
   }
 
   vpc_options {
@@ -1404,7 +1407,7 @@ resource "aws_elasticsearch_domain" "example" {
   cluster_config {
     instance_count         = 2
     zone_awareness_enabled = true
-    instance_type          = "t2.micro.elasticsearch"
+    instance_type          = "t2.small.elasticsearch"
   }
 
   vpc_options {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/10035#pullrequestreview-285218537

Now fails when IAM SLR is missing:

```
--- FAIL: TestAccAWSElasticSearchDomain_basic (1.41s)
    resource_aws_elasticsearch_domain_test.go:827: missing IAM Service Linked Role (es.amazonaws.com), please create it in the AWS account and retry
```

Fixes the previous issue where multiple `aws_subnet` resources in the test configuration could be created in the same availablility zone:

```
--- FAIL: TestAccAWSDataElasticsearchDomain_advanced (123.93s)
    testing.go:569: Step 0 error: errors during apply:

        Error: ValidationException: Each subnet must be in its own Availability Zone.
```

Fixes the unavailable instance types in AWS GovCloud (US):

```
--- FAIL: TestAccAWSDataElasticsearchDomain_basic (11.82s)
    testing.go:569: Step 0 error: errors during apply:

        Error: Error creating ElasticSearch domain: InvalidTypeException: Invalid instance type: t2.micro.elasticsearch

--- FAIL: TestAccAWSElasticSearchDomain_vpc (29.57s)
    testing.go:569: Step 0 error: errors during apply:

        Error: Error creating ElasticSearch domain: InvalidTypeException: Invalid instance type: m3.medium.elasticsearch
```

The test failures below are unrelated to this refactoring work and outside this timeboxed test fixing.

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSElasticSearchDomain_duplicate (474.12s)
--- PASS: TestAccAWSElasticSearchDomain_LogPublishingOptions (683.94s)
--- PASS: TestAccAWSDataElasticsearchDomain_basic (776.88s)
--- PASS: TestAccAWSElasticSearchDomain_encrypt_at_rest_default_key (1080.62s)
--- PASS: TestAccAWSElasticSearchDomain_policy (1085.77s)
--- PASS: TestAccAWSElasticSearchDomain_tags (1200.87s)
--- PASS: TestAccAWSDataElasticsearchDomain_advanced (1286.42s)
--- PASS: TestAccAWSElasticSearchDomain_encrypt_at_rest_specify_key (1359.59s)
--- PASS: TestAccAWSElasticSearchDomain_complex (863.71s)
--- PASS: TestAccAWSElasticSearchDomain_vpc (1197.43s)
--- FAIL: TestAccAWSElasticSearchDomain_update_version (1853.26s)
    testing.go:569: Step 1 error: errors during apply:

        Error: unexpected state '', wanted target 'SUCCEEDED'. last error: %!s(<nil>)

          on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test840863232/main.tf line 2:
          (source code not available)

--- PASS: TestAccAWSElasticSearchDomain_importBasic (1926.44s)
--- PASS: TestAccAWSElasticSearchDomain_v23 (1933.81s)
--- PASS: TestAccAWSElasticSearchDomain_update (2150.40s)
--- PASS: TestAccAWSElasticSearchDomain_basic (1572.62s)
--- PASS: TestAccAWSElasticSearchDomain_internetToVpcEndpoint (2532.29s)
--- PASS: TestAccAWSElasticSearchDomain_CognitoOptionsCreateAndRemove (2569.90s)
--- PASS: TestAccAWSElasticSearchDomain_NodeToNodeEncryption (2828.32s)
--- PASS: TestAccAWSElasticSearchDomain_vpc_update (2847.08s)
--- PASS: TestAccAWSElasticSearchDomain_withDedicatedMaster (3432.49s)
--- PASS: TestAccAWSElasticSearchDomain_update_volume_type (3918.28s)
--- PASS: TestAccAWSElasticSearchDomain_CognitoOptionsUpdate (4135.44s)
--- PASS: TestAccAWSElasticSearchDomain_ClusterConfig_ZoneAwarenessConfig (4836.72s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- SKIP: TestAccAWSElasticSearchDomain_CognitoOptionsUpdate (23.74s)
    resource_aws_cognito_user_pool_test.go:760: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSElasticSearchDomain_CognitoOptionsCreateAndRemove (29.73s)
    resource_aws_cognito_user_pool_test.go:760: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
--- PASS: TestAccAWSElasticSearchDomain_duplicate (396.68s)
--- PASS: TestAccAWSElasticSearchDomain_complex (635.22s)
--- PASS: TestAccAWSElasticSearchDomain_policy (636.07s)
--- PASS: TestAccAWSElasticSearchDomain_NodeToNodeEncryption (705.29s)
--- PASS: TestAccAWSElasticSearchDomain_v23 (702.20s)
--- PASS: TestAccAWSDataElasticsearchDomain_basic (755.19s)
--- FAIL: TestAccAWSElasticSearchDomain_update_version (900.69s)
    testing.go:569: Step 1 error: Check failed: Check 3/3 error: aws_elasticsearch_domain.example: Attribute 'elasticsearch_version' expected "5.6", got "5.5"
--- PASS: TestAccAWSElasticSearchDomain_importBasic (879.55s)
--- PASS: TestAccAWSElasticSearchDomain_basic (1091.51s)
--- PASS: TestAccAWSElasticSearchDomain_encrypt_at_rest_specify_key (1117.72s)
--- PASS: TestAccAWSElasticSearchDomain_LogPublishingOptions (1135.15s)
--- PASS: TestAccAWSElasticSearchDomain_vpc (1143.39s)
--- PASS: TestAccAWSElasticSearchDomain_tags (1147.12s)
--- PASS: TestAccAWSDataElasticsearchDomain_advanced (1173.96s)
--- PASS: TestAccAWSElasticSearchDomain_internetToVpcEndpoint (1603.77s)
--- PASS: TestAccAWSElasticSearchDomain_vpc_update (1918.00s)
--- PASS: TestAccAWSElasticSearchDomain_update_volume_type (2939.14s)
--- PASS: TestAccAWSElasticSearchDomain_withDedicatedMaster (3658.41s)
```
