### PR TITLE
add error handling for when bucket is already destroyed

### DIFF
--- a/aws/resource_aws_s3_bucket_public_access_block.go
+++ b/aws/resource_aws_s3_bucket_public_access_block.go
@@ -128,6 +128,11 @@ func resourceAwsS3BucketPublicAccessBlockRead(d *schema.ResourceData, meta inter
 		d.SetId("")
 		return nil
 	}
+	if isAWSErr(err, s3.ErrCodeNoSuchBucket, "") {
+		log.Printf("[WARN] S3 Bucket (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
 
 	if err != nil {
 		return fmt.Errorf("error reading S3 bucket Public Access Block: %s", err)
@@ -161,6 +166,16 @@ func resourceAwsS3BucketPublicAccessBlockUpdate(d *schema.ResourceData, meta int
 
 	log.Printf("[DEBUG] Updating S3 bucket Public Access Block: %s", input)
 	_, err := s3conn.PutPublicAccessBlock(input)
+	if isAWSErr(err, s3control.ErrCodeNoSuchPublicAccessBlockConfiguration, "") {
+		log.Printf("[WARN] S3 Bucket Public Access Block (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+	if isAWSErr(err, s3.ErrCodeNoSuchBucket, "") {
+		log.Printf("[WARN] S3 Bucket (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("error updating S3 Bucket Public Access Block (%s): %s", d.Id(), err)
 	}
@@ -189,6 +204,9 @@ func resourceAwsS3BucketPublicAccessBlockDelete(d *schema.ResourceData, meta int
 	_, err := s3conn.DeletePublicAccessBlock(input)
 
 	if isAWSErr(err, s3control.ErrCodeNoSuchPublicAccessBlockConfiguration, "") {
+		return nil
+	}
+	if isAWSErr(err, s3.ErrCodeNoSuchBucket, "") {
 		return nil
 	}
 

--- a/aws/resource_aws_s3_bucket_public_access_block_test.go
+++ b/aws/resource_aws_s3_bucket_public_access_block_test.go
@@ -67,6 +67,29 @@ func TestAccAWSS3BucketPublicAccessBlock_disappears(t *testing.T) {
 	})
 }
 
+func TestAccAWSS3BucketPublicAccessBlock_bucketDisappears(t *testing.T) {
+	var config s3.PublicAccessBlockConfiguration
+	name := fmt.Sprintf("tf-test-bucket-%d", acctest.RandInt())
+	resourceName := "aws_s3_bucket_public_access_block.bucket"
+	bucketResourceName := "aws_s3_bucket.bucket"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSS3BucketPublicAccessBlockConfig(name, "false", "false", "false", "false"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketPublicAccessBlockExists(resourceName, &config),
+					testAccCheckAWSS3DestroyBucket(bucketResourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSS3BucketPublicAccessBlock_BlockPublicAcls(t *testing.T) {
 	var config1, config2, config3 s3.PublicAccessBlockConfiguration
 	name := fmt.Sprintf("tf-test-bucket-%d", acctest.RandInt())


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10492

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
ter *)$ make testacc TESTARGS='-run=TestAccAWSS3BucketPublicAccessBlock_bucketDisappears'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSS3BucketPublicAccessBlock_bucketDisappears -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSS3BucketPublicAccessBlock_bucketDisappears
=== PAUSE TestAccAWSS3BucketPublicAccessBlock_bucketDisappears
=== CONT  TestAccAWSS3BucketPublicAccessBlock_bucketDisappears
--- PASS: TestAccAWSS3BucketPublicAccessBlock_bucketDisappears (35.89s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	35.954s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.013s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.025s [no tests to run]
```
