### PR TITLE
New resource - aws_ec2_client_vpn_route

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -462,6 +462,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_ec2_capacity_reservation":                            resourceAwsEc2CapacityReservation(),
 			"aws_ec2_client_vpn_endpoint":                             resourceAwsEc2ClientVpnEndpoint(),
 			"aws_ec2_client_vpn_network_association":                  resourceAwsEc2ClientVpnNetworkAssociation(),
+			"aws_ec2_client_vpn_route":                                resourceAwsEc2ClientVpnRoute(),
 			"aws_ec2_fleet":                                           resourceAwsEc2Fleet(),
 			"aws_ec2_transit_gateway":                                 resourceAwsEc2TransitGateway(),
 			"aws_ec2_transit_gateway_route":                           resourceAwsEc2TransitGatewayRoute(),

--- a/aws/resource_aws_ec2_client_vpn_route.go
+++ b/aws/resource_aws_ec2_client_vpn_route.go
@@ -1,0 +1,215 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"log"
+)
+
+func resourceAwsEc2ClientVpnRoute() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsEc2ClientVpnRouteCreate,
+		Read:   resourceAwsEc2ClientVpnRouteRead,
+		Delete: resourceAwsEc2ClientVpnRouteDelete,
+
+		Schema: map[string]*schema.Schema{
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"client_vpn_endpoint_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"client_vpn_association_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"cidr_block": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateCIDRNetworkAddress,
+			},
+			"subnet_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsEc2ClientVpnRouteCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	assoc, err := getAwsEc2ClientNetworkAssociation(conn, d.Get("client_vpn_endpoint_id").(string), d.Get("client_vpn_association_id").(string))
+	if err != nil {
+		return fmt.Errorf("Error getting Client VPN network association: %s", err)
+	}
+
+	req := &ec2.CreateClientVpnRouteInput{
+		ClientVpnEndpointId:  aws.String(d.Get("client_vpn_endpoint_id").(string)),
+		TargetVpcSubnetId:    assoc.TargetNetworkId,
+		DestinationCidrBlock: aws.String(d.Get("cidr_block").(string)),
+		Description:          aws.String(d.Get("description").(string)),
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		req.Description = aws.String((v.(string)))
+	}
+
+	log.Printf("[DEBUG] Creating Client VPN Route: %#v", req)
+	_, err = conn.CreateClientVpnRoute(req)
+	if err != nil {
+		return fmt.Errorf("Error creating Client VPN route: %s", err)
+	}
+
+	d.SetId(resource.UniqueId())
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{ec2.ClientVpnRouteStatusCodeCreating},
+		Target:  []string{ec2.ClientVpnRouteStatusCodeActive},
+		Refresh: clientVpnRouteRefreshFunc(conn,
+			*assoc.TargetNetworkId,
+			d.Get("cidr_block").(string),
+			d.Get("client_vpn_endpoint_id").(string)),
+		Timeout: d.Timeout(schema.TimeoutCreate),
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for Client VPN route create: %s", err)
+	}
+
+	return resourceAwsEc2ClientVpnRouteRead(d, meta)
+}
+
+func resourceAwsEc2ClientVpnRouteRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	assoc, err := getAwsEc2ClientNetworkAssociation(conn, d.Get("client_vpn_endpoint_id").(string), d.Get("client_vpn_association_id").(string))
+	if err != nil {
+		return fmt.Errorf("Error getting Client VPN network association: %s", err)
+	}
+
+	req := &ec2.DescribeClientVpnRoutesInput{
+		ClientVpnEndpointId: aws.String(d.Get("client_vpn_endpoint_id").(string)),
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("destinationCidr"),
+				Values: []*string{aws.String(d.Get("cidr_block").(string))},
+			},
+			{
+				Name:   aws.String("targetSubnet"),
+				Values: []*string{assoc.TargetNetworkId},
+			},
+		},
+	}
+
+	result, err := conn.DescribeClientVpnRoutes(req)
+	if err != nil {
+		log.Printf("[WARN] EC2 Client VPN route (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+	if len(result.Routes) != 1 {
+		log.Printf("[WARN] EC2 Client VPN route (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("client_vpn_endpoint_id", result.Routes[0].ClientVpnEndpointId)
+	d.Set("client_vpn_association_id", assoc.AssociationId)
+	d.Set("subnet_id", assoc.TargetNetworkId)
+	d.Set("cidr_block", result.Routes[0].DestinationCidr)
+
+	return nil
+}
+
+func resourceAwsEc2ClientVpnRouteDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	_, err := conn.DeleteClientVpnRoute(&ec2.DeleteClientVpnRouteInput{
+		ClientVpnEndpointId:  aws.String(d.Get("client_vpn_endpoint_id").(string)),
+		DestinationCidrBlock: aws.String(d.Get("cidr_block").(string)),
+		TargetVpcSubnetId:    aws.String(d.Get("subnet_id").(string)),
+	})
+
+	if err != nil {
+		return fmt.Errorf("Error deleting Client VPN route: %s", err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{ec2.ClientVpnRouteStatusCodeDeleting},
+		Target:  []string{"DELETED"},
+		Refresh: clientVpnRouteRefreshFunc(conn,
+			d.Get("subnet_id").(string),
+			d.Get("cidr_block").(string),
+			d.Get("client_vpn_endpoint_id").(string)),
+		Timeout: d.Timeout(schema.TimeoutDelete),
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for Client VPN route to delete: %s", err)
+	}
+
+	return nil
+}
+
+func clientVpnRouteRefreshFunc(conn *ec2.EC2, subnetId string, cidrBlock string, cvepID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+
+		req := &ec2.DescribeClientVpnRoutesInput{
+			ClientVpnEndpointId: aws.String(cvepID),
+			Filters: []*ec2.Filter{
+				{
+					Name:   aws.String("destinationCidr"),
+					Values: []*string{aws.String(cidrBlock)},
+				},
+				{
+					Name:   aws.String("targetSubnet"),
+					Values: []*string{aws.String(subnetId)},
+				},
+			},
+		}
+
+		resp, err := conn.DescribeClientVpnRoutes(req)
+		if err != nil {
+			return nil, "", err
+		}
+
+		if resp == nil || len(resp.Routes) == 0 || resp.Routes[0] == nil {
+			emptyResp := &ec2.DescribeClientVpnRoutesOutput{}
+			return emptyResp, "DELETED", nil
+		}
+
+		return resp.Routes[0], aws.StringValue(resp.Routes[0].Status.Code), nil
+
+	}
+}
+
+func getAwsEc2ClientNetworkAssociation(conn *ec2.EC2, cvepID string, assocId string) (*ec2.TargetNetwork, error) {
+	emptyReturn := &ec2.TargetNetwork{}
+
+	req := &ec2.DescribeClientVpnTargetNetworksInput{
+		ClientVpnEndpointId: aws.String(cvepID),
+		AssociationIds:      []*string{aws.String(assocId)},
+	}
+	resp, err := conn.DescribeClientVpnTargetNetworks(req)
+	if err != nil {
+		return emptyReturn, err
+	}
+
+	if len(resp.ClientVpnTargetNetworks) != 1 {
+		return emptyReturn, fmt.Errorf("Error getting Client VPN network association: %s", assocId)
+	}
+
+	return resp.ClientVpnTargetNetworks[0], nil
+}

--- a/aws/resource_aws_ec2_client_vpn_route_test.go
+++ b/aws/resource_aws_ec2_client_vpn_route_test.go
@@ -1,0 +1,168 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"testing"
+)
+
+func TestAccResourceAwsEc2ClientVpnRoute_basic(t *testing.T) {
+	var assoc1 ec2.ClientVpnRoute
+	rStr := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsEc2ClientVpnRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEc2ClientVpnRouteConfig(rStr),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsEc2ClientVpnRouteExists("aws_ec2_client_vpn_route.test", &assoc1),
+				),
+			},
+		},
+	})
+
+}
+
+func testAccCheckAwsEc2ClientVpnRouteDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_ec2_client_vpn_route" {
+			continue
+		}
+
+		req := &ec2.DescribeClientVpnRoutesInput{
+			ClientVpnEndpointId: aws.String(rs.Primary.Attributes["client_vpn_endpoint_id"]),
+			Filters: []*ec2.Filter{
+				{
+					Name:   aws.String("destinationCidr"),
+					Values: []*string{aws.String(rs.Primary.Attributes["cidr_block"])},
+				},
+				{
+					Name:   aws.String("targetSubnet"),
+					Values: []*string{aws.String(rs.Primary.Attributes["subnet_id"])},
+				},
+			},
+		}
+		resp, _ := conn.DescribeClientVpnRoutes(req)
+
+		for _, a := range resp.Routes {
+			if *a.DestinationCidr == rs.Primary.Attributes["cidr_block"] && *a.TargetSubnet == rs.Primary.Attributes["subnet_id"] {
+				return fmt.Errorf("[DESTROY ERROR] Client VPN route (%s) not deleted", rs.Primary.ID)
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAwsEc2ClientVpnRouteExists(name string, assoc *ec2.ClientVpnRoute) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+		req := &ec2.DescribeClientVpnRoutesInput{
+			ClientVpnEndpointId: aws.String(rs.Primary.Attributes["client_vpn_endpoint_id"]),
+			Filters: []*ec2.Filter{
+				{
+					Name:   aws.String("destinationCidr"),
+					Values: []*string{aws.String(rs.Primary.Attributes["cidr_block"])},
+				},
+				{
+					Name:   aws.String("targetSubnet"),
+					Values: []*string{aws.String(rs.Primary.Attributes["subnet_id"])},
+				},
+			},
+		}
+
+		resp, err := conn.DescribeClientVpnRoutes(req)
+		if err != nil {
+			return fmt.Errorf("Error reading Client VPN route (%s): %s", rs.Primary.ID, err)
+		}
+
+		for _, a := range resp.Routes {
+			if *a.DestinationCidr == rs.Primary.Attributes["cidr_block"] && *a.TargetSubnet == rs.Primary.Attributes["subnet_id"] {
+				return nil
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccEc2ClientVpnRouteConfigAcmCertificateBase() string {
+	key := tlsRsaPrivateKeyPem(2048)
+	certificate := tlsRsaX509SelfSignedCertificatePem(key, "example.com")
+
+	return fmt.Sprintf(`
+resource "aws_acm_certificate" "test" {
+  certificate_body = "%[1]s"
+  private_key      = "%[2]s"
+}
+`, tlsPemEscapeNewlines(certificate), tlsPemEscapeNewlines(key))
+}
+
+func testAccEc2ClientVpnRouteConfig(rName string) string {
+	return testAccEc2ClientVpnRouteConfigAcmCertificateBase() + fmt.Sprintf(`
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = "terraform-testacc-subnet-%s"
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block              = "10.1.1.0/24"
+  vpc_id                  = "${aws_vpc.test.id}"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "tf-acc-subnet-%s"
+  }
+}
+
+resource "aws_ec2_client_vpn_endpoint" "test" {
+  description            = "terraform-testacc-clientvpn-%s"
+  server_certificate_arn = "${aws_acm_certificate.test.arn}"
+  client_cidr_block      = "10.0.0.0/16"
+
+  authentication_options {
+    type                       = "certificate-authentication"
+    root_certificate_chain_arn = "${aws_acm_certificate.test.arn}"
+  }
+
+  connection_log_options {
+    enabled = false
+  }
+}
+
+resource "aws_ec2_client_vpn_network_association" "test" {
+  client_vpn_endpoint_id = "${aws_ec2_client_vpn_endpoint.test.id}"
+  subnet_id              = "${aws_subnet.test.id}"
+}
+
+resource "aws_ec2_client_vpn_route" "test" {
+  description               = "terraform testing"
+  client_vpn_endpoint_id    = "${aws_ec2_client_vpn_endpoint.test.id}"
+  client_vpn_association_id = "${aws_ec2_client_vpn_network_association.test.id}"
+  cidr_block                = "10.202.0.0/16"
+}
+`, rName, rName, rName)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1059,6 +1059,9 @@
                                     <a href="/docs/providers/aws/r/ec2_client_vpn_network_association.html">aws_ec2_client_vpn_network_association</a>
                                 </li>
                                 <li>
+                                    <a href="/docs/providers/aws/r/ec2_client_vpn_route.html">aws_ec2_client_vpn_route</a>
+                                 </li>
+                                <li>
                                     <a href="/docs/providers/aws/r/ec2_fleet.html">aws_ec2_fleet</a>
                                 </li>
                                 <li>

--- a/website/docs/r/ec2_client_vpn_route.html.markdown
+++ b/website/docs/r/ec2_client_vpn_route.html.markdown
@@ -1,0 +1,37 @@
+---
+layout: "aws"
+page_title: "AWS: aws_ec2_client_vpn_route"
+description: |-
+  Provides route resource for AWS Client VPN endpoints.
+---
+
+# Resource: aws_ec2_client_vpn_route
+
+Provides routes resource for AWS Client VPN endpoints. For more information on usage, please see the 
+[AWS Client VPN Administrator's Guide](https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/what-is.html).
+
+## Example Usage
+
+```hcl
+resource "aws_ec2_client_vpn_route" "example" {
+  client_vpn_endpoint_id    = "${aws_ec2_client_vpn_endpoint.example.id}"
+  client_vpn_association_id = "${aws_ec2_client_vpn_network_association.example.id}"
+  cidr_block                = "10.202.0.0/16"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `cidr_block` - (Required) The CIDR block for the subnet.
+* `client_vpn_endpoint_id` - (Required) The ID of the Client VPN endpoint.
+* `client_vpn_association_id` - (Required) The ID of the Client VPN network association.
+* `description` - (Optional) The description of the route.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The unique ID of the route.
+* `subnet_id` - The ID of the associated subnet.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

Create new resource for EC2 Client VPN routes (https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/cvpn-working-routes.html)

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10437 
Closes #7831

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
New Resource: aws_ec2_client_vpn_route
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAwsEc2ClientVpnRoute'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsEc2ClientVpnRoute -timeout 120m
=== RUN   TestAccAwsEc2ClientVpnRoute_basic
=== PAUSE TestAccAwsEc2ClientVpnRoute_basic
=== RUN   TestAccAwsEc2ClientVpnRoute_disappears
=== PAUSE TestAccAwsEc2ClientVpnRoute_disappears
=== CONT  TestAccAwsEc2ClientVpnRoute_basic
=== CONT  TestAccAwsEc2ClientVpnRoute_disappears
--- PASS: TestAccAwsEc2ClientVpnRoute_basic (623.28s)
--- PASS: TestAccAwsEc2ClientVpnRoute_disappears (633.34s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       633.617s
```
