### PR TITLE
Import test refactor for cloudy resources

### DIFF
--- a/aws/resource_aws_cloud9_environment_ec2_test.go
+++ b/aws/resource_aws_cloud9_environment_ec2_test.go
@@ -18,7 +18,6 @@ func TestAccAWSCloud9EnvironmentEc2_basic(t *testing.T) {
 	rString := acctest.RandString(8)
 	envName := fmt.Sprintf("tf_acc_env_basic_%s", rString)
 	uEnvName := fmt.Sprintf("tf_acc_env_basic_updated_%s", rString)
-
 	resourceName := "aws_cloud9_environment_ec2.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -35,6 +34,12 @@ func TestAccAWSCloud9EnvironmentEc2_basic(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(`^arn:[^:]+:cloud9:[^:]+:[^:]+:environment:.+$`)),
 					resource.TestMatchResourceAttr(resourceName, "owner_arn", regexp.MustCompile(`^arn:`)),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"instance_type"},
 			},
 			{
 				Config: testAccAWSCloud9EnvironmentEc2Config(uEnvName),
@@ -59,7 +64,6 @@ func TestAccAWSCloud9EnvironmentEc2_allFields(t *testing.T) {
 	description := fmt.Sprintf("Tf Acc Test %s", rString)
 	uDescription := fmt.Sprintf("Tf Acc Test Updated %s", rString)
 	userName := fmt.Sprintf("tf_acc_cloud9_env_%s", rString)
-
 	resourceName := "aws_cloud9_environment_ec2.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -79,6 +83,12 @@ func TestAccAWSCloud9EnvironmentEc2_allFields(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"instance_type", "automatic_stop_time_minutes", "subnet_id"},
+			},
+			{
 				Config: testAccAWSCloud9EnvironmentEc2AllFieldsConfig(uEnvName, uDescription, userName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCloud9EnvironmentEc2Exists(resourceName, &conf),
@@ -88,30 +98,6 @@ func TestAccAWSCloud9EnvironmentEc2_allFields(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceName, "owner_arn", regexp.MustCompile(`^arn:`)),
 					resource.TestCheckResourceAttr(resourceName, "type", "ec2"),
 				),
-			},
-		},
-	})
-}
-
-func TestAccAWSCloud9EnvironmentEc2_importBasic(t *testing.T) {
-	rString := acctest.RandString(8)
-	name := fmt.Sprintf("tf_acc_api_doc_part_import_%s", rString)
-
-	resourceName := "aws_cloud9_environment_ec2.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloud9(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCloud9EnvironmentEc2Destroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSCloud9EnvironmentEc2Config(name),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"instance_type"},
 			},
 		},
 	})

--- a/aws/resource_aws_cloudformation_stack_test.go
+++ b/aws/resource_aws_cloudformation_stack_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSCloudFormationStack_importBasic(t *testing.T) {
+func TestAccAWSCloudFormationStack_basic(t *testing.T) {
+	var stack cloudformation.Stack
 	stackName := fmt.Sprintf("tf-acc-test-basic-%s", acctest.RandString(10))
-
-	resourceName := "aws_cloudformation_stack.network"
+	resourceName := "aws_cloudformation_stack.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -23,6 +23,9 @@ func TestAccAWSCloudFormationStack_importBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSCloudFormationStackConfig(stackName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackExists(resourceName, &stack),
+				),
 			},
 			{
 				ResourceName:      resourceName,
@@ -33,28 +36,10 @@ func TestAccAWSCloudFormationStack_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccAWSCloudFormationStack_basic(t *testing.T) {
-	var stack cloudformation.Stack
-	stackName := fmt.Sprintf("tf-acc-test-basic-%s", acctest.RandString(10))
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSCloudFormationStackConfig(stackName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.network", &stack),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAWSCloudFormationStack_disappears(t *testing.T) {
 	var stack cloudformation.Stack
 	stackName := fmt.Sprintf("tf-acc-test-basic-%s", acctest.RandString(10))
+	resourceName := "aws_cloudformation_stack.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -64,7 +49,7 @@ func TestAccAWSCloudFormationStack_disappears(t *testing.T) {
 			{
 				Config: testAccAWSCloudFormationStackConfig(stackName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.network", &stack),
+					testAccCheckCloudFormationStackExists(resourceName, &stack),
 					testAccCheckCloudFormationStackDisappears(&stack),
 				),
 				ExpectNonEmptyPlan: true,
@@ -76,6 +61,7 @@ func TestAccAWSCloudFormationStack_disappears(t *testing.T) {
 func TestAccAWSCloudFormationStack_yaml(t *testing.T) {
 	var stack cloudformation.Stack
 	stackName := fmt.Sprintf("tf-acc-test-yaml-%s", acctest.RandString(10))
+	resourceName := "aws_cloudformation_stack.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -85,8 +71,13 @@ func TestAccAWSCloudFormationStack_yaml(t *testing.T) {
 			{
 				Config: testAccAWSCloudFormationStackConfig_yaml(stackName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.yaml", &stack),
+					testAccCheckCloudFormationStackExists(resourceName, &stack),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -95,6 +86,7 @@ func TestAccAWSCloudFormationStack_yaml(t *testing.T) {
 func TestAccAWSCloudFormationStack_defaultParams(t *testing.T) {
 	var stack cloudformation.Stack
 	stackName := fmt.Sprintf("tf-acc-test-default-params-%s", acctest.RandString(10))
+	resourceName := "aws_cloudformation_stack.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -104,8 +96,14 @@ func TestAccAWSCloudFormationStack_defaultParams(t *testing.T) {
 			{
 				Config: testAccAWSCloudFormationStackConfig_defaultParams(stackName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.asg-demo", &stack),
+					testAccCheckCloudFormationStackExists(resourceName, &stack),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parameters"},
 			},
 		},
 	})
@@ -114,8 +112,9 @@ func TestAccAWSCloudFormationStack_defaultParams(t *testing.T) {
 func TestAccAWSCloudFormationStack_allAttributes(t *testing.T) {
 	var stack cloudformation.Stack
 	stackName := fmt.Sprintf("tf-acc-test-all-attributes-%s", acctest.RandString(10))
-
+	resourceName := "aws_cloudformation_stack.test"
 	expectedPolicyBody := "{\"Statement\":[{\"Action\":\"Update:*\",\"Effect\":\"Deny\",\"Principal\":\"*\",\"Resource\":\"LogicalResourceId/StaticVPC\"},{\"Action\":\"Update:*\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Resource\":\"*\"}]}"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -124,37 +123,43 @@ func TestAccAWSCloudFormationStack_allAttributes(t *testing.T) {
 			{
 				Config: testAccAWSCloudFormationStackConfig_allAttributesWithBodies(stackName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.full", &stack),
-					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "name", stackName),
-					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "capabilities.#", "1"),
-					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "capabilities.1328347040", "CAPABILITY_IAM"),
-					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "disable_rollback", "false"),
-					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "notification_arns.#", "1"),
-					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "parameters.%", "1"),
-					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "parameters.VpcCIDR", "10.0.0.0/16"),
-					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "policy_body", expectedPolicyBody),
-					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "tags.%", "2"),
-					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "tags.First", "Mickey"),
-					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "tags.Second", "Mouse"),
-					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "timeout_in_minutes", "10"),
+					testAccCheckCloudFormationStackExists(resourceName, &stack),
+					resource.TestCheckResourceAttr(resourceName, "name", stackName),
+					resource.TestCheckResourceAttr(resourceName, "capabilities.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "capabilities.1328347040", "CAPABILITY_IAM"),
+					resource.TestCheckResourceAttr(resourceName, "disable_rollback", "false"),
+					resource.TestCheckResourceAttr(resourceName, "notification_arns.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.VpcCIDR", "10.0.0.0/16"),
+					resource.TestCheckResourceAttr(resourceName, "policy_body", expectedPolicyBody),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.First", "Mickey"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Second", "Mouse"),
+					resource.TestCheckResourceAttr(resourceName, "timeout_in_minutes", "10"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"on_failure", "parameters", "policy_body"},
 			},
 			{
 				Config: testAccAWSCloudFormationStackConfig_allAttributesWithBodies_modified(stackName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.full", &stack),
-					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "name", stackName),
-					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "capabilities.#", "1"),
-					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "capabilities.1328347040", "CAPABILITY_IAM"),
-					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "disable_rollback", "false"),
-					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "notification_arns.#", "1"),
-					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "parameters.%", "1"),
-					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "parameters.VpcCIDR", "10.0.0.0/16"),
-					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "policy_body", expectedPolicyBody),
-					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "tags.%", "2"),
-					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "tags.First", "Mickey"),
-					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "tags.Second", "Mouse"),
-					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "timeout_in_minutes", "10"),
+					testAccCheckCloudFormationStackExists(resourceName, &stack),
+					resource.TestCheckResourceAttr(resourceName, "name", stackName),
+					resource.TestCheckResourceAttr(resourceName, "capabilities.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "capabilities.1328347040", "CAPABILITY_IAM"),
+					resource.TestCheckResourceAttr(resourceName, "disable_rollback", "false"),
+					resource.TestCheckResourceAttr(resourceName, "notification_arns.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.VpcCIDR", "10.0.0.0/16"),
+					resource.TestCheckResourceAttr(resourceName, "policy_body", expectedPolicyBody),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.First", "Mickey"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Second", "Mouse"),
+					resource.TestCheckResourceAttr(resourceName, "timeout_in_minutes", "10"),
 				),
 			},
 		},
@@ -165,6 +170,7 @@ func TestAccAWSCloudFormationStack_allAttributes(t *testing.T) {
 func TestAccAWSCloudFormationStack_withParams(t *testing.T) {
 	var stack cloudformation.Stack
 	stackName := fmt.Sprintf("tf-acc-test-with-params-%s", acctest.RandString(10))
+	resourceName := "aws_cloudformation_stack.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -174,13 +180,19 @@ func TestAccAWSCloudFormationStack_withParams(t *testing.T) {
 			{
 				Config: testAccAWSCloudFormationStackConfig_withParams(stackName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with_params", &stack),
+					testAccCheckCloudFormationStackExists(resourceName, &stack),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"on_failure", "parameters"},
 			},
 			{
 				Config: testAccAWSCloudFormationStackConfig_withParams_modified(stackName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with_params", &stack),
+					testAccCheckCloudFormationStackExists(resourceName, &stack),
 				),
 			},
 		},
@@ -191,6 +203,7 @@ func TestAccAWSCloudFormationStack_withParams(t *testing.T) {
 func TestAccAWSCloudFormationStack_withUrl_withParams(t *testing.T) {
 	var stack cloudformation.Stack
 	rName := fmt.Sprintf("tf-acc-test-with-url-and-params-%s", acctest.RandString(10))
+	resourceName := "aws_cloudformation_stack.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -200,13 +213,19 @@ func TestAccAWSCloudFormationStack_withUrl_withParams(t *testing.T) {
 			{
 				Config: testAccAWSCloudFormationStackConfig_templateUrl_withParams(rName, "tf-cf-stack.json", "11.0.0.0/16"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with-url-and-params", &stack),
+					testAccCheckCloudFormationStackExists(resourceName, &stack),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"on_failure", "parameters", "template_url"},
 			},
 			{
 				Config: testAccAWSCloudFormationStackConfig_templateUrl_withParams(rName, "tf-cf-stack.json", "13.0.0.0/16"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with-url-and-params", &stack),
+					testAccCheckCloudFormationStackExists(resourceName, &stack),
 				),
 			},
 		},
@@ -216,6 +235,7 @@ func TestAccAWSCloudFormationStack_withUrl_withParams(t *testing.T) {
 func TestAccAWSCloudFormationStack_withUrl_withParams_withYaml(t *testing.T) {
 	var stack cloudformation.Stack
 	rName := fmt.Sprintf("tf-acc-test-with-params-and-yaml-%s", acctest.RandString(10))
+	resourceName := "aws_cloudformation_stack.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -223,10 +243,16 @@ func TestAccAWSCloudFormationStack_withUrl_withParams_withYaml(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudFormationStackConfig_templateUrl_withParams_withYaml(rName, "tf-cf-stack.yaml", "13.0.0.0/16"),
+				Config: testAccAWSCloudFormationStackConfig_templateUrl_withParams_withYaml(rName, "tf-cf-stack.test", "13.0.0.0/16"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with-url-and-params-and-yaml", &stack),
+					testAccCheckCloudFormationStackExists(resourceName, &stack),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"on_failure", "parameters", "template_url"},
 			},
 		},
 	})
@@ -236,6 +262,7 @@ func TestAccAWSCloudFormationStack_withUrl_withParams_withYaml(t *testing.T) {
 func TestAccAWSCloudFormationStack_withUrl_withParams_noUpdate(t *testing.T) {
 	var stack cloudformation.Stack
 	rName := fmt.Sprintf("tf-acc-test-with-params-no-update-%s", acctest.RandString(10))
+	resourceName := "aws_cloudformation_stack.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -245,13 +272,19 @@ func TestAccAWSCloudFormationStack_withUrl_withParams_noUpdate(t *testing.T) {
 			{
 				Config: testAccAWSCloudFormationStackConfig_templateUrl_withParams(rName, "tf-cf-stack-1.json", "11.0.0.0/16"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with-url-and-params", &stack),
+					testAccCheckCloudFormationStackExists(resourceName, &stack),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"on_failure", "parameters", "template_url"},
 			},
 			{
 				Config: testAccAWSCloudFormationStackConfig_templateUrl_withParams(rName, "tf-cf-stack-2.json", "11.0.0.0/16"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with-url-and-params", &stack),
+					testAccCheckCloudFormationStackExists(resourceName, &stack),
 				),
 			},
 		},
@@ -336,7 +369,7 @@ func testAccCheckCloudFormationStackDisappears(stack *cloudformation.Stack) reso
 
 func testAccAWSCloudFormationStackConfig(stackName string) string {
 	return fmt.Sprintf(`
-resource "aws_cloudformation_stack" "network" {
+resource "aws_cloudformation_stack" "test" {
   name = "%[1]s"
 
   template_body = <<STACK
@@ -370,7 +403,7 @@ STACK
 
 func testAccAWSCloudFormationStackConfig_yaml(stackName string) string {
 	return fmt.Sprintf(`
-resource "aws_cloudformation_stack" "yaml" {
+resource "aws_cloudformation_stack" "test" {
   name = "%[1]s"
 
   template_body = <<STACK
@@ -398,7 +431,7 @@ STACK
 
 func testAccAWSCloudFormationStackConfig_defaultParams(stackName string) string {
 	return fmt.Sprintf(`
-resource "aws_cloudformation_stack" "asg-demo" {
+resource "aws_cloudformation_stack" "test" {
   name = "%[1]s"
 
   template_body = <<BODY
@@ -454,7 +487,7 @@ BODY
 }
 
 var testAccAWSCloudFormationStackConfig_allAttributesWithBodies_tpl = `
-resource "aws_cloudformation_stack" "full" {
+resource "aws_cloudformation_stack" "test" {
   name = "%[1]s"
   template_body = <<STACK
 {
@@ -567,7 +600,7 @@ func testAccAWSCloudFormationStackConfig_allAttributesWithBodies_modified(stackN
 }
 
 var tpl_testAccAWSCloudFormationStackConfig_withParams = `
-resource "aws_cloudformation_stack" "with_params" {
+resource "aws_cloudformation_stack" "test" {
   name = "%[1]s"
   parameters = {
     VpcCIDR = "%[2]s"
@@ -648,7 +681,7 @@ resource "aws_s3_bucket_object" "object" {
   source = "test-fixtures/cloudformation-template.json"
 }
 
-resource "aws_cloudformation_stack" "with-url-and-params" {
+resource "aws_cloudformation_stack" "test" {
   name = "%[1]s"
 
   parameters = {
@@ -697,7 +730,7 @@ resource "aws_s3_bucket_object" "object" {
   source = "test-fixtures/cloudformation-template.yaml"
 }
 
-resource "aws_cloudformation_stack" "with-url-and-params-and-yaml" {
+resource "aws_cloudformation_stack" "test" {
   name = "%[1]s"
 
   parameters = {

--- a/aws/resource_aws_cloudfront_origin_access_identity_test.go
+++ b/aws/resource_aws_cloudfront_origin_access_identity_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSCloudFrontOriginAccessIdentity_importBasic(t *testing.T) {
-	resourceName := "aws_cloudfront_origin_access_identity.origin_access_identity"
+func TestAccAWSCloudFrontOriginAccessIdentity_basic(t *testing.T) {
+	resourceName := "aws_cloudfront_origin_access_identity.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
@@ -21,8 +21,21 @@ func TestAccAWSCloudFrontOriginAccessIdentity_importBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSCloudFrontOriginAccessIdentityConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFrontOriginAccessIdentityExistence(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "comment", "some comment"),
+					resource.TestMatchResourceAttr(resourceName, "caller_reference", regexp.MustCompile(fmt.Sprintf("^%s", resource.UniqueIdPrefix))),
+					resource.TestMatchResourceAttr(resourceName,
+						"s3_canonical_user_id",
+						regexp.MustCompile("^[a-z0-9]+")),
+					resource.TestMatchResourceAttr(resourceName,
+						"cloudfront_access_identity_path",
+						regexp.MustCompile("^origin-access-identity/cloudfront/[A-Z0-9]+")),
+					resource.TestMatchResourceAttr(resourceName,
+						"iam_arn",
+						regexp.MustCompile("^arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity [A-Z0-9]+")),
+				),
 			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
@@ -32,34 +45,9 @@ func TestAccAWSCloudFrontOriginAccessIdentity_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccAWSCloudFrontOriginAccessIdentity_basic(t *testing.T) {
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFrontOriginAccessIdentityDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSCloudFrontOriginAccessIdentityConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFrontOriginAccessIdentityExistence("aws_cloudfront_origin_access_identity.origin_access_identity"),
-					resource.TestCheckResourceAttr("aws_cloudfront_origin_access_identity.origin_access_identity", "comment", "some comment"),
-					resource.TestMatchResourceAttr("aws_cloudfront_origin_access_identity.origin_access_identity", "caller_reference", regexp.MustCompile(fmt.Sprintf("^%s", resource.UniqueIdPrefix))),
-					resource.TestMatchResourceAttr("aws_cloudfront_origin_access_identity.origin_access_identity",
-						"s3_canonical_user_id",
-						regexp.MustCompile("^[a-z0-9]+")),
-					resource.TestMatchResourceAttr("aws_cloudfront_origin_access_identity.origin_access_identity",
-						"cloudfront_access_identity_path",
-						regexp.MustCompile("^origin-access-identity/cloudfront/[A-Z0-9]+")),
-					resource.TestMatchResourceAttr("aws_cloudfront_origin_access_identity.origin_access_identity",
-						"iam_arn",
-						regexp.MustCompile("^arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity [A-Z0-9]+")),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAWSCloudFrontOriginAccessIdentity_noComment(t *testing.T) {
+	resourceName := "aws_cloudfront_origin_access_identity.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
 		Providers:    testAccProviders,
@@ -68,18 +56,23 @@ func TestAccAWSCloudFrontOriginAccessIdentity_noComment(t *testing.T) {
 			{
 				Config: testAccAWSCloudFrontOriginAccessIdentityNoCommentConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFrontOriginAccessIdentityExistence("aws_cloudfront_origin_access_identity.origin_access_identity"),
-					resource.TestMatchResourceAttr("aws_cloudfront_origin_access_identity.origin_access_identity", "caller_reference", regexp.MustCompile(fmt.Sprintf("^%s", resource.UniqueIdPrefix))),
-					resource.TestMatchResourceAttr("aws_cloudfront_origin_access_identity.origin_access_identity",
+					testAccCheckCloudFrontOriginAccessIdentityExistence(resourceName),
+					resource.TestMatchResourceAttr(resourceName, "caller_reference", regexp.MustCompile(fmt.Sprintf("^%s", resource.UniqueIdPrefix))),
+					resource.TestMatchResourceAttr(resourceName,
 						"s3_canonical_user_id",
 						regexp.MustCompile("^[a-z0-9]+")),
-					resource.TestMatchResourceAttr("aws_cloudfront_origin_access_identity.origin_access_identity",
+					resource.TestMatchResourceAttr(resourceName,
 						"cloudfront_access_identity_path",
 						regexp.MustCompile("^origin-access-identity/cloudfront/[A-Z0-9]+")),
-					resource.TestMatchResourceAttr("aws_cloudfront_origin_access_identity.origin_access_identity",
+					resource.TestMatchResourceAttr(resourceName,
 						"iam_arn",
 						regexp.MustCompile("^arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity [A-Z0-9]+")),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -131,12 +124,12 @@ func testAccCheckCloudFrontOriginAccessIdentityExistence(r string) resource.Test
 }
 
 const testAccAWSCloudFrontOriginAccessIdentityConfig = `
-resource "aws_cloudfront_origin_access_identity" "origin_access_identity" {
+resource "aws_cloudfront_origin_access_identity" "test" {
 	comment = "some comment"
 }
 `
 
 const testAccAWSCloudFrontOriginAccessIdentityNoCommentConfig = `
-resource "aws_cloudfront_origin_access_identity" "origin_access_identity" {
+resource "aws_cloudfront_origin_access_identity" "test" {
 }
 `


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8944

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

* NOTE: `TestAccAWSCloud9EnvironmentEc2_basic` timeout failure is not new

```
$ make testacc TESTARGS="-run=TestAccAWSCloud9EnvironmentEc2_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSCloud9EnvironmentEc2_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCloud9EnvironmentEc2_basic
=== PAUSE TestAccAWSCloud9EnvironmentEc2_basic
=== RUN   TestAccAWSCloud9EnvironmentEc2_allFields
=== PAUSE TestAccAWSCloud9EnvironmentEc2_allFields
=== CONT  TestAccAWSCloud9EnvironmentEc2_basic
=== CONT  TestAccAWSCloud9EnvironmentEc2_allFields
--- PASS: TestAccAWSCloud9EnvironmentEc2_allFields (393.15s)
--- FAIL: TestAccAWSCloud9EnvironmentEc2_basic (670.74s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: timeout while waiting for state to become 'ready' (last state: 'connecting', timeout: 10m0s)
        
          on /var/folders/pd/swwl85ks1nvbfy2pht84q2m40000gq/T/tf-test817560255/main.tf line 2:
          (source code not available)
        
        
FAIL
FAIL    github.com/terraform-providers/terraform-provider-aws/aws       672.157s

make testacc TESTARGS="-run=TestAccAWSCloudFormationStack_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSCloudFormationStack_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCloudFormationStack_dataSource_basic
=== PAUSE TestAccAWSCloudFormationStack_dataSource_basic
=== RUN   TestAccAWSCloudFormationStack_dataSource_yaml
=== PAUSE TestAccAWSCloudFormationStack_dataSource_yaml
=== RUN   TestAccAWSCloudFormationStack_basic
=== PAUSE TestAccAWSCloudFormationStack_basic
=== RUN   TestAccAWSCloudFormationStack_disappears
=== PAUSE TestAccAWSCloudFormationStack_disappears
=== RUN   TestAccAWSCloudFormationStack_yaml
=== PAUSE TestAccAWSCloudFormationStack_yaml
=== RUN   TestAccAWSCloudFormationStack_defaultParams
=== PAUSE TestAccAWSCloudFormationStack_defaultParams
=== RUN   TestAccAWSCloudFormationStack_allAttributes
=== PAUSE TestAccAWSCloudFormationStack_allAttributes
=== RUN   TestAccAWSCloudFormationStack_withParams
=== PAUSE TestAccAWSCloudFormationStack_withParams
=== RUN   TestAccAWSCloudFormationStack_withUrl_withParams
=== PAUSE TestAccAWSCloudFormationStack_withUrl_withParams
=== RUN   TestAccAWSCloudFormationStack_withUrl_withParams_withYaml
=== PAUSE TestAccAWSCloudFormationStack_withUrl_withParams_withYaml
=== RUN   TestAccAWSCloudFormationStack_withUrl_withParams_noUpdate
=== PAUSE TestAccAWSCloudFormationStack_withUrl_withParams_noUpdate
=== CONT  TestAccAWSCloudFormationStack_dataSource_basic
=== CONT  TestAccAWSCloudFormationStack_withUrl_withParams_noUpdate
=== CONT  TestAccAWSCloudFormationStack_defaultParams
=== CONT  TestAccAWSCloudFormationStack_yaml
=== CONT  TestAccAWSCloudFormationStack_withParams
=== CONT  TestAccAWSCloudFormationStack_dataSource_yaml
=== CONT  TestAccAWSCloudFormationStack_basic
=== CONT  TestAccAWSCloudFormationStack_withUrl_withParams_withYaml
=== CONT  TestAccAWSCloudFormationStack_disappears
=== CONT  TestAccAWSCloudFormationStack_allAttributes
=== CONT  TestAccAWSCloudFormationStack_withUrl_withParams
--- PASS: TestAccAWSCloudFormationStack_yaml (79.62s)
--- PASS: TestAccAWSCloudFormationStack_basic (83.72s)
--- PASS: TestAccAWSCloudFormationStack_disappears (84.29s)
--- PASS: TestAccAWSCloudFormationStack_defaultParams (90.30s)
--- PASS: TestAccAWSCloudFormationStack_dataSource_yaml (93.53s)
--- PASS: TestAccAWSCloudFormationStack_dataSource_basic (94.87s)
--- PASS: TestAccAWSCloudFormationStack_allAttributes (117.79s)
--- PASS: TestAccAWSCloudFormationStack_withUrl_withParams_withYaml (135.99s)
--- PASS: TestAccAWSCloudFormationStack_withParams (151.23s)
--- PASS: TestAccAWSCloudFormationStack_withUrl_withParams_noUpdate (193.45s)
--- PASS: TestAccAWSCloudFormationStack_withUrl_withParams (235.66s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       237.198s

make testacc TESTARGS="-run=TestAccAWSCloudFrontOriginAccessIdentity_"    
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSCloudFrontOriginAccessIdentity_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCloudFrontOriginAccessIdentity_basic
=== PAUSE TestAccAWSCloudFrontOriginAccessIdentity_basic
=== RUN   TestAccAWSCloudFrontOriginAccessIdentity_noComment
=== PAUSE TestAccAWSCloudFrontOriginAccessIdentity_noComment
=== CONT  TestAccAWSCloudFrontOriginAccessIdentity_basic
=== CONT  TestAccAWSCloudFrontOriginAccessIdentity_noComment
--- PASS: TestAccAWSCloudFrontOriginAccessIdentity_basic (25.98s)
--- PASS: TestAccAWSCloudFrontOriginAccessIdentity_noComment (26.29s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       27.718s
```
