### PR TITLE
Import test refactor for cognito resources

### DIFF
--- a/aws/resource_aws_cognito_identity_pool_test.go
+++ b/aws/resource_aws_cognito_identity_pool_test.go
@@ -14,31 +14,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSCognitoIdentityPool_importBasic(t *testing.T) {
-	resourceName := "aws_cognito_identity_pool.main"
-	rName := acctest.RandString(10)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentity(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSAPIGatewayAccountDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSCognitoIdentityPoolConfig_basic(rName),
-			},
-
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAWSCognitoIdentityPool_basic(t *testing.T) {
 	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	updatedName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	resourceName := "aws_cognito_identity_pool.main"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentity(t) },
@@ -48,18 +27,23 @@ func TestAccAWSCognitoIdentityPool_basic(t *testing.T) {
 			{
 				Config: testAccAWSCognitoIdentityPoolConfig_basic(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoIdentityPoolExists("aws_cognito_identity_pool.main"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
-					resource.TestMatchResourceAttr("aws_cognito_identity_pool.main", "arn",
+					testAccCheckAWSCognitoIdentityPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
+					resource.TestMatchResourceAttr(resourceName, "arn",
 						regexp.MustCompile("^arn:aws:cognito-identity:[^:]+:[0-9]{12}:identitypool/[^:]+:([0-9a-f]){8}-([0-9a-f]){4}-([0-9a-f]){4}-([0-9a-f]){4}-([0-9a-f]){12}$")),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "allow_unauthenticated_identities", "false"),
+					resource.TestCheckResourceAttr(resourceName, "allow_unauthenticated_identities", "false"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCognitoIdentityPoolConfig_basic(updatedName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoIdentityPoolExists("aws_cognito_identity_pool.main"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "identity_pool_name", fmt.Sprintf("identity pool %s", updatedName)),
+					testAccCheckAWSCognitoIdentityPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "identity_pool_name", fmt.Sprintf("identity pool %s", updatedName)),
 				),
 			},
 		},
@@ -68,6 +52,7 @@ func TestAccAWSCognitoIdentityPool_basic(t *testing.T) {
 
 func TestAccAWSCognitoIdentityPool_supportedLoginProviders(t *testing.T) {
 	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	resourceName := "aws_cognito_identity_pool.main"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentity(t) },
@@ -77,25 +62,30 @@ func TestAccAWSCognitoIdentityPool_supportedLoginProviders(t *testing.T) {
 			{
 				Config: testAccAWSCognitoIdentityPoolConfig_supportedLoginProviders(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoIdentityPoolExists("aws_cognito_identity_pool.main"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "supported_login_providers.graph.facebook.com", "7346241598935555"),
+					testAccCheckAWSCognitoIdentityPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
+					resource.TestCheckResourceAttr(resourceName, "supported_login_providers.graph.facebook.com", "7346241598935555"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCognitoIdentityPoolConfig_supportedLoginProvidersModified(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoIdentityPoolExists("aws_cognito_identity_pool.main"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "supported_login_providers.graph.facebook.com", "7346241598935552"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "supported_login_providers.accounts.google.com", "123456789012.apps.googleusercontent.com"),
+					testAccCheckAWSCognitoIdentityPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
+					resource.TestCheckResourceAttr(resourceName, "supported_login_providers.graph.facebook.com", "7346241598935552"),
+					resource.TestCheckResourceAttr(resourceName, "supported_login_providers.accounts.google.com", "123456789012.apps.googleusercontent.com"),
 				),
 			},
 			{
 				Config: testAccAWSCognitoIdentityPoolConfig_basic(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoIdentityPoolExists("aws_cognito_identity_pool.main"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
+					testAccCheckAWSCognitoIdentityPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
 				),
 			},
 		},
@@ -104,6 +94,7 @@ func TestAccAWSCognitoIdentityPool_supportedLoginProviders(t *testing.T) {
 
 func TestAccAWSCognitoIdentityPool_openidConnectProviderArns(t *testing.T) {
 	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	resourceName := "aws_cognito_identity_pool.main"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentity(t) },
@@ -113,24 +104,29 @@ func TestAccAWSCognitoIdentityPool_openidConnectProviderArns(t *testing.T) {
 			{
 				Config: testAccAWSCognitoIdentityPoolConfig_openidConnectProviderArns(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoIdentityPoolExists("aws_cognito_identity_pool.main"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "openid_connect_provider_arns.#", "1"),
+					testAccCheckAWSCognitoIdentityPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_provider_arns.#", "1"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCognitoIdentityPoolConfig_openidConnectProviderArnsModified(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoIdentityPoolExists("aws_cognito_identity_pool.main"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "openid_connect_provider_arns.#", "2"),
+					testAccCheckAWSCognitoIdentityPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_provider_arns.#", "2"),
 				),
 			},
 			{
 				Config: testAccAWSCognitoIdentityPoolConfig_basic(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoIdentityPoolExists("aws_cognito_identity_pool.main"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
+					testAccCheckAWSCognitoIdentityPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
 				),
 			},
 		},
@@ -139,6 +135,7 @@ func TestAccAWSCognitoIdentityPool_openidConnectProviderArns(t *testing.T) {
 
 func TestAccAWSCognitoIdentityPool_samlProviderArns(t *testing.T) {
 	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	resourceName := "aws_cognito_identity_pool.main"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentity(t) },
@@ -148,25 +145,30 @@ func TestAccAWSCognitoIdentityPool_samlProviderArns(t *testing.T) {
 			{
 				Config: testAccAWSCognitoIdentityPoolConfig_samlProviderArns(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoIdentityPoolExists("aws_cognito_identity_pool.main"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "saml_provider_arns.#", "1"),
+					testAccCheckAWSCognitoIdentityPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
+					resource.TestCheckResourceAttr(resourceName, "saml_provider_arns.#", "1"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCognitoIdentityPoolConfig_samlProviderArnsModified(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoIdentityPoolExists("aws_cognito_identity_pool.main"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "saml_provider_arns.#", "1"),
+					testAccCheckAWSCognitoIdentityPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
+					resource.TestCheckResourceAttr(resourceName, "saml_provider_arns.#", "1"),
 				),
 			},
 			{
 				Config: testAccAWSCognitoIdentityPoolConfig_basic(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoIdentityPoolExists("aws_cognito_identity_pool.main"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "saml_provider_arns.#", "0"),
+					testAccCheckAWSCognitoIdentityPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
+					resource.TestCheckResourceAttr(resourceName, "saml_provider_arns.#", "0"),
 				),
 			},
 		},
@@ -175,6 +177,7 @@ func TestAccAWSCognitoIdentityPool_samlProviderArns(t *testing.T) {
 
 func TestAccAWSCognitoIdentityPool_cognitoIdentityProviders(t *testing.T) {
 	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	resourceName := "aws_cognito_identity_pool.main"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentity(t) },
@@ -184,31 +187,36 @@ func TestAccAWSCognitoIdentityPool_cognitoIdentityProviders(t *testing.T) {
 			{
 				Config: testAccAWSCognitoIdentityPoolConfig_cognitoIdentityProviders(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoIdentityPoolExists("aws_cognito_identity_pool.main"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "cognito_identity_providers.66456389.client_id", "7lhlkkfbfb4q5kpp90urffao"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "cognito_identity_providers.66456389.provider_name", "cognito-idp.us-east-1.amazonaws.com/us-east-1_Zr231apJu"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "cognito_identity_providers.66456389.server_side_token_check", "false"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "cognito_identity_providers.3571192419.client_id", "7lhlkkfbfb4q5kpp90urffao"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "cognito_identity_providers.3571192419.provider_name", "cognito-idp.us-east-1.amazonaws.com/us-east-1_Ab129faBb"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "cognito_identity_providers.3571192419.server_side_token_check", "false"),
+					testAccCheckAWSCognitoIdentityPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
+					resource.TestCheckResourceAttr(resourceName, "cognito_identity_providers.66456389.client_id", "7lhlkkfbfb4q5kpp90urffao"),
+					resource.TestCheckResourceAttr(resourceName, "cognito_identity_providers.66456389.provider_name", "cognito-idp.us-east-1.amazonaws.com/us-east-1_Zr231apJu"),
+					resource.TestCheckResourceAttr(resourceName, "cognito_identity_providers.66456389.server_side_token_check", "false"),
+					resource.TestCheckResourceAttr(resourceName, "cognito_identity_providers.3571192419.client_id", "7lhlkkfbfb4q5kpp90urffao"),
+					resource.TestCheckResourceAttr(resourceName, "cognito_identity_providers.3571192419.provider_name", "cognito-idp.us-east-1.amazonaws.com/us-east-1_Ab129faBb"),
+					resource.TestCheckResourceAttr(resourceName, "cognito_identity_providers.3571192419.server_side_token_check", "false"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCognitoIdentityPoolConfig_cognitoIdentityProvidersModified(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoIdentityPoolExists("aws_cognito_identity_pool.main"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "cognito_identity_providers.3661724441.client_id", "6lhlkkfbfb4q5kpp90urffae"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "cognito_identity_providers.3661724441.provider_name", "cognito-idp.us-east-1.amazonaws.com/us-east-1_Zr231apJu"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "cognito_identity_providers.3661724441.server_side_token_check", "false"),
+					testAccCheckAWSCognitoIdentityPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
+					resource.TestCheckResourceAttr(resourceName, "cognito_identity_providers.3661724441.client_id", "6lhlkkfbfb4q5kpp90urffae"),
+					resource.TestCheckResourceAttr(resourceName, "cognito_identity_providers.3661724441.provider_name", "cognito-idp.us-east-1.amazonaws.com/us-east-1_Zr231apJu"),
+					resource.TestCheckResourceAttr(resourceName, "cognito_identity_providers.3661724441.server_side_token_check", "false"),
 				),
 			},
 			{
 				Config: testAccAWSCognitoIdentityPoolConfig_basic(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoIdentityPoolExists("aws_cognito_identity_pool.main"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
+					testAccCheckAWSCognitoIdentityPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
 				),
 			},
 		},
@@ -217,6 +225,7 @@ func TestAccAWSCognitoIdentityPool_cognitoIdentityProviders(t *testing.T) {
 
 func TestAccAWSCognitoIdentityPool_addingNewProviderKeepsOldProvider(t *testing.T) {
 	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	resourceName := "aws_cognito_identity_pool.main"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentity(t) },
@@ -226,27 +235,32 @@ func TestAccAWSCognitoIdentityPool_addingNewProviderKeepsOldProvider(t *testing.
 			{
 				Config: testAccAWSCognitoIdentityPoolConfig_cognitoIdentityProviders(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoIdentityPoolExists("aws_cognito_identity_pool.main"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "cognito_identity_providers.#", "2"),
+					testAccCheckAWSCognitoIdentityPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
+					resource.TestCheckResourceAttr(resourceName, "cognito_identity_providers.#", "2"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCognitoIdentityPoolConfig_cognitoIdentityProvidersAndOpenidConnectProviderArns(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoIdentityPoolExists("aws_cognito_identity_pool.main"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "cognito_identity_providers.#", "2"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "openid_connect_provider_arns.#", "1"),
+					testAccCheckAWSCognitoIdentityPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
+					resource.TestCheckResourceAttr(resourceName, "cognito_identity_providers.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_provider_arns.#", "1"),
 				),
 			},
 			{
 				Config: testAccAWSCognitoIdentityPoolConfig_basic(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoIdentityPoolExists("aws_cognito_identity_pool.main"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "cognito_identity_providers.#", "0"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "openid_connect_provider_arns.#", "0"),
+					testAccCheckAWSCognitoIdentityPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
+					resource.TestCheckResourceAttr(resourceName, "cognito_identity_providers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_provider_arns.#", "0"),
 				),
 			},
 		},
@@ -255,6 +269,7 @@ func TestAccAWSCognitoIdentityPool_addingNewProviderKeepsOldProvider(t *testing.
 
 func TestAccAWSCognitoIdentityPoolWithTags(t *testing.T) {
 	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	resourceName := "aws_cognito_identity_pool.main"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentity(t) },
@@ -264,16 +279,21 @@ func TestAccAWSCognitoIdentityPoolWithTags(t *testing.T) {
 			{
 				Config: testAccAWSCognitoIdentityPoolConfigWithTags(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoIdentityPoolExists("aws_cognito_identity_pool.main"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "tags.environment", "dev"),
+					testAccCheckAWSCognitoIdentityPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.environment", "dev"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCognitoIdentityPoolConfigWithTagsUpdated(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoIdentityPoolExists("aws_cognito_identity_pool.main"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "tags.environment", "dev"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "tags.project", "Terraform"),
+					testAccCheckAWSCognitoIdentityPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.environment", "dev"),
+					resource.TestCheckResourceAttr(resourceName, "tags.project", "Terraform"),
 				),
 			},
 		},

--- a/aws/resource_aws_cognito_user_group_test.go
+++ b/aws/resource_aws_cognito_user_group_test.go
@@ -17,6 +17,7 @@ func TestAccAWSCognitoUserGroup_basic(t *testing.T) {
 	poolName := fmt.Sprintf("tf-acc-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	groupName := fmt.Sprintf("tf-acc-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	updatedGroupName := fmt.Sprintf("tf-acc-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	resourceName := "aws_cognito_user_group.main"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
@@ -26,15 +27,20 @@ func TestAccAWSCognitoUserGroup_basic(t *testing.T) {
 			{
 				Config: testAccAWSCognitoUserGroupConfig_basic(poolName, groupName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoUserGroupExists("aws_cognito_user_group.main"),
-					resource.TestCheckResourceAttr("aws_cognito_user_group.main", "name", groupName),
+					testAccCheckAWSCognitoUserGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", groupName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCognitoUserGroupConfig_basic(poolName, updatedGroupName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoUserGroupExists("aws_cognito_user_group.main"),
-					resource.TestCheckResourceAttr("aws_cognito_user_group.main", "name", updatedGroupName),
+					testAccCheckAWSCognitoUserGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedGroupName),
 				),
 			},
 		},
@@ -45,6 +51,7 @@ func TestAccAWSCognitoUserGroup_complex(t *testing.T) {
 	poolName := fmt.Sprintf("tf-acc-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	groupName := fmt.Sprintf("tf-acc-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	updatedGroupName := fmt.Sprintf("tf-acc-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	resourceName := "aws_cognito_user_group.main"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
@@ -54,21 +61,26 @@ func TestAccAWSCognitoUserGroup_complex(t *testing.T) {
 			{
 				Config: testAccAWSCognitoUserGroupConfig_complex(poolName, groupName, "This is the user group description", 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoUserGroupExists("aws_cognito_user_group.main"),
-					resource.TestCheckResourceAttr("aws_cognito_user_group.main", "name", groupName),
-					resource.TestCheckResourceAttr("aws_cognito_user_group.main", "description", "This is the user group description"),
-					resource.TestCheckResourceAttr("aws_cognito_user_group.main", "precedence", "1"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_group.main", "role_arn"),
+					testAccCheckAWSCognitoUserGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", groupName),
+					resource.TestCheckResourceAttr(resourceName, "description", "This is the user group description"),
+					resource.TestCheckResourceAttr(resourceName, "precedence", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "role_arn"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCognitoUserGroupConfig_complex(poolName, updatedGroupName, "This is the updated user group description", 42),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoUserGroupExists("aws_cognito_user_group.main"),
-					resource.TestCheckResourceAttr("aws_cognito_user_group.main", "name", updatedGroupName),
-					resource.TestCheckResourceAttr("aws_cognito_user_group.main", "description", "This is the updated user group description"),
-					resource.TestCheckResourceAttr("aws_cognito_user_group.main", "precedence", "42"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_group.main", "role_arn"),
+					testAccCheckAWSCognitoUserGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedGroupName),
+					resource.TestCheckResourceAttr(resourceName, "description", "This is the updated user group description"),
+					resource.TestCheckResourceAttr(resourceName, "precedence", "42"),
+					resource.TestCheckResourceAttrSet(resourceName, "role_arn"),
 				),
 			},
 		},
@@ -92,33 +104,16 @@ func TestAccAWSCognitoUserGroup_RoleArn(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAWSCognitoUserGroupConfig_RoleArn_Updated(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserGroupExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "role_arn"),
 				),
-			},
-		},
-	})
-}
-
-func TestAccAWSCognitoUserGroup_importBasic(t *testing.T) {
-	resourceName := "aws_cognito_user_group.main"
-	poolName := fmt.Sprintf("tf-acc-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-	groupName := fmt.Sprintf("tf-acc-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCognitoUserGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSCognitoUserGroupConfig_basic(poolName, groupName),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})

--- a/aws/resource_aws_cognito_user_pool_client_test.go
+++ b/aws/resource_aws_cognito_user_pool_client_test.go
@@ -16,6 +16,7 @@ import (
 func TestAccAWSCognitoUserPoolClient_basic(t *testing.T) {
 	userPoolName := fmt.Sprintf("tf-acc-cognito-user-pool-%s", acctest.RandString(7))
 	clientName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	resourceName := "aws_cognito_user_pool_client.client"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
@@ -25,23 +26,201 @@ func TestAccAWSCognitoUserPoolClient_basic(t *testing.T) {
 			{
 				Config: testAccAWSCognitoUserPoolClientConfig_basic(userPoolName, clientName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoUserPoolClientExists("aws_cognito_user_pool_client.client"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "name", clientName),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "explicit_auth_flows.#", "1"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "explicit_auth_flows.245201344", "ADMIN_NO_SRP_AUTH"),
+					testAccCheckAWSCognitoUserPoolClientExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", clientName),
+					resource.TestCheckResourceAttr(resourceName, "explicit_auth_flows.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "explicit_auth_flows.245201344", "ADMIN_NO_SRP_AUTH"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccAWSCognitoUserPoolClientImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSCognitoUserPoolClient_RefreshTokenValidity(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_cognito_user_pool_client.client"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoUserPoolClientDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoUserPoolClientConfig_RefreshTokenValidity(rName, 60),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoUserPoolClientExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "refresh_token_validity", "60"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccAWSCognitoUserPoolClientImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSCognitoUserPoolClientConfig_RefreshTokenValidity(rName, 120),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoUserPoolClientExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "refresh_token_validity", "120"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAWSCognitoUserPoolClient_importBasic(t *testing.T) {
+func TestAccAWSCognitoUserPoolClient_Name(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_cognito_user_pool_client.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoUserPoolClientDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoUserPoolClientConfig_Name(rName, "name1"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoUserPoolClientExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", "name1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccAWSCognitoUserPoolClientImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSCognitoUserPoolClientConfig_Name(rName, "name2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoUserPoolClientExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", "name2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCognitoUserPoolClient_allFields(t *testing.T) {
 	userPoolName := fmt.Sprintf("tf-acc-cognito-user-pool-%s", acctest.RandString(7))
 	clientName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-
 	resourceName := "aws_cognito_user_pool_client.client"
 
-	getStateId := func(s *terraform.State) (string, error) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoUserPoolClientDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoUserPoolClientConfig_allFields(userPoolName, clientName, 300),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoUserPoolClientExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", clientName),
+					resource.TestCheckResourceAttr(resourceName, "explicit_auth_flows.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "explicit_auth_flows.1728632605", "CUSTOM_AUTH_FLOW_ONLY"),
+					resource.TestCheckResourceAttr(resourceName, "explicit_auth_flows.1860959087", "USER_PASSWORD_AUTH"),
+					resource.TestCheckResourceAttr(resourceName, "explicit_auth_flows.245201344", "ADMIN_NO_SRP_AUTH"),
+					resource.TestCheckResourceAttr(resourceName, "generate_secret", "true"),
+					resource.TestCheckResourceAttr(resourceName, "read_attributes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "read_attributes.881205744", "email"),
+					resource.TestCheckResourceAttr(resourceName, "write_attributes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "write_attributes.881205744", "email"),
+					resource.TestCheckResourceAttr(resourceName, "refresh_token_validity", "300"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_flows.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_flows.2645166319", "code"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_flows.3465961881", "implicit"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_flows_user_pool_client", "true"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_scopes.#", "5"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_scopes.2517049750", "openid"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_scopes.881205744", "email"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_scopes.2603607895", "phone"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_scopes.380129571", "aws.cognito.signin.user.admin"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_scopes.4080487570", "profile"),
+					resource.TestCheckResourceAttr(resourceName, "callback_urls.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "callback_urls.0", "https://www.example.com/callback"),
+					resource.TestCheckResourceAttr(resourceName, "callback_urls.1", "https://www.example.com/redirect"),
+					resource.TestCheckResourceAttr(resourceName, "default_redirect_uri", "https://www.example.com/redirect"),
+					resource.TestCheckResourceAttr(resourceName, "logout_urls.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logout_urls.0", "https://www.example.com/login"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccAWSCognitoUserPoolClientImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"generate_secret"},
+			},
+		},
+	})
+}
+
+func TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField(t *testing.T) {
+	userPoolName := fmt.Sprintf("tf-acc-cognito-user-pool-%s", acctest.RandString(7))
+	clientName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	resourceName := "aws_cognito_user_pool_client.client"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoUserPoolClientDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoUserPoolClientConfig_allFields(userPoolName, clientName, 300),
+			},
+			{
+				Config: testAccAWSCognitoUserPoolClientConfig_allFields(userPoolName, clientName, 299),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoUserPoolClientExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", clientName),
+					resource.TestCheckResourceAttr(resourceName, "explicit_auth_flows.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "explicit_auth_flows.1728632605", "CUSTOM_AUTH_FLOW_ONLY"),
+					resource.TestCheckResourceAttr(resourceName, "explicit_auth_flows.1860959087", "USER_PASSWORD_AUTH"),
+					resource.TestCheckResourceAttr(resourceName, "explicit_auth_flows.245201344", "ADMIN_NO_SRP_AUTH"),
+					resource.TestCheckResourceAttr(resourceName, "generate_secret", "true"),
+					resource.TestCheckResourceAttr(resourceName, "read_attributes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "read_attributes.881205744", "email"),
+					resource.TestCheckResourceAttr(resourceName, "write_attributes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "write_attributes.881205744", "email"),
+					resource.TestCheckResourceAttr(resourceName, "refresh_token_validity", "299"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_flows.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_flows.2645166319", "code"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_flows.3465961881", "implicit"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_flows_user_pool_client", "true"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_scopes.#", "5"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_scopes.2517049750", "openid"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_scopes.881205744", "email"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_scopes.2603607895", "phone"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_scopes.380129571", "aws.cognito.signin.user.admin"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_scopes.4080487570", "profile"),
+					resource.TestCheckResourceAttr(resourceName, "callback_urls.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "callback_urls.0", "https://www.example.com/callback"),
+					resource.TestCheckResourceAttr(resourceName, "callback_urls.1", "https://www.example.com/redirect"),
+					resource.TestCheckResourceAttr(resourceName, "default_redirect_uri", "https://www.example.com/redirect"),
+					resource.TestCheckResourceAttr(resourceName, "logout_urls.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logout_urls.0", "https://www.example.com/login"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccAWSCognitoUserPoolClientImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"generate_secret"},
+			},
+		},
+	})
+}
+
+func testAccAWSCognitoUserPoolClientImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -69,171 +248,6 @@ func TestAccAWSCognitoUserPoolClient_importBasic(t *testing.T) {
 
 		return fmt.Sprintf("%s/%s", userPoolId, clientId), nil
 	}
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSCognitoUserPoolClientConfig_basic(userPoolName, clientName),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportStateIdFunc: getStateId,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSCognitoUserPoolClient_RefreshTokenValidity(t *testing.T) {
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCognitoUserPoolClientDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSCognitoUserPoolClientConfig_RefreshTokenValidity(rName, 60),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoUserPoolClientExists("aws_cognito_user_pool_client.client"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "refresh_token_validity", "60"),
-				),
-			},
-			{
-				Config: testAccAWSCognitoUserPoolClientConfig_RefreshTokenValidity(rName, 120),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoUserPoolClientExists("aws_cognito_user_pool_client.client"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "refresh_token_validity", "120"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSCognitoUserPoolClient_Name(t *testing.T) {
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_cognito_user_pool_client.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCognitoUserPoolClientDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSCognitoUserPoolClientConfig_Name(rName, "name1"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoUserPoolClientExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "name", "name1"),
-				),
-			},
-			{
-				Config: testAccAWSCognitoUserPoolClientConfig_Name(rName, "name2"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoUserPoolClientExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "name", "name2"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSCognitoUserPoolClient_allFields(t *testing.T) {
-	userPoolName := fmt.Sprintf("tf-acc-cognito-user-pool-%s", acctest.RandString(7))
-	clientName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCognitoUserPoolClientDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSCognitoUserPoolClientConfig_allFields(userPoolName, clientName, 300),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoUserPoolClientExists("aws_cognito_user_pool_client.client"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "name", clientName),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "explicit_auth_flows.#", "3"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "explicit_auth_flows.1728632605", "CUSTOM_AUTH_FLOW_ONLY"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "explicit_auth_flows.1860959087", "USER_PASSWORD_AUTH"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "explicit_auth_flows.245201344", "ADMIN_NO_SRP_AUTH"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "generate_secret", "true"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "read_attributes.#", "1"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "read_attributes.881205744", "email"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "write_attributes.#", "1"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "write_attributes.881205744", "email"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "refresh_token_validity", "300"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_flows.#", "2"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_flows.2645166319", "code"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_flows.3465961881", "implicit"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_flows_user_pool_client", "true"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_scopes.#", "5"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_scopes.2517049750", "openid"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_scopes.881205744", "email"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_scopes.2603607895", "phone"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_scopes.380129571", "aws.cognito.signin.user.admin"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_scopes.4080487570", "profile"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "callback_urls.#", "2"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "callback_urls.0", "https://www.example.com/callback"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "callback_urls.1", "https://www.example.com/redirect"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "default_redirect_uri", "https://www.example.com/redirect"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "logout_urls.#", "1"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "logout_urls.0", "https://www.example.com/login"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField(t *testing.T) {
-	userPoolName := fmt.Sprintf("tf-acc-cognito-user-pool-%s", acctest.RandString(7))
-	clientName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCognitoUserPoolClientDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSCognitoUserPoolClientConfig_allFields(userPoolName, clientName, 300),
-			},
-			{
-				Config: testAccAWSCognitoUserPoolClientConfig_allFields(userPoolName, clientName, 299),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoUserPoolClientExists("aws_cognito_user_pool_client.client"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "name", clientName),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "explicit_auth_flows.#", "3"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "explicit_auth_flows.1728632605", "CUSTOM_AUTH_FLOW_ONLY"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "explicit_auth_flows.1860959087", "USER_PASSWORD_AUTH"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "explicit_auth_flows.245201344", "ADMIN_NO_SRP_AUTH"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "generate_secret", "true"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "read_attributes.#", "1"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "read_attributes.881205744", "email"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "write_attributes.#", "1"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "write_attributes.881205744", "email"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "refresh_token_validity", "299"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_flows.#", "2"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_flows.2645166319", "code"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_flows.3465961881", "implicit"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_flows_user_pool_client", "true"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_scopes.#", "5"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_scopes.2517049750", "openid"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_scopes.881205744", "email"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_scopes.2603607895", "phone"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_scopes.380129571", "aws.cognito.signin.user.admin"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_scopes.4080487570", "profile"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "callback_urls.#", "2"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "callback_urls.0", "https://www.example.com/callback"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "callback_urls.1", "https://www.example.com/redirect"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "default_redirect_uri", "https://www.example.com/redirect"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "logout_urls.#", "1"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "logout_urls.0", "https://www.example.com/login"),
-				),
-			},
-		},
-	})
 }
 
 func testAccCheckAWSCognitoUserPoolClientDestroy(s *terraform.State) error {

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -70,17 +70,27 @@ func testSweepCognitoUserPools(region string) error {
 	return nil
 }
 
-func TestAccAWSCognitoUserPool_importBasic(t *testing.T) {
-	resourceName := "aws_cognito_user_pool.pool"
+func TestAccAWSCognitoUserPool_basic(t *testing.T) {
 	name := acctest.RandString(5)
+	resourceName := "aws_cognito_user_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCloudWatchDashboardDestroy,
+		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSCognitoUserPoolConfig_basic(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoUserPoolExists(resourceName),
+					resource.TestMatchResourceAttr(resourceName, "arn",
+						regexp.MustCompile(`^arn:aws:cognito-idp:[^:]+:[0-9]{12}:userpool/[\w-]+_[0-9a-zA-Z]+$`)),
+					resource.TestMatchResourceAttr(resourceName, "endpoint",
+						regexp.MustCompile(`^cognito-idp\.[^.]+\.amazonaws.com/[\w-]+_[0-9a-zA-Z]+$`)),
+					resource.TestCheckResourceAttr(resourceName, "name", "terraform-test-pool-"+name),
+					resource.TestCheckResourceAttrSet(resourceName, "creation_date"),
+					resource.TestCheckResourceAttrSet(resourceName, "last_modified_date"),
+				),
 			},
 			{
 				ResourceName:      resourceName,
@@ -91,33 +101,9 @@ func TestAccAWSCognitoUserPool_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccAWSCognitoUserPool_basic(t *testing.T) {
-	name := acctest.RandString(5)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSCognitoUserPoolConfig_basic(name),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoUserPoolExists("aws_cognito_user_pool.pool"),
-					resource.TestMatchResourceAttr("aws_cognito_user_pool.pool", "arn",
-						regexp.MustCompile(`^arn:aws:cognito-idp:[^:]+:[0-9]{12}:userpool/[\w-]+_[0-9a-zA-Z]+$`)),
-					resource.TestMatchResourceAttr("aws_cognito_user_pool.pool", "endpoint",
-						regexp.MustCompile(`^cognito-idp\.[^.]+\.amazonaws.com/[\w-]+_[0-9a-zA-Z]+$`)),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "name", "terraform-test-pool-"+name),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.pool", "creation_date"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.pool", "last_modified_date"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration(t *testing.T) {
 	name := acctest.RandString(5)
+	resourceName := "aws_cognito_user_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
@@ -127,22 +113,27 @@ func TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration(t *testing.T) {
 			{
 				Config: testAccAWSCognitoUserPoolConfig_withAdminCreateUserConfiguration(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoUserPoolExists("aws_cognito_user_pool.pool"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "admin_create_user_config.0.unused_account_validity_days", "6"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "admin_create_user_config.0.allow_admin_create_user_only", "true"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "admin_create_user_config.0.invite_message_template.0.email_message", "Your username is {username} and temporary password is {####}. "),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "admin_create_user_config.0.invite_message_template.0.email_subject", "FooBar {####}"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "admin_create_user_config.0.invite_message_template.0.sms_message", "Your username is {username} and temporary password is {####}."),
+					testAccCheckAWSCognitoUserPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.unused_account_validity_days", "6"),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.allow_admin_create_user_only", "true"),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.email_message", "Your username is {username} and temporary password is {####}. "),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.email_subject", "FooBar {####}"),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.sms_message", "Your username is {username} and temporary password is {####}."),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCognitoUserPoolConfig_withAdminCreateUserConfigurationUpdated(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "admin_create_user_config.0.unused_account_validity_days", "7"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "admin_create_user_config.0.allow_admin_create_user_only", "false"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "admin_create_user_config.0.invite_message_template.0.email_message", "Your username is {username} and constant password is {####}. "),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "admin_create_user_config.0.invite_message_template.0.email_subject", "Foo{####}BaBaz"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "admin_create_user_config.0.invite_message_template.0.sms_message", "Your username is {username} and constant password is {####}."),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.unused_account_validity_days", "7"),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.allow_admin_create_user_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.email_message", "Your username is {username} and constant password is {####}. "),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.email_subject", "Foo{####}BaBaz"),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.sms_message", "Your username is {username} and constant password is {####}."),
 				),
 			},
 		},
@@ -151,6 +142,7 @@ func TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration(t *testing.T) {
 
 func TestAccAWSCognitoUserPool_withAdvancedSecurityMode(t *testing.T) {
 	name := acctest.RandString(5)
+	resourceName := "aws_cognito_user_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
@@ -160,20 +152,25 @@ func TestAccAWSCognitoUserPool_withAdvancedSecurityMode(t *testing.T) {
 			{
 				Config: testAccAWSCognitoUserPoolConfig_withAdvancedSecurityMode(name, "OFF"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoUserPoolExists("aws_cognito_user_pool.pool"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "user_pool_add_ons.0.advanced_security_mode", "OFF"),
+					testAccCheckAWSCognitoUserPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "user_pool_add_ons.0.advanced_security_mode", "OFF"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCognitoUserPoolConfig_withAdvancedSecurityMode(name, "ENFORCED"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "user_pool_add_ons.0.advanced_security_mode", "ENFORCED"),
+					resource.TestCheckResourceAttr(resourceName, "user_pool_add_ons.0.advanced_security_mode", "ENFORCED"),
 				),
 			},
 			{
 				Config: testAccAWSCognitoUserPoolConfig_basic(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "user_pool_add_ons.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "user_pool_add_ons.#", "0"),
 				),
 			},
 		},
@@ -182,6 +179,7 @@ func TestAccAWSCognitoUserPool_withAdvancedSecurityMode(t *testing.T) {
 
 func TestAccAWSCognitoUserPool_withDeviceConfiguration(t *testing.T) {
 	name := acctest.RandString(5)
+	resourceName := "aws_cognito_user_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
@@ -191,16 +189,21 @@ func TestAccAWSCognitoUserPool_withDeviceConfiguration(t *testing.T) {
 			{
 				Config: testAccAWSCognitoUserPoolConfig_withDeviceConfiguration(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoUserPoolExists("aws_cognito_user_pool.pool"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "device_configuration.0.challenge_required_on_new_device", "true"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "device_configuration.0.device_only_remembered_on_user_prompt", "false"),
+					testAccCheckAWSCognitoUserPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "device_configuration.0.challenge_required_on_new_device", "true"),
+					resource.TestCheckResourceAttr(resourceName, "device_configuration.0.device_only_remembered_on_user_prompt", "false"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCognitoUserPoolConfig_withDeviceConfigurationUpdated(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "device_configuration.0.challenge_required_on_new_device", "false"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "device_configuration.0.device_only_remembered_on_user_prompt", "true"),
+					resource.TestCheckResourceAttr(resourceName, "device_configuration.0.challenge_required_on_new_device", "false"),
+					resource.TestCheckResourceAttr(resourceName, "device_configuration.0.device_only_remembered_on_user_prompt", "true"),
 				),
 			},
 		},
@@ -213,6 +216,7 @@ func TestAccAWSCognitoUserPool_withEmailVerificationMessage(t *testing.T) {
 	updatedSubject := acctest.RandString(10)
 	message := fmt.Sprintf("%s {####}", acctest.RandString(10))
 	upatedMessage := fmt.Sprintf("%s {####}", acctest.RandString(10))
+	resourceName := "aws_cognito_user_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
@@ -222,16 +226,21 @@ func TestAccAWSCognitoUserPool_withEmailVerificationMessage(t *testing.T) {
 			{
 				Config: testAccAWSCognitoUserPoolConfig_withEmailVerificationMessage(name, subject, message),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoUserPoolExists("aws_cognito_user_pool.pool"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_verification_subject", subject),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_verification_message", message),
+					testAccCheckAWSCognitoUserPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "email_verification_subject", subject),
+					resource.TestCheckResourceAttr(resourceName, "email_verification_message", message),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCognitoUserPoolConfig_withEmailVerificationMessage(name, updatedSubject, upatedMessage),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_verification_subject", updatedSubject),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_verification_message", upatedMessage),
+					resource.TestCheckResourceAttr(resourceName, "email_verification_subject", updatedSubject),
+					resource.TestCheckResourceAttr(resourceName, "email_verification_message", upatedMessage),
 				),
 			},
 		},
@@ -244,6 +253,7 @@ func TestAccAWSCognitoUserPool_withSmsVerificationMessage(t *testing.T) {
 	updatedAuthenticationMessage := fmt.Sprintf("%s {####}", acctest.RandString(10))
 	verificationMessage := fmt.Sprintf("%s {####}", acctest.RandString(10))
 	upatedVerificationMessage := fmt.Sprintf("%s {####}", acctest.RandString(10))
+	resourceName := "aws_cognito_user_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
@@ -253,16 +263,21 @@ func TestAccAWSCognitoUserPool_withSmsVerificationMessage(t *testing.T) {
 			{
 				Config: testAccAWSCognitoUserPoolConfig_withSmsVerificationMessage(name, authenticationMessage, verificationMessage),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoUserPoolExists("aws_cognito_user_pool.pool"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "sms_authentication_message", authenticationMessage),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "sms_verification_message", verificationMessage),
+					testAccCheckAWSCognitoUserPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "sms_authentication_message", authenticationMessage),
+					resource.TestCheckResourceAttr(resourceName, "sms_verification_message", verificationMessage),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCognitoUserPoolConfig_withSmsVerificationMessage(name, updatedAuthenticationMessage, upatedVerificationMessage),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "sms_authentication_message", updatedAuthenticationMessage),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "sms_verification_message", upatedVerificationMessage),
+					resource.TestCheckResourceAttr(resourceName, "sms_authentication_message", updatedAuthenticationMessage),
+					resource.TestCheckResourceAttr(resourceName, "sms_verification_message", upatedVerificationMessage),
 				),
 			},
 		},
@@ -272,6 +287,7 @@ func TestAccAWSCognitoUserPool_withSmsVerificationMessage(t *testing.T) {
 func TestAccAWSCognitoUserPool_withEmailConfiguration(t *testing.T) {
 	name := acctest.RandString(5)
 	replyTo := fmt.Sprintf("tf-acc-reply-%s@terraformtesting.com", name)
+	resourceName := "aws_cognito_user_pool.test"
 
 	sourceARN, ok := os.LookupEnv("TEST_AWS_SES_VERIFIED_EMAIL_ARN")
 	if !ok {
@@ -286,18 +302,23 @@ func TestAccAWSCognitoUserPool_withEmailConfiguration(t *testing.T) {
 			{
 				Config: testAccAWSCognitoUserPoolConfig_withEmailConfiguration(name, "", "", "COGNITO_DEFAULT"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_configuration.#", "1"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_configuration.0.reply_to_email_address", ""),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_configuration.0.email_sending_account", "COGNITO_DEFAULT"),
+					resource.TestCheckResourceAttr(resourceName, "email_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "email_configuration.0.reply_to_email_address", ""),
+					resource.TestCheckResourceAttr(resourceName, "email_configuration.0.email_sending_account", "COGNITO_DEFAULT"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCognitoUserPoolConfig_withEmailConfiguration(name, replyTo, sourceARN, "DEVELOPER"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_configuration.#", "1"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_configuration.0.reply_to_email_address", replyTo),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_configuration.0.email_sending_account", "DEVELOPER"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_configuration.0.source_arn", sourceARN),
+					resource.TestCheckResourceAttr(resourceName, "email_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "email_configuration.0.reply_to_email_address", replyTo),
+					resource.TestCheckResourceAttr(resourceName, "email_configuration.0.email_sending_account", "DEVELOPER"),
+					resource.TestCheckResourceAttr(resourceName, "email_configuration.0.source_arn", sourceARN),
 				),
 			},
 		},
@@ -308,6 +329,7 @@ func TestAccAWSCognitoUserPool_withEmailConfiguration(t *testing.T) {
 // taking some time.
 func TestAccAWSCognitoUserPool_withSmsConfiguration(t *testing.T) {
 	name := acctest.RandString(5)
+	resourceName := "aws_cognito_user_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
@@ -317,10 +339,15 @@ func TestAccAWSCognitoUserPool_withSmsConfiguration(t *testing.T) {
 			{
 				Config: testAccAWSCognitoUserPoolConfig_withSmsConfiguration(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "sms_configuration.#", "1"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.pool", "sms_configuration.0.external_id"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.pool", "sms_configuration.0.sns_caller_arn"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "sms_configuration.0.external_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "sms_configuration.0.sns_caller_arn"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -329,6 +356,7 @@ func TestAccAWSCognitoUserPool_withSmsConfiguration(t *testing.T) {
 // Ensure we can update a User Pool, handling IAM role propagation.
 func TestAccAWSCognitoUserPool_withSmsConfigurationUpdated(t *testing.T) {
 	name := acctest.RandString(5)
+	resourceName := "aws_cognito_user_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
@@ -338,16 +366,21 @@ func TestAccAWSCognitoUserPool_withSmsConfigurationUpdated(t *testing.T) {
 			{
 				Config: testAccAWSCognitoUserPoolConfig_basic(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoUserPoolExists("aws_cognito_user_pool.pool"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "sms_configuration.#", "0"),
+					testAccCheckAWSCognitoUserPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCognitoUserPoolConfig_withSmsConfiguration(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "sms_configuration.#", "1"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.pool", "sms_configuration.0.external_id"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.pool", "sms_configuration.0.sns_caller_arn"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "sms_configuration.0.external_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "sms_configuration.0.sns_caller_arn"),
 				),
 			},
 		},
@@ -356,6 +389,7 @@ func TestAccAWSCognitoUserPool_withSmsConfigurationUpdated(t *testing.T) {
 
 func TestAccAWSCognitoUserPool_withTags(t *testing.T) {
 	name := acctest.RandString(5)
+	resourceName := "aws_cognito_user_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
@@ -365,15 +399,20 @@ func TestAccAWSCognitoUserPool_withTags(t *testing.T) {
 			{
 				Config: testAccAWSCognitoUserPoolConfig_withTags(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoUserPoolExists("aws_cognito_user_pool.pool"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "tags.Name", "Foo"),
+					testAccCheckAWSCognitoUserPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "Foo"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCognitoUserPoolConfig_withTagsUpdated(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "tags.Name", "FooBar"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "tags.Project", "Terraform"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "FooBar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Project", "Terraform"),
 				),
 			},
 		},
@@ -382,6 +421,7 @@ func TestAccAWSCognitoUserPool_withTags(t *testing.T) {
 
 func TestAccAWSCognitoUserPool_withAliasAttributes(t *testing.T) {
 	name := acctest.RandString(5)
+	resourceName := "aws_cognito_user_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
@@ -391,20 +431,25 @@ func TestAccAWSCognitoUserPool_withAliasAttributes(t *testing.T) {
 			{
 				Config: testAccAWSCognitoUserPoolConfig_withAliasAttributes(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoUserPoolExists("aws_cognito_user_pool.pool"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "alias_attributes.#", "1"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "alias_attributes.1888159429", "preferred_username"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "auto_verified_attributes.#", "0"),
+					testAccCheckAWSCognitoUserPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "alias_attributes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "alias_attributes.1888159429", "preferred_username"),
+					resource.TestCheckResourceAttr(resourceName, "auto_verified_attributes.#", "0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCognitoUserPoolConfig_withAliasAttributesUpdated(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "alias_attributes.#", "2"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "alias_attributes.881205744", "email"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "alias_attributes.1888159429", "preferred_username"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "auto_verified_attributes.#", "1"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "auto_verified_attributes.881205744", "email"),
+					resource.TestCheckResourceAttr(resourceName, "alias_attributes.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "alias_attributes.881205744", "email"),
+					resource.TestCheckResourceAttr(resourceName, "alias_attributes.1888159429", "preferred_username"),
+					resource.TestCheckResourceAttr(resourceName, "auto_verified_attributes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "auto_verified_attributes.881205744", "email"),
 				),
 			},
 		},
@@ -413,6 +458,7 @@ func TestAccAWSCognitoUserPool_withAliasAttributes(t *testing.T) {
 
 func TestAccAWSCognitoUserPool_withPasswordPolicy(t *testing.T) {
 	name := acctest.RandString(5)
+	resourceName := "aws_cognito_user_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
@@ -422,24 +468,29 @@ func TestAccAWSCognitoUserPool_withPasswordPolicy(t *testing.T) {
 			{
 				Config: testAccAWSCognitoUserPoolConfig_withPasswordPolicy(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoUserPoolExists("aws_cognito_user_pool.pool"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "password_policy.#", "1"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "password_policy.0.minimum_length", "7"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "password_policy.0.require_lowercase", "true"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "password_policy.0.require_numbers", "false"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "password_policy.0.require_symbols", "true"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "password_policy.0.require_uppercase", "false"),
+					testAccCheckAWSCognitoUserPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "password_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "password_policy.0.minimum_length", "7"),
+					resource.TestCheckResourceAttr(resourceName, "password_policy.0.require_lowercase", "true"),
+					resource.TestCheckResourceAttr(resourceName, "password_policy.0.require_numbers", "false"),
+					resource.TestCheckResourceAttr(resourceName, "password_policy.0.require_symbols", "true"),
+					resource.TestCheckResourceAttr(resourceName, "password_policy.0.require_uppercase", "false"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCognitoUserPoolConfig_withPasswordPolicyUpdated(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "password_policy.#", "1"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "password_policy.0.minimum_length", "9"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "password_policy.0.require_lowercase", "false"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "password_policy.0.require_numbers", "true"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "password_policy.0.require_symbols", "false"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "password_policy.0.require_uppercase", "true"),
+					resource.TestCheckResourceAttr(resourceName, "password_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "password_policy.0.minimum_length", "9"),
+					resource.TestCheckResourceAttr(resourceName, "password_policy.0.require_lowercase", "false"),
+					resource.TestCheckResourceAttr(resourceName, "password_policy.0.require_numbers", "true"),
+					resource.TestCheckResourceAttr(resourceName, "password_policy.0.require_symbols", "false"),
+					resource.TestCheckResourceAttr(resourceName, "password_policy.0.require_uppercase", "true"),
 				),
 			},
 		},
@@ -448,6 +499,7 @@ func TestAccAWSCognitoUserPool_withPasswordPolicy(t *testing.T) {
 
 func TestAccAWSCognitoUserPool_withLambdaConfig(t *testing.T) {
 	name := acctest.RandString(5)
+	resourceName := "aws_cognito_user_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
@@ -457,34 +509,39 @@ func TestAccAWSCognitoUserPool_withLambdaConfig(t *testing.T) {
 			{
 				Config: testAccAWSCognitoUserPoolConfig_withLambdaConfig(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoUserPoolExists("aws_cognito_user_pool.main"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "lambda_config.#", "1"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.main", "lambda_config.0.create_auth_challenge"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.main", "lambda_config.0.custom_message"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.main", "lambda_config.0.define_auth_challenge"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.main", "lambda_config.0.post_authentication"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.main", "lambda_config.0.post_confirmation"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.main", "lambda_config.0.pre_authentication"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.main", "lambda_config.0.pre_sign_up"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.main", "lambda_config.0.pre_token_generation"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.main", "lambda_config.0.user_migration"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.main", "lambda_config.0.verify_auth_challenge_response"),
+					testAccCheckAWSCognitoUserPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "lambda_config.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.create_auth_challenge"),
+					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.custom_message"),
+					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.define_auth_challenge"),
+					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.post_authentication"),
+					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.post_confirmation"),
+					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.pre_authentication"),
+					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.pre_sign_up"),
+					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.pre_token_generation"),
+					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.user_migration"),
+					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.verify_auth_challenge_response"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCognitoUserPoolConfig_withLambdaConfigUpdated(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "lambda_config.#", "1"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.main", "lambda_config.0.create_auth_challenge"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.main", "lambda_config.0.custom_message"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.main", "lambda_config.0.define_auth_challenge"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.main", "lambda_config.0.post_authentication"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.main", "lambda_config.0.post_confirmation"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.main", "lambda_config.0.pre_authentication"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.main", "lambda_config.0.pre_sign_up"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.main", "lambda_config.0.pre_token_generation"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.main", "lambda_config.0.user_migration"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.main", "lambda_config.0.verify_auth_challenge_response"),
+					resource.TestCheckResourceAttr(resourceName, "lambda_config.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.create_auth_challenge"),
+					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.custom_message"),
+					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.define_auth_challenge"),
+					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.post_authentication"),
+					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.post_confirmation"),
+					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.pre_authentication"),
+					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.pre_sign_up"),
+					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.pre_token_generation"),
+					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.user_migration"),
+					resource.TestCheckResourceAttrSet(resourceName, "lambda_config.0.verify_auth_challenge_response"),
 				),
 			},
 		},
@@ -493,6 +550,7 @@ func TestAccAWSCognitoUserPool_withLambdaConfig(t *testing.T) {
 
 func TestAccAWSCognitoUserPool_withSchemaAttributes(t *testing.T) {
 	name := acctest.RandString(5)
+	resourceName := "aws_cognito_user_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
@@ -502,61 +560,66 @@ func TestAccAWSCognitoUserPool_withSchemaAttributes(t *testing.T) {
 			{
 				Config: testAccAWSCognitoUserPoolConfig_withSchemaAttributes(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoUserPoolExists("aws_cognito_user_pool.main"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.#", "2"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.145451252.attribute_data_type", "String"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.145451252.developer_only_attribute", "false"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.145451252.mutable", "false"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.145451252.name", "email"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.145451252.number_attribute_constraints.#", "0"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.145451252.required", "true"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.145451252.string_attribute_constraints.#", "1"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.145451252.string_attribute_constraints.0.min_length", "5"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.145451252.string_attribute_constraints.0.max_length", "10"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.770828826.attribute_data_type", "Boolean"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.770828826.developer_only_attribute", "true"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.770828826.mutable", "false"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.770828826.name", "mybool"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.770828826.number_attribute_constraints.#", "0"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.770828826.required", "false"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.770828826.string_attribute_constraints.#", "0"),
+					testAccCheckAWSCognitoUserPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "schema.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "schema.145451252.attribute_data_type", "String"),
+					resource.TestCheckResourceAttr(resourceName, "schema.145451252.developer_only_attribute", "false"),
+					resource.TestCheckResourceAttr(resourceName, "schema.145451252.mutable", "false"),
+					resource.TestCheckResourceAttr(resourceName, "schema.145451252.name", "email"),
+					resource.TestCheckResourceAttr(resourceName, "schema.145451252.number_attribute_constraints.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "schema.145451252.required", "true"),
+					resource.TestCheckResourceAttr(resourceName, "schema.145451252.string_attribute_constraints.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "schema.145451252.string_attribute_constraints.0.min_length", "5"),
+					resource.TestCheckResourceAttr(resourceName, "schema.145451252.string_attribute_constraints.0.max_length", "10"),
+					resource.TestCheckResourceAttr(resourceName, "schema.770828826.attribute_data_type", "Boolean"),
+					resource.TestCheckResourceAttr(resourceName, "schema.770828826.developer_only_attribute", "true"),
+					resource.TestCheckResourceAttr(resourceName, "schema.770828826.mutable", "false"),
+					resource.TestCheckResourceAttr(resourceName, "schema.770828826.name", "mybool"),
+					resource.TestCheckResourceAttr(resourceName, "schema.770828826.number_attribute_constraints.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "schema.770828826.required", "false"),
+					resource.TestCheckResourceAttr(resourceName, "schema.770828826.string_attribute_constraints.#", "0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCognitoUserPoolConfig_withSchemaAttributesUpdated(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.#", "3"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2078884933.attribute_data_type", "String"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2078884933.developer_only_attribute", "false"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2078884933.mutable", "false"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2078884933.name", "email"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2078884933.number_attribute_constraints.#", "0"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2078884933.required", "true"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2078884933.string_attribute_constraints.#", "1"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2078884933.string_attribute_constraints.0.min_length", "7"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2078884933.string_attribute_constraints.0.max_length", "15"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2718111653.attribute_data_type", "Number"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2718111653.developer_only_attribute", "true"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2718111653.mutable", "true"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2718111653.name", "mynumber"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2718111653.number_attribute_constraints.#", "1"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2718111653.number_attribute_constraints.0.min_value", "2"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2718111653.number_attribute_constraints.0.max_value", "6"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2718111653.required", "false"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2718111653.string_attribute_constraints.#", "0"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2753746449.attribute_data_type", "Number"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2753746449.developer_only_attribute", "false"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2753746449.mutable", "true"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2753746449.name", "mynondevnumber"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2753746449.number_attribute_constraints.#", "1"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2753746449.number_attribute_constraints.0.min_value", "2"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2753746449.number_attribute_constraints.0.max_value", "6"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2753746449.required", "false"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2753746449.string_attribute_constraints.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "schema.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "schema.2078884933.attribute_data_type", "String"),
+					resource.TestCheckResourceAttr(resourceName, "schema.2078884933.developer_only_attribute", "false"),
+					resource.TestCheckResourceAttr(resourceName, "schema.2078884933.mutable", "false"),
+					resource.TestCheckResourceAttr(resourceName, "schema.2078884933.name", "email"),
+					resource.TestCheckResourceAttr(resourceName, "schema.2078884933.number_attribute_constraints.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "schema.2078884933.required", "true"),
+					resource.TestCheckResourceAttr(resourceName, "schema.2078884933.string_attribute_constraints.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "schema.2078884933.string_attribute_constraints.0.min_length", "7"),
+					resource.TestCheckResourceAttr(resourceName, "schema.2078884933.string_attribute_constraints.0.max_length", "15"),
+					resource.TestCheckResourceAttr(resourceName, "schema.2718111653.attribute_data_type", "Number"),
+					resource.TestCheckResourceAttr(resourceName, "schema.2718111653.developer_only_attribute", "true"),
+					resource.TestCheckResourceAttr(resourceName, "schema.2718111653.mutable", "true"),
+					resource.TestCheckResourceAttr(resourceName, "schema.2718111653.name", "mynumber"),
+					resource.TestCheckResourceAttr(resourceName, "schema.2718111653.number_attribute_constraints.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "schema.2718111653.number_attribute_constraints.0.min_value", "2"),
+					resource.TestCheckResourceAttr(resourceName, "schema.2718111653.number_attribute_constraints.0.max_value", "6"),
+					resource.TestCheckResourceAttr(resourceName, "schema.2718111653.required", "false"),
+					resource.TestCheckResourceAttr(resourceName, "schema.2718111653.string_attribute_constraints.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "schema.2753746449.attribute_data_type", "Number"),
+					resource.TestCheckResourceAttr(resourceName, "schema.2753746449.developer_only_attribute", "false"),
+					resource.TestCheckResourceAttr(resourceName, "schema.2753746449.mutable", "true"),
+					resource.TestCheckResourceAttr(resourceName, "schema.2753746449.name", "mynondevnumber"),
+					resource.TestCheckResourceAttr(resourceName, "schema.2753746449.number_attribute_constraints.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "schema.2753746449.number_attribute_constraints.0.min_value", "2"),
+					resource.TestCheckResourceAttr(resourceName, "schema.2753746449.number_attribute_constraints.0.max_value", "6"),
+					resource.TestCheckResourceAttr(resourceName, "schema.2753746449.required", "false"),
+					resource.TestCheckResourceAttr(resourceName, "schema.2753746449.string_attribute_constraints.#", "0"),
 				),
 			},
 			{
-				ResourceName:      "aws_cognito_user_pool.main",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -566,6 +629,7 @@ func TestAccAWSCognitoUserPool_withSchemaAttributes(t *testing.T) {
 
 func TestAccAWSCognitoUserPool_withVerificationMessageTemplate(t *testing.T) {
 	name := acctest.RandString(5)
+	resourceName := "aws_cognito_user_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
@@ -575,36 +639,41 @@ func TestAccAWSCognitoUserPool_withVerificationMessageTemplate(t *testing.T) {
 			{
 				Config: testAccAWSCognitoUserPoolConfig_withVerificationMessageTemplate(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoUserPoolExists("aws_cognito_user_pool.pool"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "verification_message_template.0.default_email_option", "CONFIRM_WITH_LINK"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "verification_message_template.0.email_message", "foo {####} bar"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "verification_message_template.0.email_message_by_link", "{##foobar##}"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "verification_message_template.0.email_subject", "foobar {####}"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "verification_message_template.0.email_subject_by_link", "foobar"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "verification_message_template.0.sms_message", "{####} baz"),
+					testAccCheckAWSCognitoUserPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "verification_message_template.0.default_email_option", "CONFIRM_WITH_LINK"),
+					resource.TestCheckResourceAttr(resourceName, "verification_message_template.0.email_message", "foo {####} bar"),
+					resource.TestCheckResourceAttr(resourceName, "verification_message_template.0.email_message_by_link", "{##foobar##}"),
+					resource.TestCheckResourceAttr(resourceName, "verification_message_template.0.email_subject", "foobar {####}"),
+					resource.TestCheckResourceAttr(resourceName, "verification_message_template.0.email_subject_by_link", "foobar"),
+					resource.TestCheckResourceAttr(resourceName, "verification_message_template.0.sms_message", "{####} baz"),
 
 					/* Setting Verification template attributes like EmailMessage, EmailSubject or SmsMessage
 					will implicitly set EmailVerificationMessage, EmailVerificationSubject and SmsVerificationMessage attributes.
 					*/
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_verification_message", "foo {####} bar"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_verification_subject", "foobar {####}"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "sms_verification_message", "{####} baz"),
+					resource.TestCheckResourceAttr(resourceName, "email_verification_message", "foo {####} bar"),
+					resource.TestCheckResourceAttr(resourceName, "email_verification_subject", "foobar {####}"),
+					resource.TestCheckResourceAttr(resourceName, "sms_verification_message", "{####} baz"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCognitoUserPoolConfig_withVerificationMessageTemplate_DefaultEmailOption(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "verification_message_template.0.default_email_option", "CONFIRM_WITH_CODE"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_verification_message", "{####} Baz"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_verification_subject", "BazBaz {####}"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "sms_verification_message", "{####} BazBazBar?"),
+					resource.TestCheckResourceAttr(resourceName, "verification_message_template.0.default_email_option", "CONFIRM_WITH_CODE"),
+					resource.TestCheckResourceAttr(resourceName, "email_verification_message", "{####} Baz"),
+					resource.TestCheckResourceAttr(resourceName, "email_verification_subject", "BazBaz {####}"),
+					resource.TestCheckResourceAttr(resourceName, "sms_verification_message", "{####} BazBazBar?"),
 
 					/* Setting EmailVerificationMessage, EmailVerificationSubject and SmsVerificationMessage attributes
 					will implicitly set verification template attributes like EmailMessage, EmailSubject or SmsMessage.
 					*/
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "verification_message_template.0.email_message", "{####} Baz"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "verification_message_template.0.email_subject", "BazBaz {####}"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "verification_message_template.0.sms_message", "{####} BazBazBar?"),
+					resource.TestCheckResourceAttr(resourceName, "verification_message_template.0.email_message", "{####} Baz"),
+					resource.TestCheckResourceAttr(resourceName, "verification_message_template.0.email_subject", "BazBaz {####}"),
+					resource.TestCheckResourceAttr(resourceName, "verification_message_template.0.sms_message", "{####} BazBazBar?"),
 				),
 			},
 		},
@@ -617,6 +686,7 @@ func TestAccAWSCognitoUserPool_update(t *testing.T) {
 	offMfa := "OFF"
 	authenticationMessage := fmt.Sprintf("%s {####}", acctest.RandString(10))
 	updatedAuthenticationMessage := fmt.Sprintf("%s {####}", acctest.RandString(10))
+	resourceName := "aws_cognito_user_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
@@ -626,73 +696,78 @@ func TestAccAWSCognitoUserPool_update(t *testing.T) {
 			{
 				Config: testAccAWSCognitoUserPoolConfig_update(name, optionalMfa, authenticationMessage),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoUserPoolExists("aws_cognito_user_pool.pool"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "auto_verified_attributes.#", "1"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "mfa_configuration", optionalMfa),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_verification_message", "Foo {####} Bar"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_verification_subject", "FooBar {####}"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "sms_verification_message", "{####} Baz"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "sms_authentication_message", authenticationMessage),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "admin_create_user_config.0.unused_account_validity_days", "6"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "admin_create_user_config.0.allow_admin_create_user_only", "true"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "admin_create_user_config.0.invite_message_template.0.email_message", "Your username is {username} and temporary password is {####}. "),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "admin_create_user_config.0.invite_message_template.0.email_subject", "FooBar {####}"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "admin_create_user_config.0.invite_message_template.0.sms_message", "Your username is {username} and temporary password is {####}."),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "device_configuration.0.challenge_required_on_new_device", "true"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "device_configuration.0.device_only_remembered_on_user_prompt", "false"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "verification_message_template.0.default_email_option", "CONFIRM_WITH_CODE"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "sms_configuration.#", "1"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.pool", "sms_configuration.0.external_id"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.pool", "sms_configuration.0.sns_caller_arn"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "tags.Name", "Foo"),
+					testAccCheckAWSCognitoUserPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "auto_verified_attributes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mfa_configuration", optionalMfa),
+					resource.TestCheckResourceAttr(resourceName, "email_verification_message", "Foo {####} Bar"),
+					resource.TestCheckResourceAttr(resourceName, "email_verification_subject", "FooBar {####}"),
+					resource.TestCheckResourceAttr(resourceName, "sms_verification_message", "{####} Baz"),
+					resource.TestCheckResourceAttr(resourceName, "sms_authentication_message", authenticationMessage),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.unused_account_validity_days", "6"),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.allow_admin_create_user_only", "true"),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.email_message", "Your username is {username} and temporary password is {####}. "),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.email_subject", "FooBar {####}"),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.sms_message", "Your username is {username} and temporary password is {####}."),
+					resource.TestCheckResourceAttr(resourceName, "device_configuration.0.challenge_required_on_new_device", "true"),
+					resource.TestCheckResourceAttr(resourceName, "device_configuration.0.device_only_remembered_on_user_prompt", "false"),
+					resource.TestCheckResourceAttr(resourceName, "verification_message_template.0.default_email_option", "CONFIRM_WITH_CODE"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "sms_configuration.0.external_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "sms_configuration.0.sns_caller_arn"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "Foo"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCognitoUserPoolConfig_update(name, optionalMfa, updatedAuthenticationMessage),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoUserPoolExists("aws_cognito_user_pool.pool"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "auto_verified_attributes.#", "1"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "mfa_configuration", optionalMfa),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_verification_message", "Foo {####} Bar"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_verification_subject", "FooBar {####}"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "sms_verification_message", "{####} Baz"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "sms_authentication_message", updatedAuthenticationMessage),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "admin_create_user_config.0.unused_account_validity_days", "6"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "admin_create_user_config.0.allow_admin_create_user_only", "true"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "admin_create_user_config.0.invite_message_template.0.email_message", "Your username is {username} and temporary password is {####}. "),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "admin_create_user_config.0.invite_message_template.0.email_subject", "FooBar {####}"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "admin_create_user_config.0.invite_message_template.0.sms_message", "Your username is {username} and temporary password is {####}."),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "device_configuration.0.challenge_required_on_new_device", "true"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "device_configuration.0.device_only_remembered_on_user_prompt", "false"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "verification_message_template.0.default_email_option", "CONFIRM_WITH_CODE"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "sms_configuration.#", "1"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.pool", "sms_configuration.0.external_id"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.pool", "sms_configuration.0.sns_caller_arn"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "tags.Name", "Foo"),
+					testAccCheckAWSCognitoUserPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "auto_verified_attributes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mfa_configuration", optionalMfa),
+					resource.TestCheckResourceAttr(resourceName, "email_verification_message", "Foo {####} Bar"),
+					resource.TestCheckResourceAttr(resourceName, "email_verification_subject", "FooBar {####}"),
+					resource.TestCheckResourceAttr(resourceName, "sms_verification_message", "{####} Baz"),
+					resource.TestCheckResourceAttr(resourceName, "sms_authentication_message", updatedAuthenticationMessage),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.unused_account_validity_days", "6"),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.allow_admin_create_user_only", "true"),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.email_message", "Your username is {username} and temporary password is {####}. "),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.email_subject", "FooBar {####}"),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.sms_message", "Your username is {username} and temporary password is {####}."),
+					resource.TestCheckResourceAttr(resourceName, "device_configuration.0.challenge_required_on_new_device", "true"),
+					resource.TestCheckResourceAttr(resourceName, "device_configuration.0.device_only_remembered_on_user_prompt", "false"),
+					resource.TestCheckResourceAttr(resourceName, "verification_message_template.0.default_email_option", "CONFIRM_WITH_CODE"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "sms_configuration.0.external_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "sms_configuration.0.sns_caller_arn"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "Foo"),
 				),
 			},
 			{
 				Config: testAccAWSCognitoUserPoolConfig_update(name, offMfa, updatedAuthenticationMessage),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoUserPoolExists("aws_cognito_user_pool.pool"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "auto_verified_attributes.#", "1"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "mfa_configuration", offMfa),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_verification_message", "Foo {####} Bar"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_verification_subject", "FooBar {####}"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "sms_verification_message", "{####} Baz"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "sms_authentication_message", updatedAuthenticationMessage),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "admin_create_user_config.0.unused_account_validity_days", "6"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "admin_create_user_config.0.allow_admin_create_user_only", "true"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "admin_create_user_config.0.invite_message_template.0.email_message", "Your username is {username} and temporary password is {####}. "),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "admin_create_user_config.0.invite_message_template.0.email_subject", "FooBar {####}"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "admin_create_user_config.0.invite_message_template.0.sms_message", "Your username is {username} and temporary password is {####}."),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "device_configuration.0.challenge_required_on_new_device", "true"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "device_configuration.0.device_only_remembered_on_user_prompt", "false"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "verification_message_template.0.default_email_option", "CONFIRM_WITH_CODE"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "sms_configuration.#", "1"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.pool", "sms_configuration.0.external_id"),
-					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.pool", "sms_configuration.0.sns_caller_arn"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "tags.Name", "Foo"),
+					testAccCheckAWSCognitoUserPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "auto_verified_attributes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mfa_configuration", offMfa),
+					resource.TestCheckResourceAttr(resourceName, "email_verification_message", "Foo {####} Bar"),
+					resource.TestCheckResourceAttr(resourceName, "email_verification_subject", "FooBar {####}"),
+					resource.TestCheckResourceAttr(resourceName, "sms_verification_message", "{####} Baz"),
+					resource.TestCheckResourceAttr(resourceName, "sms_authentication_message", updatedAuthenticationMessage),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.unused_account_validity_days", "6"),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.allow_admin_create_user_only", "true"),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.email_message", "Your username is {username} and temporary password is {####}. "),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.email_subject", "FooBar {####}"),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.sms_message", "Your username is {username} and temporary password is {####}."),
+					resource.TestCheckResourceAttr(resourceName, "device_configuration.0.challenge_required_on_new_device", "true"),
+					resource.TestCheckResourceAttr(resourceName, "device_configuration.0.device_only_remembered_on_user_prompt", "false"),
+					resource.TestCheckResourceAttr(resourceName, "verification_message_template.0.default_email_option", "CONFIRM_WITH_CODE"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "sms_configuration.0.external_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "sms_configuration.0.sns_caller_arn"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "Foo"),
 				),
 			},
 		},
@@ -767,7 +842,7 @@ func testAccPreCheckAWSCognitoIdentityProvider(t *testing.T) {
 
 func testAccAWSCognitoUserPoolConfig_basic(name string) string {
 	return fmt.Sprintf(`
-resource "aws_cognito_user_pool" "pool" {
+resource "aws_cognito_user_pool" "test" {
   name = "terraform-test-pool-%s"
 }
 `, name)
@@ -775,7 +850,7 @@ resource "aws_cognito_user_pool" "pool" {
 
 func testAccAWSCognitoUserPoolConfig_withAdminCreateUserConfiguration(name string) string {
 	return fmt.Sprintf(`
-resource "aws_cognito_user_pool" "pool" {
+resource "aws_cognito_user_pool" "test" {
   name = "terraform-test-pool-%s"
 
   admin_create_user_config {
@@ -794,7 +869,7 @@ resource "aws_cognito_user_pool" "pool" {
 
 func testAccAWSCognitoUserPoolConfig_withAdminCreateUserConfigurationUpdated(name string) string {
 	return fmt.Sprintf(`
-resource "aws_cognito_user_pool" "pool" {
+resource "aws_cognito_user_pool" "test" {
   name = "terraform-test-pool-%s"
 
   admin_create_user_config {
@@ -813,7 +888,7 @@ resource "aws_cognito_user_pool" "pool" {
 
 func testAccAWSCognitoUserPoolConfig_withAdvancedSecurityMode(name string, mode string) string {
 	return fmt.Sprintf(`
-resource "aws_cognito_user_pool" "pool" {
+resource "aws_cognito_user_pool" "test" {
   name = "terraform-test-pool-%s"
 
   user_pool_add_ons {
@@ -825,7 +900,7 @@ resource "aws_cognito_user_pool" "pool" {
 
 func testAccAWSCognitoUserPoolConfig_withDeviceConfiguration(name string) string {
 	return fmt.Sprintf(`
-resource "aws_cognito_user_pool" "pool" {
+resource "aws_cognito_user_pool" "test" {
   name = "terraform-test-pool-%s"
 
   device_configuration {
@@ -838,7 +913,7 @@ resource "aws_cognito_user_pool" "pool" {
 
 func testAccAWSCognitoUserPoolConfig_withDeviceConfigurationUpdated(name string) string {
 	return fmt.Sprintf(`
-resource "aws_cognito_user_pool" "pool" {
+resource "aws_cognito_user_pool" "test" {
   name = "terraform-test-pool-%s"
 
   device_configuration {
@@ -851,7 +926,7 @@ resource "aws_cognito_user_pool" "pool" {
 
 func testAccAWSCognitoUserPoolConfig_withEmailVerificationMessage(name, subject, message string) string {
 	return fmt.Sprintf(`
-resource "aws_cognito_user_pool" "pool" {
+resource "aws_cognito_user_pool" "test" {
   name                       = "terraform-test-pool-%s"
   email_verification_subject = "%s"
   email_verification_message = "%s"
@@ -865,7 +940,7 @@ resource "aws_cognito_user_pool" "pool" {
 
 func testAccAWSCognitoUserPoolConfig_withSmsVerificationMessage(name, authenticationMessage, verificationMessage string) string {
 	return fmt.Sprintf(`
-resource "aws_cognito_user_pool" "pool" {
+resource "aws_cognito_user_pool" "test" {
   name                       = "terraform-test-pool-%s"
   sms_authentication_message = "%s"
   sms_verification_message   = "%s"
@@ -875,7 +950,7 @@ resource "aws_cognito_user_pool" "pool" {
 
 func testAccAWSCognitoUserPoolConfig_withTags(name string) string {
 	return fmt.Sprintf(`
-resource "aws_cognito_user_pool" "pool" {
+resource "aws_cognito_user_pool" "test" {
   name = "terraform-test-pool-%s"
 
   tags = {
@@ -887,7 +962,7 @@ resource "aws_cognito_user_pool" "pool" {
 
 func testAccAWSCognitoUserPoolConfig_withEmailConfiguration(name, email, arn, account string) string {
 	return fmt.Sprintf(`
-resource "aws_cognito_user_pool" "pool" {
+resource "aws_cognito_user_pool" "test" {
     name = "terraform-test-pool-%[1]s"
 
 
@@ -903,7 +978,7 @@ func testAccAWSCognitoUserPoolConfig_withSmsConfiguration(name string) string {
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 
-resource "aws_iam_role" "main" {
+resource "aws_iam_role" "test" {
   name = "test-role-%[1]s"
   path = "/service-role/"
 
@@ -929,9 +1004,9 @@ resource "aws_iam_role" "main" {
 POLICY
 }
 
-resource "aws_iam_role_policy" "main" {
+resource "aws_iam_role_policy" "test" {
   name = "test-role-policy-%[1]s"
-  role = "${aws_iam_role.main.id}"
+  role = "${aws_iam_role.test.id}"
 
   policy = <<EOF
 {
@@ -951,12 +1026,12 @@ resource "aws_iam_role_policy" "main" {
 EOF
 }
 
-resource "aws_cognito_user_pool" "pool" {
+resource "aws_cognito_user_pool" "test" {
   name = "terraform-test-pool-%[1]s"
 
   sms_configuration {
     external_id    = "${data.aws_caller_identity.current.account_id}"
-    sns_caller_arn = "${aws_iam_role.main.arn}"
+    sns_caller_arn = "${aws_iam_role.test.arn}"
   }
 }
 `, name)
@@ -964,7 +1039,7 @@ resource "aws_cognito_user_pool" "pool" {
 
 func testAccAWSCognitoUserPoolConfig_withTagsUpdated(name string) string {
 	return fmt.Sprintf(`
-resource "aws_cognito_user_pool" "pool" {
+resource "aws_cognito_user_pool" "test" {
   name = "terraform-test-pool-%s"
 
   tags = {
@@ -977,7 +1052,7 @@ resource "aws_cognito_user_pool" "pool" {
 
 func testAccAWSCognitoUserPoolConfig_withAliasAttributes(name string) string {
 	return fmt.Sprintf(`
-resource "aws_cognito_user_pool" "pool" {
+resource "aws_cognito_user_pool" "test" {
   name = "terraform-test-pool-%s"
 
   alias_attributes = ["preferred_username"]
@@ -987,7 +1062,7 @@ resource "aws_cognito_user_pool" "pool" {
 
 func testAccAWSCognitoUserPoolConfig_withAliasAttributesUpdated(name string) string {
 	return fmt.Sprintf(`
-resource "aws_cognito_user_pool" "pool" {
+resource "aws_cognito_user_pool" "test" {
   name = "terraform-test-pool-%s"
 
   alias_attributes         = ["email", "preferred_username"]
@@ -998,7 +1073,7 @@ resource "aws_cognito_user_pool" "pool" {
 
 func testAccAWSCognitoUserPoolConfig_withPasswordPolicy(name string) string {
 	return fmt.Sprintf(`
-resource "aws_cognito_user_pool" "pool" {
+resource "aws_cognito_user_pool" "test" {
   name = "terraform-test-pool-%s"
 
   password_policy {
@@ -1014,7 +1089,7 @@ resource "aws_cognito_user_pool" "pool" {
 
 func testAccAWSCognitoUserPoolConfig_withPasswordPolicyUpdated(name string) string {
 	return fmt.Sprintf(`
-resource "aws_cognito_user_pool" "pool" {
+resource "aws_cognito_user_pool" "test" {
   name = "terraform-test-pool-%s"
 
   password_policy {
@@ -1030,7 +1105,7 @@ resource "aws_cognito_user_pool" "pool" {
 
 func testAccAWSCognitoUserPoolConfig_withLambdaConfig(name string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_role" "main" {
+resource "aws_iam_role" "test" {
   name = "%s"
 
   assume_role_policy = <<EOF
@@ -1050,28 +1125,28 @@ resource "aws_iam_role" "main" {
 EOF
 }
 
-resource "aws_lambda_function" "main" {
+resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = "%[1]s"
-  role          = "${aws_iam_role.main.arn}"
+  role          = "${aws_iam_role.test.arn}"
   handler       = "exports.example"
   runtime       = "nodejs8.10"
 }
 
-resource "aws_cognito_user_pool" "main" {
+resource "aws_cognito_user_pool" "test" {
   name = "%[1]s"
 
   lambda_config {
-    create_auth_challenge          = "${aws_lambda_function.main.arn}"
-    custom_message                 = "${aws_lambda_function.main.arn}"
-    define_auth_challenge          = "${aws_lambda_function.main.arn}"
-    post_authentication            = "${aws_lambda_function.main.arn}"
-    post_confirmation              = "${aws_lambda_function.main.arn}"
-    pre_authentication             = "${aws_lambda_function.main.arn}"
-    pre_sign_up                    = "${aws_lambda_function.main.arn}"
-    pre_token_generation           = "${aws_lambda_function.main.arn}"
-    user_migration                 = "${aws_lambda_function.main.arn}"
-    verify_auth_challenge_response = "${aws_lambda_function.main.arn}"
+    create_auth_challenge          = "${aws_lambda_function.test.arn}"
+    custom_message                 = "${aws_lambda_function.test.arn}"
+    define_auth_challenge          = "${aws_lambda_function.test.arn}"
+    post_authentication            = "${aws_lambda_function.test.arn}"
+    post_confirmation              = "${aws_lambda_function.test.arn}"
+    pre_authentication             = "${aws_lambda_function.test.arn}"
+    pre_sign_up                    = "${aws_lambda_function.test.arn}"
+    pre_token_generation           = "${aws_lambda_function.test.arn}"
+    user_migration                 = "${aws_lambda_function.test.arn}"
+    verify_auth_challenge_response = "${aws_lambda_function.test.arn}"
   }
 }
 `, name)
@@ -1079,7 +1154,7 @@ resource "aws_cognito_user_pool" "main" {
 
 func testAccAWSCognitoUserPoolConfig_withLambdaConfigUpdated(name string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_role" "main" {
+resource "aws_iam_role" "test" {
   name = "%s"
 
   assume_role_policy = <<EOF
@@ -1099,10 +1174,10 @@ resource "aws_iam_role" "main" {
 EOF
 }
 
-resource "aws_lambda_function" "main" {
+resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = "%[1]s"
-  role          = "${aws_iam_role.main.arn}"
+  role          = "${aws_iam_role.test.arn}"
   handler       = "exports.example"
   runtime       = "nodejs8.10"
 }
@@ -1110,12 +1185,12 @@ resource "aws_lambda_function" "main" {
 resource "aws_lambda_function" "second" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = "%[1]s_second"
-  role          = "${aws_iam_role.main.arn}"
+  role          = "${aws_iam_role.test.arn}"
   handler       = "exports.example"
   runtime       = "nodejs8.10"
 }
 
-resource "aws_cognito_user_pool" "main" {
+resource "aws_cognito_user_pool" "test" {
   name = "%[1]s"
 
   lambda_config {
@@ -1136,7 +1211,7 @@ resource "aws_cognito_user_pool" "main" {
 
 func testAccAWSCognitoUserPoolConfig_withSchemaAttributes(name string) string {
 	return fmt.Sprintf(`
-resource "aws_cognito_user_pool" "main" {
+resource "aws_cognito_user_pool" "test" {
   name = "%[1]s"
 
   schema {
@@ -1165,7 +1240,7 @@ resource "aws_cognito_user_pool" "main" {
 
 func testAccAWSCognitoUserPoolConfig_withSchemaAttributesUpdated(name string) string {
 	return fmt.Sprintf(`
-resource "aws_cognito_user_pool" "main" {
+resource "aws_cognito_user_pool" "test" {
   name = "%[1]s"
 
   schema {
@@ -1212,7 +1287,7 @@ resource "aws_cognito_user_pool" "main" {
 
 func testAccAWSCognitoUserPoolConfig_withVerificationMessageTemplate(name string) string {
 	return fmt.Sprintf(`
-resource "aws_cognito_user_pool" "pool" {
+resource "aws_cognito_user_pool" "test" {
   name = "terraform-test-pool-%s"
 
   # Setting Verification template attributes like EmailMessage, EmailSubject or SmsMessage
@@ -1232,7 +1307,7 @@ resource "aws_cognito_user_pool" "pool" {
 
 func testAccAWSCognitoUserPoolConfig_withVerificationMessageTemplate_DefaultEmailOption(name string) string {
 	return fmt.Sprintf(`
-resource "aws_cognito_user_pool" "pool" {
+resource "aws_cognito_user_pool" "test" {
   name = "terraform-test-pool-%s"
 
   email_verification_message = "{####} Baz"
@@ -1250,7 +1325,7 @@ func testAccAWSCognitoUserPoolConfig_update(name string, mfaconfig, smsAuthMsg s
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 
-resource "aws_iam_role" "main" {
+resource "aws_iam_role" "test" {
   name = "test-role-%s"
   path = "/service-role/"
 
@@ -1276,9 +1351,9 @@ resource "aws_iam_role" "main" {
 POLICY
 }
 
-resource "aws_iam_role_policy" "main" {
+resource "aws_iam_role_policy" "test" {
   name = "test-role-policy-%s"
-  role = "${aws_iam_role.main.id}"
+  role = "${aws_iam_role.test.id}"
 
   policy = <<EOF
 {
@@ -1298,7 +1373,7 @@ resource "aws_iam_role_policy" "main" {
 EOF
 }
 
-resource "aws_cognito_user_pool" "pool" {
+resource "aws_cognito_user_pool" "test" {
   name                     = "terraform-test-pool-%s"
   auto_verified_attributes = ["email"]
   mfa_configuration        = "%s"
@@ -1330,7 +1405,7 @@ resource "aws_cognito_user_pool" "pool" {
 
   sms_configuration {
     external_id    = "${data.aws_caller_identity.current.account_id}"
-    sns_caller_arn = "${aws_iam_role.main.arn}"
+    sns_caller_arn = "${aws_iam_role.test.arn}"
   }
 
   tags = {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8944

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

* NOTE: the `TestAccAWSCognitoIdentityPool_openidConnectProviderArns` failure is not new

```
$ make testacc TESTARGS="-run=TestAccAWSCognitoIdentityPool_"     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSCognitoIdentityPool_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCognitoIdentityPool_basic
=== PAUSE TestAccAWSCognitoIdentityPool_basic
=== RUN   TestAccAWSCognitoIdentityPool_supportedLoginProviders
=== PAUSE TestAccAWSCognitoIdentityPool_supportedLoginProviders
=== RUN   TestAccAWSCognitoIdentityPool_openidConnectProviderArns
=== PAUSE TestAccAWSCognitoIdentityPool_openidConnectProviderArns
=== RUN   TestAccAWSCognitoIdentityPool_samlProviderArns
=== PAUSE TestAccAWSCognitoIdentityPool_samlProviderArns
=== RUN   TestAccAWSCognitoIdentityPool_cognitoIdentityProviders
=== PAUSE TestAccAWSCognitoIdentityPool_cognitoIdentityProviders
=== RUN   TestAccAWSCognitoIdentityPool_addingNewProviderKeepsOldProvider
--- PASS: TestAccAWSCognitoIdentityPool_addingNewProviderKeepsOldProvider (63.78s)
=== CONT  TestAccAWSCognitoIdentityPool_basic
=== CONT  TestAccAWSCognitoIdentityPool_samlProviderArns
=== CONT  TestAccAWSCognitoIdentityPool_cognitoIdentityProviders
=== CONT  TestAccAWSCognitoIdentityPool_openidConnectProviderArns
=== CONT  TestAccAWSCognitoIdentityPool_supportedLoginProviders
--- FAIL: TestAccAWSCognitoIdentityPool_openidConnectProviderArns (37.74s)
    testing.go:569: Step 2 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        UPDATE: aws_cognito_identity_pool.main
          allow_unauthenticated_identities: "false" => "false"
          arn:                              "arn:aws:cognito-identity:us-west-2:187416307283:identitypool/us-west-2:00e43a2d-dffb-4be3-bd2c-71a025907279" => "arn:aws:cognito-identity:us-west-2:187416307283:identitypool/us-west-2:00e43a2d-dffb-4be3-bd2c-71a025907279"
          cognito_identity_providers.#:     "0" => "0"
          developer_provider_name:          "" => ""
          id:                               "us-west-2:00e43a2d-dffb-4be3-bd2c-71a025907279" => "us-west-2:00e43a2d-dffb-4be3-bd2c-71a025907279"
          identity_pool_name:               "identity pool 2yp3gvvsik" => "identity pool 2yp3gvvsik"
          openid_connect_provider_arns.#:   "2" => "2"
          openid_connect_provider_arns.0:   "arn:aws:iam::123456789012:oidc-provider/bar.example.com" => "arn:aws:iam::123456789012:oidc-provider/foo.example.com"
          openid_connect_provider_arns.1:   "arn:aws:iam::123456789012:oidc-provider/foo.example.com" => "arn:aws:iam::123456789012:oidc-provider/bar.example.com"
          saml_provider_arns.#:             "0" => "0"
        
        
        
        STATE:
        
        aws_cognito_identity_pool.main:
          ID = us-west-2:00e43a2d-dffb-4be3-bd2c-71a025907279
          provider = provider.aws
          allow_unauthenticated_identities = false
          arn = arn:aws:cognito-identity:us-west-2:187416307283:identitypool/us-west-2:00e43a2d-dffb-4be3-bd2c-71a025907279
          developer_provider_name = 
          identity_pool_name = identity pool 2yp3gvvsik
          openid_connect_provider_arns.# = 2
          openid_connect_provider_arns.0 = arn:aws:iam::123456789012:oidc-provider/bar.example.com
          openid_connect_provider_arns.1 = arn:aws:iam::123456789012:oidc-provider/foo.example.com
--- PASS: TestAccAWSCognitoIdentityPool_basic (44.56s)
--- PASS: TestAccAWSCognitoIdentityPool_supportedLoginProviders (59.57s)
--- PASS: TestAccAWSCognitoIdentityPool_cognitoIdentityProviders (59.61s)
--- PASS: TestAccAWSCognitoIdentityPool_samlProviderArns (65.25s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-aws/aws       130.443s

make testacc TESTARGS="-run=TestAccAWSCognitoUserGroup_"     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSCognitoUserGroup_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCognitoUserGroup_basic
=== PAUSE TestAccAWSCognitoUserGroup_basic
=== RUN   TestAccAWSCognitoUserGroup_complex
=== PAUSE TestAccAWSCognitoUserGroup_complex
=== RUN   TestAccAWSCognitoUserGroup_RoleArn
=== PAUSE TestAccAWSCognitoUserGroup_RoleArn
=== CONT  TestAccAWSCognitoUserGroup_basic
=== CONT  TestAccAWSCognitoUserGroup_RoleArn
=== CONT  TestAccAWSCognitoUserGroup_complex
--- PASS: TestAccAWSCognitoUserGroup_basic (45.78s)
--- PASS: TestAccAWSCognitoUserGroup_RoleArn (46.61s)
--- PASS: TestAccAWSCognitoUserGroup_complex (51.64s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       53.111s

make testacc TESTARGS="-run=TestAccAWSCognitoUserPoolClient_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSCognitoUserPoolClient_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCognitoUserPoolClient_basic
=== PAUSE TestAccAWSCognitoUserPoolClient_basic
=== RUN   TestAccAWSCognitoUserPoolClient_RefreshTokenValidity
=== PAUSE TestAccAWSCognitoUserPoolClient_RefreshTokenValidity
=== RUN   TestAccAWSCognitoUserPoolClient_Name
=== PAUSE TestAccAWSCognitoUserPoolClient_Name
=== RUN   TestAccAWSCognitoUserPoolClient_allFields
=== PAUSE TestAccAWSCognitoUserPoolClient_allFields
=== RUN   TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField
=== PAUSE TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField
=== CONT  TestAccAWSCognitoUserPoolClient_basic
=== CONT  TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField
=== CONT  TestAccAWSCognitoUserPoolClient_RefreshTokenValidity
=== CONT  TestAccAWSCognitoUserPoolClient_Name
=== CONT  TestAccAWSCognitoUserPoolClient_allFields
--- PASS: TestAccAWSCognitoUserPoolClient_basic (36.80s)
--- PASS: TestAccAWSCognitoUserPoolClient_allFields (37.08s)
--- PASS: TestAccAWSCognitoUserPoolClient_Name (49.01s)
--- PASS: TestAccAWSCognitoUserPoolClient_RefreshTokenValidity (55.10s)
--- PASS: TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField (58.16s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       59.593s

make testacc TESTARGS="-run=TestAccAWSCognitoUserPool_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSCognitoUserPool_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCognitoUserPool_basic
=== PAUSE TestAccAWSCognitoUserPool_basic
=== RUN   TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration
=== PAUSE TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration
=== RUN   TestAccAWSCognitoUserPool_withAdvancedSecurityMode
=== PAUSE TestAccAWSCognitoUserPool_withAdvancedSecurityMode
=== RUN   TestAccAWSCognitoUserPool_withDeviceConfiguration
=== PAUSE TestAccAWSCognitoUserPool_withDeviceConfiguration
=== RUN   TestAccAWSCognitoUserPool_withEmailVerificationMessage
=== PAUSE TestAccAWSCognitoUserPool_withEmailVerificationMessage
=== RUN   TestAccAWSCognitoUserPool_withSmsVerificationMessage
=== PAUSE TestAccAWSCognitoUserPool_withSmsVerificationMessage
=== RUN   TestAccAWSCognitoUserPool_withEmailConfiguration
--- SKIP: TestAccAWSCognitoUserPool_withEmailConfiguration (0.00s)
    resource_aws_cognito_user_pool_test.go:294: 'TEST_AWS_SES_VERIFIED_EMAIL_ARN' not set, skipping test.
=== RUN   TestAccAWSCognitoUserPool_withSmsConfiguration
=== PAUSE TestAccAWSCognitoUserPool_withSmsConfiguration
=== RUN   TestAccAWSCognitoUserPool_withSmsConfigurationUpdated
=== PAUSE TestAccAWSCognitoUserPool_withSmsConfigurationUpdated
=== RUN   TestAccAWSCognitoUserPool_withTags
=== PAUSE TestAccAWSCognitoUserPool_withTags
=== RUN   TestAccAWSCognitoUserPool_withAliasAttributes
=== PAUSE TestAccAWSCognitoUserPool_withAliasAttributes
=== RUN   TestAccAWSCognitoUserPool_withPasswordPolicy
=== PAUSE TestAccAWSCognitoUserPool_withPasswordPolicy
=== RUN   TestAccAWSCognitoUserPool_withLambdaConfig
=== PAUSE TestAccAWSCognitoUserPool_withLambdaConfig
=== RUN   TestAccAWSCognitoUserPool_withSchemaAttributes
=== PAUSE TestAccAWSCognitoUserPool_withSchemaAttributes
=== RUN   TestAccAWSCognitoUserPool_withVerificationMessageTemplate
=== PAUSE TestAccAWSCognitoUserPool_withVerificationMessageTemplate
=== RUN   TestAccAWSCognitoUserPool_update
=== PAUSE TestAccAWSCognitoUserPool_update
=== CONT  TestAccAWSCognitoUserPool_basic
=== CONT  TestAccAWSCognitoUserPool_withTags
=== CONT  TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration
=== CONT  TestAccAWSCognitoUserPool_withSchemaAttributes
=== CONT  TestAccAWSCognitoUserPool_withLambdaConfig
=== CONT  TestAccAWSCognitoUserPool_withAliasAttributes
=== CONT  TestAccAWSCognitoUserPool_withSmsConfigurationUpdated
=== CONT  TestAccAWSCognitoUserPool_withSmsConfiguration
=== CONT  TestAccAWSCognitoUserPool_withSmsVerificationMessage
=== CONT  TestAccAWSCognitoUserPool_withEmailVerificationMessage
=== CONT  TestAccAWSCognitoUserPool_withAdvancedSecurityMode
=== CONT  TestAccAWSCognitoUserPool_withDeviceConfiguration
=== CONT  TestAccAWSCognitoUserPool_update
=== CONT  TestAccAWSCognitoUserPool_withVerificationMessageTemplate
=== CONT  TestAccAWSCognitoUserPool_withPasswordPolicy
--- PASS: TestAccAWSCognitoUserPool_basic (28.71s)
--- PASS: TestAccAWSCognitoUserPool_withVerificationMessageTemplate (45.02s)
--- PASS: TestAccAWSCognitoUserPool_withEmailVerificationMessage (45.04s)
--- PASS: TestAccAWSCognitoUserPool_withDeviceConfiguration (45.31s)
--- PASS: TestAccAWSCognitoUserPool_withSmsVerificationMessage (45.35s)
--- PASS: TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration (45.43s)
--- PASS: TestAccAWSCognitoUserPool_withTags (45.43s)
--- PASS: TestAccAWSCognitoUserPool_withSmsConfiguration (45.49s)
--- PASS: TestAccAWSCognitoUserPool_withPasswordPolicy (45.50s)
--- PASS: TestAccAWSCognitoUserPool_withAliasAttributes (47.93s)
--- PASS: TestAccAWSCognitoUserPool_withSchemaAttributes (48.91s)
--- PASS: TestAccAWSCognitoUserPool_withAdvancedSecurityMode (62.00s)
--- PASS: TestAccAWSCognitoUserPool_withSmsConfigurationUpdated (62.29s)
--- PASS: TestAccAWSCognitoUserPool_withLambdaConfig (71.07s)
--- PASS: TestAccAWSCognitoUserPool_update (85.56s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       86.996s
```
