### PR TITLE
Import test refactor for db resources

### DIFF
--- a/aws/resource_aws_db_event_subscription_test.go
+++ b/aws/resource_aws_db_event_subscription_test.go
@@ -13,9 +13,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSDBEventSubscription_importBasic(t *testing.T) {
-	resourceName := "aws_db_event_subscription.bar"
+func TestAccAWSDBEventSubscription_basicUpdate(t *testing.T) {
+	var v rds.EventSubscription
 	rInt := acctest.RandInt()
+	resourceName := "aws_db_event_subscription.test"
 	subscriptionName := fmt.Sprintf("tf-acc-test-rds-event-subs-%d", rInt)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -25,48 +26,30 @@ func TestAccAWSDBEventSubscription_importBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSDBEventSubscriptionConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBEventSubscriptionExists(resourceName, &v),
+					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:rds:[^:]+:[^:]+:es:%s$", subscriptionName))),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "source_type", "db-instance"),
+					resource.TestCheckResourceAttr(resourceName, "name", subscriptionName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "name"),
+				),
 			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateId:     subscriptionName,
 			},
-		},
-	})
-}
-
-func TestAccAWSDBEventSubscription_basicUpdate(t *testing.T) {
-	var v rds.EventSubscription
-	rInt := acctest.RandInt()
-	rName := fmt.Sprintf("tf-acc-test-rds-event-subs-%d", rInt)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSDBEventSubscriptionDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSDBEventSubscriptionConfig(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDBEventSubscriptionExists("aws_db_event_subscription.bar", &v),
-					resource.TestMatchResourceAttr("aws_db_event_subscription.bar", "arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:rds:[^:]+:[^:]+:es:%s$", rName))),
-					resource.TestCheckResourceAttr("aws_db_event_subscription.bar", "enabled", "true"),
-					resource.TestCheckResourceAttr("aws_db_event_subscription.bar", "source_type", "db-instance"),
-					resource.TestCheckResourceAttr("aws_db_event_subscription.bar", "name", rName),
-					resource.TestCheckResourceAttr("aws_db_event_subscription.bar", "tags.%", "1"),
-					resource.TestCheckResourceAttr("aws_db_event_subscription.bar", "tags.Name", "name"),
-				),
-			},
 			{
 				Config: testAccAWSDBEventSubscriptionConfigUpdate(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDBEventSubscriptionExists("aws_db_event_subscription.bar", &v),
-					resource.TestCheckResourceAttr("aws_db_event_subscription.bar", "enabled", "false"),
-					resource.TestCheckResourceAttr("aws_db_event_subscription.bar", "source_type", "db-parameter-group"),
-					resource.TestCheckResourceAttr("aws_db_event_subscription.bar", "tags.%", "1"),
-					resource.TestCheckResourceAttr("aws_db_event_subscription.bar", "tags.Name", "new-name"),
+					testAccCheckAWSDBEventSubscriptionExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "source_type", "db-parameter-group"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "new-name"),
 				),
 			},
 		},
@@ -76,7 +59,7 @@ func TestAccAWSDBEventSubscription_basicUpdate(t *testing.T) {
 func TestAccAWSDBEventSubscription_disappears(t *testing.T) {
 	var eventSubscription rds.EventSubscription
 	rInt := acctest.RandInt()
-	resourceName := "aws_db_event_subscription.bar"
+	resourceName := "aws_db_event_subscription.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -99,6 +82,7 @@ func TestAccAWSDBEventSubscription_withPrefix(t *testing.T) {
 	var v rds.EventSubscription
 	rInt := acctest.RandInt()
 	startsWithPrefix := regexp.MustCompile("^tf-acc-test-rds-event-subs-")
+	resourceName := "aws_db_event_subscription.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -108,15 +92,15 @@ func TestAccAWSDBEventSubscription_withPrefix(t *testing.T) {
 			{
 				Config: testAccAWSDBEventSubscriptionConfigWithPrefix(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDBEventSubscriptionExists("aws_db_event_subscription.bar", &v),
+					testAccCheckAWSDBEventSubscriptionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_db_event_subscription.bar", "enabled", "true"),
+						resourceName, "enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_db_event_subscription.bar", "source_type", "db-instance"),
+						resourceName, "source_type", "db-instance"),
 					resource.TestMatchResourceAttr(
-						"aws_db_event_subscription.bar", "name", startsWithPrefix),
+						resourceName, "name", startsWithPrefix),
 					resource.TestCheckResourceAttr(
-						"aws_db_event_subscription.bar", "tags.Name", "name"),
+						resourceName, "tags.Name", "name"),
 				),
 			},
 		},
@@ -126,6 +110,8 @@ func TestAccAWSDBEventSubscription_withPrefix(t *testing.T) {
 func TestAccAWSDBEventSubscription_withSourceIds(t *testing.T) {
 	var v rds.EventSubscription
 	rInt := acctest.RandInt()
+	resourceName := "aws_db_event_subscription.test"
+	subscriptionName := fmt.Sprintf("tf-acc-test-rds-event-subs-with-ids-%d", rInt)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -135,29 +121,35 @@ func TestAccAWSDBEventSubscription_withSourceIds(t *testing.T) {
 			{
 				Config: testAccAWSDBEventSubscriptionConfigWithSourceIds(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDBEventSubscriptionExists("aws_db_event_subscription.bar", &v),
+					testAccCheckAWSDBEventSubscriptionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_db_event_subscription.bar", "enabled", "true"),
+						resourceName, "enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_db_event_subscription.bar", "source_type", "db-parameter-group"),
+						resourceName, "source_type", "db-parameter-group"),
 					resource.TestCheckResourceAttr(
-						"aws_db_event_subscription.bar", "name", fmt.Sprintf("tf-acc-test-rds-event-subs-with-ids-%d", rInt)),
+						resourceName, "name", fmt.Sprintf("tf-acc-test-rds-event-subs-with-ids-%d", rInt)),
 					resource.TestCheckResourceAttr(
-						"aws_db_event_subscription.bar", "source_ids.#", "1"),
+						resourceName, "source_ids.#", "1"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     subscriptionName,
 			},
 			{
 				Config: testAccAWSDBEventSubscriptionConfigUpdateSourceIds(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDBEventSubscriptionExists("aws_db_event_subscription.bar", &v),
+					testAccCheckAWSDBEventSubscriptionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_db_event_subscription.bar", "enabled", "true"),
+						resourceName, "enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_db_event_subscription.bar", "source_type", "db-parameter-group"),
+						resourceName, "source_type", "db-parameter-group"),
 					resource.TestCheckResourceAttr(
-						"aws_db_event_subscription.bar", "name", fmt.Sprintf("tf-acc-test-rds-event-subs-with-ids-%d", rInt)),
+						resourceName, "name", fmt.Sprintf("tf-acc-test-rds-event-subs-with-ids-%d", rInt)),
 					resource.TestCheckResourceAttr(
-						"aws_db_event_subscription.bar", "source_ids.#", "2"),
+						resourceName, "source_ids.#", "2"),
 				),
 			},
 		},
@@ -167,6 +159,8 @@ func TestAccAWSDBEventSubscription_withSourceIds(t *testing.T) {
 func TestAccAWSDBEventSubscription_categoryUpdate(t *testing.T) {
 	var v rds.EventSubscription
 	rInt := acctest.RandInt()
+	resourceName := "aws_db_event_subscription.test"
+	subscriptionName := fmt.Sprintf("tf-acc-test-rds-event-subs-%d", rInt)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -176,23 +170,29 @@ func TestAccAWSDBEventSubscription_categoryUpdate(t *testing.T) {
 			{
 				Config: testAccAWSDBEventSubscriptionConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDBEventSubscriptionExists("aws_db_event_subscription.bar", &v),
+					testAccCheckAWSDBEventSubscriptionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_db_event_subscription.bar", "enabled", "true"),
+						resourceName, "enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_db_event_subscription.bar", "source_type", "db-instance"),
+						resourceName, "source_type", "db-instance"),
 					resource.TestCheckResourceAttr(
-						"aws_db_event_subscription.bar", "name", fmt.Sprintf("tf-acc-test-rds-event-subs-%d", rInt)),
+						resourceName, "name", fmt.Sprintf("tf-acc-test-rds-event-subs-%d", rInt)),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     subscriptionName,
 			},
 			{
 				Config: testAccAWSDBEventSubscriptionConfigUpdateCategories(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDBEventSubscriptionExists("aws_db_event_subscription.bar", &v),
+					testAccCheckAWSDBEventSubscriptionExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_db_event_subscription.bar", "enabled", "true"),
+						resourceName, "enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_db_event_subscription.bar", "source_type", "db-instance"),
+						resourceName, "source_type", "db-instance"),
 				),
 			},
 		},
@@ -278,7 +278,7 @@ resource "aws_sns_topic" "aws_sns_topic" {
   name = "tf-acc-test-rds-event-subs-sns-topic-%d"
 }
 
-resource "aws_db_event_subscription" "bar" {
+resource "aws_db_event_subscription" "test" {
   name        = "tf-acc-test-rds-event-subs-%d"
   sns_topic   = "${aws_sns_topic.aws_sns_topic.arn}"
   source_type = "db-instance"
@@ -304,7 +304,7 @@ resource "aws_sns_topic" "aws_sns_topic" {
   name = "tf-acc-test-rds-event-subs-sns-topic-%d"
 }
 
-resource "aws_db_event_subscription" "bar" {
+resource "aws_db_event_subscription" "test" {
   name_prefix = "tf-acc-test-rds-event-subs-"
   sns_topic   = "${aws_sns_topic.aws_sns_topic.arn}"
   source_type = "db-instance"
@@ -330,7 +330,7 @@ resource "aws_sns_topic" "aws_sns_topic" {
   name = "tf-acc-test-rds-event-subs-sns-topic-%d"
 }
 
-resource "aws_db_event_subscription" "bar" {
+resource "aws_db_event_subscription" "test" {
   name        = "tf-acc-test-rds-event-subs-%d"
   sns_topic   = "${aws_sns_topic.aws_sns_topic.arn}"
   enabled     = false
@@ -353,17 +353,17 @@ resource "aws_sns_topic" "aws_sns_topic" {
   name = "tf-acc-test-rds-event-subs-sns-topic-%d"
 }
 
-resource "aws_db_parameter_group" "bar" {
+resource "aws_db_parameter_group" "test" {
   name        = "db-parameter-group-event-%d"
   family      = "mysql5.6"
   description = "Test parameter group for terraform"
 }
 
-resource "aws_db_event_subscription" "bar" {
+resource "aws_db_event_subscription" "test" {
   name        = "tf-acc-test-rds-event-subs-with-ids-%d"
   sns_topic   = "${aws_sns_topic.aws_sns_topic.arn}"
   source_type = "db-parameter-group"
-  source_ids  = ["${aws_db_parameter_group.bar.id}"]
+  source_ids  = ["${aws_db_parameter_group.test.id}"]
 
   event_categories = [
     "configuration change",
@@ -382,23 +382,23 @@ resource "aws_sns_topic" "aws_sns_topic" {
   name = "tf-acc-test-rds-event-subs-sns-topic-%d"
 }
 
-resource "aws_db_parameter_group" "bar" {
+resource "aws_db_parameter_group" "test" {
   name        = "db-parameter-group-event-%d"
   family      = "mysql5.6"
   description = "Test parameter group for terraform"
 }
 
-resource "aws_db_parameter_group" "foo" {
+resource "aws_db_parameter_group" "test2" {
   name        = "db-parameter-group-event-2-%d"
   family      = "mysql5.6"
   description = "Test parameter group for terraform"
 }
 
-resource "aws_db_event_subscription" "bar" {
+resource "aws_db_event_subscription" "test" {
   name        = "tf-acc-test-rds-event-subs-with-ids-%d"
   sns_topic   = "${aws_sns_topic.aws_sns_topic.arn}"
   source_type = "db-parameter-group"
-  source_ids  = ["${aws_db_parameter_group.bar.id}", "${aws_db_parameter_group.foo.id}"]
+  source_ids  = ["${aws_db_parameter_group.test.id}", "${aws_db_parameter_group.test2.id}"]
 
   event_categories = [
     "configuration change",
@@ -417,7 +417,7 @@ resource "aws_sns_topic" "aws_sns_topic" {
   name = "tf-acc-test-rds-event-subs-sns-topic-%d"
 }
 
-resource "aws_db_event_subscription" "bar" {
+resource "aws_db_event_subscription" "test" {
   name        = "tf-acc-test-rds-event-subs-%d"
   sns_topic   = "${aws_sns_topic.aws_sns_topic.arn}"
   source_type = "db-instance"

--- a/aws/resource_aws_db_parameter_group_test.go
+++ b/aws/resource_aws_db_parameter_group_test.go
@@ -73,8 +73,9 @@ func testSweepRdsDbParameterGroups(region string) error {
 	return nil
 }
 
-func TestAccAWSDBParameterGroup_importBasic(t *testing.T) {
-	resourceName := "aws_db_parameter_group.bar"
+func TestAccAWSDBParameterGroup_basic(t *testing.T) {
+	var v rds.DBParameterGroup
+	resourceName := "aws_db_parameter_group.test"
 	groupName := fmt.Sprintf("parameter-group-test-terraform-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -84,12 +85,74 @@ func TestAccAWSDBParameterGroup_importBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSDBParameterGroupConfig(groupName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBParameterGroupExists(resourceName, &v),
+					testAccCheckAWSDBParameterGroupAttributes(&v, groupName),
+					resource.TestCheckResourceAttr(
+						resourceName, "name", groupName),
+					resource.TestCheckResourceAttr(
+						resourceName, "family", "mysql5.6"),
+					resource.TestCheckResourceAttr(
+						resourceName, "description", "Managed by Terraform"),
+					resource.TestCheckResourceAttr(
+						resourceName, "parameter.1708034931.name", "character_set_results"),
+					resource.TestCheckResourceAttr(
+						resourceName, "parameter.1708034931.value", "utf8"),
+					resource.TestCheckResourceAttr(
+						resourceName, "parameter.2421266705.name", "character_set_server"),
+					resource.TestCheckResourceAttr(
+						resourceName, "parameter.2421266705.value", "utf8"),
+					resource.TestCheckResourceAttr(
+						resourceName, "parameter.2478663599.name", "character_set_client"),
+					resource.TestCheckResourceAttr(
+						resourceName, "parameter.2478663599.value", "utf8"),
+					resource.TestCheckResourceAttr(
+						resourceName, "tags.%", "1"),
+					resource.TestMatchResourceAttr(
+						resourceName, "arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:rds:[^:]+:\\d{12}:pg:%s", groupName))),
+				),
 			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSDBParameterGroupAddParametersConfig(groupName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBParameterGroupExists(resourceName, &v),
+					testAccCheckAWSDBParameterGroupAttributes(&v, groupName),
+					resource.TestCheckResourceAttr(
+						resourceName, "name", groupName),
+					resource.TestCheckResourceAttr(
+						resourceName, "family", "mysql5.6"),
+					resource.TestCheckResourceAttr(
+						resourceName, "description", "Test parameter group for terraform"),
+					resource.TestCheckResourceAttr(
+						resourceName, "parameter.1706463059.name", "collation_connection"),
+					resource.TestCheckResourceAttr(
+						resourceName, "parameter.1706463059.value", "utf8_unicode_ci"),
+					resource.TestCheckResourceAttr(
+						resourceName, "parameter.1708034931.name", "character_set_results"),
+					resource.TestCheckResourceAttr(
+						resourceName, "parameter.1708034931.value", "utf8"),
+					resource.TestCheckResourceAttr(
+						resourceName, "parameter.2421266705.name", "character_set_server"),
+					resource.TestCheckResourceAttr(
+						resourceName, "parameter.2421266705.value", "utf8"),
+					resource.TestCheckResourceAttr(
+						resourceName, "parameter.2475805061.name", "collation_server"),
+					resource.TestCheckResourceAttr(
+						resourceName, "parameter.2475805061.value", "utf8_unicode_ci"),
+					resource.TestCheckResourceAttr(
+						resourceName, "parameter.2478663599.name", "character_set_client"),
+					resource.TestCheckResourceAttr(
+						resourceName, "parameter.2478663599.value", "utf8"),
+					resource.TestCheckResourceAttr(
+						resourceName, "tags.%", "2"),
+					resource.TestMatchResourceAttr(
+						resourceName, "arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:rds:[^:]+:\\d{12}:pg:%s", groupName))),
+				),
 			},
 		},
 	})
@@ -97,7 +160,7 @@ func TestAccAWSDBParameterGroup_importBasic(t *testing.T) {
 
 func TestAccAWSDBParameterGroup_limit(t *testing.T) {
 	var v rds.DBParameterGroup
-
+	resourceName := "aws_db_parameter_group.test"
 	groupName := fmt.Sprintf("parameter-group-test-terraform-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -108,267 +171,192 @@ func TestAccAWSDBParameterGroup_limit(t *testing.T) {
 			{
 				Config: createAwsDbParameterGroupsExceedDefaultAwsLimit(groupName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDBParameterGroupExists("aws_db_parameter_group.large", &v),
+					testAccCheckAWSDBParameterGroupExists(resourceName, &v),
 					testAccCheckAWSDBParameterGroupAttributes(&v, groupName),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "name", groupName),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "family", "mysql5.6"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "description", "RDS default parameter group: Exceed default AWS parameter group limit of twenty"),
+					resource.TestCheckResourceAttr(resourceName, "name", groupName),
+					resource.TestCheckResourceAttr(resourceName, "family", "mysql5.6"),
+					resource.TestCheckResourceAttr(resourceName, "description", "RDS default parameter group: Exceed default AWS parameter group limit of twenty"),
 
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2421266705.name", "character_set_server"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2421266705.value", "utf8"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2478663599.name", "character_set_client"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2478663599.value", "utf8"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1680942586.name", "collation_server"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1680942586.value", "utf8_general_ci"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2450940716.name", "collation_connection"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2450940716.value", "utf8_general_ci"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.242489837.name", "join_buffer_size"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.242489837.value", "16777216"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2026669454.name", "key_buffer_size"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2026669454.value", "67108864"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2705275319.name", "max_connections"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2705275319.value", "3200"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.3512697936.name", "max_heap_table_size"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.3512697936.value", "67108864"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.780730667.name", "performance_schema"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.780730667.value", "1"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2020346918.name", "performance_schema_users_size"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2020346918.value", "1048576"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1460834103.name", "query_cache_limit"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1460834103.value", "2097152"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.484865451.name", "query_cache_size"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.484865451.value", "67108864"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.255276438.name", "sort_buffer_size"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.255276438.value", "16777216"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2981725119.name", "table_open_cache"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2981725119.value", "4096"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2703661820.name", "tmp_table_size"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2703661820.value", "67108864"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2386583229.name", "binlog_cache_size"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2386583229.value", "131072"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.4012389720.name", "innodb_flush_log_at_trx_commit"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.4012389720.value", "0"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2688783017.name", "innodb_open_files"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2688783017.value", "4000"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.782983977.name", "innodb_read_io_threads"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.782983977.value", "64"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2809980413.name", "innodb_thread_concurrency"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2809980413.value", "0"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.3599115250.name", "innodb_write_io_threads"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.3599115250.value", "64"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2557156277.name", "character_set_connection"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2557156277.value", "utf8"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2475346812.name", "character_set_database"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2475346812.value", "utf8"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1986528518.name", "character_set_filesystem"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1986528518.value", "utf8"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1708034931.name", "character_set_results"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1708034931.value", "utf8"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1937131004.name", "event_scheduler"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1937131004.value", "ON"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.3437079877.name", "innodb_buffer_pool_dump_at_shutdown"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.3437079877.value", "1"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1092112861.name", "innodb_file_format"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1092112861.value", "Barracuda"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.615571931.name", "innodb_io_capacity"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.615571931.value", "2000"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1065962799.name", "innodb_io_capacity_max"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1065962799.value", "3000"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1411161182.name", "innodb_lock_wait_timeout"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1411161182.value", "120"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.3133315879.name", "innodb_max_dirty_pages_pct"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.3133315879.value", "90"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.950177639.name", "log_bin_trust_function_creators"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.950177639.value", "1"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.591700516.name", "log_warnings"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.591700516.value", "2"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1918306725.name", "log_output"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1918306725.value", "FILE"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.386204433.name", "max_allowed_packet"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.386204433.value", "1073741824"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1700901269.name", "max_connect_errors"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1700901269.value", "100"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2839701698.name", "query_cache_min_res_unit"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2839701698.value", "512"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.427634017.name", "slow_query_log"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.427634017.value", "1"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.881816039.name", "sync_binlog"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.881816039.value", "0"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.748684209.name", "tx_isolation"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.748684209.value", "REPEATABLE-READ"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2421266705.name", "character_set_server"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2421266705.value", "utf8"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2478663599.name", "character_set_client"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2478663599.value", "utf8"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1680942586.name", "collation_server"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1680942586.value", "utf8_general_ci"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2450940716.name", "collation_connection"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2450940716.value", "utf8_general_ci"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.242489837.name", "join_buffer_size"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.242489837.value", "16777216"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2026669454.name", "key_buffer_size"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2026669454.value", "67108864"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2705275319.name", "max_connections"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2705275319.value", "3200"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.3512697936.name", "max_heap_table_size"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.3512697936.value", "67108864"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.780730667.name", "performance_schema"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.780730667.value", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2020346918.name", "performance_schema_users_size"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2020346918.value", "1048576"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1460834103.name", "query_cache_limit"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1460834103.value", "2097152"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.484865451.name", "query_cache_size"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.484865451.value", "67108864"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.255276438.name", "sort_buffer_size"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.255276438.value", "16777216"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2981725119.name", "table_open_cache"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2981725119.value", "4096"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2703661820.name", "tmp_table_size"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2703661820.value", "67108864"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2386583229.name", "binlog_cache_size"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2386583229.value", "131072"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.4012389720.name", "innodb_flush_log_at_trx_commit"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.4012389720.value", "0"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2688783017.name", "innodb_open_files"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2688783017.value", "4000"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.782983977.name", "innodb_read_io_threads"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.782983977.value", "64"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2809980413.name", "innodb_thread_concurrency"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2809980413.value", "0"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.3599115250.name", "innodb_write_io_threads"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.3599115250.value", "64"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2557156277.name", "character_set_connection"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2557156277.value", "utf8"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2475346812.name", "character_set_database"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2475346812.value", "utf8"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1986528518.name", "character_set_filesystem"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1986528518.value", "utf8"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1708034931.name", "character_set_results"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1708034931.value", "utf8"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1937131004.name", "event_scheduler"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1937131004.value", "ON"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.3437079877.name", "innodb_buffer_pool_dump_at_shutdown"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.3437079877.value", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1092112861.name", "innodb_file_format"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1092112861.value", "barracuda"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.615571931.name", "innodb_io_capacity"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.615571931.value", "2000"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1065962799.name", "innodb_io_capacity_max"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1065962799.value", "3000"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1411161182.name", "innodb_lock_wait_timeout"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1411161182.value", "120"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.3133315879.name", "innodb_max_dirty_pages_pct"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.3133315879.value", "90"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.950177639.name", "log_bin_trust_function_creators"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.950177639.value", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.591700516.name", "log_warnings"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.591700516.value", "2"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1918306725.name", "log_output"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1918306725.value", "FILE"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.386204433.name", "max_allowed_packet"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.386204433.value", "1073741824"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1700901269.name", "max_connect_errors"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1700901269.value", "100"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2839701698.name", "query_cache_min_res_unit"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2839701698.value", "512"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.427634017.name", "slow_query_log"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.427634017.value", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.881816039.name", "sync_binlog"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.881816039.value", "0"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.748684209.name", "tx_isolation"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.748684209.value", "REPEATABLE-READ"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: updateAwsDbParameterGroupsExceedDefaultAwsLimit(groupName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDBParameterGroupExists("aws_db_parameter_group.large", &v),
+					testAccCheckAWSDBParameterGroupExists(resourceName, &v),
 					testAccCheckAWSDBParameterGroupAttributes(&v, groupName),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "name", groupName),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "family", "mysql5.6"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "description", "Updated RDS default parameter group: Exceed default AWS parameter group limit of twenty"),
+					resource.TestCheckResourceAttr(resourceName, "name", groupName),
+					resource.TestCheckResourceAttr(resourceName, "family", "mysql5.6"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated RDS default parameter group: Exceed default AWS parameter group limit of twenty"),
 
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2421266705.name", "character_set_server"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2421266705.value", "utf8"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2478663599.name", "character_set_client"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2478663599.value", "utf8"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1680942586.name", "collation_server"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1680942586.value", "utf8_general_ci"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2450940716.name", "collation_connection"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2450940716.value", "utf8_general_ci"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.242489837.name", "join_buffer_size"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.242489837.value", "16777216"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2026669454.name", "key_buffer_size"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2026669454.value", "67108864"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2705275319.name", "max_connections"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2705275319.value", "3200"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.3512697936.name", "max_heap_table_size"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.3512697936.value", "67108864"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.780730667.name", "performance_schema"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.780730667.value", "1"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2020346918.name", "performance_schema_users_size"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2020346918.value", "1048576"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1460834103.name", "query_cache_limit"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1460834103.value", "2097152"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.484865451.name", "query_cache_size"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.484865451.value", "67108864"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.255276438.name", "sort_buffer_size"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.255276438.value", "16777216"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2981725119.name", "table_open_cache"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2981725119.value", "4096"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2703661820.name", "tmp_table_size"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2703661820.value", "67108864"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2386583229.name", "binlog_cache_size"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2386583229.value", "131072"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.4012389720.name", "innodb_flush_log_at_trx_commit"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.4012389720.value", "0"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2688783017.name", "innodb_open_files"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2688783017.value", "4000"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.782983977.name", "innodb_read_io_threads"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.782983977.value", "64"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2809980413.name", "innodb_thread_concurrency"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2809980413.value", "0"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.3599115250.name", "innodb_write_io_threads"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.3599115250.value", "64"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2557156277.name", "character_set_connection"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2557156277.value", "utf8"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2475346812.name", "character_set_database"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2475346812.value", "utf8"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1986528518.name", "character_set_filesystem"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1986528518.value", "utf8"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1708034931.name", "character_set_results"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1708034931.value", "utf8"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1937131004.name", "event_scheduler"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1937131004.value", "ON"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.3437079877.name", "innodb_buffer_pool_dump_at_shutdown"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.3437079877.value", "1"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1092112861.name", "innodb_file_format"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1092112861.value", "Barracuda"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.615571931.name", "innodb_io_capacity"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.615571931.value", "2000"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1065962799.name", "innodb_io_capacity_max"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1065962799.value", "3000"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1411161182.name", "innodb_lock_wait_timeout"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1411161182.value", "120"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.3133315879.name", "innodb_max_dirty_pages_pct"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.3133315879.value", "90"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.950177639.name", "log_bin_trust_function_creators"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.950177639.value", "1"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.591700516.name", "log_warnings"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.591700516.value", "2"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1918306725.name", "log_output"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1918306725.value", "FILE"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.386204433.name", "max_allowed_packet"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.386204433.value", "1073741824"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1700901269.name", "max_connect_errors"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.1700901269.value", "100"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2839701698.name", "query_cache_min_res_unit"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.2839701698.value", "512"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.427634017.name", "slow_query_log"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.427634017.value", "1"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.881816039.name", "sync_binlog"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.881816039.value", "0"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.748684209.name", "tx_isolation"),
-					resource.TestCheckResourceAttr("aws_db_parameter_group.large", "parameter.748684209.value", "REPEATABLE-READ"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSDBParameterGroup_basic(t *testing.T) {
-	var v rds.DBParameterGroup
-
-	groupName := fmt.Sprintf("parameter-group-test-terraform-%d", acctest.RandInt())
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSDBParameterGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSDBParameterGroupConfig(groupName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDBParameterGroupExists("aws_db_parameter_group.bar", &v),
-					testAccCheckAWSDBParameterGroupAttributes(&v, groupName),
-					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "name", groupName),
-					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "family", "mysql5.6"),
-					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "description", "Managed by Terraform"),
-					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "parameter.1708034931.name", "character_set_results"),
-					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "parameter.1708034931.value", "utf8"),
-					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "parameter.2421266705.name", "character_set_server"),
-					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "parameter.2421266705.value", "utf8"),
-					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "parameter.2478663599.name", "character_set_client"),
-					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "parameter.2478663599.value", "utf8"),
-					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "tags.%", "1"),
-					resource.TestMatchResourceAttr(
-						"aws_db_parameter_group.bar", "arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:rds:[^:]+:\\d{12}:pg:%s", groupName))),
-				),
-			},
-			{
-				Config: testAccAWSDBParameterGroupAddParametersConfig(groupName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDBParameterGroupExists("aws_db_parameter_group.bar", &v),
-					testAccCheckAWSDBParameterGroupAttributes(&v, groupName),
-					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "name", groupName),
-					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "family", "mysql5.6"),
-					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "description", "Test parameter group for terraform"),
-					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "parameter.1706463059.name", "collation_connection"),
-					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "parameter.1706463059.value", "utf8_unicode_ci"),
-					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "parameter.1708034931.name", "character_set_results"),
-					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "parameter.1708034931.value", "utf8"),
-					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "parameter.2421266705.name", "character_set_server"),
-					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "parameter.2421266705.value", "utf8"),
-					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "parameter.2475805061.name", "collation_server"),
-					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "parameter.2475805061.value", "utf8_unicode_ci"),
-					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "parameter.2478663599.name", "character_set_client"),
-					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "parameter.2478663599.value", "utf8"),
-					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "tags.%", "2"),
-					resource.TestMatchResourceAttr(
-						"aws_db_parameter_group.bar", "arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:rds:[^:]+:\\d{12}:pg:%s", groupName))),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2421266705.name", "character_set_server"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2421266705.value", "utf8"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2478663599.name", "character_set_client"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2478663599.value", "utf8"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1680942586.name", "collation_server"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1680942586.value", "utf8_general_ci"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2450940716.name", "collation_connection"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2450940716.value", "utf8_general_ci"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.242489837.name", "join_buffer_size"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.242489837.value", "16777216"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2026669454.name", "key_buffer_size"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2026669454.value", "67108864"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2705275319.name", "max_connections"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2705275319.value", "3200"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.3512697936.name", "max_heap_table_size"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.3512697936.value", "67108864"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.780730667.name", "performance_schema"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.780730667.value", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2020346918.name", "performance_schema_users_size"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2020346918.value", "1048576"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1460834103.name", "query_cache_limit"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1460834103.value", "2097152"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.484865451.name", "query_cache_size"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.484865451.value", "67108864"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.255276438.name", "sort_buffer_size"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.255276438.value", "16777216"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2981725119.name", "table_open_cache"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2981725119.value", "4096"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2703661820.name", "tmp_table_size"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2703661820.value", "67108864"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2386583229.name", "binlog_cache_size"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2386583229.value", "131072"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.4012389720.name", "innodb_flush_log_at_trx_commit"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.4012389720.value", "0"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2688783017.name", "innodb_open_files"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2688783017.value", "4000"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.782983977.name", "innodb_read_io_threads"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.782983977.value", "64"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2809980413.name", "innodb_thread_concurrency"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2809980413.value", "0"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.3599115250.name", "innodb_write_io_threads"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.3599115250.value", "64"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2557156277.name", "character_set_connection"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2557156277.value", "utf8"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2475346812.name", "character_set_database"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2475346812.value", "utf8"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1986528518.name", "character_set_filesystem"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1986528518.value", "utf8"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1708034931.name", "character_set_results"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1708034931.value", "utf8"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1937131004.name", "event_scheduler"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1937131004.value", "ON"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.3437079877.name", "innodb_buffer_pool_dump_at_shutdown"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.3437079877.value", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1092112861.name", "innodb_file_format"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1092112861.value", "barracuda"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.615571931.name", "innodb_io_capacity"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.615571931.value", "2000"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1065962799.name", "innodb_io_capacity_max"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1065962799.value", "3000"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1411161182.name", "innodb_lock_wait_timeout"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1411161182.value", "120"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.3133315879.name", "innodb_max_dirty_pages_pct"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.3133315879.value", "90"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.950177639.name", "log_bin_trust_function_creators"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.950177639.value", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.591700516.name", "log_warnings"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.591700516.value", "2"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1918306725.name", "log_output"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1918306725.value", "FILE"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.386204433.name", "max_allowed_packet"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.386204433.value", "1073741824"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1700901269.name", "max_connect_errors"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1700901269.value", "100"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2839701698.name", "query_cache_min_res_unit"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2839701698.value", "512"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.427634017.name", "slow_query_log"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.427634017.value", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.881816039.name", "sync_binlog"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.881816039.value", "0"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.748684209.name", "tx_isolation"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.748684209.value", "REPEATABLE-READ"),
 				),
 			},
 		},
@@ -377,7 +365,9 @@ func TestAccAWSDBParameterGroup_basic(t *testing.T) {
 
 func TestAccAWSDBParameterGroup_Disappears(t *testing.T) {
 	var v rds.DBParameterGroup
+	resourceName := "aws_db_parameter_group.test"
 	groupName := fmt.Sprintf("parameter-group-test-terraform-%d", acctest.RandInt())
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -386,7 +376,7 @@ func TestAccAWSDBParameterGroup_Disappears(t *testing.T) {
 			{
 				Config: testAccAWSDBParameterGroupConfig(groupName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDBParameterGroupExists("aws_db_parameter_group.bar", &v),
+					testAccCheckAWSDBParameterGroupExists(resourceName, &v),
 					testAccCheckAWSDbParamaterGroupDisappears(&v),
 				),
 				ExpectNonEmptyPlan: true,
@@ -435,7 +425,7 @@ func TestAccAWSDBParameterGroup_generatedName(t *testing.T) {
 
 func TestAccAWSDBParameterGroup_withApplyMethod(t *testing.T) {
 	var v rds.DBParameterGroup
-
+	resourceName := "aws_db_parameter_group.test"
 	groupName := fmt.Sprintf("parameter-group-test-terraform-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -446,27 +436,32 @@ func TestAccAWSDBParameterGroup_withApplyMethod(t *testing.T) {
 			{
 				Config: testAccAWSDBParameterGroupConfigWithApplyMethod(groupName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDBParameterGroupExists("aws_db_parameter_group.bar", &v),
+					testAccCheckAWSDBParameterGroupExists(resourceName, &v),
 					testAccCheckAWSDBParameterGroupAttributes(&v, groupName),
 					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "name", groupName),
+						resourceName, "name", groupName),
 					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "family", "mysql5.6"),
+						resourceName, "family", "mysql5.6"),
 					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "description", "Managed by Terraform"),
+						resourceName, "description", "Managed by Terraform"),
 					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "parameter.2421266705.name", "character_set_server"),
+						resourceName, "parameter.2421266705.name", "character_set_server"),
 					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "parameter.2421266705.value", "utf8"),
+						resourceName, "parameter.2421266705.value", "utf8"),
 					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "parameter.2421266705.apply_method", "immediate"),
+						resourceName, "parameter.2421266705.apply_method", "immediate"),
 					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "parameter.2478663599.name", "character_set_client"),
+						resourceName, "parameter.2478663599.name", "character_set_client"),
 					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "parameter.2478663599.value", "utf8"),
+						resourceName, "parameter.2478663599.value", "utf8"),
 					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "parameter.2478663599.apply_method", "pending-reboot"),
+						resourceName, "parameter.2478663599.apply_method", "pending-reboot"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -474,8 +469,9 @@ func TestAccAWSDBParameterGroup_withApplyMethod(t *testing.T) {
 
 func TestAccAWSDBParameterGroup_Only(t *testing.T) {
 	var v rds.DBParameterGroup
-
+	resourceName := "aws_db_parameter_group.test"
 	groupName := fmt.Sprintf("parameter-group-test-terraform-%d", acctest.RandInt())
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -484,13 +480,18 @@ func TestAccAWSDBParameterGroup_Only(t *testing.T) {
 			{
 				Config: testAccAWSDBParameterGroupOnlyConfig(groupName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDBParameterGroupExists("aws_db_parameter_group.bar", &v),
+					testAccCheckAWSDBParameterGroupExists(resourceName, &v),
 					testAccCheckAWSDBParameterGroupAttributes(&v, groupName),
 					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "name", groupName),
+						resourceName, "name", groupName),
 					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "family", "mysql5.6"),
+						resourceName, "family", "mysql5.6"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -498,8 +499,9 @@ func TestAccAWSDBParameterGroup_Only(t *testing.T) {
 
 func TestAccAWSDBParameterGroup_MatchDefault(t *testing.T) {
 	var v rds.DBParameterGroup
-
+	resourceName := "aws_db_parameter_group.test"
 	groupName := fmt.Sprintf("parameter-group-test-terraform-%d", acctest.RandInt())
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -508,12 +510,18 @@ func TestAccAWSDBParameterGroup_MatchDefault(t *testing.T) {
 			{
 				Config: testAccAWSDBParameterGroupIncludeDefaultConfig(groupName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDBParameterGroupExists("aws_db_parameter_group.bar", &v),
+					testAccCheckAWSDBParameterGroupExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "name", groupName),
+						resourceName, "name", groupName),
 					resource.TestCheckResourceAttr(
-						"aws_db_parameter_group.bar", "family", "postgres9.4"),
+						resourceName, "family", "postgres9.4"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parameter"},
 			},
 		},
 	})
@@ -621,7 +629,7 @@ func testAccCheckAWSDBParameterGroupExists(n string, v *rds.DBParameterGroup) re
 
 func testAccAWSDBParameterGroupConfig(n string) string {
 	return fmt.Sprintf(`
-resource "aws_db_parameter_group" "bar" {
+resource "aws_db_parameter_group" "test" {
   name   = "%s"
   family = "mysql5.6"
 
@@ -641,7 +649,7 @@ resource "aws_db_parameter_group" "bar" {
   }
 
   tags = {
-    foo = "bar"
+    foo = "test"
   }
 }
 `, n)
@@ -649,7 +657,7 @@ resource "aws_db_parameter_group" "bar" {
 
 func testAccAWSDBParameterGroupConfigWithApplyMethod(n string) string {
 	return fmt.Sprintf(`
-resource "aws_db_parameter_group" "bar" {
+resource "aws_db_parameter_group" "test" {
   name   = "%s"
   family = "mysql5.6"
 
@@ -665,7 +673,7 @@ resource "aws_db_parameter_group" "bar" {
   }
 
   tags = {
-    foo = "bar"
+    foo = "test"
   }
 }
 `, n)
@@ -673,7 +681,7 @@ resource "aws_db_parameter_group" "bar" {
 
 func testAccAWSDBParameterGroupAddParametersConfig(n string) string {
 	return fmt.Sprintf(`
-resource "aws_db_parameter_group" "bar" {
+resource "aws_db_parameter_group" "test" {
   name        = "%s"
   family      = "mysql5.6"
   description = "Test parameter group for terraform"
@@ -704,7 +712,7 @@ resource "aws_db_parameter_group" "bar" {
   }
 
   tags = {
-    foo = "bar"
+    foo = "test"
     baz = "foo"
   }
 }
@@ -713,7 +721,7 @@ resource "aws_db_parameter_group" "bar" {
 
 func testAccAWSDBParameterGroupOnlyConfig(n string) string {
 	return fmt.Sprintf(`
-resource "aws_db_parameter_group" "bar" {
+resource "aws_db_parameter_group" "test" {
   name        = "%s"
   family      = "mysql5.6"
   description = "Test parameter group for terraform"
@@ -723,7 +731,7 @@ resource "aws_db_parameter_group" "bar" {
 
 func createAwsDbParameterGroupsExceedDefaultAwsLimit(n string) string {
 	return fmt.Sprintf(`
-resource "aws_db_parameter_group" "large" {
+resource "aws_db_parameter_group" "test" {
   name        = "%s"
   family      = "mysql5.6"
   description = "RDS default parameter group: Exceed default AWS parameter group limit of twenty"
@@ -785,7 +793,7 @@ resource "aws_db_parameter_group" "large" {
 
   parameter {
     name  = "innodb_file_format"
-    value = "Barracuda"
+    value = "barracuda"
   }
 
   parameter {
@@ -943,7 +951,7 @@ resource "aws_db_parameter_group" "large" {
 
 func updateAwsDbParameterGroupsExceedDefaultAwsLimit(n string) string {
 	return fmt.Sprintf(`
-resource "aws_db_parameter_group" "large" {
+resource "aws_db_parameter_group" "test" {
   name        = "%s"
   family      = "mysql5.6"
   description = "Updated RDS default parameter group: Exceed default AWS parameter group limit of twenty"
@@ -1005,7 +1013,7 @@ resource "aws_db_parameter_group" "large" {
 
   parameter {
     name  = "innodb_file_format"
-    value = "Barracuda"
+    value = "barracuda"
   }
 
   parameter {
@@ -1163,7 +1171,7 @@ resource "aws_db_parameter_group" "large" {
 
 func testAccAWSDBParameterGroupIncludeDefaultConfig(n string) string {
 	return fmt.Sprintf(`
-resource "aws_db_parameter_group" "bar" {
+resource "aws_db_parameter_group" "test" {
   name   = "%s"
   family = "postgres9.4"
 

--- a/aws/resource_aws_db_security_group_test.go
+++ b/aws/resource_aws_db_security_group_test.go
@@ -14,39 +14,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSDBSecurityGroup_importBasic(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
-	rName := fmt.Sprintf("tf-acc-%s", acctest.RandString(5))
-	resourceName := "aws_db_security_group.bar"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSDBSecurityGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSDBSecurityGroupConfig(rName),
-			},
-
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAWSDBSecurityGroup_basic(t *testing.T) {
 	var v rds.DBSecurityGroup
 
 	oldvar := os.Getenv("AWS_DEFAULT_REGION")
 	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
 	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
+	resourceName := "aws_db_security_group.test"
 	rName := fmt.Sprintf("tf-acc-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -57,20 +31,25 @@ func TestAccAWSDBSecurityGroup_basic(t *testing.T) {
 			{
 				Config: testAccAWSDBSecurityGroupConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDBSecurityGroupExists("aws_db_security_group.bar", &v),
+					testAccCheckAWSDBSecurityGroupExists(resourceName, &v),
 					testAccCheckAWSDBSecurityGroupAttributes(&v),
-					resource.TestMatchResourceAttr("aws_db_security_group.bar", "arn", regexp.MustCompile(`^arn:[^:]+:rds:[^:]+:\d{12}:secgrp:.+`)),
+					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(`^arn:[^:]+:rds:[^:]+:\d{12}:secgrp:.+`)),
 					resource.TestCheckResourceAttr(
-						"aws_db_security_group.bar", "name", rName),
+						resourceName, "name", rName),
 					resource.TestCheckResourceAttr(
-						"aws_db_security_group.bar", "description", "Managed by Terraform"),
+						resourceName, "description", "Managed by Terraform"),
 					resource.TestCheckResourceAttr(
-						"aws_db_security_group.bar", "ingress.3363517775.cidr", "10.0.0.1/24"),
+						resourceName, "ingress.3363517775.cidr", "10.0.0.1/24"),
 					resource.TestCheckResourceAttr(
-						"aws_db_security_group.bar", "ingress.#", "1"),
+						resourceName, "ingress.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_db_security_group.bar", "tags.%", "1"),
+						resourceName, "tags.%", "1"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -169,7 +148,7 @@ func testAccCheckAWSDBSecurityGroupExists(n string, v *rds.DBSecurityGroup) reso
 
 func testAccAWSDBSecurityGroupConfig(name string) string {
 	return fmt.Sprintf(`
-resource "aws_db_security_group" "bar" {
+resource "aws_db_security_group" "test" {
   name = "%s"
 
   ingress {
@@ -177,7 +156,7 @@ resource "aws_db_security_group" "bar" {
   }
 
   tags = {
-    foo = "bar"
+    foo = "test"
   }
 }
 `, name)

--- a/aws/resource_aws_db_subnet_group_test.go
+++ b/aws/resource_aws_db_subnet_group_test.go
@@ -65,10 +65,15 @@ func testSweepRdsDbSubnetGroups(region string) error {
 	return nil
 }
 
-func TestAccAWSDBSubnetGroup_importBasic(t *testing.T) {
-	resourceName := "aws_db_subnet_group.foo"
+func TestAccAWSDBSubnetGroup_basic(t *testing.T) {
+	var v rds.DBSubnetGroup
 
+	testCheck := func(*terraform.State) error {
+		return nil
+	}
+	resourceName := "aws_db_subnet_group.test"
 	rName := fmt.Sprintf("tf-test-%d", acctest.RandInt())
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -76,8 +81,18 @@ func TestAccAWSDBSubnetGroup_importBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDBSubnetGroupConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDBSubnetGroupExists(
+						resourceName, &v),
+					resource.TestCheckResourceAttr(
+						resourceName, "name", rName),
+					resource.TestCheckResourceAttr(
+						resourceName, "description", "Managed by Terraform"),
+					resource.TestMatchResourceAttr(
+						resourceName, "arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:rds:[^:]+:\\d{12}:subgrp:%s", rName))),
+					testCheck,
+				),
 			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
@@ -89,40 +104,9 @@ func TestAccAWSDBSubnetGroup_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccAWSDBSubnetGroup_basic(t *testing.T) {
-	var v rds.DBSubnetGroup
-
-	testCheck := func(*terraform.State) error {
-		return nil
-	}
-
-	rName := fmt.Sprintf("tf-test-%d", acctest.RandInt())
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckDBSubnetGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDBSubnetGroupConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDBSubnetGroupExists(
-						"aws_db_subnet_group.foo", &v),
-					resource.TestCheckResourceAttr(
-						"aws_db_subnet_group.foo", "name", rName),
-					resource.TestCheckResourceAttr(
-						"aws_db_subnet_group.foo", "description", "Managed by Terraform"),
-					resource.TestMatchResourceAttr(
-						"aws_db_subnet_group.foo", "arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:rds:[^:]+:\\d{12}:subgrp:%s", rName))),
-					testCheck,
-				),
-			},
-		},
-	})
-}
-
 func TestAccAWSDBSubnetGroup_namePrefix(t *testing.T) {
 	var v rds.DBSubnetGroup
+	resourceName := "aws_db_subnet_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -133,9 +117,9 @@ func TestAccAWSDBSubnetGroup_namePrefix(t *testing.T) {
 				Config: testAccDBSubnetGroupConfig_namePrefix,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDBSubnetGroupExists(
-						"aws_db_subnet_group.test", &v),
+						resourceName, &v),
 					resource.TestMatchResourceAttr(
-						"aws_db_subnet_group.test", "name", regexp.MustCompile("^tf_test-")),
+						resourceName, "name", regexp.MustCompile("^tf_test-")),
 				),
 			},
 		},
@@ -144,6 +128,7 @@ func TestAccAWSDBSubnetGroup_namePrefix(t *testing.T) {
 
 func TestAccAWSDBSubnetGroup_generatedName(t *testing.T) {
 	var v rds.DBSubnetGroup
+	resourceName := "aws_db_subnet_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -154,7 +139,7 @@ func TestAccAWSDBSubnetGroup_generatedName(t *testing.T) {
 				Config: testAccDBSubnetGroupConfig_generatedName,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDBSubnetGroupExists(
-						"aws_db_subnet_group.test", &v),
+						resourceName, &v),
 				),
 			},
 		},
@@ -169,6 +154,7 @@ func TestAccAWSDBSubnetGroup_withUndocumentedCharacters(t *testing.T) {
 	testCheck := func(*terraform.State) error {
 		return nil
 	}
+	resourceName := "aws_db_subnet_group.underscores"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -187,14 +173,22 @@ func TestAccAWSDBSubnetGroup_withUndocumentedCharacters(t *testing.T) {
 					testCheck,
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"description"},
+			},
 		},
 	})
 }
 
 func TestAccAWSDBSubnetGroup_updateDescription(t *testing.T) {
 	var v rds.DBSubnetGroup
-
+	resourceName := "aws_db_subnet_group.test"
 	rName := fmt.Sprintf("tf-test-%d", acctest.RandInt())
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -204,19 +198,25 @@ func TestAccAWSDBSubnetGroup_updateDescription(t *testing.T) {
 				Config: testAccDBSubnetGroupConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDBSubnetGroupExists(
-						"aws_db_subnet_group.foo", &v),
+						resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_db_subnet_group.foo", "description", "Managed by Terraform"),
+						resourceName, "description", "Managed by Terraform"),
 				),
 			},
-
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"description"},
+			},
 			{
 				Config: testAccDBSubnetGroupConfig_updatedDescription(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDBSubnetGroupExists(
-						"aws_db_subnet_group.foo", &v),
+						resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_db_subnet_group.foo", "description", "foo description updated"),
+						resourceName, "description", "test description updated"),
 				),
 			},
 		},
@@ -288,7 +288,7 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
   tags = {
@@ -296,10 +296,10 @@ resource "aws_vpc" "foo" {
   }
 }
 
-resource "aws_subnet" "foo" {
+resource "aws_subnet" "test" {
   cidr_block        = "10.1.1.0/24"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  vpc_id            = "${aws_vpc.foo.id}"
+  vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
     Name = "tf-acc-db-subnet-group-1"
@@ -309,16 +309,16 @@ resource "aws_subnet" "foo" {
 resource "aws_subnet" "bar" {
   cidr_block        = "10.1.2.0/24"
   availability_zone = "${data.aws_availability_zones.available.names[1]}"
-  vpc_id            = "${aws_vpc.foo.id}"
+  vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
     Name = "tf-acc-db-subnet-group-2"
   }
 }
 
-resource "aws_db_subnet_group" "foo" {
+resource "aws_db_subnet_group" "test" {
   name       = "%s"
-  subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
+  subnet_ids = ["${aws_subnet.test.id}", "${aws_subnet.bar.id}"]
 
   tags = {
     Name = "tf-dbsubnet-group-test"
@@ -333,7 +333,7 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
   tags = {
@@ -341,10 +341,10 @@ resource "aws_vpc" "foo" {
   }
 }
 
-resource "aws_subnet" "foo" {
+resource "aws_subnet" "test" {
   cidr_block        = "10.1.1.0/24"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  vpc_id            = "${aws_vpc.foo.id}"
+  vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
     Name = "tf-acc-db-subnet-group-1"
@@ -354,17 +354,17 @@ resource "aws_subnet" "foo" {
 resource "aws_subnet" "bar" {
   cidr_block        = "10.1.2.0/24"
   availability_zone = "${data.aws_availability_zones.available.names[1]}"
-  vpc_id            = "${aws_vpc.foo.id}"
+  vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
     Name = "tf-acc-db-subnet-group-2"
   }
 }
 
-resource "aws_db_subnet_group" "foo" {
+resource "aws_db_subnet_group" "test" {
   name        = "%s"
-  description = "foo description updated"
-  subnet_ids  = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
+  description = "test description updated"
+  subnet_ids  = ["${aws_subnet.test.id}", "${aws_subnet.bar.id}"]
 
   tags = {
     Name = "tf-dbsubnet-group-test"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8944

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSDBEventSubscription_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSDBEventSubscription_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSDBEventSubscription_basicUpdate
=== PAUSE TestAccAWSDBEventSubscription_basicUpdate
=== RUN   TestAccAWSDBEventSubscription_disappears
=== PAUSE TestAccAWSDBEventSubscription_disappears
=== RUN   TestAccAWSDBEventSubscription_withPrefix
=== PAUSE TestAccAWSDBEventSubscription_withPrefix
=== RUN   TestAccAWSDBEventSubscription_withSourceIds
=== PAUSE TestAccAWSDBEventSubscription_withSourceIds
=== RUN   TestAccAWSDBEventSubscription_categoryUpdate
=== PAUSE TestAccAWSDBEventSubscription_categoryUpdate
=== CONT  TestAccAWSDBEventSubscription_basicUpdate
=== CONT  TestAccAWSDBEventSubscription_categoryUpdate
=== CONT  TestAccAWSDBEventSubscription_withSourceIds
=== CONT  TestAccAWSDBEventSubscription_withPrefix
=== CONT  TestAccAWSDBEventSubscription_disappears
--- PASS: TestAccAWSDBEventSubscription_disappears (92.32s)
--- PASS: TestAccAWSDBEventSubscription_withPrefix (96.45s)
--- PASS: TestAccAWSDBEventSubscription_withSourceIds (129.04s)
--- PASS: TestAccAWSDBEventSubscription_categoryUpdate (152.57s)
--- PASS: TestAccAWSDBEventSubscription_basicUpdate (154.02s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       155.480s

make testacc TESTARGS="-run=TestAccAWSDBParameterGroup_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSDBParameterGroup_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSDBParameterGroup_basic
=== PAUSE TestAccAWSDBParameterGroup_basic
=== RUN   TestAccAWSDBParameterGroup_limit
=== PAUSE TestAccAWSDBParameterGroup_limit
=== RUN   TestAccAWSDBParameterGroup_Disappears
=== PAUSE TestAccAWSDBParameterGroup_Disappears
=== RUN   TestAccAWSDBParameterGroup_namePrefix
=== PAUSE TestAccAWSDBParameterGroup_namePrefix
=== RUN   TestAccAWSDBParameterGroup_generatedName
=== PAUSE TestAccAWSDBParameterGroup_generatedName
=== RUN   TestAccAWSDBParameterGroup_withApplyMethod
=== PAUSE TestAccAWSDBParameterGroup_withApplyMethod
=== RUN   TestAccAWSDBParameterGroup_Only
=== PAUSE TestAccAWSDBParameterGroup_Only
=== RUN   TestAccAWSDBParameterGroup_MatchDefault
=== PAUSE TestAccAWSDBParameterGroup_MatchDefault
=== CONT  TestAccAWSDBParameterGroup_basic
=== CONT  TestAccAWSDBParameterGroup_MatchDefault
=== CONT  TestAccAWSDBParameterGroup_limit
=== CONT  TestAccAWSDBParameterGroup_generatedName
=== CONT  TestAccAWSDBParameterGroup_Only
=== CONT  TestAccAWSDBParameterGroup_withApplyMethod
=== CONT  TestAccAWSDBParameterGroup_Disappears
=== CONT  TestAccAWSDBParameterGroup_namePrefix
--- PASS: TestAccAWSDBParameterGroup_Disappears (26.94s)
--- PASS: TestAccAWSDBParameterGroup_Only (34.32s)
--- PASS: TestAccAWSDBParameterGroup_namePrefix (37.78s)
--- PASS: TestAccAWSDBParameterGroup_generatedName (38.53s)
--- PASS: TestAccAWSDBParameterGroup_MatchDefault (39.84s)
--- PASS: TestAccAWSDBParameterGroup_withApplyMethod (43.67s)
--- PASS: TestAccAWSDBParameterGroup_basic (78.79s)
--- PASS: TestAccAWSDBParameterGroup_limit (79.96s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       81.369s

make testacc TESTARGS="-run=TestAccAWSDBSecurityGroup_"     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSDBSecurityGroup_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSDBSecurityGroup_basic
=== PAUSE TestAccAWSDBSecurityGroup_basic
=== CONT  TestAccAWSDBSecurityGroup_basic
--- PASS: TestAccAWSDBSecurityGroup_basic (31.25s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       32.653s

make testacc TESTARGS="-run=TestAccAWSDBSubnetGroup_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSDBSubnetGroup_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSDBSubnetGroup_basic
=== PAUSE TestAccAWSDBSubnetGroup_basic
=== RUN   TestAccAWSDBSubnetGroup_namePrefix
=== PAUSE TestAccAWSDBSubnetGroup_namePrefix
=== RUN   TestAccAWSDBSubnetGroup_generatedName
=== PAUSE TestAccAWSDBSubnetGroup_generatedName
=== RUN   TestAccAWSDBSubnetGroup_withUndocumentedCharacters
=== PAUSE TestAccAWSDBSubnetGroup_withUndocumentedCharacters
=== RUN   TestAccAWSDBSubnetGroup_updateDescription
=== PAUSE TestAccAWSDBSubnetGroup_updateDescription
=== CONT  TestAccAWSDBSubnetGroup_basic
=== CONT  TestAccAWSDBSubnetGroup_withUndocumentedCharacters
=== CONT  TestAccAWSDBSubnetGroup_namePrefix
=== CONT  TestAccAWSDBSubnetGroup_updateDescription
=== CONT  TestAccAWSDBSubnetGroup_generatedName
--- PASS: TestAccAWSDBSubnetGroup_namePrefix (66.16s)
--- PASS: TestAccAWSDBSubnetGroup_basic (66.62s)
--- PASS: TestAccAWSDBSubnetGroup_generatedName (66.80s)
--- PASS: TestAccAWSDBSubnetGroup_withUndocumentedCharacters (69.84s)
--- PASS: TestAccAWSDBSubnetGroup_updateDescription (111.89s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       113.329s
```
