### PR TITLE
Acceptance test import refactor for EFS resources

### DIFF
--- a/aws/resource_aws_efs_file_system_test.go
+++ b/aws/resource_aws_efs_file_system_test.go
@@ -35,9 +35,9 @@ func TestResourceAWSEFSFileSystem_hasEmptyFileSystems(t *testing.T) {
 
 }
 
-func TestAccAWSEFSFileSystem_importBasic(t *testing.T) {
-	resourceName := "aws_efs_file_system.foo-with-tags"
+func TestAccAWSEFSFileSystem_basic(t *testing.T) {
 	rInt := acctest.RandInt()
+	resourceName := "aws_efs_file_system.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -45,7 +45,100 @@ func TestAccAWSEFSFileSystem_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckEfsFileSystemDestroy,
 		Steps: []resource.TestStep{
 			{
+				Config: testAccAWSEFSFileSystemConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccMatchResourceAttrRegionalARN("aws_efs_file_system.test", "arn", "elasticfilesystem", regexp.MustCompile(`file-system/fs-.+`)),
+					resource.TestCheckResourceAttr(
+						"aws_efs_file_system.test",
+						"performance_mode",
+						"generalPurpose"),
+					resource.TestCheckResourceAttr(
+						"aws_efs_file_system.test",
+						"throughput_mode",
+						efs.ThroughputModeBursting),
+					testAccCheckEfsFileSystem(
+						"aws_efs_file_system.test",
+					),
+					testAccCheckEfsFileSystemPerformanceMode(
+						"aws_efs_file_system.test",
+						"generalPurpose",
+					),
+					resource.TestMatchResourceAttr(
+						"aws_efs_file_system.test",
+						"dns_name",
+						regexp.MustCompile("^[^.]+.efs.us-west-2.amazonaws.com$"),
+					),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"creation_token"},
+			},
+			{
 				Config: testAccAWSEFSFileSystemConfigWithTags(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEfsFileSystem(
+						"aws_efs_file_system.test",
+					),
+					testAccCheckEfsFileSystemPerformanceMode(
+						"aws_efs_file_system.test",
+						"generalPurpose",
+					),
+					testAccCheckEfsFileSystemTags(
+						"aws_efs_file_system.test",
+						map[string]string{
+							"Name":    fmt.Sprintf("test-efs-%d", rInt),
+							"Another": "tag",
+						},
+					),
+				),
+			},
+			{
+				Config: testAccAWSEFSFileSystemConfigWithPerformanceMode,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEfsFileSystem(
+						"aws_efs_file_system.test2",
+					),
+					testAccCheckEfsCreationToken(
+						"aws_efs_file_system.test2",
+						"supercalifragilisticexpialidocious",
+					),
+					testAccCheckEfsFileSystemPerformanceMode(
+						"aws_efs_file_system.test2",
+						"maxIO",
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEFSFileSystem_pagedTags(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "aws_efs_file_system.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckEfsFileSystemDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEFSFileSystemConfigPagedTags(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"aws_efs_file_system.test",
+						"tags.%",
+						"11"),
+					//testAccCheckEfsFileSystem(
+					//	"aws_efs_file_system.test",
+					//),
+					//testAccCheckEfsFileSystemPerformanceMode(
+					//	"aws_efs_file_system.test",
+					//	"generalPurpose",
+					//),
+				),
 			},
 			{
 				ResourceName:            resourceName,
@@ -57,108 +150,10 @@ func TestAccAWSEFSFileSystem_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccAWSEFSFileSystem_basic(t *testing.T) {
-	rInt := acctest.RandInt()
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckEfsFileSystemDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSEFSFileSystemConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccMatchResourceAttrRegionalARN("aws_efs_file_system.foo", "arn", "elasticfilesystem", regexp.MustCompile(`file-system/fs-.+`)),
-					resource.TestCheckResourceAttr(
-						"aws_efs_file_system.foo",
-						"performance_mode",
-						"generalPurpose"),
-					resource.TestCheckResourceAttr(
-						"aws_efs_file_system.foo",
-						"throughput_mode",
-						efs.ThroughputModeBursting),
-					testAccCheckEfsFileSystem(
-						"aws_efs_file_system.foo",
-					),
-					testAccCheckEfsFileSystemPerformanceMode(
-						"aws_efs_file_system.foo",
-						"generalPurpose",
-					),
-					resource.TestMatchResourceAttr(
-						"aws_efs_file_system.foo",
-						"dns_name",
-						regexp.MustCompile("^[^.]+.efs.us-west-2.amazonaws.com$"),
-					),
-				),
-			},
-			{
-				Config: testAccAWSEFSFileSystemConfigWithTags(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystem(
-						"aws_efs_file_system.foo-with-tags",
-					),
-					testAccCheckEfsFileSystemPerformanceMode(
-						"aws_efs_file_system.foo-with-tags",
-						"generalPurpose",
-					),
-					testAccCheckEfsFileSystemTags(
-						"aws_efs_file_system.foo-with-tags",
-						map[string]string{
-							"Name":    fmt.Sprintf("foo-efs-%d", rInt),
-							"Another": "tag",
-						},
-					),
-				),
-			},
-			{
-				Config: testAccAWSEFSFileSystemConfigWithPerformanceMode,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsFileSystem(
-						"aws_efs_file_system.foo-with-performance-mode",
-					),
-					testAccCheckEfsCreationToken(
-						"aws_efs_file_system.foo-with-performance-mode",
-						"supercalifragilisticexpialidocious",
-					),
-					testAccCheckEfsFileSystemPerformanceMode(
-						"aws_efs_file_system.foo-with-performance-mode",
-						"maxIO",
-					),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSEFSFileSystem_pagedTags(t *testing.T) {
-	rInt := acctest.RandInt()
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckEfsFileSystemDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSEFSFileSystemConfigPagedTags(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"aws_efs_file_system.foo",
-						"tags.%",
-						"11"),
-					//testAccCheckEfsFileSystem(
-					//	"aws_efs_file_system.foo",
-					//),
-					//testAccCheckEfsFileSystemPerformanceMode(
-					//	"aws_efs_file_system.foo",
-					//	"generalPurpose",
-					//),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAWSEFSFileSystem_kmsKey(t *testing.T) {
 	rInt := acctest.RandInt()
-	kmsKeyResourceName := "aws_kms_key.foo"
+	kmsKeyResourceName := "aws_kms_key.test"
+	resourceName := "aws_efs_file_system.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -168,9 +163,15 @@ func TestAccAWSEFSFileSystem_kmsKey(t *testing.T) {
 			{
 				Config: testAccAWSEFSFileSystemConfigWithKmsKey(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair("aws_efs_file_system.foo-with-kms", "kms_key_id", kmsKeyResourceName, "arn"),
-					resource.TestCheckResourceAttr("aws_efs_file_system.foo-with-kms", "encrypted", "true"),
+					resource.TestCheckResourceAttrPair("aws_efs_file_system.test", "kms_key_id", kmsKeyResourceName, "arn"),
+					resource.TestCheckResourceAttr("aws_efs_file_system.test", "encrypted", "true"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"creation_token"},
 			},
 		},
 	})
@@ -261,7 +262,7 @@ func TestAccAWSEFSFileSystem_ThroughputMode(t *testing.T) {
 }
 
 func TestAccAWSEFSFileSystem_lifecyclePolicy(t *testing.T) {
-	resourceName := "aws_efs_file_system.foo-with-lifecycle-policy"
+	resourceName := "aws_efs_file_system.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -306,7 +307,7 @@ func TestAccAWSEFSFileSystem_lifecyclePolicy(t *testing.T) {
 }
 
 func TestAccAWSEFSFileSystem_lifecyclePolicy_update(t *testing.T) {
-	resourceName := "aws_efs_file_system.foo-with-lifecycle-policy"
+	resourceName := "aws_efs_file_system.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -343,7 +344,7 @@ func TestAccAWSEFSFileSystem_lifecyclePolicy_update(t *testing.T) {
 }
 
 func TestAccAWSEFSFileSystem_lifecyclePolicy_removal(t *testing.T) {
-	resourceName := "aws_efs_file_system.foo-with-lifecycle-policy"
+	resourceName := "aws_efs_file_system.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -552,16 +553,16 @@ func testAccCheckEfsFileSystemLifecyclePolicy(resourceID string, expectedVal str
 }
 
 const testAccAWSEFSFileSystemConfig = `
-resource "aws_efs_file_system" "foo" {
+resource "aws_efs_file_system" "test" {
 	creation_token = "radeksimko"
 }
 `
 
 func testAccAWSEFSFileSystemConfigPagedTags(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_efs_file_system" "foo" {
+resource "aws_efs_file_system" "test" {
   tags = {
-    Name           = "foo-efs-%d"
+    Name           = "test-efs-%d"
     Another        = "tag"
     Test           = "yes"
     User           = "root"
@@ -579,9 +580,9 @@ resource "aws_efs_file_system" "foo" {
 
 func testAccAWSEFSFileSystemConfigWithTags(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_efs_file_system" "foo-with-tags" {
+resource "aws_efs_file_system" "test" {
   tags = {
-    Name    = "foo-efs-%d"
+    Name    = "test-efs-%d"
     Another = "tag"
   }
 }
@@ -589,7 +590,7 @@ resource "aws_efs_file_system" "foo-with-tags" {
 }
 
 const testAccAWSEFSFileSystemConfigWithPerformanceMode = `
-resource "aws_efs_file_system" "foo-with-performance-mode" {
+resource "aws_efs_file_system" "test2" {
 	creation_token = "supercalifragilisticexpialidocious"
 	performance_mode = "maxIO"
 }
@@ -597,26 +598,26 @@ resource "aws_efs_file_system" "foo-with-performance-mode" {
 
 func testAccAWSEFSFileSystemConfigWithKmsKey(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_kms_key" "foo" {
+resource "aws_kms_key" "test" {
   description = "Terraform acc test %d"
 }
 
-resource "aws_efs_file_system" "foo-with-kms" {
+resource "aws_efs_file_system" "test" {
   encrypted  = true
-  kms_key_id = "${aws_kms_key.foo.arn}"
+  kms_key_id = "${aws_kms_key.test.arn}"
 }
 `, rInt)
 }
 
 func testAccAWSEFSFileSystemConfigWithKmsKeyNoEncryption(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_kms_key" "foo" {
+resource "aws_kms_key" "test" {
   description = "Terraform acc test %d"
 }
 
-resource "aws_efs_file_system" "foo-with-kms" {
+resource "aws_efs_file_system" "test" {
   encrypted  = false
-  kms_key_id = "${aws_kms_key.foo.arn}"
+  kms_key_id = "${aws_kms_key.test.arn}"
 }
 `, rInt)
 }
@@ -640,7 +641,7 @@ resource "aws_efs_file_system" "test" {
 
 func testAccAWSEFSFileSystemConfigWithLifecyclePolicy(lpName string, lpVal string) string {
 	return fmt.Sprintf(`
-resource "aws_efs_file_system" "foo-with-lifecycle-policy" {
+resource "aws_efs_file_system" "test" {
   lifecycle_policy {
     %s = %q
   }
@@ -649,5 +650,5 @@ resource "aws_efs_file_system" "foo-with-lifecycle-policy" {
 }
 
 const testAccAWSEFSFileSystemConfigRemovedLifecyclePolicy = `
-resource "aws_efs_file_system" "foo-with-lifecycle-policy" {}
+resource "aws_efs_file_system" "test" {}
 `

--- a/aws/resource_aws_efs_mount_target_test.go
+++ b/aws/resource_aws_efs_mount_target_test.go
@@ -15,31 +15,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSEFSMountTarget_importBasic(t *testing.T) {
-	resourceName := "aws_efs_mount_target.alpha"
-
-	ct := fmt.Sprintf("createtoken-%d", acctest.RandInt())
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckEfsMountTargetDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSEFSMountTargetConfig(ct),
-			},
-
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAWSEFSMountTarget_basic(t *testing.T) {
 	var mount efs.MountTargetDescription
 	ct := fmt.Sprintf("createtoken-%d", acctest.RandInt())
+	resourceName := "aws_efs_mount_target.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -49,36 +28,41 @@ func TestAccAWSEFSMountTarget_basic(t *testing.T) {
 			{
 				Config: testAccAWSEFSMountTargetConfig(ct),
 				Check: resource.ComposeTestCheckFunc(
-					testAccMatchResourceAttrRegionalARN("aws_efs_mount_target.alpha", "file_system_arn", "elasticfilesystem", regexp.MustCompile(`file-system/fs-.+`)),
+					testAccMatchResourceAttrRegionalARN(resourceName, "file_system_arn", "elasticfilesystem", regexp.MustCompile(`file-system/fs-.+`)),
 					testAccCheckEfsMountTarget(
-						"aws_efs_mount_target.alpha",
+						resourceName,
 						&mount,
 					),
 					resource.TestMatchResourceAttr(
-						"aws_efs_mount_target.alpha",
+						resourceName,
 						"dns_name",
 						regexp.MustCompile("^[^.]+.efs.us-west-2.amazonaws.com$"),
 					),
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAWSEFSMountTargetConfigModified(ct),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEfsMountTarget(
-						"aws_efs_mount_target.alpha",
+						resourceName,
 						&mount,
 					),
 					resource.TestMatchResourceAttr(
-						"aws_efs_mount_target.alpha",
+						resourceName,
 						"dns_name",
 						regexp.MustCompile("^[^.]+.efs.us-west-2.amazonaws.com$"),
 					),
 					testAccCheckEfsMountTarget(
-						"aws_efs_mount_target.beta",
+						"aws_efs_mount_target.test2",
 						&mount,
 					),
 					resource.TestMatchResourceAttr(
-						"aws_efs_mount_target.beta",
+						"aws_efs_mount_target.test2",
 						"dns_name",
 						regexp.MustCompile("^[^.]+.efs.us-west-2.amazonaws.com$"),
 					),
@@ -90,7 +74,7 @@ func TestAccAWSEFSMountTarget_basic(t *testing.T) {
 
 func TestAccAWSEFSMountTarget_disappears(t *testing.T) {
 	var mount efs.MountTargetDescription
-
+	resourceName := "aws_efs_mount_target.test"
 	ct := fmt.Sprintf("createtoken-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -102,7 +86,7 @@ func TestAccAWSEFSMountTarget_disappears(t *testing.T) {
 				Config: testAccAWSEFSMountTargetConfig(ct),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEfsMountTarget(
-						"aws_efs_mount_target.alpha",
+						resourceName,
 						&mount,
 					),
 					testAccAWSEFSMountTargetDisappears(&mount),
@@ -248,9 +232,9 @@ resource "aws_efs_file_system" "foo" {
   creation_token = "%s"
 }
 
-resource "aws_efs_mount_target" "alpha" {
+resource "aws_efs_mount_target" "test" {
   file_system_id = "${aws_efs_file_system.foo.id}"
-  subnet_id      = "${aws_subnet.alpha.id}"
+  subnet_id      = "${aws_subnet.test.id}"
 }
 
 resource "aws_vpc" "foo" {
@@ -261,13 +245,13 @@ resource "aws_vpc" "foo" {
   }
 }
 
-resource "aws_subnet" "alpha" {
+resource "aws_subnet" "test" {
   vpc_id            = "${aws_vpc.foo.id}"
   availability_zone = "us-west-2a"
   cidr_block        = "10.0.1.0/24"
 
   tags = {
-    Name = "tf-acc-efs-mount-target-alpha"
+    Name = "tf-acc-efs-mount-target-test"
   }
 }
 `, ct)
@@ -279,14 +263,14 @@ resource "aws_efs_file_system" "foo" {
   creation_token = "%s"
 }
 
-resource "aws_efs_mount_target" "alpha" {
+resource "aws_efs_mount_target" "test" {
   file_system_id = "${aws_efs_file_system.foo.id}"
-  subnet_id      = "${aws_subnet.alpha.id}"
+  subnet_id      = "${aws_subnet.test.id}"
 }
 
-resource "aws_efs_mount_target" "beta" {
+resource "aws_efs_mount_target" "test2" {
   file_system_id = "${aws_efs_file_system.foo.id}"
-  subnet_id      = "${aws_subnet.beta.id}"
+  subnet_id      = "${aws_subnet.test2.id}"
 }
 
 resource "aws_vpc" "foo" {
@@ -297,23 +281,23 @@ resource "aws_vpc" "foo" {
   }
 }
 
-resource "aws_subnet" "alpha" {
+resource "aws_subnet" "test" {
   vpc_id            = "${aws_vpc.foo.id}"
   availability_zone = "us-west-2a"
   cidr_block        = "10.0.1.0/24"
 
   tags = {
-    Name = "tf-acc-efs-mount-target-alpha"
+    Name = "tf-acc-efs-mount-target-test"
   }
 }
 
-resource "aws_subnet" "beta" {
+resource "aws_subnet" "test2" {
   vpc_id            = "${aws_vpc.foo.id}"
   availability_zone = "us-west-2b"
   cidr_block        = "10.0.2.0/24"
 
   tags = {
-    Name = "tf-acc-efs-mount-target-beta"
+    Name = "tf-acc-efs-mount-target-test2"
   }
 }
 `, ct)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8944

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSEFSMountTarget_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSEFSMountTarget_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEFSMountTarget_basic
=== PAUSE TestAccAWSEFSMountTarget_basic
=== RUN   TestAccAWSEFSMountTarget_disappears
=== PAUSE TestAccAWSEFSMountTarget_disappears
=== CONT  TestAccAWSEFSMountTarget_basic
=== CONT  TestAccAWSEFSMountTarget_disappears
--- PASS: TestAccAWSEFSMountTarget_disappears (162.18s)
--- PASS: TestAccAWSEFSMountTarget_basic (384.48s)
PASS

make testacc TESTARGS="-run=TestAccAWSEFSFileSystem_"     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSEFSFileSystem_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEFSFileSystem_basic
=== PAUSE TestAccAWSEFSFileSystem_basic
=== RUN   TestAccAWSEFSFileSystem_pagedTags
=== PAUSE TestAccAWSEFSFileSystem_pagedTags
=== RUN   TestAccAWSEFSFileSystem_kmsKey
=== PAUSE TestAccAWSEFSFileSystem_kmsKey
=== RUN   TestAccAWSEFSFileSystem_kmsConfigurationWithoutEncryption
=== PAUSE TestAccAWSEFSFileSystem_kmsConfigurationWithoutEncryption
=== RUN   TestAccAWSEFSFileSystem_ProvisionedThroughputInMibps
=== PAUSE TestAccAWSEFSFileSystem_ProvisionedThroughputInMibps
=== RUN   TestAccAWSEFSFileSystem_ThroughputMode
=== PAUSE TestAccAWSEFSFileSystem_ThroughputMode
=== RUN   TestAccAWSEFSFileSystem_lifecyclePolicy
=== PAUSE TestAccAWSEFSFileSystem_lifecyclePolicy
=== RUN   TestAccAWSEFSFileSystem_lifecyclePolicy_update
=== PAUSE TestAccAWSEFSFileSystem_lifecyclePolicy_update
=== RUN   TestAccAWSEFSFileSystem_lifecyclePolicy_removal
=== PAUSE TestAccAWSEFSFileSystem_lifecyclePolicy_removal
=== CONT  TestAccAWSEFSFileSystem_basic
=== CONT  TestAccAWSEFSFileSystem_lifecyclePolicy_removal
=== CONT  TestAccAWSEFSFileSystem_ThroughputMode
=== CONT  TestAccAWSEFSFileSystem_kmsKey
=== CONT  TestAccAWSEFSFileSystem_lifecyclePolicy_update
=== CONT  TestAccAWSEFSFileSystem_lifecyclePolicy
=== CONT  TestAccAWSEFSFileSystem_pagedTags
=== CONT  TestAccAWSEFSFileSystem_kmsConfigurationWithoutEncryption
=== CONT  TestAccAWSEFSFileSystem_ProvisionedThroughputInMibps
--- PASS: TestAccAWSEFSFileSystem_pagedTags (45.16s)
--- PASS: TestAccAWSEFSFileSystem_kmsConfigurationWithoutEncryption (48.46s)
--- PASS: TestAccAWSEFSFileSystem_lifecyclePolicy (70.50s)
--- PASS: TestAccAWSEFSFileSystem_ThroughputMode (70.50s)
--- PASS: TestAccAWSEFSFileSystem_ProvisionedThroughputInMibps (79.42s)
--- PASS: TestAccAWSEFSFileSystem_lifecyclePolicy_update (101.32s)
--- PASS: TestAccAWSEFSFileSystem_kmsKey (110.18s)
--- PASS: TestAccAWSEFSFileSystem_basic (111.41s)
--- PASS: TestAccAWSEFSFileSystem_lifecyclePolicy_removal (120.03s)
PASS
```
