### PR TITLE
Rename `Quick Sight` in output to `QuickSight`.

### DIFF
--- a/aws/resource_aws_quicksight_group.go
+++ b/aws/resource_aws_quicksight_group.go
@@ -82,7 +82,7 @@ func resourceAwsQuickSightGroupCreate(d *schema.ResourceData, meta interface{}) 
 
 	resp, err := conn.CreateGroup(createOpts)
 	if err != nil {
-		return fmt.Errorf("Error creating Quick Sight Group: %s", err)
+		return fmt.Errorf("Error creating QuickSight Group: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s/%s", awsAccountID, namespace, aws.StringValue(resp.Group.GroupName)))
@@ -106,12 +106,12 @@ func resourceAwsQuickSightGroupRead(d *schema.ResourceData, meta interface{}) er
 
 	resp, err := conn.DescribeGroup(descOpts)
 	if isAWSErr(err, quicksight.ErrCodeResourceNotFoundException, "") {
-		log.Printf("[WARN] Quick Sight Group %s is already gone", d.Id())
+		log.Printf("[WARN] QuickSight Group %s is already gone", d.Id())
 		d.SetId("")
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf("Error describing Quick Sight Group (%s): %s", d.Id(), err)
+		return fmt.Errorf("Error describing QuickSight Group (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", resp.Group.Arn)
@@ -143,12 +143,12 @@ func resourceAwsQuickSightGroupUpdate(d *schema.ResourceData, meta interface{}) 
 
 	_, err = conn.UpdateGroup(updateOpts)
 	if isAWSErr(err, quicksight.ErrCodeResourceNotFoundException, "") {
-		log.Printf("[WARN] Quick Sight Group %s is already gone", d.Id())
+		log.Printf("[WARN] QuickSight Group %s is already gone", d.Id())
 		d.SetId("")
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf("Error updating Quick Sight Group %s: %s", d.Id(), err)
+		return fmt.Errorf("Error updating QuickSight Group %s: %s", d.Id(), err)
 	}
 
 	return resourceAwsQuickSightGroupRead(d, meta)
@@ -172,7 +172,7 @@ func resourceAwsQuickSightGroupDelete(d *schema.ResourceData, meta interface{}) 
 		if isAWSErr(err, quicksight.ErrCodeResourceNotFoundException, "") {
 			return nil
 		}
-		return fmt.Errorf("Error deleting Quick Sight Group %s: %s", d.Id(), err)
+		return fmt.Errorf("Error deleting QuickSight Group %s: %s", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_quicksight_group_test.go
+++ b/aws/resource_aws_quicksight_group_test.go
@@ -132,7 +132,7 @@ func testAccCheckQuickSightGroupExists(resourceName string, group *quicksight.Gr
 		}
 
 		if output == nil || output.Group == nil {
-			return fmt.Errorf("Quick Sight Group (%s) not found", rs.Primary.ID)
+			return fmt.Errorf("QuickSight Group (%s) not found", rs.Primary.ID)
 		}
 
 		*group = *output.Group
@@ -166,7 +166,7 @@ func testAccCheckQuickSightGroupDestroy(s *terraform.State) error {
 			return err
 		}
 
-		return fmt.Errorf("Quick Sight Group '%s' was not deleted properly", rs.Primary.ID)
+		return fmt.Errorf("QuickSight Group '%s' was not deleted properly", rs.Primary.ID)
 	}
 
 	return nil

--- a/website/docs/r/quicksight_group.html.markdown
+++ b/website/docs/r/quicksight_group.html.markdown
@@ -2,12 +2,12 @@
 layout: "aws"
 page_title: "AWS: aws_quicksight_group"
 description: |-
-  Manages a Resource Quick Sight Group.
+  Manages a Resource QuickSight Group.
 ---
 
 # Resource: aws_quicksight_group
 
-Resource for managing Quick Sight Group
+Resource for managing QuickSight Group
 
 ## Example Usage
 
@@ -34,7 +34,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Quick Sight Group can be imported using the aws account id, namespace and group name separated by `/`.
+QuickSight Group can be imported using the aws account id, namespace and group name separated by `/`.
 
 ```
 $ terraform import aws_quicksight_group.example 123456789123/default/tf-example


### PR DESCRIPTION
This makes things consistent with
https://github.com/terraform-providers/terraform-provider-aws/pull/10401
and the AWS documentation.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Rename "QuickSight" in error output and documentation.
```
