### PR TITLE
RDS DB Cluster Snapshot Tags

### DIFF
--- a/aws/data_source_aws_db_cluster_snapshot.go
+++ b/aws/data_source_aws_db_cluster_snapshot.go
@@ -104,6 +104,7 @@ func dataSourceAwsDbClusterSnapshot() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"tags": tagsSchemaComputed(),
 		},
 	}
 }
@@ -176,6 +177,11 @@ func dataSourceAwsDbClusterSnapshotRead(d *schema.ResourceData, meta interface{}
 	d.Set("status", snapshot.Status)
 	d.Set("storage_encrypted", snapshot.StorageEncrypted)
 	d.Set("vpc_id", snapshot.VpcId)
+
+	// Fetch and save tags
+	if err := saveTagsRDS(conn, d, aws.StringValue(snapshot.DBClusterSnapshotArn)); err != nil {
+		log.Printf("[WARN] Failed to save tags for RDS DB Cluster Snapshot (%s): %s", aws.StringValue(snapshot.DBClusterSnapshotArn), err)
+	}
 
 	return nil
 }

--- a/aws/data_source_aws_db_cluster_snapshot_test.go
+++ b/aws/data_source_aws_db_cluster_snapshot_test.go
@@ -38,6 +38,7 @@ func TestAccAWSDbClusterSnapshotDataSource_DbClusterSnapshotIdentifier(t *testin
 					resource.TestCheckResourceAttrPair(dataSourceName, "status", resourceName, "status"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "storage_encrypted", resourceName, "storage_encrypted"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "vpc_id", resourceName, "vpc_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags", resourceName, "tags"),
 				),
 			},
 		},
@@ -73,6 +74,7 @@ func TestAccAWSDbClusterSnapshotDataSource_DbClusterIdentifier(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "status", resourceName, "status"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "storage_encrypted", resourceName, "storage_encrypted"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "vpc_id", resourceName, "vpc_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags", resourceName, "tags"),
 				),
 			},
 		},
@@ -154,12 +156,15 @@ resource "aws_rds_cluster" "test" {
 resource "aws_db_cluster_snapshot" "test" {
   db_cluster_identifier          = "${aws_rds_cluster.test.id}"
   db_cluster_snapshot_identifier = %q
+  tags = {
+    Name = %q
+  }
 }
 
 data "aws_db_cluster_snapshot" "test" {
   db_cluster_snapshot_identifier = "${aws_db_cluster_snapshot.test.id}"
 }
-`, rName, rName, rName, rName, rName)
+`, rName, rName, rName, rName, rName, rName)
 }
 
 func testAccCheckAwsDbClusterSnapshotDataSourceConfig_DbClusterIdentifier(rName string) string {
@@ -202,12 +207,15 @@ resource "aws_rds_cluster" "test" {
 resource "aws_db_cluster_snapshot" "test" {
   db_cluster_identifier          = "${aws_rds_cluster.test.id}"
   db_cluster_snapshot_identifier = %q
+  tags = {
+    Name = %q
+  }
 }
 
 data "aws_db_cluster_snapshot" "test" {
   db_cluster_identifier = "${aws_db_cluster_snapshot.test.db_cluster_identifier}"
 }
-`, rName, rName, rName, rName, rName)
+`, rName, rName, rName, rName, rName, rName)
 }
 
 func testAccCheckAwsDbClusterSnapshotDataSourceConfig_MostRecent(rName string) string {

--- a/aws/resource_aws_db_cluster_snapshot.go
+++ b/aws/resource_aws_db_cluster_snapshot.go
@@ -89,6 +89,7 @@ func resourceAwsDbClusterSnapshot() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -99,6 +100,7 @@ func resourceAwsDbClusterSnapshotCreate(d *schema.ResourceData, meta interface{}
 	params := &rds.CreateDBClusterSnapshotInput{
 		DBClusterIdentifier:         aws.String(d.Get("db_cluster_identifier").(string)),
 		DBClusterSnapshotIdentifier: aws.String(d.Get("db_cluster_snapshot_identifier").(string)),
+		Tags:                        tagsFromMapRDS(d.Get("tags").(map[string]interface{})),
 	}
 
 	_, err := conn.CreateDBClusterSnapshot(params)
@@ -166,6 +168,10 @@ func resourceAwsDbClusterSnapshotRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("status", snapshot.Status)
 	d.Set("storage_encrypted", snapshot.StorageEncrypted)
 	d.Set("vpc_id", snapshot.VpcId)
+
+	if err := saveTagsRDS(conn, d, aws.StringValue(snapshot.DBClusterSnapshotArn)); err != nil {
+		log.Printf("[WARN] Failed to save tags for RDS DB Cluster Snapshot (%s): %s", d.Id(), err)
+	}
 
 	return nil
 }

--- a/aws/resource_aws_db_cluster_snapshot.go
+++ b/aws/resource_aws_db_cluster_snapshot.go
@@ -16,6 +16,7 @@ func resourceAwsDbClusterSnapshot() *schema.Resource {
 		Create: resourceAwsDbClusterSnapshotCreate,
 		Read:   resourceAwsDbClusterSnapshotRead,
 		Delete: resourceAwsDbClusterSnapshotDelete,
+		Update: resourceAwsdbClusterSnapshotUpdate,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -171,6 +172,20 @@ func resourceAwsDbClusterSnapshotRead(d *schema.ResourceData, meta interface{}) 
 
 	if err := saveTagsRDS(conn, d, aws.StringValue(snapshot.DBClusterSnapshotArn)); err != nil {
 		log.Printf("[WARN] Failed to save tags for RDS DB Cluster Snapshot (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceAwsdbClusterSnapshotUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).rdsconn
+
+	if d.HasChange("tags") {
+		if err := setTagsRDS(conn, d, d.Get("db_cluster_snapshot_arn").(string)); err != nil {
+			return err
+		} else {
+			d.SetPartial("tags")
+		}
 	}
 
 	return nil

--- a/aws/resource_aws_db_cluster_snapshot_test.go
+++ b/aws/resource_aws_db_cluster_snapshot_test.go
@@ -39,12 +39,64 @@ func TestAccAWSDBClusterSnapshot_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "status", "available"),
 					resource.TestCheckResourceAttr(resourceName, "storage_encrypted", "false"),
 					resource.TestMatchResourceAttr(resourceName, "vpc_id", regexp.MustCompile(`^vpc-.+`)),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSDBClusterSnapshot_Tags(t *testing.T) {
+	var dbClusterSnapshot rds.DBClusterSnapshot
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_db_cluster_snapshot.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDbClusterSnapshotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsDbClusterSnapshotConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDbClusterSnapshotExists(resourceName, &dbClusterSnapshot),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"master_password",
+					"skip_final_snapshot",
+					"snapshot_identifier",
+				},
+			},
+			{
+				Config: testAccAwsDbClusterSnapshotConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDbClusterSnapshotExists(resourceName, &dbClusterSnapshot),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAwsDbClusterSnapshotConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDbClusterSnapshotExists(resourceName, &dbClusterSnapshot),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
 			},
 		},
 	})
@@ -152,4 +204,99 @@ resource "aws_db_cluster_snapshot" "test" {
   db_cluster_snapshot_identifier = %q
 }
 `, rName, rName, rName, rName, rName)
+}
+
+func testAccAwsDbClusterSnapshotConfigTags1(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "test" {
+  cidr_block = "192.168.0.0/16"
+
+  tags = {
+    Name = %q
+  }
+}
+
+resource "aws_subnet" "test" {
+  count = 2
+
+  availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
+  cidr_block        = "192.168.${count.index}.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
+
+  tags = {
+    Name = %q
+  }
+}
+
+resource "aws_db_subnet_group" "test" {
+  name       = %q
+  subnet_ids = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
+}
+
+resource "aws_rds_cluster" "test" {
+  cluster_identifier   = %q
+  db_subnet_group_name = "${aws_db_subnet_group.test.name}"
+  master_password      = "barbarbarbar"
+  master_username      = "foo"
+  skip_final_snapshot  = true
+}
+
+resource "aws_db_cluster_snapshot" "test" {
+  db_cluster_identifier          = "${aws_rds_cluster.test.id}"
+  db_cluster_snapshot_identifier = %q
+  tags = {
+    %q = %q
+  }
+}
+`, rName, rName, rName, rName, rName, tagKey1, tagValue1)
+}
+
+func testAccAwsDbClusterSnapshotConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "test" {
+  cidr_block = "192.168.0.0/16"
+
+  tags = {
+    Name = %q
+  }
+}
+
+resource "aws_subnet" "test" {
+  count = 2
+
+  availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
+  cidr_block        = "192.168.${count.index}.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
+
+  tags = {
+    Name = %q
+  }
+}
+
+resource "aws_db_subnet_group" "test" {
+  name       = %q
+  subnet_ids = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
+}
+
+resource "aws_rds_cluster" "test" {
+  cluster_identifier   = %q
+  db_subnet_group_name = "${aws_db_subnet_group.test.name}"
+  master_password      = "barbarbarbar"
+  master_username      = "foo"
+  skip_final_snapshot  = true
+}
+
+resource "aws_db_cluster_snapshot" "test" {
+  db_cluster_identifier          = "${aws_rds_cluster.test.id}"
+  db_cluster_snapshot_identifier = %q
+  tags = {
+    %q = %q
+    %q = %q
+  }
+}
+`, rName, rName, rName, rName, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }

--- a/website/docs/d/db_cluster_snapshot.html.markdown
+++ b/website/docs/d/db_cluster_snapshot.html.markdown
@@ -79,3 +79,4 @@ In addition to all arguments above, the following attributes are exported:
 * `status` - The status of this DB Cluster Snapshot.
 * `storage_encrypted` - Specifies whether the DB cluster snapshot is encrypted.
 * `vpc_id` - The VPC ID associated with the DB cluster snapshot.
+* `tags` - A mapping of tags for the resource.

--- a/website/docs/r/db_cluster_snapshot.html.markdown
+++ b/website/docs/r/db_cluster_snapshot.html.markdown
@@ -24,6 +24,7 @@ The following arguments are supported:
 
 * `db_cluster_identifier` - (Required) The DB Cluster Identifier from which to take the snapshot.
 * `db_cluster_snapshot_identifier` - (Required) The Identifier for the snapshot.
+* `tags` - (Optional) A mapping of tags to assign to the DB cluster.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #8722

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
New Attribute: `tags` for resource and and data source `aws_db_cluster_snapshot` 
```

Output from acceptance testing:

```
❯ AWS_PROFILE=default make testacc TESTARGS='-run=TestAccAWSD\(B\|b\)ClusterSnapshot' TEST=./aws
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSD\(B\|b\)ClusterSnapshot -timeout 120m
=== RUN   TestAccAWSDbClusterSnapshotDataSource_DbClusterSnapshotIdentifier
=== PAUSE TestAccAWSDbClusterSnapshotDataSource_DbClusterSnapshotIdentifier
=== RUN   TestAccAWSDbClusterSnapshotDataSource_DbClusterIdentifier
=== PAUSE TestAccAWSDbClusterSnapshotDataSource_DbClusterIdentifier
=== RUN   TestAccAWSDbClusterSnapshotDataSource_MostRecent
=== PAUSE TestAccAWSDbClusterSnapshotDataSource_MostRecent
=== RUN   TestAccAWSDBClusterSnapshot_basic
=== PAUSE TestAccAWSDBClusterSnapshot_basic
=== RUN   TestAccAWSDBClusterSnapshot_Tags
=== PAUSE TestAccAWSDBClusterSnapshot_Tags
=== CONT  TestAccAWSDbClusterSnapshotDataSource_DbClusterSnapshotIdentifier
=== CONT  TestAccAWSDBClusterSnapshot_Tags
=== CONT  TestAccAWSDbClusterSnapshotDataSource_DbClusterIdentifier
=== CONT  TestAccAWSDbClusterSnapshotDataSource_MostRecent
=== CONT  TestAccAWSDBClusterSnapshot_basic
--- PASS: TestAccAWSDBClusterSnapshot_basic (234.24s)
--- PASS: TestAccAWSDbClusterSnapshotDataSource_DbClusterIdentifier (234.51s)
--- PASS: TestAccAWSDbClusterSnapshotDataSource_DbClusterSnapshotIdentifier (235.06s)
--- PASS: TestAccAWSDbClusterSnapshotDataSource_MostRecent (299.73s)
--- PASS: TestAccAWSDBClusterSnapshot_Tags (360.95s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       361.014s

...
```
