### PR TITLE
Update aws_ebs_default_kms_key key_id to key_arn in the document

### DIFF
--- a/website/docs/d/ebs_default_kms_key.html.markdown
+++ b/website/docs/d/ebs_default_kms_key.html.markdown
@@ -16,7 +16,7 @@ resource "aws_ebs_volume" "example" {
   availability_zone = "us-west-2a"
   
   encrypted         = true
-  kms_key_id        = "${data.aws_ebs_default_kms_key.current.key_id}"
+  kms_key_id        = "${data.aws_ebs_default_kms_key.current.key_arn}"
 
 }
 ```


### PR DESCRIPTION
Fix incorrect `key_id` reference in the documentation (`Example Usage`).
- The original `key_id` was updated with correct `key_arn` with the following Commit / PR (#8884), but only this part (`Example Usage`) seems not updated.
    - https://github.com/terraform-providers/terraform-provider-aws/commit/2bf99464c57e6a2e196edf37c16af9e616e21b6f#diff-b94010b82e31e6801028d9d2bd1ac633
- The `kms_key_id` part of `aws_ebs_volume` seems correct (matched with the implementation).
   - https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/resource_aws_ebs_volume.go#L51

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
