### PR TITLE
internal/keyvaluetags: Use Go 1.13 error wrapping with UpdateTags errors

### DIFF
--- a/aws/awserr.go
+++ b/aws/awserr.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"errors"
 	"strings"
 	"time"
 
@@ -13,8 +14,9 @@ import (
 //  * Error.Code() matches code
 //  * Error.Message() contains message
 func isAWSErr(err error, code string, message string) bool {
-	if err, ok := err.(awserr.Error); ok {
-		return err.Code() == code && strings.Contains(err.Message(), message)
+	var awsErr awserr.Error
+	if errors.As(err, &awsErr) {
+		return awsErr.Code() == code && strings.Contains(awsErr.Message(), message)
 	}
 	return false
 }

--- a/aws/awserr_test.go
+++ b/aws/awserr_test.go
@@ -1,0 +1,180 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+)
+
+func TestIsAwsErr(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		Err      error
+		Code     string
+		Message  string
+		Expected bool
+	}{
+		{
+			Name: "nil error",
+			Err:  nil,
+		},
+		{
+			Name: "nil error code",
+			Err:  nil,
+			Code: "test",
+		},
+		{
+			Name:    "nil error message",
+			Err:     nil,
+			Message: "test",
+		},
+		{
+			Name:    "nil error code and message",
+			Err:     nil,
+			Code:    "test",
+			Message: "test",
+		},
+		{
+			Name: "other error",
+			Err:  errors.New("test"),
+		},
+		{
+			Name: "other error code",
+			Err:  errors.New("test"),
+			Code: "test",
+		},
+		{
+			Name:    "other error message",
+			Err:     errors.New("test"),
+			Message: "test",
+		},
+		{
+			Name:    "other error code and message",
+			Err:     errors.New("test"),
+			Code:    "test",
+			Message: "test",
+		},
+		{
+			Name:     "awserr error matching code and no message",
+			Err:      awserr.New("TestCode", "TestMessage", nil),
+			Code:     "TestCode",
+			Expected: true,
+		},
+		{
+			Name:     "awserr error matching code and matching message exact",
+			Err:      awserr.New("TestCode", "TestMessage", nil),
+			Code:     "TestCode",
+			Message:  "TestMessage",
+			Expected: true,
+		},
+		{
+			Name:     "awserr error matching code and matching message contains",
+			Err:      awserr.New("TestCode", "TestMessage", nil),
+			Code:     "TestCode",
+			Message:  "Message",
+			Expected: true,
+		},
+		{
+			Name:    "awserr error matching code and non-matching message",
+			Err:     awserr.New("TestCode", "TestMessage", nil),
+			Code:    "TestCode",
+			Message: "NotMatching",
+		},
+		{
+			Name: "awserr error no code",
+			Err:  awserr.New("TestCode", "TestMessage", nil),
+		},
+		{
+			Name:    "awserr error no code and matching message exact",
+			Err:     awserr.New("TestCode", "TestMessage", nil),
+			Message: "TestMessage",
+		},
+		{
+			Name: "awserr error non-matching code",
+			Err:  awserr.New("TestCode", "TestMessage", nil),
+			Code: "NotMatching",
+		},
+		{
+			Name:    "awserr error non-matching code and message exact",
+			Err:     awserr.New("TestCode", "TestMessage", nil),
+			Message: "TestMessage",
+		},
+		{
+			Name: "wrapped other error",
+			Err:  fmt.Errorf("test: %w", errors.New("test")),
+		},
+		{
+			Name: "wrapped other error code",
+			Err:  fmt.Errorf("test: %w", errors.New("test")),
+			Code: "test",
+		},
+		{
+			Name:    "wrapped other error message",
+			Err:     fmt.Errorf("test: %w", errors.New("test")),
+			Message: "test",
+		},
+		{
+			Name:    "wrapped other error code and message",
+			Err:     fmt.Errorf("test: %w", errors.New("test")),
+			Code:    "test",
+			Message: "test",
+		},
+		{
+			Name:     "wrapped awserr error matching code and no message",
+			Err:      fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
+			Code:     "TestCode",
+			Expected: true,
+		},
+		{
+			Name:     "wrapped awserr error matching code and matching message exact",
+			Err:      fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
+			Code:     "TestCode",
+			Message:  "TestMessage",
+			Expected: true,
+		},
+		{
+			Name:     "wrapped awserr error matching code and matching message contains",
+			Err:      fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
+			Code:     "TestCode",
+			Message:  "Message",
+			Expected: true,
+		},
+		{
+			Name:    "wrapped awserr error matching code and non-matching message",
+			Err:     fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
+			Code:    "TestCode",
+			Message: "NotMatching",
+		},
+		{
+			Name: "wrapped awserr error no code",
+			Err:  fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
+		},
+		{
+			Name:    "wrapped awserr error no code and matching message exact",
+			Err:     fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
+			Message: "TestMessage",
+		},
+		{
+			Name: "wrapped awserr error non-matching code",
+			Err:  fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
+			Code: "NotMatching",
+		},
+		{
+			Name:    "wrapped awserr error non-matching code and message exact",
+			Err:     fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
+			Message: "TestMessage",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			got := isAWSErr(testCase.Err, testCase.Code, testCase.Message)
+
+			if got != testCase.Expected {
+				t.Errorf("got %t, expected %t", got, testCase.Expected)
+			}
+		})
+	}
+}

--- a/aws/internal/keyvaluetags/generators/updatetags/main.go
+++ b/aws/internal/keyvaluetags/generators/updatetags/main.go
@@ -190,7 +190,7 @@ func {{ . | Title }}UpdateTags(conn {{ . | ClientType }}, identifier string{{ if
 		_, err := conn.{{ . | UntagFunction }}(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -210,7 +210,7 @@ func {{ . | Title }}UpdateTags(conn {{ . | ClientType }}, identifier string{{ if
 		_, err := conn.{{ . | TagFunction }}(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 

--- a/aws/internal/keyvaluetags/update_tags_gen.go
+++ b/aws/internal/keyvaluetags/update_tags_gen.go
@@ -95,7 +95,7 @@ func AmplifyUpdateTags(conn *amplify.Amplify, identifier string, oldTagsMap inte
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -108,7 +108,7 @@ func AmplifyUpdateTags(conn *amplify.Amplify, identifier string, oldTagsMap inte
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -131,7 +131,7 @@ func ApigatewayUpdateTags(conn *apigateway.APIGateway, identifier string, oldTag
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -144,7 +144,7 @@ func ApigatewayUpdateTags(conn *apigateway.APIGateway, identifier string, oldTag
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -167,7 +167,7 @@ func Apigatewayv2UpdateTags(conn *apigatewayv2.ApiGatewayV2, identifier string, 
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -180,7 +180,7 @@ func Apigatewayv2UpdateTags(conn *apigatewayv2.ApiGatewayV2, identifier string, 
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -203,7 +203,7 @@ func AppmeshUpdateTags(conn *appmesh.AppMesh, identifier string, oldTagsMap inte
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -216,7 +216,7 @@ func AppmeshUpdateTags(conn *appmesh.AppMesh, identifier string, oldTagsMap inte
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -239,7 +239,7 @@ func AppstreamUpdateTags(conn *appstream.AppStream, identifier string, oldTagsMa
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -252,7 +252,7 @@ func AppstreamUpdateTags(conn *appstream.AppStream, identifier string, oldTagsMa
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -275,7 +275,7 @@ func AppsyncUpdateTags(conn *appsync.AppSync, identifier string, oldTagsMap inte
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -288,7 +288,7 @@ func AppsyncUpdateTags(conn *appsync.AppSync, identifier string, oldTagsMap inte
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -311,7 +311,7 @@ func AthenaUpdateTags(conn *athena.Athena, identifier string, oldTagsMap interfa
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -324,7 +324,7 @@ func AthenaUpdateTags(conn *athena.Athena, identifier string, oldTagsMap interfa
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -347,7 +347,7 @@ func BackupUpdateTags(conn *backup.Backup, identifier string, oldTagsMap interfa
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -360,7 +360,7 @@ func BackupUpdateTags(conn *backup.Backup, identifier string, oldTagsMap interfa
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -383,7 +383,7 @@ func Cloudhsmv2UpdateTags(conn *cloudhsmv2.CloudHSMV2, identifier string, oldTag
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -396,7 +396,7 @@ func Cloudhsmv2UpdateTags(conn *cloudhsmv2.CloudHSMV2, identifier string, oldTag
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -419,7 +419,7 @@ func CloudwatchUpdateTags(conn *cloudwatch.CloudWatch, identifier string, oldTag
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -432,7 +432,7 @@ func CloudwatchUpdateTags(conn *cloudwatch.CloudWatch, identifier string, oldTag
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -455,7 +455,7 @@ func CloudwatcheventsUpdateTags(conn *cloudwatchevents.CloudWatchEvents, identif
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -468,7 +468,7 @@ func CloudwatcheventsUpdateTags(conn *cloudwatchevents.CloudWatchEvents, identif
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -491,7 +491,7 @@ func CodecommitUpdateTags(conn *codecommit.CodeCommit, identifier string, oldTag
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -504,7 +504,7 @@ func CodecommitUpdateTags(conn *codecommit.CodeCommit, identifier string, oldTag
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -527,7 +527,7 @@ func CodedeployUpdateTags(conn *codedeploy.CodeDeploy, identifier string, oldTag
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -540,7 +540,7 @@ func CodedeployUpdateTags(conn *codedeploy.CodeDeploy, identifier string, oldTag
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -563,7 +563,7 @@ func CodepipelineUpdateTags(conn *codepipeline.CodePipeline, identifier string, 
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -576,7 +576,7 @@ func CodepipelineUpdateTags(conn *codepipeline.CodePipeline, identifier string, 
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -599,7 +599,7 @@ func CognitoidentityUpdateTags(conn *cognitoidentity.CognitoIdentity, identifier
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -612,7 +612,7 @@ func CognitoidentityUpdateTags(conn *cognitoidentity.CognitoIdentity, identifier
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -635,7 +635,7 @@ func CognitoidentityproviderUpdateTags(conn *cognitoidentityprovider.CognitoIden
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -648,7 +648,7 @@ func CognitoidentityproviderUpdateTags(conn *cognitoidentityprovider.CognitoIden
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -671,7 +671,7 @@ func ConfigserviceUpdateTags(conn *configservice.ConfigService, identifier strin
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -684,7 +684,7 @@ func ConfigserviceUpdateTags(conn *configservice.ConfigService, identifier strin
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -707,7 +707,7 @@ func DatabasemigrationserviceUpdateTags(conn *databasemigrationservice.DatabaseM
 		_, err := conn.RemoveTagsFromResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -720,7 +720,7 @@ func DatabasemigrationserviceUpdateTags(conn *databasemigrationservice.DatabaseM
 		_, err := conn.AddTagsToResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -743,7 +743,7 @@ func DatapipelineUpdateTags(conn *datapipeline.DataPipeline, identifier string, 
 		_, err := conn.RemoveTags(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -756,7 +756,7 @@ func DatapipelineUpdateTags(conn *datapipeline.DataPipeline, identifier string, 
 		_, err := conn.AddTags(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -779,7 +779,7 @@ func DatasyncUpdateTags(conn *datasync.DataSync, identifier string, oldTagsMap i
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -792,7 +792,7 @@ func DatasyncUpdateTags(conn *datasync.DataSync, identifier string, oldTagsMap i
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -815,7 +815,7 @@ func DaxUpdateTags(conn *dax.DAX, identifier string, oldTagsMap interface{}, new
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -828,7 +828,7 @@ func DaxUpdateTags(conn *dax.DAX, identifier string, oldTagsMap interface{}, new
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -851,7 +851,7 @@ func DevicefarmUpdateTags(conn *devicefarm.DeviceFarm, identifier string, oldTag
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -864,7 +864,7 @@ func DevicefarmUpdateTags(conn *devicefarm.DeviceFarm, identifier string, oldTag
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -887,7 +887,7 @@ func DirectconnectUpdateTags(conn *directconnect.DirectConnect, identifier strin
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -900,7 +900,7 @@ func DirectconnectUpdateTags(conn *directconnect.DirectConnect, identifier strin
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -923,7 +923,7 @@ func DirectoryserviceUpdateTags(conn *directoryservice.DirectoryService, identif
 		_, err := conn.RemoveTagsFromResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -936,7 +936,7 @@ func DirectoryserviceUpdateTags(conn *directoryservice.DirectoryService, identif
 		_, err := conn.AddTagsToResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -959,7 +959,7 @@ func DocdbUpdateTags(conn *docdb.DocDB, identifier string, oldTagsMap interface{
 		_, err := conn.RemoveTagsFromResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -972,7 +972,7 @@ func DocdbUpdateTags(conn *docdb.DocDB, identifier string, oldTagsMap interface{
 		_, err := conn.AddTagsToResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -995,7 +995,7 @@ func DynamodbUpdateTags(conn *dynamodb.DynamoDB, identifier string, oldTagsMap i
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1008,7 +1008,7 @@ func DynamodbUpdateTags(conn *dynamodb.DynamoDB, identifier string, oldTagsMap i
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1031,7 +1031,7 @@ func Ec2UpdateTags(conn *ec2.EC2, identifier string, oldTagsMap interface{}, new
 		_, err := conn.DeleteTags(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1044,7 +1044,7 @@ func Ec2UpdateTags(conn *ec2.EC2, identifier string, oldTagsMap interface{}, new
 		_, err := conn.CreateTags(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1067,7 +1067,7 @@ func EcrUpdateTags(conn *ecr.ECR, identifier string, oldTagsMap interface{}, new
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1080,7 +1080,7 @@ func EcrUpdateTags(conn *ecr.ECR, identifier string, oldTagsMap interface{}, new
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1103,7 +1103,7 @@ func EcsUpdateTags(conn *ecs.ECS, identifier string, oldTagsMap interface{}, new
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1116,7 +1116,7 @@ func EcsUpdateTags(conn *ecs.ECS, identifier string, oldTagsMap interface{}, new
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1139,7 +1139,7 @@ func EfsUpdateTags(conn *efs.EFS, identifier string, oldTagsMap interface{}, new
 		_, err := conn.DeleteTags(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1152,7 +1152,7 @@ func EfsUpdateTags(conn *efs.EFS, identifier string, oldTagsMap interface{}, new
 		_, err := conn.CreateTags(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1175,7 +1175,7 @@ func EksUpdateTags(conn *eks.EKS, identifier string, oldTagsMap interface{}, new
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1188,7 +1188,7 @@ func EksUpdateTags(conn *eks.EKS, identifier string, oldTagsMap interface{}, new
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1211,7 +1211,7 @@ func ElasticacheUpdateTags(conn *elasticache.ElastiCache, identifier string, old
 		_, err := conn.RemoveTagsFromResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1224,7 +1224,7 @@ func ElasticacheUpdateTags(conn *elasticache.ElastiCache, identifier string, old
 		_, err := conn.AddTagsToResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1247,7 +1247,7 @@ func ElasticsearchserviceUpdateTags(conn *elasticsearchservice.ElasticsearchServ
 		_, err := conn.RemoveTags(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1260,7 +1260,7 @@ func ElasticsearchserviceUpdateTags(conn *elasticsearchservice.ElasticsearchServ
 		_, err := conn.AddTags(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1283,7 +1283,7 @@ func EmrUpdateTags(conn *emr.EMR, identifier string, oldTagsMap interface{}, new
 		_, err := conn.RemoveTags(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1296,7 +1296,7 @@ func EmrUpdateTags(conn *emr.EMR, identifier string, oldTagsMap interface{}, new
 		_, err := conn.AddTags(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1319,7 +1319,7 @@ func FirehoseUpdateTags(conn *firehose.Firehose, identifier string, oldTagsMap i
 		_, err := conn.UntagDeliveryStream(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1332,7 +1332,7 @@ func FirehoseUpdateTags(conn *firehose.Firehose, identifier string, oldTagsMap i
 		_, err := conn.TagDeliveryStream(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1355,7 +1355,7 @@ func FsxUpdateTags(conn *fsx.FSx, identifier string, oldTagsMap interface{}, new
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1368,7 +1368,7 @@ func FsxUpdateTags(conn *fsx.FSx, identifier string, oldTagsMap interface{}, new
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1391,7 +1391,7 @@ func GlueUpdateTags(conn *glue.Glue, identifier string, oldTagsMap interface{}, 
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1404,7 +1404,7 @@ func GlueUpdateTags(conn *glue.Glue, identifier string, oldTagsMap interface{}, 
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1427,7 +1427,7 @@ func GuarddutyUpdateTags(conn *guardduty.GuardDuty, identifier string, oldTagsMa
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1440,7 +1440,7 @@ func GuarddutyUpdateTags(conn *guardduty.GuardDuty, identifier string, oldTagsMa
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1463,7 +1463,7 @@ func IotUpdateTags(conn *iot.IoT, identifier string, oldTagsMap interface{}, new
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1476,7 +1476,7 @@ func IotUpdateTags(conn *iot.IoT, identifier string, oldTagsMap interface{}, new
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1499,7 +1499,7 @@ func IotanalyticsUpdateTags(conn *iotanalytics.IoTAnalytics, identifier string, 
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1512,7 +1512,7 @@ func IotanalyticsUpdateTags(conn *iotanalytics.IoTAnalytics, identifier string, 
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1535,7 +1535,7 @@ func IoteventsUpdateTags(conn *iotevents.IoTEvents, identifier string, oldTagsMa
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1548,7 +1548,7 @@ func IoteventsUpdateTags(conn *iotevents.IoTEvents, identifier string, oldTagsMa
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1571,7 +1571,7 @@ func KafkaUpdateTags(conn *kafka.Kafka, identifier string, oldTagsMap interface{
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1584,7 +1584,7 @@ func KafkaUpdateTags(conn *kafka.Kafka, identifier string, oldTagsMap interface{
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1607,7 +1607,7 @@ func KinesisanalyticsUpdateTags(conn *kinesisanalytics.KinesisAnalytics, identif
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1620,7 +1620,7 @@ func KinesisanalyticsUpdateTags(conn *kinesisanalytics.KinesisAnalytics, identif
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1643,7 +1643,7 @@ func Kinesisanalyticsv2UpdateTags(conn *kinesisanalyticsv2.KinesisAnalyticsV2, i
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1656,7 +1656,7 @@ func Kinesisanalyticsv2UpdateTags(conn *kinesisanalyticsv2.KinesisAnalyticsV2, i
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1679,7 +1679,7 @@ func KmsUpdateTags(conn *kms.KMS, identifier string, oldTagsMap interface{}, new
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1692,7 +1692,7 @@ func KmsUpdateTags(conn *kms.KMS, identifier string, oldTagsMap interface{}, new
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1715,7 +1715,7 @@ func LambdaUpdateTags(conn *lambda.Lambda, identifier string, oldTagsMap interfa
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1728,7 +1728,7 @@ func LambdaUpdateTags(conn *lambda.Lambda, identifier string, oldTagsMap interfa
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1751,7 +1751,7 @@ func LicensemanagerUpdateTags(conn *licensemanager.LicenseManager, identifier st
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1764,7 +1764,7 @@ func LicensemanagerUpdateTags(conn *licensemanager.LicenseManager, identifier st
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1787,7 +1787,7 @@ func LightsailUpdateTags(conn *lightsail.Lightsail, identifier string, oldTagsMa
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1800,7 +1800,7 @@ func LightsailUpdateTags(conn *lightsail.Lightsail, identifier string, oldTagsMa
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1823,7 +1823,7 @@ func MediaconnectUpdateTags(conn *mediaconnect.MediaConnect, identifier string, 
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1836,7 +1836,7 @@ func MediaconnectUpdateTags(conn *mediaconnect.MediaConnect, identifier string, 
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1859,7 +1859,7 @@ func MediaconvertUpdateTags(conn *mediaconvert.MediaConvert, identifier string, 
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1872,7 +1872,7 @@ func MediaconvertUpdateTags(conn *mediaconvert.MediaConvert, identifier string, 
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1895,7 +1895,7 @@ func MedialiveUpdateTags(conn *medialive.MediaLive, identifier string, oldTagsMa
 		_, err := conn.DeleteTags(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1908,7 +1908,7 @@ func MedialiveUpdateTags(conn *medialive.MediaLive, identifier string, oldTagsMa
 		_, err := conn.CreateTags(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1931,7 +1931,7 @@ func MediapackageUpdateTags(conn *mediapackage.MediaPackage, identifier string, 
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1944,7 +1944,7 @@ func MediapackageUpdateTags(conn *mediapackage.MediaPackage, identifier string, 
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1967,7 +1967,7 @@ func MediastoreUpdateTags(conn *mediastore.MediaStore, identifier string, oldTag
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -1980,7 +1980,7 @@ func MediastoreUpdateTags(conn *mediastore.MediaStore, identifier string, oldTag
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2003,7 +2003,7 @@ func MqUpdateTags(conn *mq.MQ, identifier string, oldTagsMap interface{}, newTag
 		_, err := conn.DeleteTags(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2016,7 +2016,7 @@ func MqUpdateTags(conn *mq.MQ, identifier string, oldTagsMap interface{}, newTag
 		_, err := conn.CreateTags(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2039,7 +2039,7 @@ func NeptuneUpdateTags(conn *neptune.Neptune, identifier string, oldTagsMap inte
 		_, err := conn.RemoveTagsFromResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2052,7 +2052,7 @@ func NeptuneUpdateTags(conn *neptune.Neptune, identifier string, oldTagsMap inte
 		_, err := conn.AddTagsToResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2075,7 +2075,7 @@ func OpsworksUpdateTags(conn *opsworks.OpsWorks, identifier string, oldTagsMap i
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2088,7 +2088,7 @@ func OpsworksUpdateTags(conn *opsworks.OpsWorks, identifier string, oldTagsMap i
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2111,7 +2111,7 @@ func OrganizationsUpdateTags(conn *organizations.Organizations, identifier strin
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2124,7 +2124,7 @@ func OrganizationsUpdateTags(conn *organizations.Organizations, identifier strin
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2147,7 +2147,7 @@ func RamUpdateTags(conn *ram.RAM, identifier string, oldTagsMap interface{}, new
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2160,7 +2160,7 @@ func RamUpdateTags(conn *ram.RAM, identifier string, oldTagsMap interface{}, new
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2183,7 +2183,7 @@ func RdsUpdateTags(conn *rds.RDS, identifier string, oldTagsMap interface{}, new
 		_, err := conn.RemoveTagsFromResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2196,7 +2196,7 @@ func RdsUpdateTags(conn *rds.RDS, identifier string, oldTagsMap interface{}, new
 		_, err := conn.AddTagsToResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2219,7 +2219,7 @@ func RedshiftUpdateTags(conn *redshift.Redshift, identifier string, oldTagsMap i
 		_, err := conn.DeleteTags(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2232,7 +2232,7 @@ func RedshiftUpdateTags(conn *redshift.Redshift, identifier string, oldTagsMap i
 		_, err := conn.CreateTags(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2255,7 +2255,7 @@ func Route53resolverUpdateTags(conn *route53resolver.Route53Resolver, identifier
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2268,7 +2268,7 @@ func Route53resolverUpdateTags(conn *route53resolver.Route53Resolver, identifier
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2291,7 +2291,7 @@ func SecretsmanagerUpdateTags(conn *secretsmanager.SecretsManager, identifier st
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2304,7 +2304,7 @@ func SecretsmanagerUpdateTags(conn *secretsmanager.SecretsManager, identifier st
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2327,7 +2327,7 @@ func SecurityhubUpdateTags(conn *securityhub.SecurityHub, identifier string, old
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2340,7 +2340,7 @@ func SecurityhubUpdateTags(conn *securityhub.SecurityHub, identifier string, old
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2363,7 +2363,7 @@ func SfnUpdateTags(conn *sfn.SFN, identifier string, oldTagsMap interface{}, new
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2376,7 +2376,7 @@ func SfnUpdateTags(conn *sfn.SFN, identifier string, oldTagsMap interface{}, new
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2399,7 +2399,7 @@ func SnsUpdateTags(conn *sns.SNS, identifier string, oldTagsMap interface{}, new
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2412,7 +2412,7 @@ func SnsUpdateTags(conn *sns.SNS, identifier string, oldTagsMap interface{}, new
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2436,7 +2436,7 @@ func SsmUpdateTags(conn *ssm.SSM, identifier string, resourceType string, oldTag
 		_, err := conn.RemoveTagsFromResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2450,7 +2450,7 @@ func SsmUpdateTags(conn *ssm.SSM, identifier string, resourceType string, oldTag
 		_, err := conn.AddTagsToResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2473,7 +2473,7 @@ func StoragegatewayUpdateTags(conn *storagegateway.StorageGateway, identifier st
 		_, err := conn.RemoveTagsFromResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2486,7 +2486,7 @@ func StoragegatewayUpdateTags(conn *storagegateway.StorageGateway, identifier st
 		_, err := conn.AddTagsToResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2509,7 +2509,7 @@ func SwfUpdateTags(conn *swf.SWF, identifier string, oldTagsMap interface{}, new
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2522,7 +2522,7 @@ func SwfUpdateTags(conn *swf.SWF, identifier string, oldTagsMap interface{}, new
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2545,7 +2545,7 @@ func TransferUpdateTags(conn *transfer.Transfer, identifier string, oldTagsMap i
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2558,7 +2558,7 @@ func TransferUpdateTags(conn *transfer.Transfer, identifier string, oldTagsMap i
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2581,7 +2581,7 @@ func WafUpdateTags(conn *waf.WAF, identifier string, oldTagsMap interface{}, new
 		_, err := conn.UntagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2594,7 +2594,7 @@ func WafUpdateTags(conn *waf.WAF, identifier string, oldTagsMap interface{}, new
 		_, err := conn.TagResource(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2617,7 +2617,7 @@ func WorkspacesUpdateTags(conn *workspaces.WorkSpaces, identifier string, oldTag
 		_, err := conn.DeleteTags(input)
 
 		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
 		}
 	}
 
@@ -2630,7 +2630,7 @@ func WorkspacesUpdateTags(conn *workspaces.WorkSpaces, identifier string, oldTag
 		_, err := conn.CreateTags(input)
 
 		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %s", identifier, err)
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 		}
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://blog.golang.org/go1.13-errors
Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/10411
Reference: https://github.com/terraform-providers/terraform-provider-aws/blob/c64f19eebf6e1c5d31374b02def9226b2945f52c/aws/resource_aws_subnet.go#L146-L151

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Found via acceptance testing prior to an actual release:

```
--- FAIL: TestAccAWSEMRCluster_basic (19.03s)
    testing.go:615: Step 0 error: errors during apply:
        
        Error: error adding tags: error tagging resource (subnet-04c4088b2c7f3aa42): InvalidSubnetID.NotFound: The subnet ID 'subnet-04c4088b2c7f3aa42' does not exist
        	status code: 400, request id: 2dafd3b1-ffef-49f9-98e0-1ede0726e8bb
```

Any logic attempting to check the returned AWS Go SDK error code/message from `keyvaluetags` package `UpdateTags` usage will not work since the errors are currently wrapped by value, which was the only option in Go 1.12 and earlier. Go 1.13 introduced the new `%w` verb for `fmt.Errorf()` for wrapping errors, which allows downstream logic to check wrapped error types via `errors.As()`.

Updated via:

```console
$ make gen
```

