### PR TITLE
Add support for Client VPN Route resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -460,6 +460,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_ec2_capacity_reservation":                            resourceAwsEc2CapacityReservation(),
 			"aws_ec2_client_vpn_endpoint":                             resourceAwsEc2ClientVpnEndpoint(),
 			"aws_ec2_client_vpn_network_association":                  resourceAwsEc2ClientVpnNetworkAssociation(),
+			"aws_ec2_client_vpn_route":                                resourceAwsEc2ClientVpnRoute(),
 			"aws_ec2_fleet":                                           resourceAwsEc2Fleet(),
 			"aws_ec2_transit_gateway":                                 resourceAwsEc2TransitGateway(),
 			"aws_ec2_transit_gateway_route":                           resourceAwsEc2TransitGatewayRoute(),

--- a/aws/resource_aws_ec2_client_vpn_route.go
+++ b/aws/resource_aws_ec2_client_vpn_route.go
@@ -1,0 +1,165 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"log"
+)
+
+func resourceAwsEc2ClientVpnRoute() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsEc2ClientVpnRouteCreate,
+		Read:   resourceAwsEc2ClientVpnRouteRead,
+		Delete: resourceAwsEc2ClientVpnRouteDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"client_vpn_endpoint_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"destination_cidr_block": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"target_vpc_subnet_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"origin": {
+				Type:     schema.TypeString,
+				Computed: true,
+				ForceNew: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+				ForceNew: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAwsEc2ClientVpnRouteCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	req := &ec2.CreateClientVpnRouteInput{
+		ClientVpnEndpointId:  aws.String(d.Get("client_vpn_endpoint_id").(string)),
+		DestinationCidrBlock: aws.String(d.Get("destination_cidr_block").(string)),
+		TargetVpcSubnetId:    aws.String(d.Get("target_vpc_subnet_id").(string)),
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		req.Description = aws.String(v.(string))
+	}
+
+	_, err := conn.CreateClientVpnRoute(req)
+
+	if err != nil {
+		return fmt.Errorf("error creating client VPN route: %s", err)
+	}
+
+	d.SetId(resource.UniqueId())
+	return resourceAwsEc2ClientVpnRouteRead(d, meta)
+}
+
+func resourceAwsEc2ClientVpnRouteRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	resp, err := conn.DescribeClientVpnRoutes(&ec2.DescribeClientVpnRoutesInput{
+		ClientVpnEndpointId: aws.String(d.Get("client_vpn_endpoint_id").(string)),
+	})
+
+	if isAWSErr(err, "InvalidClientVpnRouteNotFound", "") {
+		log.Printf("[WARN] EC2 Client VPN Route (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading client VPN route: %s", err)
+	}
+
+	if resp == nil || len(resp.Routes) == 0 || resp.Routes[0] == nil {
+		log.Printf("[WARN] EC2 Client VPN Route (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if resp.Routes[0].Status != nil && aws.StringValue(resp.Routes[0].Status.Code) == ec2.ClientVpnRouteStatusCodeDeleting {
+		log.Printf("[WARN] EC2 Client VPN Route (%s) has been deleted, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	_, exists := d.GetOk("client_vpn_endpoint_id")
+	if !exists {
+		d.Set("client_vpn_endpoint_id", resp.Routes[0].ClientVpnEndpointId)
+	}
+	_, exists = d.GetOk("destination_cidr_block")
+	if !exists {
+		d.Set("destination_cidr_block", resp.Routes[0].DestinationCidr)
+	}
+	_, exists = d.GetOk("description")
+	if !exists {
+		d.Set("description", resp.Routes[0].Description)
+	}
+	_, exists = d.GetOk("target_vpc_subnet_id")
+	if !exists {
+		d.Set("target_vpc_subnet_id", resp.Routes[0].TargetSubnet)
+	}
+	_, exists = d.GetOk("origin")
+	if !exists {
+		d.Set("origin", resp.Routes[0].Origin)
+	}
+	_, exists = d.GetOk("status")
+	if !exists {
+		d.Set("status", resp.Routes[0].Status)
+	}
+	_, exists = d.GetOk("type")
+	if !exists {
+		d.Set("type", resp.Routes[0].Type)
+	}
+
+	return nil
+}
+
+func resourceAwsEc2ClientVpnRouteDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	_, err := conn.DeleteClientVpnRoute(&ec2.DeleteClientVpnRouteInput{
+		ClientVpnEndpointId:  aws.String(d.Get("client_vpn_endpoint_id").(string)),
+		DestinationCidrBlock: aws.String(d.Get("destination_cidr_block").(string)),
+		TargetVpcSubnetId:    aws.String(d.Get("target_vpc_subnet_id").(string)),
+	})
+
+	if isAWSErr(err, "InvalidClientVpnRouteNotFound", "") {
+		log.Printf("[WARN] EC2 Client VPN Route (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting client VPN route: %s", err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_ec2_client_vpn_route_test.go
+++ b/aws/resource_aws_ec2_client_vpn_route_test.go
@@ -1,0 +1,182 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"testing"
+)
+
+func TestAccAwsEc2ClientVpnRoute_basic(t *testing.T) {
+	var route1 ec2.ClientVpnRoute
+	rStr := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsEc2ClientVpnRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEc2ClientVpnRouteConfig(rStr),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsEc2ClientVpnRouteExists("aws_ec2_client_vpn_route.test", &route1),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAwsEc2ClientVpnRoute_disappears(t *testing.T) {
+	var route1 ec2.ClientVpnRoute
+	rStr := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsEc2ClientVpnRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEc2ClientVpnRouteConfig(rStr),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsEc2ClientVpnRouteExists("aws_ec2_client_vpn_route.test", &route1),
+					testAccCheckAwsEc2ClientVpnRouteDisappears("aws_ec2_client_vpn_route.test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsEc2ClientVpnRouteDisappears(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+		_, err := conn.DeleteClientVpnRoute(&ec2.DeleteClientVpnRouteInput{
+			ClientVpnEndpointId:  aws.String(rs.Primary.Attributes["client_vpn_endpoint_id"]),
+			DestinationCidrBlock: aws.String(rs.Primary.Attributes["destination_cidr_block"]),
+			TargetVpcSubnetId:    aws.String(rs.Primary.Attributes["target_vpc_subnet_id"]),
+		})
+
+		return err
+	}
+}
+
+func testAccCheckAwsEc2ClientVpnRouteDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_ec2_client_vpn_route" {
+			continue
+		}
+
+		resp, _ := conn.DescribeClientVpnRoutes(&ec2.DescribeClientVpnRoutesInput{
+			ClientVpnEndpointId: aws.String(rs.Primary.Attributes["client_vpn_endpoint_id"]),
+		})
+
+		for _, r := range resp.Routes {
+			if *r.ClientVpnEndpointId == rs.Primary.Attributes["client_vpn_endpoint_id"] && !(*r.Status.Code == ec2.ClientVpnRouteStatusCodeDeleting) {
+				return fmt.Errorf("[DESTROY ERROR] client VPN route (%s) was not destroyed", rs.Primary.ID)
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAwsEc2ClientVpnRouteExists(name string, route *ec2.ClientVpnRoute) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+		resp, err := conn.DescribeClientVpnRoutes(&ec2.DescribeClientVpnRoutesInput{
+			ClientVpnEndpointId: aws.String(rs.Primary.Attributes["client_vpn_endpoint_id"]),
+		})
+
+		if err != nil {
+			return fmt.Errorf("Error reading client VPN route (%s): %s", rs.Primary.ID, err)
+		}
+
+		for _, r := range resp.Routes {
+			if *r.ClientVpnEndpointId == rs.Primary.Attributes["client_vpn_endpoint_id"] && !(*r.Status.Code == ec2.ClientVpnRouteStatusCodeDeleting) {
+				*route = *r
+				return nil
+			}
+		}
+
+		return fmt.Errorf("client VPN route route (%s) not found", rs.Primary.ID)
+	}
+}
+
+func testAccEc2ClientVpnRouteConfigAcmCertificateBase() string {
+	key := tlsRsaPrivateKeyPem(2048)
+	certificate := tlsRsaX509SelfSignedCertificatePem(key, "example.com")
+
+	return fmt.Sprintf(`
+resource "aws_acm_certificate" "test" {
+  certificate_body = "%[1]s"
+  private_key      = "%[2]s"
+}
+`, tlsPemEscapeNewlines(certificate), tlsPemEscapeNewlines(key))
+}
+
+func testAccEc2ClientVpnRouteConfig(rName string) string {
+	return testAccEc2ClientVpnRouteConfigAcmCertificateBase() + fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = "terraform-testacc-subnet-%s"
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block              = "10.1.1.0/24"
+  vpc_id                  = "${aws_vpc.test.id}"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "tf-acc-subnet-%s"
+  }
+}
+
+resource "aws_ec2_client_vpn_endpoint" "test" {
+  description            = "terraform-testacc-clientvpn-%s"
+  server_certificate_arn = "${aws_acm_certificate.test.arn}"
+  client_cidr_block      = "10.0.0.0/16"
+
+  authentication_options {
+    type                       = "certificate-authentication"
+    root_certificate_chain_arn = "${aws_acm_certificate.test.arn}"
+  }
+
+  connection_log_options {
+    enabled = false
+  }
+}
+
+resource "aws_ec2_client_vpn_network_association" "test" {
+  client_vpn_endpoint_id = "${aws_ec2_client_vpn_endpoint.test.id}"
+  subnet_id              = "${aws_subnet.test.id}"
+}
+
+resource "aws_ec2_client_vpn_route" "test" {
+  client_vpn_endpoint_id = "${aws_ec2_client_vpn_endpoint.test.id}"
+  destination_cidr_block = "0.0.0.0/0"
+  target_vpc_subnet_id   = "${aws_ec2_client_vpn_network_association.test.subnet_id}"
+  description            = "test client VPN route"
+}
+`, rName, rName, rName)
+}


### PR DESCRIPTION
Adds support for the following resource:
https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/cvpn-working-routes.html

Curently a workaround is implemented to access this API:
https://github.com/terraform-providers/terraform-provider-aws/issues/7831#issuecomment-525970793

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10437
Closes #7831

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
New Resource: aws_ec2_client_vpn_route
```

Output from acceptance testing:

```
=== RUN   TestAccAwsEc2ClientVpnRoute_basic
=== PAUSE TestAccAwsEc2ClientVpnRoute_basic
=== CONT  TestAccAwsEc2ClientVpnRoute_basic
--- PASS: TestAccAwsEc2ClientVpnRoute_basic (587.52s)
PASS

=== RUN   TestAccAwsEc2ClientVpnRoute_disappears
=== PAUSE TestAccAwsEc2ClientVpnRoute_disappears
=== CONT  TestAccAwsEc2ClientVpnRoute_disappears
--- PASS: TestAccAwsEc2ClientVpnRoute_disappears (635.60s)
PASS


...
```
