### PR TITLE
tests/resource/aws_transfer_server: Add sweeper

### DIFF
--- a/aws/resource_aws_transfer_server_test.go
+++ b/aws/resource_aws_transfer_server_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 	"testing"
 
@@ -13,6 +14,56 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_transfer_server", &resource.Sweeper{
+		Name: "aws_transfer_server",
+		F:    testSweepTransferServers,
+	})
+}
+
+func testSweepTransferServers(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).transferconn
+	input := &transfer.ListServersInput{}
+
+	err = conn.ListServersPages(input, func(page *transfer.ListServersOutput, lastPage bool) bool {
+		for _, server := range page.Servers {
+			id := aws.StringValue(server.ServerId)
+			input := &transfer.DeleteServerInput{
+				ServerId: server.ServerId,
+			}
+
+			log.Printf("[INFO] Deleting Transfer Server: %s", id)
+			_, err := conn.DeleteServer(input)
+
+			if err != nil {
+				log.Printf("[ERROR] Error deleting Transfer Server (%s): %s", id, err)
+				continue
+			}
+
+			if err := waitForTransferServerDeletion(conn, id); err != nil {
+				log.Printf("[ERROR] Error waiting for Transfer Server (%s) deletion: %s", id, err)
+			}
+		}
+
+		return !lastPage
+	})
+
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping Transfer Server sweep for %s: %s", region, err)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error listing Transfer Servers: %s", err)
+	}
+
+	return nil
+}
 
 func TestAccAWSTransferServer_basic(t *testing.T) {
 	var conf transfer.DescribedServer


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Transfer endpoints are costly if left behind.

Output from sweeper in AWS Commercial:

```console
$ go test ./aws -v -sweep=us-east-1,us-west-2 -sweep-run=aws_transfer_server -timeout 10h
2019/10/09 09:48:52 [DEBUG] Running Sweepers for region (us-east-1):
2019/10/09 09:48:55 Sweeper Tests ran:
	- aws_transfer_server
2019/10/09 09:48:55 [DEBUG] Running Sweepers for region (us-west-2):
2019/10/09 09:48:57 [INFO] Deleting Transfer Server: s-7eb2d7c3d1d342e5a
2019/10/09 09:48:58 [DEBUG] Waiting for state to become: [success]
2019/10/09 09:48:58 [INFO] Deleting Transfer Server: s-eb4eaedbf546445f9
2019/10/09 09:48:59 [DEBUG] Waiting for state to become: [success]
2019/10/09 09:48:59 Sweeper Tests ran:
	- aws_transfer_server
ok  	github.com/terraform-providers/terraform-provider-aws/aws	9.023s
```

Output from sweeper in AWS GovCloud (US):

```console
$ go test ./aws -v -sweep=us-gov-west-1 -sweep-run=aws_transfer_server -timeout 10h
2019/10/09 09:50:39 [DEBUG] Running Sweepers for region (us-gov-west-1):
2019/10/09 09:50:43 [WARN] Skipping Transfer Server sweep for us-gov-west-1: RequestError: send request failed
caused by: Post https://transfer.us-gov-west-1.amazonaws.com/: dial tcp: lookup transfer.us-gov-west-1.amazonaws.com: no such host
2019/10/09 09:50:43 Sweeper Tests ran:
	- aws_transfer_server
ok  	github.com/terraform-providers/terraform-provider-aws/aws	4.772s
```
