### PR TITLE
r/aws_vpc_endpoint_route_table_association: Fix resource import

### DIFF
--- a/aws/resource_aws_vpc_endpoint_route_table_association.go
+++ b/aws/resource_aws_vpc_endpoint_route_table_association.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -17,7 +18,7 @@ func resourceAwsVpcEndpointRouteTableAssociation() *schema.Resource {
 		Read:   resourceAwsVpcEndpointRouteTableAssociationRead,
 		Delete: resourceAwsVpcEndpointRouteTableAssociationDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: resourceAwsVpcEndpointRouteTableAssociationImport,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -121,6 +122,23 @@ func resourceAwsVpcEndpointRouteTableAssociationDelete(d *schema.ResourceData, m
 	}
 
 	return nil
+}
+
+func resourceAwsVpcEndpointRouteTableAssociationImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("Wrong format of resource: %s. Please follow 'vpc-endpoint-id/route-table-id'", d.Id())
+	}
+
+	vpceId := parts[0]
+	rtId := parts[1]
+	log.Printf("[DEBUG] Importing VPC Endpoint (%s) Route Table (%s) association", vpceId, rtId)
+
+	d.SetId(vpcEndpointIdRouteTableIdHash(vpceId, rtId))
+	d.Set("vpc_endpoint_id", vpceId)
+	d.Set("route_table_id", rtId)
+
+	return []*schema.ResourceData{d}, nil
 }
 
 func findResourceVpcEndpoint(conn *ec2.EC2, id string) (*ec2.VpcEndpoint, error) {

--- a/aws/resource_aws_vpc_endpoint_route_table_association_test.go
+++ b/aws/resource_aws_vpc_endpoint_route_table_association_test.go
@@ -7,12 +7,15 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func TestAccAWSVpcEndpointRouteTableAssociation_basic(t *testing.T) {
 	var vpce ec2.VpcEndpoint
+	resourceName := "aws_vpc_endpoint_route_table_association.test"
+	rName := fmt.Sprintf("tf-testacc-vpce-%s", acctest.RandStringFromCharSet(16, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -20,11 +23,16 @@ func TestAccAWSVpcEndpointRouteTableAssociation_basic(t *testing.T) {
 		CheckDestroy: testAccCheckVpcEndpointRouteTableAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVpcEndpointRouteTableAssociationConfig,
+				Config: testAccVpcEndpointRouteTableAssociationConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVpcEndpointRouteTableAssociationExists(
-						"aws_vpc_endpoint_route_table_association.a", &vpce),
+					testAccCheckVpcEndpointRouteTableAssociationExists(resourceName, &vpce),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSVpcEndpointRouteTableAssociationImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -72,7 +80,7 @@ func testAccCheckVpcEndpointRouteTableAssociationExists(n string, vpce *ec2.VpcE
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
+			return fmt.Errorf("No VPC Endpoint Route Table Association ID is set")
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
@@ -83,48 +91,65 @@ func testAccCheckVpcEndpointRouteTableAssociationExists(n string, vpce *ec2.VpcE
 			return err
 		}
 		if len(resp.VpcEndpoints) == 0 {
-			return fmt.Errorf("VPC endpoint not found")
+			return fmt.Errorf("VPC Endpoint not found")
 		}
 
 		*vpce = *resp.VpcEndpoints[0]
 
 		if len(vpce.RouteTableIds) == 0 {
-			return fmt.Errorf("no route table associations")
+			return fmt.Errorf("No VPC Endpoint Route Table Associations")
 		}
 
-		for _, id := range vpce.RouteTableIds {
-			if *id == rs.Primary.Attributes["route_table_id"] {
+		for _, rtId := range vpce.RouteTableIds {
+			if aws.StringValue(rtId) == rs.Primary.Attributes["route_table_id"] {
 				return nil
 			}
 		}
 
-		return fmt.Errorf("route table association not found")
+		return fmt.Errorf("VPC Endpoint Route Table Association not found")
 	}
 }
 
-const testAccVpcEndpointRouteTableAssociationConfig = `
-resource "aws_vpc" "foo" {
-    cidr_block = "10.0.0.0/16"
+func testAccAWSVpcEndpointRouteTableAssociationImportStateIdFunc(n string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", n)
+		}
+
+		id := fmt.Sprintf("%s/%s", rs.Primary.Attributes["vpc_endpoint_id"], rs.Primary.Attributes["route_table_id"])
+		return id, nil
+	}
+}
+
+func testAccVpcEndpointRouteTableAssociationConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
   tags = {
-        Name = "terraform-testacc-vpc-endpoint-route-table-association"
-    }
+    Name = %[1]q
+  }
 }
 
-resource "aws_vpc_endpoint" "s3" {
-    vpc_id = "${aws_vpc.foo.id}"
-    service_name = "com.amazonaws.us-west-2.s3"
+data "aws_region" "current" {}
+
+resource "aws_vpc_endpoint" "test" {
+  vpc_id       = "${aws_vpc.test.id}"
+  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
 }
 
-resource "aws_route_table" "rt" {
-    vpc_id = "${aws_vpc.foo.id}"
+resource "aws_route_table" "test" {
+  vpc_id = "${aws_vpc.test.id}"
 
   tags = {
-        Name = "test"
-    }
+    Name = %[1]q
+  }
 }
 
-resource "aws_vpc_endpoint_route_table_association" "a" {
-	vpc_endpoint_id = "${aws_vpc_endpoint.s3.id}"
-	route_table_id  = "${aws_route_table.rt.id}"
+resource "aws_vpc_endpoint_route_table_association" "test" {
+  vpc_endpoint_id = "${aws_vpc_endpoint.test.id}"
+  route_table_id  = "${aws_route_table.test.id}"
 }
-`
+`, rName)
+}

--- a/website/docs/r/vpc_endpoint_route_table_association.html.markdown
+++ b/website/docs/r/vpc_endpoint_route_table_association.html.markdown
@@ -30,3 +30,13 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - A hash of the EC2 Route Table and VPC Endpoint identifiers.
+
+
+## Import
+
+VPC Endpoint Route Table Associations can be imported using `vpc_endpoint_id` together with `route_table_id`,
+e.g.
+
+```
+$ terraform import aws_vpc_endpoint_route_table_association.example vpce-aaaaaaaa/rt-bbbbbbbb
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/9693.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_vpc_endpoint_route_table_association: Correct resource import
```

Output from acceptance testing:

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSVpcEndpointRouteTableAssociation_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSVpcEndpointRouteTableAssociation_ -timeout 120m
=== RUN   TestAccAWSVpcEndpointRouteTableAssociation_basic
=== PAUSE TestAccAWSVpcEndpointRouteTableAssociation_basic
=== CONT  TestAccAWSVpcEndpointRouteTableAssociation_basic
--- PASS: TestAccAWSVpcEndpointRouteTableAssociation_basic (50.36s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	50.520s
```
