### PR TITLE
resource/aws_network_interface: Add the mac_address attribute

### DIFF
--- a/aws/resource_aws_network_interface.go
+++ b/aws/resource_aws_network_interface.go
@@ -34,6 +34,11 @@ func resourceAwsNetworkInterface() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"mac_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"private_ip": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -178,6 +183,7 @@ func resourceAwsNetworkInterfaceRead(d *schema.ResourceData, meta interface{}) e
 
 	d.Set("description", eni.Description)
 	d.Set("private_dns_name", eni.PrivateDnsName)
+	d.Set("mac_address", eni.MacAddress)
 	d.Set("private_ip", eni.PrivateIpAddress)
 
 	if err := d.Set("private_ips", flattenNetworkInterfacesPrivateIPAddresses(eni.PrivateIpAddresses)); err != nil {

--- a/aws/resource_aws_network_interface_test.go
+++ b/aws/resource_aws_network_interface_test.go
@@ -85,6 +85,8 @@ func TestAccAWSENI_basic(t *testing.T) {
 						"aws_network_interface.bar", "private_ips.#", "1"),
 					resource.TestCheckResourceAttrSet(
 						"aws_network_interface.bar", "private_dns_name"),
+					resource.TestCheckResourceAttrSet(
+						"aws_network_interface.bar", "mac_address"),
 					resource.TestCheckResourceAttr(
 						"aws_network_interface.bar", "tags.Name", "bar_interface"),
 					resource.TestCheckResourceAttr(
@@ -376,6 +378,10 @@ func testAccCheckAWSENIAttributes(conf *ec2.NetworkInterface) resource.TestCheck
 
 		if *conf.PrivateDnsName != "ip-172-16-10-100.us-west-2.compute.internal" {
 			return fmt.Errorf("expected private dns name to be ip-172-16-10-100.us-west-2.compute.internal, but was %s", *conf.PrivateDnsName)
+		}
+
+		if len(*conf.MacAddress) == 0 {
+			return fmt.Errorf("expected mac_address to be set")
 		}
 
 		if !*conf.SourceDestCheck {

--- a/website/docs/r/network_interface.markdown
+++ b/website/docs/r/network_interface.markdown
@@ -48,6 +48,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the network interface.
 * `subnet_id` - Subnet ID the ENI is in.
+* `mac_address` - The MAC address of the network interface.
+* `private_dns_name` - The private DNS name of the network interface (IPv4).
 * `description` - A description for the network interface.
 * `private_ips` - List of private IPs assigned to the ENI.
 * `security_groups` - List of security groups attached to the ENI.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->
### Summary
Adds a `mac_address` attribute to the `aws_network_interface` resource, which is already exposed by the `aws_network_interface` data source. This is useful when used in conjunction with `cloud-init` in cases when there is a need to identify an attached interface by its MAC address. For example, when using `netplan` to add specific routes to a network interface on EC2 instance creation.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #6863

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_network_interface: Add `mac_address` attribute.
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run "TestAccAWSENI_.*"'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run "TestAccAWSENI_.*" -timeout 120m
=== RUN   TestAccAWSENI_basic
=== PAUSE TestAccAWSENI_basic
=== RUN   TestAccAWSENI_disappears
=== PAUSE TestAccAWSENI_disappears
=== RUN   TestAccAWSENI_updatedDescription
=== PAUSE TestAccAWSENI_updatedDescription
=== RUN   TestAccAWSENI_attached
=== PAUSE TestAccAWSENI_attached
=== RUN   TestAccAWSENI_ignoreExternalAttachment
=== PAUSE TestAccAWSENI_ignoreExternalAttachment
=== RUN   TestAccAWSENI_sourceDestCheck
=== PAUSE TestAccAWSENI_sourceDestCheck
=== RUN   TestAccAWSENI_computedIPs
=== PAUSE TestAccAWSENI_computedIPs
=== RUN   TestAccAWSENI_PrivateIpsCount
=== PAUSE TestAccAWSENI_PrivateIpsCount
=== CONT  TestAccAWSENI_basic
=== CONT  TestAccAWSENI_sourceDestCheck
=== CONT  TestAccAWSENI_computedIPs
=== CONT  TestAccAWSENI_PrivateIpsCount
=== CONT  TestAccAWSENI_attached
=== CONT  TestAccAWSENI_updatedDescription
=== CONT  TestAccAWSENI_disappears
=== CONT  TestAccAWSENI_ignoreExternalAttachment
--- PASS: TestAccAWSENI_computedIPs (63.40s)
--- PASS: TestAccAWSENI_sourceDestCheck (64.07s)
--- PASS: TestAccAWSENI_disappears (64.33s)
--- PASS: TestAccAWSENI_basic (70.01s)
--- PASS: TestAccAWSENI_updatedDescription (115.33s)
--- PASS: TestAccAWSENI_ignoreExternalAttachment (146.42s)
--- PASS: TestAccAWSENI_PrivateIpsCount (178.06s)
--- PASS: TestAccAWSENI_attached (292.23s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       292.251s
```
