### PR TITLE
add aws_provider_credentials data source

### DIFF
--- a/aws/data_source_aws_provider_credentials.go
+++ b/aws/data_source_aws_provider_credentials.go
@@ -1,0 +1,49 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAwsProviderCredentials() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsProviderCredentialsRead,
+
+		Schema: map[string]*schema.Schema{
+			"access_key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"secret_key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"session_token": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsProviderCredentialsRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AWSClient).stsconn
+
+	log.Printf("[DEBUG] Provider Credentials fetching credentials from session")
+	creds, err := client.Config.Credentials.Get()
+	if err != nil {
+		return fmt.Errorf("Error getting credentials: %v", err)
+	}
+
+	d.SetId(time.Now().UTC().String())
+	d.Set("access_key", creds.AccessKeyID)
+	d.Set("secret_key", creds.SecretAccessKey)
+	d.Set("session_token", creds.SessionToken)
+
+	return nil
+}

--- a/aws/data_source_aws_provider_credentials_test.go
+++ b/aws/data_source_aws_provider_credentials_test.go
@@ -1,0 +1,73 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccAWSProviderCredentials_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsProviderCredentialsConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsProviderCredentialsAccountId("data.aws_provider_credentials.current"),
+				),
+			},
+		},
+	})
+}
+
+// Protects against a panic in the AWS Provider configuration.
+// See https://github.com/terraform-providers/terraform-provider-aws/pull/1227
+func TestAccAWSProviderCredentials_basic_panic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsProviderCredentialsConfig_basic_panic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsProviderCredentialsAccountId("data.aws_provider_credentials.current"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsProviderCredentialsAccountId(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find AccountID resource: %s", n)
+		}
+
+		if rs.Primary.Attributes["access_key"] == "" {
+			return fmt.Errorf("Access Key expected to not be nil")
+		}
+
+		if rs.Primary.Attributes["secret_key"] == "" {
+			return fmt.Errorf("Secret Key expected to not be nil")
+		}
+
+		return nil
+	}
+}
+
+const testAccCheckAwsProviderCredentialsConfig_basic = `
+data "aws_provider_credentials" "current" { }
+`
+
+const testAccCheckAwsProviderCredentialsConfig_basic_panic = `
+provider "aws" {
+  assume_role {
+  }
+}
+
+data "aws_provider_credentials" "current" {}
+`

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -158,6 +158,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_batch_job_queue":                           dataSourceAwsBatchJobQueue(),
 			"aws_billing_service_account":                   dataSourceAwsBillingServiceAccount(),
 			"aws_caller_identity":                           dataSourceAwsCallerIdentity(),
+			"aws_provider_credentials":                      dataSourceAwsProviderCredentials(),
 			"aws_canonical_user_id":                         dataSourceAwsCanonicalUserId(),
 			"aws_cloudformation_export":                     dataSourceAwsCloudFormationExport(),
 			"aws_cloudformation_stack":                      dataSourceAwsCloudFormationStack(),


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

This allows local-exec provisioners to be able to retrieve the
credentials that the aws provider is using.

Ex:

```
provider "aws" {
    version = "~> v2.33.1" # to use local copy of terraform-provider-aws
}

data "aws_provider_credentials" "current" {}

resource "null_resource" "my_resource" {
  provisioner "local-exec" {
    command = "echo $AWS_ACCESS_KEY_ID - $AWS_SECRET_ACCESS_KEY - $AWS_SESSION_TOKEN"
    environment = {
      AWS_ACCESS_KEY_ID = "${data.aws_provider_credentials.current.access_key}"
      AWS_SECRET_ACCESS_KEY = "${data.aws_provider_credentials.current.secret_key}"
      AWS_SESSION_TOKEN = "${data.aws_provider_credentials.current.session_token}"
    }
  }
}

```


Closes #8242

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
Allows credentials (access_key, secret_key, and session_token) to be fetched from new data source aws_provider_credentials to be used within local-exec provisioners.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
```
I was not able to run acceptance testing as I don't have access to a personal AWS account.  I did run `make tests`.