### PR TITLE
Import test refactor for cloudwatch resources

### DIFF
--- a/aws/resource_aws_cloudwatch_dashboard_test.go
+++ b/aws/resource_aws_cloudwatch_dashboard_test.go
@@ -14,8 +14,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSCloudWatchDashboard_importBasic(t *testing.T) {
-	resourceName := "aws_cloudwatch_dashboard.foobar"
+func TestAccAWSCloudWatchDashboard_basic(t *testing.T) {
+	var dashboard cloudwatch.GetDashboardOutput
+	resourceName := "aws_cloudwatch_dashboard.test"
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -25,6 +26,10 @@ func TestAccAWSCloudWatchDashboard_importBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSCloudWatchDashboardConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchDashboardExists(resourceName, &dashboard),
+					resource.TestCheckResourceAttr(resourceName, "dashboard_name", testAccAWSCloudWatchDashboardName(rInt)),
+				),
 			},
 			{
 				ResourceName:      resourceName,
@@ -35,28 +40,11 @@ func TestAccAWSCloudWatchDashboard_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccAWSCloudWatchDashboard_basic(t *testing.T) {
-	var dashboard cloudwatch.GetDashboardOutput
-	rInt := acctest.RandInt()
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCloudWatchDashboardDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSCloudWatchDashboardConfig(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchDashboardExists("aws_cloudwatch_dashboard.foobar", &dashboard),
-					resource.TestCheckResourceAttr("aws_cloudwatch_dashboard.foobar", "dashboard_name", testAccAWSCloudWatchDashboardName(rInt)),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAWSCloudWatchDashboard_update(t *testing.T) {
 	var dashboard cloudwatch.GetDashboardOutput
+	resourceName := "aws_cloudwatch_dashboard.test"
 	rInt := acctest.RandInt()
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -65,17 +53,22 @@ func TestAccAWSCloudWatchDashboard_update(t *testing.T) {
 			{
 				Config: testAccAWSCloudWatchDashboardConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchDashboardExists("aws_cloudwatch_dashboard.foobar", &dashboard),
-					testAccCloudWatchCheckDashboardBodyIsExpected("aws_cloudwatch_dashboard.foobar", basicWidget),
-					resource.TestCheckResourceAttr("aws_cloudwatch_dashboard.foobar", "dashboard_name", testAccAWSCloudWatchDashboardName(rInt)),
+					testAccCheckCloudWatchDashboardExists(resourceName, &dashboard),
+					testAccCloudWatchCheckDashboardBodyIsExpected(resourceName, basicWidget),
+					resource.TestCheckResourceAttr(resourceName, "dashboard_name", testAccAWSCloudWatchDashboardName(rInt)),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCloudWatchDashboardConfig_updateBody(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchDashboardExists("aws_cloudwatch_dashboard.foobar", &dashboard),
-					testAccCloudWatchCheckDashboardBodyIsExpected("aws_cloudwatch_dashboard.foobar", updatedWidget),
-					resource.TestCheckResourceAttr("aws_cloudwatch_dashboard.foobar", "dashboard_name", testAccAWSCloudWatchDashboardName(rInt)),
+					testAccCheckCloudWatchDashboardExists(resourceName, &dashboard),
+					testAccCloudWatchCheckDashboardBodyIsExpected(resourceName, updatedWidget),
+					resource.TestCheckResourceAttr(resourceName, "dashboard_name", testAccAWSCloudWatchDashboardName(rInt)),
 				),
 			},
 		},
@@ -163,7 +156,7 @@ func testAccAWSCloudWatchDashboardName(rInt int) string {
 
 func testAccAWSCloudWatchDashboardConfig(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_dashboard" "foobar" {
+resource "aws_cloudwatch_dashboard" "test" {
   dashboard_name = "terraform-test-dashboard-%d"
 
   dashboard_body = <<EOF
@@ -175,7 +168,7 @@ resource "aws_cloudwatch_dashboard" "foobar" {
 
 func testAccAWSCloudWatchDashboardConfig_updateBody(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_dashboard" "foobar" {
+resource "aws_cloudwatch_dashboard" "test" {
   dashboard_name = "terraform-test-dashboard-%d"
 
   dashboard_body = <<EOF

--- a/aws/resource_aws_cloudwatch_event_rule_test.go
+++ b/aws/resource_aws_cloudwatch_event_rule_test.go
@@ -68,8 +68,9 @@ func testSweepCloudWatchEventRules(region string) error {
 	return nil
 }
 
-func TestAccAWSCloudWatchEventRule_importBasic(t *testing.T) {
-	resourceName := "aws_cloudwatch_event_rule.foo"
+func TestAccAWSCloudWatchEventRule_basic(t *testing.T) {
+	var rule events.DescribeRuleOutput
+	resourceName := "aws_cloudwatch_event_rule.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -78,38 +79,22 @@ func TestAccAWSCloudWatchEventRule_importBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSCloudWatchEventRuleConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchEventRuleExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "name", "tf-acc-cw-event-rule"),
+				),
 			},
-
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"is_enabled"}, //this has a default value
 			},
-		},
-	})
-}
-
-func TestAccAWSCloudWatchEventRule_basic(t *testing.T) {
-	var rule events.DescribeRuleOutput
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCloudWatchEventRuleDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSCloudWatchEventRuleConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchEventRuleExists("aws_cloudwatch_event_rule.foo", &rule),
-					resource.TestCheckResourceAttr("aws_cloudwatch_event_rule.foo", "name", "tf-acc-cw-event-rule"),
-				),
-			},
 			{
 				Config: testAccAWSCloudWatchEventRuleConfigModified,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchEventRuleExists("aws_cloudwatch_event_rule.foo", &rule),
-					resource.TestCheckResourceAttr("aws_cloudwatch_event_rule.foo", "name", "tf-acc-cw-event-rule-mod"),
+					testAccCheckCloudWatchEventRuleExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "name", "tf-acc-cw-event-rule-mod"),
 				),
 			},
 		},
@@ -119,6 +104,7 @@ func TestAccAWSCloudWatchEventRule_basic(t *testing.T) {
 func TestAccAWSCloudWatchEventRule_prefix(t *testing.T) {
 	var rule events.DescribeRuleOutput
 	startsWithPrefix := regexp.MustCompile("^tf-acc-cw-event-rule-prefix-")
+	resourceName := "aws_cloudwatch_event_rule.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -128,8 +114,8 @@ func TestAccAWSCloudWatchEventRule_prefix(t *testing.T) {
 			{
 				Config: testAccAWSCloudWatchEventRuleConfig_prefix,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchEventRuleExists("aws_cloudwatch_event_rule.moobar", &rule),
-					resource.TestMatchResourceAttr("aws_cloudwatch_event_rule.moobar", "name", startsWithPrefix),
+					testAccCheckCloudWatchEventRuleExists(resourceName, &rule),
+					resource.TestMatchResourceAttr(resourceName, "name", startsWithPrefix),
 				),
 			},
 		},
@@ -151,8 +137,14 @@ func TestAccAWSCloudWatchEventRule_tags(t *testing.T) {
 					testAccCheckCloudWatchEventRuleExists(resourceName, &rule),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.fizz", "buzz"),
-					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.test", "bar"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"is_enabled"},
 			},
 			{
 				Config: testAccAWSCloudWatchEventRuleConfig_updateTags,
@@ -160,7 +152,7 @@ func TestAccAWSCloudWatchEventRule_tags(t *testing.T) {
 					testAccCheckCloudWatchEventRuleExists(resourceName, &rule),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
 					resource.TestCheckResourceAttr(resourceName, "tags.fizz", "buzz"),
-					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.test", "bar2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.good", "bad"),
 				),
 			},
@@ -183,6 +175,7 @@ func TestAccAWSCloudWatchEventRule_tags(t *testing.T) {
 
 func TestAccAWSCloudWatchEventRule_full(t *testing.T) {
 	var rule events.DescribeRuleOutput
+	resourceName := "aws_cloudwatch_event_rule.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -192,16 +185,22 @@ func TestAccAWSCloudWatchEventRule_full(t *testing.T) {
 			{
 				Config: testAccAWSCloudWatchEventRuleConfig_full,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchEventRuleExists("aws_cloudwatch_event_rule.moobar", &rule),
-					resource.TestCheckResourceAttr("aws_cloudwatch_event_rule.moobar", "name", "tf-acc-cw-event-rule-full"),
-					resource.TestCheckResourceAttr("aws_cloudwatch_event_rule.moobar", "schedule_expression", "rate(5 minutes)"),
-					resource.TestCheckResourceAttr("aws_cloudwatch_event_rule.moobar", "event_pattern", "{\"source\":[\"aws.ec2\"]}"),
-					resource.TestCheckResourceAttr("aws_cloudwatch_event_rule.moobar", "description", "He's not dead, he's just resting!"),
-					resource.TestCheckResourceAttr("aws_cloudwatch_event_rule.moobar", "role_arn", ""),
-					testAccCheckCloudWatchEventRuleEnabled("aws_cloudwatch_event_rule.moobar", "DISABLED", &rule),
-					resource.TestCheckResourceAttr("aws_cloudwatch_event_rule.moobar", "tags.%", "1"),
-					resource.TestCheckResourceAttr("aws_cloudwatch_event_rule.moobar", "tags.Name", "tf-acc-cw-event-rule-full"),
+					testAccCheckCloudWatchEventRuleExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "name", "tf-acc-cw-event-rule-full"),
+					resource.TestCheckResourceAttr(resourceName, "schedule_expression", "rate(5 minutes)"),
+					resource.TestCheckResourceAttr(resourceName, "event_pattern", "{\"source\":[\"aws.ec2\"]}"),
+					resource.TestCheckResourceAttr(resourceName, "description", "He's not dead, he's just resting!"),
+					resource.TestCheckResourceAttr(resourceName, "role_arn", ""),
+					testAccCheckCloudWatchEventRuleEnabled(resourceName, "DISABLED", &rule),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "tf-acc-cw-event-rule-full"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"is_enabled"},
 			},
 		},
 	})
@@ -209,6 +208,7 @@ func TestAccAWSCloudWatchEventRule_full(t *testing.T) {
 
 func TestAccAWSCloudWatchEventRule_enable(t *testing.T) {
 	var rule events.DescribeRuleOutput
+	resourceName := "aws_cloudwatch_event_rule.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -218,22 +218,28 @@ func TestAccAWSCloudWatchEventRule_enable(t *testing.T) {
 			{
 				Config: testAccAWSCloudWatchEventRuleConfigEnabled,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchEventRuleExists("aws_cloudwatch_event_rule.moo", &rule),
-					testAccCheckCloudWatchEventRuleEnabled("aws_cloudwatch_event_rule.moo", "ENABLED", &rule),
+					testAccCheckCloudWatchEventRuleExists("aws_cloudwatch_event_rule.test", &rule),
+					testAccCheckCloudWatchEventRuleEnabled("aws_cloudwatch_event_rule.test", "ENABLED", &rule),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"is_enabled"},
 			},
 			{
 				Config: testAccAWSCloudWatchEventRuleConfigDisabled,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchEventRuleExists("aws_cloudwatch_event_rule.moo", &rule),
-					testAccCheckCloudWatchEventRuleEnabled("aws_cloudwatch_event_rule.moo", "DISABLED", &rule),
+					testAccCheckCloudWatchEventRuleExists("aws_cloudwatch_event_rule.test", &rule),
+					testAccCheckCloudWatchEventRuleEnabled("aws_cloudwatch_event_rule.test", "DISABLED", &rule),
 				),
 			},
 			{
 				Config: testAccAWSCloudWatchEventRuleConfigEnabled,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchEventRuleExists("aws_cloudwatch_event_rule.moo", &rule),
-					testAccCheckCloudWatchEventRuleEnabled("aws_cloudwatch_event_rule.moo", "ENABLED", &rule),
+					testAccCheckCloudWatchEventRuleExists("aws_cloudwatch_event_rule.test", &rule),
+					testAccCheckCloudWatchEventRuleEnabled("aws_cloudwatch_event_rule.test", "ENABLED", &rule),
 				),
 			},
 		},
@@ -364,20 +370,20 @@ func TestResourceAWSCloudWatchEventRule_validateEventPatternValue(t *testing.T) 
 }
 
 var testAccAWSCloudWatchEventRuleConfig = `
-resource "aws_cloudwatch_event_rule" "foo" {
+resource "aws_cloudwatch_event_rule" "test" {
     name = "tf-acc-cw-event-rule"
     schedule_expression = "rate(1 hour)"
 }
 `
 
 var testAccAWSCloudWatchEventRuleConfigEnabled = `
-resource "aws_cloudwatch_event_rule" "moo" {
+resource "aws_cloudwatch_event_rule" "test" {
     name = "tf-acc-cw-event-rule-state"
     schedule_expression = "rate(1 hour)"
 }
 `
 var testAccAWSCloudWatchEventRuleConfigDisabled = `
-resource "aws_cloudwatch_event_rule" "moo" {
+resource "aws_cloudwatch_event_rule" "test" {
     name = "tf-acc-cw-event-rule-state"
     schedule_expression = "rate(1 hour)"
     is_enabled = false
@@ -385,14 +391,14 @@ resource "aws_cloudwatch_event_rule" "moo" {
 `
 
 var testAccAWSCloudWatchEventRuleConfigModified = `
-resource "aws_cloudwatch_event_rule" "foo" {
+resource "aws_cloudwatch_event_rule" "test" {
     name = "tf-acc-cw-event-rule-mod"
     schedule_expression = "rate(1 hour)"
 }
 `
 
 var testAccAWSCloudWatchEventRuleConfig_prefix = `
-resource "aws_cloudwatch_event_rule" "moobar" {
+resource "aws_cloudwatch_event_rule" "test" {
     name_prefix = "tf-acc-cw-event-rule-prefix-"
     schedule_expression = "rate(5 minutes)"
 	event_pattern = <<PATTERN
@@ -410,7 +416,7 @@ resource "aws_cloudwatch_event_rule" "default" {
 	
 	tags = {
 		fizz 	= "buzz"
-		foo		= "bar"
+		test		= "bar"
 	}
 }
 `
@@ -422,7 +428,7 @@ resource "aws_cloudwatch_event_rule" "default" {
 	
 	tags = {
 		fizz 	= "buzz"
-		foo		= "bar2"
+		test		= "bar2"
 		good	= "bad"
 	}
 }
@@ -440,7 +446,7 @@ resource "aws_cloudwatch_event_rule" "default" {
 `
 
 var testAccAWSCloudWatchEventRuleConfig_full = `
-resource "aws_cloudwatch_event_rule" "moobar" {
+resource "aws_cloudwatch_event_rule" "test" {
     name = "tf-acc-cw-event-rule-full"
     schedule_expression = "rate(5 minutes)"
 	event_pattern = <<PATTERN

--- a/aws/resource_aws_cloudwatch_log_destination_policy_test.go
+++ b/aws/resource_aws_cloudwatch_log_destination_policy_test.go
@@ -10,32 +10,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSCloudwatchLogDestinationPolicy_importBasic(t *testing.T) {
-	resourceName := "aws_cloudwatch_log_destination_policy.test"
-
-	rstring := acctest.RandString(5)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCloudwatchLogDestinationPolicyDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSCloudwatchLogDestinationPolicyConfig(rstring),
-			},
-
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAWSCloudwatchLogDestinationPolicy_basic(t *testing.T) {
 	var destination cloudwatchlogs.Destination
-
+	resourceName := "aws_cloudwatch_log_destination_policy.test"
 	rstring := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -46,8 +23,13 @@ func TestAccAWSCloudwatchLogDestinationPolicy_basic(t *testing.T) {
 			{
 				Config: testAccAWSCloudwatchLogDestinationPolicyConfig(rstring),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCloudwatchLogDestinationPolicyExists("aws_cloudwatch_log_destination_policy.test", &destination),
+					testAccCheckAWSCloudwatchLogDestinationPolicyExists(resourceName, &destination),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/aws/resource_aws_cloudwatch_log_destination_test.go
+++ b/aws/resource_aws_cloudwatch_log_destination_test.go
@@ -10,32 +10,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSCloudwatchLogDestination_importBasic(t *testing.T) {
-	resourceName := "aws_cloudwatch_log_destination.test"
-
-	rstring := acctest.RandString(5)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCloudwatchLogDestinationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSCloudwatchLogDestinationConfig(rstring),
-			},
-
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAWSCloudwatchLogDestination_basic(t *testing.T) {
 	var destination cloudwatchlogs.Destination
-
+	resourceName := "aws_cloudwatch_log_destination.test"
 	rstring := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -46,8 +23,13 @@ func TestAccAWSCloudwatchLogDestination_basic(t *testing.T) {
 			{
 				Config: testAccAWSCloudwatchLogDestinationConfig(rstring),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCloudwatchLogDestinationExists("aws_cloudwatch_log_destination.test", &destination),
+					testAccCheckAWSCloudwatchLogDestinationExists(resourceName, &destination),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/aws/resource_aws_cloudwatch_log_group_test.go
+++ b/aws/resource_aws_cloudwatch_log_group_test.go
@@ -11,9 +11,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSCloudWatchLogGroup_importBasic(t *testing.T) {
-	resourceName := "aws_cloudwatch_log_group.foobar"
+func TestAccAWSCloudWatchLogGroup_basic(t *testing.T) {
+	var lg cloudwatchlogs.LogGroup
 	rInt := acctest.RandInt()
+	resourceName := "aws_cloudwatch_log_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -22,8 +23,11 @@ func TestAccAWSCloudWatchLogGroup_importBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSCloudWatchLogGroupConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchLogGroupExists(resourceName, &lg),
+					resource.TestCheckResourceAttr(resourceName, "retention_in_days", "0"),
+				),
 			},
-
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
@@ -34,28 +38,9 @@ func TestAccAWSCloudWatchLogGroup_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccAWSCloudWatchLogGroup_basic(t *testing.T) {
-	var lg cloudwatchlogs.LogGroup
-	rInt := acctest.RandInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCloudWatchLogGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSCloudWatchLogGroupConfig(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchLogGroupExists("aws_cloudwatch_log_group.foobar", &lg),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.foobar", "retention_in_days", "0"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAWSCloudWatchLogGroup_namePrefix(t *testing.T) {
 	var lg cloudwatchlogs.LogGroup
+	resourceName := "aws_cloudwatch_log_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -65,9 +50,15 @@ func TestAccAWSCloudWatchLogGroup_namePrefix(t *testing.T) {
 			{
 				Config: testAccAWSCloudWatchLogGroup_namePrefix,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchLogGroupExists("aws_cloudwatch_log_group.test", &lg),
-					resource.TestMatchResourceAttr("aws_cloudwatch_log_group.test", "name", regexp.MustCompile("^tf-test-")),
+					testAccCheckCloudWatchLogGroupExists(resourceName, &lg),
+					resource.TestMatchResourceAttr(resourceName, "name", regexp.MustCompile("^tf-test-")),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retention_in_days", "name_prefix"},
 			},
 		},
 	})
@@ -76,6 +67,7 @@ func TestAccAWSCloudWatchLogGroup_namePrefix(t *testing.T) {
 func TestAccAWSCloudWatchLogGroup_namePrefix_retention(t *testing.T) {
 	var lg cloudwatchlogs.LogGroup
 	rName := acctest.RandString(5)
+	resourceName := "aws_cloudwatch_log_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -85,17 +77,23 @@ func TestAccAWSCloudWatchLogGroup_namePrefix_retention(t *testing.T) {
 			{
 				Config: testAccAWSCloudWatchLogGroup_namePrefix_retention(rName, 365),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchLogGroupExists("aws_cloudwatch_log_group.test", &lg),
-					resource.TestMatchResourceAttr("aws_cloudwatch_log_group.test", "name", regexp.MustCompile("^tf-test-")),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.test", "retention_in_days", "365"),
+					testAccCheckCloudWatchLogGroupExists(resourceName, &lg),
+					resource.TestMatchResourceAttr(resourceName, "name", regexp.MustCompile("^tf-test-")),
+					resource.TestCheckResourceAttr(resourceName, "retention_in_days", "365"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retention_in_days", "name_prefix"},
 			},
 			{
 				Config: testAccAWSCloudWatchLogGroup_namePrefix_retention(rName, 7),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchLogGroupExists("aws_cloudwatch_log_group.test", &lg),
-					resource.TestMatchResourceAttr("aws_cloudwatch_log_group.test", "name", regexp.MustCompile("^tf-test-")),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.test", "retention_in_days", "7"),
+					testAccCheckCloudWatchLogGroupExists(resourceName, &lg),
+					resource.TestMatchResourceAttr(resourceName, "name", regexp.MustCompile("^tf-test-")),
+					resource.TestCheckResourceAttr(resourceName, "retention_in_days", "7"),
 				),
 			},
 		},
@@ -104,6 +102,7 @@ func TestAccAWSCloudWatchLogGroup_namePrefix_retention(t *testing.T) {
 
 func TestAccAWSCloudWatchLogGroup_generatedName(t *testing.T) {
 	var lg cloudwatchlogs.LogGroup
+	resourceName := "aws_cloudwatch_log_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -113,8 +112,14 @@ func TestAccAWSCloudWatchLogGroup_generatedName(t *testing.T) {
 			{
 				Config: testAccAWSCloudWatchLogGroup_generatedName,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchLogGroupExists("aws_cloudwatch_log_group.test", &lg),
+					testAccCheckCloudWatchLogGroupExists(resourceName, &lg),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retention_in_days"},
 			},
 		},
 	})
@@ -123,6 +128,7 @@ func TestAccAWSCloudWatchLogGroup_generatedName(t *testing.T) {
 func TestAccAWSCloudWatchLogGroup_retentionPolicy(t *testing.T) {
 	var lg cloudwatchlogs.LogGroup
 	rInt := acctest.RandInt()
+	resourceName := "aws_cloudwatch_log_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -132,15 +138,21 @@ func TestAccAWSCloudWatchLogGroup_retentionPolicy(t *testing.T) {
 			{
 				Config: testAccAWSCloudWatchLogGroupConfig_withRetention(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchLogGroupExists("aws_cloudwatch_log_group.foobar", &lg),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.foobar", "retention_in_days", "365"),
+					testAccCheckCloudWatchLogGroupExists(resourceName, &lg),
+					resource.TestCheckResourceAttr(resourceName, "retention_in_days", "365"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retention_in_days"},
 			},
 			{
 				Config: testAccAWSCloudWatchLogGroupConfigModified_withRetention(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchLogGroupExists("aws_cloudwatch_log_group.foobar", &lg),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.foobar", "retention_in_days", "0"),
+					testAccCheckCloudWatchLogGroupExists(resourceName, &lg),
+					resource.TestCheckResourceAttr(resourceName, "retention_in_days", "0"),
 				),
 			},
 		},
@@ -150,6 +162,7 @@ func TestAccAWSCloudWatchLogGroup_retentionPolicy(t *testing.T) {
 func TestAccAWSCloudWatchLogGroup_multiple(t *testing.T) {
 	var lg cloudwatchlogs.LogGroup
 	rInt := acctest.RandInt()
+	resourceName := "aws_cloudwatch_log_group.alpha"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -167,6 +180,12 @@ func TestAccAWSCloudWatchLogGroup_multiple(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.charlie", "retention_in_days", "3653"),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retention_in_days"},
+			},
 		},
 	})
 }
@@ -174,6 +193,7 @@ func TestAccAWSCloudWatchLogGroup_multiple(t *testing.T) {
 func TestAccAWSCloudWatchLogGroup_disappears(t *testing.T) {
 	var lg cloudwatchlogs.LogGroup
 	rInt := acctest.RandInt()
+	resourceName := "aws_cloudwatch_log_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -183,7 +203,7 @@ func TestAccAWSCloudWatchLogGroup_disappears(t *testing.T) {
 			{
 				Config: testAccAWSCloudWatchLogGroupConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchLogGroupExists("aws_cloudwatch_log_group.foobar", &lg),
+					testAccCheckCloudWatchLogGroupExists(resourceName, &lg),
 					testAccCheckCloudWatchLogGroupDisappears(&lg),
 				),
 				ExpectNonEmptyPlan: true,
@@ -195,6 +215,7 @@ func TestAccAWSCloudWatchLogGroup_disappears(t *testing.T) {
 func TestAccAWSCloudWatchLogGroup_tagging(t *testing.T) {
 	var lg cloudwatchlogs.LogGroup
 	rInt := acctest.RandInt()
+	resourceName := "aws_cloudwatch_log_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -204,43 +225,49 @@ func TestAccAWSCloudWatchLogGroup_tagging(t *testing.T) {
 			{
 				Config: testAccAWSCloudWatchLogGroupConfigWithTags(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchLogGroupExists("aws_cloudwatch_log_group.foobar", &lg),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.foobar", "tags.%", "3"),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.foobar", "tags.Environment", "Production"),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.foobar", "tags.Foo", "Bar"),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.foobar", "tags.Empty", ""),
+					testAccCheckCloudWatchLogGroupExists(resourceName, &lg),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Environment", "Production"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Foo", "Bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Empty", ""),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retention_in_days"},
 			},
 			{
 				Config: testAccAWSCloudWatchLogGroupConfigWithTagsAdded(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchLogGroupExists("aws_cloudwatch_log_group.foobar", &lg),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.foobar", "tags.%", "4"),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.foobar", "tags.Environment", "Development"),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.foobar", "tags.Foo", "Bar"),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.foobar", "tags.Empty", ""),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.foobar", "tags.Bar", "baz"),
+					testAccCheckCloudWatchLogGroupExists(resourceName, &lg),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Environment", "Development"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Foo", "Bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Empty", ""),
+					resource.TestCheckResourceAttr(resourceName, "tags.Bar", "baz"),
 				),
 			},
 			{
 				Config: testAccAWSCloudWatchLogGroupConfigWithTagsUpdated(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchLogGroupExists("aws_cloudwatch_log_group.foobar", &lg),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.foobar", "tags.%", "4"),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.foobar", "tags.Environment", "Development"),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.foobar", "tags.Empty", "NotEmpty"),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.foobar", "tags.Foo", "UpdatedBar"),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.foobar", "tags.Bar", "baz"),
+					testAccCheckCloudWatchLogGroupExists(resourceName, &lg),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Environment", "Development"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Empty", "NotEmpty"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Foo", "UpdatedBar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Bar", "baz"),
 				),
 			},
 			{
 				Config: testAccAWSCloudWatchLogGroupConfigWithTags(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchLogGroupExists("aws_cloudwatch_log_group.foobar", &lg),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.foobar", "tags.%", "3"),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.foobar", "tags.Environment", "Production"),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.foobar", "tags.Foo", "Bar"),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.foobar", "tags.Empty", ""),
+					testAccCheckCloudWatchLogGroupExists(resourceName, &lg),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Environment", "Production"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Foo", "Bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Empty", ""),
 				),
 			},
 		},
@@ -250,6 +277,7 @@ func TestAccAWSCloudWatchLogGroup_tagging(t *testing.T) {
 func TestAccAWSCloudWatchLogGroup_kmsKey(t *testing.T) {
 	var lg cloudwatchlogs.LogGroup
 	rInt := acctest.RandInt()
+	resourceName := "aws_cloudwatch_log_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -259,14 +287,20 @@ func TestAccAWSCloudWatchLogGroup_kmsKey(t *testing.T) {
 			{
 				Config: testAccAWSCloudWatchLogGroupConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchLogGroupExists("aws_cloudwatch_log_group.foobar", &lg),
+					testAccCheckCloudWatchLogGroupExists(resourceName, &lg),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retention_in_days"},
 			},
 			{
 				Config: testAccAWSCloudWatchLogGroupConfigWithKmsKeyId(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchLogGroupExists("aws_cloudwatch_log_group.foobar", &lg),
-					resource.TestCheckResourceAttrSet("aws_cloudwatch_log_group.foobar", "kms_key_id"),
+					testAccCheckCloudWatchLogGroupExists(resourceName, &lg),
+					resource.TestCheckResourceAttrSet(resourceName, "kms_key_id"),
 				),
 			},
 		},
@@ -329,7 +363,7 @@ func testAccCheckAWSCloudWatchLogGroupDestroy(s *terraform.State) error {
 
 func testAccAWSCloudWatchLogGroupConfig(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "foobar" {
+resource "aws_cloudwatch_log_group" "test" {
   name = "foo-bar-%d"
 }
 `, rInt)
@@ -337,7 +371,7 @@ resource "aws_cloudwatch_log_group" "foobar" {
 
 func testAccAWSCloudWatchLogGroupConfigWithTags(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "foobar" {
+resource "aws_cloudwatch_log_group" "test" {
   name = "foo-bar-%d"
 
   tags = {
@@ -351,7 +385,7 @@ resource "aws_cloudwatch_log_group" "foobar" {
 
 func testAccAWSCloudWatchLogGroupConfigWithTagsAdded(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "foobar" {
+resource "aws_cloudwatch_log_group" "test" {
   name = "foo-bar-%d"
 
   tags = {
@@ -366,7 +400,7 @@ resource "aws_cloudwatch_log_group" "foobar" {
 
 func testAccAWSCloudWatchLogGroupConfigWithTagsUpdated(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "foobar" {
+resource "aws_cloudwatch_log_group" "test" {
   name = "foo-bar-%d"
 
   tags = {
@@ -381,7 +415,7 @@ resource "aws_cloudwatch_log_group" "foobar" {
 
 func testAccAWSCloudWatchLogGroupConfig_withRetention(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "foobar" {
+resource "aws_cloudwatch_log_group" "test" {
   name              = "foo-bar-%d"
   retention_in_days = 365
 }
@@ -390,7 +424,7 @@ resource "aws_cloudwatch_log_group" "foobar" {
 
 func testAccAWSCloudWatchLogGroupConfigModified_withRetention(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "foobar" {
+resource "aws_cloudwatch_log_group" "test" {
   name = "foo-bar-%d"
 }
 `, rInt)
@@ -439,7 +473,7 @@ resource "aws_kms_key" "foo" {
 POLICY
 }
 
-resource "aws_cloudwatch_log_group" "foobar" {
+resource "aws_cloudwatch_log_group" "test" {
   name       = "foo-bar-%d"
   kms_key_id = "${aws_kms_key.foo.arn}"
 }

--- a/aws/resource_aws_cloudwatch_log_resource_policy_test.go
+++ b/aws/resource_aws_cloudwatch_log_resource_policy_test.go
@@ -63,38 +63,10 @@ func testSweepCloudWatchLogResourcePolicies(region string) error {
 	return nil
 }
 
-func TestAccAWSCloudWatchLogResourcePolicy_Basic(t *testing.T) {
+func TestAccAWSCloudWatchLogResourcePolicy_basic(t *testing.T) {
 	name := acctest.RandString(5)
-	var resourcePolicy cloudwatchlogs.ResourcePolicy
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudWatchLogResourcePolicyDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckAWSCloudWatchLogResourcePolicyResourceConfigBasic1(name),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchLogResourcePolicy("aws_cloudwatch_log_resource_policy.test", &resourcePolicy),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_resource_policy.test", "policy_name", name),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_resource_policy.test", "policy_document", "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"route53.amazonaws.com\"},\"Action\":[\"logs:PutLogEvents\",\"logs:CreateLogStream\"],\"Resource\":\"arn:aws:logs:*:*:log-group:/aws/route53/*\"}]}"),
-				),
-			},
-			{
-				Config: testAccCheckAWSCloudWatchLogResourcePolicyResourceConfigBasic2(name),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchLogResourcePolicy("aws_cloudwatch_log_resource_policy.test", &resourcePolicy),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_resource_policy.test", "policy_name", name),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_resource_policy.test", "policy_document", "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"route53.amazonaws.com\"},\"Action\":[\"logs:PutLogEvents\",\"logs:CreateLogStream\"],\"Resource\":\"arn:aws:logs:*:*:log-group:/aws/route53/example.com\"}]}"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSCloudWatchLogResourcePolicy_Import(t *testing.T) {
 	resourceName := "aws_cloudwatch_log_resource_policy.test"
-
-	name := acctest.RandString(5)
+	var resourcePolicy cloudwatchlogs.ResourcePolicy
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -103,12 +75,24 @@ func TestAccAWSCloudWatchLogResourcePolicy_Import(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckAWSCloudWatchLogResourcePolicyResourceConfigBasic1(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchLogResourcePolicy(resourceName, &resourcePolicy),
+					resource.TestCheckResourceAttr(resourceName, "policy_name", name),
+					resource.TestCheckResourceAttr(resourceName, "policy_document", "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"route53.amazonaws.com\"},\"Action\":[\"logs:PutLogEvents\",\"logs:CreateLogStream\"],\"Resource\":\"arn:aws:logs:*:*:log-group:/aws/route53/*\"}]}"),
+				),
 			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccCheckAWSCloudWatchLogResourcePolicyResourceConfigBasic2(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchLogResourcePolicy(resourceName, &resourcePolicy),
+					resource.TestCheckResourceAttr(resourceName, "policy_name", name),
+					resource.TestCheckResourceAttr(resourceName, "policy_document", "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"route53.amazonaws.com\"},\"Action\":[\"logs:PutLogEvents\",\"logs:CreateLogStream\"],\"Resource\":\"arn:aws:logs:*:*:log-group:/aws/route53/example.com\"}]}"),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8944

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSCloudWatchDashboard_"     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSCloudWatchDashboard_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCloudWatchDashboard_basic
=== PAUSE TestAccAWSCloudWatchDashboard_basic
=== RUN   TestAccAWSCloudWatchDashboard_update
=== PAUSE TestAccAWSCloudWatchDashboard_update
=== CONT  TestAccAWSCloudWatchDashboard_basic
=== CONT  TestAccAWSCloudWatchDashboard_update
--- PASS: TestAccAWSCloudWatchDashboard_basic (29.06s)
--- PASS: TestAccAWSCloudWatchDashboard_update (49.18s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       50.623s

make testacc TESTARGS="-run=TestAccAWSCloudWatchEventRule_"     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSCloudWatchEventRule_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCloudWatchEventRule_basic
=== PAUSE TestAccAWSCloudWatchEventRule_basic
=== RUN   TestAccAWSCloudWatchEventRule_prefix
=== PAUSE TestAccAWSCloudWatchEventRule_prefix
=== RUN   TestAccAWSCloudWatchEventRule_tags
=== PAUSE TestAccAWSCloudWatchEventRule_tags
=== RUN   TestAccAWSCloudWatchEventRule_full
=== PAUSE TestAccAWSCloudWatchEventRule_full
=== RUN   TestAccAWSCloudWatchEventRule_enable
=== PAUSE TestAccAWSCloudWatchEventRule_enable
=== CONT  TestAccAWSCloudWatchEventRule_basic
=== CONT  TestAccAWSCloudWatchEventRule_full
=== CONT  TestAccAWSCloudWatchEventRule_tags
=== CONT  TestAccAWSCloudWatchEventRule_enable
=== CONT  TestAccAWSCloudWatchEventRule_prefix
--- PASS: TestAccAWSCloudWatchEventRule_prefix (26.61s)
--- PASS: TestAccAWSCloudWatchEventRule_full (32.70s)
--- PASS: TestAccAWSCloudWatchEventRule_basic (52.97s)
--- PASS: TestAccAWSCloudWatchEventRule_enable (74.29s)
--- PASS: TestAccAWSCloudWatchEventRule_tags (78.16s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       79.584s

make testacc TESTARGS="-run=TestAccAWSCloudwatchLogDestinationPolicy_"    
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSCloudwatchLogDestinationPolicy_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCloudwatchLogDestinationPolicy_basic
=== PAUSE TestAccAWSCloudwatchLogDestinationPolicy_basic
=== CONT  TestAccAWSCloudwatchLogDestinationPolicy_basic
--- PASS: TestAccAWSCloudwatchLogDestinationPolicy_basic (108.18s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       109.603s

make testacc TESTARGS="-run=TestAccAWSCloudwatchLogDestination_"==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSCloudwatchLogDestination_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCloudwatchLogDestination_basic
=== PAUSE TestAccAWSCloudwatchLogDestination_basic
=== CONT  TestAccAWSCloudwatchLogDestination_basic
--- PASS: TestAccAWSCloudwatchLogDestination_basic (107.40s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       108.821s

make testacc TESTARGS="-run=TestAccAWSCloudWatchLogGroup_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSCloudWatchLogGroup_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCloudWatchLogGroup_basic
=== PAUSE TestAccAWSCloudWatchLogGroup_basic
=== RUN   TestAccAWSCloudWatchLogGroup_namePrefix
=== PAUSE TestAccAWSCloudWatchLogGroup_namePrefix
=== RUN   TestAccAWSCloudWatchLogGroup_namePrefix_retention
=== PAUSE TestAccAWSCloudWatchLogGroup_namePrefix_retention
=== RUN   TestAccAWSCloudWatchLogGroup_generatedName
=== PAUSE TestAccAWSCloudWatchLogGroup_generatedName
=== RUN   TestAccAWSCloudWatchLogGroup_retentionPolicy
=== PAUSE TestAccAWSCloudWatchLogGroup_retentionPolicy
=== RUN   TestAccAWSCloudWatchLogGroup_multiple
=== PAUSE TestAccAWSCloudWatchLogGroup_multiple
=== RUN   TestAccAWSCloudWatchLogGroup_disappears
=== PAUSE TestAccAWSCloudWatchLogGroup_disappears
=== RUN   TestAccAWSCloudWatchLogGroup_tagging
=== PAUSE TestAccAWSCloudWatchLogGroup_tagging
=== RUN   TestAccAWSCloudWatchLogGroup_kmsKey
=== PAUSE TestAccAWSCloudWatchLogGroup_kmsKey
=== CONT  TestAccAWSCloudWatchLogGroup_basic
=== CONT  TestAccAWSCloudWatchLogGroup_kmsKey
=== CONT  TestAccAWSCloudWatchLogGroup_retentionPolicy
=== CONT  TestAccAWSCloudWatchLogGroup_tagging
=== CONT  TestAccAWSCloudWatchLogGroup_namePrefix_retention
=== CONT  TestAccAWSCloudWatchLogGroup_namePrefix
=== CONT  TestAccAWSCloudWatchLogGroup_disappears
=== CONT  TestAccAWSCloudWatchLogGroup_multiple
=== CONT  TestAccAWSCloudWatchLogGroup_generatedName
--- PASS: TestAccAWSCloudWatchLogGroup_disappears (21.28s)
--- PASS: TestAccAWSCloudWatchLogGroup_namePrefix (27.10s)
--- PASS: TestAccAWSCloudWatchLogGroup_basic (30.97s)
--- PASS: TestAccAWSCloudWatchLogGroup_generatedName (31.01s)
--- PASS: TestAccAWSCloudWatchLogGroup_multiple (34.61s)
--- PASS: TestAccAWSCloudWatchLogGroup_retentionPolicy (50.32s)
--- PASS: TestAccAWSCloudWatchLogGroup_namePrefix_retention (50.61s)
--- PASS: TestAccAWSCloudWatchLogGroup_tagging (91.06s)
--- PASS: TestAccAWSCloudWatchLogGroup_kmsKey (92.46s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       93.881s

 make testacc TESTARGS="-run=TestAccAWSCloudWatchLogResourcePolicy_"    
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSCloudWatchLogResourcePolicy_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCloudWatchLogResourcePolicy_basic
=== PAUSE TestAccAWSCloudWatchLogResourcePolicy_basic
=== CONT  TestAccAWSCloudWatchLogResourcePolicy_basic
--- PASS: TestAccAWSCloudWatchLogResourcePolicy_basic (49.55s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       50.982s
```
