### PR TITLE
Docs: use aws_iam_role_policy_attachment for aws_s3_bucket example

### DIFF
--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -245,9 +245,8 @@ resource "aws_iam_policy" "replication" {
 POLICY
 }
 
-resource "aws_iam_policy_attachment" "replication" {
-  name       = "tf-iam-role-attachment-replication-12345"
-  roles      = ["${aws_iam_role.replication.name}"]
+resource "aws_iam_role_policy_attachment" "replication" {
+  role       = "${aws_iam_role.replication.name}"
   policy_arn = "${aws_iam_policy.replication.arn}"
 }
 


### PR DESCRIPTION
Remove last reference to `aws_iam_policy_attachment` to discourage using the old attachment method in favor of the newer (safer) method, even though it is safe in this example.

Using the `aws_iam_policy_attachment` example encourages use in other places, which can cause problems if it is a widely-used built-in policy.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```
NONE
```

Output from acceptance testing: N/A
