### PR TITLE
Add configuration support for EMR Instance Groups

### DIFF
--- a/aws/resource_aws_emr_instance_group.go
+++ b/aws/resource_aws_emr_instance_group.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/emr"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
@@ -49,6 +50,17 @@ func resourceAwsEMRInstanceGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+			},
+			"configurations_json": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         false,
+				ValidateFunc:     validation.ValidateJsonString,
+				DiffSuppressFunc: suppressEquivalentJsonDiffs,
+				StateFunc: func(v interface{}) string {
+					json, _ := structure.NormalizeJsonString(v)
+					return json
+				},
 			},
 			"ebs_optimized": {
 				Type:     schema.TypeBool,
@@ -136,6 +148,17 @@ func resourceAwsEMRInstanceGroupCreate(d *schema.ResourceData, meta interface{})
 		groupConfig.AutoScalingPolicy = autoScalingPolicy
 	}
 
+	if v, ok := d.GetOk("configurations_json"); ok {
+		info, err := structure.NormalizeJsonString(v)
+		if err != nil {
+			return fmt.Errorf("configurations_json contains an invalid JSON: %s", err)
+		}
+		groupConfig.Configurations, err = expandConfigurationJson(info)
+		if err != nil {
+			return fmt.Errorf("Error reading EMR configurations_json: %s", err)
+		}
+	}
+
 	groupConfig.Market = aws.String(emr.MarketTypeOnDemand)
 	if v, ok := d.GetOk("bid_price"); ok {
 		groupConfig.BidPrice = aws.String(v.(string))
@@ -175,6 +198,19 @@ func resourceAwsEMRInstanceGroupRead(d *schema.ResourceData, meta interface{}) e
 
 	if err != nil {
 		return fmt.Errorf("error reading EMR Instance Group (%s): %s", d.Id(), err)
+	}
+
+	switch {
+	case len(ig.Configurations) > 0:
+		configOut, err := flattenConfigurationJson(ig.Configurations)
+		if err != nil {
+			return fmt.Errorf("Error reading EMR instance group configurations: %s", err)
+		}
+		if err := d.Set("configurations_json", configOut); err != nil {
+			return fmt.Errorf("Error setting EMR configurations_json for instance group (%s): %s", d.Id(), err)
+		}
+	default:
+		d.Set("configurations_json", "")
 	}
 
 	var autoscalingPolicyString string
@@ -230,15 +266,30 @@ func resourceAwsEMRInstanceGroupUpdate(d *schema.ResourceData, meta interface{})
 	conn := meta.(*AWSClient).emrconn
 
 	log.Printf("[DEBUG] Modify EMR task group")
-	if d.HasChange("instance_count") {
-		instanceCount := d.Get("instance_count").(int)
+	if d.HasChange("instance_count") || d.HasChange("configurations_json") {
+		instanceGroupModifyConfig := emr.InstanceGroupModifyConfig{
+			InstanceGroupId: aws.String(d.Id()),
+		}
 
+		if d.HasChange("instance_count") {
+			instanceCount := d.Get("instance_count").(int)
+			instanceGroupModifyConfig.InstanceCount = aws.Int64(int64(instanceCount))
+		}
+		if d.HasChange("configurations_json") {
+			if v, ok := d.GetOk("configurations_json"); ok {
+				info, err := structure.NormalizeJsonString(v)
+				if err != nil {
+					return fmt.Errorf("configurations_json contains an invalid JSON: %s", err)
+				}
+				instanceGroupModifyConfig.Configurations, err = expandConfigurationJson(info)
+				if err != nil {
+					return fmt.Errorf("Error reading EMR configurations_json: %s", err)
+				}
+			}
+		}
 		params := &emr.ModifyInstanceGroupsInput{
 			InstanceGroups: []*emr.InstanceGroupModifyConfig{
-				{
-					InstanceGroupId: aws.String(d.Id()),
-					InstanceCount:   aws.Int64(int64(instanceCount)),
-				},
+				&instanceGroupModifyConfig,
 			},
 		}
 

--- a/aws/resource_aws_emr_instance_group_test.go
+++ b/aws/resource_aws_emr_instance_group_test.go
@@ -91,6 +91,46 @@ func TestAccAWSEMRInstanceGroup_BidPrice(t *testing.T) {
 	})
 }
 
+func TestAccAWSEMRInstanceGroup_ConfigurationsJson(t *testing.T) {
+	var ig emr.InstanceGroup
+	rInt := acctest.RandInt()
+
+	resourceName := "aws_emr_instance_group.task"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEmrInstanceGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEmrInstanceGroupConfig_ConfigurationsJson(rInt, "partitionName1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEmrInstanceGroupExists(resourceName, &ig),
+					resource.TestCheckResourceAttrSet(resourceName, "configurations_json"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSEMRInstanceGroupResourceImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSEmrInstanceGroupConfig_ConfigurationsJson(rInt, "partitionName2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEmrInstanceGroupExists(resourceName, &ig),
+					resource.TestCheckResourceAttrSet(resourceName, "configurations_json"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSEMRInstanceGroupResourceImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSEMRInstanceGroup_AutoScalingPolicy(t *testing.T) {
 	var ig emr.InstanceGroup
 	rInt := acctest.RandInt()
@@ -333,7 +373,7 @@ resource "aws_main_route_table_association" "a" {
 ## EMR Cluster Configuration
 resource "aws_emr_cluster" "tf-test-cluster" {
   name          = "tf-test-emr-%[1]d"
-  release_label = "emr-4.6.0"
+  release_label = "emr-5.26.0"
   applications  = ["Spark"]
 
   ec2_attributes {
@@ -574,6 +614,27 @@ func testAccAWSEmrInstanceGroupConfig_BidPrice(r int) string {
     instance_type  = "c4.large"
   }
 `, r)
+}
+
+func testAccAWSEmrInstanceGroupConfig_ConfigurationsJson(r int, name string) string {
+	return fmt.Sprintf(testAccAWSEmrInstanceGroupBase+`
+	resource "aws_emr_instance_group" "task" {
+    cluster_id     = "${aws_emr_cluster.tf-test-cluster.id}"
+    instance_count = 1
+    instance_type  = "c4.large"
+    configurations_json =  <<EOF
+    [
+      {
+        "Classification": "yarn-site",
+        "Properties": {
+          "yarn.nodemanager.node-labels.provider": "config",
+          "yarn.nodemanager.node-labels.provider.configured-node-partition": "%s"
+        }
+      }
+    ]
+EOF
+  }
+`, r, name)
 }
 
 func testAccAWSEmrInstanceGroupConfig_AutoScalingPolicy(r, min, max int) string {

--- a/website/docs/r/emr_instance_group.html.markdown
+++ b/website/docs/r/emr_instance_group.html.markdown
@@ -37,7 +37,26 @@ The following arguments are supported:
 * `ebs_optimized` (Optional) Indicates whether an Amazon EBS volume is EBS-optimized. Changing this forces a new resource to be created.
 * `ebs_config` (Optional) One or more `ebs_config` blocks as defined below. Changing this forces a new resource to be created.
 * `autoscaling_policy` - (Optional) The autoscaling policy document. This is a JSON formatted string. See [EMR Auto Scaling](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-automatic-scaling.html)
+* `configurations_json` - (Optional) A JSON string for supplying list of configurations specific to the EMR instance group. Note that this can only be changed when using EMR release 5.21 or later.
 
+```hcl
+configurations_json = <<EOF
+  [
+    {
+      "Classification": "hadoop-env",
+      "Configurations": [
+        {
+          "Classification": "export",
+          "Properties": {
+            "JAVA_HOME": "/usr/lib/jvm/java-1.8.0"
+          }
+        }
+      ],
+      "Properties": {}
+    }
+  ]
+EOF
+```
 
 `ebs_config` supports the following:
 


### PR DESCRIPTION
This adds a configurations_json property for the aws_emr_instance_group
resource similar to the configurations_json property for the
aws_emr_cluster resource as they are processed the same by AWS.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9342

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Support configurations_json property for aws_emr_instance_group resources
```

Output from acceptance testing:

Note that two tests failed the first time -- one due to resource limits in my test AWS account and the other looks to have been due to a flaky test due to a race condition with AWS's EMR cluster provisioning process. Rerunning both of them individually succeeded.

```
$ make testacc TESTARGS='-run=TestAccAWSEMRInstanceGroup'         
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSEMRInstanceGroup -timeout 120m
go: finding github.com/terraform-providers/terraform-provider-tls v2.1.1+incompatible
go: finding github.com/terraform-providers/terraform-provider-tls v2.1.1+incompatible
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEMRInstanceGroup_basic
=== PAUSE TestAccAWSEMRInstanceGroup_basic
=== RUN   TestAccAWSEMRInstanceGroup_BidPrice
=== PAUSE TestAccAWSEMRInstanceGroup_BidPrice
=== RUN   TestAccAWSEMRInstanceGroup_ConfigurationsJson
=== PAUSE TestAccAWSEMRInstanceGroup_ConfigurationsJson
=== RUN   TestAccAWSEMRInstanceGroup_AutoScalingPolicy
=== PAUSE TestAccAWSEMRInstanceGroup_AutoScalingPolicy
=== RUN   TestAccAWSEMRInstanceGroup_InstanceCount
=== PAUSE TestAccAWSEMRInstanceGroup_InstanceCount
=== RUN   TestAccAWSEMRInstanceGroup_EbsConfig_EbsOptimized
=== PAUSE TestAccAWSEMRInstanceGroup_EbsConfig_EbsOptimized
=== CONT  TestAccAWSEMRInstanceGroup_basic
=== CONT  TestAccAWSEMRInstanceGroup_InstanceCount
=== CONT  TestAccAWSEMRInstanceGroup_EbsConfig_EbsOptimized
=== CONT  TestAccAWSEMRInstanceGroup_AutoScalingPolicy
=== CONT  TestAccAWSEMRInstanceGroup_BidPrice
=== CONT  TestAccAWSEMRInstanceGroup_ConfigurationsJson
--- FAIL: TestAccAWSEMRInstanceGroup_InstanceCount (6.38s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating internet gateway: InternetGatewayLimitExceeded: The maximum number of internet gateways has been reached.
                status code: 400, request id: 7b3c326b-971f-441c-bede-d3a0e94b7936
        
          on /tmp/tf-test590806217/main.tf line 38:
          (source code not available)
        
        
--- PASS: TestAccAWSEMRInstanceGroup_EbsConfig_EbsOptimized (545.38s)
--- FAIL: TestAccAWSEMRInstanceGroup_BidPrice (552.05s)
    testing.go:569: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.
        
        (map[string]string) (len=1) {
         (string) (len=6) "status": (string) (len=8) "RESIZING"
        }
        
        
        (map[string]string) (len=1) {
         (string) (len=6) "status": (string) (len=12) "PROVISIONING"
        }
        
--- PASS: TestAccAWSEMRInstanceGroup_AutoScalingPolicy (556.20s)
--- PASS: TestAccAWSEMRInstanceGroup_basic (591.83s)
--- PASS: TestAccAWSEMRInstanceGroup_ConfigurationsJson (839.93s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-aws/aws       839.969s
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap      0.030s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags 0.004s [no tests to run]
FAIL
make: *** [testacc] Error 1

$ make testacc TESTARGS='-run=TestAccAWSEMRInstanceGroup_BidPrice'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSEMRInstanceGroup_BidPrice -timeout 120m
go: finding github.com/terraform-providers/terraform-provider-tls v2.1.1+incompatible
go: finding github.com/terraform-providers/terraform-provider-tls v2.1.1+incompatible
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEMRInstanceGroup_BidPrice
=== PAUSE TestAccAWSEMRInstanceGroup_BidPrice
=== CONT  TestAccAWSEMRInstanceGroup_BidPrice
--- PASS: TestAccAWSEMRInstanceGroup_BidPrice (569.24s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       569.287s
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap      0.002s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags 0.004s [no tests to run]

$ make testacc TESTARGS='-run=TestAccAWSEMRInstanceGroup_InstanceCount'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSEMRInstanceGroup_InstanceCount -timeout 120m
go: finding github.com/terraform-providers/terraform-provider-tls v2.1.1+incompatible
go: finding github.com/terraform-providers/terraform-provider-tls v2.1.1+incompatible
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEMRInstanceGroup_InstanceCount
=== PAUSE TestAccAWSEMRInstanceGroup_InstanceCount
=== CONT  TestAccAWSEMRInstanceGroup_InstanceCount
--- PASS: TestAccAWSEMRInstanceGroup_InstanceCount (593.90s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       593.921s
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap      0.007s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags 0.005s [no tests to run]
```
