### PR TITLE
resource/aws_servicequotas_service_quota: Remove resource from Terraform state on NoSuchResourceException error

### DIFF
--- a/aws/resource_aws_servicequotas_service_quota.go
+++ b/aws/resource_aws_servicequotas_service_quota.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -128,6 +129,12 @@ func resourceAwsServiceQuotasServiceQuotaRead(d *schema.ResourceData, meta inter
 	}
 
 	output, err := conn.GetServiceQuota(input)
+
+	if isAWSErr(err, servicequotas.ErrCodeNoSuchResourceException, "") {
+		log.Printf("[WARN] Service Quotas Service Quota (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
 
 	if err != nil {
 		return fmt.Errorf("error getting Service Quotas Service Quota (%s): %s", d.Id(), err)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://aws.amazon.com/blogs/compute/preview-vcpu-based-instance-limits/

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_servicequotas_service_quota: Remove resource from Terraform state on `NoSuchResourceException` error
```

Recently, AWS EC2 removed certain instance service quotas:

> Beginning October 24, 2019, all accounts will switch to vCPU-based instance limits, and the current count-based instance limits will no longer be supported.

These may have been managed previously by Terraform configurations, however they now return the following error (as would any other quotas removed in the future):

```
Error: error getting Service Quotas Service Quota (ec2/L-F26B0BF2): NoSuchResourceException:
	status code: 400, request id: d37df234-c1eb-420e-abce-a73c6cde2999
```

Given this error, it is not possible to remove the problematic resource without manually calling `terraform state rm`. The correct behavior in this case is for the Terraform resource to remove itself from the state and propose recreation, which would allow operators to successfully remove the missing quotas from their configurations.

This particular change cannot be directly acceptance tested since the availability of quotas is managed by AWS, not a managable resource.

Output from acceptance testing (requesting increase of VPC internet gateways and VPCs limits in a personal testing account):

```
export SERVICEQUOTAS_INCREASE_ON_CREATE_QUOTA_CODE=L-A4707A72
export SERVICEQUOTAS_INCREASE_ON_CREATE_SERVICE_CODE=vpc
export SERVICEQUOTAS_INCREASE_ON_CREATE_VALUE=6
export SERVICEQUOTAS_INCREASE_ON_UPDATE_QUOTA_CODE=L-F678F1CE
export SERVICEQUOTAS_INCREASE_ON_UPDATE_SERVICE_CODE=vpc
export SERVICEQUOTAS_INCREASE_ON_UPDATE_VALUE=6

--- PASS: TestAccAwsServiceQuotasServiceQuota_Value_IncreaseOnCreate (13.62s)
--- PASS: TestAccAwsServiceQuotasServiceQuota_basic (15.23s)
--- PASS: TestAccAwsServiceQuotasServiceQuota_Value_IncreaseOnUpdate (23.09s)
```