### PR TITLE
resource/aws_gamelift_fleet: Increase default deletion timeout to 20 minutes, add missing timeouts documentation

### DIFF
--- a/aws/resource_aws_gamelift_fleet.go
+++ b/aws/resource_aws_gamelift_fleet.go
@@ -22,7 +22,7 @@ func resourceAwsGameliftFleet() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(70 * time.Minute),
-			Delete: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/website/docs/r/gamelift_fleet.html.markdown
+++ b/website/docs/r/gamelift_fleet.html.markdown
@@ -74,6 +74,13 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - Fleet ARN.
 * `operating_system` - Operating system of the fleet's computing resources.
 
+## Timeouts
+
+`aws_gamelift_fleet` provides the following [Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+* `create` - (Default `70m`) How long to wait for a fleet to be created.
+* `delete` - (Default `20m`) How long to wait for a fleet to be deleted.
+
 ## Import
 
 Gamelift Fleets cannot be imported at this time.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://docs.aws.amazon.com/gamelift/latest/developerguide/fleets-editing.html

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_gamelift_fleet: Increase default deletion timeout to 20 minutes to match service timing
```

Our daily acceptance testing is often failing due to the current default deletion timeout of 5 minutes:

```
--- FAIL: TestAccAWSGameliftFleet_basic (1350.58s)
    testing.go:630: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: errors during apply: timeout while waiting for resource to be gone (last state: 'DELETING', timeout: 5m0s)
```

The GameLift documentation does not provide too much guidance on the expected deletion time, but increasing this to 20 minutes to match typical EC2 instance deletion maximums should help.

Output from acceptance testing:

```
--- PASS: TestAccAWSGameliftFleet_basic (1494.07s)
--- PASS: TestAccAWSGameliftFleet_allFields (1535.56s)
```
