### PR TITLE
import test lintignores for API gateway resources

### DIFF
--- a/aws/resource_aws_api_gateway_account_test.go
+++ b/aws/resource_aws_api_gateway_account_test.go
@@ -11,34 +11,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSAPIGatewayAccount_importBasic(t *testing.T) {
-	resourceName := "aws_api_gateway_account.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSAPIGatewayAccountDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSAPIGatewayAccountConfig_empty,
-			},
-
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAWSAPIGatewayAccount_basic(t *testing.T) {
 	var conf apigateway.Account
 
 	rInt := acctest.RandInt()
 	firstName := fmt.Sprintf("tf_acc_api_gateway_cloudwatch_%d", rInt)
 	secondName := fmt.Sprintf("tf_acc_api_gateway_cloudwatch_modified_%d", rInt)
-
+	resourceName := "aws_api_gateway_account.test"
 	expectedRoleArn_first := regexp.MustCompile(":role/" + firstName + "$")
 	expectedRoleArn_second := regexp.MustCompile(":role/" + secondName + "$")
 
@@ -50,23 +29,29 @@ func TestAccAWSAPIGatewayAccount_basic(t *testing.T) {
 			{
 				Config: testAccAWSAPIGatewayAccountConfig_updated(firstName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayAccountExists("aws_api_gateway_account.test", &conf),
+					testAccCheckAWSAPIGatewayAccountExists(resourceName, &conf),
 					testAccCheckAWSAPIGatewayAccountCloudwatchRoleArn(&conf, expectedRoleArn_first),
-					resource.TestMatchResourceAttr("aws_api_gateway_account.test", "cloudwatch_role_arn", expectedRoleArn_first),
+					resource.TestMatchResourceAttr(resourceName, "cloudwatch_role_arn", expectedRoleArn_first),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"cloudwatch_role_arn"},
 			},
 			{
 				Config: testAccAWSAPIGatewayAccountConfig_updated2(secondName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayAccountExists("aws_api_gateway_account.test", &conf),
+					testAccCheckAWSAPIGatewayAccountExists(resourceName, &conf),
 					testAccCheckAWSAPIGatewayAccountCloudwatchRoleArn(&conf, expectedRoleArn_second),
-					resource.TestMatchResourceAttr("aws_api_gateway_account.test", "cloudwatch_role_arn", expectedRoleArn_second),
+					resource.TestMatchResourceAttr(resourceName, "cloudwatch_role_arn", expectedRoleArn_second),
 				),
 			},
 			{
 				Config: testAccAWSAPIGatewayAccountConfig_empty,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayAccountExists("aws_api_gateway_account.test", &conf),
+					testAccCheckAWSAPIGatewayAccountExists(resourceName, &conf),
 					testAccCheckAWSAPIGatewayAccountCloudwatchRoleArn(&conf, expectedRoleArn_second),
 				),
 			},

--- a/aws/resource_aws_api_gateway_client_certificate_test.go
+++ b/aws/resource_aws_api_gateway_client_certificate_test.go
@@ -13,6 +13,7 @@ import (
 
 func TestAccAWSAPIGatewayClientCertificate_basic(t *testing.T) {
 	var conf apigateway.ClientCertificate
+	resourceName := "aws_api_gateway_client_certificate.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -22,37 +23,21 @@ func TestAccAWSAPIGatewayClientCertificate_basic(t *testing.T) {
 			{
 				Config: testAccAWSAPIGatewayClientCertificateConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayClientCertificateExists("aws_api_gateway_client_certificate.cow", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_client_certificate.cow", "description", "Hello from TF acceptance test"),
+					testAccCheckAWSAPIGatewayClientCertificateExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "description", "Hello from TF acceptance test"),
 				),
 			},
-			{
-				Config: testAccAWSAPIGatewayClientCertificateConfig_basic_updated,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayClientCertificateExists("aws_api_gateway_client_certificate.cow", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_client_certificate.cow", "description", "Hello from TF acceptance test - updated"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSAPIGatewayClientCertificate_importBasic(t *testing.T) {
-	resourceName := "aws_api_gateway_client_certificate.cow"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSAPIGatewayClientCertificateDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSAPIGatewayClientCertificateConfig_basic,
-			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSAPIGatewayClientCertificateConfig_basic_updated,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayClientCertificateExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "description", "Hello from TF acceptance test - updated"),
+				),
 			},
 		},
 	})
@@ -116,13 +101,13 @@ func testAccCheckAWSAPIGatewayClientCertificateDestroy(s *terraform.State) error
 }
 
 const testAccAWSAPIGatewayClientCertificateConfig_basic = `
-resource "aws_api_gateway_client_certificate" "cow" {
+resource "aws_api_gateway_client_certificate" "test" {
   description = "Hello from TF acceptance test"
 }
 `
 
 const testAccAWSAPIGatewayClientCertificateConfig_basic_updated = `
-resource "aws_api_gateway_client_certificate" "cow" {
+resource "aws_api_gateway_client_certificate" "test" {
   description = "Hello from TF acceptance test - updated"
 }
 `

--- a/aws/resource_aws_api_gateway_documentation_part_test.go
+++ b/aws/resource_aws_api_gateway_documentation_part_test.go
@@ -38,6 +38,11 @@ func TestAccAWSAPIGatewayDocumentationPart_basic(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAWSAPIGatewayDocumentationPartConfig(apiName, strconv.Quote(uProperties)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayDocumentationPartExists(resourceName, &conf),
@@ -77,6 +82,11 @@ func TestAccAWSAPIGatewayDocumentationPart_method(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "properties", properties),
 					resource.TestCheckResourceAttrSet(resourceName, "rest_api_id"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSAPIGatewayDocumentationPartMethodConfig(apiName, strconv.Quote(uProperties)),
@@ -124,6 +134,11 @@ func TestAccAWSAPIGatewayDocumentationPart_responseHeader(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAWSAPIGatewayDocumentationPartResponseHeaderConfig(apiName, strconv.Quote(uProperties)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayDocumentationPartExists(resourceName, &conf),
@@ -136,39 +151,6 @@ func TestAccAWSAPIGatewayDocumentationPart_responseHeader(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "properties", uProperties),
 					resource.TestCheckResourceAttrSet(resourceName, "rest_api_id"),
 				),
-			},
-		},
-	})
-}
-
-func TestAccAWSAPIGatewayDocumentationPart_importBasic(t *testing.T) {
-	var conf apigateway.DocumentationPart
-
-	rString := acctest.RandString(8)
-	apiName := fmt.Sprintf("tf_acc_api_doc_part_import_%s", rString)
-	properties := `{"description":"Terraform Acceptance Test"}`
-
-	resourceName := "aws_api_gateway_documentation_part.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSAPIGatewayDocumentationPartDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSAPIGatewayDocumentationPartConfig(apiName, strconv.Quote(properties)),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayDocumentationPartExists(resourceName, &conf),
-					resource.TestCheckResourceAttr(resourceName, "location.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "location.0.type", "API"),
-					resource.TestCheckResourceAttr(resourceName, "properties", properties),
-					resource.TestCheckResourceAttrSet(resourceName, "rest_api_id"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})

--- a/aws/resource_aws_api_gateway_documentation_version_test.go
+++ b/aws/resource_aws_api_gateway_documentation_version_test.go
@@ -33,6 +33,11 @@ func TestAccAWSAPIGatewayDocumentationVersion_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "rest_api_id"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -64,6 +69,11 @@ func TestAccAWSAPIGatewayDocumentationVersion_allFields(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAWSAPIGatewayDocumentationVersionAllFieldsConfig(version, apiName, stageName, uDescription),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayDocumentationVersionExists(resourceName, &conf),
@@ -71,56 +81,6 @@ func TestAccAWSAPIGatewayDocumentationVersion_allFields(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", uDescription),
 					resource.TestCheckResourceAttrSet(resourceName, "rest_api_id"),
 				),
-			},
-		},
-	})
-}
-
-func TestAccAWSAPIGatewayDocumentationVersion_importBasic(t *testing.T) {
-	rString := acctest.RandString(8)
-	version := fmt.Sprintf("tf_acc_version_import_%s", rString)
-	apiName := fmt.Sprintf("tf_acc_api_doc_version_import_%s", rString)
-
-	resourceName := "aws_api_gateway_documentation_version.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSAPIGatewayDocumentationVersionDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSAPIGatewayDocumentationVersionBasicConfig(version, apiName),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSAPIGatewayDocumentationVersion_importAllFields(t *testing.T) {
-	rString := acctest.RandString(8)
-	version := fmt.Sprintf("tf_acc_version_import_af_%s", rString)
-	apiName := fmt.Sprintf("tf_acc_api_doc_version_import_af_%s", rString)
-	stageName := fmt.Sprintf("tf_acc_stage_%s", rString)
-	description := fmt.Sprintf("Tf Acc Test description %s", rString)
-
-	resourceName := "aws_api_gateway_documentation_version.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSAPIGatewayDocumentationVersionDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSAPIGatewayDocumentationVersionAllFieldsConfig(version, apiName, stageName, description),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})

--- a/aws/resource_aws_api_gateway_usage_plan_test.go
+++ b/aws/resource_aws_api_gateway_usage_plan_test.go
@@ -12,9 +12,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSAPIGatewayUsagePlan_importBasic(t *testing.T) {
-	resourceName := "aws_api_gateway_usage_plan.main"
-	rName := acctest.RandString(10)
+func TestAccAWSAPIGatewayUsagePlan_basic(t *testing.T) {
+	var conf apigateway.UsagePlan
+	name := acctest.RandString(10)
+	updatedName := acctest.RandString(10)
+	resourceName := "aws_api_gateway_usage_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -22,49 +24,31 @@ func TestAccAWSAPIGatewayUsagePlan_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSAPIGatewayUsagePlanDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSApiGatewayUsagePlanBasicConfig(rName),
+				Config: testAccAWSApiGatewayUsagePlanBasicConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+				),
 			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-		},
-	})
-}
-
-func TestAccAWSAPIGatewayUsagePlan_basic(t *testing.T) {
-	var conf apigateway.UsagePlan
-	name := acctest.RandString(10)
-	updatedName := acctest.RandString(10)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSAPIGatewayUsagePlanDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSApiGatewayUsagePlanBasicConfig(name),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayUsagePlanExists("aws_api_gateway_usage_plan.main", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "name", name),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "description", ""),
-				),
-			},
 			{
 				Config: testAccAWSApiGatewayUsagePlanBasicUpdatedConfig(updatedName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "name", updatedName),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
 				),
 			},
 			{
 				Config: testAccAWSApiGatewayUsagePlanBasicConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayUsagePlanExists("aws_api_gateway_usage_plan.main", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "name", name),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "description", ""),
+					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
 				),
 			},
 		},
@@ -74,6 +58,7 @@ func TestAccAWSAPIGatewayUsagePlan_basic(t *testing.T) {
 func TestAccAWSAPIGatewayUsagePlan_description(t *testing.T) {
 	var conf apigateway.UsagePlan
 	name := acctest.RandString(10)
+	resourceName := "aws_api_gateway_usage_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -83,35 +68,40 @@ func TestAccAWSAPIGatewayUsagePlan_description(t *testing.T) {
 			{
 				Config: testAccAWSApiGatewayUsagePlanBasicConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayUsagePlanExists("aws_api_gateway_usage_plan.main", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "description", ""),
+					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSApiGatewayUsagePlanDescriptionConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayUsagePlanExists("aws_api_gateway_usage_plan.main", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "description", "This is a description"),
+					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "description", "This is a description"),
 				),
 			},
 			{
 				Config: testAccAWSApiGatewayUsagePlanDescriptionUpdatedConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "description", "This is a new description"),
+					resource.TestCheckResourceAttr(resourceName, "description", "This is a new description"),
 				),
 			},
 			{
 				Config: testAccAWSApiGatewayUsagePlanDescriptionConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayUsagePlanExists("aws_api_gateway_usage_plan.main", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "description", "This is a description"),
+					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "description", "This is a description"),
 				),
 			},
 			{
 				Config: testAccAWSApiGatewayUsagePlanBasicConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayUsagePlanExists("aws_api_gateway_usage_plan.main", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "description", ""),
+					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
 				),
 			},
 		},
@@ -121,6 +111,7 @@ func TestAccAWSAPIGatewayUsagePlan_description(t *testing.T) {
 func TestAccAWSAPIGatewayUsagePlan_productCode(t *testing.T) {
 	var conf apigateway.UsagePlan
 	name := acctest.RandString(10)
+	resourceName := "aws_api_gateway_usage_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -130,35 +121,40 @@ func TestAccAWSAPIGatewayUsagePlan_productCode(t *testing.T) {
 			{
 				Config: testAccAWSApiGatewayUsagePlanBasicConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayUsagePlanExists("aws_api_gateway_usage_plan.main", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "product_code", ""),
+					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "product_code", ""),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSApiGatewayUsagePlanProductCodeConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayUsagePlanExists("aws_api_gateway_usage_plan.main", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "product_code", "MYCODE"),
+					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "product_code", "MYCODE"),
 				),
 			},
 			{
 				Config: testAccAWSApiGatewayUsagePlanProductCodeUpdatedConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "product_code", "MYCODE2"),
+					resource.TestCheckResourceAttr(resourceName, "product_code", "MYCODE2"),
 				),
 			},
 			{
 				Config: testAccAWSApiGatewayUsagePlanProductCodeConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayUsagePlanExists("aws_api_gateway_usage_plan.main", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "product_code", "MYCODE"),
+					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "product_code", "MYCODE"),
 				),
 			},
 			{
 				Config: testAccAWSApiGatewayUsagePlanBasicConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayUsagePlanExists("aws_api_gateway_usage_plan.main", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "product_code", ""),
+					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "product_code", ""),
 				),
 			},
 		},
@@ -168,6 +164,7 @@ func TestAccAWSAPIGatewayUsagePlan_productCode(t *testing.T) {
 func TestAccAWSAPIGatewayUsagePlan_throttling(t *testing.T) {
 	var conf apigateway.UsagePlan
 	name := acctest.RandString(10)
+	resourceName := "aws_api_gateway_usage_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -177,35 +174,40 @@ func TestAccAWSAPIGatewayUsagePlan_throttling(t *testing.T) {
 			{
 				Config: testAccAWSApiGatewayUsagePlanBasicConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayUsagePlanExists("aws_api_gateway_usage_plan.main", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "name", name),
-					resource.TestCheckNoResourceAttr("aws_api_gateway_usage_plan.main", "throttle_settings"),
+					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckNoResourceAttr(resourceName, "throttle_settings"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSApiGatewayUsagePlanThrottlingConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayUsagePlanExists("aws_api_gateway_usage_plan.main", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "name", name),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "throttle_settings.4173790118.burst_limit", "2"),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "throttle_settings.4173790118.rate_limit", "5"),
+					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "throttle_settings.4173790118.burst_limit", "2"),
+					resource.TestCheckResourceAttr(resourceName, "throttle_settings.4173790118.rate_limit", "5"),
 				),
 			},
 			{
 				Config: testAccAWSApiGatewayUsagePlanThrottlingModifiedConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayUsagePlanExists("aws_api_gateway_usage_plan.main", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "name", name),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "throttle_settings.1779463053.burst_limit", "3"),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "throttle_settings.1779463053.rate_limit", "6"),
+					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "throttle_settings.1779463053.burst_limit", "3"),
+					resource.TestCheckResourceAttr(resourceName, "throttle_settings.1779463053.rate_limit", "6"),
 				),
 			},
 			{
 				Config: testAccAWSApiGatewayUsagePlanBasicConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayUsagePlanExists("aws_api_gateway_usage_plan.main", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "name", name),
-					resource.TestCheckNoResourceAttr("aws_api_gateway_usage_plan.main", "throttle_settings"),
+					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckNoResourceAttr(resourceName, "throttle_settings"),
 				),
 			},
 		},
@@ -216,6 +218,7 @@ func TestAccAWSAPIGatewayUsagePlan_throttling(t *testing.T) {
 func TestAccAWSAPIGatewayUsagePlan_throttlingInitialRateLimit(t *testing.T) {
 	var conf apigateway.UsagePlan
 	name := acctest.RandString(10)
+	resourceName := "aws_api_gateway_usage_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -225,9 +228,14 @@ func TestAccAWSAPIGatewayUsagePlan_throttlingInitialRateLimit(t *testing.T) {
 			{
 				Config: testAccAWSApiGatewayUsagePlanThrottlingConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayUsagePlanExists("aws_api_gateway_usage_plan.main", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "throttle_settings.4173790118.rate_limit", "5"),
+					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "throttle_settings.4173790118.rate_limit", "5"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -236,6 +244,7 @@ func TestAccAWSAPIGatewayUsagePlan_throttlingInitialRateLimit(t *testing.T) {
 func TestAccAWSAPIGatewayUsagePlan_quota(t *testing.T) {
 	var conf apigateway.UsagePlan
 	name := acctest.RandString(10)
+	resourceName := "aws_api_gateway_usage_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -245,37 +254,42 @@ func TestAccAWSAPIGatewayUsagePlan_quota(t *testing.T) {
 			{
 				Config: testAccAWSApiGatewayUsagePlanBasicConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayUsagePlanExists("aws_api_gateway_usage_plan.main", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "name", name),
-					resource.TestCheckNoResourceAttr("aws_api_gateway_usage_plan.main", "quota_settings"),
+					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckNoResourceAttr(resourceName, "quota_settings"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSApiGatewayUsagePlanQuotaConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayUsagePlanExists("aws_api_gateway_usage_plan.main", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "name", name),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "quota_settings.1956747625.limit", "100"),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "quota_settings.1956747625.offset", "6"),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "quota_settings.1956747625.period", "WEEK"),
+					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "quota_settings.1956747625.limit", "100"),
+					resource.TestCheckResourceAttr(resourceName, "quota_settings.1956747625.offset", "6"),
+					resource.TestCheckResourceAttr(resourceName, "quota_settings.1956747625.period", "WEEK"),
 				),
 			},
 			{
 				Config: testAccAWSApiGatewayUsagePlanQuotaModifiedConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayUsagePlanExists("aws_api_gateway_usage_plan.main", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "name", name),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "quota_settings.3909168194.limit", "200"),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "quota_settings.3909168194.offset", "20"),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "quota_settings.3909168194.period", "MONTH"),
+					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "quota_settings.3909168194.limit", "200"),
+					resource.TestCheckResourceAttr(resourceName, "quota_settings.3909168194.offset", "20"),
+					resource.TestCheckResourceAttr(resourceName, "quota_settings.3909168194.period", "MONTH"),
 				),
 			},
 			{
 				Config: testAccAWSApiGatewayUsagePlanBasicConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayUsagePlanExists("aws_api_gateway_usage_plan.main", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "name", name),
-					resource.TestCheckNoResourceAttr("aws_api_gateway_usage_plan.main", "quota_settings"),
+					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckNoResourceAttr(resourceName, "quota_settings"),
 				),
 			},
 		},
@@ -285,6 +299,7 @@ func TestAccAWSAPIGatewayUsagePlan_quota(t *testing.T) {
 func TestAccAWSAPIGatewayUsagePlan_apiStages(t *testing.T) {
 	var conf apigateway.UsagePlan
 	name := acctest.RandString(10)
+	resourceName := "aws_api_gateway_usage_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -296,44 +311,49 @@ func TestAccAWSAPIGatewayUsagePlan_apiStages(t *testing.T) {
 			{
 				Config: testAccAWSApiGatewayUsagePlanApiStagesConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayUsagePlanExists("aws_api_gateway_usage_plan.main", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "name", name),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "api_stages.0.stage", "test"),
+					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "api_stages.0.stage", "test"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			// Handle api stages removal
 			{
 				Config: testAccAWSApiGatewayUsagePlanBasicConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayUsagePlanExists("aws_api_gateway_usage_plan.main", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "name", name),
-					resource.TestCheckNoResourceAttr("aws_api_gateway_usage_plan.main", "api_stages"),
+					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckNoResourceAttr(resourceName, "api_stages"),
 				),
 			},
 			// Handle api stages additions
 			{
 				Config: testAccAWSApiGatewayUsagePlanApiStagesConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayUsagePlanExists("aws_api_gateway_usage_plan.main", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "name", name),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "api_stages.0.stage", "test"),
+					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "api_stages.0.stage", "test"),
 				),
 			},
 			// Handle api stages updates
 			{
 				Config: testAccAWSApiGatewayUsagePlanApiStagesModifiedConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayUsagePlanExists("aws_api_gateway_usage_plan.main", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "name", name),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "api_stages.0.stage", "foo"),
+					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "api_stages.0.stage", "foo"),
 				),
 			},
 			{
 				Config: testAccAWSApiGatewayUsagePlanBasicConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayUsagePlanExists("aws_api_gateway_usage_plan.main", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "name", name),
-					resource.TestCheckNoResourceAttr("aws_api_gateway_usage_plan.main", "api_stages"),
+					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckNoResourceAttr(resourceName, "api_stages"),
 				),
 			},
 		},
@@ -469,7 +489,7 @@ resource "aws_api_gateway_deployment" "foo" {
 
 func testAccAWSApiGatewayUsagePlanBasicConfig(rName string) string {
 	return fmt.Sprintf(testAccAWSAPIGatewayUsagePlanConfig+`
-resource "aws_api_gateway_usage_plan" "main" {
+resource "aws_api_gateway_usage_plan" "test" {
   name = "%s"
 }
 `, rName)
@@ -477,7 +497,7 @@ resource "aws_api_gateway_usage_plan" "main" {
 
 func testAccAWSApiGatewayUsagePlanDescriptionConfig(rName string) string {
 	return fmt.Sprintf(testAccAWSAPIGatewayUsagePlanConfig+`
-resource "aws_api_gateway_usage_plan" "main" {
+resource "aws_api_gateway_usage_plan" "test" {
   name        = "%s"
   description = "This is a description"
 }
@@ -486,7 +506,7 @@ resource "aws_api_gateway_usage_plan" "main" {
 
 func testAccAWSApiGatewayUsagePlanDescriptionUpdatedConfig(rName string) string {
 	return fmt.Sprintf(testAccAWSAPIGatewayUsagePlanConfig+`
-resource "aws_api_gateway_usage_plan" "main" {
+resource "aws_api_gateway_usage_plan" "test" {
   name        = "%s"
   description = "This is a new description"
 }
@@ -495,7 +515,7 @@ resource "aws_api_gateway_usage_plan" "main" {
 
 func testAccAWSApiGatewayUsagePlanProductCodeConfig(rName string) string {
 	return fmt.Sprintf(testAccAWSAPIGatewayUsagePlanConfig+`
-resource "aws_api_gateway_usage_plan" "main" {
+resource "aws_api_gateway_usage_plan" "test" {
   name         = "%s"
   product_code = "MYCODE"
 }
@@ -504,7 +524,7 @@ resource "aws_api_gateway_usage_plan" "main" {
 
 func testAccAWSApiGatewayUsagePlanProductCodeUpdatedConfig(rName string) string {
 	return fmt.Sprintf(testAccAWSAPIGatewayUsagePlanConfig+`
-resource "aws_api_gateway_usage_plan" "main" {
+resource "aws_api_gateway_usage_plan" "test" {
   name         = "%s"
   product_code = "MYCODE2"
 }
@@ -513,7 +533,7 @@ resource "aws_api_gateway_usage_plan" "main" {
 
 func testAccAWSApiGatewayUsagePlanBasicUpdatedConfig(rName string) string {
 	return fmt.Sprintf(testAccAWSAPIGatewayUsagePlanConfig+`
-resource "aws_api_gateway_usage_plan" "main" {
+resource "aws_api_gateway_usage_plan" "test" {
   name = "%s"
 }
 `, rName)
@@ -521,7 +541,7 @@ resource "aws_api_gateway_usage_plan" "main" {
 
 func testAccAWSApiGatewayUsagePlanThrottlingConfig(rName string) string {
 	return fmt.Sprintf(testAccAWSAPIGatewayUsagePlanConfig+`
-resource "aws_api_gateway_usage_plan" "main" {
+resource "aws_api_gateway_usage_plan" "test" {
   name        = "%s"
 
   throttle_settings {
@@ -534,7 +554,7 @@ resource "aws_api_gateway_usage_plan" "main" {
 
 func testAccAWSApiGatewayUsagePlanThrottlingModifiedConfig(rName string) string {
 	return fmt.Sprintf(testAccAWSAPIGatewayUsagePlanConfig+`
-resource "aws_api_gateway_usage_plan" "main" {
+resource "aws_api_gateway_usage_plan" "test" {
   name        = "%s"
 
   throttle_settings {
@@ -547,7 +567,7 @@ resource "aws_api_gateway_usage_plan" "main" {
 
 func testAccAWSApiGatewayUsagePlanQuotaConfig(rName string) string {
 	return fmt.Sprintf(testAccAWSAPIGatewayUsagePlanConfig+`
-resource "aws_api_gateway_usage_plan" "main" {
+resource "aws_api_gateway_usage_plan" "test" {
   name        = "%s"
 
   quota_settings {
@@ -561,7 +581,7 @@ resource "aws_api_gateway_usage_plan" "main" {
 
 func testAccAWSApiGatewayUsagePlanQuotaModifiedConfig(rName string) string {
 	return fmt.Sprintf(testAccAWSAPIGatewayUsagePlanConfig+`
-resource "aws_api_gateway_usage_plan" "main" {
+resource "aws_api_gateway_usage_plan" "test" {
   name        = "%s"
 
   quota_settings {
@@ -575,7 +595,7 @@ resource "aws_api_gateway_usage_plan" "main" {
 
 func testAccAWSApiGatewayUsagePlanApiStagesConfig(rName string) string {
 	return fmt.Sprintf(testAccAWSAPIGatewayUsagePlanConfig+`
-resource "aws_api_gateway_usage_plan" "main" {
+resource "aws_api_gateway_usage_plan" "test" {
   name        = "%s"
 
   api_stages {
@@ -588,7 +608,7 @@ resource "aws_api_gateway_usage_plan" "main" {
 
 func testAccAWSApiGatewayUsagePlanApiStagesModifiedConfig(rName string) string {
 	return fmt.Sprintf(testAccAWSAPIGatewayUsagePlanConfig+`
-resource "aws_api_gateway_usage_plan" "main" {
+resource "aws_api_gateway_usage_plan" "test" {
   name        = "%s"
 
   api_stages {

--- a/aws/resource_aws_api_gateway_vpc_link_test.go
+++ b/aws/resource_aws_api_gateway_vpc_link_test.go
@@ -60,35 +60,6 @@ func testSweepAPIGatewayVpcLinks(region string) error {
 
 func TestAccAWSAPIGatewayVpcLink_basic(t *testing.T) {
 	rName := acctest.RandString(5)
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsAPIGatewayVpcLinkDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAPIGatewayVpcLinkConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsAPIGatewayVpcLinkExists("aws_api_gateway_vpc_link.test"),
-					resource.TestCheckResourceAttr("aws_api_gateway_vpc_link.test", "name", fmt.Sprintf("tf-apigateway-%s", rName)),
-					resource.TestCheckResourceAttr("aws_api_gateway_vpc_link.test", "description", "test"),
-					resource.TestCheckResourceAttr("aws_api_gateway_vpc_link.test", "target_arns.#", "1"),
-				),
-			},
-			{
-				Config: testAccAPIGatewayVpcLinkConfig_Update(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsAPIGatewayVpcLinkExists("aws_api_gateway_vpc_link.test"),
-					resource.TestCheckResourceAttr("aws_api_gateway_vpc_link.test", "name", fmt.Sprintf("tf-apigateway-update-%s", rName)),
-					resource.TestCheckResourceAttr("aws_api_gateway_vpc_link.test", "description", "test update"),
-					resource.TestCheckResourceAttr("aws_api_gateway_vpc_link.test", "target_arns.#", "1"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSAPIGatewayVpcLink_importBasic(t *testing.T) {
-	rName := acctest.RandString(5)
 	resourceName := "aws_api_gateway_vpc_link.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -98,11 +69,26 @@ func TestAccAWSAPIGatewayVpcLink_importBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAPIGatewayVpcLinkConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAPIGatewayVpcLinkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("tf-apigateway-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "target_arns.#", "1"),
+				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAPIGatewayVpcLinkConfig_Update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAPIGatewayVpcLinkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("tf-apigateway-update-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "description", "test update"),
+					resource.TestCheckResourceAttr(resourceName, "target_arns.#", "1"),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8944

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSAPIGatewayAccount_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSAPIGatewayAccount_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSAPIGatewayAccount_basic
=== PAUSE TestAccAWSAPIGatewayAccount_basic
=== CONT  TestAccAWSAPIGatewayAccount_basic
--- PASS: TestAccAWSAPIGatewayAccount_basic (135.55s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       137.072s

make testacc TESTARGS="-run=TestAccAWSAPIGatewayClientCertificate_"   ==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSAPIGatewayClientCertificate_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSAPIGatewayClientCertificate_basic
=== PAUSE TestAccAWSAPIGatewayClientCertificate_basic
=== CONT  TestAccAWSAPIGatewayClientCertificate_basic
--- PASS: TestAccAWSAPIGatewayClientCertificate_basic (44.69s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       46.141s
make testacc TESTARGS="-run=TestAccAWSAPIGatewayDocumentationPart_"  ==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSAPIGatewayDocumentationPart_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSAPIGatewayDocumentationPart_basic
=== PAUSE TestAccAWSAPIGatewayDocumentationPart_basic
=== RUN   TestAccAWSAPIGatewayDocumentationPart_method
=== PAUSE TestAccAWSAPIGatewayDocumentationPart_method
=== RUN   TestAccAWSAPIGatewayDocumentationPart_responseHeader
=== PAUSE TestAccAWSAPIGatewayDocumentationPart_responseHeader
=== CONT  TestAccAWSAPIGatewayDocumentationPart_basic
=== CONT  TestAccAWSAPIGatewayDocumentationPart_responseHeader
=== CONT  TestAccAWSAPIGatewayDocumentationPart_method
--- PASS: TestAccAWSAPIGatewayDocumentationPart_method (50.75s)
--- PASS: TestAccAWSAPIGatewayDocumentationPart_basic (81.91s)
--- PASS: TestAccAWSAPIGatewayDocumentationPart_responseHeader (146.99s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       148.380s

make testacc TESTARGS="-run=TestAccAWSAPIGatewayDocumentationVersion_"     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSAPIGatewayDocumentationVersion_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSAPIGatewayDocumentationVersion_basic
=== PAUSE TestAccAWSAPIGatewayDocumentationVersion_basic
=== RUN   TestAccAWSAPIGatewayDocumentationVersion_allFields
=== PAUSE TestAccAWSAPIGatewayDocumentationVersion_allFields
=== CONT  TestAccAWSAPIGatewayDocumentationVersion_basic
=== CONT  TestAccAWSAPIGatewayDocumentationVersion_allFields
--- PASS: TestAccAWSAPIGatewayDocumentationVersion_basic (69.25s)
--- PASS: TestAccAWSAPIGatewayDocumentationVersion_allFields (100.08s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       101.626s

make testacc TESTARGS="-run=TestAccAWSAPIGatewayUsagePlan_"          ==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSAPIGatewayUsagePlan_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSAPIGatewayUsagePlan_basic
=== PAUSE TestAccAWSAPIGatewayUsagePlan_basic
=== RUN   TestAccAWSAPIGatewayUsagePlan_description
=== PAUSE TestAccAWSAPIGatewayUsagePlan_description
=== RUN   TestAccAWSAPIGatewayUsagePlan_productCode
=== PAUSE TestAccAWSAPIGatewayUsagePlan_productCode
=== RUN   TestAccAWSAPIGatewayUsagePlan_throttling
=== PAUSE TestAccAWSAPIGatewayUsagePlan_throttling
=== RUN   TestAccAWSAPIGatewayUsagePlan_throttlingInitialRateLimit
=== PAUSE TestAccAWSAPIGatewayUsagePlan_throttlingInitialRateLimit
=== RUN   TestAccAWSAPIGatewayUsagePlan_quota
=== PAUSE TestAccAWSAPIGatewayUsagePlan_quota
=== RUN   TestAccAWSAPIGatewayUsagePlan_apiStages
=== PAUSE TestAccAWSAPIGatewayUsagePlan_apiStages
=== CONT  TestAccAWSAPIGatewayUsagePlan_basic
=== CONT  TestAccAWSAPIGatewayUsagePlan_apiStages
=== CONT  TestAccAWSAPIGatewayUsagePlan_throttling
=== CONT  TestAccAWSAPIGatewayUsagePlan_quota
=== CONT  TestAccAWSAPIGatewayUsagePlan_throttlingInitialRateLimit
=== CONT  TestAccAWSAPIGatewayUsagePlan_productCode
=== CONT  TestAccAWSAPIGatewayUsagePlan_description
--- PASS: TestAccAWSAPIGatewayUsagePlan_throttlingInitialRateLimit (88.78s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_basic (121.68s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_apiStages (243.98s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_productCode (282.32s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_throttling (343.19s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_description (362.30s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_quota (408.78s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       410.338s

make testacc TESTARGS="-run=TestAccAWSAPIGatewayVpcLink_"     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSAPIGatewayVpcLink_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSAPIGatewayVpcLink_basic
=== PAUSE TestAccAWSAPIGatewayVpcLink_basic
=== CONT  TestAccAWSAPIGatewayVpcLink_basic
--- PASS: TestAccAWSAPIGatewayVpcLink_basic (802.11s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       803.544s
```
