### PR TITLE
Make response_templates a map expression

### DIFF
--- a/website/docs/r/api_gateway_integration_response.html.markdown
+++ b/website/docs/r/api_gateway_integration_response.html.markdown
@@ -54,7 +54,7 @@ resource "aws_api_gateway_integration_response" "MyDemoIntegrationResponse" {
   status_code = "${aws_api_gateway_method_response.response_200.status_code}"
 
   # Transforms the backend JSON response to XML
-  response_templates {
+  response_templates = {
     "application/xml" = <<EOF
 #set($inputRoot = $input.path('$'))
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
Running the current example with terraform 0.12, the plan will fail with "Error: Invalid argument name".  

Changing to a map expression by adding the `=` fixes the error.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
