### PR TITLE
Allow aws instance create spot instances #1243

### DIFF
--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -3048,20 +3048,6 @@ resource "aws_instance" "foo" {
 `, rInt)
 }
 
-const testAccInstanceSpotMaxPriceConfig = `
-
-resource "aws_instance" "foo" {
-  # us-west-2
-  ami               = "ami-4fccb37f"
-  availability_zone = "us-west-2a"
-  use_spot_market	= true
-  max_price 		= "0.007"
-
-  instance_type   = "m1.small"
-  user_data       = "foo:-with-character's"
-}
-`
-
 const testAccInstanceSpotAttrConfig = `
 
 resource "aws_instance" "foo" {

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -148,28 +148,6 @@ func TestFetchRootDevice(t *testing.T) {
 
 func TestAccAWSInstance_inDefaultVpcBySgName(t *testing.T) {
 	resourceName := "aws_instance.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccInstanceConfigVPC,
-			},
-
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"associate_public_ip_address", "user_data", "use_spot_market"},
-			},
-		},
-	})
-}
-
-func TestAccAWSInstance_importInDefaultVpcBySgName(t *testing.T) {
-	resourceName := "aws_instance.foo"
 	rInt := acctest.RandInt()
 	var v ec2.Instance
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
Relates  #1243

This is a Draft pull request of an example of how to make aws_instance resource to support the spot market. 

This is an example of how to do it. Please make comments if this is an good way to do it. I think this makes it easier to switch between normal ec2 instances and spot instances. I do not think we need to expose attributes like spot_request_state,  spot_bid_status, etc or?

I have not yet look into the terraform provider documentation but that needs to be updated.