### PR TITLE
Add Cognito user pool identity provider resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -387,6 +387,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_cognito_user_pool":                                   resourceAwsCognitoUserPool(),
 			"aws_cognito_user_pool_client":                            resourceAwsCognitoUserPoolClient(),
 			"aws_cognito_user_pool_domain":                            resourceAwsCognitoUserPoolDomain(),
+			"aws_cognito_user_pool_identity_provider":                 resourceAwsCognitoUserPoolIdentityProvider(),
 			"aws_cloudhsm_v2_cluster":                                 resourceAwsCloudHsm2Cluster(),
 			"aws_cloudhsm_v2_hsm":                                     resourceAwsCloudHsm2Hsm(),
 			"aws_cognito_resource_server":                             resourceAwsCognitoResourceServer(),

--- a/aws/resource_aws_cognito_user_pool_identity_provider.go
+++ b/aws/resource_aws_cognito_user_pool_identity_provider.go
@@ -1,0 +1,221 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func resourceAwsCognitoUserPoolIdentityProvider() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsCognitoUserPoolIdentityProviderCreate,
+		Read:   resourceAwsCognitoUserPoolIdentityProviderRead,
+		Update: resourceAwsCognitoUserPoolIdentityProviderUpdate,
+		Delete: resourceAwsCognitoUserPoolIdentityProviderDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsCognitoUserPoolIdentityProviderImport,
+		},
+
+		// https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateIdentityProvider.html
+		Schema: map[string]*schema.Schema{
+			"attribute_mapping": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringLenBetween(1, 32),
+				},
+			},
+
+			"idp_identifiers": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				MaxItems: 50,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 40),
+						validation.StringMatch(regexp.MustCompile(`^[\w\s+=.@-]+$`), "see https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateIdentityProvider.html#API_CreateIdentityProvider_RequestSyntax"),
+					),
+				},
+			},
+
+			"provider_details": {
+				Type:     schema.TypeMap,
+				Required: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"provider_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 32),
+					validation.StringMatch(regexp.MustCompile(`^[^_][\p{L}\p{M}\p{S}\p{N}\p{P}][^_]+$`), "see https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateIdentityProvider.html#API_CreateIdentityProvider_RequestSyntax"),
+				),
+			},
+
+			"provider_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					cognitoidentityprovider.IdentityProviderTypeTypeSaml,
+					cognitoidentityprovider.IdentityProviderTypeTypeFacebook,
+					cognitoidentityprovider.IdentityProviderTypeTypeGoogle,
+					cognitoidentityprovider.IdentityProviderTypeTypeLoginWithAmazon,
+					cognitoidentityprovider.IdentityProviderTypeTypeOidc,
+				}, false),
+			},
+
+			"user_pool_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateCognitoUserPoolId,
+			},
+		},
+	}
+}
+
+func resourceAwsCognitoUserPoolIdentityProviderCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cognitoidpconn
+
+	params := &cognitoidentityprovider.CreateIdentityProviderInput{
+		ProviderName:    aws.String(d.Get("provider_name").(string)),
+		ProviderType:    aws.String(d.Get("provider_type").(string)),
+		UserPoolId:      aws.String(d.Get("user_pool_id").(string)),
+		ProviderDetails: stringMapToPointers(d.Get("provider_details").(map[string]interface{})),
+	}
+
+	if v, ok := d.GetOk("attribute_mapping"); ok {
+		params.AttributeMapping = stringMapToPointers(v.(map[string]interface{}))
+	}
+
+	if v, ok := d.GetOk("idp_identifiers"); ok {
+		params.IdpIdentifiers = expandStringList(v.([]interface{}))
+	}
+
+	log.Printf("[DEBUG] Creating Cognito User Pool Identity Provider: %s", params)
+
+	resp, err := conn.CreateIdentityProvider(params)
+
+	if err != nil {
+		return fmt.Errorf("Error creating Cognito User Pool Identity Provider: %s", err)
+	}
+
+	d.SetId(*resp.IdentityProvider.ProviderName)
+
+	return resourceAwsCognitoUserPoolIdentityProviderRead(d, meta)
+}
+
+func resourceAwsCognitoUserPoolIdentityProviderRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cognitoidpconn
+
+	params := &cognitoidentityprovider.DescribeIdentityProviderInput{
+		UserPoolId:   aws.String(d.Get("user_pool_id").(string)),
+		ProviderName: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Reading Cognito User Pool Identity Provider: %s", params)
+
+	resp, err := conn.DescribeIdentityProvider(params)
+
+	if err != nil {
+		if isAWSErr(err, "ResourceNotFoundException", "") {
+			log.Printf("[WARN] Cognito User Pool Identity Provider %s is already gone", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	d.SetId(*resp.IdentityProvider.ProviderName)
+	d.Set("provider_name", *resp.IdentityProvider.ProviderName)
+	d.Set("user_pool_id", *resp.IdentityProvider.UserPoolId)
+	d.Set("provider_type", *resp.IdentityProvider.ProviderType)
+	if err := d.Set("idp_identifiers", flattenStringList(resp.IdentityProvider.IdpIdentifiers)); err != nil {
+		return fmt.Errorf("error setting idp_identifiers for resource %s: %s", d.Id(), err)
+	}
+	if err := d.Set("attribute_mapping", pointersMapToStringList(resp.IdentityProvider.AttributeMapping)); err != nil {
+		return fmt.Errorf("error setting attribute_mapping for resource %s: %s", d.Id(), err)
+	}
+	if err := d.Set("provider_details", pointersMapToStringList(resp.IdentityProvider.ProviderDetails)); err != nil {
+		return fmt.Errorf("error setting provider_details for resource %s: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceAwsCognitoUserPoolIdentityProviderUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cognitoidpconn
+
+	params := &cognitoidentityprovider.UpdateIdentityProviderInput{
+		ProviderName: aws.String(d.Id()),
+		UserPoolId:   aws.String(d.Get("user_pool_id").(string)),
+	}
+
+	if v, ok := d.GetOk("provider_details"); ok {
+		params.ProviderDetails = stringMapToPointers(v.(map[string]interface{}))
+	}
+
+	if v, ok := d.GetOk("attribute_mapping"); ok {
+		params.AttributeMapping = stringMapToPointers(v.(map[string]interface{}))
+	}
+
+	if v, ok := d.GetOk("idp_identifiers"); ok {
+		params.IdpIdentifiers = expandStringList(v.([]interface{}))
+	}
+
+	log.Printf("[DEBUG] Updating Cognito User Pool Identity Provider: %s", params)
+
+	_, err := conn.UpdateIdentityProvider(params)
+	if err != nil {
+		return fmt.Errorf("Error updating Cognito User Pool Identity Provider: %s", err)
+	}
+
+	return resourceAwsCognitoUserPoolIdentityProviderRead(d, meta)
+}
+
+func resourceAwsCognitoUserPoolIdentityProviderDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cognitoidpconn
+
+	params := &cognitoidentityprovider.DeleteIdentityProviderInput{
+		ProviderName: aws.String(d.Id()),
+		UserPoolId:   aws.String(d.Get("user_pool_id").(string)),
+	}
+
+	log.Printf("[DEBUG] Deleting Cognito User Pool Identity Provider: %s", params)
+
+	_, err := conn.DeleteIdentityProvider(params)
+
+	if err != nil {
+		return fmt.Errorf("Error deleting Cognito User Pool Identity Provider: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsCognitoUserPoolIdentityProviderImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	if len(strings.Split(d.Id(), "/")) != 2 || len(d.Id()) < 3 {
+		return []*schema.ResourceData{}, fmt.Errorf("Wrong format of resource: %s. Please follow 'user-pool-id/provider-name'", d.Id())
+	}
+	userPoolId := strings.Split(d.Id(), "/")[0]
+	providerName := strings.Split(d.Id(), "/")[1]
+	d.SetId(providerName)
+	d.Set("user_pool_id", userPoolId)
+	log.Printf("[DEBUG] Importing identity provider %s for user pool %s", providerName, userPoolId)
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/aws/resource_aws_cognito_user_pool_identity_provider_test.go
+++ b/aws/resource_aws_cognito_user_pool_identity_provider_test.go
@@ -1,0 +1,175 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccAWSCognitoUserPoolIdentityProvider_basic(t *testing.T) {
+	userPoolName := fmt.Sprintf("tf-acc-cognito-user-pool-%s", acctest.RandString(7))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoUserPoolIdentityProviderDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoUserPoolIdentityProvider_basic(userPoolName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoUserPoolIdentityProviderExists("aws_cognito_user_pool_identity_provider.basic"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_identity_provider.basic", "provider_name", "Google"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_identity_provider.basic", "provider_type", "Google"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_identity_provider.basic", "provider_details.authorize_scopes", "email"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_identity_provider.basic", "provider_details.attributes_url_add_attributes", "true"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_identity_provider.basic", "provider_details.authorize_url", "https://accounts.google.com/o/oauth2/v2/auth"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_identity_provider.basic", "provider_details.token_url", "https://www.googleapis.com/oauth2/v4/token"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_identity_provider.basic", "provider_details.oidc_issuer", "https://accounts.google.com"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_identity_provider.basic", "provider_details.client_id", "123456789012-a1b2c3d4f5g6h7i8j9k0l1m2n3o4p5q6.apps.googleusercontent.com"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_identity_provider.basic", "provider_details.attributes_url", "https://people.googleapis.com/v1/people/me?personFields="),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_identity_provider.basic", "provider_details.client_secret", "rAnDoMly_GeNeRaTeD_sEcReT"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_identity_provider.basic", "provider_details.token_request_method", "POST"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_identity_provider.basic", "attribute_mapping.username", "sub"),
+				),
+			},
+			{
+				Config: testAccAWSCognitoUserPoolIdentityProvider_basicUpdated(userPoolName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoUserPoolIdentityProviderExists("aws_cognito_user_pool_identity_provider.basic"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_identity_provider.basic", "provider_name", "Google"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_identity_provider.basic", "provider_type", "Google"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_identity_provider.basic", "provider_details.authorize_scopes", "email"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_identity_provider.basic", "provider_details.attributes_url_add_attributes", "true"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_identity_provider.basic", "provider_details.authorize_url", "https://accounts.google.com/o/oauth2/v2/auth"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_identity_provider.basic", "provider_details.token_url", "https://www.googleapis.com/oauth2/v4/token"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_identity_provider.basic", "provider_details.oidc_issuer", "https://accounts.google.com"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_identity_provider.basic", "provider_details.client_id", "123456789012-updatedclientid.apps.googleusercontent.com"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_identity_provider.basic", "provider_details.attributes_url", "https://people.googleapis.com/v1/people/me?personFields="),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_identity_provider.basic", "provider_details.client_secret", "aDifferentRandomlyGeneratedSecret"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_identity_provider.basic", "provider_details.token_request_method", "POST"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_identity_provider.basic", "attribute_mapping.username", "sub"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_identity_provider.basic", "attribute_mapping.email", "email"),
+				),
+			},
+			{
+				ResourceName:      "aws_cognito_user_pool.pool",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSCognitoUserPoolIdentityProviderDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).cognitoidpconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_cognito_user_pool_identity_provider" {
+			continue
+		}
+
+		params := &cognitoidentityprovider.DescribeIdentityProviderInput{
+			ProviderName: aws.String(rs.Primary.ID),
+			UserPoolId:   aws.String(rs.Primary.Attributes["user_pool_id"]),
+		}
+
+		_, err := conn.DescribeIdentityProvider(params)
+
+		if err != nil {
+			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "ResourceNotFoundException" {
+				return nil
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAWSCognitoUserPoolIdentityProviderExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("No Cognito User Pool Identity Provider ID set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).cognitoidpconn
+
+		params := &cognitoidentityprovider.DescribeIdentityProviderInput{
+			ProviderName: aws.String(rs.Primary.ID),
+			UserPoolId:   aws.String(rs.Primary.Attributes["user_pool_id"]),
+		}
+
+		_, err := conn.DescribeIdentityProvider(params)
+
+		return err
+	}
+}
+
+func testAccAWSCognitoUserPoolIdentityProvider_basic(userPoolName string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "pool" {
+  name = "%s"
+}
+
+resource "aws_cognito_user_pool_identity_provider" "basic" {
+  provider_name    = "Google"
+  user_pool_id     = "${aws_cognito_user_pool.pool.id}"
+  provider_type    = "Google"
+
+  provider_details = {
+    authorize_scopes              = "email"
+	attributes_url_add_attributes = "true"
+	authorize_url                 = "https://accounts.google.com/o/oauth2/v2/auth"
+	token_url                     = "https://www.googleapis.com/oauth2/v4/token"
+	oidc_issuer                   = "https://accounts.google.com"
+    client_id                     = "123456789012-a1b2c3d4f5g6h7i8j9k0l1m2n3o4p5q6.apps.googleusercontent.com"
+    attributes_url                = "https://people.googleapis.com/v1/people/me?personFields="
+    client_secret                 = "rAnDoMly_GeNeRaTeD_sEcReT"
+    token_request_method          = "POST"
+  }
+}
+`, userPoolName)
+}
+
+func testAccAWSCognitoUserPoolIdentityProvider_basicUpdated(userPoolName string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "pool" {
+  name = "%s"
+}
+
+resource "aws_cognito_user_pool_identity_provider" "basic" {
+  provider_name    = "Google"
+  user_pool_id     = "${aws_cognito_user_pool.pool.id}"
+  provider_type    = "Google"
+
+  provider_details = {
+    authorize_scopes              = "email"
+    attributes_url_add_attributes = "true"
+    authorize_url                 = "https://accounts.google.com/o/oauth2/v2/auth"
+    token_url                     = "https://www.googleapis.com/oauth2/v4/token"
+    oidc_issuer                   = "https://accounts.google.com"
+    client_id                     = "123456789012-updatedclientid.apps.googleusercontent.com"
+    attributes_url                = "https://people.googleapis.com/v1/people/me?personFields="
+    client_secret                 = "aDifferentRandomlyGeneratedSecret"
+    token_request_method          = "POST"
+  }
+
+  attribute_mapping = {
+    username = "sub"
+    email    = "email"
+  }
+}
+`, userPoolName)
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/10572

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
New Resource: aws_cognito_user_pool_identity_provider
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSCognitoUserPoolIdentityProvider_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSCognitoUserPoolIdentityProvider_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSCognitoUserPoolIdentityProvider_basic
=== PAUSE TestAccAWSCognitoUserPoolIdentityProvider_basic
=== CONT  TestAccAWSCognitoUserPoolIdentityProvider_basic
--- PASS: TestAccAWSCognitoUserPoolIdentityProvider_basic (66.37s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	66.392s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.024s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.003s [no tests to run]
```
