### PR TITLE
CloudWatch Logs destination does not support a lambda target

### DIFF
--- a/website/docs/r/cloudwatch_log_destination.html.markdown
+++ b/website/docs/r/cloudwatch_log_destination.html.markdown
@@ -25,7 +25,7 @@ The following arguments are supported:
 
 * `name` - (Required) A name for the log destination
 * `role_arn` - (Required) The ARN of an IAM role that grants Amazon CloudWatch Logs permissions to put data into the target
-* `target_arn` - (Required) The ARN of the target Amazon Kinesis stream or Amazon Lambda resource for the destination
+* `target_arn` - (Required) The ARN of the target Amazon Kinesis stream resource for the destination
 
 ## Attributes Reference
 


### PR DESCRIPTION
See [documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CrossAccountSubscriptions.html). I have tested this for myself and does not work with a lambda function. Remove invalid target_arn documentation.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
