### PR TITLE
Import test refactor for launch resources

### DIFF
--- a/aws/resource_aws_launch_configuration_test.go
+++ b/aws/resource_aws_launch_configuration_test.go
@@ -63,8 +63,9 @@ func testSweepLaunchConfigurations(region string) error {
 	return nil
 }
 
-func TestAccAWSLaunchConfiguration_importBasic(t *testing.T) {
-	resourceName := "aws_launch_configuration.bar"
+func TestAccAWSLaunchConfiguration_basic(t *testing.T) {
+	var conf autoscaling.LaunchConfiguration
+	resourceName := "aws_launch_configuration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -73,8 +74,48 @@ func TestAccAWSLaunchConfiguration_importBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLaunchConfigurationNoNameConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchConfigurationExists(resourceName, &conf),
+					testAccCheckAWSLaunchConfigurationGeneratedNamePrefix(resourceName, "terraform-"),
+				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"associate_public_ip_address"},
+			},
+			{
+				Config: testAccAWSLaunchConfigurationPrefixNameConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchConfigurationExists(resourceName, &conf),
+					testAccCheckAWSLaunchConfigurationGeneratedNamePrefix(resourceName, "tf-acc-test-"),
+				),
+			},
+		},
+	})
+}
 
+func TestAccAWSLaunchConfiguration_withBlockDevices(t *testing.T) {
+	var conf autoscaling.LaunchConfiguration
+	resourceName := "aws_launch_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchConfigurationConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchConfigurationExists(resourceName, &conf),
+					testAccCheckAWSLaunchConfigurationAttributes(&conf),
+					resource.TestMatchResourceAttr(resourceName, "image_id", regexp.MustCompile("^ami-[0-9a-z]+")),
+					resource.TestCheckResourceAttr(resourceName, "instance_type", "m1.small"),
+					resource.TestCheckResourceAttr(resourceName, "associate_public_ip_address", "true"),
+					resource.TestCheckResourceAttr(resourceName, "spot_price", ""),
+				),
+			},
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
@@ -85,57 +126,9 @@ func TestAccAWSLaunchConfiguration_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccAWSLaunchConfiguration_basic(t *testing.T) {
-	var conf autoscaling.LaunchConfiguration
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSLaunchConfigurationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSLaunchConfigurationNoNameConfig(),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.bar", &conf),
-					testAccCheckAWSLaunchConfigurationGeneratedNamePrefix("aws_launch_configuration.bar", "terraform-"),
-				),
-			},
-			{
-				Config: testAccAWSLaunchConfigurationPrefixNameConfig(),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.baz", &conf),
-					testAccCheckAWSLaunchConfigurationGeneratedNamePrefix("aws_launch_configuration.baz", "tf-acc-test-"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSLaunchConfiguration_withBlockDevices(t *testing.T) {
-	var conf autoscaling.LaunchConfiguration
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSLaunchConfigurationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSLaunchConfigurationConfig(),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.bar", &conf),
-					testAccCheckAWSLaunchConfigurationAttributes(&conf),
-					resource.TestMatchResourceAttr("aws_launch_configuration.bar", "image_id", regexp.MustCompile("^ami-[0-9a-z]+")),
-					resource.TestCheckResourceAttr("aws_launch_configuration.bar", "instance_type", "m1.small"),
-					resource.TestCheckResourceAttr("aws_launch_configuration.bar", "associate_public_ip_address", "true"),
-					resource.TestCheckResourceAttr("aws_launch_configuration.bar", "spot_price", ""),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAWSLaunchConfiguration_updateRootBlockDevice(t *testing.T) {
 	var conf autoscaling.LaunchConfiguration
+	resourceName := "aws_launch_configuration.test"
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -146,15 +139,21 @@ func TestAccAWSLaunchConfiguration_updateRootBlockDevice(t *testing.T) {
 			{
 				Config: testAccAWSLaunchConfigurationConfigWithRootBlockDevice(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.bar", &conf),
-					resource.TestCheckResourceAttr("aws_launch_configuration.bar", "root_block_device.0.volume_size", "11"),
+					testAccCheckAWSLaunchConfigurationExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_size", "11"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"associate_public_ip_address", "name_prefix"},
 			},
 			{
 				Config: testAccAWSLaunchConfigurationConfigWithRootBlockDeviceUpdated(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.bar", &conf),
-					resource.TestCheckResourceAttr("aws_launch_configuration.bar", "root_block_device.0.volume_size", "20"),
+					testAccCheckAWSLaunchConfigurationExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_size", "20"),
 				),
 			},
 		},
@@ -164,6 +163,7 @@ func TestAccAWSLaunchConfiguration_updateRootBlockDevice(t *testing.T) {
 func TestAccAWSLaunchConfiguration_encryptedRootBlockDevice(t *testing.T) {
 	var conf autoscaling.LaunchConfiguration
 	rInt := acctest.RandInt()
+	resourceName := "aws_launch_configuration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -173,9 +173,15 @@ func TestAccAWSLaunchConfiguration_encryptedRootBlockDevice(t *testing.T) {
 			{
 				Config: testAccAWSLaunchConfigurationConfigWithEncryptedRootBlockDevice(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.bar", &conf),
-					resource.TestCheckResourceAttr("aws_launch_configuration.bar", "root_block_device.0.encrypted", "true"),
+					testAccCheckAWSLaunchConfigurationExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.encrypted", "true"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"associate_public_ip_address", "name_prefix"},
 			},
 		},
 	})
@@ -183,6 +189,7 @@ func TestAccAWSLaunchConfiguration_encryptedRootBlockDevice(t *testing.T) {
 
 func TestAccAWSLaunchConfiguration_withSpotPrice(t *testing.T) {
 	var conf autoscaling.LaunchConfiguration
+	resourceName := "aws_launch_configuration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -192,9 +199,15 @@ func TestAccAWSLaunchConfiguration_withSpotPrice(t *testing.T) {
 			{
 				Config: testAccAWSLaunchConfigurationWithSpotPriceConfig(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.bar", &conf),
-					resource.TestCheckResourceAttr("aws_launch_configuration.bar", "spot_price", "0.01"),
+					testAccCheckAWSLaunchConfigurationExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "spot_price", "0.01"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"associate_public_ip_address"},
 			},
 		},
 	})
@@ -205,6 +218,7 @@ func TestAccAWSLaunchConfiguration_withVpcClassicLink(t *testing.T) {
 	var group ec2.SecurityGroup
 	var conf autoscaling.LaunchConfiguration
 	rInt := acctest.RandInt()
+	resourceName := "aws_launch_configuration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -214,13 +228,13 @@ func TestAccAWSLaunchConfiguration_withVpcClassicLink(t *testing.T) {
 			{
 				Config: testAccAWSLaunchConfigurationConfig_withVpcClassicLink(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.foo", &conf),
-					testAccCheckVpcExists("aws_vpc.foo", &vpc),
-					testAccCheckAWSSecurityGroupExists("aws_security_group.foo", &group),
+					testAccCheckAWSLaunchConfigurationExists(resourceName, &conf),
+					testAccCheckVpcExists("aws_vpc.test", &vpc),
+					testAccCheckAWSSecurityGroupExists("aws_security_group.test", &group),
 				),
 			},
 			{
-				ResourceName:      "aws_launch_configuration.foo",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -231,6 +245,7 @@ func TestAccAWSLaunchConfiguration_withVpcClassicLink(t *testing.T) {
 func TestAccAWSLaunchConfiguration_withIAMProfile(t *testing.T) {
 	var conf autoscaling.LaunchConfiguration
 	rInt := acctest.RandInt()
+	resourceName := "aws_launch_configuration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -240,7 +255,133 @@ func TestAccAWSLaunchConfiguration_withIAMProfile(t *testing.T) {
 			{
 				Config: testAccAWSLaunchConfigurationConfig_withIAMProfile(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.bar", &conf),
+					testAccCheckAWSLaunchConfigurationExists(resourceName, &conf),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"associate_public_ip_address"},
+			},
+		},
+	})
+}
+
+func TestAccAWSLaunchConfiguration_withEncryption(t *testing.T) {
+	var conf autoscaling.LaunchConfiguration
+	resourceName := "aws_launch_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchConfigurationWithEncryption(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.test", &conf),
+					testAccCheckAWSLaunchConfigurationWithEncryption(&conf),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"associate_public_ip_address"},
+			},
+		},
+	})
+}
+
+func TestAccAWSLaunchConfiguration_updateEbsBlockDevices(t *testing.T) {
+	var conf autoscaling.LaunchConfiguration
+	resourceName := "aws_launch_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchConfigurationWithEncryption(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchConfigurationExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.1393547169.volume_size", "9"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"associate_public_ip_address"},
+			},
+			{
+				Config: testAccAWSLaunchConfigurationWithEncryptionUpdated(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchConfigurationExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.4131155854.volume_size", "10"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSLaunchConfiguration_ebs_noDevice(t *testing.T) {
+	var conf autoscaling.LaunchConfiguration
+	rInt := acctest.RandInt()
+	resourceName := "aws_launch_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchConfigurationConfigEbsNoDevice(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchConfigurationExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.3099842682.device_name", "/dev/sda2"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.3099842682.no_device", "true"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"associate_public_ip_address", "name_prefix"},
+			},
+		},
+	})
+}
+func TestAccAWSLaunchConfiguration_userData(t *testing.T) {
+	var conf autoscaling.LaunchConfiguration
+	resourceName := "aws_launch_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchConfigurationConfig_userData(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchConfigurationExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "user_data", "3dc39dda39be1205215e776bad998da361a5955d"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"associate_public_ip_address"},
+			},
+			{
+				Config: testAccAWSLaunchConfigurationConfig_userDataBase64(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchConfigurationExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "user_data_base64", "aGVsbG8gd29ybGQ="),
 				),
 			},
 		},
@@ -271,98 +412,6 @@ func testAccCheckAWSLaunchConfigurationWithEncryption(conf *autoscaling.LaunchCo
 
 		return nil
 	}
-}
-
-func TestAccAWSLaunchConfiguration_withEncryption(t *testing.T) {
-	var conf autoscaling.LaunchConfiguration
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSLaunchConfigurationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSLaunchConfigurationWithEncryption(),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.baz", &conf),
-					testAccCheckAWSLaunchConfigurationWithEncryption(&conf),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSLaunchConfiguration_updateEbsBlockDevices(t *testing.T) {
-	var conf autoscaling.LaunchConfiguration
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSLaunchConfigurationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSLaunchConfigurationWithEncryption(),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.baz", &conf),
-					resource.TestCheckResourceAttr("aws_launch_configuration.baz", "ebs_block_device.1393547169.volume_size", "9"),
-				),
-			},
-			{
-				Config: testAccAWSLaunchConfigurationWithEncryptionUpdated(),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.baz", &conf),
-					resource.TestCheckResourceAttr("aws_launch_configuration.baz", "ebs_block_device.4131155854.volume_size", "10"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSLaunchConfiguration_ebs_noDevice(t *testing.T) {
-	var conf autoscaling.LaunchConfiguration
-	rInt := acctest.RandInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSLaunchConfigurationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSLaunchConfigurationConfigEbsNoDevice(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.bar", &conf),
-					resource.TestCheckResourceAttr("aws_launch_configuration.bar", "ebs_block_device.#", "1"),
-					resource.TestCheckResourceAttr("aws_launch_configuration.bar", "ebs_block_device.3099842682.device_name", "/dev/sda2"),
-					resource.TestCheckResourceAttr("aws_launch_configuration.bar", "ebs_block_device.3099842682.no_device", "true"),
-				),
-			},
-		},
-	})
-}
-func TestAccAWSLaunchConfiguration_userData(t *testing.T) {
-	var conf autoscaling.LaunchConfiguration
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSLaunchConfigurationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSLaunchConfigurationConfig_userData(),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.bar", &conf),
-					resource.TestCheckResourceAttr("aws_launch_configuration.bar", "user_data", "3dc39dda39be1205215e776bad998da361a5955d"),
-				),
-			},
-			{
-				Config: testAccAWSLaunchConfigurationConfig_userDataBase64(),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.bar", &conf),
-					resource.TestCheckResourceAttr("aws_launch_configuration.bar", "user_data_base64", "aGVsbG8gd29ybGQ="),
-				),
-			},
-		},
-	})
 }
 
 func testAccCheckAWSLaunchConfigurationGeneratedNamePrefix(
@@ -501,11 +550,11 @@ data "aws_ami" "ubuntu" {
 
 func testAccAWSLaunchConfigurationConfigWithRootBlockDevice(rInt int) string {
 	return testAccAWSLaunchConfigurationConfig_ami() + fmt.Sprintf(`
-resource "aws_launch_configuration" "bar" {
+resource "aws_launch_configuration" "test" {
   name_prefix = "tf-acc-test-%d"
   image_id = "${data.aws_ami.ubuntu.id}"
   instance_type = "m1.small"
-  user_data = "foobar-user-data"
+  user_data = "testtest-user-data"
   associate_public_ip_address = true
 
   root_block_device {
@@ -518,7 +567,7 @@ resource "aws_launch_configuration" "bar" {
 
 func testAccAWSLaunchConfigurationConfigWithEncryptedRootBlockDevice(rInt int) string {
 	return testAccAWSLaunchConfigurationConfig_ami() + fmt.Sprintf(`
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
   tags = {
@@ -526,9 +575,9 @@ resource "aws_vpc" "foo" {
   }
 }
 
-resource "aws_subnet" "foo" {
+resource "aws_subnet" "test" {
   cidr_block = "10.1.1.0/24"
-  vpc_id = "${aws_vpc.foo.id}"
+  vpc_id = "${aws_vpc.test.id}"
   availability_zone = "us-west-2a"
 
   tags = {
@@ -536,11 +585,11 @@ resource "aws_subnet" "foo" {
   }
 }
 
-resource "aws_launch_configuration" "bar" {
+resource "aws_launch_configuration" "test" {
   name_prefix = "tf-acc-test-%d"
   image_id = "${data.aws_ami.ubuntu.id}"
   instance_type = "t3.nano"
-  user_data = "foobar-user-data"
+  user_data = "testtest-user-data"
   associate_public_ip_address = true
 
   root_block_device {
@@ -554,11 +603,11 @@ resource "aws_launch_configuration" "bar" {
 
 func testAccAWSLaunchConfigurationConfigWithRootBlockDeviceUpdated(rInt int) string {
 	return testAccAWSLaunchConfigurationConfig_ami() + fmt.Sprintf(`
-resource "aws_launch_configuration" "bar" {
+resource "aws_launch_configuration" "test" {
   name_prefix = "tf-acc-test-%d"
   image_id = "${data.aws_ami.ubuntu.id}"
   instance_type = "m1.small"
-  user_data = "foobar-user-data"
+  user_data = "testtest-user-data"
   associate_public_ip_address = true
 
   root_block_device {
@@ -571,11 +620,11 @@ resource "aws_launch_configuration" "bar" {
 
 func testAccAWSLaunchConfigurationConfig() string {
 	return testAccAWSLaunchConfigurationConfig_ami() + fmt.Sprintf(`
-resource "aws_launch_configuration" "bar" {
+resource "aws_launch_configuration" "test" {
   name = "tf-acc-test-%d"
   image_id = "${data.aws_ami.ubuntu.id}"
   instance_type = "m1.small"
-  user_data = "foobar-user-data"
+  user_data = "testtest-user-data"
   associate_public_ip_address = true
 
   root_block_device {
@@ -602,7 +651,7 @@ resource "aws_launch_configuration" "bar" {
 
 func testAccAWSLaunchConfigurationWithSpotPriceConfig() string {
 	return testAccAWSLaunchConfigurationConfig_ami() + fmt.Sprintf(`
-resource "aws_launch_configuration" "bar" {
+resource "aws_launch_configuration" "test" {
   name = "tf-acc-test-%d"
   image_id = "${data.aws_ami.ubuntu.id}"
   instance_type = "t2.micro"
@@ -613,10 +662,10 @@ resource "aws_launch_configuration" "bar" {
 
 func testAccAWSLaunchConfigurationNoNameConfig() string {
 	return testAccAWSLaunchConfigurationConfig_ami() + fmt.Sprintf(`
-resource "aws_launch_configuration" "bar" {
+resource "aws_launch_configuration" "test" {
   image_id = "${data.aws_ami.ubuntu.id}"
   instance_type = "t2.micro"
-  user_data = "foobar-user-data-change"
+  user_data = "testtest-user-data-change"
   associate_public_ip_address = false
 }
 `)
@@ -624,11 +673,11 @@ resource "aws_launch_configuration" "bar" {
 
 func testAccAWSLaunchConfigurationPrefixNameConfig() string {
 	return testAccAWSLaunchConfigurationConfig_ami() + fmt.Sprintf(`
-resource "aws_launch_configuration" "baz" {
+resource "aws_launch_configuration" "test" {
   name_prefix = "tf-acc-test-"
   image_id = "${data.aws_ami.ubuntu.id}"
   instance_type = "t2.micro"
-  user_data = "foobar-user-data-change"
+  user_data = "testtest-user-data-change"
   associate_public_ip_address = false
 }
 `)
@@ -636,7 +685,7 @@ resource "aws_launch_configuration" "baz" {
 
 func testAccAWSLaunchConfigurationWithEncryption() string {
 	return testAccAWSLaunchConfigurationConfig_ami() + fmt.Sprintf(`
-resource "aws_launch_configuration" "baz" {
+resource "aws_launch_configuration" "test" {
   image_id = "${data.aws_ami.ubuntu.id}"
   instance_type = "t2.micro"
   associate_public_ip_address = false
@@ -656,7 +705,7 @@ resource "aws_launch_configuration" "baz" {
 
 func testAccAWSLaunchConfigurationWithEncryptionUpdated() string {
 	return testAccAWSLaunchConfigurationConfig_ami() + fmt.Sprintf(`
-resource "aws_launch_configuration" "baz" {
+resource "aws_launch_configuration" "test" {
   image_id = "${data.aws_ami.ubuntu.id}"
   instance_type = "t2.micro"
   associate_public_ip_address = false
@@ -676,7 +725,7 @@ resource "aws_launch_configuration" "baz" {
 
 func testAccAWSLaunchConfigurationConfig_withVpcClassicLink(rInt int) string {
 	return testAccAWSLaunchConfigurationConfig_ami() + fmt.Sprintf(`
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
     cidr_block = "10.0.0.0/16"
     enable_classiclink = true
   tags = {
@@ -684,18 +733,18 @@ resource "aws_vpc" "foo" {
     }
 }
 
-resource "aws_security_group" "foo" {
+resource "aws_security_group" "test" {
   name = "tf-acc-test-%[1]d"
-  vpc_id = "${aws_vpc.foo.id}"
+  vpc_id = "${aws_vpc.test.id}"
 }
 
-resource "aws_launch_configuration" "foo" {
+resource "aws_launch_configuration" "test" {
   name = "tf-acc-test-%[1]d"
   image_id = "${data.aws_ami.ubuntu.id}"
   instance_type = "t2.micro"
 
-  vpc_classic_link_id = "${aws_vpc.foo.id}"
-  vpc_classic_link_security_groups = ["${aws_security_group.foo.id}"]
+  vpc_classic_link_id = "${aws_vpc.test.id}"
+  vpc_classic_link_security_groups = ["${aws_security_group.test.id}"]
 }
 `, rInt)
 }
@@ -726,7 +775,7 @@ resource "aws_iam_instance_profile" "profile" {
   roles = ["${aws_iam_role.role.name}"]
 }
 
-resource "aws_launch_configuration" "bar" {
+resource "aws_launch_configuration" "test" {
   image_id             = "${data.aws_ami.ubuntu.id}"
   instance_type        = "t2.nano"
   iam_instance_profile = "${aws_iam_instance_profile.profile.name}"
@@ -736,7 +785,7 @@ resource "aws_launch_configuration" "bar" {
 
 func testAccAWSLaunchConfigurationConfigEbsNoDevice(rInt int) string {
 	return testAccAWSLaunchConfigurationConfig_ami() + fmt.Sprintf(`
-resource "aws_launch_configuration" "bar" {
+resource "aws_launch_configuration" "test" {
   name_prefix = "tf-acc-test-%d"
   image_id = "${data.aws_ami.ubuntu.id}"
   instance_type = "m1.small"
@@ -750,7 +799,7 @@ resource "aws_launch_configuration" "bar" {
 
 func testAccAWSLaunchConfigurationConfig_userData() string {
 	return testAccAWSLaunchConfigurationConfig_ami() + fmt.Sprintf(`
-resource "aws_launch_configuration" "bar" {
+resource "aws_launch_configuration" "test" {
   image_id = "${data.aws_ami.ubuntu.id}"
   instance_type = "t2.micro"
   user_data = "foo:-with-character's"
@@ -761,7 +810,7 @@ resource "aws_launch_configuration" "bar" {
 
 func testAccAWSLaunchConfigurationConfig_userDataBase64() string {
 	return testAccAWSLaunchConfigurationConfig_ami() + fmt.Sprintf(`
-resource "aws_launch_configuration" "bar" {
+resource "aws_launch_configuration" "test" {
   image_id = "${data.aws_ami.ubuntu.id}"
   instance_type = "t2.micro"
   user_data_base64 = "${base64encode("hello world")}"

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -13,51 +13,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSLaunchTemplate_importBasic(t *testing.T) {
-	resName := "aws_launch_template.foo"
-	rInt := acctest.RandInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSLaunchTemplateConfig_basic(rInt),
-			},
-			{
-				ResourceName:      resName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSLaunchTemplate_importData(t *testing.T) {
-	resName := "aws_launch_template.foo"
-	rInt := acctest.RandInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSLaunchTemplateConfig_data(rInt),
-			},
-			{
-				ResourceName:      resName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAWSLaunchTemplate_basic(t *testing.T) {
 	var template ec2.LaunchTemplate
-	resName := "aws_launch_template.foo"
+	resourceName := "aws_launch_template.test"
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -68,13 +26,18 @@ func TestAccAWSLaunchTemplate_basic(t *testing.T) {
 			{
 				Config: testAccAWSLaunchTemplateConfig_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchTemplateExists(resName, &template),
-					resource.TestCheckResourceAttr(resName, "default_version", "1"),
-					resource.TestCheckResourceAttr(resName, "latest_version", "1"),
-					resource.TestCheckResourceAttrSet(resName, "arn"),
-					resource.TestCheckResourceAttr(resName, "ebs_optimized", ""),
-					resource.TestCheckResourceAttr(resName, "elastic_inference_accelerator.#", "0"),
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "default_version", "1"),
+					resource.TestCheckResourceAttr(resourceName, "latest_version", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_optimized", ""),
+					resource.TestCheckResourceAttr(resourceName, "elastic_inference_accelerator.#", "0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -82,7 +45,7 @@ func TestAccAWSLaunchTemplate_basic(t *testing.T) {
 
 func TestAccAWSLaunchTemplate_disappears(t *testing.T) {
 	var launchTemplate ec2.LaunchTemplate
-	resourceName := "aws_launch_template.foo"
+	resourceName := "aws_launch_template.test"
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -263,7 +226,7 @@ func TestAccAWSLaunchTemplate_ElasticInferenceAccelerator(t *testing.T) {
 
 func TestAccAWSLaunchTemplate_data(t *testing.T) {
 	var template ec2.LaunchTemplate
-	resName := "aws_launch_template.foo"
+	resourceName := "aws_launch_template.test"
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -274,26 +237,31 @@ func TestAccAWSLaunchTemplate_data(t *testing.T) {
 			{
 				Config: testAccAWSLaunchTemplateConfig_data(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchTemplateExists(resName, &template),
-					resource.TestCheckResourceAttr(resName, "block_device_mappings.#", "1"),
-					resource.TestCheckResourceAttrSet(resName, "disable_api_termination"),
-					resource.TestCheckResourceAttr(resName, "ebs_optimized", "false"),
-					resource.TestCheckResourceAttr(resName, "elastic_gpu_specifications.#", "1"),
-					resource.TestCheckResourceAttr(resName, "iam_instance_profile.#", "1"),
-					resource.TestCheckResourceAttrSet(resName, "image_id"),
-					resource.TestCheckResourceAttrSet(resName, "instance_initiated_shutdown_behavior"),
-					resource.TestCheckResourceAttr(resName, "instance_market_options.#", "1"),
-					resource.TestCheckResourceAttrSet(resName, "instance_type"),
-					resource.TestCheckResourceAttrSet(resName, "kernel_id"),
-					resource.TestCheckResourceAttrSet(resName, "key_name"),
-					resource.TestCheckResourceAttr(resName, "monitoring.#", "1"),
-					resource.TestCheckResourceAttr(resName, "network_interfaces.#", "1"),
-					resource.TestCheckResourceAttr(resName, "network_interfaces.0.security_groups.#", "1"),
-					resource.TestCheckResourceAttr(resName, "placement.#", "1"),
-					resource.TestCheckResourceAttrSet(resName, "ram_disk_id"),
-					resource.TestCheckResourceAttr(resName, "vpc_security_group_ids.#", "1"),
-					resource.TestCheckResourceAttr(resName, "tag_specifications.#", "1"),
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "disable_api_termination"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_optimized", "false"),
+					resource.TestCheckResourceAttr(resourceName, "elastic_gpu_specifications.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "iam_instance_profile.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "image_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "instance_initiated_shutdown_behavior"),
+					resource.TestCheckResourceAttr(resourceName, "instance_market_options.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "instance_type"),
+					resource.TestCheckResourceAttrSet(resourceName, "kernel_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "key_name"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.security_groups.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "placement.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "ram_disk_id"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_security_group_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tag_specifications.#", "1"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -301,7 +269,7 @@ func TestAccAWSLaunchTemplate_data(t *testing.T) {
 
 func TestAccAWSLaunchTemplate_description(t *testing.T) {
 	var template ec2.LaunchTemplate
-	resName := "aws_launch_template.foo"
+	resourceName := "aws_launch_template.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -312,15 +280,20 @@ func TestAccAWSLaunchTemplate_description(t *testing.T) {
 			{
 				Config: testAccAWSLaunchTemplateConfig_description(rName, "Test Description 1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchTemplateExists(resName, &template),
-					resource.TestCheckResourceAttr(resName, "description", "Test Description 1"),
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "description", "Test Description 1"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSLaunchTemplateConfig_description(rName, "Test Description 2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchTemplateExists(resName, &template),
-					resource.TestCheckResourceAttr(resName, "description", "Test Description 2"),
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "description", "Test Description 2"),
 				),
 			},
 		},
@@ -329,7 +302,7 @@ func TestAccAWSLaunchTemplate_description(t *testing.T) {
 
 func TestAccAWSLaunchTemplate_update(t *testing.T) {
 	var template ec2.LaunchTemplate
-	resName := "aws_launch_template.foo"
+	resourceName := "aws_launch_template.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -339,20 +312,26 @@ func TestAccAWSLaunchTemplate_update(t *testing.T) {
 			{
 				Config: testAccAWSLaunchTemplateConfig_asg_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchTemplateExists(resName, &template),
-					resource.TestCheckResourceAttr(resName, "default_version", "1"),
-					resource.TestCheckResourceAttr(resName, "latest_version", "1"),
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "default_version", "1"),
+					resource.TestCheckResourceAttr(resourceName, "latest_version", "1"),
 					resource.TestCheckResourceAttr(
 						"aws_autoscaling_group.bar", "launch_template.0.version", "1"),
 				),
 			},
 			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name_prefix"},
+			},
+			{
 				Config: testAccAWSLaunchTemplateConfig_asg_update,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchTemplateExists(resName, &template),
-					resource.TestCheckResourceAttr(resName, "default_version", "1"),
-					resource.TestCheckResourceAttr(resName, "latest_version", "2"),
-					resource.TestCheckResourceAttrSet(resName, "instance_type"),
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "default_version", "1"),
+					resource.TestCheckResourceAttr(resourceName, "latest_version", "2"),
+					resource.TestCheckResourceAttrSet(resourceName, "instance_type"),
 					resource.TestCheckResourceAttr(
 						"aws_autoscaling_group.bar", "launch_template.0.version", "2"),
 				),
@@ -363,7 +342,7 @@ func TestAccAWSLaunchTemplate_update(t *testing.T) {
 
 func TestAccAWSLaunchTemplate_tags(t *testing.T) {
 	var template ec2.LaunchTemplate
-	resName := "aws_launch_template.foo"
+	resourceName := "aws_launch_template.test"
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -374,15 +353,20 @@ func TestAccAWSLaunchTemplate_tags(t *testing.T) {
 			{
 				Config: testAccAWSLaunchTemplateConfig_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchTemplateExists(resName, &template),
-					testAccCheckTags(&template.Tags, "foo", "bar"),
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
+					testAccCheckTags(&template.Tags, "test", "bar"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSLaunchTemplateConfig_tagsUpdate(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchTemplateExists(resName, &template),
-					testAccCheckTags(&template.Tags, "foo", ""),
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
+					testAccCheckTags(&template.Tags, "test", ""),
 					testAccCheckTags(&template.Tags, "bar", "baz"),
 				),
 			},
@@ -392,7 +376,7 @@ func TestAccAWSLaunchTemplate_tags(t *testing.T) {
 
 func TestAccAWSLaunchTemplate_capacityReservation_preference(t *testing.T) {
 	var template ec2.LaunchTemplate
-	resName := "aws_launch_template.foo"
+	resourceName := "aws_launch_template.test"
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -403,8 +387,13 @@ func TestAccAWSLaunchTemplate_capacityReservation_preference(t *testing.T) {
 			{
 				Config: testAccAWSLaunchTemplateConfig_capacityReservation_preference(rInt, "open"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchTemplateExists(resName, &template),
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -412,7 +401,7 @@ func TestAccAWSLaunchTemplate_capacityReservation_preference(t *testing.T) {
 
 func TestAccAWSLaunchTemplate_capacityReservation_target(t *testing.T) {
 	var template ec2.LaunchTemplate
-	resName := "aws_launch_template.foo"
+	resourceName := "aws_launch_template.test"
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -423,8 +412,13 @@ func TestAccAWSLaunchTemplate_capacityReservation_target(t *testing.T) {
 			{
 				Config: testAccAWSLaunchTemplateConfig_capacityReservation_target(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchTemplateExists(resName, &template),
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -433,7 +427,7 @@ func TestAccAWSLaunchTemplate_capacityReservation_target(t *testing.T) {
 func TestAccAWSLaunchTemplate_creditSpecification_nonBurstable(t *testing.T) {
 	var template ec2.LaunchTemplate
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resName := "aws_launch_template.foo"
+	resourceName := "aws_launch_template.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -443,8 +437,14 @@ func TestAccAWSLaunchTemplate_creditSpecification_nonBurstable(t *testing.T) {
 			{
 				Config: testAccAWSLaunchTemplateConfig_creditSpecification(rName, "m1.small", "standard"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchTemplateExists(resName, &template),
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"credit_specification"},
 			},
 		},
 	})
@@ -453,7 +453,7 @@ func TestAccAWSLaunchTemplate_creditSpecification_nonBurstable(t *testing.T) {
 func TestAccAWSLaunchTemplate_creditSpecification_t2(t *testing.T) {
 	var template ec2.LaunchTemplate
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resName := "aws_launch_template.foo"
+	resourceName := "aws_launch_template.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -463,10 +463,15 @@ func TestAccAWSLaunchTemplate_creditSpecification_t2(t *testing.T) {
 			{
 				Config: testAccAWSLaunchTemplateConfig_creditSpecification(rName, "t2.micro", "unlimited"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchTemplateExists(resName, &template),
-					resource.TestCheckResourceAttr(resName, "credit_specification.#", "1"),
-					resource.TestCheckResourceAttr(resName, "credit_specification.0.cpu_credits", "unlimited"),
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "credit_specification.0.cpu_credits", "unlimited"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -475,7 +480,7 @@ func TestAccAWSLaunchTemplate_creditSpecification_t2(t *testing.T) {
 func TestAccAWSLaunchTemplate_creditSpecification_t3(t *testing.T) {
 	var template ec2.LaunchTemplate
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resName := "aws_launch_template.foo"
+	resourceName := "aws_launch_template.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -485,10 +490,15 @@ func TestAccAWSLaunchTemplate_creditSpecification_t3(t *testing.T) {
 			{
 				Config: testAccAWSLaunchTemplateConfig_creditSpecification(rName, "t3.micro", "unlimited"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchTemplateExists(resName, &template),
-					resource.TestCheckResourceAttr(resName, "credit_specification.#", "1"),
-					resource.TestCheckResourceAttr(resName, "credit_specification.0.cpu_credits", "unlimited"),
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "credit_specification.0.cpu_credits", "unlimited"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -518,7 +528,7 @@ func TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock(t *test
 
 func TestAccAWSLaunchTemplate_networkInterface(t *testing.T) {
 	var template ec2.LaunchTemplate
-	resName := "aws_launch_template.test"
+	resourceName := "aws_launch_template.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -528,12 +538,17 @@ func TestAccAWSLaunchTemplate_networkInterface(t *testing.T) {
 			{
 				Config: testAccAWSLaunchTemplateConfig_networkInterface,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchTemplateExists(resName, &template),
-					resource.TestCheckResourceAttr(resName, "network_interfaces.#", "1"),
-					resource.TestCheckResourceAttrSet(resName, "network_interfaces.0.network_interface_id"),
-					resource.TestCheckResourceAttr(resName, "network_interfaces.0.associate_public_ip_address", "false"),
-					resource.TestCheckResourceAttr(resName, "network_interfaces.0.ipv4_address_count", "2"),
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "network_interfaces.0.network_interface_id"),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.associate_public_ip_address", "false"),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.ipv4_address_count", "2"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -541,7 +556,7 @@ func TestAccAWSLaunchTemplate_networkInterface(t *testing.T) {
 
 func TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses(t *testing.T) {
 	var template ec2.LaunchTemplate
-	resName := "aws_launch_template.test"
+	resourceName := "aws_launch_template.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -551,10 +566,15 @@ func TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses(t *testing.T) {
 			{
 				Config: testAccAWSLaunchTemplateConfig_networkInterface_ipv6Addresses,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchTemplateExists(resName, &template),
-					resource.TestCheckResourceAttr(resName, "network_interfaces.#", "1"),
-					resource.TestCheckResourceAttr(resName, "network_interfaces.0.ipv6_addresses.#", "2"),
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.ipv6_addresses.#", "2"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -562,7 +582,7 @@ func TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses(t *testing.T) {
 
 func TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount(t *testing.T) {
 	var template ec2.LaunchTemplate
-	resName := "aws_launch_template.foo"
+	resourceName := "aws_launch_template.test"
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -573,10 +593,15 @@ func TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount(t *testing.T) {
 			{
 				Config: testAccAWSLaunchTemplateConfig_ipv6_count(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchTemplateExists(resName, &template),
-					resource.TestCheckResourceAttr(resName, "network_interfaces.#", "1"),
-					resource.TestCheckResourceAttr(resName, "network_interfaces.0.ipv6_address_count", "1"),
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.ipv6_address_count", "1"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -585,8 +610,8 @@ func TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount(t *testing.T) {
 func TestAccAWSLaunchTemplate_instanceMarketOptions(t *testing.T) {
 	var template ec2.LaunchTemplate
 	var group autoscaling.Group
-	templateName := "aws_launch_template.test"
 	groupName := "aws_autoscaling_group.test"
+	resourceName := "aws_launch_template.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -596,21 +621,27 @@ func TestAccAWSLaunchTemplate_instanceMarketOptions(t *testing.T) {
 			{
 				Config: testAccAWSLaunchTemplateConfig_instanceMarketOptions_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchTemplateExists(templateName, &template),
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
 					testAccCheckAWSAutoScalingGroupExists(groupName, &group),
-					resource.TestCheckResourceAttr(templateName, "instance_market_options.#", "1"),
-					resource.TestCheckResourceAttr(templateName, "instance_market_options.0.spot_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "instance_market_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "instance_market_options.0.spot_options.#", "1"),
 					resource.TestCheckResourceAttr(groupName, "launch_template.#", "1"),
 					resource.TestCheckResourceAttr(groupName, "launch_template.0.version", "1"),
 				),
 			},
 			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name_prefix", "instance_market_options"},
+			},
+			{
 				Config: testAccAWSLaunchTemplateConfig_instanceMarketOptions_update,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchTemplateExists(templateName, &template),
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
 					testAccCheckAWSAutoScalingGroupExists(groupName, &group),
-					resource.TestCheckResourceAttr(templateName, "instance_market_options.#", "1"),
-					resource.TestCheckResourceAttr(templateName, "instance_market_options.0.spot_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "instance_market_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "instance_market_options.0.spot_options.#", "1"),
 					resource.TestCheckResourceAttr(groupName, "launch_template.#", "1"),
 					resource.TestCheckResourceAttr(groupName, "launch_template.0.version", "2"),
 				),
@@ -621,7 +652,7 @@ func TestAccAWSLaunchTemplate_instanceMarketOptions(t *testing.T) {
 
 func TestAccAWSLaunchTemplate_licenseSpecification(t *testing.T) {
 	var template ec2.LaunchTemplate
-	resName := "aws_launch_template.example"
+	resourceName := "aws_launch_template.example"
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -632,9 +663,14 @@ func TestAccAWSLaunchTemplate_licenseSpecification(t *testing.T) {
 			{
 				Config: testAccAWSLaunchTemplateConfig_licenseSpecification(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLaunchTemplateExists(resName, &template),
-					resource.TestCheckResourceAttr(resName, "license_specification.#", "1"),
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "license_specification.#", "1"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -714,11 +750,11 @@ func testAccCheckAWSLaunchTemplateDisappears(launchTemplate *ec2.LaunchTemplate)
 
 func testAccAWSLaunchTemplateConfig_basic(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_launch_template" "foo" {
-  name = "foo_%d"
+resource "aws_launch_template" "test" {
+  name = "test_%d"
 
   tags = {
-    foo = "bar"
+    test = "bar"
   }
 }
 `, rInt)
@@ -726,8 +762,8 @@ resource "aws_launch_template" "foo" {
 
 func testAccAWSLaunchTemplateConfig_ipv6_count(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_launch_template" "foo" {
-  name = "set_ipv6_count_foo_%d"
+resource "aws_launch_template" "test" {
+  name = "set_ipv6_count_test_%d"
 
   network_interfaces {
     ipv6_address_count = 1
@@ -860,8 +896,8 @@ resource "aws_launch_template" "test" {
 
 func testAccAWSLaunchTemplateConfig_data(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_launch_template" "foo" {
-  name = "foo_%d"
+resource "aws_launch_template" "test" {
+  name = "test_%d"
 
   block_device_mappings {
     device_name = "test"
@@ -923,8 +959,8 @@ resource "aws_launch_template" "foo" {
 
 func testAccAWSLaunchTemplateConfig_tagsUpdate(rInt int) string {
 	return fmt.Sprintf(`
-resource "aws_launch_template" "foo" {
-  name = "foo_%d"
+resource "aws_launch_template" "test" {
+  name = "test_%d"
 
   tags = {
     bar = "baz"
@@ -935,8 +971,8 @@ resource "aws_launch_template" "foo" {
 
 func testAccAWSLaunchTemplateConfig_capacityReservation_preference(rInt int, preference string) string {
 	return fmt.Sprintf(`
-resource "aws_launch_template" "foo" {
-  name = "foo_%d"
+resource "aws_launch_template" "test" {
+  name = "test_%d"
 
   capacity_reservation_specification {
     capacity_reservation_preference = %q
@@ -956,8 +992,8 @@ resource "aws_ec2_capacity_reservation" "test" {
   instance_type     = "t2.micro"
 }
 
-resource "aws_launch_template" "foo" {
-  name = "foo_%d"
+resource "aws_launch_template" "test" {
+  name = "test_%d"
 
   capacity_reservation_specification {
     capacity_reservation_target {
@@ -970,7 +1006,7 @@ resource "aws_launch_template" "foo" {
 
 func testAccAWSLaunchTemplateConfig_creditSpecification(rName, instanceType, cpuCredits string) string {
 	return fmt.Sprintf(`
-resource "aws_launch_template" "foo" {
+resource "aws_launch_template" "test" {
   instance_type = %q
   name          = %q
 
@@ -999,7 +1035,7 @@ resource "aws_licensemanager_license_configuration" "example" {
 }
 
 resource "aws_launch_template" "example" {
-  name = "foo_%d"
+  name = "test_%d"
 
   license_specification {
     license_configuration_arn = "${aws_licensemanager_license_configuration.example.id}"
@@ -1010,7 +1046,7 @@ resource "aws_launch_template" "example" {
 
 func testAccAWSLaunchTemplateConfig_description(rName, description string) string {
 	return fmt.Sprintf(`
-resource "aws_launch_template" "foo" {
+resource "aws_launch_template" "test" {
   name        = "%s"
   description = "%s"
 }
@@ -1065,8 +1101,8 @@ data "aws_ami" "test_ami" {
   }
 }
 
-resource "aws_launch_template" "foo" {
-  name_prefix = "foobar"
+resource "aws_launch_template" "test" {
+  name_prefix = "testbar"
   image_id = "${data.aws_ami.test_ami.id}"
   instance_type = "t2.micro"
 }
@@ -1079,8 +1115,8 @@ resource "aws_autoscaling_group" "bar" {
   max_size = 0
   min_size = 0
   launch_template {
-    id = "${aws_launch_template.foo.id}"
-    version = "${aws_launch_template.foo.latest_version}"
+    id = "${aws_launch_template.test.id}"
+    version = "${aws_launch_template.test.latest_version}"
   }
 }
 `
@@ -1096,8 +1132,8 @@ data "aws_ami" "test_ami" {
   }
 }
 
-resource "aws_launch_template" "foo" {
-  name_prefix = "foobar"
+resource "aws_launch_template" "test" {
+  name_prefix = "testbar"
   image_id = "${data.aws_ami.test_ami.id}"
   instance_type = "t2.nano"
 }
@@ -1110,8 +1146,8 @@ resource "aws_autoscaling_group" "bar" {
   max_size = 0
   min_size = 0
   launch_template {
-    id = "${aws_launch_template.foo.id}"
-    version = "${aws_launch_template.foo.latest_version}"
+    id = "${aws_launch_template.test.id}"
+    version = "${aws_launch_template.test.latest_version}"
   }
 }
 `


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8944

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSLaunchTemplate_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSLaunchTemplate_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSLaunchTemplate_basic
=== PAUSE TestAccAWSLaunchTemplate_basic
=== RUN   TestAccAWSLaunchTemplate_disappears
=== PAUSE TestAccAWSLaunchTemplate_disappears
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
=== PAUSE TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
=== PAUSE TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
=== RUN   TestAccAWSLaunchTemplate_EbsOptimized
=== PAUSE TestAccAWSLaunchTemplate_EbsOptimized
=== RUN   TestAccAWSLaunchTemplate_ElasticInferenceAccelerator
=== PAUSE TestAccAWSLaunchTemplate_ElasticInferenceAccelerator
=== RUN   TestAccAWSLaunchTemplate_data
=== PAUSE TestAccAWSLaunchTemplate_data
=== RUN   TestAccAWSLaunchTemplate_description
=== PAUSE TestAccAWSLaunchTemplate_description
=== RUN   TestAccAWSLaunchTemplate_update
=== PAUSE TestAccAWSLaunchTemplate_update
=== RUN   TestAccAWSLaunchTemplate_tags
=== PAUSE TestAccAWSLaunchTemplate_tags
=== RUN   TestAccAWSLaunchTemplate_capacityReservation_preference
=== PAUSE TestAccAWSLaunchTemplate_capacityReservation_preference
=== RUN   TestAccAWSLaunchTemplate_capacityReservation_target
=== PAUSE TestAccAWSLaunchTemplate_capacityReservation_target
=== RUN   TestAccAWSLaunchTemplate_creditSpecification_nonBurstable
=== PAUSE TestAccAWSLaunchTemplate_creditSpecification_nonBurstable
=== RUN   TestAccAWSLaunchTemplate_creditSpecification_t2
=== PAUSE TestAccAWSLaunchTemplate_creditSpecification_t2
=== RUN   TestAccAWSLaunchTemplate_creditSpecification_t3
=== PAUSE TestAccAWSLaunchTemplate_creditSpecification_t3
=== RUN   TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock
=== PAUSE TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock
=== RUN   TestAccAWSLaunchTemplate_networkInterface
=== PAUSE TestAccAWSLaunchTemplate_networkInterface
=== RUN   TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses
=== PAUSE TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses
=== RUN   TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount
=== PAUSE TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount
=== RUN   TestAccAWSLaunchTemplate_instanceMarketOptions
=== PAUSE TestAccAWSLaunchTemplate_instanceMarketOptions
=== RUN   TestAccAWSLaunchTemplate_licenseSpecification
=== PAUSE TestAccAWSLaunchTemplate_licenseSpecification
=== CONT  TestAccAWSLaunchTemplate_basic
=== CONT  TestAccAWSLaunchTemplate_capacityReservation_target
=== CONT  TestAccAWSLaunchTemplate_disappears
=== CONT  TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses
=== CONT  TestAccAWSLaunchTemplate_instanceMarketOptions
=== CONT  TestAccAWSLaunchTemplate_networkInterface
=== CONT  TestAccAWSLaunchTemplate_tags
=== CONT  TestAccAWSLaunchTemplate_update
=== CONT  TestAccAWSLaunchTemplate_description
=== CONT  TestAccAWSLaunchTemplate_data
=== CONT  TestAccAWSLaunchTemplate_ElasticInferenceAccelerator
=== CONT  TestAccAWSLaunchTemplate_EbsOptimized
=== CONT  TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
=== CONT  TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
=== CONT  TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock
=== CONT  TestAccAWSLaunchTemplate_creditSpecification_t3
=== CONT  TestAccAWSLaunchTemplate_creditSpecification_t2
=== CONT  TestAccAWSLaunchTemplate_licenseSpecification
=== CONT  TestAccAWSLaunchTemplate_creditSpecification_nonBurstable
=== CONT  TestAccAWSLaunchTemplate_capacityReservation_preference
=== CONT  TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount
--- PASS: TestAccAWSLaunchTemplate_licenseSpecification (36.10s)
--- PASS: TestAccAWSLaunchTemplate_disappears (22.63s)
--- PASS: TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock (27.53s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_nonBurstable (31.60s)
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_preference (31.64s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t3 (31.72s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses (31.77s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t2 (31.79s)
--- PASS: TestAccAWSLaunchTemplate_data (31.83s)
--- PASS: TestAccAWSLaunchTemplate_basic (32.97s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount (29.77s)
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_target (39.88s)
--- PASS: TestAccAWSLaunchTemplate_description (51.32s)
--- PASS: TestAccAWSLaunchTemplate_ElasticInferenceAccelerator (51.42s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS (54.30s)
--- PASS: TestAccAWSLaunchTemplate_tags (54.79s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface (68.30s)
--- PASS: TestAccAWSLaunchTemplate_instanceMarketOptions (84.50s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination (86.04s)
--- PASS: TestAccAWSLaunchTemplate_update (86.55s)
--- PASS: TestAccAWSLaunchTemplate_EbsOptimized (111.24s)

make testacc TESTARGS="-run=TestAccAWSLaunchConfiguration_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSLaunchConfiguration_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSLaunchConfiguration_basic
=== PAUSE TestAccAWSLaunchConfiguration_basic
=== RUN   TestAccAWSLaunchConfiguration_withBlockDevices
=== PAUSE TestAccAWSLaunchConfiguration_withBlockDevices
=== RUN   TestAccAWSLaunchConfiguration_updateRootBlockDevice
=== PAUSE TestAccAWSLaunchConfiguration_updateRootBlockDevice
=== RUN   TestAccAWSLaunchConfiguration_encryptedRootBlockDevice
=== PAUSE TestAccAWSLaunchConfiguration_encryptedRootBlockDevice
=== RUN   TestAccAWSLaunchConfiguration_withSpotPrice
=== PAUSE TestAccAWSLaunchConfiguration_withSpotPrice
=== RUN   TestAccAWSLaunchConfiguration_withVpcClassicLink
=== PAUSE TestAccAWSLaunchConfiguration_withVpcClassicLink
=== RUN   TestAccAWSLaunchConfiguration_withIAMProfile
=== PAUSE TestAccAWSLaunchConfiguration_withIAMProfile
=== RUN   TestAccAWSLaunchConfiguration_withEncryption
=== PAUSE TestAccAWSLaunchConfiguration_withEncryption
=== RUN   TestAccAWSLaunchConfiguration_updateEbsBlockDevices
=== PAUSE TestAccAWSLaunchConfiguration_updateEbsBlockDevices
=== RUN   TestAccAWSLaunchConfiguration_ebs_noDevice
=== PAUSE TestAccAWSLaunchConfiguration_ebs_noDevice
=== RUN   TestAccAWSLaunchConfiguration_userData
=== PAUSE TestAccAWSLaunchConfiguration_userData
=== CONT  TestAccAWSLaunchConfiguration_basic
=== CONT  TestAccAWSLaunchConfiguration_userData
=== CONT  TestAccAWSLaunchConfiguration_withVpcClassicLink
=== CONT  TestAccAWSLaunchConfiguration_withIAMProfile
=== CONT  TestAccAWSLaunchConfiguration_updateEbsBlockDevices
=== CONT  TestAccAWSLaunchConfiguration_withSpotPrice
=== CONT  TestAccAWSLaunchConfiguration_encryptedRootBlockDevice
=== CONT  TestAccAWSLaunchConfiguration_updateRootBlockDevice
=== CONT  TestAccAWSLaunchConfiguration_ebs_noDevice
=== CONT  TestAccAWSLaunchConfiguration_withBlockDevices
=== CONT  TestAccAWSLaunchConfiguration_withEncryption
--- PASS: TestAccAWSLaunchConfiguration_withSpotPrice (33.05s)
--- PASS: TestAccAWSLaunchConfiguration_ebs_noDevice (35.92s)
--- PASS: TestAccAWSLaunchConfiguration_withBlockDevices (36.65s)
--- PASS: TestAccAWSLaunchConfiguration_withEncryption (37.26s)
--- PASS: TestAccAWSLaunchConfiguration_withIAMProfile (45.42s)
--- PASS: TestAccAWSLaunchConfiguration_basic (57.93s)
--- PASS: TestAccAWSLaunchConfiguration_userData (58.84s)
--- PASS: TestAccAWSLaunchConfiguration_encryptedRootBlockDevice (61.40s)
--- PASS: TestAccAWSLaunchConfiguration_updateRootBlockDevice (64.57s)
--- PASS: TestAccAWSLaunchConfiguration_updateEbsBlockDevices (65.97s)
--- PASS: TestAccAWSLaunchConfiguration_withVpcClassicLink (68.52s)
```
