### PR TITLE
Import test refactor for DX resources

### DIFF
--- a/aws/resource_aws_dx_connection_test.go
+++ b/aws/resource_aws_dx_connection_test.go
@@ -11,29 +11,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSDxConnection_importBasic(t *testing.T) {
-	resourceName := "aws_dx_connection.hoge"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsDxConnectionDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDxConnectionConfig(acctest.RandString(5)),
-			},
-
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAWSDxConnection_basic(t *testing.T) {
 	connectionName := fmt.Sprintf("tf-dx-%s", acctest.RandString(5))
+	resourceName := "aws_dx_connection.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -43,12 +23,17 @@ func TestAccAWSDxConnection_basic(t *testing.T) {
 			{
 				Config: testAccDxConnectionConfig(connectionName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsDxConnectionExists("aws_dx_connection.hoge"),
-					resource.TestCheckResourceAttr("aws_dx_connection.hoge", "name", connectionName),
-					resource.TestCheckResourceAttr("aws_dx_connection.hoge", "bandwidth", "1Gbps"),
-					resource.TestCheckResourceAttr("aws_dx_connection.hoge", "location", "EqSe2"),
-					resource.TestCheckResourceAttr("aws_dx_connection.hoge", "tags.%", "0"),
+					testAccCheckAwsDxConnectionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", connectionName),
+					resource.TestCheckResourceAttr(resourceName, "bandwidth", "1Gbps"),
+					resource.TestCheckResourceAttr(resourceName, "location", "EqSe2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -56,6 +41,7 @@ func TestAccAWSDxConnection_basic(t *testing.T) {
 
 func TestAccAWSDxConnection_tags(t *testing.T) {
 	connectionName := fmt.Sprintf("tf-dx-%s", acctest.RandString(5))
+	resourceName := "aws_dx_connection.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -65,19 +51,24 @@ func TestAccAWSDxConnection_tags(t *testing.T) {
 			{
 				Config: testAccDxConnectionConfig_tags(connectionName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsDxConnectionExists("aws_dx_connection.hoge"),
-					resource.TestCheckResourceAttr("aws_dx_connection.hoge", "name", connectionName),
-					resource.TestCheckResourceAttr("aws_dx_connection.hoge", "tags.%", "2"),
-					resource.TestCheckResourceAttr("aws_dx_connection.hoge", "tags.Usage", "original"),
+					testAccCheckAwsDxConnectionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", connectionName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Usage", "original"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccDxConnectionConfig_tagsChanged(connectionName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsDxConnectionExists("aws_dx_connection.hoge"),
-					resource.TestCheckResourceAttr("aws_dx_connection.hoge", "name", connectionName),
-					resource.TestCheckResourceAttr("aws_dx_connection.hoge", "tags.%", "1"),
-					resource.TestCheckResourceAttr("aws_dx_connection.hoge", "tags.Usage", "changed"),
+					testAccCheckAwsDxConnectionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", connectionName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Usage", "changed"),
 				),
 			},
 		},
@@ -122,7 +113,7 @@ func testAccCheckAwsDxConnectionExists(name string) resource.TestCheckFunc {
 
 func testAccDxConnectionConfig(n string) string {
 	return fmt.Sprintf(`
-resource "aws_dx_connection" "hoge" {
+resource "aws_dx_connection" "test" {
   name      = "%s"
   bandwidth = "1Gbps"
   location  = "EqSe2"
@@ -132,7 +123,7 @@ resource "aws_dx_connection" "hoge" {
 
 func testAccDxConnectionConfig_tags(n string) string {
 	return fmt.Sprintf(`
-resource "aws_dx_connection" "hoge" {
+resource "aws_dx_connection" "test" {
   name      = "%s"
   bandwidth = "1Gbps"
   location  = "EqSe2"
@@ -147,7 +138,7 @@ resource "aws_dx_connection" "hoge" {
 
 func testAccDxConnectionConfig_tagsChanged(n string) string {
 	return fmt.Sprintf(`
-resource "aws_dx_connection" "hoge" {
+resource "aws_dx_connection" "test" {
   name      = "%s"
   bandwidth = "1Gbps"
   location  = "EqSe2"

--- a/aws/resource_aws_dx_gateway_test.go
+++ b/aws/resource_aws_dx_gateway_test.go
@@ -115,7 +115,7 @@ func testSweepDirectConnectGateways(region string) error {
 	return nil
 }
 
-func TestAccAwsDxGateway_importBasic(t *testing.T) {
+func TestAccAwsDxGateway_basic(t *testing.T) {
 	resourceName := "aws_dx_gateway.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -125,8 +125,11 @@ func TestAccAwsDxGateway_importBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDxGatewayConfig(acctest.RandString(5), randIntRange(64512, 65534)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsDxGatewayExists(resourceName),
+					testAccCheckResourceAttrAccountID(resourceName, "owner_account_id"),
+				),
 			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
@@ -136,7 +139,7 @@ func TestAccAwsDxGateway_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccAwsDxGateway_importComplex(t *testing.T) {
+func TestAccAwsDxGateway_complex(t *testing.T) {
 	checkFn := func(s []*terraform.InstanceState) error {
 		if len(s) != 3 {
 			return fmt.Errorf("Got %d resources, expected 3. State: %#v", len(s), s)
@@ -147,6 +150,7 @@ func TestAccAwsDxGateway_importComplex(t *testing.T) {
 	rName1 := fmt.Sprintf("terraform-testacc-dxgwassoc-%d", acctest.RandInt())
 	rName2 := fmt.Sprintf("terraform-testacc-dxgwassoc-%d", acctest.RandInt())
 	rBgpAsn := randIntRange(64512, 65534)
+	resourceName := "aws_dx_gateway.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -155,30 +159,16 @@ func TestAccAwsDxGateway_importComplex(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDxGatewayAssociationConfig_multiVpnGatewaysSingleAccount(rName1, rName2, rBgpAsn),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsDxGatewayExists(resourceName),
+					testAccCheckResourceAttrAccountID(resourceName, "owner_account_id"),
+				),
 			},
-
 			{
-				ResourceName:      "aws_dx_gateway.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateCheck:  checkFn,
 				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAwsDxGateway_basic(t *testing.T) {
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsDxGatewayDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDxGatewayConfig(acctest.RandString(5), randIntRange(64512, 65534)),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsDxGatewayExists("aws_dx_gateway.test"),
-					testAccCheckResourceAttrAccountID("aws_dx_gateway.test", "owner_account_id"),
-				),
 			},
 		},
 	})

--- a/aws/resource_aws_dx_lag_test.go
+++ b/aws/resource_aws_dx_lag_test.go
@@ -11,31 +11,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSDxLag_importBasic(t *testing.T) {
-	resourceName := "aws_dx_lag.hoge"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsDxLagDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDxLagConfig(acctest.RandString(5)),
-			},
-
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy"},
-			},
-		},
-	})
-}
-
 func TestAccAWSDxLag_basic(t *testing.T) {
 	lagName1 := fmt.Sprintf("tf-dx-lag-%s", acctest.RandString(5))
 	lagName2 := fmt.Sprintf("tf-dx-lag-%s", acctest.RandString(5))
+	resourceName := "aws_dx_lag.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -45,21 +24,27 @@ func TestAccAWSDxLag_basic(t *testing.T) {
 			{
 				Config: testAccDxLagConfig(lagName1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsDxLagExists("aws_dx_lag.hoge"),
-					resource.TestCheckResourceAttr("aws_dx_lag.hoge", "name", lagName1),
-					resource.TestCheckResourceAttr("aws_dx_lag.hoge", "connections_bandwidth", "1Gbps"),
-					resource.TestCheckResourceAttr("aws_dx_lag.hoge", "location", "EqSe2"),
-					resource.TestCheckResourceAttr("aws_dx_lag.hoge", "tags.%", "0"),
+					testAccCheckAwsDxLagExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", lagName1),
+					resource.TestCheckResourceAttr(resourceName, "connections_bandwidth", "1Gbps"),
+					resource.TestCheckResourceAttr(resourceName, "location", "EqSe2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 			{
 				Config: testAccDxLagConfig(lagName2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsDxLagExists("aws_dx_lag.hoge"),
-					resource.TestCheckResourceAttr("aws_dx_lag.hoge", "name", lagName2),
-					resource.TestCheckResourceAttr("aws_dx_lag.hoge", "connections_bandwidth", "1Gbps"),
-					resource.TestCheckResourceAttr("aws_dx_lag.hoge", "location", "EqSe2"),
-					resource.TestCheckResourceAttr("aws_dx_lag.hoge", "tags.%", "0"),
+					testAccCheckAwsDxLagExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", lagName2),
+					resource.TestCheckResourceAttr(resourceName, "connections_bandwidth", "1Gbps"),
+					resource.TestCheckResourceAttr(resourceName, "location", "EqSe2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 		},
@@ -68,6 +53,7 @@ func TestAccAWSDxLag_basic(t *testing.T) {
 
 func TestAccAWSDxLag_tags(t *testing.T) {
 	lagName := fmt.Sprintf("tf-dx-lag-%s", acctest.RandString(5))
+	resourceName := "aws_dx_lag.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -77,27 +63,33 @@ func TestAccAWSDxLag_tags(t *testing.T) {
 			{
 				Config: testAccDxLagConfig_tags(lagName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsDxLagExists("aws_dx_lag.hoge"),
-					resource.TestCheckResourceAttr("aws_dx_lag.hoge", "name", lagName),
-					resource.TestCheckResourceAttr("aws_dx_lag.hoge", "tags.%", "2"),
-					resource.TestCheckResourceAttr("aws_dx_lag.hoge", "tags.Usage", "original"),
+					testAccCheckAwsDxLagExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", lagName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Usage", "original"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 			{
 				Config: testAccDxLagConfig_tagsChanged(lagName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsDxLagExists("aws_dx_lag.hoge"),
-					resource.TestCheckResourceAttr("aws_dx_lag.hoge", "name", lagName),
-					resource.TestCheckResourceAttr("aws_dx_lag.hoge", "tags.%", "1"),
-					resource.TestCheckResourceAttr("aws_dx_lag.hoge", "tags.Usage", "changed"),
+					testAccCheckAwsDxLagExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", lagName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Usage", "changed"),
 				),
 			},
 			{
 				Config: testAccDxLagConfig(lagName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsDxLagExists("aws_dx_lag.hoge"),
-					resource.TestCheckResourceAttr("aws_dx_lag.hoge", "name", lagName),
-					resource.TestCheckResourceAttr("aws_dx_lag.hoge", "tags.%", "0"),
+					testAccCheckAwsDxLagExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", lagName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 		},
@@ -143,7 +135,7 @@ func testAccCheckAwsDxLagExists(name string) resource.TestCheckFunc {
 
 func testAccDxLagConfig(n string) string {
 	return fmt.Sprintf(`
-resource "aws_dx_lag" "hoge" {
+resource "aws_dx_lag" "test" {
   name                  = "%s"
   connections_bandwidth = "1Gbps"
   location              = "EqSe2"
@@ -154,7 +146,7 @@ resource "aws_dx_lag" "hoge" {
 
 func testAccDxLagConfig_tags(n string) string {
 	return fmt.Sprintf(`
-resource "aws_dx_lag" "hoge" {
+resource "aws_dx_lag" "test" {
   name                  = "%s"
   connections_bandwidth = "1Gbps"
   location              = "EqSe2"
@@ -170,7 +162,7 @@ resource "aws_dx_lag" "hoge" {
 
 func testAccDxLagConfig_tagsChanged(n string) string {
 	return fmt.Sprintf(`
-resource "aws_dx_lag" "hoge" {
+resource "aws_dx_lag" "test" {
   name                  = "%s"
   connections_bandwidth = "1Gbps"
   location              = "EqSe2"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8944

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
make testacc TESTARGS="-run=TestAccAWSDxConnection_"     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSDxConnection_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSDxConnection_basic
=== PAUSE TestAccAWSDxConnection_basic
=== RUN   TestAccAWSDxConnection_tags
=== PAUSE TestAccAWSDxConnection_tags
=== CONT  TestAccAWSDxConnection_basic
=== CONT  TestAccAWSDxConnection_tags
--- PASS: TestAccAWSDxConnection_basic (40.44s)
--- PASS: TestAccAWSDxConnection_tags (60.99s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       62.422s

make testacc TESTARGS="-run=TestAccAwsDxGateway_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAwsDxGateway_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAwsDxGateway_basic
=== PAUSE TestAccAwsDxGateway_basic
=== RUN   TestAccAwsDxGateway_complex
=== PAUSE TestAccAwsDxGateway_complex
=== CONT  TestAccAwsDxGateway_basic
=== CONT  TestAccAwsDxGateway_complex
--- PASS: TestAccAwsDxGateway_basic (50.14s)
--- PASS: TestAccAwsDxGateway_complex (1218.72s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       1220.152s

make testacc TESTARGS="-run=TestAccAWSDxLag_"     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSDxLag_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSDxLag_basic
=== PAUSE TestAccAWSDxLag_basic
=== RUN   TestAccAWSDxLag_tags
=== PAUSE TestAccAWSDxLag_tags
=== CONT  TestAccAWSDxLag_basic
=== CONT  TestAccAWSDxLag_tags
--- PASS: TestAccAWSDxLag_basic (62.31s)
--- PASS: TestAccAWSDxLag_tags (82.70s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       84.119s
```
