### PR TITLE
Various aws_cognito_identity_provider improvements

### DIFF
--- a/aws/resource_aws_cognito_identity_provider.go
+++ b/aws/resource_aws_cognito_identity_provider.go
@@ -3,11 +3,13 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 func resourceAwsCognitoIdentityProvider() *schema.Resource {
@@ -25,6 +27,11 @@ func resourceAwsCognitoIdentityProvider() *schema.Resource {
 			"attribute_mapping": {
 				Type:     schema.TypeMap,
 				Optional: true,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringLenBetween(1, 32),
+				},
 			},
 
 			"idp_identifiers": {
@@ -32,6 +39,10 @@ func resourceAwsCognitoIdentityProvider() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 40),
+						validation.StringMatch(regexp.MustCompile(`^[\w\s+=.@-]+$`), "see https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateIdentityProvider.html#API_CreateIdentityProvider_RequestSyntax"),
+					),
 				},
 			},
 
@@ -43,11 +54,24 @@ func resourceAwsCognitoIdentityProvider() *schema.Resource {
 			"provider_name": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 32),
+					validation.StringMatch(regexp.MustCompile(`^[^_][\p{L}\p{M}\p{S}\p{N}\p{P}][^_]+$`), "see https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateIdentityProvider.html#API_CreateIdentityProvider_RequestSyntax"),
+				),
 			},
 
 			"provider_type": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					cognitoidentityprovider.IdentityProviderTypeTypeSaml,
+					cognitoidentityprovider.IdentityProviderTypeTypeFacebook,
+					cognitoidentityprovider.IdentityProviderTypeTypeGoogle,
+					cognitoidentityprovider.IdentityProviderTypeTypeLoginWithAmazon,
+					cognitoidentityprovider.IdentityProviderTypeTypeOidc,
+				}, false),
 			},
 
 			"user_pool_id": {

--- a/aws/resource_aws_cognito_identity_provider_test.go
+++ b/aws/resource_aws_cognito_identity_provider_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
@@ -13,6 +14,7 @@ import (
 func TestAccAWSCognitoIdentityProvider_basic(t *testing.T) {
 	var identityProvider cognitoidentityprovider.IdentityProviderType
 	resourceName := "aws_cognito_identity_provider.test"
+	userPoolName := fmt.Sprintf("tf-acc-cognito-user-pool-%s", acctest.RandString(7))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
@@ -20,14 +22,37 @@ func TestAccAWSCognitoIdentityProvider_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoIdentityProviderDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoIdentityProviderConfig_basic(),
+				Config: testAccAWSCognitoIdentityProviderConfig_basic(userPoolName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoIdentityProviderExists(resourceName, &identityProvider),
+					resource.TestCheckResourceAttr(resourceName, "attribute_mapping.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "attribute_mapping.username", "sub"),
 					resource.TestCheckResourceAttr(resourceName, "provider_details.%", "9"),
 					resource.TestCheckResourceAttr(resourceName, "provider_details.authorize_scopes", "email"),
 					resource.TestCheckResourceAttr(resourceName, "provider_details.authorize_url", "https://accounts.google.com/o/oauth2/v2/auth"),
 					resource.TestCheckResourceAttr(resourceName, "provider_details.client_id", "test-url.apps.googleusercontent.com"),
 					resource.TestCheckResourceAttr(resourceName, "provider_details.client_secret", "client_secret"),
+					resource.TestCheckResourceAttr(resourceName, "provider_details.attributes_url", "https://people.googleapis.com/v1/people/me?personFields="),
+					resource.TestCheckResourceAttr(resourceName, "provider_details.attributes_url_add_attributes", "true"),
+					resource.TestCheckResourceAttr(resourceName, "provider_details.token_request_method", "POST"),
+					resource.TestCheckResourceAttr(resourceName, "provider_details.token_url", "https://www.googleapis.com/oauth2/v4/token"),
+					resource.TestCheckResourceAttr(resourceName, "provider_details.oidc_issuer", "https://accounts.google.com"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", "Google"),
+					resource.TestCheckResourceAttr(resourceName, "provider_type", "Google"),
+				),
+			},
+			{
+				Config: testAccAWSCognitoIdentityProviderConfig_basicUpdated(userPoolName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoIdentityProviderExists(resourceName, &identityProvider),
+					resource.TestCheckResourceAttr(resourceName, "attribute_mapping.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "attribute_mapping.username", "sub"),
+					resource.TestCheckResourceAttr(resourceName, "attribute_mapping.email", "email"),
+					resource.TestCheckResourceAttr(resourceName, "provider_details.%", "9"),
+					resource.TestCheckResourceAttr(resourceName, "provider_details.authorize_scopes", "email"),
+					resource.TestCheckResourceAttr(resourceName, "provider_details.authorize_url", "https://accounts.google.com/o/oauth2/v2/auth"),
+					resource.TestCheckResourceAttr(resourceName, "provider_details.client_id", "new-client-id-url.apps.googleusercontent.com"),
+					resource.TestCheckResourceAttr(resourceName, "provider_details.client_secret", "updated_client_secret"),
 					resource.TestCheckResourceAttr(resourceName, "provider_details.attributes_url", "https://people.googleapis.com/v1/people/me?personFields="),
 					resource.TestCheckResourceAttr(resourceName, "provider_details.attributes_url_add_attributes", "true"),
 					resource.TestCheckResourceAttr(resourceName, "provider_details.token_request_method", "POST"),
@@ -110,11 +135,11 @@ func testAccCheckAWSCognitoIdentityProviderExists(resourceName string, identityP
 	}
 }
 
-func testAccAWSCognitoIdentityProviderConfig_basic() string {
-	return `
+func testAccAWSCognitoIdentityProviderConfig_basic(userPoolName string) string {
+	return fmt.Sprintf(`
 
 resource "aws_cognito_user_pool" "test" {
-  name                     = "tfmytestpool"
+  name                     = "%s"
   auto_verified_attributes = ["email"]
 }
 
@@ -134,11 +159,39 @@ resource "aws_cognito_identity_provider" "test" {
     token_request_method          = "POST"
     token_url                     = "https://www.googleapis.com/oauth2/v4/token"
   }
+}
+`, userPoolName)
+}
+
+func testAccAWSCognitoIdentityProviderConfig_basicUpdated(userPoolName string) string {
+	return fmt.Sprintf(`
+
+resource "aws_cognito_user_pool" "test" {
+  name                     = "%s"
+  auto_verified_attributes = ["email"]
+}
+
+resource "aws_cognito_identity_provider" "test" {
+  user_pool_id  = "${aws_cognito_user_pool.test.id}"
+  provider_name = "Google"
+  provider_type = "Google"
+
+  provider_details = {
+    attributes_url                = "https://people.googleapis.com/v1/people/me?personFields="
+    attributes_url_add_attributes = "true"
+    authorize_scopes              = "email"
+    authorize_url                 = "https://accounts.google.com/o/oauth2/v2/auth"
+    client_id                     = "new-client-id-url.apps.googleusercontent.com"
+    client_secret                 = "updated_client_secret"
+    oidc_issuer                   = "https://accounts.google.com"
+    token_request_method          = "POST"
+    token_url                     = "https://www.googleapis.com/oauth2/v4/token"
+  }
 
   attribute_mapping = {
     email    = "email"
     username = "sub"
   }
 }
-`
+`, userPoolName)
 }


### PR DESCRIPTION
Added plan time checks for some parameters and also ignored the computed diff caused by not specifying the optional attribute_mapping.

Came across this while idiotically missing that the resource already existed and then trying to implement it from scratch in https://github.com/terraform-providers/terraform-provider-aws/pull/10675. Noticed that this resource was still missing a few useful things so figured I could at least salvage those parts.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Bug fix:
resource/aws_cognito_identity_provider: Validate parameters at plan time and avoid diff from unspecified `attribute_mapping`.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSCognitoIdentityProvider_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSCognitoIdentityProvider_basic -timeout 120m
go: downloading github.com/hashicorp/terraform-plugin-sdk v1.2.0
go: downloading github.com/aws/aws-sdk-go v1.25.24
go: extracting github.com/hashicorp/terraform-plugin-sdk v1.2.0
go: extracting github.com/aws/aws-sdk-go v1.25.24
go: finding github.com/hashicorp/terraform-plugin-sdk v1.2.0
go: finding github.com/aws/aws-sdk-go v1.25.24
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSCognitoIdentityProvider_basic
=== PAUSE TestAccAWSCognitoIdentityProvider_basic
=== CONT  TestAccAWSCognitoIdentityProvider_basic
--- PASS: TestAccAWSCognitoIdentityProvider_basic (87.87s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	87.899s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.001s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.010s [no tests to run]
```
