### PR TITLE
add tags to aws_db_instance data source

### DIFF
--- a/aws/data_source_aws_db_instance.go
+++ b/aws/data_source_aws_db_instance.go
@@ -20,6 +20,8 @@ func dataSourceAwsDbInstance() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"tags": tagsSchemaComputed(),
+
 			"address": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -311,6 +313,11 @@ func dataSourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error
 	}
 	if err := d.Set("vpc_security_groups", vpcSecurityGroups); err != nil {
 		return fmt.Errorf("Error setting vpc_security_groups attribute: %#v, error: %#v", vpcSecurityGroups, err)
+	}
+
+	// Fetch and save tags
+	if err := saveTagsRDS(conn, d, aws.StringValue(dbInstance.DBInstanceArn)); err != nil {
+		log.Printf("[WARN] Failed to save tags for RDS Instance (%s): %s", aws.StringValue(dbInstance.DBInstanceArn), err)
 	}
 
 	return nil

--- a/aws/data_source_aws_db_instance_test.go
+++ b/aws/data_source_aws_db_instance_test.go
@@ -31,6 +31,8 @@ func TestAccAWSDbInstanceDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.aws_db_instance.bar", "enabled_cloudwatch_logs_exports.0"),
 					resource.TestCheckResourceAttrSet("data.aws_db_instance.bar", "enabled_cloudwatch_logs_exports.1"),
 					resource.TestCheckResourceAttrPair("data.aws_db_instance.bar", "resource_id", "aws_db_instance.bar", "resource_id"),
+					resource.TestCheckResourceAttrPair("data.aws_db_instance.bar", "tags.%", "aws_db_instance.bar", "tags.%"),
+					resource.TestCheckResourceAttrPair("data.aws_db_instance.bar", "tags.Environment", "aws_db_instance.bar", "tags.Environment"),
 				),
 			},
 		},
@@ -77,6 +79,10 @@ resource "aws_db_instance" "bar" {
     "audit",
     "error",
   ]
+
+  tags = {
+    Environment = "test"
+  }
 }
 
 data "aws_db_instance" "bar" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2988 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Support tags for aws_db_instance data source
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDbInstanceDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDbInstanceDataSource_basic -timeout 120m
=== RUN   TestAccAWSDbInstanceDataSource_basic
=== PAUSE TestAccAWSDbInstanceDataSource_basic
=== CONT  TestAccAWSDbInstanceDataSource_basic
--- PASS: TestAccAWSDbInstanceDataSource_basic (607.59s)
PASS
ok  	github.com/sean-zou/terraform-provider-aws/aws	609.224s
```
