### PR TITLE
Import test refactor for codebuild project

### DIFF
--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -39,27 +39,6 @@ func testAccAWSCodeBuildGitHubSourceLocationFromEnv() string {
 	return sourceLocation
 }
 
-func TestAccAWSCodeBuildProject_importBasic(t *testing.T) {
-	resourceName := "aws_codebuild_project.test"
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCodeBuild(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCodeBuildProjectDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSCodeBuildProjectConfig_basic(rName),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAWSCodeBuildProject_basic(t *testing.T) {
 	var project codebuild.Project
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -130,6 +109,11 @@ func TestAccAWSCodeBuildProject_BadgeEnabled(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceName, "badge_url", regexp.MustCompile(`\b(https?).*\b`)),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -150,6 +134,11 @@ func TestAccAWSCodeBuildProject_BuildTimeout(t *testing.T) {
 					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "build_timeout", "120"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCodeBuildProjectConfig_BuildTimeout(rName, 240),
@@ -183,6 +172,11 @@ func TestAccAWSCodeBuildProject_Cache(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cache.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "cache.0.type", "NO_CACHE"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCodeBuildProjectConfig_basic(rName),
@@ -249,6 +243,11 @@ func TestAccAWSCodeBuildProject_Description(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAWSCodeBuildProjectConfig_Description(rName, "description2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
@@ -275,6 +274,11 @@ func TestAccAWSCodeBuildProject_EncryptionKey(t *testing.T) {
 					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
 					resource.TestMatchResourceAttr(resourceName, "encryption_key", regexp.MustCompile(`.+`)),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -349,6 +353,11 @@ func TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type(t *testing.
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAWSCodeBuildProjectConfig_Environment_EnvironmentVariable_Type(rName, "PARAMETER_STORE"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
@@ -378,6 +387,11 @@ func TestAccAWSCodeBuildProject_Environment_Certificate(t *testing.T) {
 					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
 					testAccCheckAWSCodeBuildProjectCertificate(&project, fmt.Sprintf("%s/%s", bName, oName)),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -495,6 +509,11 @@ func TestAccAWSCodeBuildProject_Source_Auth(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "source.3680505372.auth.2706882902.type", "OAUTH"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -515,6 +534,11 @@ func TestAccAWSCodeBuildProject_Source_GitCloneDepth(t *testing.T) {
 					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "source.1181740906.git_clone_depth", "1"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCodeBuildProjectConfig_Source_GitCloneDepth(rName, 2),
@@ -545,6 +569,11 @@ func TestAccAWSCodeBuildProject_Source_InsecureSSL(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAWSCodeBuildProjectConfig_Source_InsecureSSL(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
@@ -571,6 +600,11 @@ func TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket(t *testing.T)
 					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "source.2876219937.report_build_status", "true"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCodeBuildProjectConfig_Source_ReportBuildStatus_Bitbucket(rName, false),
@@ -601,6 +635,11 @@ func TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAWSCodeBuildProjectConfig_Source_ReportBuildStatus_GitHub(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
@@ -627,6 +666,11 @@ func TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise(t *tes
 					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "source.2964899175.report_build_status", "true"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCodeBuildProjectConfig_Source_ReportBuildStatus_GitHubEnterprise(rName, false),
@@ -656,6 +700,11 @@ func TestAccAWSCodeBuildProject_Source_Type_Bitbucket(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "source.3210444828.type", "BITBUCKET"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -676,6 +725,11 @@ func TestAccAWSCodeBuildProject_Source_Type_CodeCommit(t *testing.T) {
 					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "source.3715340088.type", "CODECOMMIT"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -698,6 +752,11 @@ func TestAccAWSCodeBuildProject_Source_Type_CodePipeline(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "source.2280907000.type", "CODEPIPELINE"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -719,6 +778,11 @@ func TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "source.553628638.type", "GITHUB_ENTERPRISE"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -738,6 +802,11 @@ func TestAccAWSCodeBuildProject_Source_Type_S3(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -765,6 +834,11 @@ phases:
 					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "source.2726343112.type", "NO_SOURCE"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -816,6 +890,11 @@ func TestAccAWSCodeBuildProject_Tags(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAWSCodeBuildProjectConfig_Tags(rName, "tag2", "tag2value-updated"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
@@ -847,6 +926,11 @@ func TestAccAWSCodeBuildProject_VpcConfig(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "vpc_config.0.subnets.#", "2"),
 					resource.TestMatchResourceAttr(resourceName, "vpc_config.0.vpc_id", regexp.MustCompile(`^vpc-`)),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCodeBuildProjectConfig_VpcConfig1(rName),
@@ -891,6 +975,11 @@ func TestAccAWSCodeBuildProject_WindowsContainer(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "environment.2306861956.image_pull_credentials_type", "CODEBUILD"),
 					resource.TestCheckResourceAttr(resourceName, "environment.2306861956.type", "WINDOWS_CONTAINER"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -1625,6 +1714,11 @@ func TestAccAWSCodeBuildProject_SecondarySources_CodeCommit(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "secondary_sources.3525046785.source_identifier", "secondarySource1"),
 					resource.TestCheckResourceAttr(resourceName, "secondary_sources.2644986630.source_identifier", "secondarySource2"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8944

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

* NOTE: The `TestAccAWSCodeBuildProject_Source_Auth` failure is not new

```
$ make testacc TESTARGS="-run=TestAccAWSCodeBuildProject_"     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSCodeBuildProject_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCodeBuildProject_basic
=== PAUSE TestAccAWSCodeBuildProject_basic
=== RUN   TestAccAWSCodeBuildProject_BadgeEnabled
=== PAUSE TestAccAWSCodeBuildProject_BadgeEnabled
=== RUN   TestAccAWSCodeBuildProject_BuildTimeout
=== PAUSE TestAccAWSCodeBuildProject_BuildTimeout
=== RUN   TestAccAWSCodeBuildProject_Cache
=== PAUSE TestAccAWSCodeBuildProject_Cache
=== RUN   TestAccAWSCodeBuildProject_Description
=== PAUSE TestAccAWSCodeBuildProject_Description
=== RUN   TestAccAWSCodeBuildProject_EncryptionKey
=== PAUSE TestAccAWSCodeBuildProject_EncryptionKey
=== RUN   TestAccAWSCodeBuildProject_Environment_EnvironmentVariable
=== PAUSE TestAccAWSCodeBuildProject_Environment_EnvironmentVariable
=== RUN   TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type
=== PAUSE TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type
=== RUN   TestAccAWSCodeBuildProject_Environment_Certificate
=== PAUSE TestAccAWSCodeBuildProject_Environment_Certificate
=== RUN   TestAccAWSCodeBuildProject_LogsConfig_CloudWatchLogs
=== PAUSE TestAccAWSCodeBuildProject_LogsConfig_CloudWatchLogs
=== RUN   TestAccAWSCodeBuildProject_LogsConfig_S3Logs
=== PAUSE TestAccAWSCodeBuildProject_LogsConfig_S3Logs
=== RUN   TestAccAWSCodeBuildProject_Source_Auth
=== PAUSE TestAccAWSCodeBuildProject_Source_Auth
=== RUN   TestAccAWSCodeBuildProject_Source_GitCloneDepth
=== PAUSE TestAccAWSCodeBuildProject_Source_GitCloneDepth
=== RUN   TestAccAWSCodeBuildProject_Source_InsecureSSL
=== PAUSE TestAccAWSCodeBuildProject_Source_InsecureSSL
=== RUN   TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket
=== PAUSE TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket
=== RUN   TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub
=== PAUSE TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub
=== RUN   TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise
=== PAUSE TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise
=== RUN   TestAccAWSCodeBuildProject_Source_Type_Bitbucket
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_Bitbucket
=== RUN   TestAccAWSCodeBuildProject_Source_Type_CodeCommit
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_CodeCommit
=== RUN   TestAccAWSCodeBuildProject_Source_Type_CodePipeline
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_CodePipeline
=== RUN   TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise
=== RUN   TestAccAWSCodeBuildProject_Source_Type_S3
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_S3
=== RUN   TestAccAWSCodeBuildProject_Source_Type_NoSource
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_NoSource
=== RUN   TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid
=== RUN   TestAccAWSCodeBuildProject_Tags
=== PAUSE TestAccAWSCodeBuildProject_Tags
=== RUN   TestAccAWSCodeBuildProject_VpcConfig
=== PAUSE TestAccAWSCodeBuildProject_VpcConfig
=== RUN   TestAccAWSCodeBuildProject_WindowsContainer
=== PAUSE TestAccAWSCodeBuildProject_WindowsContainer
=== RUN   TestAccAWSCodeBuildProject_Artifacts_ArtifactIdentifier
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_ArtifactIdentifier
=== RUN   TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled
=== RUN   TestAccAWSCodeBuildProject_Artifacts_Location
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_Location
=== RUN   TestAccAWSCodeBuildProject_Artifacts_Name
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_Name
=== RUN   TestAccAWSCodeBuildProject_Artifacts_NamespaceType
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_NamespaceType
=== RUN   TestAccAWSCodeBuildProject_Artifacts_OverrideArtifactName
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_OverrideArtifactName
=== RUN   TestAccAWSCodeBuildProject_Artifacts_Packaging
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_Packaging
=== RUN   TestAccAWSCodeBuildProject_Artifacts_Path
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_Path
=== RUN   TestAccAWSCodeBuildProject_Artifacts_Type
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_Type
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_ArtifactIdentifier
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_ArtifactIdentifier
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_OverrideArtifactName
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_OverrideArtifactName
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_EncryptionDisabled
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_EncryptionDisabled
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_Location
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_Location
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_Name
--- SKIP: TestAccAWSCodeBuildProject_SecondaryArtifacts_Name (0.00s)
    resource_aws_codebuild_project_test.go:1507: Currently no solution to allow updates on name attribute
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_NamespaceType
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_NamespaceType
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_Packaging
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_Packaging
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_Path
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_Path
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_Type
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_Type
=== RUN   TestAccAWSCodeBuildProject_SecondarySources_CodeCommit
=== PAUSE TestAccAWSCodeBuildProject_SecondarySources_CodeCommit
=== RUN   TestAccAWSCodeBuildProject_Environment_RegistryCredential
=== PAUSE TestAccAWSCodeBuildProject_Environment_RegistryCredential
=== CONT  TestAccAWSCodeBuildProject_basic
=== CONT  TestAccAWSCodeBuildProject_Environment_RegistryCredential
=== CONT  TestAccAWSCodeBuildProject_Environment_Certificate
=== CONT  TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_NamespaceType
=== CONT  TestAccAWSCodeBuildProject_Source_Type_NoSource
=== CONT  TestAccAWSCodeBuildProject_Source_Type_S3
=== CONT  TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise
=== CONT  TestAccAWSCodeBuildProject_Artifacts_Type
=== CONT  TestAccAWSCodeBuildProject_SecondarySources_CodeCommit
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_Type
=== CONT  TestAccAWSCodeBuildProject_Source_Type_CodePipeline
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_Path
=== CONT  TestAccAWSCodeBuildProject_LogsConfig_CloudWatchLogs
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_Packaging
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_Location
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_EncryptionDisabled
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_OverrideArtifactName
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_ArtifactIdentifier
=== CONT  TestAccAWSCodeBuildProject_Tags
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid (25.70s)
=== CONT  TestAccAWSCodeBuildProject_LogsConfig_S3Logs
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSource (42.93s)
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodePipeline (43.06s)
=== CONT  TestAccAWSCodeBuildProject_Source_Type_CodeCommit
--- PASS: TestAccAWSCodeBuildProject_basic (43.11s)
=== CONT  TestAccAWSCodeBuildProject_Artifacts_Path
--- PASS: TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise (43.11s)
=== CONT  TestAccAWSCodeBuildProject_Description
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_CodeCommit (43.16s)
=== CONT  TestAccAWSCodeBuildProject_Artifacts_Packaging
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_ArtifactIdentifier (103.39s)
=== CONT  TestAccAWSCodeBuildProject_Artifacts_OverrideArtifactName
--- PASS: TestAccAWSCodeBuildProject_Tags (63.10s)
=== CONT  TestAccAWSCodeBuildProject_Artifacts_NamespaceType
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Type (65.66s)
=== CONT  TestAccAWSCodeBuildProject_Artifacts_Name
--- PASS: TestAccAWSCodeBuildProject_Environment_Certificate (70.04s)
=== CONT  TestAccAWSCodeBuildProject_Artifacts_Location
--- PASS: TestAccAWSCodeBuildProject_Source_Type_S3 (70.71s)
=== CONT  TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled
--- PASS: TestAccAWSCodeBuildProject_Environment_RegistryCredential (72.46s)
=== CONT  TestAccAWSCodeBuildProject_Artifacts_ArtifactIdentifier
--- PASS: TestAccAWSCodeBuildProject_LogsConfig_CloudWatchLogs (80.73s)
=== CONT  TestAccAWSCodeBuildProject_WindowsContainer
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodeCommit (41.51s)
=== CONT  TestAccAWSCodeBuildProject_VpcConfig
--- PASS: TestAccAWSCodeBuildProject_Description (59.43s)
=== CONT  TestAccAWSCodeBuildProject_BuildTimeout
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Packaging (103.58s)
=== CONT  TestAccAWSCodeBuildProject_Cache
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Path (104.44s)
=== CONT  TestAccAWSCodeBuildProject_Environment_EnvironmentVariable
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts (63.22s)
=== CONT  TestAccAWSCodeBuildProject_BadgeEnabled
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_EncryptionDisabled (106.46s)
=== CONT  TestAccAWSCodeBuildProject_Source_GitCloneDepth
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_NamespaceType (107.35s)
=== CONT  TestAccAWSCodeBuildProject_Source_InsecureSSL
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Type (109.71s)
=== CONT  TestAccAWSCodeBuildProject_Source_Auth
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_OverrideArtifactName (115.64s)
=== CONT  TestAccAWSCodeBuildProject_EncryptionKey
--- PASS: TestAccAWSCodeBuildProject_WindowsContainer (41.06s)
=== CONT  TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type
--- FAIL: TestAccAWSCodeBuildProject_Source_Auth (17.12s)
    testing.go:569: Step 1 error: errors during apply:
        
        Error: Error creating CodeBuild project: InvalidInputException: No Access token found, please visit AWS CodeBuild console to connect to GitHub
                status code: 400, request id: e991fae8-a8f8-4fc0-9acd-fd0423f5610f
        
          on /var/folders/pd/swwl85ks1nvbfy2pht84q2m40000gq/T/tf-test714867518/main.tf line 64:
          (source code not available)
        
        
=== CONT  TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Location (128.13s)
=== CONT  TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise
--- PASS: TestAccAWSCodeBuildProject_BadgeEnabled (41.51s)
=== CONT  TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Path (106.25s)
=== CONT  TestAccAWSCodeBuildProject_Source_Type_Bitbucket
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Packaging (107.34s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_OverrideArtifactName (110.50s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitCloneDepth (60.38s)
--- PASS: TestAccAWSCodeBuildProject_Source_InsecureSSL (60.16s)
--- PASS: TestAccAWSCodeBuildProject_LogsConfig_S3Logs (136.08s)
--- PASS: TestAccAWSCodeBuildProject_BuildTimeout (68.35s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_NamespaceType (108.88s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Name (114.33s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type (61.00s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise (60.46s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket (61.85s)
--- PASS: TestAccAWSCodeBuildProject_EncryptionKey (73.23s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable (85.58s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled (119.70s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_Bitbucket (41.74s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_ArtifactIdentifier (125.05s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Location (129.28s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub (61.77s)
--- PASS: TestAccAWSCodeBuildProject_VpcConfig (129.01s)
--- PASS: TestAccAWSCodeBuildProject_Cache (137.65s)
```
