### PR TITLE
tests/provider: Replace deleted AWS Managed IAM Policy AmazonEC2SpotFleetRole, use data sources in those tests

### DIFF
--- a/aws/resource_aws_appautoscaling_scheduled_action_test.go
+++ b/aws/resource_aws_appautoscaling_scheduled_action_test.go
@@ -207,6 +207,14 @@ resource "aws_appautoscaling_scheduled_action" "hoge" {
 
 func testAccAppautoscalingScheduledActionConfig_EMR(rName, ts string) string {
 	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  # The requested instance type c4.large is not supported in the requested availability zone.
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
+}
+
+data "aws_partition" "current" {}
+
 resource "aws_emr_cluster" "hoge" {
   name          = "tf-emr-%s"
   release_label = "emr-5.4.0"
@@ -288,8 +296,9 @@ resource "aws_vpc" "hoge" {
 }
 
 resource "aws_subnet" "hoge" {
-  vpc_id     = "${aws_vpc.hoge.id}"
-  cidr_block = "168.31.0.0/20"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  cidr_block        = "168.31.0.0/20"
+  vpc_id            = "${aws_vpc.hoge.id}"
 
   tags = {
     Name = "tf-acc-appautoscaling-scheduled-action"
@@ -323,7 +332,7 @@ resource "aws_iam_role" "emr_role" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "Service": "elasticmapreduce.amazonaws.com"
+        "Service": "elasticmapreduce.${data.aws_partition.current.dns_suffix}"
       },
       "Action": "sts:AssumeRole"
     }
@@ -414,7 +423,7 @@ resource "aws_iam_role" "instance_role" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "Service": "ec2.amazonaws.com"
+        "Service": "ec2.${data.aws_partition.current.dns_suffix}"
       },
       "Action": "sts:AssumeRole"
     }
@@ -481,14 +490,14 @@ data "aws_iam_policy_document" "autoscale_role" {
 
     principals {
       type        = "Service"
-      identifiers = ["elasticmapreduce.amazonaws.com", "application-autoscaling.amazonaws.com"]
+      identifiers = ["elasticmapreduce.${data.aws_partition.current.dns_suffix}", "application-autoscaling.${data.aws_partition.current.dns_suffix}"]
     }
   }
 }
 
 resource "aws_iam_role_policy_attachment" "autoscale_role" {
   role       = "${aws_iam_role.autoscale_role.name}"
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceforAutoScalingRole"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonElasticMapReduceforAutoScalingRole"
 }
 
 resource "aws_appautoscaling_target" "hoge" {
@@ -517,6 +526,23 @@ resource "aws_appautoscaling_scheduled_action" "hoge" {
 
 func testAccAppautoscalingScheduledActionConfig_SpotFleet(rName, ts string) string {
 	return fmt.Sprintf(`
+data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn-ami-minimal-hvm-*"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+}
+
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "fleet_role" {
   assume_role_policy = <<EOF
 {
@@ -526,8 +552,8 @@ resource "aws_iam_role" "fleet_role" {
       "Effect": "Allow",
       "Principal": {
         "Service": [
-          "spotfleet.amazonaws.com",
-          "ec2.amazonaws.com"
+          "spotfleet.${data.aws_partition.current.dns_suffix}",
+          "ec2.${data.aws_partition.current.dns_suffix}"
         ]
       },
       "Action": "sts:AssumeRole"
@@ -539,7 +565,7 @@ EOF
 
 resource "aws_iam_role_policy_attachment" "fleet_role_policy" {
   role       = "${aws_iam_role.fleet_role.name}"
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole"
 }
 
 resource "aws_spot_fleet_request" "hoge" {
@@ -551,7 +577,7 @@ resource "aws_spot_fleet_request" "hoge" {
 
   launch_specification {
     instance_type = "m3.medium"
-    ami           = "ami-d06a90b0"
+    ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   }
 }
 

--- a/aws/resource_aws_appautoscaling_target_test.go
+++ b/aws/resource_aws_appautoscaling_target_test.go
@@ -320,6 +320,14 @@ resource "aws_appautoscaling_target" "bar" {
 
 func testAccAWSAppautoscalingTargetEmrClusterConfig(rInt int) string {
 	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  # The requested instance type m3.xlarge is not supported in the requested availability zone.
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
+}
+
+data "aws_partition" "current" {}
+
 resource "aws_emr_cluster" "tf-test-cluster" {
   name          = "emr-test-%d"
   release_label = "emr-4.6.0"
@@ -405,8 +413,9 @@ resource "aws_vpc" "main" {
 }
 
 resource "aws_subnet" "main" {
-  vpc_id     = "${aws_vpc.main.id}"
-  cidr_block = "168.31.0.0/20"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  cidr_block        = "168.31.0.0/20"
+  vpc_id            = "${aws_vpc.main.id}"
 
   tags = {
     Name = "tf-acc-appautoscaling-target-emr-cluster"
@@ -442,7 +451,7 @@ resource "aws_iam_role" "iam_emr_default_role" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "Service": "elasticmapreduce.amazonaws.com"
+        "Service": "elasticmapreduce.${data.aws_partition.current.dns_suffix}"
       },
       "Action": "sts:AssumeRole"
     }
@@ -537,7 +546,7 @@ resource "aws_iam_role" "iam_emr_profile_role" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "Service": "ec2.amazonaws.com"
+        "Service": "ec2.${data.aws_partition.current.dns_suffix}"
       },
       "Action": "sts:AssumeRole"
     }
@@ -607,14 +616,14 @@ data "aws_iam_policy_document" "emr-autoscaling-role-policy" {
 
     principals {
       type        = "Service"
-      identifiers = ["elasticmapreduce.amazonaws.com", "application-autoscaling.amazonaws.com"]
+      identifiers = ["elasticmapreduce.${data.aws_partition.current.dns_suffix}", "application-autoscaling.${data.aws_partition.current.dns_suffix}"]
     }
   }
 }
 
 resource "aws_iam_role_policy_attachment" "emr-autoscaling-role" {
   role       = "${aws_iam_role.emr-autoscaling-role.name}"
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceforAutoScalingRole"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonElasticMapReduceforAutoScalingRole"
 }
 
 resource "aws_appautoscaling_target" "bar" {
@@ -629,6 +638,23 @@ resource "aws_appautoscaling_target" "bar" {
 }
 
 var testAccAWSAppautoscalingTargetSpotFleetRequestConfig = fmt.Sprintf(`
+data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn-ami-minimal-hvm-*"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+}
+
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "fleet_role" {
   assume_role_policy = <<EOF
 {
@@ -651,7 +677,7 @@ EOF
 
 resource "aws_iam_role_policy_attachment" "fleet_role_policy" {
   role = "${aws_iam_role.fleet_role.name}"
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole"
 }
 
 resource "aws_spot_fleet_request" "test" {
@@ -663,7 +689,7 @@ resource "aws_spot_fleet_request" "test" {
 
   launch_specification {
     instance_type = "m3.medium"
-    ami = "ami-d06a90b0"
+    ami = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   }
 }
 

--- a/aws/resource_aws_batch_compute_environment_test.go
+++ b/aws/resource_aws_batch_compute_environment_test.go
@@ -391,6 +391,8 @@ func testAccPreCheckAWSBatch(t *testing.T) {
 
 func testAccAWSBatchComputeEnvironmentConfigBase(rInt int) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 ########## ecs_instance_role ##########
 
 resource "aws_iam_role" "ecs_instance_role" {
@@ -404,7 +406,7 @@ resource "aws_iam_role" "ecs_instance_role" {
 	    "Action": "sts:AssumeRole",
 	    "Effect": "Allow",
 	    "Principal": {
-		"Service": "ec2.amazonaws.com"
+		"Service": "ec2.${data.aws_partition.current.dns_suffix}"
 	    }
 	}
     ]
@@ -414,7 +416,7 @@ EOF
 
 resource "aws_iam_role_policy_attachment" "ecs_instance_role" {
   role       = "${aws_iam_role.ecs_instance_role.name}"
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
 }
 
 resource "aws_iam_instance_profile" "ecs_instance_role" {
@@ -435,7 +437,7 @@ resource "aws_iam_role" "aws_batch_service_role" {
 	    "Action": "sts:AssumeRole",
 	    "Effect": "Allow",
 	    "Principal": {
-		"Service": "batch.amazonaws.com"
+		"Service": "batch.${data.aws_partition.current.dns_suffix}"
 	    }
 	}
     ]
@@ -445,7 +447,7 @@ EOF
 
 resource "aws_iam_role_policy_attachment" "aws_batch_service_role" {
   role       = "${aws_iam_role.aws_batch_service_role.name}"
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSBatchServiceRole"
 }
 
 ########## aws_ec2_spot_fleet_role ##########
@@ -461,7 +463,7 @@ resource "aws_iam_role" "aws_ec2_spot_fleet_role" {
 	    "Action": "sts:AssumeRole",
 	    "Effect": "Allow",
 	    "Principal": {
-		"Service": "spotfleet.amazonaws.com"
+		"Service": "spotfleet.${data.aws_partition.current.dns_suffix}"
 	    }
 	}
     ]
@@ -471,7 +473,7 @@ EOF
 
 resource "aws_iam_role_policy_attachment" "aws_ec2_spot_fleet_role" {
   role       = "${aws_iam_role.aws_ec2_spot_fleet_role.name}"
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole"
 }
 
 ########## security group ##########


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Starting yesterday, October 30th, the `AmazonEC2SpotFleetRole` AWS managed IAM policy is no longer available, which was causing test failures:

```
--- FAIL: TestAccAWSAppautoScalingTarget_spotFleetRequest (605.77s)
    testing.go:615: Step 0 error: errors during apply:

        Error: Error attaching policy arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole to IAM Role terraform-20191031031853283200000001: NoSuchEntity: Policy arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole does not exist or is not attachable.
```

Here we switch to the newer `AmazonEC2SpotFleetTaggingRole`. While adjusting these tests anyways (such as the Batch base configuration), also fixed some other region/partition issues such as:

```
--- FAIL: TestAccAWSAppautoScalingTarget_emrCluster (64.87s)
    testing.go:615: Step 0 error: errors during apply:

        Error: Error waiting for EMR Cluster state to be "WAITING" or "RUNNING": TERMINATING: VALIDATION_ERROR: The requested instance type m3.xlarge is not supported in the requested availability zone. Learn more at https://docs.aws.amazon.com/console/elasticmapreduce/ERROR_noinstancetype
```

Output from acceptance testing:

```
--- PASS: TestAccAWSBatchComputeEnvironment_createSpotWithoutBidPercentage (21.92s)
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources (30.60s)
--- PASS: TestAccAWSBatchComputeEnvironment_createUnmanaged (53.53s)
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2WithTags (53.69s)
--- PASS: TestAccAWSBatchComputeEnvironment_createSpot (58.61s)
--- PASS: TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources (59.71s)
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2 (60.56s)
--- PASS: TestAccAWSAppautoScalingTarget_spotFleetRequest (70.48s)
--- PASS: TestAccAWSBatchComputeEnvironment_launchTemplate (71.45s)
--- PASS: TestAccAWSAppautoscalingScheduledAction_SpotFleet (73.48s)
--- PASS: TestAccAWSBatchComputeEnvironment_updateMaxvCpus (79.34s)
--- PASS: TestAccAWSAppautoScalingPolicy_spotFleetRequest (81.54s)
--- PASS: TestAccAWSBatchComputeEnvironment_updateInstanceType (81.85s)
--- PASS: TestAccAWSBatchComputeEnvironment_updateState (84.27s)
--- PASS: TestAccAWSBatchComputeEnvironment_updateComputeEnvironmentName (93.77s)
--- PASS: TestAccAWSAppautoscalingScheduledAction_EMR (376.28s)
--- PASS: TestAccAWSAppautoScalingTarget_emrCluster (437.48s)
```
