### PR TITLE
increase cognito scope limit

### DIFF
--- a/aws/resource_aws_cognito_resource_server.go
+++ b/aws/resource_aws_cognito_resource_server.go
@@ -37,7 +37,7 @@ func resourceAwsCognitoResourceServer() *schema.Resource {
 			"scope": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				MaxItems: 25,
+				MaxItems: 100,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"scope_description": {

--- a/aws/resource_aws_cognito_user_pool_client.go
+++ b/aws/resource_aws_cognito_user_pool_client.go
@@ -104,7 +104,7 @@ func resourceAwsCognitoUserPoolClient() *schema.Resource {
 			"allowed_oauth_scopes": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				MaxItems: 25,
+				MaxItems: 50,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 					// https://docs.aws.amazon.com/cognito/latest/developerguide/authorization-endpoint.html


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Increased cognito scope based on updated API docs
https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateUserPoolClient.html#CognitoUserPools-CreateUserPoolClient-request-AllowedOAuthScopes

https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateResourceServer.html#API_CreateResourceServer_RequestSyntax
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestValidate -timeout 120m
=== RUN   TestValidateAppautoscalingPolicyImportInput
--- PASS: TestValidateAppautoscalingPolicyImportInput (0.00s)
=== RUN   TestValidateCloudWatchLogStreamName
--- PASS: TestValidateCloudWatchLogStreamName (0.00s)
=== RUN   TestValidateAwsEcsTaskDefinitionContainerDefinitions
--- PASS: TestValidateAwsEcsTaskDefinitionContainerDefinitions (0.00s)
=== RUN   TestValidateIamGroupName
--- PASS: TestValidateIamGroupName (0.00s)
=== RUN   TestValidateIamUserName
--- PASS: TestValidateIamUserName (0.00s)
=== RUN   TestValidateRedshiftClusterDbName
--- PASS: TestValidateRedshiftClusterDbName (0.00s)
=== RUN   TestValidateTypeStringNullableBoolean
--- PASS: TestValidateTypeStringNullableBoolean (0.00s)
=== RUN   TestValidateTypeStringNullableFloat
--- PASS: TestValidateTypeStringNullableFloat (0.00s)
=== RUN   TestValidateCloudWatchDashboardName
--- PASS: TestValidateCloudWatchDashboardName (0.00s)
=== RUN   TestValidateCloudWatchEventRuleName
--- PASS: TestValidateCloudWatchEventRuleName (0.00s)
=== RUN   TestValidateLambdaFunctionName
--- PASS: TestValidateLambdaFunctionName (0.00s)
=== RUN   TestValidateLambdaQualifier
--- PASS: TestValidateLambdaQualifier (0.00s)
=== RUN   TestValidateLambdaPermissionAction
--- PASS: TestValidateLambdaPermissionAction (0.00s)
=== RUN   TestValidateLambdaPermissionEventSourceToken
--- PASS: TestValidateLambdaPermissionEventSourceToken (0.00s)
=== RUN   TestValidateAwsAccountId
--- PASS: TestValidateAwsAccountId (0.00s)
=== RUN   TestValidateArn
--- PASS: TestValidateArn (0.00s)
=== RUN   TestValidateEC2AutomateARN
--- PASS: TestValidateEC2AutomateARN (0.00s)
=== RUN   TestValidatePolicyStatementId
--- PASS: TestValidatePolicyStatementId (0.00s)
=== RUN   TestValidateCIDRNetworkAddress
--- PASS: TestValidateCIDRNetworkAddress (0.00s)
=== RUN   TestValidateLogMetricFilterName
--- PASS: TestValidateLogMetricFilterName (0.00s)
=== RUN   TestValidateLogMetricTransformationName
--- PASS: TestValidateLogMetricTransformationName (0.00s)
=== RUN   TestValidateLogGroupName
--- PASS: TestValidateLogGroupName (0.00s)
=== RUN   TestValidateLogGroupNamePrefix
--- PASS: TestValidateLogGroupNamePrefix (0.00s)
=== RUN   TestValidateS3BucketLifecycleTimestamp
--- PASS: TestValidateS3BucketLifecycleTimestamp (0.00s)
=== RUN   TestValidateSagemakerName
--- PASS: TestValidateSagemakerName (0.00s)
=== RUN   TestValidateDbEventSubscriptionName
--- PASS: TestValidateDbEventSubscriptionName (0.00s)
=== RUN   TestValidateIAMPolicyJsonString
--- PASS: TestValidateIAMPolicyJsonString (0.00s)
=== RUN   TestValidateCloudFormationTemplate
--- PASS: TestValidateCloudFormationTemplate (0.00s)
=== RUN   TestValidateSQSQueueName
--- PASS: TestValidateSQSQueueName (0.00s)
=== RUN   TestValidateSQSFifoQueueName
--- PASS: TestValidateSQSFifoQueueName (0.00s)
=== RUN   TestValidateOnceAWeekWindowFormat
--- PASS: TestValidateOnceAWeekWindowFormat (0.00s)
=== RUN   TestValidateOnceADayWindowFormat
--- PASS: TestValidateOnceADayWindowFormat (0.00s)
=== RUN   TestValidateEcsPlacementConstraint
--- PASS: TestValidateEcsPlacementConstraint (0.00s)
=== RUN   TestValidateEcsPlacementStrategy
--- PASS: TestValidateEcsPlacementStrategy (0.00s)
=== RUN   TestValidateStepFunctionStateMachineName
--- PASS: TestValidateStepFunctionStateMachineName (0.00s)
=== RUN   TestValidateEmrCustomAmiId
--- PASS: TestValidateEmrCustomAmiId (0.00s)
=== RUN   TestValidateDmsEndpointId
--- PASS: TestValidateDmsEndpointId (0.00s)
=== RUN   TestValidateDmsCertificateId
--- PASS: TestValidateDmsCertificateId (0.00s)
=== RUN   TestValidateDmsReplicationInstanceId
--- PASS: TestValidateDmsReplicationInstanceId (0.00s)
=== RUN   TestValidateDmsReplicationSubnetGroupId
--- PASS: TestValidateDmsReplicationSubnetGroupId (0.00s)
=== RUN   TestValidateDmsReplicationTaskId
--- PASS: TestValidateDmsReplicationTaskId (0.00s)
=== RUN   TestValidateAccountAlias
--- PASS: TestValidateAccountAlias (0.00s)
=== RUN   TestValidateIamRoleProfileName
--- PASS: TestValidateIamRoleProfileName (0.00s)
=== RUN   TestValidateIamRoleProfileNamePrefix
--- PASS: TestValidateIamRoleProfileNamePrefix (0.00s)
=== RUN   TestValidateApiGatewayUsagePlanQuotaSettings
--- PASS: TestValidateApiGatewayUsagePlanQuotaSettings (0.00s)
=== RUN   TestValidateElbName
--- PASS: TestValidateElbName (0.00s)
=== RUN   TestValidateElbNamePrefix
--- PASS: TestValidateElbNamePrefix (0.00s)
=== RUN   TestValidateNeptuneEventSubscriptionName
--- PASS: TestValidateNeptuneEventSubscriptionName (0.00s)
=== RUN   TestValidateNeptuneEventSubscriptionNamePrefix
--- PASS: TestValidateNeptuneEventSubscriptionNamePrefix (0.00s)
=== RUN   TestValidateDbSubnetGroupName
--- PASS: TestValidateDbSubnetGroupName (0.00s)
=== RUN   TestValidateNeptuneSubnetGroupName
--- PASS: TestValidateNeptuneSubnetGroupName (0.00s)
=== RUN   TestValidateDbSubnetGroupNamePrefix
--- PASS: TestValidateDbSubnetGroupNamePrefix (0.00s)
=== RUN   TestValidateNeptuneSubnetGroupNamePrefix
--- PASS: TestValidateNeptuneSubnetGroupNamePrefix (0.00s)
=== RUN   TestValidateDbOptionGroupName
--- PASS: TestValidateDbOptionGroupName (0.00s)
=== RUN   TestValidateDbOptionGroupNamePrefix
--- PASS: TestValidateDbOptionGroupNamePrefix (0.00s)
=== RUN   TestValidateDbParamGroupName
--- PASS: TestValidateDbParamGroupName (0.00s)
=== RUN   TestValidateOpenIdURL
--- PASS: TestValidateOpenIdURL (0.00s)
=== RUN   TestValidateAwsKmsName
--- PASS: TestValidateAwsKmsName (0.00s)
=== RUN   TestValidateAwsKmsGrantName
--- PASS: TestValidateAwsKmsGrantName (0.00s)
=== RUN   TestValidateCognitoIdentityPoolName
--- PASS: TestValidateCognitoIdentityPoolName (0.00s)
=== RUN   TestValidateCognitoProviderDeveloperName
--- PASS: TestValidateCognitoProviderDeveloperName (0.00s)
=== RUN   TestValidateCognitoSupportedLoginProviders
--- PASS: TestValidateCognitoSupportedLoginProviders (0.00s)
=== RUN   TestValidateCognitoIdentityProvidersClientId
--- PASS: TestValidateCognitoIdentityProvidersClientId (0.00s)
=== RUN   TestValidateCognitoIdentityProvidersProviderName
--- PASS: TestValidateCognitoIdentityProvidersProviderName (0.00s)
=== RUN   TestValidateCognitoUserPoolEmailVerificationMessage
--- PASS: TestValidateCognitoUserPoolEmailVerificationMessage (0.01s)
=== RUN   TestValidateCognitoUserPoolEmailVerificationSubject
--- PASS: TestValidateCognitoUserPoolEmailVerificationSubject (0.00s)
=== RUN   TestValidateCognitoUserPoolSmsAuthenticationMessage
--- PASS: TestValidateCognitoUserPoolSmsAuthenticationMessage (0.00s)
=== RUN   TestValidateCognitoUserPoolSmsVerificationMessage
--- PASS: TestValidateCognitoUserPoolSmsVerificationMessage (0.00s)
=== RUN   TestValidateWafMetricName
--- PASS: TestValidateWafMetricName (0.00s)
=== RUN   TestValidateIamRoleDescription
--- PASS: TestValidateIamRoleDescription (0.00s)
=== RUN   TestValidateAwsSSMName
--- PASS: TestValidateAwsSSMName (0.00s)
=== RUN   TestValidateBatchName
--- PASS: TestValidateBatchName (0.00s)
=== RUN   TestValidateCognitoRoleMappingsAmbiguousRoleResolutionAgainstType
--- PASS: TestValidateCognitoRoleMappingsAmbiguousRoleResolutionAgainstType (0.00s)
=== RUN   TestValidateCognitoRoleMappingsRulesConfiguration
--- PASS: TestValidateCognitoRoleMappingsRulesConfiguration (0.00s)
=== RUN   TestValidateSecurityGroupRuleDescription
--- PASS: TestValidateSecurityGroupRuleDescription (0.00s)
=== RUN   TestValidateCognitoRoles
--- PASS: TestValidateCognitoRoles (0.00s)
=== RUN   TestValidateKmsKey
--- PASS: TestValidateKmsKey (0.00s)
=== RUN   TestValidateCognitoUserGroupName
--- PASS: TestValidateCognitoUserGroupName (0.00s)
=== RUN   TestValidateCognitoUserPoolId
--- PASS: TestValidateCognitoUserPoolId (0.00s)
=== RUN   TestValidateAmazonSideAsn
--- PASS: TestValidateAmazonSideAsn (0.00s)
=== RUN   TestValidateLaunchTemplateName
--- PASS: TestValidateLaunchTemplateName (0.00s)
=== RUN   TestValidateLaunchTemplateId
--- PASS: TestValidateLaunchTemplateId (0.00s)
=== RUN   TestValidateNeptuneParamGroupName
--- PASS: TestValidateNeptuneParamGroupName (0.00s)
=== RUN   TestValidateNeptuneParamGroupNamePrefix
--- PASS: TestValidateNeptuneParamGroupNamePrefix (0.00s)
=== RUN   TestValidateCloudFrontPublicKeyName
--- PASS: TestValidateCloudFrontPublicKeyName (0.00s)
=== RUN   TestValidateCloudFrontPublicKeyNamePrefix
--- PASS: TestValidateCloudFrontPublicKeyNamePrefix (0.00s)
=== RUN   TestValidateDxConnectionBandWidth
--- PASS: TestValidateDxConnectionBandWidth (0.00s)
=== RUN   TestValidateLbTargetGroupName
--- PASS: TestValidateLbTargetGroupName (0.00s)
=== RUN   TestValidateLbTargetGroupNamePrefix
--- PASS: TestValidateLbTargetGroupNamePrefix (0.00s)
=== RUN   TestValidateSecretManagerSecretName
--- PASS: TestValidateSecretManagerSecretName (0.00s)
=== RUN   TestValidateSecretManagerSecretNamePrefix
--- PASS: TestValidateSecretManagerSecretNamePrefix (0.00s)
=== RUN   TestValidateRoute53ResolverName
--- PASS: TestValidateRoute53ResolverName (0.00s)
PASS

...
```
