### PR TITLE
d/aws_vpc_endpoint: Add support for tag filters

### DIFF
--- a/aws/data_source_aws_vpc_endpoint.go
+++ b/aws/data_source_aws_vpc_endpoint.go
@@ -36,6 +36,7 @@ func dataSourceAwsVpcEndpoint() *schema.Resource {
 					},
 				},
 			},
+			"filter": ec2CustomFiltersSchema(),
 			"id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -125,6 +126,12 @@ func dataSourceAwsVpcEndpointRead(d *schema.ResourceData, meta interface{}) erro
 			"service-name":       d.Get("service_name").(string),
 		},
 	)
+	req.Filters = append(req.Filters, buildEC2TagFilterList(
+		tagsFromMap(d.Get("tags").(map[string]interface{})),
+	)...)
+	req.Filters = append(req.Filters, buildEC2CustomFilterList(
+		d.Get("filter").(*schema.Set),
+	)...)
 	if len(req.Filters) == 0 {
 		// Don't send an empty filters list; the EC2 API won't accept it.
 		req.Filters = nil

--- a/aws/data_source_aws_vpc_endpoint_test.go
+++ b/aws/data_source_aws_vpc_endpoint_test.go
@@ -64,6 +64,62 @@ func TestAccDataSourceAwsVpcEndpoint_byId(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAwsVpcEndpoint_byFilter(t *testing.T) {
+	datasourceName := "data.aws_vpc_endpoint.test"
+	rName := fmt.Sprintf("tf-testacc-vpce-%s", acctest.RandStringFromCharSet(16, acctest.CharSetAlphaNum))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsVpcEndpointConfig_byFilter(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(datasourceName, "vpc_endpoint_type", "Gateway"),
+					resource.TestCheckResourceAttrSet(datasourceName, "prefix_list_id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "cidr_blocks.#"),
+					resource.TestCheckResourceAttr(datasourceName, "route_table_ids.#", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "subnet_ids.#", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "network_interface_ids.#", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "security_group_ids.#", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "private_dns_enabled", "false"),
+					resource.TestCheckResourceAttr(datasourceName, "requester_managed", "false"),
+					resource.TestCheckResourceAttr(datasourceName, "tags.%", "0"),
+					testAccCheckResourceAttrAccountID(datasourceName, "owner_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsVpcEndpoint_byTags(t *testing.T) {
+	datasourceName := "data.aws_vpc_endpoint.test"
+	rName := fmt.Sprintf("tf-testacc-vpce-%s", acctest.RandStringFromCharSet(16, acctest.CharSetAlphaNum))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsVpcEndpointConfig_byTags(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(datasourceName, "vpc_endpoint_type", "Gateway"),
+					resource.TestCheckResourceAttrSet(datasourceName, "prefix_list_id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "cidr_blocks.#"),
+					resource.TestCheckResourceAttr(datasourceName, "route_table_ids.#", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "subnet_ids.#", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "network_interface_ids.#", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "security_group_ids.#", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "private_dns_enabled", "false"),
+					resource.TestCheckResourceAttr(datasourceName, "requester_managed", "false"),
+					resource.TestCheckResourceAttr(datasourceName, "tags.%", "3"),
+					testAccCheckResourceAttrAccountID(datasourceName, "owner_id"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDataSourceAwsVpcEndpoint_gatewayWithRouteTableAndTags(t *testing.T) {
 	datasourceName := "data.aws_vpc_endpoint.test"
 	rName := fmt.Sprintf("tf-testacc-vpce-%s", acctest.RandStringFromCharSet(16, acctest.CharSetAlphaNum))
@@ -166,6 +222,67 @@ resource "aws_vpc_endpoint" "test" {
 
 data "aws_vpc_endpoint" "test" {
   id = "${aws_vpc_endpoint.test.id}"
+}
+`, rName)
+}
+
+func testAccDataSourceAwsVpcEndpointConfig_byFilter(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_region" "current" {}
+
+resource "aws_vpc_endpoint" "test" {
+  vpc_id       = "${aws_vpc.test.id}"
+  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+}
+
+data "aws_vpc_endpoint" "test" {
+  filter {
+    name   = "vpc-endpoint-id"
+    values = ["${aws_vpc_endpoint.test.id}"]
+  }
+}
+`, rName)
+}
+
+func testAccDataSourceAwsVpcEndpointConfig_byTags(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_region" "current" {}
+
+resource "aws_vpc_endpoint" "test" {
+  vpc_id       = "${aws_vpc.test.id}"
+  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+
+  tags = {
+    Key1 = "Value1"
+    Key2 = "Value2"
+    Key3 = "Value3"
+  }
+}
+
+data "aws_vpc_endpoint" "test" {
+  vpc_id = "${aws_vpc_endpoint.test.vpc_id}"
+
+  tags = {
+    Key1 = "Value1"
+    Key2 = "Value2"
+    Key3 = "Value3"
+  }
 }
 `, rName)
 }

--- a/website/docs/d/vpc_endpoint.html.markdown
+++ b/website/docs/d/vpc_endpoint.html.markdown
@@ -30,14 +30,25 @@ resource "aws_vpc_endpoint_route_table_association" "private_s3" {
 The arguments of this data source act as filters for querying the available VPC endpoints.
 The given filters must match exactly one VPC endpoint whose data will be exported as attributes.
 
+* `filter` - (Optional) Custom filter block as described below.
 * `id` - (Optional) The ID of the specific VPC Endpoint to retrieve.
 * `service_name` - (Optional) The AWS service name of the specific VPC Endpoint to retrieve.
 * `state` - (Optional) The state of the specific VPC Endpoint to retrieve.
+* `tags` - (Optional) A mapping of tags, each pair of which must exactly match
+  a pair on the specific VPC Endpoint to retrieve.
 * `vpc_id` - (Optional) The ID of the VPC in which the specific VPC Endpoint is used.
+
+More complex filters can be expressed using one or more `filter` sub-blocks,
+which take the following arguments:
+
+* `name` - (Required) The name of the field to filter by, as defined by
+  [the underlying AWS API](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeVpcPeeringConnections.html).
+* `values` - (Required) Set of values that are accepted for the given field.
+  A VPC Endpoint will be selected if any one of the given values matches.
 
 ## Attributes Reference
 
-In addition to all arguments above, the following attributes are exported:
+In addition to all arguments above except `filter`, the following attributes are exported:
 
 * `cidr_blocks` - The list of CIDR blocks for the exposed AWS service. Applicable for endpoints of type `Gateway`.
 * `dns_entry` - The DNS entries for the VPC Endpoint. Applicable for endpoints of type `Interface`. DNS blocks are documented below.
@@ -50,7 +61,6 @@ In addition to all arguments above, the following attributes are exported:
 * `route_table_ids` - One or more route tables associated with the VPC Endpoint. Applicable for endpoints of type `Gateway`.
 * `security_group_ids` - One or more security groups associated with the network interfaces. Applicable for endpoints of type `Interface`.
 * `subnet_ids` - One or more subnets in which the VPC Endpoint is located. Applicable for endpoints of type `Interface`.
-* `tags` - A mapping of tags assigned to the resource.
 * `vpc_endpoint_type` - The VPC Endpoint type, `Gateway` or `Interface`.
 
 DNS blocks (for `dns_entry`) support the following attributes:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/10465.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data-source/aws_vpc_endpoint: Add `filter` attribute and support for filtering by `tags`
```

Output from acceptance testing:

```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsVpcEndpoint_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsVpcEndpoint_ -timeout 120m
=== RUN   TestAccDataSourceAwsVpcEndpoint_gatewayBasic
=== PAUSE TestAccDataSourceAwsVpcEndpoint_gatewayBasic
=== RUN   TestAccDataSourceAwsVpcEndpoint_byId
=== PAUSE TestAccDataSourceAwsVpcEndpoint_byId
=== RUN   TestAccDataSourceAwsVpcEndpoint_byFilter
=== PAUSE TestAccDataSourceAwsVpcEndpoint_byFilter
=== RUN   TestAccDataSourceAwsVpcEndpoint_byTags
=== PAUSE TestAccDataSourceAwsVpcEndpoint_byTags
=== RUN   TestAccDataSourceAwsVpcEndpoint_gatewayWithRouteTableAndTags
=== PAUSE TestAccDataSourceAwsVpcEndpoint_gatewayWithRouteTableAndTags
=== RUN   TestAccDataSourceAwsVpcEndpoint_interface
=== PAUSE TestAccDataSourceAwsVpcEndpoint_interface
=== CONT  TestAccDataSourceAwsVpcEndpoint_gatewayBasic
=== CONT  TestAccDataSourceAwsVpcEndpoint_interface
=== CONT  TestAccDataSourceAwsVpcEndpoint_gatewayWithRouteTableAndTags
=== CONT  TestAccDataSourceAwsVpcEndpoint_byTags
=== CONT  TestAccDataSourceAwsVpcEndpoint_byFilter
=== CONT  TestAccDataSourceAwsVpcEndpoint_byId
--- PASS: TestAccDataSourceAwsVpcEndpoint_byFilter (46.98s)
--- PASS: TestAccDataSourceAwsVpcEndpoint_gatewayBasic (47.24s)
--- PASS: TestAccDataSourceAwsVpcEndpoint_byId (47.37s)
--- PASS: TestAccDataSourceAwsVpcEndpoint_byTags (47.94s)
--- PASS: TestAccDataSourceAwsVpcEndpoint_gatewayWithRouteTableAndTags (52.93s)
--- PASS: TestAccDataSourceAwsVpcEndpoint_interface (188.69s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	188.724s
```
