### PR TITLE
adding tags support for athena

### DIFF
--- a/aws/resource_aws_athena_database.go
+++ b/aws/resource_aws_athena_database.go
@@ -60,11 +60,12 @@ func resourceAwsAthenaDatabase() *schema.Resource {
 					},
 				},
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
 
-func expandAthenaResultConfiguration(bucket string, encryptionConfigurationList []interface{}) (*athena.ResultConfiguration, error) {
+func expandAthenaResultConfiguration(bucket string, encryptionConfigurationList []interface{}, tags map[string]interface{}) (*athena.ResultConfiguration, error) {
 	resultConfig := athena.ResultConfiguration{
 		OutputLocation: aws.String("s3://" + bucket),
 	}
@@ -86,6 +87,7 @@ func expandAthenaResultConfiguration(bucket string, encryptionConfigurationList 
 	}
 
 	resultConfig.EncryptionConfiguration = &encryptionConfig
+	resultConfig.Tags = tagsFromMapGeneric(tags)
 
 	return &resultConfig, nil
 }
@@ -93,7 +95,7 @@ func expandAthenaResultConfiguration(bucket string, encryptionConfigurationList 
 func resourceAwsAthenaDatabaseCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).athenaconn
 
-	resultConfig, err := expandAthenaResultConfiguration(d.Get("bucket").(string), d.Get("encryption_configuration").([]interface{}))
+	resultConfig, err := expandAthenaResultConfiguration(d.Get("bucket").(string), d.Get("encryption_configuration").([]interface{}), d.Get("tags").(map[string]interface{}))
 	if err != nil {
 		return err
 	}

--- a/website/docs/r/athena_database.html.markdown
+++ b/website/docs/r/athena_database.html.markdown
@@ -35,6 +35,7 @@ An `encryption_configuration` block supports the following arguments:
 
 * `encryption_option` - (Required) The type of key; one of `SSE_S3`, `SSE_KMS`, `CSE_KMS`
 * `kms_key` - (Optional) The KMS key ARN or ID; required for key types `SSE_KMS` and `CSE_KMS`.
+* `tags` - (Optional) Key-value mapping of resource tags
 
 ~> **NOTE:** When Athena queries are executed, result files may be created in the specified bucket. Consider using `force_destroy` on the bucket too in order to avoid any problems when destroying the bucket.  
 


### PR DESCRIPTION
This is a work in progress. I started with the AWS Athena job resource first just to make sure that I had the necessary changes to add tags for one resource. As per https://aws.amazon.com/about-aws/whats-new/2019/02/athena_support_for_tags/ AWS Athena supports tags. Need to add tests.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request


Relates OR Closes #10558 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
 Support AWS resource tagging for Athena
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
