### PR TITLE
nil checks to prevent crashes on empty config blocks

### DIFF
--- a/aws/resource_aws_ssm_maintenance_window_task.go
+++ b/aws/resource_aws_ssm_maintenance_window_task.go
@@ -329,6 +329,9 @@ func resourceAwsSsmMaintenanceWindowTask() *schema.Resource {
 }
 
 func expandAwsSsmMaintenanceWindowLoggingInfo(config []interface{}) *ssm.LoggingInfo {
+	if len(config) == 0 || config[0] == nil {
+		return nil
+	}
 
 	loggingConfig := config[0].(map[string]interface{})
 
@@ -382,6 +385,10 @@ func flattenAwsSsmTaskParameters(taskParameters map[string]*ssm.MaintenanceWindo
 }
 
 func expandAwsSsmTaskInvocationParameters(config []interface{}) *ssm.MaintenanceWindowTaskInvocationParameters {
+	if len(config) == 0 || config[0] == nil {
+		return nil
+	}
+
 	params := &ssm.MaintenanceWindowTaskInvocationParameters{}
 	for _, v := range config {
 		paramConfig := v.(map[string]interface{})
@@ -423,6 +430,10 @@ func flattenAwsSsmTaskInvocationParameters(parameters *ssm.MaintenanceWindowTask
 }
 
 func expandAwsSsmTaskInvocationAutomationParameters(config []interface{}) *ssm.MaintenanceWindowAutomationParameters {
+	if len(config) == 0 || config[0] == nil {
+		return nil
+	}
+
 	params := &ssm.MaintenanceWindowAutomationParameters{}
 	configParam := config[0].(map[string]interface{})
 	if attr, ok := configParam["document_version"]; ok && len(attr.(string)) != 0 {
@@ -449,6 +460,10 @@ func flattenAwsSsmTaskInvocationAutomationParameters(parameters *ssm.Maintenance
 }
 
 func expandAwsSsmTaskInvocationLambdaParameters(config []interface{}) *ssm.MaintenanceWindowLambdaParameters {
+	if len(config) == 0 || config[0] == nil {
+		return nil
+	}
+
 	params := &ssm.MaintenanceWindowLambdaParameters{}
 	configParam := config[0].(map[string]interface{})
 	if attr, ok := configParam["client_context"]; ok && len(attr.(string)) != 0 {
@@ -479,6 +494,10 @@ func flattenAwsSsmTaskInvocationLambdaParameters(parameters *ssm.MaintenanceWind
 }
 
 func expandAwsSsmTaskInvocationRunCommandParameters(config []interface{}) *ssm.MaintenanceWindowRunCommandParameters {
+	if len(config) == 0 || config[0] == nil {
+		return nil
+	}
+
 	params := &ssm.MaintenanceWindowRunCommandParameters{}
 	configParam := config[0].(map[string]interface{})
 	if attr, ok := configParam["comment"]; ok && len(attr.(string)) != 0 {
@@ -546,6 +565,10 @@ func flattenAwsSsmTaskInvocationRunCommandParameters(parameters *ssm.Maintenance
 }
 
 func expandAwsSsmTaskInvocationStepFunctionsParameters(config []interface{}) *ssm.MaintenanceWindowStepFunctionsParameters {
+	if len(config) == 0 || config[0] == nil {
+		return nil
+	}
+
 	params := &ssm.MaintenanceWindowStepFunctionsParameters{}
 	configParam := config[0].(map[string]interface{})
 
@@ -572,6 +595,10 @@ func flattenAwsSsmTaskInvocationStepFunctionsParameters(parameters *ssm.Maintena
 }
 
 func expandAwsSsmTaskInvocationRunCommandParametersNotificationConfig(config []interface{}) *ssm.NotificationConfig {
+	if len(config) == 0 || config[0] == nil {
+		return nil
+	}
+
 	params := &ssm.NotificationConfig{}
 	configParam := config[0].(map[string]interface{})
 
@@ -605,6 +632,10 @@ func flattenAwsSsmTaskInvocationRunCommandParametersNotificationConfig(config *s
 }
 
 func expandAwsSsmTaskInvocationCommonParameters(config []interface{}) map[string][]*string {
+	if len(config) == 0 || config[0] == nil {
+		return nil
+	}
+
 	params := make(map[string][]*string)
 
 	for _, v := range config {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10702 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_ssm_maintenance_window_task: Add nil checks to prevent crashes when empty config blocks are provided
```

Output from acceptance testing:

* First, reproducing the crash with a new test:

```
$ make testacc TESTARGS="-run=TestAccAWSSSMMaintenanceWindowTask_emptyNotificationConfig"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSSSMMaintenanceWindowTask_emptyNotificationConfig -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSSSMMaintenanceWindowTask_emptyNotificationConfig
=== PAUSE TestAccAWSSSMMaintenanceWindowTask_emptyNotificationConfig
=== CONT  TestAccAWSSSMMaintenanceWindowTask_emptyNotificationConfig
panic: interface conversion: interface {} is nil, not map[string]interface {}

goroutine 301 [running]:
github.com/terraform-providers/terraform-provider-aws/aws.expandAwsSsmTaskInvocationRunCommandParametersNotificationConfig(0xc0014c3ce0, 0x1, 0x1, 0x13)
        /Users/ryndaniels/terraform-providers/terraform-provider-aws/aws/resource_aws_ssm_maintenance_window_task.go:581 +0x306
github.com/terraform-providers/terraform-provider-aws/aws.expandAwsSsmTaskInvocationRunCommandParameters(0xc0014c3bc0, 0x1, 0x1, 0x16)
        /Users/ryndaniels/terraform-providers/terraform-provider-aws/aws/resource_aws_ssm_maintenance_window_task.go:494 +0x62b
github.com/terraform-providers/terraform-provider-aws/aws.expandAwsSsmTaskInvocationParameters(0xc0014c3b60, 0x1, 0x1, 0x53834a0)
        /Users/ryndaniels/terraform-providers/terraform-provider-aws/aws/resource_aws_ssm_maintenance_window_task.go:395 +0x485
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsSsmMaintenanceWindowTaskCreate(0xc00049ae70, 0x5324280, 0xc0004c8000, 0x2, 0xa1c93e0)
        /Users/ryndaniels/terraform-providers/terraform-provider-aws/aws/resource_aws_ssm_maintenance_window_task.go:683 +0x856
github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Resource).Apply(0xc0006beb80, 0xc000960500, 0xc0006d8760, 0x5324280, 0xc0004c8000, 0xc000c35201, 0xc000ca5b00, 0xc000c352f0)
        /Users/ryndaniels/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.2.0/helper/schema/resource.go:305 +0x365
github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Provider).Apply(0xc00076d980, 0xc000a53918, 0xc000960500, 0xc0006d8760, 0xc000ca3ca8, 0xc0000d7a38, 0x588e180)
        /Users/ryndaniels/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.2.0/helper/schema/provider.go:294 +0x99
github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin.(*GRPCProviderServer).ApplyResourceChange(0xc000487190, 0x70ddb20, 0xc000c73da0, 0xc0000d91a0, 0xc000487190, 0xc000c73da0, 0xc000076a80)
        /Users/ryndaniels/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.2.0/internal/helper/plugin/grpc_provider.go:885 +0x882
github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5._Provider_ApplyResourceChange_Handler(0x624ae60, 0xc000487190, 0x70ddb20, 0xc000c73da0, 0xc0000d9140, 0x0, 0x70ddb20, 0xc000c73da0, 0xc000c8cc00, 0x5c0)
        /Users/ryndaniels/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.2.0/internal/tfplugin5/tfplugin5.pb.go:3189 +0x217
google.golang.org/grpc.(*Server).processUnaryRPC(0xc001844f20, 0x7113b20, 0xc0004f3b00, 0xc000b13200, 0xc001394690, 0xa1863e0, 0x0, 0x0, 0x0)
        /Users/ryndaniels/go/pkg/mod/google.golang.org/grpc@v1.23.0/server.go:995 +0x460
google.golang.org/grpc.(*Server).handleStream(0xc001844f20, 0x7113b20, 0xc0004f3b00, 0xc000b13200, 0x0)
        /Users/ryndaniels/go/pkg/mod/google.golang.org/grpc@v1.23.0/server.go:1275 +0xd97
google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc0006e6d00, 0xc001844f20, 0x7113b20, 0xc0004f3b00, 0xc000b13200)
        /Users/ryndaniels/go/pkg/mod/google.golang.org/grpc@v1.23.0/server.go:710 +0xbb
created by google.golang.org/grpc.(*Server).serveStreams.func1
        /Users/ryndaniels/go/pkg/mod/google.golang.org/grpc@v1.23.0/server.go:708 +0xa1
FAIL    github.com/terraform-providers/terraform-provider-aws/aws       13.805s
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap      0.032s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags 0.071s [no tests to run]
FAIL
make: *** [testacc] Error 1
```

* Next, fixing the crash:
```
make testacc TESTARGS="-run=TestAccAWSSSMMaintenanceWindowTask_emptyNotificationConfig"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSSSMMaintenanceWindowTask_emptyNotificationConfig -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSSSMMaintenanceWindowTask_emptyNotificationConfig
=== PAUSE TestAccAWSSSMMaintenanceWindowTask_emptyNotificationConfig
=== CONT  TestAccAWSSSMMaintenanceWindowTask_emptyNotificationConfig
--- PASS: TestAccAWSSSMMaintenanceWindowTask_emptyNotificationConfig (22.15s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       22.936s
```

* Finally, all the tests:
```
make testacc TESTARGS="-run=TestAccAWSSSMMaintenanceWindowTask_"        
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSSSMMaintenanceWindowTask_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSSSMMaintenanceWindowTask_basic
=== PAUSE TestAccAWSSSMMaintenanceWindowTask_basic
=== RUN   TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource
=== PAUSE TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource
=== RUN   TestAccAWSSSMMaintenanceWindowTask_TaskInvocationAutomationParameters
=== PAUSE TestAccAWSSSMMaintenanceWindowTask_TaskInvocationAutomationParameters
=== RUN   TestAccAWSSSMMaintenanceWindowTask_TaskInvocationLambdaParameters
=== PAUSE TestAccAWSSSMMaintenanceWindowTask_TaskInvocationLambdaParameters
=== RUN   TestAccAWSSSMMaintenanceWindowTask_TaskInvocationRunCommandParameters
=== PAUSE TestAccAWSSSMMaintenanceWindowTask_TaskInvocationRunCommandParameters
=== RUN   TestAccAWSSSMMaintenanceWindowTask_TaskInvocationStepFunctionParameters
=== PAUSE TestAccAWSSSMMaintenanceWindowTask_TaskInvocationStepFunctionParameters
=== RUN   TestAccAWSSSMMaintenanceWindowTask_TaskParameters
=== PAUSE TestAccAWSSSMMaintenanceWindowTask_TaskParameters
=== RUN   TestAccAWSSSMMaintenanceWindowTask_emptyNotificationConfig
=== PAUSE TestAccAWSSSMMaintenanceWindowTask_emptyNotificationConfig
=== CONT  TestAccAWSSSMMaintenanceWindowTask_basic
=== CONT  TestAccAWSSSMMaintenanceWindowTask_TaskInvocationStepFunctionParameters
=== CONT  TestAccAWSSSMMaintenanceWindowTask_TaskParameters
=== CONT  TestAccAWSSSMMaintenanceWindowTask_emptyNotificationConfig
=== CONT  TestAccAWSSSMMaintenanceWindowTask_TaskInvocationLambdaParameters
=== CONT  TestAccAWSSSMMaintenanceWindowTask_TaskInvocationRunCommandParameters
=== CONT  TestAccAWSSSMMaintenanceWindowTask_TaskInvocationAutomationParameters
=== CONT  TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource
--- PASS: TestAccAWSSSMMaintenanceWindowTask_emptyNotificationConfig (35.36s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationStepFunctionParameters (38.63s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskParameters (38.81s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource (60.41s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_basic (61.43s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationLambdaParameters (63.02s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationAutomationParameters (84.44s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationRunCommandParameters (88.47s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       89.293s
```