### PR TITLE
Fix ses_identity_policy documentation

### DIFF
--- a/website/docs/r/ses_identity_policy.html.markdown
+++ b/website/docs/r/ses_identity_policy.html.markdown
@@ -19,7 +19,7 @@ resource "aws_ses_domain_identity" "example" {
 data "aws_iam_policy_document" "example" {
   statement {
     actions   = ["SES:SendEmail", "SES:SendRawEmail"]
-    resources = ["${aws_ses_domain_identity.test.arn}"]
+    resources = ["${aws_ses_domain_identity.example.arn}"]
 
     principals {
       identifiers = ["*"]
@@ -48,5 +48,5 @@ The following arguments are supported:
 SES Identity Policies can be imported using the identity and policy name, separated by a pipe character (`|`), e.g.
 
 ```
-$ terraform import aws_ses_identity_policy.test 'example.com|example'
+$ terraform import aws_ses_identity_policy.example 'example.com|example'
 ```


### PR DESCRIPTION
This is a tiny improvement to the documentation, I was reading it and found it to be outdated.
Examples refer to aws_ses_identity_policy.test. However, the actual resource is called aws_ses_identity_policy.example.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
