### PR TITLE
tests/service/storagegateway: Blacklist usw2-az4 from test configuration due to instance type unavailability

### DIFF
--- a/aws/resource_aws_storagegateway_gateway_test.go
+++ b/aws/resource_aws_storagegateway_gateway_test.go
@@ -391,6 +391,12 @@ func testAccCheckAWSStorageGatewayGatewayExists(resourceName string, gateway *st
 // and security group, suitable for Storage Gateway EC2 instances of any type
 func testAccAWSStorageGateway_VPCBase(rName string) string {
 	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  # Error launching source instance: Unsupported: Your requested instance type (m4.xlarge) is not supported in your requested Availability Zone (us-west-2d).
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
+}
+
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -400,8 +406,9 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  cidr_block = "10.0.0.0/24"
-  vpc_id     = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  cidr_block        = "10.0.0.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
     Name = %q
@@ -577,7 +584,11 @@ resource "aws_storagegateway_gateway" "test" {
 
 func testAccAWSStorageGatewayGatewayConfig_SmbActiveDirectorySettings(rName string) string {
 	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  # Error launching source instance: Unsupported: Your requested instance type (m4.xlarge) is not supported in your requested Availability Zone (us-west-2d).
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
+}
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously, could receive these errors:

```
--- FAIL: TestAccAWSStorageGatewayGateway_GatewayName (19.06s)
    testing.go:569: Step 0 error: errors during apply:

        Error: Error launching source instance: Unsupported: Your requested instance type (m4.xlarge) is not supported in your requested Availability Zone (us-west-2d). Please retry your request by not specifying an Availability Zone or choosing us-west-2a, us-west-2b, us-west-2c.

--- FAIL: TestAccAWSStorageGatewayNfsFileShare_basic (19.07s)
    testing.go:569: Step 0 error: errors during apply:

        Error: Error launching source instance: Unsupported: Your requested instance type (m4.xlarge) is not supported in your requested Availability Zone (us-west-2d). Please retry your request by not specifying an Availability Zone or choosing us-west-2a, us-west-2b, us-west-2c.
```

Output from acceptance testing (one unrelated failure):

```
--- SKIP: TestAccAWSStorageGatewayCachedIscsiVolume_SourceVolumeArn (0.00s)
--- PASS: TestAccAWSStorageGatewayLocalDiskDataSource_DiskNode (147.71s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_basic (163.73s)
--- PASS: TestAccAWSStorageGatewayGateway_GatewayType_Cached (211.47s)
--- PASS: TestAccAWSStorageGatewayGateway_GatewayType_Stored (212.70s)
--- PASS: TestAccAWSStorageGatewayGateway_GatewayType_Vtl (218.82s)
--- PASS: TestAccAWSStorageGatewayCache_TapeAndVolumeGateway (229.49s)
--- PASS: TestAccAWSStorageGatewayGateway_SmbGuestPassword (230.27s)
--- PASS: TestAccAWSStorageGatewayCachedIscsiVolume_SnapshotId (234.99s)
--- PASS: TestAccAWSStorageGatewayCachedIscsiVolume_Basic (235.95s)
--- FAIL: TestAccAWSStorageGatewayCache_FileGateway (243.30s)
    testing.go:569: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        DESTROY/CREATE: aws_storagegateway_cache.test
          disk_id:     "1236ea07-49f2-4a5f-a1ca-9946a412c0b4" => "/dev/xvdb" (forces new resource)
          gateway_arn: "arn:aws:storagegateway:us-west-2:*******:gateway/sgw-F532DE9C" => "arn:aws:storagegateway:us-west-2:*******:gateway/sgw-F532DE9C"
          id:          "arn:aws:storagegateway:us-west-2:*******:gateway/sgw-F532DE9C:1236ea07-49f2-4a5f-a1ca-9946a412c0b4" => "<computed>"

--- PASS: TestAccAWSStorageGatewayGateway_GatewayType_FileS3 (276.81s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_DefaultStorageClass (280.34s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_KMSEncrypted (298.93s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_KMSKeyArn (317.55s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_ClientList (346.94s)
--- PASS: TestAccAWSStorageGatewayLocalDiskDataSource_DiskPath (379.81s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_NFSFileShareDefaults (243.49s)
--- PASS: TestAccAWSStorageGatewayGateway_GatewayName (405.04s)
--- PASS: TestAccAWSStorageGatewayGateway_GatewayTimezone (413.34s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_Authentication_GuestAccess (221.46s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_GuessMIMETypeEnabled (475.32s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_ReadOnly (289.72s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_KMSEncrypted (234.47s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_RequesterPays (312.04s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_DefaultStorageClass (296.97s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_ReadOnly (260.51s)
--- PASS: TestAccAWSStorageGatewayUploadBuffer_Basic (227.74s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_KMSKeyArn (340.45s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_RequesterPays (300.51s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_ObjectACL (476.09s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_GuessMIMETypeEnabled (468.50s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_Squash (487.55s)
--- PASS: TestAccAWSStorageGatewayWorkingStorage_Basic (306.62s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_ObjectACL (468.39s)
--- PASS: TestAccAWSStorageGatewayGateway_SmbActiveDirectorySettings (807.33s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_ValidUserList (775.94s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_Authentication_ActiveDirectory (951.58s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_InvalidUserList (1095.85s)
```
