### PR TITLE
Add support for vpc_endpoint_ids in api_gateway_rest_api endpoint_configuration

### DIFF
--- a/website/docs/r/api_gateway_rest_api.html.markdown
+++ b/website/docs/r/api_gateway_rest_api.html.markdown
@@ -59,6 +59,7 @@ __Note__: If the `body` argument is provided, the OpenAPI specification will be 
 ### endpoint_configuration
 
 * `types` - (Required) A list of endpoint types. This resource currently only supports managing a single value. Valid values: `EDGE`, `REGIONAL` or `PRIVATE`. If unspecified, defaults to `EDGE`. Must be declared as `REGIONAL` in non-Commercial partitions. Refer to the [documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/create-regional-api.html) for more information on the difference between edge-optimized and regional APIs.
+* `vpc_endpoint_ids` - (Optional) A list of VPC endpoint ids. This resource currently only supports managing a single value. Endpoint type must be specified as `PRIVATE` to use. Associates the private API with a VPC endpoint. Refer to the [documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/associate-private-api-with-vpc-endpoint.html) for more information on the feature.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10154

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```
Add support for vpc_endpoint_ids in api_gateway_rest_api endpoint_configuration
```

Output from acceptance testing:

```
$make testacc TEST=./aws TESTARGS='-run=TestAccAWSAPIGatewayRestApi_EndpointConfiguration'
==> Checking that code complies with gofmt requirements...
Add test for creating API Gateway with attached vpc_endpoint_id
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAPIGatewayRestApi_EndpointConfiguration -timeout 120m
=== RUN   TestAccAWSAPIGatewayRestApi_EndpointConfiguration
=== PAUSE TestAccAWSAPIGatewayRestApi_EndpointConfiguration
=== RUN   TestAccAWSAPIGatewayRestApi_EndpointConfiguration_Private
=== PAUSE TestAccAWSAPIGatewayRestApi_EndpointConfiguration_Private
=== RUN   TestAccAWSAPIGatewayRestApi_EndpointConfiguration_PrivateVPCEndpoint
=== PAUSE TestAccAWSAPIGatewayRestApi_EndpointConfiguration_PrivateVPCEndpoint
=== CONT  TestAccAWSAPIGatewayRestApi_EndpointConfiguration
=== CONT  TestAccAWSAPIGatewayRestApi_EndpointConfiguration_Private
=== CONT  TestAccAWSAPIGatewayRestApi_EndpointConfiguration_PrivateVPCEndpoint
--- PASS: TestAccAWSAPIGatewayRestApi_EndpointConfiguration (96.98s)
--- PASS: TestAccAWSAPIGatewayRestApi_EndpointConfiguration_Private (129.83s)
--- PASS: TestAccAWSAPIGatewayRestApi_EndpointConfiguration_PrivateVPCEndpoint (171.57s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	171.668s
```