### PR TITLE
Add custom cert requirement for protocol version

### DIFF
--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -498,7 +498,8 @@ The arguments of `geo_restriction` are:
     this, `acm_certificate_arn`, or `cloudfront_default_certificate`.
 
   * `minimum_protocol_version` - The minimum version of the SSL protocol that
-    you want CloudFront to use for HTTPS connections. One of `SSLv3`, `TLSv1`,
+    you want CloudFront to use for HTTPS connections. Can only be set if 
+    `cloudfront_default_certificate = false`. One of `SSLv3`, `TLSv1`,
     `TLSv1_2016`, `TLSv1.1_2016` or `TLSv1.2_2018`. Default: `TLSv1`. **NOTE**:
     If you are using a custom certificate (specified with `acm_certificate_arn`
     or `iam_certificate_id`), and have specified `sni-only` in


### PR DESCRIPTION
We tried setting this value multiple times, and kept getting changes on the plan:

```
~ aws_cloudfront_distribution.iavform_s3_distribution
    viewer_certificate.0.minimum_protocol_version:   "TLSv1" => "TLSv1.2_2018"

Plan: 0 to add, 1 to change, 0 to destroy.
```

According to the [cloudfront docs](https://docs.aws.amazon.com/cli/latest/reference/cloudfront/create-distribution.html):

> If you specify true for CloudFrontDefaultCertificate , CloudFront automatically sets the security policy to TLSv1 regardless of the value that you specify for MinimumProtocolVersion

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


```release-note
NONE
```
