### PR TITLE
resource/aws_mq_broker: security group changes not require broker reboot or recreation

### DIFF
--- a/aws/resource_aws_mq_broker.go
+++ b/aws/resource_aws_mq_broker.go
@@ -163,7 +163,6 @@ func resourceAwsMqBroker() *schema.Resource {
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Required: true,
-				ForceNew: true,
 			},
 			"subnet_ids": {
 				Type:     schema.TypeSet,

--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -690,14 +690,16 @@ func TestAccAWSMqBroker_updateSecurityGroup(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_mq_broker.test", "security_groups.#", "2"),
 				),
 			},
-			// Trigger a reboot
+			// Trigger a reboot and ensure the password change was applied
+			// User hashcode can be retrieved by calling resourceAwsMqUserHash
 			{
 				Config: testAccMqBrokerConfig_updateUsersSecurityGroups(sgName, brokerName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqBrokerExists("aws_mq_broker.test"),
 					resource.TestCheckResourceAttr("aws_mq_broker.test", "security_groups.#", "1"),
 					resource.TestCheckResourceAttr("aws_mq_broker.test", "user.#", "1"),
-					resource.TestCheckResourceAttr("aws_mq_broker.test", "user.6404715923.password", "TestTest9999"),
+					resource.TestCheckResourceAttr("aws_mq_broker.test", "user.2209734970.username", "Test"),
+					resource.TestCheckResourceAttr("aws_mq_broker.test", "user.2209734970.password", "TestTest9999"),
 				),
 			},
 		},

--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -644,7 +644,7 @@ func TestAccAWSMqBroker_updateTags(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_mq_broker.test", "tags.env", "test"),
 				),
 			},
-			// Adding new user + modify existing
+			// Modify existing tags
 			{
 				Config: testAccMqBrokerConfig_updateTags2(sgName, brokerName),
 				Check: resource.ComposeTestCheckFunc(
@@ -654,7 +654,7 @@ func TestAccAWSMqBroker_updateTags(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_mq_broker.test", "tags.role", "test-role"),
 				),
 			},
-			// Deleting user + modify existing
+			// Deleting tags
 			{
 				Config: testAccMqBrokerConfig_updateTags3(sgName, brokerName),
 				Check: resource.ComposeTestCheckFunc(
@@ -695,8 +695,9 @@ func TestAccAWSMqBroker_updateSecurityGroup(t *testing.T) {
 				Config: testAccMqBrokerConfig_updateUsersSecurityGroups(sgName, brokerName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqBrokerExists("aws_mq_broker.test"),
-					resource.TestCheckResourceAttr("aws_mq_broker.test", "user.1074486012.password", "TestTest9999"),
 					resource.TestCheckResourceAttr("aws_mq_broker.test", "security_groups.#", "1"),
+					resource.TestCheckResourceAttr("aws_mq_broker.test", "user.#", "1"),
+					resource.TestCheckResourceAttr("aws_mq_broker.test", "user.6404715923.password", "TestTest9999"),
 				),
 			},
 		},
@@ -1151,8 +1152,16 @@ resource "aws_mq_broker" "test" {
   engine_type        = "ActiveMQ"
   engine_version     = "5.15.0"
   host_instance_type = "mq.t2.micro"
-  security_groups    = ["${aws_security_group.test.id}"]
+	security_groups    = ["${aws_security_group.test.id}"]
 
+	user {
+    username = "Test"
+    password = "TestTest1234"
+	}
+
+	tags = {
+		role = "test-role"
+	}
 }
 `, sgName, brokerName)
 }

--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -1154,16 +1154,16 @@ resource "aws_mq_broker" "test" {
   engine_type        = "ActiveMQ"
   engine_version     = "5.15.0"
   host_instance_type = "mq.t2.micro"
-	security_groups    = ["${aws_security_group.test.id}"]
+  security_groups    = ["${aws_security_group.test.id}"]
 
-	user {
+  user {
     username = "Test"
     password = "TestTest1234"
-	}
+  }
 
-	tags = {
-		role = "test-role"
-	}
+  tags = {
+    role = "test-role"
+  }
 }
 `, sgName, brokerName)
 }

--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -1186,7 +1186,7 @@ resource "aws_mq_broker" "test" {
   host_instance_type = "mq.t2.micro"
   security_groups    = ["${aws_security_group.test.id}", "${aws_security_group.test2.id}"]
 
-	logs {
+  logs {
     general = true
   }
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Closes https://github.com/terraform-providers/terraform-provider-aws/issues/10209

Background: 

As of Aug 30th, you can update the security groups of an AWS MQ broker without replacing the broker. [Link to the source](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/amazon-mq-release-notes.html).

Changes proposed in this pull request:

* `aws_mq_broker.security_groups` is not marked as `ForceNew` anymore.
* Update `resourceAwsMqBrokerUpdate()` so it handles Security Group updates
* Added `rebootMarker` to determine if changes require a broker reboot. Prior to this change, any update operation will trigger a reboot if `apply_immediately` is set to true. After this change, broker changes such as tags and security group updates are applied without a reboot.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
Security group updates on `aws_mq_broker` are applied without the broker instance being recreated or rebooted.
```

Output from acceptance testing (ran the entire `TestAccAWSMqBroker` suite):

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSMq'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSMq -timeout 120m
(...)
--- PASS: TestAccAWSMqConfiguration_withData (17.90s)
--- PASS: TestAccAWSMqConfiguration_basic (31.44s)
--- PASS: TestAccAWSMqConfiguration_updateTags (45.70s)
--- PASS: TestAccAWSMqBroker_basic (1074.68s)
--- PASS: TestAccAWSMqBroker_EncryptionOptions_UseAwsOwnedKey_Disabled (1136.15s)
--- PASS: TestAccAWSMqBroker_EncryptionOptions_UseAwsOwnedKey_Enabled (1142.81s)
--- PASS: TestAccAWSMqBroker_updateTags (1180.18s)
--- PASS: TestAccAWSMqBroker_EncryptionOptions_KmsKeyId (1238.39s)
--- PASS: TestAccAWSMqBroker_updateSecurityGroup (1390.94s)
--- PASS: TestAccAWSMqBroker_updateUsers (1618.90s)
--- PASS: TestAccAWSMqBroker_allFieldsCustomVpc (1722.76s)
--- PASS: TestAccAWSMqBroker_allFieldsDefaultVpc (1858.83s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1859.057s
```
