### PR TITLE
Don't require a role for aws_iam_instance_profile

### DIFF
--- a/aws/resource_aws_iam_instance_profile.go
+++ b/aws/resource_aws_iam_instance_profile.go
@@ -119,13 +119,6 @@ func resourceAwsIamInstanceProfileCreate(d *schema.ResourceData, meta interface{
 		name = resource.UniqueId()
 	}
 
-	_, hasRoles := d.GetOk("roles")
-	_, hasRole := d.GetOk("role")
-
-	if !hasRole && !hasRoles {
-		return fmt.Errorf("Either `role` or `roles` (deprecated) must be specified when creating an IAM Instance Profile")
-	}
-
 	request := &iam.CreateInstanceProfileInput{
 		InstanceProfileName: aws.String(name),
 		Path:                aws.String(d.Get("path").(string)),

--- a/aws/resource_aws_iam_instance_profile_test.go
+++ b/aws/resource_aws_iam_instance_profile_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -64,7 +63,9 @@ func TestAccAWSIAMInstanceProfile_withRoleNotRoles(t *testing.T) {
 	})
 }
 
-func TestAccAWSIAMInstanceProfile_missingRoleThrowsError(t *testing.T) {
+func TestAccAWSIAMInstanceProfile_withoutRole(t *testing.T) {
+	var conf iam.GetInstanceProfileOutput
+	resourceName := "aws_iam_instance_profile.test"
 	rName := acctest.RandString(5)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -72,8 +73,16 @@ func TestAccAWSIAMInstanceProfile_missingRoleThrowsError(t *testing.T) {
 		CheckDestroy: testAccCheckAWSInstanceProfileDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAwsIamInstanceProfileConfigMissingRole(rName),
-				ExpectError: regexp.MustCompile(regexp.QuoteMeta("Either `role` or `roles` (deprecated) must be specified when creating an IAM Instance Profile")),
+				Config: testAccAwsIamInstanceProfileConfigWithoutRole(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSInstanceProfileExists(resourceName, &conf),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name_prefix"},
 			},
 		},
 	})
@@ -192,7 +201,7 @@ resource "aws_iam_instance_profile" "test" {
 `, rName)
 }
 
-func testAccAwsIamInstanceProfileConfigMissingRole(rName string) string {
+func testAccAwsIamInstanceProfileConfigWithoutRole(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_instance_profile" "test" {
   name = "test-%s"

--- a/website/docs/r/iam_instance_profile.html.markdown
+++ b/website/docs/r/iam_instance_profile.html.markdown
@@ -9,8 +9,6 @@ description: |-
 
 Provides an IAM instance profile.
 
-~> **NOTE:** Either `role` or `roles` (**deprecated**) must be specified.
-
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
The IAM API does not require a role be attached to instance profiles,
and there are use cases (eg Vault EC2 authentication) where a bare
instance profile may be all that is required.

This PR:

* Removes the requirement for `role` or `roles` attributes to exist and
  to be set to some value before creating an `aws_iam_instance_profile`
  resource.

* Adjusts the acceptance tests to explicitly test and allow an instance
  profile with no specified role to be created.

* Removes the notice that either `role` or `roles` is required from the
  website documentation for the `aws_iam_instance_profile` resource.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Closes #10522

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
Removes requirement to specify a role when creating an instance profile to match the API.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSIAMInstanceProfile_withoutRole'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSIAMInstanceProfile_withoutRole -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSIAMInstanceProfile_withoutRole
=== PAUSE TestAccAWSIAMInstanceProfile_withoutRole
=== CONT  TestAccAWSIAMInstanceProfile_withoutRole
--- PASS: TestAccAWSIAMInstanceProfile_withoutRole (18.86s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	18.894s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.056s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.004s [no tests to run]
```