### PR TITLE
add status attribute to resource/datasource aws_organizaion

### DIFF
--- a/aws/data_source_aws_organizations_organization.go
+++ b/aws/data_source_aws_organizations_organization.go
@@ -26,6 +26,10 @@ func dataSourceAwsOrganizationsOrganization() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"id": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -79,6 +83,10 @@ func dataSourceAwsOrganizationsOrganization() *schema.Resource {
 							Computed: true,
 						},
 						"email": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},

--- a/aws/data_source_aws_organizations_organization_test.go
+++ b/aws/data_source_aws_organizations_organization_test.go
@@ -29,6 +29,7 @@ func testAccDataSourceAwsOrganizationsOrganization_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "enabled_policy_types.#", dataSourceName, "enabled_policy_types.#"),
 					resource.TestCheckResourceAttrPair(resourceName, "feature_set", dataSourceName, "feature_set"),
 					resource.TestCheckResourceAttrPair(resourceName, "id", dataSourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "status", dataSourceName, "status"),
 					resource.TestCheckResourceAttrPair(resourceName, "master_account_arn", dataSourceName, "master_account_arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "master_account_email", dataSourceName, "master_account_email"),
 					resource.TestCheckResourceAttrPair(resourceName, "master_account_id", dataSourceName, "master_account_id"),

--- a/aws/resource_aws_organizations_organization.go
+++ b/aws/resource_aws_organizations_organization.go
@@ -67,6 +67,10 @@ func resourceAwsOrganizationsOrganization() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -88,6 +92,10 @@ func resourceAwsOrganizationsOrganization() *schema.Resource {
 							Computed: true,
 						},
 						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
@@ -412,10 +420,11 @@ func flattenOrganizationsAccounts(accounts []*organizations.Account) []map[strin
 	var result []map[string]interface{}
 	for _, account := range accounts {
 		result = append(result, map[string]interface{}{
-			"arn":   aws.StringValue(account.Arn),
-			"email": aws.StringValue(account.Email),
-			"id":    aws.StringValue(account.Id),
-			"name":  aws.StringValue(account.Name),
+			"arn":    aws.StringValue(account.Arn),
+			"email":  aws.StringValue(account.Email),
+			"id":     aws.StringValue(account.Id),
+			"name":   aws.StringValue(account.Name),
+			"status": aws.StringValue(account.Status),
 		})
 	}
 	return result

--- a/website/docs/r/organizations_organization.html.markdown
+++ b/website/docs/r/organizations_organization.html.markdown
@@ -39,6 +39,7 @@ In addition to all arguments above, the following attributes are exported:
   * `email` - Email of the account
   * `id` - Identifier of the account
   * `name` - Name of the account
+  * `status` - Current status of the account
 * `arn` - ARN of the organization
 * `id` - Identifier of the organization
 * `master_account_arn` - ARN of the master account
@@ -49,6 +50,7 @@ In addition to all arguments above, the following attributes are exported:
   * `email` - Email of the account
   * `id` - Identifier of the account
   * `name` - Name of the account
+  * `status` - Current status of the account
 * `roots` - List of organization roots. All elements have these attributes:
   * `arn` - ARN of the root
   * `id` - Identifier of the root


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes [#10646](https://github.com/terraform-providers/terraform-provider-aws/issues/10646)

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_organizations_organization: Add status nested attribute to an account attribute. 
datasource/aws_organizations_organization: Add status nested attribute to an account attribute. 

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=testAccOrganizationsAccount'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=testAccOrganizationsAccount -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	0.881s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.028s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.079s [no tests to run]
```
