### PR TITLE
resource/aws_autoscaling_group: Batch ELB attachments and detachments by 10 to prevent API and rate limiting errors

### DIFF
--- a/aws/resource_aws_autoscaling_group.go
+++ b/aws/resource_aws_autoscaling_group.go
@@ -884,22 +884,56 @@ func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{})
 		add := expandStringList(ns.Difference(os).List())
 
 		if len(remove) > 0 {
-			_, err := conn.DetachLoadBalancers(&autoscaling.DetachLoadBalancersInput{
-				AutoScalingGroupName: aws.String(d.Id()),
-				LoadBalancerNames:    remove,
-			})
-			if err != nil {
-				return fmt.Errorf("Error updating Load Balancers for AutoScaling Group (%s), error: %s", d.Id(), err)
+			// API only supports removing 10 at a time
+			var batches [][]*string
+
+			batchSize := 10
+
+			for batchSize < len(remove) {
+				remove, batches = remove[batchSize:], append(batches, remove[0:batchSize:batchSize])
+			}
+			batches = append(batches, remove)
+
+			for _, batch := range batches {
+				_, err := conn.DetachLoadBalancers(&autoscaling.DetachLoadBalancersInput{
+					AutoScalingGroupName: aws.String(d.Id()),
+					LoadBalancerNames:    batch,
+				})
+
+				if err != nil {
+					return fmt.Errorf("error detaching AutoScaling Group (%s) Load Balancers: %s", d.Id(), err)
+				}
+
+				if err := waitUntilAutoscalingGroupLoadBalancersRemoved(conn, d.Id()); err != nil {
+					return fmt.Errorf("error describing AutoScaling Group (%s) Load Balancers being removed: %s", d.Id(), err)
+				}
 			}
 		}
 
 		if len(add) > 0 {
-			_, err := conn.AttachLoadBalancers(&autoscaling.AttachLoadBalancersInput{
-				AutoScalingGroupName: aws.String(d.Id()),
-				LoadBalancerNames:    add,
-			})
-			if err != nil {
-				return fmt.Errorf("Error updating Load Balancers for AutoScaling Group (%s), error: %s", d.Id(), err)
+			// API only supports adding 10 at a time
+			batchSize := 10
+
+			var batches [][]*string
+
+			for batchSize < len(add) {
+				add, batches = add[batchSize:], append(batches, add[0:batchSize:batchSize])
+			}
+			batches = append(batches, add)
+
+			for _, batch := range batches {
+				_, err := conn.AttachLoadBalancers(&autoscaling.AttachLoadBalancersInput{
+					AutoScalingGroupName: aws.String(d.Id()),
+					LoadBalancerNames:    batch,
+				})
+
+				if err != nil {
+					return fmt.Errorf("error attaching AutoScaling Group (%s) Load Balancers: %s", d.Id(), err)
+				}
+
+				if err := waitUntilAutoscalingGroupLoadBalancersAdded(conn, d.Id()); err != nil {
+					return fmt.Errorf("error describing AutoScaling Group (%s) Load Balancers being added: %s", d.Id(), err)
+				}
 			}
 		}
 	}
@@ -1492,4 +1526,76 @@ func flattenAutoScalingMixedInstancesPolicy(mixedInstancesPolicy *autoscaling.Mi
 	}
 
 	return []interface{}{m}
+}
+
+func waitUntilAutoscalingGroupLoadBalancersAdded(conn *autoscaling.AutoScaling, asgName string) error {
+	input := &autoscaling.DescribeLoadBalancersInput{
+		AutoScalingGroupName: aws.String(asgName),
+	}
+	var lbAdding bool
+
+	for {
+		output, err := conn.DescribeLoadBalancers(input)
+
+		if err != nil {
+			return err
+		}
+
+		for _, tg := range output.LoadBalancers {
+			if aws.StringValue(tg.State) == "Adding" {
+				lbAdding = true
+				break
+			}
+		}
+
+		if lbAdding {
+			lbAdding = false
+			input.NextToken = nil
+			continue
+		}
+
+		if aws.StringValue(output.NextToken) == "" {
+			break
+		}
+
+		input.NextToken = output.NextToken
+	}
+
+	return nil
+}
+
+func waitUntilAutoscalingGroupLoadBalancersRemoved(conn *autoscaling.AutoScaling, asgName string) error {
+	input := &autoscaling.DescribeLoadBalancersInput{
+		AutoScalingGroupName: aws.String(asgName),
+	}
+	var lbRemoving bool
+
+	for {
+		output, err := conn.DescribeLoadBalancers(input)
+
+		if err != nil {
+			return err
+		}
+
+		for _, tg := range output.LoadBalancers {
+			if aws.StringValue(tg.State) == "Removing" {
+				lbRemoving = true
+				break
+			}
+		}
+
+		if lbRemoving {
+			lbRemoving = false
+			input.NextToken = nil
+			continue
+		}
+
+		if aws.StringValue(output.NextToken) == "" {
+			break
+		}
+
+		input.NextToken = output.NextToken
+	}
+
+	return nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/256 (being closed by #10435)
Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/10435
Reference: https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_AttachLoadBalancers.html
Reference: https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_DetachLoadBalancers.html

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_autoscaling_group: Batch ELB attachments and detachments by 10 to prevent API and rate limiting errors
```

This change is complementary to the target group batching in #10435. The AutoScaling API for `AttachLoadBalancers` and `DetachLoadBalancers` only allow 10 elements at a time. In addition to the batching to split the API requests, we must wait for the batch to fully complete before moving onto the next batch, otherwise the API returns a rate limiting error:

```
--- FAIL: TestAccAWSAutoScalingGroup_LoadBalancers (360.22s)
    testing.go:569: Step 2 error: errors during apply:

        Error: Error updating Load Balancers for AutoScaling Group (tf-asg-2019101000090127270000000d), error: ValidationError: Trying to update too many Load Balancers/Target Groups at once. The limit is 10
```

Output from acceptance testing:

```
--- PASS: TestAccAWSAutoScalingGroup_LoadBalancers (443.84s)
```
