### PR TITLE
Acceptance test import refactor for ECR lifecycle policy

### DIFF
--- a/aws/resource_aws_ecr_lifecycle_policy_test.go
+++ b/aws/resource_aws_ecr_lifecycle_policy_test.go
@@ -14,6 +14,7 @@ import (
 func TestAccAWSEcrLifecyclePolicy_basic(t *testing.T) {
 	randString := acctest.RandString(10)
 	rName := fmt.Sprintf("tf-acc-test-lifecycle-%s", randString)
+	resourceName := "aws_ecr_lifecycle_policy.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -23,27 +24,9 @@ func TestAccAWSEcrLifecyclePolicy_basic(t *testing.T) {
 			{
 				Config: testAccEcrLifecyclePolicyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEcrLifecyclePolicyExists("aws_ecr_lifecycle_policy.foo"),
+					testAccCheckAWSEcrLifecyclePolicyExists(resourceName),
 				),
 			},
-		},
-	})
-}
-
-func TestAccAWSEcrLifecyclePolicy_import(t *testing.T) {
-	resourceName := "aws_ecr_lifecycle_policy.foo"
-	randString := acctest.RandString(10)
-	rName := fmt.Sprintf("tf-acc-test-lifecycle-%s", randString)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSEcrLifecyclePolicyDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccEcrLifecyclePolicyConfig(rName),
-			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
@@ -100,12 +83,12 @@ func testAccCheckAWSEcrLifecyclePolicyExists(name string) resource.TestCheckFunc
 
 func testAccEcrLifecyclePolicyConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_ecr_repository" "foo" {
+resource "aws_ecr_repository" "test" {
   name = "%s"
 }
 
-resource "aws_ecr_lifecycle_policy" "foo" {
-  repository = "${aws_ecr_repository.foo.name}"
+resource "aws_ecr_lifecycle_policy" "test" {
+  repository = "${aws_ecr_repository.test.name}"
 
   policy = <<EOF
 {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8944

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSEcrLifecyclePolicy_"     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSEcrLifecyclePolicy_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEcrLifecyclePolicy_basic
=== PAUSE TestAccAWSEcrLifecyclePolicy_basic
=== CONT  TestAccAWSEcrLifecyclePolicy_basic
--- PASS: TestAccAWSEcrLifecyclePolicy_basic (36.52s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       37.402s
```
