### PR TITLE
Import test refactor for opsworks resources

### DIFF
--- a/aws/resource_aws_opsworks_custom_layer_test.go
+++ b/aws/resource_aws_opsworks_custom_layer_test.go
@@ -14,11 +14,11 @@ import (
 )
 
 // These tests assume the existence of predefined Opsworks IAM roles named `aws-opsworks-ec2-role`
-// and `aws-opsworks-service-role`.
+// and `aws-opsworks-service-role`, and Opsworks stacks named `tf-acc`.
 
-func TestAccAWSOpsworksCustomLayer_importBasic(t *testing.T) {
+func TestAccAWSOpsworksCustomLayer_basic(t *testing.T) {
 	name := acctest.RandString(10)
-
+	var opslayer opsworks.Layer
 	resourceName := "aws_opsworks_custom_layer.tf-acc"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -28,8 +28,24 @@ func TestAccAWSOpsworksCustomLayer_importBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAwsOpsworksCustomLayerConfigVpcCreate(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksCustomLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "auto_assign_elastic_ips", "false"),
+					resource.TestCheckResourceAttr(resourceName, "auto_healing", "true"),
+					resource.TestCheckResourceAttr(resourceName, "drain_elb_on_shutdown", "true"),
+					resource.TestCheckResourceAttr(resourceName, "instance_shutdown_timeout", "300"),
+					resource.TestCheckResourceAttr(resourceName, "custom_security_group_ids.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "system_packages.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "system_packages.1368285564", "git"),
+					resource.TestCheckResourceAttr(resourceName, "system_packages.2937857443", "golang"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_volume.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_volume.3575749636.type", "gp2"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_volume.3575749636.number_of_disks", "2"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_volume.3575749636.mount_point", "/home"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_volume.3575749636.size", "100"),
+				),
 			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
@@ -39,9 +55,11 @@ func TestAccAWSOpsworksCustomLayer_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccAWSOpsworksCustomLayer_basic(t *testing.T) {
+func TestAccAWSOpsworksCustomLayer_noVPC(t *testing.T) {
 	stackName := fmt.Sprintf("tf-%d", acctest.RandInt())
 	var opslayer opsworks.Layer
+	resourceName := "aws_opsworks_custom_layer.tf-acc"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -50,116 +68,47 @@ func TestAccAWSOpsworksCustomLayer_basic(t *testing.T) {
 			{
 				Config: testAccAwsOpsworksCustomLayerConfigNoVpcCreate(stackName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSOpsworksCustomLayerExists(
-						"aws_opsworks_custom_layer.tf-acc", &opslayer),
+					testAccCheckAWSOpsworksCustomLayerExists(resourceName, &opslayer),
 					testAccCheckAWSOpsworksCreateLayerAttributes(&opslayer, stackName),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "name", stackName,
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "auto_assign_elastic_ips", "false",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "auto_healing", "true",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "drain_elb_on_shutdown", "true",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "instance_shutdown_timeout", "300",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "custom_security_group_ids.#", "2",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "system_packages.#", "2",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "system_packages.1368285564", "git",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "system_packages.2937857443", "golang",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "ebs_volume.#", "1",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "ebs_volume.3575749636.type", "gp2",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "ebs_volume.3575749636.number_of_disks", "2",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "ebs_volume.3575749636.mount_point", "/home",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "ebs_volume.3575749636.size", "100",
-					),
+					resource.TestCheckResourceAttr(resourceName, "name", stackName),
+					resource.TestCheckResourceAttr(resourceName, "auto_assign_elastic_ips", "false"),
+					resource.TestCheckResourceAttr(resourceName, "auto_healing", "true"),
+					resource.TestCheckResourceAttr(resourceName, "drain_elb_on_shutdown", "true"),
+					resource.TestCheckResourceAttr(resourceName, "instance_shutdown_timeout", "300"),
+					resource.TestCheckResourceAttr(resourceName, "custom_security_group_ids.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "system_packages.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "system_packages.1368285564", "git"),
+					resource.TestCheckResourceAttr(resourceName, "system_packages.2937857443", "golang"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_volume.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_volume.3575749636.type", "gp2"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_volume.3575749636.number_of_disks", "2"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_volume.3575749636.mount_point", "/home"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_volume.3575749636.size", "100"),
 				),
 			},
 			{
 				Config: testAccAwsOpsworksCustomLayerConfigUpdate(stackName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "name", stackName,
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "drain_elb_on_shutdown", "false",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "instance_shutdown_timeout", "120",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "custom_security_group_ids.#", "3",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "system_packages.#", "3",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "system_packages.1368285564", "git",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "system_packages.2937857443", "golang",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "system_packages.4101929740", "subversion",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "ebs_volume.#", "2",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "ebs_volume.3575749636.type", "gp2",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "ebs_volume.3575749636.number_of_disks", "2",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "ebs_volume.3575749636.mount_point", "/home",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "ebs_volume.3575749636.size", "100",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "ebs_volume.1266957920.type", "io1",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "ebs_volume.1266957920.number_of_disks", "4",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "ebs_volume.1266957920.mount_point", "/var",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "ebs_volume.1266957920.size", "100",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "ebs_volume.1266957920.raid_level", "1",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "ebs_volume.1266957920.iops", "3000",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_custom_layer.tf-acc", "custom_json", `{"layer_key":"layer_value2"}`,
-					),
+					resource.TestCheckResourceAttr(resourceName, "name", stackName),
+					resource.TestCheckResourceAttr(resourceName, "drain_elb_on_shutdown", "false"),
+					resource.TestCheckResourceAttr(resourceName, "instance_shutdown_timeout", "120"),
+					resource.TestCheckResourceAttr(resourceName, "custom_security_group_ids.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "system_packages.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "system_packages.1368285564", "git"),
+					resource.TestCheckResourceAttr(resourceName, "system_packages.2937857443", "golang"),
+					resource.TestCheckResourceAttr(resourceName, "system_packages.4101929740", "subversion"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_volume.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_volume.3575749636.type", "gp2"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_volume.3575749636.number_of_disks", "2"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_volume.3575749636.mount_point", "/home"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_volume.3575749636.size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_volume.1266957920.type", "io1"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_volume.1266957920.number_of_disks", "4"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_volume.1266957920.mount_point", "/var"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_volume.1266957920.size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_volume.1266957920.raid_level", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_volume.1266957920.iops", "3000"),
+					resource.TestCheckResourceAttr(resourceName, "custom_json", `{"layer_key":"layer_value2"}`),
 				),
 			},
 		},

--- a/aws/resource_aws_opsworks_instance_test.go
+++ b/aws/resource_aws_opsworks_instance_test.go
@@ -12,8 +12,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSOpsworksInstance_importBasic(t *testing.T) {
+func TestAccAWSOpsworksInstance_basic(t *testing.T) {
 	stackName := fmt.Sprintf("tf-%d", acctest.RandInt())
+	var opsinst opsworks.Instance
 	resourceName := "aws_opsworks_instance.tf-acc"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -23,85 +24,37 @@ func TestAccAWSOpsworksInstance_importBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAwsOpsworksInstanceConfigCreate(stackName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksInstanceExists(resourceName, &opsinst),
+					testAccCheckAWSOpsworksInstanceAttributes(&opsinst),
+					resource.TestCheckResourceAttr(resourceName, "hostname", "tf-acc1"),
+					resource.TestCheckResourceAttr(resourceName, "instance_type", "t2.micro"),
+					resource.TestCheckResourceAttr(resourceName, "state", "stopped"),
+					resource.TestCheckResourceAttr(resourceName, "layer_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "install_updates_on_boot", "true"),
+					resource.TestCheckResourceAttr(resourceName, "architecture", "x86_64"),
+					resource.TestCheckResourceAttr(resourceName, "tenancy", "default"),
+					resource.TestCheckResourceAttr(resourceName, "os", "Amazon Linux 2016.09"),      // inherited from opsworks_stack_test
+					resource.TestCheckResourceAttr(resourceName, "root_device_type", "ebs"),         // inherited from opsworks_stack_test
+					resource.TestCheckResourceAttr(resourceName, "availability_zone", "us-west-2a"), // inherited from opsworks_stack_test
+				),
 			},
-
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"state"}, //state is something we pass to the API and get back as status :(
 			},
-		},
-	})
-}
-
-func TestAccAWSOpsworksInstance(t *testing.T) {
-	stackName := fmt.Sprintf("tf-%d", acctest.RandInt())
-	var opsinst opsworks.Instance
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsOpsworksInstanceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAwsOpsworksInstanceConfigCreate(stackName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSOpsworksInstanceExists(
-						"aws_opsworks_instance.tf-acc", &opsinst),
-					testAccCheckAWSOpsworksInstanceAttributes(&opsinst),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_instance.tf-acc", "hostname", "tf-acc1",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_instance.tf-acc", "instance_type", "t2.micro",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_instance.tf-acc", "state", "stopped",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_instance.tf-acc", "layer_ids.#", "1",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_instance.tf-acc", "install_updates_on_boot", "true",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_instance.tf-acc", "architecture", "x86_64",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_instance.tf-acc", "tenancy", "default",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_instance.tf-acc", "os", "Amazon Linux 2016.09", // inherited from opsworks_stack_test
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_instance.tf-acc", "root_device_type", "ebs", // inherited from opsworks_stack_test
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_instance.tf-acc", "availability_zone", "us-west-2a", // inherited from opsworks_stack_test
-					),
-				),
-			},
 			{
 				Config: testAccAwsOpsworksInstanceConfigUpdate(stackName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSOpsworksInstanceExists(
-						"aws_opsworks_instance.tf-acc", &opsinst),
+					testAccCheckAWSOpsworksInstanceExists(resourceName, &opsinst),
 					testAccCheckAWSOpsworksInstanceAttributes(&opsinst),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_instance.tf-acc", "hostname", "tf-acc1",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_instance.tf-acc", "instance_type", "t2.small",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_instance.tf-acc", "layer_ids.#", "2",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_instance.tf-acc", "os", "Amazon Linux 2015.09",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_instance.tf-acc", "tenancy", "default",
-					),
+					resource.TestCheckResourceAttr(resourceName, "hostname", "tf-acc1"),
+					resource.TestCheckResourceAttr(resourceName, "instance_type", "t2.small"),
+					resource.TestCheckResourceAttr(resourceName, "layer_ids.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "os", "Amazon Linux 2015.09"),
+					resource.TestCheckResourceAttr(resourceName, "tenancy", "default"),
 				),
 			},
 		},
@@ -110,8 +63,9 @@ func TestAccAWSOpsworksInstance(t *testing.T) {
 
 func TestAccAWSOpsworksInstance_UpdateHostNameForceNew(t *testing.T) {
 	stackName := fmt.Sprintf("tf-%d", acctest.RandInt())
-
+	resourceName := "aws_opsworks_instance.tf-acc"
 	var before, after opsworks.Instance
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -120,15 +74,21 @@ func TestAccAWSOpsworksInstance_UpdateHostNameForceNew(t *testing.T) {
 			{
 				Config: testAccAwsOpsworksInstanceConfigCreate(stackName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSOpsworksInstanceExists("aws_opsworks_instance.tf-acc", &before),
-					resource.TestCheckResourceAttr("aws_opsworks_instance.tf-acc", "hostname", "tf-acc1"),
+					testAccCheckAWSOpsworksInstanceExists(resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "hostname", "tf-acc1"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"state"},
 			},
 			{
 				Config: testAccAwsOpsworksInstanceConfigUpdateHostName(stackName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSOpsworksInstanceExists("aws_opsworks_instance.tf-acc", &after),
-					resource.TestCheckResourceAttr("aws_opsworks_instance.tf-acc", "hostname", "tf-acc2"),
+					testAccCheckAWSOpsworksInstanceExists(resourceName, &after),
+					resource.TestCheckResourceAttr(resourceName, "hostname", "tf-acc2"),
 					testAccCheckAwsOpsworksInstanceRecreated(t, &before, &after),
 				),
 			},

--- a/aws/resource_aws_opsworks_stack_test.go
+++ b/aws/resource_aws_opsworks_stack_test.go
@@ -13,10 +13,14 @@ import (
 	"github.com/aws/aws-sdk-go/service/opsworks"
 )
 
-func TestAccAWSOpsworksStack_ImportBasic(t *testing.T) {
-	name := acctest.RandString(10)
+///////////////////////////////
+//// Tests for the No-VPC case
+///////////////////////////////
 
+func TestAccAWSOpsworksStack_noVpcBasic(t *testing.T) {
+	stackName := fmt.Sprintf("tf-opsworks-acc-%d", acctest.RandInt())
 	resourceName := "aws_opsworks_stack.tf-acc"
+	var opsstack opsworks.Stack
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -24,9 +28,13 @@ func TestAccAWSOpsworksStack_ImportBasic(t *testing.T) {
 		CheckDestroy: testAccCheckAwsOpsworksStackDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsOpsworksStackConfigVpcCreate(name),
+				Config: testAccAwsOpsworksStackConfigNoVpcCreate(stackName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksStackExists(resourceName, false, &opsstack),
+					testAccCheckAWSOpsworksCreateStackAttributes(&opsstack, "us-east-1a", stackName),
+					testAccAwsOpsworksStackCheckResourceAttrsCreate("us-east-1a", stackName),
+				),
 			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
@@ -36,13 +44,11 @@ func TestAccAWSOpsworksStack_ImportBasic(t *testing.T) {
 	})
 }
 
-///////////////////////////////
-//// Tests for the No-VPC case
-///////////////////////////////
-
-func TestAccAWSOpsworksStack_NoVpc(t *testing.T) {
+func TestAccAWSOpsworksStack_noVpcChangeServiceRoleForceNew(t *testing.T) {
 	stackName := fmt.Sprintf("tf-opsworks-acc-%d", acctest.RandInt())
-	var opsstack opsworks.Stack
+	resourceName := "aws_opsworks_stack.tf-acc"
+	var before, after opsworks.Stack
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -51,38 +57,18 @@ func TestAccAWSOpsworksStack_NoVpc(t *testing.T) {
 			{
 				Config: testAccAwsOpsworksStackConfigNoVpcCreate(stackName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSOpsworksStackExists(
-						"aws_opsworks_stack.tf-acc", false, &opsstack),
-					testAccCheckAWSOpsworksCreateStackAttributes(
-						&opsstack, "us-east-1a", stackName),
-					testAccAwsOpsworksStackCheckResourceAttrsCreate(
-						"us-east-1a", stackName),
+					testAccCheckAWSOpsworksStackExists(resourceName, false, &before),
 				),
 			},
-		},
-	})
-}
-
-func TestAccAWSOpsworksStack_NoVpcChangeServiceRoleForceNew(t *testing.T) {
-	stackName := fmt.Sprintf("tf-opsworks-acc-%d", acctest.RandInt())
-	var before, after opsworks.Stack
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsOpsworksStackDestroy,
-		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsOpsworksStackConfigNoVpcCreate(stackName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSOpsworksStackExists(
-						"aws_opsworks_stack.tf-acc", false, &before),
-				),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAwsOpsworksStackConfigNoVpcCreateUpdateServiceRole(stackName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSOpsworksStackExists(
-						"aws_opsworks_stack.tf-acc", false, &after),
+					testAccCheckAWSOpsworksStackExists(resourceName, false, &after),
 					testAccCheckAWSOpsworksStackRecreated(t, &before, &after),
 				),
 			},
@@ -90,9 +76,11 @@ func TestAccAWSOpsworksStack_NoVpcChangeServiceRoleForceNew(t *testing.T) {
 	})
 }
 
-func TestAccAWSOpsworksStack_Vpc(t *testing.T) {
+func TestAccAWSOpsworksStack_vpc(t *testing.T) {
 	stackName := fmt.Sprintf("tf-opsworks-acc-%d", acctest.RandInt())
+	resourceName := "aws_opsworks_stack.tf-acc"
 	var opsstack opsworks.Stack
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -101,32 +89,33 @@ func TestAccAWSOpsworksStack_Vpc(t *testing.T) {
 			{
 				Config: testAccAwsOpsworksStackConfigVpcCreate(stackName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSOpsworksStackExists(
-						"aws_opsworks_stack.tf-acc", true, &opsstack),
-					testAccCheckAWSOpsworksCreateStackAttributes(
-						&opsstack, "us-west-2a", stackName),
-					testAccAwsOpsworksStackCheckResourceAttrsCreate(
-						"us-west-2a", stackName),
+					testAccCheckAWSOpsworksStackExists(resourceName, true, &opsstack),
+					testAccCheckAWSOpsworksCreateStackAttributes(&opsstack, "us-west-2a", stackName),
+					testAccAwsOpsworksStackCheckResourceAttrsCreate("us-west-2a", stackName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSOpsworksStackConfigVpcUpdate(stackName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSOpsworksStackExists(
-						"aws_opsworks_stack.tf-acc", true, &opsstack),
-					testAccCheckAWSOpsworksUpdateStackAttributes(
-						&opsstack, "us-west-2a", stackName),
-					testAccAwsOpsworksStackCheckResourceAttrsUpdate(
-						"us-west-2a", stackName),
+					testAccCheckAWSOpsworksStackExists(resourceName, true, &opsstack),
+					testAccCheckAWSOpsworksUpdateStackAttributes(&opsstack, "us-west-2a", stackName),
+					testAccAwsOpsworksStackCheckResourceAttrsUpdate("us-west-2a", stackName),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAWSOpsworksStack_NoVpcCreateTags(t *testing.T) {
+func TestAccAWSOpsworksStack_noVpcCreateTags(t *testing.T) {
 	stackName := fmt.Sprintf("tf-opsworks-acc-%d", acctest.RandInt())
+	resourceName := "aws_opsworks_stack.tf-acc"
 	var opsstack opsworks.Stack
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -135,19 +124,23 @@ func TestAccAWSOpsworksStack_NoVpcCreateTags(t *testing.T) {
 			{
 				Config: testAccAwsOpsworksStackConfigNoVpcCreateTags(stackName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSOpsworksStackExists(
-						"aws_opsworks_stack.tf-acc", false, &opsstack),
-					resource.TestCheckResourceAttr("aws_opsworks_stack.tf-acc", "tags.%", "1"),
-					resource.TestCheckResourceAttr("aws_opsworks_stack.tf-acc", "tags.foo", "bar"),
+					testAccCheckAWSOpsworksStackExists(resourceName, false, &opsstack),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"tags"},
 			},
 			{
 				Config: testAccAwsOpsworksStackConfigNoVpcUpdateTags(stackName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSOpsworksStackExists(
-						"aws_opsworks_stack.tf-acc", false, &opsstack),
-					resource.TestCheckResourceAttr("aws_opsworks_stack.tf-acc", "tags.%", "1"),
-					resource.TestCheckResourceAttr("aws_opsworks_stack.tf-acc", "tags.wut", "asdf"),
+					testAccCheckAWSOpsworksStackExists(resourceName, false, &opsstack),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.wut", "asdf"),
 				),
 			},
 		},
@@ -157,10 +150,12 @@ func TestAccAWSOpsworksStack_NoVpcCreateTags(t *testing.T) {
 // Tests the addition of regional endpoints and supporting the classic link used
 // to create Stack's prior to v0.9.0.
 // See https://github.com/hashicorp/terraform/issues/12842
-func TestAccAWSOpsWorksStack_classic_endpoints(t *testing.T) {
+func TestAccAWSOpsWorksStack_classicEndpoints(t *testing.T) {
 	stackName := fmt.Sprintf("tf-opsworks-acc-%d", acctest.RandInt())
+	resourceName := "aws_opsworks_stack.main"
 	rInt := acctest.RandInt()
 	var opsstack opsworks.Stack
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -169,9 +164,13 @@ func TestAccAWSOpsWorksStack_classic_endpoints(t *testing.T) {
 			{
 				Config: testAccAwsOpsWorksStack_classic_endpoint(stackName, rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSOpsworksStackExists(
-						"aws_opsworks_stack.main", false, &opsstack),
+					testAccCheckAWSOpsworksStackExists(resourceName, false, &opsstack),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			// Ensure that changing to us-west-2 region results in no plan
 			{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8944

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
--- PASS: TestAccAWSOpsworksCustomLayer_basic (71.06s)
--- PASS: TestAccAWSOpsworksCustomLayer_noVPC (66.17s)

--- PASS: TestAccAWSOpsworksInstance_UpdateHostNameForceNew (118.36s)
--- PASS: TestAccAWSOpsworksInstance_basic (119.94s)

--- PASS: TestAccAWSOpsworksStack_noVpcBasic (43.89s)
--- PASS: TestAccAWSOpsworksStack_noVpcChangeServiceRoleForceNew (70.71s)
--- PASS: TestAccAWSOpsworksStack_vpc (108.51s)
--- PASS: TestAccAWSOpsworksStack_noVpcCreateTags (71.16s)
--- PASS: TestAccAWSOpsWorksStack_classicEndpoints (57.56s)
```
