### PR TITLE
tests/resource/aws_lightsail_instance: Add sweeper

### DIFF
--- a/aws/resource_aws_lightsail_instance_test.go
+++ b/aws/resource_aws_lightsail_instance_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"errors"
 	"fmt"
+	"log"
 	"regexp"
 	"testing"
 	"time"
@@ -10,10 +11,66 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/lightsail"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_lightsail_instance", &resource.Sweeper{
+		Name: "aws_lightsail_instance",
+		F:    testSweepLightsailInstances,
+	})
+}
+
+func testSweepLightsailInstances(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("Error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).lightsailconn
+
+	input := &lightsail.GetInstancesInput{}
+	var sweeperErrs *multierror.Error
+
+	for {
+		output, err := conn.GetInstances(input)
+
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Lightsail Instance sweep for %s: %s", region, err)
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("Error retrieving Lightsail Instances: %s", err)
+		}
+
+		for _, instance := range output.Instances {
+			name := aws.StringValue(instance.Name)
+			input := &lightsail.DeleteInstanceInput{
+				InstanceName: instance.Name,
+			}
+
+			log.Printf("[INFO] Deleting Lightsail Instance: %s", name)
+			_, err := conn.DeleteInstance(input)
+
+			if err != nil {
+				sweeperErr := fmt.Errorf("error deleting Lightsail Instance (%s): %s", name, err)
+				log.Printf("[ERROR] %s", sweeperErr)
+				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+			}
+		}
+
+		if aws.StringValue(output.NextPageToken) == "" {
+			break
+		}
+
+		input.PageToken = output.NextPageToken
+	}
+
+	return sweeperErrs.ErrorOrNil()
+}
 
 func TestAccAWSLightsailInstance_basic(t *testing.T) {
 	var conf lightsail.Instance


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from sweeper in AWS Commercial:

```console
$ go test ./aws -v -timeout=10h -sweep=eu-west-1 -sweep-run=aws_lightsail_instance -sweep-allow-failures
...
2019/10/29 00:25:55 [INFO] Deleting Lightsail Instance: tf-test-lightsail-7047725526204136707
2019/10/29 00:25:56 [INFO] Deleting Lightsail Instance: tf-test-lightsail-4687202417593705632
2019/10/29 00:25:58 Sweeper Tests ran successfully:
	- aws_lightsail_instance
ok  	github.com/terraform-providers/terraform-provider-aws/aws	8.935s
```

Output from sweeper in AWS GovCloud (US):

```console
$ go test ./aws -v -timeout=10h -sweep=us-gov-west-1 -sweep-run=aws_lightsail_instance -sweep-allow-failures
...
2019/10/29 00:26:46 [WARN] Skipping Lightsail Instance sweep for us-gov-west-1: RequestError: send request failed
caused by: Post https://lightsail.us-gov-west-1.amazonaws.com/: dial tcp: lookup lightsail.us-gov-west-1.amazonaws.com: no such host
2019/10/29 00:26:46 Sweeper Tests ran successfully:
	- aws_lightsail_instance
ok  	github.com/terraform-providers/terraform-provider-aws/aws	4.261s
```