### PR TITLE
Import test refactor for athena named queries

### DIFF
--- a/aws/resource_aws_athena_named_query_test.go
+++ b/aws/resource_aws_athena_named_query_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAccAWSAthenaNamedQuery_basic(t *testing.T) {
+	resourceName := "aws_athena_named_query.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -20,14 +22,21 @@ func TestAccAWSAthenaNamedQuery_basic(t *testing.T) {
 			{
 				Config: testAccAthenaNamedQueryConfig(acctest.RandInt(), acctest.RandString(5)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaNamedQueryExists("aws_athena_named_query.foo"),
+					testAccCheckAWSAthenaNamedQueryExists(resourceName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
 func TestAccAWSAthenaNamedQuery_withWorkGroup(t *testing.T) {
+	resourceName := "aws_athena_named_query.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -36,25 +45,9 @@ func TestAccAWSAthenaNamedQuery_withWorkGroup(t *testing.T) {
 			{
 				Config: testAccAthenaNamedWorkGroupQueryConfig(acctest.RandInt(), acctest.RandString(5)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAthenaNamedQueryExists("aws_athena_named_query.bar"),
+					testAccCheckAWSAthenaNamedQueryExists(resourceName),
 				),
 			},
-		},
-	})
-}
-
-func TestAccAWSAthenaNamedQuery_import(t *testing.T) {
-	resourceName := "aws_athena_named_query.foo"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSAthenaNamedQueryDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAthenaNamedQueryConfig(acctest.RandInt(), acctest.RandString(5)),
-			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
@@ -109,20 +102,20 @@ func testAccCheckAWSAthenaNamedQueryExists(name string) resource.TestCheckFunc {
 
 func testAccAthenaNamedQueryConfig(rInt int, rName string) string {
 	return fmt.Sprintf(`
-resource "aws_s3_bucket" "hoge" {
+resource "aws_s3_bucket" "test" {
   bucket        = "tf-athena-db-%s-%d"
   force_destroy = true
 }
 
-resource "aws_athena_database" "hoge" {
+resource "aws_athena_database" "test" {
   name   = "%s"
-  bucket = "${aws_s3_bucket.hoge.bucket}"
+  bucket = "${aws_s3_bucket.test.bucket}"
 }
 
-resource "aws_athena_named_query" "foo" {
+resource "aws_athena_named_query" "test" {
   name        = "tf-athena-named-query-%s"
-  database    = "${aws_athena_database.hoge.name}"
-  query       = "SELECT * FROM ${aws_athena_database.hoge.name} limit 10;"
+  database    = "${aws_athena_database.test.name}"
+  query       = "SELECT * FROM ${aws_athena_database.test.name} limit 10;"
   description = "tf test"
 }
 `, rName, rInt, rName, rName)
@@ -130,7 +123,7 @@ resource "aws_athena_named_query" "foo" {
 
 func testAccAthenaNamedWorkGroupQueryConfig(rInt int, rName string) string {
 	return fmt.Sprintf(`
-resource "aws_s3_bucket" "hoge" {
+resource "aws_s3_bucket" "test" {
   bucket        = "tf-athena-db-%s-%d"
   force_destroy = true
 }
@@ -139,16 +132,16 @@ resource "aws_athena_workgroup" "test" {
   name = "tf-athena-workgroup-%s-%d"
 }
 
-resource "aws_athena_database" "hoge" {
+resource "aws_athena_database" "test" {
   name   = "%s"
-  bucket = "${aws_s3_bucket.hoge.bucket}"
+  bucket = "${aws_s3_bucket.test.bucket}"
 }
 
-resource "aws_athena_named_query" "bar" {
+resource "aws_athena_named_query" "test" {
   name        = "tf-athena-named-query-%s"
   workgroup   = "${aws_athena_workgroup.test.id}"
-  database    = "${aws_athena_database.hoge.name}"
-  query       = "SELECT * FROM ${aws_athena_database.hoge.name} limit 10;"
+  database    = "${aws_athena_database.test.name}"
+  query       = "SELECT * FROM ${aws_athena_database.test.name} limit 10;"
   description = "tf test"
 }
 `, rName, rInt, rName, rInt, rName, rName)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8944

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSAthenaNamedQuery_"            ==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSAthenaNamedQuery_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSAthenaNamedQuery_basic
=== PAUSE TestAccAWSAthenaNamedQuery_basic
=== RUN   TestAccAWSAthenaNamedQuery_withWorkGroup
=== PAUSE TestAccAWSAthenaNamedQuery_withWorkGroup
=== CONT  TestAccAWSAthenaNamedQuery_basic
=== CONT  TestAccAWSAthenaNamedQuery_withWorkGroup
--- PASS: TestAccAWSAthenaNamedQuery_withWorkGroup (97.48s)
--- PASS: TestAccAWSAthenaNamedQuery_basic (97.58s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       99.021s
```
