### PR TITLE
tests/resource/aws_globalaccelerator_accelerator: Add sweeper

### DIFF
--- a/aws/resource_aws_globalaccelerator_accelerator_test.go
+++ b/aws/resource_aws_globalaccelerator_accelerator_test.go
@@ -2,13 +2,98 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/globalaccelerator"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_globalaccelerator_accelerator", &resource.Sweeper{
+		Name: "aws_globalaccelerator_accelerator",
+		F:    testSweepGlobalAcceleratorAccelerators,
+	})
+}
+
+func testSweepGlobalAcceleratorAccelerators(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("Error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).globalacceleratorconn
+
+	input := &globalaccelerator.ListAcceleratorsInput{}
+	var sweeperErrs *multierror.Error
+
+	for {
+		output, err := conn.ListAccelerators(input)
+
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Global Accelerator Accelerator sweep for %s: %s", region, err)
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("Error retrieving Global Accelerator Accelerators: %s", err)
+		}
+
+		for _, accelerator := range output.Accelerators {
+			arn := aws.StringValue(accelerator.AcceleratorArn)
+
+			if aws.BoolValue(accelerator.Enabled) {
+				input := &globalaccelerator.UpdateAcceleratorInput{
+					AcceleratorArn: accelerator.AcceleratorArn,
+					Enabled:        aws.Bool(false),
+				}
+
+				log.Printf("[INFO] Disabling Global Accelerator Accelerator: %s", arn)
+
+				_, err := conn.UpdateAccelerator(input)
+
+				if err != nil {
+					sweeperErr := fmt.Errorf("error disabling Global Accelerator Accelerator (%s): %s", arn, err)
+					log.Printf("[ERROR] %s", sweeperErr)
+					sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+					continue
+				}
+
+				if err := resourceAwsGlobalAcceleratorAcceleratorWaitForState(conn, arn); err != nil {
+					sweeperErr := fmt.Errorf("error waiting for Global Accelerator Accelerator (%s) disable: %s", arn, err)
+					log.Printf("[ERROR] %s", sweeperErr)
+					sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+					continue
+				}
+			}
+
+			input := &globalaccelerator.DeleteAcceleratorInput{
+				AcceleratorArn: accelerator.AcceleratorArn,
+			}
+
+			log.Printf("[INFO] Deleting Global Accelerator Accelerator: %s", arn)
+			_, err := conn.DeleteAccelerator(input)
+
+			if err != nil {
+				sweeperErr := fmt.Errorf("error deleting Global Accelerator Accelerator (%s): %s", arn, err)
+				log.Printf("[ERROR] %s", sweeperErr)
+				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+			}
+		}
+
+		if aws.StringValue(output.NextToken) == "" {
+			break
+		}
+
+		input.NextToken = output.NextToken
+	}
+
+	return sweeperErrs.ErrorOrNil()
+}
 
 func TestAccAwsGlobalAcceleratorAccelerator_basic(t *testing.T) {
 	resourceName := "aws_globalaccelerator_accelerator.example"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from sweeper in AWS Commercial:

```console
$ go test ./aws -v -timeout=10h -sweep=us-west-2,us-east-1 -sweep-run=aws_globalaccelerator_accelerator -sweep-allow-failures
2019/10/29 01:10:45 [DEBUG] Running Sweepers for region (us-west-2):
2019/10/29 01:10:45 [DEBUG] Running Sweeper (aws_globalaccelerator_accelerator) in region (us-west-2)
...
2019/10/29 01:10:47 [INFO] Deleting Global Accelerator Accelerator: arn:aws:globalaccelerator::187416307283:accelerator/79b92eb9-b2db-47d1-976c-15259a52c8d1
2019/10/29 01:10:48 [INFO] Deleting Global Accelerator Accelerator: arn:aws:globalaccelerator::187416307283:accelerator/a8cfdff1-a0f2-412a-9c6d-b28ebffe1138
2019/10/29 01:10:49 [INFO] Deleting Global Accelerator Accelerator: arn:aws:globalaccelerator::187416307283:accelerator/349ecdba-4490-43f7-923e-e7934fe8b363
2019/10/29 01:10:50 [INFO] Deleting Global Accelerator Accelerator: arn:aws:globalaccelerator::187416307283:accelerator/51971cbf-809b-4f2a-b62f-fc279513bf25
2019/10/29 01:10:51 [INFO] Deleting Global Accelerator Accelerator: arn:aws:globalaccelerator::187416307283:accelerator/5548abed-1c92-49ab-9a8f-87d87e543294
2019/10/29 01:10:52 [INFO] Deleting Global Accelerator Accelerator: arn:aws:globalaccelerator::187416307283:accelerator/8a897a08-13d7-45b7-a37a-bf8257a4a538
2019/10/29 01:10:53 Sweeper Tests ran successfully:
	- aws_globalaccelerator_accelerator
2019/10/29 01:10:53 [DEBUG] Running Sweepers for region (us-east-1):
2019/10/29 01:10:53 [DEBUG] Running Sweeper (aws_globalaccelerator_accelerator) in region (us-east-1)
...
2019/10/29 01:10:55 Sweeper Tests ran successfully:
	- aws_globalaccelerator_accelerator
ok  	github.com/terraform-providers/terraform-provider-aws/aws	11.625s
```

Output from sweeper in AWS GovCloud (US):

```console
$ go test ./aws -v -timeout=10h -sweep=us-gov-west-1 -sweep-run=aws_globalaccelerator_accelerator -sweep-allow-failures
2019/10/29 01:11:28 [DEBUG] Running Sweepers for region (us-gov-west-1):
2019/10/29 01:11:28 [DEBUG] Running Sweeper (aws_globalaccelerator_accelerator) in region (us-gov-west-1)
...
2019/10/29 01:11:32 [WARN] Skipping Global Accelerator Accelerator sweep for us-gov-west-1: RequestError: send request failed
caused by: Post https://globalaccelerator.us-gov-west-1.amazonaws.com/: dial tcp: lookup globalaccelerator.us-gov-west-1.amazonaws.com: no such host
2019/10/29 01:11:32 Sweeper Tests ran successfully:
	- aws_globalaccelerator_accelerator
ok  	github.com/terraform-providers/terraform-provider-aws/aws	4.333s
```

