### PR TITLE
S3: support MethodNotAllowed for Object Lock Configuration

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -2452,6 +2452,11 @@ func readS3ObjectLockConfiguration(conn *s3.S3, bucket string) ([]interface{}, e
 		})
 	})
 	if err != nil {
+		// Certain S3 implementations do not include this API
+		if isAWSErr(err, "MethodNotAllowed", "") {
+			return nil, nil
+		}
+
 		if isAWSErr(err, "ObjectLockConfigurationNotFoundError", "") {
 			return nil, nil
 		}


### PR DESCRIPTION
Some environments do not support Bucket Object Lock Configuration which was causing errors when reading the bucket configuration. This changes allows us to ignore Object Lock Configuration
if the endpoint responds with `MethodNotAllowed`.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request


Closes #10153

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
NONE
```

Output from acceptance testing:

Did not run. Can follow up if needed. Would that be `make testacc TESTARGS='-run=TestAccAWSS3Bucket_'`?

Did test using the provider with this change to create an S3 bucket in the environment that originally motivated opening #10153.
