### PR TITLE
Add HashiBot behavior to lock closed issues after 30 days.

### DIFF
--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -1,10 +1,13 @@
-queued_behavior "release_commenter" "releases" {
-  repo_prefix = "terraform-provider-"
+poll "closed_issue_locker" "locker" {
+  schedule             = "0 50 14 * * *"
+  closed_for           = "720h" # 30 days
+  max_issues           = 500
+  sleep_between_issues = "5s"
 
   message = <<-EOF
-    This has been released in [version ${var.release_version} of the Terraform AWS provider](${var.changelog_link}). Please see the [Terraform documentation on provider versioning](https://www.terraform.io/docs/configuration/providers.html#provider-versions) or reach out if you need any assistance upgrading.
+    I'm going to lock this issue because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
 
-    For further feature requests or bug reports with this functionality, please create a [new GitHub issue](https://github.com/terraform-providers/terraform-provider-aws/issues/new/choose) following the template for triage. Thanks!
+    If you feel this issue should be reopened, we encourage creating a new issue linking back to this one for added context. If you feel I made an error 🤖 🙉 , please reach out to my human friends 👉  team-terraform-aws@hashicorp.com. Thanks!
   EOF
 }
 
@@ -29,6 +32,16 @@ behavior "deprecated_import_commenter" "hashicorp_terraform" {
     Another option is to create a new branch from the current master with the same code changes (replacing the import paths), submit a new pull request, and close this existing pull request.
 
     We apologize for this inconvenience and appreciate your effort. Thank you for contributing and helping make the Terraform AWS Provider better for everyone.
+  EOF
+}
+
+queued_behavior "release_commenter" "releases" {
+  repo_prefix = "terraform-provider-"
+
+  message = <<-EOF
+    This has been released in [version ${var.release_version} of the Terraform AWS provider](${var.changelog_link}). Please see the [Terraform documentation on provider versioning](https://www.terraform.io/docs/configuration/providers.html#provider-versions) or reach out if you need any assistance upgrading.
+
+    For further feature requests or bug reports with this functionality, please create a [new GitHub issue](https://github.com/terraform-providers/terraform-provider-aws/issues/new/choose) following the template for triage. Thanks!
   EOF
 }
 

--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -7,7 +7,7 @@ poll "closed_issue_locker" "locker" {
   message = <<-EOF
     I'm going to lock this issue because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
 
-    If you feel this issue should be reopened, we encourage creating a new issue linking back to this one for added context. If you feel I made an error 🤖 🙉 , please reach out to my human friends 👉  team-terraform-aws@hashicorp.com. Thanks!
+    If you feel this issue should be reopened, we encourage creating a new issue linking back to this one for added context. Thanks!
   EOF
 }
 


### PR DESCRIPTION
Organize short behavior blocks alphabetically.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
