### PR TITLE
set users for data_iam_group

### DIFF
--- a/aws/data_source_aws_iam_group.go
+++ b/aws/data_source_aws_iam_group.go
@@ -30,6 +30,55 @@ func dataSourceAwsIAMGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"users": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"path": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"user_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"user_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"create_date": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"password_last_used": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"permissions_boundary": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"permissions_boundary_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"permissions_boundary_arn": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"tags": tagsSchemaComputed(),
+					},
+				},
+			},
 		},
 	}
 }
@@ -59,5 +108,37 @@ func dataSourceAwsIAMGroupRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("path", group.Path)
 	d.Set("group_id", group.GroupId)
 
+	if err := d.Set("users", getUsers(resp.Users)); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+func getUsers(u []*iam.User) interface{} {
+	s := []interface{}{}
+	for _, v := range u {
+		user := map[string]interface{}{
+			"path":        aws.StringValue(v.Path),
+			"user_name":   aws.StringValue(v.UserName),
+			"user_id":     aws.StringValue(v.UserId),
+			"arn":         aws.StringValue(v.Arn),
+			"create_date": aws.TimeValue(v.CreateDate).String(),
+			"tags":        tagsToMapIAM(v.Tags),
+		}
+
+		if v.PasswordLastUsed != nil {
+			user["password_last_used"] = aws.TimeValue(v.PasswordLastUsed).String()
+		}
+
+		if v.PermissionsBoundary != nil {
+			pb := map[string]interface{}{
+				"permissions_boundary_type": aws.StringValue(v.PermissionsBoundary.PermissionsBoundaryType),
+				"permissions_boundary_arn":  aws.StringValue(v.PermissionsBoundary.PermissionsBoundaryArn),
+			}
+			user["permissions_boundary"] = pb
+		}
+		s = append(s, user)
+	}
+	return s
 }

--- a/aws/data_source_aws_iam_group_test.go
+++ b/aws/data_source_aws_iam_group_test.go
@@ -29,6 +29,25 @@ func TestAccAWSDataSourceIAMGroup_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSDataSourceIAMGroup_users(t *testing.T) {
+	groupName := fmt.Sprintf("test-datasource-user-%d", acctest.RandInt())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsIAMGroupUsersConfig(groupName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.aws_iam_group.test", "group_id"),
+					resource.TestCheckResourceAttr("data.aws_iam_group.test", "group_name", groupName),
+					resource.TestCheckResourceAttr("data.aws_iam_group.test", "users.#", "2"),
+				),
+			},
+		},
+	})
+}
+
 func testAccAwsIAMGroupConfig(name string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_group" "group" {
@@ -40,4 +59,37 @@ data "aws_iam_group" "test" {
   group_name = "${aws_iam_group.group.name}"
 }
 `, name)
+}
+
+func testAccAwsIAMGroupUsersConfig(name string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_user" "user_one" {
+  name = "%s_user_one"
+  path = "/"
+}
+
+resource "aws_iam_user" "user_two" {
+  name = "%s_user_two"
+  path = "/"
+}
+
+resource "aws_iam_group" "group" {
+  name = "%s"
+  path = "/"
+}
+
+resource "aws_iam_group_membership" "group" {
+  name = "%s"
+  group = "${aws_iam_group.group.name}"
+
+  users = [
+    "${aws_iam_user.user_one.name}",
+    "${aws_iam_user.user_two.name}",
+  ]
+}
+
+data "aws_iam_group" "test" {
+  group_name = "${aws_iam_group_membership.group.name}"
+}
+`, name, name, name, name)
 }

--- a/website/docs/d/iam_group.html.markdown
+++ b/website/docs/d/iam_group.html.markdown
@@ -30,3 +30,17 @@ data "aws_iam_group" "example" {
 * `path` - The path to the group.
 
 * `group_id` - The stable and unique string identifying the group.
+
+* `users` - The list of users in the group.
+  * `path` - The path to the user.
+  * `user_name` - The friendly name identifying the user.
+  * `user_id` - The stable and unique string identifying the user.
+  * `arn` - The Amazon Resource Name (ARN) that identifies the user.
+  * `create_date` - The date and time the user was created.
+  * `password_last_used` - The date and time when the user's password was last used to sign in to an AWS website.
+  * `permissions_boundary` - The ARN of the policy used to set the permissions boundary for the user.
+    * `permissions_boundary_type` - The permissions boundary usage type for an entity.
+    * `permissions_boundary_arn` - The ARN of the policy used to set the permissions boundary for the user or role.
+  * `tags` - Tags associated to the user.
+    * `tags.#.key` - The key name of the tag.
+    * `tags.#.value` - The value of the tag.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1154

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add `users` property to iam_group data source.
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDataSourceIAMGroup_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDataSourceIAMGroup_ -timeout 120m
go: finding golang.org/x/net latest
=== RUN   TestAccAWSDataSourceIAMGroup_basic
=== PAUSE TestAccAWSDataSourceIAMGroup_basic
=== RUN   TestAccAWSDataSourceIAMGroup_users
=== PAUSE TestAccAWSDataSourceIAMGroup_users
=== CONT  TestAccAWSDataSourceIAMGroup_basic
=== CONT  TestAccAWSDataSourceIAMGroup_users
--- PASS: TestAccAWSDataSourceIAMGroup_basic (15.43s)
--- PASS: TestAccAWSDataSourceIAMGroup_users (16.68s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	16.741s
```
