### PR TITLE
`aws_batch_compute_environment` to support name prefix

### DIFF
--- a/aws/resource_aws_batch_compute_environment.go
+++ b/aws/resource_aws_batch_compute_environment.go
@@ -21,19 +21,19 @@ func resourceAwsBatchComputeEnvironment() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"compute_environment_name": {
-				Type:         schema.TypeString,
+				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
-				ForceNew:     true,
+				ForceNew:      true,
 				ConflictsWith: []string{"compute_environment_name_prefix"},
-				ValidateFunc: validateBatchName,
+				ValidateFunc:  validateBatchName,
 			},
 			"compute_environment_name_prefix": {
-				Type:         schema.TypeString,
+				Type:          schema.TypeString,
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"compute_environment_name"},
-				ValidateFunc: validateBatchPrefix,
+				ValidateFunc:  validateBatchPrefix,
 			},
 			"compute_resources": {
 				Type:     schema.TypeList,

--- a/aws/resource_aws_batch_compute_environment.go
+++ b/aws/resource_aws_batch_compute_environment.go
@@ -22,9 +22,18 @@ func resourceAwsBatchComputeEnvironment() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"compute_environment_name": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:      true,
+				Computed:      true,
 				ForceNew:     true,
+				ConflictsWith: []string{"compute_environment_name_prefix"},
 				ValidateFunc: validateBatchName,
+			},
+			"compute_environment_name_prefix": {
+				Type:         schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"compute_environment_name"},
+				ValidateFunc: validateBatchPrefix,
 			},
 			"compute_resources": {
 				Type:     schema.TypeList,
@@ -169,7 +178,16 @@ func resourceAwsBatchComputeEnvironment() *schema.Resource {
 func resourceAwsBatchComputeEnvironmentCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).batchconn
 
-	computeEnvironmentName := d.Get("compute_environment_name").(string)
+	// Build the compute environment name.
+	var computeEnvironmentName string
+	if v, ok := d.GetOk("compute_environment_name"); ok {
+		computeEnvironmentName = v.(string)
+	} else if v, ok := d.GetOk("compute_environment_name_prefix"); ok {
+		computeEnvironmentName = resource.PrefixedUniqueId(v.(string))
+	} else {
+		computeEnvironmentName = resource.UniqueId()
+	}
+	d.Set("compute_environment_name", computeEnvironmentName)
 
 	serviceRole := d.Get("service_role").(string)
 	computeEnvironmentType := d.Get("type").(string)

--- a/aws/resource_aws_batch_compute_environment_test.go
+++ b/aws/resource_aws_batch_compute_environment_test.go
@@ -81,6 +81,27 @@ func TestAccAWSBatchComputeEnvironment_createEc2(t *testing.T) {
 	})
 }
 
+func TestAccAWSBatchComputeEnvironment_createWithNamePrefix(t *testing.T) {
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSBatchComputeEnvironmentConfigNamePrefix(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBatchComputeEnvironmentExists(),
+					resource.TestMatchResourceAttr(
+						"aws_batch_compute_environment.ec2", "compute_environment_name", regexp.MustCompile("^tf_acc_test-"),
+					),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSBatchComputeEnvironment_createEc2WithTags(t *testing.T) {
 	rInt := acctest.RandInt()
 
@@ -525,6 +546,32 @@ resource "aws_batch_compute_environment" "ec2" {
   depends_on = ["aws_iam_role_policy_attachment.aws_batch_service_role"]
 }
 `, rInt)
+}
+
+func testAccAWSBatchComputeEnvironmentConfigNamePrefix(rInt int) string {
+	return testAccAWSBatchComputeEnvironmentConfigBase(rInt) + `
+resource "aws_batch_compute_environment" "ec2" {
+  compute_environment_name_prefix = "tf_acc_test"
+  compute_resources {
+    instance_role = "${aws_iam_instance_profile.ecs_instance_role.arn}"
+    instance_type = [
+      "c4.large",
+    ]
+    max_vcpus = 16
+    min_vcpus = 0
+    security_group_ids = [
+      "${aws_security_group.test_acc.id}"
+    ]
+    subnets = [
+      "${aws_subnet.test_acc.id}"
+    ]
+    type = "EC2"
+  }
+  service_role = "${aws_iam_role.aws_batch_service_role.arn}"
+  type = "MANAGED"
+  depends_on = ["aws_iam_role_policy_attachment.aws_batch_service_role"]
+}
+`
 }
 
 func testAccAWSBatchComputeEnvironmentConfigEC2WithTags(rInt int) string {

--- a/aws/resource_aws_batch_compute_environment_test.go
+++ b/aws/resource_aws_batch_compute_environment_test.go
@@ -94,7 +94,7 @@ func TestAccAWSBatchComputeEnvironment_createWithNamePrefix(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsBatchComputeEnvironmentExists(),
 					resource.TestMatchResourceAttr(
-						"aws_batch_compute_environment.ec2", "compute_environment_name", regexp.MustCompile("^tf_acc_test-"),
+						"aws_batch_compute_environment.ec2", "compute_environment_name", regexp.MustCompile("^tf_acc_test"),
 					),
 				),
 			},

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1821,6 +1821,14 @@ func validateBatchName(v interface{}, k string) (ws []string, errors []error) {
 	return
 }
 
+func validateBatchPrefix(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[0-9a-zA-Z]{1}[0-9a-zA-Z_\-]{0,101}$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf("%q (%q) must be up to 102 letters (uppercase and lowercase), numbers, underscores and dashes, and must start with an alphanumeric.", k, v))
+	}
+	return
+}
+
 func validateSecurityGroupRuleDescription(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if len(value) > 255 {

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2225,6 +2225,29 @@ func TestValidateBatchName(t *testing.T) {
 	}
 }
 
+func TestValidateBatchPrefix(t *testing.T) {
+	validPrefixes := []string{
+		strings.Repeat("W", 102), // <= 102
+	}
+	for _, v := range validPrefixes {
+		_, errors := validateBatchPrefix(v, "prefix")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid Batch prefix: %q", v, errors)
+		}
+	}
+
+	invalidPrefixes := []string{
+		"s@mple",
+		strings.Repeat("W", 103), // >= 103
+	}
+	for _, v := range invalidPrefixes {
+		_, errors := validateBatchPrefix(v, "prefix")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be a invalid Batch prefix: %q", v, errors)
+		}
+	}
+}
+
 func TestValidateCognitoRoleMappingsAmbiguousRoleResolutionAgainstType(t *testing.T) {
 	cases := []struct {
 		AmbiguousRoleResolution interface{}

--- a/website/docs/r/batch_compute_environment.html.markdown
+++ b/website/docs/r/batch_compute_environment.html.markdown
@@ -116,44 +116,44 @@ resource "aws_batch_compute_environment" "sample" {
 
 ## Argument Reference
 
-- `compute_environment_name` - (Optional, Forces new resource) The name for your compute environment. Up to 128 letters (uppercase and lowercase), numbers, and underscores are allowed. If omitted, Terraform will assign a random, unique name.
-- `compute_environment_name_prefix` - (Optional, Forces new resource) Creates a unique compute environment name beginning with the specified prefix. Conflicts with `compute_environment_name`.
-- `compute_resources` - (Optional) Details of the compute resources managed by the compute environment. This parameter is required for managed compute environments. See details below.
-- `service_role` - (Required) The full Amazon Resource Name (ARN) of the IAM role that allows AWS Batch to make calls to other AWS services on your behalf.
-- `state` - (Optional) The state of the compute environment. If the state is `ENABLED`, then the compute environment accepts jobs from a queue and can scale out automatically based on queues. Valid items are `ENABLED` or `DISABLED`. Defaults to `ENABLED`.
-- `type` - (Required) The type of the compute environment. Valid items are `MANAGED` or `UNMANAGED`.
+* `compute_environment_name` - (Optional, Forces new resource) The name for your compute environment. Up to 128 letters (uppercase and lowercase), numbers, and underscores are allowed. If omitted, Terraform will assign a random, unique name.
+* `compute_environment_name_prefix` - (Optional, Forces new resource) Creates a unique compute environment name beginning with the specified prefix. Conflicts with `compute_environment_name`.
+* `compute_resources` - (Optional) Details of the compute resources managed by the compute environment. This parameter is required for managed compute environments. See details below.
+* `service_role` - (Required) The full Amazon Resource Name (ARN) of the IAM role that allows AWS Batch to make calls to other AWS services on your behalf.
+* `state` - (Optional) The state of the compute environment. If the state is `ENABLED`, then the compute environment accepts jobs from a queue and can scale out automatically based on queues. Valid items are `ENABLED` or `DISABLED`. Defaults to `ENABLED`.
+* `type` - (Required) The type of the compute environment. Valid items are `MANAGED` or `UNMANAGED`.
 
 **compute_resources** is a child block with a single argument:
 
-- `bid_percentage` - (Optional) Integer of minimum percentage that a Spot Instance price must be when compared with the On-Demand price for that instance type before instances are launched. For example, if your bid percentage is 20% (`20`), then the Spot price must be below 20% of the current On-Demand price for that EC2 instance. This parameter is required for SPOT compute environments.
-- `desired_vcpus` - (Optional) The desired number of EC2 vCPUS in the compute environment.
-- `ec2_key_pair` - (Optional) The EC2 key pair that is used for instances launched in the compute environment.
-- `image_id` - (Optional) The Amazon Machine Image (AMI) ID used for instances launched in the compute environment.
-- `instance_role` - (Required) The Amazon ECS instance role applied to Amazon EC2 instances in a compute environment.
-- `instance_type` - (Required) A list of instance types that may be launched.
-- `launch_template` - (Optional) The launch template to use for your compute resources. See details below.
-- `max_vcpus` - (Required) The maximum number of EC2 vCPUs that an environment can reach.
-- `min_vcpus` - (Required) The minimum number of EC2 vCPUs that an environment should maintain.
-- `security_group_ids` - (Required) A list of EC2 security group that are associated with instances launched in the compute environment.
-- `spot_iam_fleet_role` - (Optional) The Amazon Resource Name (ARN) of the Amazon EC2 Spot Fleet IAM role applied to a SPOT compute environment. This parameter is required for SPOT compute environments.
-- `subnets` - (Required) A list of VPC subnets into which the compute resources are launched.
-- `tags` - (Optional) Key-value pair tags to be applied to resources that are launched in the compute environment.
-- `type` - (Required) The type of compute environment. Valid items are `EC2` or `SPOT`.
+* `bid_percentage` - (Optional) Integer of minimum percentage that a Spot Instance price must be when compared with the On-Demand price for that instance type before instances are launched. For example, if your bid percentage is 20% (`20`), then the Spot price must be below 20% of the current On-Demand price for that EC2 instance. This parameter is required for SPOT compute environments.
+* `desired_vcpus` - (Optional) The desired number of EC2 vCPUS in the compute environment.
+* `ec2_key_pair` - (Optional) The EC2 key pair that is used for instances launched in the compute environment.
+* `image_id` - (Optional) The Amazon Machine Image (AMI) ID used for instances launched in the compute environment.
+* `instance_role` - (Required) The Amazon ECS instance role applied to Amazon EC2 instances in a compute environment.
+* `instance_type` - (Required) A list of instance types that may be launched.
+* `launch_template` - (Optional) The launch template to use for your compute resources. See details below.
+* `max_vcpus` - (Required) The maximum number of EC2 vCPUs that an environment can reach.
+* `min_vcpus` - (Required) The minimum number of EC2 vCPUs that an environment should maintain.
+* `security_group_ids` - (Required) A list of EC2 security group that are associated with instances launched in the compute environment.
+* `spot_iam_fleet_role` - (Optional) The Amazon Resource Name (ARN) of the Amazon EC2 Spot Fleet IAM role applied to a SPOT compute environment. This parameter is required for SPOT compute environments.
+* `subnets` - (Required) A list of VPC subnets into which the compute resources are launched.
+* `tags` - (Optional) Key-value pair tags to be applied to resources that are launched in the compute environment.
+* `type` - (Required) The type of compute environment. Valid items are `EC2` or `SPOT`.
 
 ### launch_template
 
 `launch_template` supports the following:
 
-- `launch_template_id` - (Optional) ID of the launch template. You must specify either the launch template ID or launch template name in the request, but not both.
-- `launch_template_name` - (Optional) Name of the launch template.
-- `version` - (Optional) The version number of the launch template. Default: The default version of the launch template.
+* `launch_template_id` - (Optional) ID of the launch template. You must specify either the launch template ID or launch template name in the request, but not both.
+* `launch_template_name` - (Optional) Name of the launch template.
+* `version` - (Optional) The version number of the launch template. Default: The default version of the launch template.
 
 ## Attributes Reference
 
-- `arn` - The Amazon Resource Name (ARN) of the compute environment.
-- `ecs_cluster_arn` - The Amazon Resource Name (ARN) of the underlying Amazon ECS cluster used by the compute environment.
-- `status` - The current status of the compute environment (for example, CREATING or VALID).
-- `status_reason` - A short, human-readable string to provide additional details about the current status of the compute environment.
+* `arn` - The Amazon Resource Name (ARN) of the compute environment.
+* `ecs_cluster_arn` - The Amazon Resource Name (ARN) of the underlying Amazon ECS cluster used by the compute environment.
+* `status` - The current status of the compute environment (for example, CREATING or VALID).
+* `status_reason` - A short, human-readable string to provide additional details about the current status of the compute environment.
 
 [1]: http://docs.aws.amazon.com/batch/latest/userguide/what-is-batch.html
 [2]: http://docs.aws.amazon.com/batch/latest/userguide/compute_environments.html

--- a/website/docs/r/batch_compute_environment.html.markdown
+++ b/website/docs/r/batch_compute_environment.html.markdown
@@ -13,7 +13,7 @@ For information about AWS Batch, see [What is AWS Batch?][1] .
 For information about compute environment, see [Compute Environments][2] .
 
 ~> **Note:** To prevent a race condition during environment deletion, make sure to set `depends_on` to the related `aws_iam_role_policy_attachment`;
-   otherwise, the policy may be destroyed too soon and the compute environment will then get stuck in the `DELETING` state, see [Troubleshooting AWS Batch][3] .
+otherwise, the policy may be destroyed too soon and the compute environment will then get stuck in the `DELETING` state, see [Troubleshooting AWS Batch][3] .
 
 ## Example Usage
 
@@ -116,43 +116,44 @@ resource "aws_batch_compute_environment" "sample" {
 
 ## Argument Reference
 
-* `compute_environment_name` - (Required) The name for your compute environment. Up to 128 letters (uppercase and lowercase), numbers, and underscores are allowed.
-* `compute_resources` - (Optional) Details of the compute resources managed by the compute environment. This parameter is required for managed compute environments. See details below.
-* `service_role` - (Required) The full Amazon Resource Name (ARN) of the IAM role that allows AWS Batch to make calls to other AWS services on your behalf.
-* `state` - (Optional) The state of the compute environment. If the state is `ENABLED`, then the compute environment accepts jobs from a queue and can scale out automatically based on queues. Valid items are `ENABLED` or `DISABLED`. Defaults to `ENABLED`.
-* `type` - (Required) The type of the compute environment. Valid items are `MANAGED` or `UNMANAGED`.
+- `compute_environment_name` - (Optional, Forces new resource) The name for your compute environment. Up to 128 letters (uppercase and lowercase), numbers, and underscores are allowed. If omitted, Terraform will assign a random, unique name.
+- `compute_environment_name_prefix` - (Optional, Forces new resource) Creates a unique compute environment name beginning with the specified prefix. Conflicts with `compute_environment_name`.
+- `compute_resources` - (Optional) Details of the compute resources managed by the compute environment. This parameter is required for managed compute environments. See details below.
+- `service_role` - (Required) The full Amazon Resource Name (ARN) of the IAM role that allows AWS Batch to make calls to other AWS services on your behalf.
+- `state` - (Optional) The state of the compute environment. If the state is `ENABLED`, then the compute environment accepts jobs from a queue and can scale out automatically based on queues. Valid items are `ENABLED` or `DISABLED`. Defaults to `ENABLED`.
+- `type` - (Required) The type of the compute environment. Valid items are `MANAGED` or `UNMANAGED`.
 
 **compute_resources** is a child block with a single argument:
 
-* `bid_percentage` - (Optional) Integer of minimum percentage that a Spot Instance price must be when compared with the On-Demand price for that instance type before instances are launched. For example, if your bid percentage is 20% (`20`), then the Spot price must be below 20% of the current On-Demand price for that EC2 instance. This parameter is required for SPOT compute environments.
-* `desired_vcpus` - (Optional) The desired number of EC2 vCPUS in the compute environment.
-* `ec2_key_pair` - (Optional) The EC2 key pair that is used for instances launched in the compute environment.
-* `image_id` - (Optional) The Amazon Machine Image (AMI) ID used for instances launched in the compute environment.
-* `instance_role` - (Required) The Amazon ECS instance role applied to Amazon EC2 instances in a compute environment.
-* `instance_type` - (Required) A list of instance types that may be launched.
-* `launch_template` - (Optional) The launch template to use for your compute resources. See details below.
-* `max_vcpus` - (Required) The maximum number of EC2 vCPUs that an environment can reach.
-* `min_vcpus` - (Required) The minimum number of EC2 vCPUs that an environment should maintain.
-* `security_group_ids` - (Required) A list of EC2 security group that are associated with instances launched in the compute environment.
-* `spot_iam_fleet_role` - (Optional) The Amazon Resource Name (ARN) of the Amazon EC2 Spot Fleet IAM role applied to a SPOT compute environment. This parameter is required for SPOT compute environments.
-* `subnets` - (Required) A list of VPC subnets into which the compute resources are launched.
-* `tags` - (Optional) Key-value pair tags to be applied to resources that are launched in the compute environment.
-* `type` - (Required) The type of compute environment. Valid items are `EC2` or `SPOT`.
+- `bid_percentage` - (Optional) Integer of minimum percentage that a Spot Instance price must be when compared with the On-Demand price for that instance type before instances are launched. For example, if your bid percentage is 20% (`20`), then the Spot price must be below 20% of the current On-Demand price for that EC2 instance. This parameter is required for SPOT compute environments.
+- `desired_vcpus` - (Optional) The desired number of EC2 vCPUS in the compute environment.
+- `ec2_key_pair` - (Optional) The EC2 key pair that is used for instances launched in the compute environment.
+- `image_id` - (Optional) The Amazon Machine Image (AMI) ID used for instances launched in the compute environment.
+- `instance_role` - (Required) The Amazon ECS instance role applied to Amazon EC2 instances in a compute environment.
+- `instance_type` - (Required) A list of instance types that may be launched.
+- `launch_template` - (Optional) The launch template to use for your compute resources. See details below.
+- `max_vcpus` - (Required) The maximum number of EC2 vCPUs that an environment can reach.
+- `min_vcpus` - (Required) The minimum number of EC2 vCPUs that an environment should maintain.
+- `security_group_ids` - (Required) A list of EC2 security group that are associated with instances launched in the compute environment.
+- `spot_iam_fleet_role` - (Optional) The Amazon Resource Name (ARN) of the Amazon EC2 Spot Fleet IAM role applied to a SPOT compute environment. This parameter is required for SPOT compute environments.
+- `subnets` - (Required) A list of VPC subnets into which the compute resources are launched.
+- `tags` - (Optional) Key-value pair tags to be applied to resources that are launched in the compute environment.
+- `type` - (Required) The type of compute environment. Valid items are `EC2` or `SPOT`.
 
 ### launch_template
 
 `launch_template` supports the following:
 
-* `launch_template_id` - (Optional) ID of the launch template. You must specify either the launch template ID or launch template name in the request, but not both.
-* `launch_template_name` - (Optional) Name of the launch template.
-* `version` - (Optional) The version number of the launch template. Default: The default version of the launch template.
+- `launch_template_id` - (Optional) ID of the launch template. You must specify either the launch template ID or launch template name in the request, but not both.
+- `launch_template_name` - (Optional) Name of the launch template.
+- `version` - (Optional) The version number of the launch template. Default: The default version of the launch template.
 
 ## Attributes Reference
 
-* `arn` - The Amazon Resource Name (ARN) of the compute environment.
-* `ecs_cluster_arn` - The Amazon Resource Name (ARN) of the underlying Amazon ECS cluster used by the compute environment.
-* `status` - The current status of the compute environment (for example, CREATING or VALID).
-* `status_reason` - A short, human-readable string to provide additional details about the current status of the compute environment.
+- `arn` - The Amazon Resource Name (ARN) of the compute environment.
+- `ecs_cluster_arn` - The Amazon Resource Name (ARN) of the underlying Amazon ECS cluster used by the compute environment.
+- `status` - The current status of the compute environment (for example, CREATING or VALID).
+- `status_reason` - A short, human-readable string to provide additional details about the current status of the compute environment.
 
 [1]: http://docs.aws.amazon.com/batch/latest/userguide/what-is-batch.html
 [2]: http://docs.aws.amazon.com/batch/latest/userguide/compute_environments.html


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Closes #3207

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
Adds `compute_environment_name_prefix` argument to `aws_batch_compute_environment` to allow cleanly replacing environments using `lifecycle.create_before_destroy = true`.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
...
```
