### PR TITLE
Fix aws_batch_compute_environment example 

### DIFF
--- a/website/docs/r/batch_compute_environment.html.markdown
+++ b/website/docs/r/batch_compute_environment.html.markdown
@@ -73,6 +73,13 @@ resource "aws_iam_role_policy_attachment" "aws_batch_service_role" {
 
 resource "aws_security_group" "sample" {
   name = "aws_batch_compute_environment_security_group"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 }
 
 resource "aws_vpc" "sample" {


### PR DESCRIPTION
Jobs will get stucked in runnable state if security group does not specify outbound rules. 

Explanation:
https://aws.amazon.com/premiumsupport/knowledge-center/batch-job-stuck-runnable-status/

> 8.    For each security group specified in the compute environment, choose the Outbound Rules view, and then confirm that a rule exists with the following settings: 
> For Type, choose ALL Traffic. 
> For Protocol, choose ALL. 
> For Port Range, choose ALL. 
> For Destination, choose and 0.0.0.0/0.




<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
