### PR TITLE
Change `ebs_volume_size` to number type

### DIFF
--- a/website/docs/r/msk_cluster.html.markdown
+++ b/website/docs/r/msk_cluster.html.markdown
@@ -54,7 +54,7 @@ resource "aws_msk_cluster" "example" {
 
   broker_node_group_info {
     instance_type  = "kafka.m5.large"
-    ebs_volume_size = "1000"
+    ebs_volume_size = 1000
     client_subnets = [
       "${aws_subnet.subnet_az1.id}",
       "${aws_subnet.subnet_az2.id}",


### PR DESCRIPTION
From an example `terraform plan` output snippet, it seems that the `ebs_volume_size` is set to a number instead of a string (as indicated from the documentation). I'm assuming that it depends on the implicit type conversion from string to number, which is not ideal.

```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.kafka-cluster.aws_msk_cluster.kafka_cluster will be created
  + resource "aws_msk_cluster" "kafka_cluster" {
      + arn                      = (known after apply)
      + bootstrap_brokers        = (known after apply)
      + bootstrap_brokers_tls    = (known after apply)
      + cluster_name             = "markhuang-msk"
      + current_version          = (known after apply)
      + enhanced_monitoring      = "DEFAULT"
      + id                       = (known after apply)
      + kafka_version            = "2.2.1"
      + number_of_broker_nodes   = 2
      + zookeeper_connect_string = (known after apply)

      + broker_node_group_info {
          + az_distribution = "DEFAULT"
          + client_subnets  = [
              + "xxx",
              + "xxx",
            ]
          + ebs_volume_size = 10
          + instance_type   = "kafka.m5.large"
          + security_groups = (known after apply)
        }
    }

  # module.kafka-cluster.aws_security_group.msk will be created
  + resource "aws_security_group" "msk" {
      + arn                    = (known after apply)
      + description            = "Security group for kafka cluster"
      + egress                 = (known after apply)
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = "markhuang-msk"
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Name"      = "markhuang-msk"
          + "Terraform" = "true"
        }
      + vpc_id                 = "xxx"
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Correct aws_msk_cluster.ebs_volume_size in documentation to be number type instead of string.
```

Output from acceptance testing: I don't think it's needed for this PR.