### PR TITLE
Cleanup randomString()

### DIFF
--- a/aws/resource_aws_db_parameter_group_test.go
+++ b/aws/resource_aws_db_parameter_group_test.go
@@ -3,11 +3,9 @@ package aws
 import (
 	"fmt"
 	"log"
-	"math/rand"
 	"regexp"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -619,16 +617,6 @@ func testAccCheckAWSDBParameterGroupExists(n string, v *rds.DBParameterGroup) re
 
 		return nil
 	}
-}
-
-func randomString(strlen int) string {
-	rand.Seed(time.Now().UTC().UnixNano())
-	const chars = "abcdefghijklmnopqrstuvwxyz"
-	result := make([]byte, strlen)
-	for i := 0; i < strlen; i++ {
-		result[i] = chars[rand.Intn(len(chars))]
-	}
-	return string(result)
 }
 
 func testAccAWSDBParameterGroupConfig(n string) string {

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2,11 +2,11 @@ package aws
 
 import (
 	"fmt"
+	"github.com/aws/aws-sdk-go/service/cognitoidentity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"regexp"
 	"strings"
 	"testing"
-
-	"github.com/aws/aws-sdk-go/service/cognitoidentity"
 )
 
 func TestValidateTypeStringNullableBoolean(t *testing.T) {
@@ -1474,7 +1474,7 @@ func TestValidateNeptuneEventSubscriptionName(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    randomString(256),
+			Value:    acctest.RandStringFromCharSet(256, acctest.CharSetAlpha),
 			ErrCount: 1,
 		},
 	}
@@ -1504,7 +1504,7 @@ func TestValidateNeptuneEventSubscriptionNamePrefix(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    randomString(254),
+			Value:    acctest.RandStringFromCharSet(254, acctest.CharSetAlpha),
 			ErrCount: 1,
 		},
 	}
@@ -1534,7 +1534,7 @@ func TestValidateDbSubnetGroupName(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    randomString(300),
+			Value:    acctest.RandStringFromCharSet(300, acctest.CharSetAlpha),
 			ErrCount: 1,
 		},
 	}
@@ -1566,7 +1566,7 @@ func TestValidateNeptuneSubnetGroupName(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    randomString(300),
+			Value:    acctest.RandStringFromCharSet(300, acctest.CharSetAlpha),
 			ErrCount: 1,
 		},
 	}
@@ -1594,7 +1594,7 @@ func TestValidateDbSubnetGroupNamePrefix(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    randomString(230),
+			Value:    acctest.RandStringFromCharSet(230, acctest.CharSetAlpha),
 			ErrCount: 1,
 		},
 	}
@@ -1622,7 +1622,7 @@ func TestValidateNeptuneSubnetGroupNamePrefix(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    randomString(230),
+			Value:    acctest.RandStringFromCharSet(230, acctest.CharSetAlpha),
 			ErrCount: 1,
 		},
 	}
@@ -1658,7 +1658,7 @@ func TestValidateDbOptionGroupName(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    randomString(256),
+			Value:    acctest.RandStringFromCharSet(256, acctest.CharSetAlpha),
 			ErrCount: 1,
 		},
 	}
@@ -1690,7 +1690,7 @@ func TestValidateDbOptionGroupNamePrefix(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    randomString(230),
+			Value:    acctest.RandStringFromCharSet(230, acctest.CharSetAlpha),
 			ErrCount: 1,
 		},
 	}
@@ -1734,7 +1734,7 @@ func TestValidateDbParamGroupName(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    randomString(256),
+			Value:    acctest.RandStringFromCharSet(256, acctest.CharSetAlpha),
 			ErrCount: 1,
 		},
 	}
@@ -2451,7 +2451,7 @@ func TestResourceAWSElastiCacheReplicationGroupAuthTokenValidation(t *testing.T)
 			ErrCount: 1,
 		},
 		{
-			Value:    randomString(129),
+			Value:    acctest.RandStringFromCharSet(129, acctest.CharSetAlpha),
 			ErrCount: 1,
 		},
 	}
@@ -2664,7 +2664,7 @@ func TestValidateNeptuneParamGroupName(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    randomString(256),
+			Value:    acctest.RandStringFromCharSet(256, acctest.CharSetAlpha),
 			ErrCount: 1,
 		},
 	}
@@ -2704,7 +2704,7 @@ func TestValidateNeptuneParamGroupNamePrefix(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    randomString(256),
+			Value:    acctest.RandStringFromCharSet(256, acctest.CharSetAlpha),
 			ErrCount: 1,
 		},
 	}
@@ -2732,7 +2732,7 @@ func TestValidateCloudFrontPublicKeyName(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    randomString(129),
+			Value:    acctest.RandStringFromCharSet(129, acctest.CharSetAlpha),
 			ErrCount: 1,
 		},
 	}
@@ -2760,7 +2760,7 @@ func TestValidateCloudFrontPublicKeyNamePrefix(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    randomString(128),
+			Value:    acctest.RandStringFromCharSet(128, acctest.CharSetAlpha),
 			ErrCount: 1,
 		},
 	}
@@ -2827,7 +2827,7 @@ func TestValidateLbTargetGroupName(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    randomString(33),
+			Value:    acctest.RandStringFromCharSet(33, acctest.CharSetAlpha),
 			ErrCount: 1,
 		},
 	}
@@ -2853,7 +2853,7 @@ func TestValidateLbTargetGroupNamePrefix(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    randomString(32),
+			Value:    acctest.RandStringFromCharSet(32, acctest.CharSetAlpha),
 			ErrCount: 1,
 		},
 	}
@@ -2879,7 +2879,7 @@ func TestValidateSecretManagerSecretName(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    randomString(513),
+			Value:    acctest.RandStringFromCharSet(513, acctest.CharSetAlpha),
 			ErrCount: 1,
 		},
 	}
@@ -2905,7 +2905,7 @@ func TestValidateSecretManagerSecretNamePrefix(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    randomString(512),
+			Value:    acctest.RandStringFromCharSet(512, acctest.CharSetAlpha),
 			ErrCount: 1,
 		},
 	}
@@ -2931,7 +2931,7 @@ func TestValidateRoute53ResolverName(t *testing.T) {
 			ErrCount: 0,
 		},
 		{
-			Value:    randomString(65),
+			Value:    acctest.RandStringFromCharSet(65, acctest.CharSetAlpha),
 			ErrCount: 1,
 		},
 		{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10040

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
None
-->

```release-note
None - code refactor
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestValidate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestValidate -timeout 120m
=== RUN   TestValidateAppautoscalingPolicyImportInput
--- PASS: TestValidateAppautoscalingPolicyImportInput (0.00s)
=== RUN   TestValidateCloudWatchLogStreamName
--- PASS: TestValidateCloudWatchLogStreamName (0.00s)
=== RUN   TestValidateAwsEcsTaskDefinitionContainerDefinitions
--- PASS: TestValidateAwsEcsTaskDefinitionContainerDefinitions (0.00s)
=== RUN   TestValidateIamGroupName
--- PASS: TestValidateIamGroupName (0.00s)
=== RUN   TestValidateIamUserName
--- PASS: TestValidateIamUserName (0.00s)
=== RUN   TestValidateRedshiftClusterDbName
--- PASS: TestValidateRedshiftClusterDbName (0.00s)
=== RUN   TestValidateTypeStringNullableBoolean
--- PASS: TestValidateTypeStringNullableBoolean (0.00s)
=== RUN   TestValidateTypeStringNullableFloat
--- PASS: TestValidateTypeStringNullableFloat (0.00s)
=== RUN   TestValidateCloudWatchDashboardName
--- PASS: TestValidateCloudWatchDashboardName (0.00s)
=== RUN   TestValidateCloudWatchEventRuleName
--- PASS: TestValidateCloudWatchEventRuleName (0.00s)
=== RUN   TestValidateLambdaFunctionName
--- PASS: TestValidateLambdaFunctionName (0.00s)
=== RUN   TestValidateLambdaQualifier
--- PASS: TestValidateLambdaQualifier (0.00s)
=== RUN   TestValidateLambdaPermissionAction
--- PASS: TestValidateLambdaPermissionAction (0.00s)
=== RUN   TestValidateLambdaPermissionEventSourceToken
--- PASS: TestValidateLambdaPermissionEventSourceToken (0.00s)
=== RUN   TestValidateAwsAccountId
--- PASS: TestValidateAwsAccountId (0.00s)
=== RUN   TestValidateArn
--- PASS: TestValidateArn (0.00s)
=== RUN   TestValidateEC2AutomateARN
--- PASS: TestValidateEC2AutomateARN (0.00s)
=== RUN   TestValidatePolicyStatementId
--- PASS: TestValidatePolicyStatementId (0.00s)
=== RUN   TestValidateCIDRNetworkAddress
--- PASS: TestValidateCIDRNetworkAddress (0.00s)
=== RUN   TestValidateLogMetricFilterName
--- PASS: TestValidateLogMetricFilterName (0.00s)
=== RUN   TestValidateLogMetricTransformationName
--- PASS: TestValidateLogMetricTransformationName (0.00s)
=== RUN   TestValidateLogGroupName
--- PASS: TestValidateLogGroupName (0.00s)
=== RUN   TestValidateLogGroupNamePrefix
--- PASS: TestValidateLogGroupNamePrefix (0.00s)
=== RUN   TestValidateS3BucketLifecycleTimestamp
--- PASS: TestValidateS3BucketLifecycleTimestamp (0.00s)
=== RUN   TestValidateSagemakerName
--- PASS: TestValidateSagemakerName (0.00s)
=== RUN   TestValidateDbEventSubscriptionName
--- PASS: TestValidateDbEventSubscriptionName (0.00s)
=== RUN   TestValidateIAMPolicyJsonString
--- PASS: TestValidateIAMPolicyJsonString (0.00s)
=== RUN   TestValidateCloudFormationTemplate
--- PASS: TestValidateCloudFormationTemplate (0.00s)
=== RUN   TestValidateSQSQueueName
--- PASS: TestValidateSQSQueueName (0.00s)
=== RUN   TestValidateSQSFifoQueueName
--- PASS: TestValidateSQSFifoQueueName (0.00s)
=== RUN   TestValidateOnceAWeekWindowFormat
--- PASS: TestValidateOnceAWeekWindowFormat (0.00s)
=== RUN   TestValidateOnceADayWindowFormat
--- PASS: TestValidateOnceADayWindowFormat (0.00s)
=== RUN   TestValidateEcsPlacementConstraint
--- PASS: TestValidateEcsPlacementConstraint (0.00s)
=== RUN   TestValidateEcsPlacementStrategy
--- PASS: TestValidateEcsPlacementStrategy (0.00s)
=== RUN   TestValidateStepFunctionStateMachineName
--- PASS: TestValidateStepFunctionStateMachineName (0.00s)
=== RUN   TestValidateEmrCustomAmiId
--- PASS: TestValidateEmrCustomAmiId (0.00s)
=== RUN   TestValidateDmsEndpointId
--- PASS: TestValidateDmsEndpointId (0.00s)
=== RUN   TestValidateDmsCertificateId
--- PASS: TestValidateDmsCertificateId (0.00s)
=== RUN   TestValidateDmsReplicationInstanceId
--- PASS: TestValidateDmsReplicationInstanceId (0.00s)
=== RUN   TestValidateDmsReplicationSubnetGroupId
--- PASS: TestValidateDmsReplicationSubnetGroupId (0.00s)
=== RUN   TestValidateDmsReplicationTaskId
--- PASS: TestValidateDmsReplicationTaskId (0.00s)
=== RUN   TestValidateAccountAlias
--- PASS: TestValidateAccountAlias (0.00s)
=== RUN   TestValidateIamRoleProfileName
--- PASS: TestValidateIamRoleProfileName (0.00s)
=== RUN   TestValidateIamRoleProfileNamePrefix
--- PASS: TestValidateIamRoleProfileNamePrefix (0.00s)
=== RUN   TestValidateApiGatewayUsagePlanQuotaSettings
--- PASS: TestValidateApiGatewayUsagePlanQuotaSettings (0.00s)
=== RUN   TestValidateElbName
--- PASS: TestValidateElbName (0.00s)
=== RUN   TestValidateElbNamePrefix
--- PASS: TestValidateElbNamePrefix (0.00s)
=== RUN   TestValidateNeptuneEventSubscriptionName
--- PASS: TestValidateNeptuneEventSubscriptionName (0.00s)
=== RUN   TestValidateNeptuneEventSubscriptionNamePrefix
--- PASS: TestValidateNeptuneEventSubscriptionNamePrefix (0.00s)
=== RUN   TestValidateDbSubnetGroupName
--- PASS: TestValidateDbSubnetGroupName (0.00s)
=== RUN   TestValidateNeptuneSubnetGroupName
--- PASS: TestValidateNeptuneSubnetGroupName (0.00s)
=== RUN   TestValidateDbSubnetGroupNamePrefix
--- PASS: TestValidateDbSubnetGroupNamePrefix (0.00s)
=== RUN   TestValidateNeptuneSubnetGroupNamePrefix
--- PASS: TestValidateNeptuneSubnetGroupNamePrefix (0.00s)
=== RUN   TestValidateDbOptionGroupName
--- PASS: TestValidateDbOptionGroupName (0.00s)
=== RUN   TestValidateDbOptionGroupNamePrefix
--- PASS: TestValidateDbOptionGroupNamePrefix (0.00s)
=== RUN   TestValidateDbParamGroupName
--- PASS: TestValidateDbParamGroupName (0.00s)
=== RUN   TestValidateOpenIdURL
--- PASS: TestValidateOpenIdURL (0.00s)
=== RUN   TestValidateAwsKmsName
--- PASS: TestValidateAwsKmsName (0.00s)
=== RUN   TestValidateAwsKmsGrantName
--- PASS: TestValidateAwsKmsGrantName (0.00s)
=== RUN   TestValidateCognitoIdentityPoolName
--- PASS: TestValidateCognitoIdentityPoolName (0.00s)
=== RUN   TestValidateCognitoProviderDeveloperName
--- PASS: TestValidateCognitoProviderDeveloperName (0.00s)
=== RUN   TestValidateCognitoSupportedLoginProviders
--- PASS: TestValidateCognitoSupportedLoginProviders (0.00s)
=== RUN   TestValidateCognitoIdentityProvidersClientId
--- PASS: TestValidateCognitoIdentityProvidersClientId (0.00s)
=== RUN   TestValidateCognitoIdentityProvidersProviderName
--- PASS: TestValidateCognitoIdentityProvidersProviderName (0.00s)
=== RUN   TestValidateCognitoUserPoolEmailVerificationMessage
--- PASS: TestValidateCognitoUserPoolEmailVerificationMessage (0.01s)
=== RUN   TestValidateCognitoUserPoolEmailVerificationSubject
--- PASS: TestValidateCognitoUserPoolEmailVerificationSubject (0.00s)
=== RUN   TestValidateCognitoUserPoolSmsAuthenticationMessage
--- PASS: TestValidateCognitoUserPoolSmsAuthenticationMessage (0.00s)
=== RUN   TestValidateCognitoUserPoolSmsVerificationMessage
--- PASS: TestValidateCognitoUserPoolSmsVerificationMessage (0.00s)
=== RUN   TestValidateWafMetricName
--- PASS: TestValidateWafMetricName (0.00s)
=== RUN   TestValidateIamRoleDescription
--- PASS: TestValidateIamRoleDescription (0.00s)
=== RUN   TestValidateAwsSSMName
--- PASS: TestValidateAwsSSMName (0.00s)
=== RUN   TestValidateBatchName
--- PASS: TestValidateBatchName (0.00s)
=== RUN   TestValidateCognitoRoleMappingsAmbiguousRoleResolutionAgainstType
--- PASS: TestValidateCognitoRoleMappingsAmbiguousRoleResolutionAgainstType (0.00s)
=== RUN   TestValidateCognitoRoleMappingsRulesConfiguration
--- PASS: TestValidateCognitoRoleMappingsRulesConfiguration (0.00s)
=== RUN   TestValidateSecurityGroupRuleDescription
--- PASS: TestValidateSecurityGroupRuleDescription (0.00s)
=== RUN   TestValidateCognitoRoles
--- PASS: TestValidateCognitoRoles (0.00s)
=== RUN   TestValidateKmsKey
--- PASS: TestValidateKmsKey (0.00s)
=== RUN   TestValidateCognitoUserGroupName
--- PASS: TestValidateCognitoUserGroupName (0.00s)
=== RUN   TestValidateCognitoUserPoolId
--- PASS: TestValidateCognitoUserPoolId (0.00s)
=== RUN   TestValidateAmazonSideAsn
--- PASS: TestValidateAmazonSideAsn (0.00s)
=== RUN   TestValidateLaunchTemplateName
--- PASS: TestValidateLaunchTemplateName (0.00s)
=== RUN   TestValidateLaunchTemplateId
--- PASS: TestValidateLaunchTemplateId (0.00s)
=== RUN   TestValidateNeptuneParamGroupName
--- PASS: TestValidateNeptuneParamGroupName (0.00s)
=== RUN   TestValidateNeptuneParamGroupNamePrefix
--- PASS: TestValidateNeptuneParamGroupNamePrefix (0.00s)
=== RUN   TestValidateCloudFrontPublicKeyName
--- PASS: TestValidateCloudFrontPublicKeyName (0.00s)
=== RUN   TestValidateCloudFrontPublicKeyNamePrefix
--- PASS: TestValidateCloudFrontPublicKeyNamePrefix (0.00s)
=== RUN   TestValidateDxConnectionBandWidth
--- PASS: TestValidateDxConnectionBandWidth (0.00s)
=== RUN   TestValidateLbTargetGroupName
--- PASS: TestValidateLbTargetGroupName (0.00s)
=== RUN   TestValidateLbTargetGroupNamePrefix
--- PASS: TestValidateLbTargetGroupNamePrefix (0.00s)
=== RUN   TestValidateSecretManagerSecretName
--- PASS: TestValidateSecretManagerSecretName (0.00s)
=== RUN   TestValidateSecretManagerSecretNamePrefix
--- PASS: TestValidateSecretManagerSecretNamePrefix (0.00s)
=== RUN   TestValidateRoute53ResolverName
--- PASS: TestValidateRoute53ResolverName (0.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1.306s

...
```
