### PR TITLE
Update resource_aws_sns_topic_subscription to create the subscription…

### DIFF
--- a/aws/resource_aws_sns_topic_subscription.go
+++ b/aws/resource_aws_sns_topic_subscription.go
@@ -117,7 +117,7 @@ func resourceAwsSnsTopicSubscriptionCreate(d *schema.ResourceData, meta interfac
 	// Write the ARN to the 'arn' field for export
 	d.Set("arn", output.SubscriptionArn)
 
-	return resourceAwsSnsTopicSubscriptionUpdate(d, meta)
+	return resourceAwsSnsTopicSubscriptionRead(d, meta)
 }
 
 func resourceAwsSnsTopicSubscriptionUpdate(d *schema.ResourceData, meta interface{}) error {
@@ -201,12 +201,37 @@ func resourceAwsSnsTopicSubscriptionDelete(d *schema.ResourceData, meta interfac
 	return err
 }
 
+// Assembles supplied attributes into a single map - empty/default values are excluded from the map
+func getResourceAttributes(d *schema.ResourceData) (output map[string]*string) {
+	delivery_policy := d.Get("delivery_policy").(string)
+	filter_policy := d.Get("filter_policy").(string)
+	raw_message_delivery := d.Get("raw_message_delivery").(bool)
+
+	// Collect attributes if available
+	attributes := map[string]*string{}
+
+	if delivery_policy != "" {
+		attributes["DeliveryPolicy"] = aws.String(delivery_policy)
+	}
+
+	if filter_policy != "" {
+		attributes["FilterPolicy"] = aws.String(filter_policy)
+	}
+
+	if raw_message_delivery != false {
+		attributes["RawMessageDelivery"] = aws.String(fmt.Sprintf("%t", raw_message_delivery))
+	}
+
+	return attributes
+}
+
 func subscribeToSNSTopic(d *schema.ResourceData, snsconn *sns.SNS) (output *sns.SubscribeOutput, err error) {
 	protocol := d.Get("protocol").(string)
 	endpoint := d.Get("endpoint").(string)
 	topic_arn := d.Get("topic_arn").(string)
 	endpoint_auto_confirms := d.Get("endpoint_auto_confirms").(bool)
 	confirmation_timeout_in_minutes := d.Get("confirmation_timeout_in_minutes").(int)
+	attributes := getResourceAttributes(d)
 
 	if strings.Contains(protocol, "http") && !endpoint_auto_confirms {
 		return nil, fmt.Errorf("Protocol http/https is only supported for endpoints which auto confirms!")
@@ -215,9 +240,10 @@ func subscribeToSNSTopic(d *schema.ResourceData, snsconn *sns.SNS) (output *sns.
 	log.Printf("[DEBUG] SNS create topic subscription: %s (%s) @ '%s'", endpoint, protocol, topic_arn)
 
 	req := &sns.SubscribeInput{
-		Protocol: aws.String(protocol),
-		Endpoint: aws.String(endpoint),
-		TopicArn: aws.String(topic_arn),
+		Protocol:   aws.String(protocol),
+		Endpoint:   aws.String(endpoint),
+		TopicArn:   aws.String(topic_arn),
+		Attributes: attributes,
 	}
 
 	output, err = snsconn.Subscribe(req)

--- a/aws/resource_aws_sns_topic_subscription.go
+++ b/aws/resource_aws_sns_topic_subscription.go
@@ -218,7 +218,7 @@ func getResourceAttributes(d *schema.ResourceData) (output map[string]*string) {
 		attributes["FilterPolicy"] = aws.String(filter_policy)
 	}
 
-	if raw_message_delivery != false {
+	if raw_message_delivery {
 		attributes["RawMessageDelivery"] = aws.String(fmt.Sprintf("%t", raw_message_delivery))
 	}
 


### PR DESCRIPTION
… attributes simulatenously with the general subscription creation

Previously the attributes were created _after_ the subscription was created. This left a few seconds in time where messages from the topic could make it through to the endpoint without adhering to things like the FilterPolicy and the RawMessageDelivery flag.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #10495

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
SNS Subscription attributes (`raw_message_delivery`, `filter_policy`, and `delivery_policy`) will now be created at the same time the subscription is created rather than afterwards.
```

### Output from acceptance testing:

When I run the tests one at a time, they pass successfully. The tests also pass when run concurrently [on the automated build server](https://travis-ci.org/terraform-providers/terraform-provider-aws/builds/597376759?utm_source=github_status&utm_medium=notification).

I have issues running the tests concurrently on my machine but the issue happens both on this branch and on master so I believe this issue is a problem with my local environment. 

For completeness' sake, I've included the test results of running both concurrently and running one at a time. They are listed separately below.

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSSNSTopicSubscription'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 40 -run=TestAccAWSSNSTopicSubscription -timeout 120m
=== RUN   TestAccAWSSNSTopicSubscription_basic
=== PAUSE TestAccAWSSNSTopicSubscription_basic
=== RUN   TestAccAWSSNSTopicSubscription_filterPolicy
=== PAUSE TestAccAWSSNSTopicSubscription_filterPolicy
=== RUN   TestAccAWSSNSTopicSubscription_deliveryPolicy
=== PAUSE TestAccAWSSNSTopicSubscription_deliveryPolicy
=== RUN   TestAccAWSSNSTopicSubscription_rawMessageDelivery
=== PAUSE TestAccAWSSNSTopicSubscription_rawMessageDelivery
=== RUN   TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint
=== PAUSE TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint
=== RUN   TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint
=== PAUSE TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint
=== CONT  TestAccAWSSNSTopicSubscription_basic
=== CONT  TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint
=== CONT  TestAccAWSSNSTopicSubscription_deliveryPolicy
=== CONT  TestAccAWSSNSTopicSubscription_rawMessageDelivery
=== CONT  TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint
=== CONT  TestAccAWSSNSTopicSubscription_filterPolicy
--- FAIL: TestAccAWSSNSTopicSubscription_filterPolicy (14.31s)
    testing.go:569: Step 0 error: Check failed: Check 2/2 error: aws_sns_topic_subscription.test_subscription: Attribute 'filter_policy' expected "{\"key1\": [\"val1\"], \"key2\": [\"val2\"]}", got ""
    testing.go:630: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: errors during apply: AWS.SimpleQueueService.NonExistentQueue: The specified queue does not exist for this wsdl version.
                status code: 400, request id: 832a200f-a5f1-58b1-b128-76122e3a8a2e

        State: aws_sqs_queue.test_queue:
          ID = https://sqs.us-west-2.amazonaws.com/072662658510/terraform-subscription-test-queue-9103664681323863048
          provider = provider.aws
          arn = arn:aws:sqs:us-west-2:072662658510:terraform-subscription-test-queue-9103664681323863048
          content_based_deduplication = false
          delay_seconds = 0
          fifo_queue = false
          kms_data_key_reuse_period_seconds = 300
          kms_master_key_id =
          max_message_size = 262144
          message_retention_seconds = 345600
          name = terraform-subscription-test-queue-9103664681323863048
          policy =
          receive_wait_time_seconds = 0
          redrive_policy =
          tags.% = 0
          visibility_timeout_seconds = 30
--- FAIL: TestAccAWSSNSTopicSubscription_rawMessageDelivery (14.41s)
    testing.go:569: Step 0 error: Check failed: Check 2/2 error: aws_sns_topic_subscription.test_subscription: Attribute 'raw_message_delivery' expected "true", got "false"
--- FAIL: TestAccAWSSNSTopicSubscription_basic (14.41s)
    testing.go:569: Step 0 error: Check failed: Check 3/8 error: aws_sns_topic_subscription.test_subscription: Attribute 'delivery_policy' expected "", got "{\"healthyRetryPolicy\":{\"minDelayTarget\":5,\"maxDelayTarget\":20,\"numRetries\":5,\"numMaxDelayRetries\":null,\"numNoDelayRetries\":null,\"numMinDelayRetries\":null,\"backoffFunction\":null},\"sicklyRetryPolicy\":null,\"throttlePolicy\":null,\"guaranteed\":false}"
--- FAIL: TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint (19.37s)
    testing.go:569: Step 0 error: errors during apply:

        Error: Error creating IAM Role tf-acc-test-sns-9103664681323863048: EntityAlreadyExists: Role with name tf-acc-test-sns-9103664681323863048 already exists.
                status code: 409, request id: 7083aa00-689b-4fb8-94cd-3857002a45a0

          on C:\Users\socce\AppData\Local\Temp\tf-test576338621\main.tf line 51:
          (source code not available)


--- FAIL: TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint (51.90s)
    testing.go:569: Step 0 error: errors during apply:

        Error: Error creating SNS topic: NotFound: Topic does not exist
                status code: 404, request id: b9a48349-709f-5d2b-af55-d554fb452784

          on C:\Users\socce\AppData\Local\Temp\tf-test233225962\main.tf line 113:
          (source code not available)


--- PASS: TestAccAWSSNSTopicSubscription_deliveryPolicy (111.66s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-aws/aws       112.014s
FAIL
make: *** [GNUmakefile:24: testacc] Error 1
```

Results of running all the tests one at a time.

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSSNSTopicSubscription_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSNSTopicSubscription_basic -timeout 120m
=== RUN   TestAccAWSSNSTopicSubscription_basic
=== PAUSE TestAccAWSSNSTopicSubscription_basic
=== CONT  TestAccAWSSNSTopicSubscription_basic
--- PASS: TestAccAWSSNSTopicSubscription_basic (47.87s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       48.291s


$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSSNSTopicSubscription_filterPolicy'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSNSTopicSubscription_filterPolicy -timeout 120m
=== RUN   TestAccAWSSNSTopicSubscription_filterPolicy
=== PAUSE TestAccAWSSNSTopicSubscription_filterPolicy
=== CONT  TestAccAWSSNSTopicSubscription_filterPolicy
--- PASS: TestAccAWSSNSTopicSubscription_filterPolicy (59.27s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       59.608s


$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSSNSTopicSubscription_deliveryPolicy'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSNSTopicSubscription_deliveryPolicy -timeout 120m
=== RUN   TestAccAWSSNSTopicSubscription_deliveryPolicy
=== PAUSE TestAccAWSSNSTopicSubscription_deliveryPolicy
=== CONT  TestAccAWSSNSTopicSubscription_deliveryPolicy
--- PASS: TestAccAWSSNSTopicSubscription_deliveryPolicy (53.87s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       54.091s


$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSSNSTopicSubscription_rawMessageDelivery'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSNSTopicSubscription_rawMessageDelivery -timeout 120m
=== RUN   TestAccAWSSNSTopicSubscription_rawMessageDelivery
=== PAUSE TestAccAWSSNSTopicSubscription_rawMessageDelivery
=== CONT  TestAccAWSSNSTopicSubscription_rawMessageDelivery
--- PASS: TestAccAWSSNSTopicSubscription_rawMessageDelivery (61.36s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       61.681s


$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint -timeout 120m
=== RUN   TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint
=== PAUSE TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint
=== CONT  TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint
--- PASS: TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint (46.61s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       46.825s


$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint -timeout 120m
=== RUN   TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint
=== PAUSE TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint
=== CONT  TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint
--- PASS: TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint (111.10s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       111.425s
```
