### PR TITLE
tests/resource/aws_batch_job_queue: Remove sweeper prefix checking

### DIFF
--- a/aws/resource_aws_batch_job_queue_test.go
+++ b/aws/resource_aws_batch_job_queue_test.go
@@ -28,10 +28,6 @@ func testSweepBatchJobQueues(region string) error {
 	}
 	conn := client.(*AWSClient).batchconn
 
-	prefixes := []string{
-		"tf_acc",
-	}
-
 	out, err := conn.DescribeJobQueues(&batch.DescribeJobQueuesInput{})
 	if err != nil {
 		if testSweepSkipSweepError(err) {
@@ -42,17 +38,6 @@ func testSweepBatchJobQueues(region string) error {
 	}
 	for _, jobQueue := range out.JobQueues {
 		name := jobQueue.JobQueueName
-		skip := true
-		for _, prefix := range prefixes {
-			if strings.HasPrefix(*name, prefix) {
-				skip = false
-				break
-			}
-		}
-		if skip {
-			log.Printf("[INFO] Skipping Batch Job Queue: %s", *name)
-			continue
-		}
 
 		log.Printf("[INFO] Disabling Batch Job Queue: %s", *name)
 		err := disableBatchJobQueue(*name, conn)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously, resource sweepers were implemented with name prefix checking to potentially allow them to run more safely in accounts with other active resources. In practice though, this was unmaintainable across the community contributed test configurations so sweepers were then made to be wholly responsible for cleaning up a resource within an account. This appears to be a place where that prefix checking was not removed, which causes issues with sweeping `aws_batch_compute_environment` resources:

```console
$ go test ./aws -v -timeout=10h -sweep=us-west-2 -sweep-run=aws_batch_job_queue,aws_batch_compute_environment -sweep-allow-failures
2019/11/01 09:25:58 [DEBUG] Running Sweepers for region (us-west-2):
2019/11/01 09:25:58 [DEBUG] Sweeper (aws_batch_compute_environment) has dependency (aws_batch_job_queue), running..
...
2019/11/01 09:26:00 [INFO] Skipping Batch Job Queue: tf_batch_target-2680393626223669634
2019/11/01 09:26:00 [DEBUG] Running Sweeper (aws_batch_compute_environment) in region (us-west-2)
...
2019/11/01 09:26:02 [INFO] Deleting Batch Compute Environment: tf_batch_target-2680393626223669634
2019/11/01 09:26:02 [ERROR] Failed to delete Batch Compute Environment tf_batch_target-2680393626223669634: : Cannot delete, found existing JobQueue relationship
```

Output from sweepers after update:

```console
$ go test ./aws -v -timeout=10h -sweep=us-west-2 -sweep-run=aws_batch_job_queue,aws_batch_compute_environment -sweep-allow-failures
2019/11/01 09:32:01 [DEBUG] Running Sweepers for region (us-west-2):
2019/11/01 09:32:01 [DEBUG] Sweeper (aws_batch_compute_environment) has dependency (aws_batch_job_queue), running..
...
2019/11/01 09:32:03 [INFO] Disabling Batch Job Queue: tf_batch_target-2680393626223669634
2019/11/01 09:32:04 [DEBUG] Waiting for state to become: [VALID]
2019/11/01 09:32:14 [INFO] Deleting Batch Job Queue: tf_batch_target-2680393626223669634
2019/11/01 09:32:15 [DEBUG] Waiting for state to become: [DELETED]
2019/11/01 09:32:25 [DEBUG] Job Queue "tf_batch_target-2680393626223669634" is already gone
2019/11/01 09:32:25 [DEBUG] Running Sweeper (aws_batch_compute_environment) in region (us-west-2)
...
2019/11/01 09:32:27 [INFO] Deleting Batch Compute Environment: tf_batch_target-2680393626223669634
2019/11/01 09:32:28 [DEBUG] Waiting for state to become: [DELETED]
2019/11/01 09:32:29 [TRACE] Waiting 5s before next try
2019/11/01 09:32:34 [DEBUG] Sweeper (aws_batch_job_queue) already ran in region (us-west-2)
2019/11/01 09:32:34 Sweeper Tests ran successfully:
	- aws_batch_job_queue
	- aws_batch_compute_environment
ok  	github.com/terraform-providers/terraform-provider-aws/aws	34.796s
```