### PR TITLE
Allow users to set Elastic Beanstalk tags that include `Name`

### DIFF
--- a/aws/tagsBeanstalk.go
+++ b/aws/tagsBeanstalk.go
@@ -100,7 +100,7 @@ func tagsToMapBeanstalk(ts []*elasticbeanstalk.Tag) map[string]string {
 // compare a tag against a list of strings and checks if it should
 // be ignored or not
 func tagIgnoredBeanstalk(t *elasticbeanstalk.Tag) bool {
-	filter := []string{"^aws:", "^elasticbeanstalk:", "Name"}
+	filter := []string{"^aws:", "^elasticbeanstalk:", "^Name$"}
 	for _, v := range filter {
 		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.Key)
 		r, _ := regexp.MatchString(v, *t.Key)

--- a/aws/tagsBeanstalk_test.go
+++ b/aws/tagsBeanstalk_test.go
@@ -71,9 +71,28 @@ func TestIgnoringTagsBeanstalk(t *testing.T) {
 		Key:   aws.String("aws:foo:bar"),
 		Value: aws.String("baz"),
 	})
+	ignoredTags = append(ignoredTags, &elasticbeanstalk.Tag{
+		Key:   aws.String("Name"),
+		Value: aws.String("shouldBeIgnored"),
+	})
 	for _, tag := range ignoredTags {
 		if !tagIgnoredBeanstalk(tag) {
 			t.Fatalf("Tag %v with value %v not ignored, but should be!", *tag.Key, *tag.Value)
+		}
+	}
+
+	var validTags []*elasticbeanstalk.Tag
+	validTags = append(validTags, &elasticbeanstalk.Tag{
+		Key:   aws.String("MyName"),
+		Value: aws.String("shouldNotBeIgnored"),
+	})
+	validTags = append(validTags, &elasticbeanstalk.Tag{
+		Key:   aws.String("NameOfSomething"),
+		Value: aws.String("shouldNotBeIgnored"),
+	})
+	for _, tag := range validTags {
+		if tagIgnoredBeanstalk(tag) {
+			t.Fatalf("Tag %v with value %v was ignored, but should not be!", *tag.Key, *tag.Value)
 		}
 	}
 }


### PR DESCRIPTION
Elastic Beanstalk automatically creates the `Name` tag for an Elastic
Beanstalk environment, and that tag is not editable.  However, tags
that include `Name` in the tag name are supported by Elastic Beanstalk.

The `aws_elastic_beanstalk_environment` resource incorrectly ignored
any tag that includes `Name` in the tag name.  This updates the regex
used for identifying ignored tags so that only a tag with the exact
name `Name` will be ignored, so that terraform users are not blocked
from creating valid Elastic Beanstalk environment tags.

    https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.tagging.html

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #3963

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_elastic_beanstalk_environment: Add support for tags that contain `Name` in the tag name
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSBeanstalkEnv_tagsWithName'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSBeanstalkEnv_tagsWithName -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSBeanstalkEnv_tagsWithName
=== PAUSE TestAccAWSBeanstalkEnv_tagsWithName
=== CONT  TestAccAWSBeanstalkEnv_tagsWithName
--- PASS: TestAccAWSBeanstalkEnv_tagsWithName (561.30s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	564.573s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.727s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.352s [no tests to run]
```
