### PR TITLE
tests/resource/aws_instance: Allow sweeper to enable API termination

### DIFF
--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -1233,7 +1233,12 @@ func resourceAwsInstanceDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
 	err := awsTerminateInstance(conn, d.Id(), d.Timeout(schema.TimeoutDelete))
-	return err
+
+	if err != nil {
+		return fmt.Errorf("error terminating EC2 Instance (%s): %s", d.Id(), err)
+	}
+
+	return nil
 }
 
 // InstanceStateRefreshFunc returns a resource.StateRefreshFunc that is used to watch
@@ -1967,7 +1972,7 @@ func awsTerminateInstance(conn *ec2.EC2, id string, timeout time.Duration) error
 		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidInstanceID.NotFound" {
 			return nil
 		}
-		return fmt.Errorf("Error terminating instance: %s", err)
+		return err
 	}
 
 	return waitForInstanceDeletion(conn, id, timeout)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously, if a dangling EC2 Instance with API termination protection was left, the sweeper would skip it but subnet deletion would fail:

```
2019/10/25 12:33:07 [INFO] Terminating instance: i-0408dc7bb6fefcb34
2019/10/25 12:33:07 [ERROR] Error terminating EC2 Instance (i-0408dc7bb6fefcb34): Error terminating instance: OperationNotPermitted: The instance 'i-0408dc7bb6fefcb34' may not be terminated. Modify its 'disableApiTermination' instance attribute and try again.
	status code: 400, request id: 6fa7d582-3a5d-4de3-93c5-c6073f96fb95
...
[02:24:57] :	 [Step 2/4] 2019/10/25 02:24:57 [ERR] error running (aws_internet_gateway): Error deleting Subnet (subnet-03eff7ed143053793): DependencyViolation: The subnet 'subnet-03eff7ed143053793' has dependencies and cannot be deleted.
[02:24:57] :	 [Step 2/4] 	status code: 400, request id: 872f5342-3eb8-4eaa-9b20-5b0509aa12c3
```

This change allows the sweeper to modify that EC2 Instance attribute and properly delete these:

```console
$ go test ./aws -v -timeout=10h -sweep=us-west-2 -sweep-run=aws_instance
...
2019/10/25 12:43:47 [INFO] Terminating EC2 Instance: i-0408dc7bb6fefcb34
2019/10/25 12:43:47 [INFO] Terminating instance: i-0408dc7bb6fefcb34
2019/10/25 12:43:48 [INFO] Enabling API Termination on EC2 Instance: i-0408dc7bb6fefcb34
2019/10/25 12:43:48 [INFO] Terminating instance: i-0408dc7bb6fefcb34
```
