### PR TITLE
Add support for force destroy unmanaged signing certificate for aws_iam_user resource

### DIFF
--- a/aws/resource_aws_iam_user.go
+++ b/aws/resource_aws_iam_user.go
@@ -240,6 +240,10 @@ func resourceAwsIamUserDelete(d *schema.ResourceData, meta interface{}) error {
 		if err := deleteAwsIamUserLoginProfile(iamconn, d.Id()); err != nil {
 			return fmt.Errorf("error removing IAM User (%s) login profile: %s", d.Id(), err)
 		}
+
+		if err := deleteAwsIamUserSigningCertificates(iamconn, d.Id()); err != nil {
+			return fmt.Errorf("error removing IAM User (%s) signing certificate: %s", d.Id(), err)
+		}
 	}
 
 	deleteUserInput := &iam.DeleteUserInput{
@@ -408,6 +412,36 @@ func deleteAwsIamUserAccessKeys(svc *iam.IAM, username string) error {
 		})
 		if err != nil {
 			return fmt.Errorf("Error deleting access key %s: %s", k, err)
+		}
+	}
+
+	return nil
+}
+
+func deleteAwsIamUserSigningCertificates(svc *iam.IAM, userName string) error {
+	var certificateIDList []string
+
+	listInput := &iam.ListSigningCertificatesInput{
+		UserName: aws.String(userName),
+	}
+	err := svc.ListSigningCertificatesPages(listInput,
+		func(page *iam.ListSigningCertificatesOutput, lastPage bool) bool {
+			for _, c := range page.Certificates {
+				certificateIDList = append(certificateIDList, aws.StringValue(c.CertificateId))
+			}
+			return !lastPage
+		})
+	if err != nil {
+		return fmt.Errorf("Error removing signing certificates of user %s: %s", userName, err)
+	}
+
+	for _, c := range certificateIDList {
+		_, err := svc.DeleteSigningCertificate(&iam.DeleteSigningCertificateInput{
+			CertificateId: aws.String(c),
+			UserName:      aws.String(userName),
+		})
+		if err != nil {
+			return fmt.Errorf("Error deleting signing certificate %s: %s", c, err)
 		}
 	}
 

--- a/aws/resource_aws_iam_user_test.go
+++ b/aws/resource_aws_iam_user_test.go
@@ -343,6 +343,35 @@ func TestAccAWSUser_ForceDestroy_SSHKey(t *testing.T) {
 	})
 }
 
+func TestAccAWSUser_ForceDestroy_SigningCertificate(t *testing.T) {
+	var user iam.GetUserOutput
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_iam_user.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSUserConfigForceDestroy(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSUserExists(resourceName, &user),
+					testAccCheckAWSUserUploadSigningCertificate(&user),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy"},
+			},
+		},
+	})
+}
+
 func TestAccAWSUser_nameChange(t *testing.T) {
 	var conf iam.GetUserOutput
 
@@ -720,6 +749,27 @@ func testAccCheckAWSUserUploadsSSHKey(getUserOutput *iam.GetUserOutput) resource
 		_, err = iamconn.UploadSSHPublicKey(input)
 		if err != nil {
 			return fmt.Errorf("error uploading IAM User (%s) SSH key: %s", *getUserOutput.User.UserName, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSUserUploadSigningCertificate(getUserOutput *iam.GetUserOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		iamconn := testAccProvider.Meta().(*AWSClient).iamconn
+
+		signingCertificate, err := ioutil.ReadFile("./test-fixtures/iam-ssl-unix-line-endings.pem")
+		if err != nil {
+			return fmt.Errorf("error reading signing certificate fixture: %s", err)
+		}
+		input := &iam.UploadSigningCertificateInput{
+			CertificateBody: aws.String(string(signingCertificate)),
+			UserName:        getUserOutput.User.UserName,
+		}
+
+		if _, err := iamconn.UploadSigningCertificate(input); err != nil {
+			return fmt.Errorf("error uploading IAM User (%s) Signing Certificate : %s", aws.StringValue(getUserOutput.User.UserName), err)
 		}
 
 		return nil


### PR DESCRIPTION

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10322

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSUser_ForceDestroy_SigningCertificate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSUser_ForceDestroy_SigningCertificate -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSUser_ForceDestroy_SigningCertificate
=== PAUSE TestAccAWSUser_ForceDestroy_SigningCertificate
=== CONT  TestAccAWSUser_ForceDestroy_SigningCertificate
--- PASS: TestAccAWSUser_ForceDestroy_SigningCertificate (37.33s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	37.399s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.013s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.023s [no tests to run]
```
