### PR TITLE
fix issue 10511 - aws_backup_selection

### DIFF
--- a/aws/resource_aws_backup_selection.go
+++ b/aws/resource_aws_backup_selection.go
@@ -105,14 +105,14 @@ func resourceAwsBackupSelectionCreate(d *schema.ResourceData, meta interface{}) 
 		// Retry on the following error:
 		// InvalidParameterValueException: IAM Role arn:aws:iam::123456789012:role/XXX cannot be assumed by AWS Backup
 		if isAWSErr(err, backup.ErrCodeInvalidParameterValueException, "cannot be assumed") {
-                        log.Printf("[DEBUG] Received %s, retrying create backup selection.", err)
+			log.Printf("[DEBUG] Received %s, retrying create backup selection.", err)
 			return resource.RetryableError(err)
 		}
 
 		// Retry on the following error:
 		// InvalidParameterValueException: IAM Role arn:aws:iam::123456789012:role/XXX is not authorized to call tag:GetResources
 		if isAWSErr(err, backup.ErrCodeInvalidParameterValueException, "is not authorized to call") {
-                        log.Printf("[DEBUG] Received %s, retrying create backup selection.", err)
+			log.Printf("[DEBUG] Received %s, retrying create backup selection.", err)
 			return resource.RetryableError(err)
 		}
 

--- a/aws/resource_aws_backup_selection.go
+++ b/aws/resource_aws_backup_selection.go
@@ -105,6 +105,14 @@ func resourceAwsBackupSelectionCreate(d *schema.ResourceData, meta interface{}) 
 		// Retry on the following error:
 		// InvalidParameterValueException: IAM Role arn:aws:iam::123456789012:role/XXX cannot be assumed by AWS Backup
 		if isAWSErr(err, backup.ErrCodeInvalidParameterValueException, "cannot be assumed") {
+                        log.Printf("[DEBUG] Received %s, retrying create backup selection.", err)
+			return resource.RetryableError(err)
+		}
+
+		// Retry on the following error:
+		// InvalidParameterValueException: IAM Role arn:aws:iam::123456789012:role/XXX is not authorized to call tag:GetResources
+		if isAWSErr(err, backup.ErrCodeInvalidParameterValueException, "is not authorized to call") {
+                        log.Printf("[DEBUG] Received %s, retrying create backup selection.", err)
 			return resource.RetryableError(err)
 		}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10511 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_backup_selection: Retry creation for IAM eventual consistency error in case the role attachment isn't consistent yet.
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAwsBackupSelection'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsBackupSelection -timeout 120m
=== RUN   TestAccAwsBackupSelection_basic
=== PAUSE TestAccAwsBackupSelection_basic
=== RUN   TestAccAwsBackupSelection_disappears
=== PAUSE TestAccAwsBackupSelection_disappears
=== RUN   TestAccAwsBackupSelection_withTags
=== PAUSE TestAccAwsBackupSelection_withTags
=== RUN   TestAccAwsBackupSelection_withResources
=== PAUSE TestAccAwsBackupSelection_withResources
=== RUN   TestAccAwsBackupSelection_updateTag
=== PAUSE TestAccAwsBackupSelection_updateTag
=== CONT  TestAccAwsBackupSelection_basic
=== CONT  TestAccAwsBackupSelection_withResources
=== CONT  TestAccAwsBackupSelection_updateTag
=== CONT  TestAccAwsBackupSelection_withTags
=== CONT  TestAccAwsBackupSelection_disappears
--- PASS: TestAccAwsBackupSelection_disappears (151.34s)
--- PASS: TestAccAwsBackupSelection_withTags (156.46s)
--- PASS: TestAccAwsBackupSelection_basic (158.43s)
--- PASS: TestAccAwsBackupSelection_withResources (164.58s)
--- PASS: TestAccAwsBackupSelection_updateTag (202.13s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       202.170s

...
```
