### PR TITLE
data-source/aws_guardduty_detector

### DIFF
--- a/aws/data_source_aws_guardduty_detector.go
+++ b/aws/data_source_aws_guardduty_detector.go
@@ -1,0 +1,95 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/guardduty"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAwsGuarddutyDetector() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsGuarddutyDetectorRead,
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"service_role_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"finding_publishing_frequency": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsGuarddutyDetectorRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).guarddutyconn
+
+	detectorId := d.Get("id").(string)
+
+	if detectorId == "" {
+		log.Print("[DEBUG] No Guardduty ID has been defined, try to lookup using find (There should be only one)")
+		input := &guardduty.ListDetectorsInput{}
+
+		resp, err := conn.ListDetectors(input)
+		if err != nil {
+			return err
+		}
+
+		if resp == nil || len(resp.DetectorIds) == 0 {
+			return fmt.Errorf("no detectors found")
+		}
+		if len(resp.DetectorIds) > 1 {
+			return fmt.Errorf("multiple detectors found; Amazon AWS API behavior has changed; this is a bug in the provider an should be reported")
+		}
+
+		detectorId = aws.StringValue(resp.DetectorIds[0])
+	}
+
+	getInput := &guardduty.GetDetectorInput{
+		DetectorId: aws.String(detectorId),
+	}
+
+	getResp, err := conn.GetDetector(getInput)
+	if err != nil {
+		return err
+	}
+
+	if getResp == nil {
+		return fmt.Errorf("cannot receive detector details")
+	}
+
+	status := getResp.Status
+	enabled := false
+	if *status == "ENABLED" {
+		enabled = true
+	} else {
+		enabled = false
+	}
+
+	serviceRole := getResp.ServiceRole
+	frequency := getResp.FindingPublishingFrequency
+
+	log.Printf("[DEBUG] Setting AWS Guardduty Detector ID to %s.", detectorId)
+	d.SetId(detectorId)
+	log.Printf("[DEBUG] Setting AWS Guardduty enabled to %t.", enabled)
+	d.Set("enabled", enabled)
+	log.Printf("[DEBUG] Setting AWS Guardduty Service Role ARN to %s.", *serviceRole)
+	d.Set("service_role_arn", *serviceRole)
+	log.Printf("[DEBUG] Setting AWS Guardduty Log Publishing Frequency to %s.", *frequency)
+	d.Set("finding_publishing_frequency", *frequency)
+
+	return nil
+}

--- a/aws/data_source_aws_guardduty_detector_test.go
+++ b/aws/data_source_aws_guardduty_detector_test.go
@@ -9,27 +9,63 @@ import (
 )
 
 func TestAccAWSGuarddutyDetectorDataSource_basic(t *testing.T) {
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+	resource.Test(t, resource.TestCase{
+		PreCheck:                  func() { testAccPreCheck(t) },
+		Providers:                 testAccProviders,
+		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsGuarddutyDetectorConfig(),
+				Config: testAccAwsGuarddutyDetectorBasicResourceConfig(),
+				Check:  resource.ComposeTestCheckFunc(),
+			},
+			{
+				Config: testAccAwsGuarddutyDetectorBasicResourceDataConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair("data.aws_guardduty_detector.test", "id", "aws_guardduty_detector.test", "id"),
-					resource.TestCheckResourceAttr("data.aws_guardduty_detector.test", "enabled", "true"),
+					resource.TestCheckResourceAttrPair("data.aws_guardduty_detector.test", "status", "aws_guardduty_detector.test", "status"),
 					resource.TestMatchResourceAttr("data.aws_guardduty_detector.test", "service_role_arn", regexp.MustCompile("^arn:aws:iam::[0-9]{12}:role/aws-service-role/guardduty.amazonaws.com/AWSServiceRoleForAmazonGuardDuty")),
-					resource.TestCheckResourceAttr("data.aws_guardduty_detector.test", "finding_publishing_frequency", "SIX_HOURS"),
+					resource.TestCheckResourceAttrPair("data.aws_guardduty_detector.test", "finding_publishing_frequency", "aws_guardduty_detector.test", "finding_publishing_frequency"),
 				),
 			},
 		},
 	})
 }
 
-func testAccAwsGuarddutyDetectorConfig() string {
-	return fmt.Sprintf(`
-resource "aws_guardduty_detector" "test" {
+func TestAccAWSGuarddutyDetectorDataSource_explicit(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsGuarddutyDetectorExplicitConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("data.aws_guardduty_detector.test", "id", "aws_guardduty_detector.test", "id"),
+					resource.TestCheckResourceAttrPair("data.aws_guardduty_detector.test", "status", "aws_guardduty_detector.test", "status"),
+					resource.TestMatchResourceAttr("data.aws_guardduty_detector.test", "service_role_arn", regexp.MustCompile("^arn:aws:iam::[0-9]{12}:role/aws-service-role/guardduty.amazonaws.com/AWSServiceRoleForAmazonGuardDuty")),
+					resource.TestCheckResourceAttrPair("data.aws_guardduty_detector.test", "finding_publishing_frequency", "aws_guardduty_detector.test", "finding_publishing_frequency"),
+				),
+			},
+		},
+	})
 }
+
+func testAccAwsGuarddutyDetectorBasicResourceConfig() string {
+	return fmt.Sprintf(`
+resource "aws_guardduty_detector" "test" {}
+`)
+}
+
+func testAccAwsGuarddutyDetectorBasicResourceDataConfig() string {
+	return fmt.Sprintf(`
+resource "aws_guardduty_detector" "test" {}
+
+data "aws_guardduty_detector" "test" {}
+`)
+}
+
+func testAccAwsGuarddutyDetectorExplicitConfig() string {
+	return fmt.Sprintf(`
+resource "aws_guardduty_detector" "test" {}
 
 data "aws_guardduty_detector" "test" {
 	id = "${aws_guardduty_detector.test.id}"

--- a/aws/data_source_aws_guardduty_detector_test.go
+++ b/aws/data_source_aws_guardduty_detector_test.go
@@ -1,0 +1,38 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccAWSGuarddutyDetectorDataSource_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsGuarddutyDetectorConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("data.aws_guardduty_detector.test", "id", "aws_guardduty_detector.test", "id"),
+					resource.TestCheckResourceAttr("data.aws_guardduty_detector.test", "enabled", "true"),
+					resource.TestMatchResourceAttr("data.aws_guardduty_detector.test", "service_role_arn", regexp.MustCompile("^arn:aws:iam::[0-9]{12}:role/aws-service-role/guardduty.amazonaws.com/AWSServiceRoleForAmazonGuardDuty")),
+					resource.TestCheckResourceAttr("data.aws_guardduty_detector.test", "finding_publishing_frequency", "SIX_HOURS"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAwsGuarddutyDetectorConfig() string {
+	return fmt.Sprintf(`
+resource "aws_guardduty_detector" "test" {
+}
+
+data "aws_guardduty_detector" "test" {
+	id = "${aws_guardduty_detector.test.id}"
+}
+`)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -205,6 +205,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_elb_hosted_zone_id":                        dataSourceAwsElbHostedZoneId(),
 			"aws_elb_service_account":                       dataSourceAwsElbServiceAccount(),
 			"aws_glue_script":                               dataSourceAwsGlueScript(),
+			"aws_guardduty_detector":                        dataSourceAwsGuarddutyDetector(),
 			"aws_iam_account_alias":                         dataSourceAwsIamAccountAlias(),
 			"aws_iam_group":                                 dataSourceAwsIAMGroup(),
 			"aws_iam_instance_profile":                      dataSourceAwsIAMInstanceProfile(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1604,6 +1604,14 @@
                     <a href="#">GuardDuty</a>
                     <ul class="nav">
                         <li>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/guardduty_detector.html">aws_guardduty_detector</a>
+                                </li>
+                            </ul>
+                        </li>
+                        <li>
                             <a href="#">Resources</a>
                             <ul class="nav nav-auto-expand">
                                 <li>

--- a/website/docs/d/guardduty_detector.html.markdown
+++ b/website/docs/d/guardduty_detector.html.markdown
@@ -23,6 +23,6 @@ data "aws_guardduty_detector" "example" {
 ## Attributes Reference
 
 * `id` - The ID of the detector.
-* `enabled` - The current status of the detector.
+* `status` - The current status of the detector.
 * `service_role_arn` - The service-linked role that grants GuardDuty access to the resources in the AWS account.
 * `finding_publishing_frequency` - The frequency of notifications sent about subsequent finding occurrences.

--- a/website/docs/d/guardduty_detector.html.markdown
+++ b/website/docs/d/guardduty_detector.html.markdown
@@ -23,6 +23,6 @@ data "aws_guardduty_detector" "example" {
 ## Attributes Reference
 
 * `id` - The ID of the detector.
-* `enabled` - State of the detector.
-* `service_role_arn` - Service role used by the detector.
-* `finding_publishing_frequency` - Finding publishing frequence configured.
+* `enabled` - The current status of the detector.
+* `service_role_arn` - The service-linked role that grants GuardDuty access to the resources in the AWS account.
+* `finding_publishing_frequency` - The frequency of notifications sent about subsequent finding occurrences.

--- a/website/docs/d/guardduty_detector.html.markdown
+++ b/website/docs/d/guardduty_detector.html.markdown
@@ -1,0 +1,28 @@
+---
+layout: "aws"
+page_title: "AWS: aws_guardduty_detector"
+description: |-
+  Retrieve information about a GuardDuty detector.
+---
+
+# Data Source: aws_guardduty_detector
+
+Retrieve information about a GuardDuty detector.
+
+## Example Usage
+
+```hcl
+data "aws_guardduty_detector" "example" {
+}
+```
+
+## Argument Reference
+
+* `id` - (optional) The ID of the detector.
+
+## Attributes Reference
+
+* `id` - The ID of the detector.
+* `enabled` - State of the detector.
+* `service_role_arn` - Service role used by the detector.
+* `finding_publishing_frequency` - Finding publishing frequence configured.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #8084

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
New Data Source: aws_guardduty_detector
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSGuarddutyDetectorDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSGuarddutyDetectorDataSource_basic -timeout 120m
=== RUN   TestAccAWSGuarddutyDetectorDataSource_basic
=== PAUSE TestAccAWSGuarddutyDetectorDataSource_basic
=== CONT  TestAccAWSGuarddutyDetectorDataSource_basic
--- PASS: TestAccAWSGuarddutyDetectorDataSource_basic (51.20s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       54.039s
...
```

My use case scenario for this is cross account look-ups of a detector ID in a GuardDuty master account.

I started without any input but I then had trouble to get the test working properly, a explicit dependency ```depends_on``` seem to enforce a recreation of a data-source on every plan execution. This caused my test failing with a message like this:
```
    testing.go:569: Step 0 error: After applying this step and refreshing, the plan was not empty:

        DIFF:

        UPDATE: data.aws_guardduty_detector.test
          id: "" => "<computed>"



        STATE:

        aws_guardduty_detector.test:
          ID = e8b6db08c74ba7246391c8074a6742e5
          provider = provider.aws
          account_id = 1234567891012
          enable = true
          finding_publishing_frequency = SIX_HOURS
```

Can somebody give me a hint how to avoid that behavior? I would like to create another test that does not use a input parameter.