### PR TITLE
Add Missing Comma in JSON Example

### DIFF
--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -74,7 +74,7 @@ resource "aws_iam_role_policy" "example" {
       ],
       "Resource": [
         "arn:aws:ec2:us-east-1:123456789012:network-interface/*"
-      ]
+      ],
       "Condition": {
         "StringEquals": {
           "ec2:Subnet": [


### PR DESCRIPTION
Documentation Update

 Reasoning for Change: The JSON policy in the documentation example is broken. Attempting to use this example in a project will lead to a silent failure to create the policy and a difficult problem to identify.


### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
