### PR TITLE
r/aws_backup_plan: Correctly handle changes to recovery_point_tags

### DIFF
--- a/aws/resource_aws_backup_plan_test.go
+++ b/aws/resource_aws_backup_plan_test.go
@@ -34,6 +34,7 @@ func TestAccAwsBackupPlan_basic(t *testing.T) {
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "target_vault_name", rName),
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "schedule", "cron(0 12 * * ? *)"),
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "lifecycle.#", "0"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "recovery_point_tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttrSet(resourceName, "version"),
 				),
@@ -114,10 +115,12 @@ func TestAccAwsBackupPlan_withRules(t *testing.T) {
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule1Name, "target_vault_name", rName),
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule1Name, "schedule", "cron(0 12 * * ? *)"),
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule1Name, "lifecycle.#", "0"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule1Name, "recovery_point_tags.%", "0"),
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule2Name, "rule_name", rule2Name),
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule2Name, "target_vault_name", rName),
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule2Name, "schedule", "cron(0 6 * * ? *)"),
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule2Name, "lifecycle.#", "0"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule2Name, "recovery_point_tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
@@ -131,14 +134,17 @@ func TestAccAwsBackupPlan_withRules(t *testing.T) {
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule1Name, "target_vault_name", rName),
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule1Name, "schedule", "cron(0 6 * * ? *)"),
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule1Name, "lifecycle.#", "0"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule1Name, "recovery_point_tags.%", "0"),
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule2Name, "rule_name", rule2Name),
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule2Name, "target_vault_name", rName),
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule2Name, "schedule", "cron(0 12 * * ? *)"),
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule2Name, "lifecycle.#", "0"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule2Name, "recovery_point_tags.%", "0"),
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule3Name, "rule_name", rule3Name),
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule3Name, "target_vault_name", rName),
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule3Name, "schedule", "cron(0 18 * * ? *)"),
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule3Name, "lifecycle.#", "0"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule3Name, "recovery_point_tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
@@ -152,6 +158,7 @@ func TestAccAwsBackupPlan_withRules(t *testing.T) {
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "target_vault_name", rName),
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "schedule", "cron(0 12 * * ? *)"),
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "lifecycle.#", "0"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "recovery_point_tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
@@ -180,6 +187,7 @@ func TestAccAwsBackupPlan_withLifecycle(t *testing.T) {
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "lifecycle.#", "1"),
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "lifecycle.0.cold_storage_after", "7"),
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "lifecycle.0.delete_after", "0"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "recovery_point_tags.%", "0"),
 				),
 			},
 			{
@@ -192,6 +200,7 @@ func TestAccAwsBackupPlan_withLifecycle(t *testing.T) {
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "lifecycle.#", "1"),
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "lifecycle.0.cold_storage_after", "0"),
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "lifecycle.0.delete_after", "120"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "recovery_point_tags.%", "0"),
 				),
 			},
 			{
@@ -204,6 +213,7 @@ func TestAccAwsBackupPlan_withLifecycle(t *testing.T) {
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "lifecycle.#", "1"),
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "lifecycle.0.cold_storage_after", "30"),
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "lifecycle.0.delete_after", "180"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "recovery_point_tags.%", "0"),
 				),
 			},
 			{
@@ -214,6 +224,70 @@ func TestAccAwsBackupPlan_withLifecycle(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "rule_name", rName),
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "lifecycle.#", "0"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "recovery_point_tags.%", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAwsBackupPlan_withRecoveryPointTags(t *testing.T) {
+	var plan backup.GetBackupPlanOutput
+	ruleNameMap := map[string]string{}
+	resourceName := "aws_backup_plan.test"
+	rName := fmt.Sprintf("tf-testacc-backup-%s", acctest.RandStringFromCharSet(14, acctest.CharSetAlphaNum))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsBackupPlanDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsBackupPlanConfig_recoveryPointTags(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBackupPlanExists(resourceName, &plan, &ruleNameMap),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "rule_name", rName),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "target_vault_name", rName),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "schedule", "cron(0 12 * * ? *)"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "lifecycle.#", "0"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "recovery_point_tags.%", "3"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "recovery_point_tags.Name", rName),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "recovery_point_tags.Key1", "Value1"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "recovery_point_tags.Key2", "Value2a"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				Config: testAccAwsBackupPlanConfig_recoveryPointTagsUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBackupPlanExists(resourceName, &plan, &ruleNameMap),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "rule_name", rName),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "target_vault_name", rName),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "schedule", "cron(0 12 * * ? *)"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "lifecycle.#", "0"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "recovery_point_tags.%", "3"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "recovery_point_tags.Name", rName),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "recovery_point_tags.Key2", "Value2b"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "recovery_point_tags.Key3", "Value3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				Config: testAccAwsBackupPlanConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBackupPlanExists(resourceName, &plan, &ruleNameMap),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "rule_name", rName),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "target_vault_name", rName),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "schedule", "cron(0 12 * * ? *)"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "lifecycle.#", "0"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "recovery_point_tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 		},
@@ -498,6 +572,54 @@ resource "aws_backup_plan" "test" {
     lifecycle {
       cold_storage_after = 30
       delete_after       = 180
+    }
+  }
+}
+`, rName)
+}
+
+func testAccAwsBackupPlanConfig_recoveryPointTags(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_backup_vault" "test" {
+  name = %[1]q
+}
+
+resource "aws_backup_plan" "test" {
+  name = %[1]q
+
+  rule {
+    rule_name         = %[1]q
+    target_vault_name = "${aws_backup_vault.test.name}"
+    schedule          = "cron(0 12 * * ? *)"
+
+    recovery_point_tags = {
+      Name = %[1]q
+      Key1 = "Value1"
+      Key2 = "Value2a"
+    }
+  }
+}
+`, rName)
+}
+
+func testAccAwsBackupPlanConfig_recoveryPointTagsUpdated(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_backup_vault" "test" {
+  name = %[1]q
+}
+
+resource "aws_backup_plan" "test" {
+  name = %[1]q
+
+  rule {
+    rule_name         = %[1]q
+    target_vault_name = "${aws_backup_vault.test.name}"
+    schedule          = "cron(0 12 * * ? *)"
+
+    recovery_point_tags = {
+      Name = %[1]q
+      Key2 = "Value2b"
+      Key3 = "Value3"
     }
   }
 }

--- a/aws/resource_aws_backup_plan_test.go
+++ b/aws/resource_aws_backup_plan_test.go
@@ -14,7 +14,9 @@ import (
 
 func TestAccAwsBackupPlan_basic(t *testing.T) {
 	var plan backup.GetBackupPlanOutput
-	rInt := acctest.RandInt()
+	ruleNameMap := map[string]string{}
+	resourceName := "aws_backup_plan.test"
+	rName := fmt.Sprintf("tf-testacc-backup-%s", acctest.RandStringFromCharSet(14, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
@@ -22,13 +24,18 @@ func TestAccAwsBackupPlan_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAwsBackupPlanDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBackupPlanConfig(rInt),
+				Config: testAccAwsBackupPlanConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsBackupPlanExists("aws_backup_plan.test", &plan),
-					testAccMatchResourceAttrRegionalARN("aws_backup_plan.test", "arn", "backup", regexp.MustCompile(`backup-plan:.+`)),
-					resource.TestCheckResourceAttrSet("aws_backup_plan.test", "version"),
-					resource.TestCheckResourceAttr("aws_backup_plan.test", "rule.#", "1"),
-					resource.TestCheckNoResourceAttr("aws_backup_plan.test", "rule.712706565.lifecycle.#"),
+					testAccCheckAwsBackupPlanExists(resourceName, &plan, &ruleNameMap),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "backup", regexp.MustCompile(`backup-plan:.+`)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "rule_name", rName),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "target_vault_name", rName),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "schedule", "cron(0 12 * * ? *)"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "lifecycle.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "version"),
 				),
 			},
 		},
@@ -37,7 +44,9 @@ func TestAccAwsBackupPlan_basic(t *testing.T) {
 
 func TestAccAwsBackupPlan_withTags(t *testing.T) {
 	var plan backup.GetBackupPlanOutput
-	rInt := acctest.RandInt()
+	ruleNameMap := map[string]string{}
+	resourceName := "aws_backup_plan.test"
+	rName := fmt.Sprintf("tf-testacc-backup-%s", acctest.RandStringFromCharSet(14, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
@@ -45,28 +54,36 @@ func TestAccAwsBackupPlan_withTags(t *testing.T) {
 		CheckDestroy: testAccCheckAwsBackupPlanDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBackupPlanWithTag(rInt),
+				Config: testAccAwsBackupPlanConfig_tags(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsBackupPlanExists("aws_backup_plan.test", &plan),
-					resource.TestCheckResourceAttr("aws_backup_plan.test", "tags.%", "1"),
-					resource.TestCheckResourceAttr("aws_backup_plan.test", "tags.env", "test"),
+					testAccCheckAwsBackupPlanExists(resourceName, &plan, &ruleNameMap),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "Value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "Value2a"),
 				),
 			},
 			{
-				Config: testAccBackupPlanWithTags(rInt),
+				Config: testAccAwsBackupPlanConfig_tagsUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsBackupPlanExists("aws_backup_plan.test", &plan),
-					resource.TestCheckResourceAttr("aws_backup_plan.test", "tags.%", "2"),
-					resource.TestCheckResourceAttr("aws_backup_plan.test", "tags.env", "test"),
-					resource.TestCheckResourceAttr("aws_backup_plan.test", "tags.app", "widget"),
+					testAccCheckAwsBackupPlanExists(resourceName, &plan, &ruleNameMap),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "Value2b"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key3", "Value3"),
 				),
 			},
 			{
-				Config: testAccBackupPlanWithTag(rInt),
+				Config: testAccAwsBackupPlanConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsBackupPlanExists("aws_backup_plan.test", &plan),
-					resource.TestCheckResourceAttr("aws_backup_plan.test", "tags.%", "1"),
-					resource.TestCheckResourceAttr("aws_backup_plan.test", "tags.env", "test"),
+					testAccCheckAwsBackupPlanExists(resourceName, &plan, &ruleNameMap),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 		},
@@ -75,7 +92,12 @@ func TestAccAwsBackupPlan_withTags(t *testing.T) {
 
 func TestAccAwsBackupPlan_withRules(t *testing.T) {
 	var plan backup.GetBackupPlanOutput
-	rInt := acctest.RandInt()
+	ruleNameMap := map[string]string{}
+	resourceName := "aws_backup_plan.test"
+	rName := fmt.Sprintf("tf-testacc-backup-%s", acctest.RandStringFromCharSet(14, acctest.CharSetAlphaNum))
+	rule1Name := fmt.Sprintf("%s_1", rName)
+	rule2Name := fmt.Sprintf("%s_2", rName)
+	rule3Name := fmt.Sprintf("%s_3", rName)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
@@ -83,64 +105,54 @@ func TestAccAwsBackupPlan_withRules(t *testing.T) {
 		CheckDestroy: testAccCheckAwsBackupPlanDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBackupPlanWithRules(rInt),
+				Config: testAccAwsBackupPlanConfig_twoRules(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsBackupPlanExists("aws_backup_plan.test", &plan),
-					resource.TestCheckResourceAttr("aws_backup_plan.test", "rule.#", "2"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAwsBackupPlan_withRuleRemove(t *testing.T) {
-	var plan backup.GetBackupPlanOutput
-	rInt := acctest.RandInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsBackupPlanDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccBackupPlanWithRules(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsBackupPlanExists("aws_backup_plan.test", &plan),
-					resource.TestCheckResourceAttr("aws_backup_plan.test", "rule.#", "2"),
+					testAccCheckAwsBackupPlanExists(resourceName, &plan, &ruleNameMap),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "2"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule1Name, "rule_name", rule1Name),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule1Name, "target_vault_name", rName),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule1Name, "schedule", "cron(0 12 * * ? *)"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule1Name, "lifecycle.#", "0"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule2Name, "rule_name", rule2Name),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule2Name, "target_vault_name", rName),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule2Name, "schedule", "cron(0 6 * * ? *)"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule2Name, "lifecycle.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
-				Config: testAccBackupPlanConfig(rInt),
+				Config: testAccAwsBackupPlanConfig_threeRules(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsBackupPlanExists("aws_backup_plan.test", &plan),
-					resource.TestCheckResourceAttr("aws_backup_plan.test", "rule.#", "1"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAwsBackupPlan_withRuleAdd(t *testing.T) {
-	var plan backup.GetBackupPlanOutput
-	rInt := acctest.RandInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsBackupPlanDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccBackupPlanConfig(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsBackupPlanExists("aws_backup_plan.test", &plan),
-					resource.TestCheckResourceAttr("aws_backup_plan.test", "rule.#", "1"),
+					testAccCheckAwsBackupPlanExists(resourceName, &plan, &ruleNameMap),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "3"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule1Name, "rule_name", rule1Name),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule1Name, "target_vault_name", rName),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule1Name, "schedule", "cron(0 6 * * ? *)"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule1Name, "lifecycle.#", "0"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule2Name, "rule_name", rule2Name),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule2Name, "target_vault_name", rName),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule2Name, "schedule", "cron(0 12 * * ? *)"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule2Name, "lifecycle.#", "0"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule3Name, "rule_name", rule3Name),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule3Name, "target_vault_name", rName),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule3Name, "schedule", "cron(0 18 * * ? *)"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule3Name, "lifecycle.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
-				Config: testAccBackupPlanWithRules(rInt),
+				Config: testAccAwsBackupPlanConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsBackupPlanExists("aws_backup_plan.test", &plan),
-					resource.TestCheckResourceAttr("aws_backup_plan.test", "rule.#", "2"),
+					testAccCheckAwsBackupPlanExists(resourceName, &plan, &ruleNameMap),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "rule_name", rName),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "target_vault_name", rName),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "schedule", "cron(0 12 * * ? *)"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "lifecycle.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 		},
@@ -149,7 +161,9 @@ func TestAccAwsBackupPlan_withRuleAdd(t *testing.T) {
 
 func TestAccAwsBackupPlan_withLifecycle(t *testing.T) {
 	var plan backup.GetBackupPlanOutput
-	rStr := "lifecycle_policy"
+	ruleNameMap := map[string]string{}
+	resourceName := "aws_backup_plan.test"
+	rName := fmt.Sprintf("tf-testacc-backup-%s", acctest.RandStringFromCharSet(14, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
@@ -157,54 +171,49 @@ func TestAccAwsBackupPlan_withLifecycle(t *testing.T) {
 		CheckDestroy: testAccCheckAwsBackupPlanDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBackupPlanWithLifecycle(rStr),
+				Config: testAccAwsBackupPlanConfig_lifecycleColdStorageAfterOnly(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsBackupPlanExists("aws_backup_plan.test", &plan),
-					resource.TestCheckResourceAttr("aws_backup_plan.test", "rule.1028372010.lifecycle.#", "1"),
+					testAccCheckAwsBackupPlanExists(resourceName, &plan, &ruleNameMap),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "rule_name", rName),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "lifecycle.#", "1"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "lifecycle.0.cold_storage_after", "7"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "lifecycle.0.delete_after", "0"),
 				),
 			},
-		},
-	})
-}
-
-func TestAccAwsBackupPlan_withLifecycleDeleteAfterOnly(t *testing.T) {
-	var plan backup.GetBackupPlanOutput
-	rStr := "lifecycle_policy_two"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsBackupPlanDestroy,
-		Steps: []resource.TestStep{
 			{
-				Config: testAccBackupPlanWithLifecycleDeleteAfterOnly(rStr),
+				Config: testAccAwsBackupPlanConfig_lifecycleDeleteAfterOnly(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsBackupPlanExists("aws_backup_plan.test", &plan),
-					resource.TestCheckResourceAttr("aws_backup_plan.test", "rule.2156287050.lifecycle.#", "1"),
-					resource.TestCheckResourceAttr("aws_backup_plan.test", "rule.2156287050.lifecycle.0.delete_after", "7"),
-					resource.TestCheckResourceAttr("aws_backup_plan.test", "rule.2156287050.lifecycle.0.cold_storage_after", "0"),
+					testAccCheckAwsBackupPlanExists(resourceName, &plan, &ruleNameMap),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "rule_name", rName),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "lifecycle.#", "1"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "lifecycle.0.cold_storage_after", "0"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "lifecycle.0.delete_after", "120"),
 				),
 			},
-		},
-	})
-}
-
-func TestAccAwsBackupPlan_withLifecycleColdStorageAfterOnly(t *testing.T) {
-	var plan backup.GetBackupPlanOutput
-	rStr := "lifecycle_policy_three"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsBackupPlanDestroy,
-		Steps: []resource.TestStep{
 			{
-				Config: testAccBackupPlanWithLifecycleColdStorageAfterOnly(rStr),
+				Config: testAccAwsBackupPlanConfig_lifecycleColdStorageAfterAndDeleteAfter(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsBackupPlanExists("aws_backup_plan.test", &plan),
-					resource.TestCheckResourceAttr("aws_backup_plan.test", "rule.1300859512.lifecycle.#", "1"),
-					resource.TestCheckResourceAttr("aws_backup_plan.test", "rule.1300859512.lifecycle.0.delete_after", "0"),
-					resource.TestCheckResourceAttr("aws_backup_plan.test", "rule.1300859512.lifecycle.0.cold_storage_after", "7"),
+					testAccCheckAwsBackupPlanExists(resourceName, &plan, &ruleNameMap),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "rule_name", rName),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "lifecycle.#", "1"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "lifecycle.0.cold_storage_after", "30"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "lifecycle.0.delete_after", "180"),
+				),
+			},
+			{
+				Config: testAccAwsBackupPlanConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBackupPlanExists(resourceName, &plan, &ruleNameMap),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "rule_name", rName),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "lifecycle.#", "0"),
 				),
 			},
 		},
@@ -213,7 +222,9 @@ func TestAccAwsBackupPlan_withLifecycleColdStorageAfterOnly(t *testing.T) {
 
 func TestAccAwsBackupPlan_disappears(t *testing.T) {
 	var plan backup.GetBackupPlanOutput
-	rInt := acctest.RandInt()
+	ruleNameMap := map[string]string{}
+	resourceName := "aws_backup_plan.test"
+	rName := fmt.Sprintf("tf-testacc-backup-%s", acctest.RandStringFromCharSet(14, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
@@ -221,9 +232,9 @@ func TestAccAwsBackupPlan_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAwsBackupPlanDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBackupPlanConfig(rInt),
+				Config: testAccAwsBackupPlanConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsBackupPlanExists("aws_backup_plan.test", &plan),
+					testAccCheckAwsBackupPlanExists(resourceName, &plan, &ruleNameMap),
 					testAccCheckAwsBackupPlanDisappears(&plan),
 				),
 				ExpectNonEmptyPlan: true,
@@ -269,186 +280,226 @@ func testAccCheckAwsBackupPlanDisappears(backupPlan *backup.GetBackupPlanOutput)
 	}
 }
 
-func testAccCheckAwsBackupPlanExists(name string, plan *backup.GetBackupPlanOutput) resource.TestCheckFunc {
+func testAccCheckAwsBackupPlanExists(name string, plan *backup.GetBackupPlanOutput, ruleNameMap *map[string]string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		conn := testAccProvider.Meta().(*AWSClient).backupconn
 
+		rs, ok := s.RootModule().Resources[name]
 		if !ok {
 			return fmt.Errorf("Not found: %s", name)
 		}
-
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("Resource ID is not set")
+			return fmt.Errorf("No ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*AWSClient).backupconn
-
-		input := &backup.GetBackupPlanInput{
+		output, err := conn.GetBackupPlan(&backup.GetBackupPlanInput{
 			BackupPlanId: aws.String(rs.Primary.ID),
-		}
-
-		output, err := conn.GetBackupPlan(input)
-
+		})
 		if err != nil {
 			return err
 		}
 
 		*plan = *output
 
+		// Build map of rule name to hash value.
+		re := regexp.MustCompile(`^rule\.(\d+)\.rule_name$`)
+		for k, v := range rs.Primary.Attributes {
+			matches := re.FindStringSubmatch(k)
+			if matches != nil {
+				(*ruleNameMap)[v] = matches[1]
+			}
+		}
+
 		return nil
 	}
 }
 
-func testAccBackupPlanConfig(randInt int) string {
+func testAccCheckAwsBackupPlanRuleAttr(name string, ruleNameMap *map[string]string, ruleName, key, value string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		return resource.TestCheckResourceAttr(name, fmt.Sprintf("rule.%s.%s", (*ruleNameMap)[ruleName], key), value)(s)
+	}
+}
+
+func testAccAwsBackupPlanConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_backup_vault" "test" {
-  name = "tf_acc_test_backup_vault_%[1]d"
+  name = %[1]q
 }
 
 resource "aws_backup_plan" "test" {
-  name = "tf_acc_test_backup_plan_%[1]d"
+  name = %[1]q
 
   rule {
-    rule_name         = "tf_acc_test_backup_rule_%[1]d"
+    rule_name         = %[1]q
     target_vault_name = "${aws_backup_vault.test.name}"
     schedule          = "cron(0 12 * * ? *)"
   }
 }
-`, randInt)
+`, rName)
 }
 
-func testAccBackupPlanWithTag(randInt int) string {
+func testAccAwsBackupPlanConfig_tags(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_backup_vault" "test" {
-  name = "tf_acc_test_backup_vault_%[1]d"
+  name = %[1]q
 }
 
 resource "aws_backup_plan" "test" {
-  name = "tf_acc_test_backup_plan_%[1]d"
+  name = %[1]q
 
   rule {
-    rule_name         = "tf_acc_test_backup_rule_%[1]d"
-    target_vault_name = "${aws_backup_vault.test.name}"
-    schedule          = "cron(0 12 * * ? *)"
-  }
-
-  tags = {
-    env = "test"
-  }
-}
-`, randInt)
-}
-
-func testAccBackupPlanWithTags(randInt int) string {
-	return fmt.Sprintf(`
-resource "aws_backup_vault" "test" {
-  name = "tf_acc_test_backup_vault_%[1]d"
-}
-
-resource "aws_backup_plan" "test" {
-  name = "tf_acc_test_backup_plan_%[1]d"
-
-  rule {
-    rule_name         = "tf_acc_test_backup_rule_%[1]d"
+    rule_name         = %[1]q
     target_vault_name = "${aws_backup_vault.test.name}"
     schedule          = "cron(0 12 * * ? *)"
   }
 
   tags = {
-    env = "test"
-    app = "widget"
+    Name = %[1]q
+    Key1 = "Value1"
+    Key2 = "Value2a"
   }
 }
-`, randInt)
+`, rName)
 }
 
-func testAccBackupPlanWithLifecycle(stringID string) string {
+func testAccAwsBackupPlanConfig_tagsUpdated(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_backup_vault" "test" {
-  name = "tf_acc_test_backup_vault_%[1]s"
+  name = %[1]q
 }
 
 resource "aws_backup_plan" "test" {
-  name = "tf_acc_test_backup_plan_%[1]s"
+  name = %[1]q
 
   rule {
-    rule_name         = "tf_acc_test_backup_rule_%[1]s"
+    rule_name         = %[1]q
+    target_vault_name = "${aws_backup_vault.test.name}"
+    schedule          = "cron(0 12 * * ? *)"
+  }
+
+  tags = {
+    Name = %[1]q
+    Key2 = "Value2b"
+    Key3 = "Value3"
+  }
+}
+`, rName)
+}
+
+func testAccAwsBackupPlanConfig_twoRules(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_backup_vault" "test" {
+  name = %[1]q
+}
+
+resource "aws_backup_plan" "test" {
+  name = %[1]q
+
+  rule {
+    rule_name         = "%[1]s_1"
+    target_vault_name = "${aws_backup_vault.test.name}"
+    schedule          = "cron(0 12 * * ? *)"
+  }
+  rule {
+    rule_name         = "%[1]s_2"
+    target_vault_name = "${aws_backup_vault.test.name}"
+    schedule          = "cron(0 6 * * ? *)"
+  }
+}
+`, rName)
+}
+
+func testAccAwsBackupPlanConfig_threeRules(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_backup_vault" "test" {
+  name = %[1]q
+}
+
+resource "aws_backup_plan" "test" {
+  name = %[1]q
+
+  rule {
+    rule_name         = "%[1]s_1"
+    target_vault_name = "${aws_backup_vault.test.name}"
+    schedule          = "cron(0 6 * * ? *)"
+  }
+  rule {
+    rule_name         = "%[1]s_2"
+    target_vault_name = "${aws_backup_vault.test.name}"
+    schedule          = "cron(0 12 * * ? *)"
+  }
+  rule {
+    rule_name         = "%[1]s_3"
+    target_vault_name = "${aws_backup_vault.test.name}"
+    schedule          = "cron(0 18 * * ? *)"
+  }
+}
+`, rName)
+}
+
+func testAccAwsBackupPlanConfig_lifecycleColdStorageAfterOnly(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_backup_vault" "test" {
+  name = %[1]q
+}
+
+resource "aws_backup_plan" "test" {
+  name = %[1]q
+
+  rule {
+    rule_name         = %[1]q
+    target_vault_name = "${aws_backup_vault.test.name}"
+    schedule          = "cron(0 12 * * ? *)"
+
+    lifecycle {
+      cold_storage_after = 7
+    }
+  }
+}
+`, rName)
+}
+
+func testAccAwsBackupPlanConfig_lifecycleDeleteAfterOnly(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_backup_vault" "test" {
+  name = %[1]q
+}
+
+resource "aws_backup_plan" "test" {
+  name = %[1]q
+
+  rule {
+    rule_name         = %[1]q
+    target_vault_name = "${aws_backup_vault.test.name}"
+    schedule          = "cron(0 12 * * ? *)"
+
+    lifecycle {
+      delete_after = 120
+    }
+  }
+}
+`, rName)
+}
+
+func testAccAwsBackupPlanConfig_lifecycleColdStorageAfterAndDeleteAfter(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_backup_vault" "test" {
+  name = %[1]q
+}
+
+resource "aws_backup_plan" "test" {
+  name = %[1]q
+
+  rule {
+    rule_name         = %[1]q
     target_vault_name = "${aws_backup_vault.test.name}"
     schedule          = "cron(0 12 * * ? *)"
 
     lifecycle {
       cold_storage_after = 30
-      delete_after       = 160
+      delete_after       = 180
     }
   }
 }
-`, stringID)
-}
-
-func testAccBackupPlanWithLifecycleDeleteAfterOnly(stringID string) string {
-	return fmt.Sprintf(`
-resource "aws_backup_vault" "test" {
-  name = "tf_acc_test_backup_vault_%[1]s"
-}
-
-resource "aws_backup_plan" "test" {
-  name = "tf_acc_test_backup_plan_%[1]s"
-
-  rule {
-    rule_name         = "tf_acc_test_backup_rule_%[1]s"
-    target_vault_name = "${aws_backup_vault.test.name}"
-    schedule          = "cron(0 12 * * ? *)"
-
-    lifecycle {
-      delete_after = "7"
-    }
-  }
-}
-`, stringID)
-}
-
-func testAccBackupPlanWithLifecycleColdStorageAfterOnly(stringID string) string {
-	return fmt.Sprintf(`
-resource "aws_backup_vault" "test" {
-  name = "tf_acc_test_backup_vault_%[1]s"
-}
-
-resource "aws_backup_plan" "test" {
-  name = "tf_acc_test_backup_plan_%[1]s"
-
-  rule {
-    rule_name         = "tf_acc_test_backup_rule_%[1]s"
-    target_vault_name = "${aws_backup_vault.test.name}"
-    schedule          = "cron(0 12 * * ? *)"
-
-    lifecycle {
-      cold_storage_after = "7"
-    }
-  }
-}
-`, stringID)
-}
-
-func testAccBackupPlanWithRules(randInt int) string {
-	return fmt.Sprintf(`
-resource "aws_backup_vault" "test" {
-  name = "tf_acc_test_backup_vault_%[1]d"
-}
-
-resource "aws_backup_plan" "test" {
-  name = "tf_acc_test_backup_plan_%[1]d"
-
-  rule {
-    rule_name         = "tf_acc_test_backup_rule_%[1]d"
-    target_vault_name = "${aws_backup_vault.test.name}"
-    schedule          = "cron(0 12 * * ? *)"
-  }
-
-  rule {
-    rule_name         = "tf_acc_test_backup_rule_%[1]d_2"
-    target_vault_name = "${aws_backup_vault.test.name}"
-    schedule          = "cron(0 6 * * ? *)"
-  }
-}
-`, randInt)
+`, rName)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/8431,
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/9502.
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/8193.
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/8737.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_backup_plan: Correctly handle changes to recovery_point_tags
```

Output from acceptance testing:

```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccAwsBackupPlan_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsBackupPlan_ -timeout 120m
=== RUN   TestAccAwsBackupPlan_basic
=== PAUSE TestAccAwsBackupPlan_basic
=== RUN   TestAccAwsBackupPlan_withTags
=== PAUSE TestAccAwsBackupPlan_withTags
=== RUN   TestAccAwsBackupPlan_withRules
=== PAUSE TestAccAwsBackupPlan_withRules
=== RUN   TestAccAwsBackupPlan_withLifecycle
=== PAUSE TestAccAwsBackupPlan_withLifecycle
=== RUN   TestAccAwsBackupPlan_withRecoveryPointTags
=== PAUSE TestAccAwsBackupPlan_withRecoveryPointTags
=== RUN   TestAccAwsBackupPlan_disappears
=== PAUSE TestAccAwsBackupPlan_disappears
=== CONT  TestAccAwsBackupPlan_basic
=== CONT  TestAccAwsBackupPlan_withRecoveryPointTags
=== CONT  TestAccAwsBackupPlan_withLifecycle
=== CONT  TestAccAwsBackupPlan_disappears
=== CONT  TestAccAwsBackupPlan_withRules
=== CONT  TestAccAwsBackupPlan_withTags
--- PASS: TestAccAwsBackupPlan_disappears (19.47s)
--- PASS: TestAccAwsBackupPlan_basic (21.03s)
--- PASS: TestAccAwsBackupPlan_withRecoveryPointTags (47.45s)
--- PASS: TestAccAwsBackupPlan_withTags (47.99s)
--- PASS: TestAccAwsBackupPlan_withRules (51.20s)
--- PASS: TestAccAwsBackupPlan_withLifecycle (61.37s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	61.428s
```
