### PR TITLE
r/aws_s3_bucket_inventory: Add support for 'IntelligentTieringAccessTier'

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -128,7 +128,7 @@ func testAccMatchResourceAttrRegionalARN(resourceName, attributeName, arnService
 	}
 }
 
-// testAccMatchResourceAttrRegionalARN ensures the Terraform state regexp matches a formatted ARN with region and no account id
+// testAccMatchResourceAttrRegionalARNNoAccount ensures the Terraform state regexp matches a formatted ARN with region but without account ID
 func testAccMatchResourceAttrRegionalARNNoAccount(resourceName, attributeName, arnService string, arnResourceRegexp *regexp.Regexp) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		arnRegexp := arn.ARN{
@@ -153,6 +153,18 @@ func testAccCheckResourceAttrGlobalARN(resourceName, attributeName, arnService, 
 	return func(s *terraform.State) error {
 		attributeValue := arn.ARN{
 			AccountID: testAccGetAccountID(),
+			Partition: testAccGetPartition(),
+			Resource:  arnResource,
+			Service:   arnService,
+		}.String()
+		return resource.TestCheckResourceAttr(resourceName, attributeName, attributeValue)(s)
+	}
+}
+
+// testAccCheckResourceAttrGlobalARNNoAccount ensures the Terraform state exactly matches a formatted ARN without region or account ID
+func testAccCheckResourceAttrGlobalARNNoAccount(resourceName, attributeName, arnService, arnResource string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		attributeValue := arn.ARN{
 			Partition: testAccGetPartition(),
 			Resource:  arnResource,
 			Service:   arnService,

--- a/aws/resource_aws_s3_bucket_inventory.go
+++ b/aws/resource_aws_s3_bucket_inventory.go
@@ -82,8 +82,9 @@ func resourceAwsS3BucketInventory() *schema.Resource {
 										ValidateFunc: validateArn,
 									},
 									"account_id": {
-										Type:     schema.TypeString,
-										Optional: true,
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validateAwsAccountId,
 									},
 									"prefix": {
 										Type:     schema.TypeString,
@@ -172,6 +173,7 @@ func resourceAwsS3BucketInventory() *schema.Resource {
 						s3.InventoryOptionalFieldObjectLockMode,
 						s3.InventoryOptionalFieldObjectLockRetainUntilDate,
 						s3.InventoryOptionalFieldObjectLockLegalHoldStatus,
+						s3.InventoryOptionalFieldIntelligentTieringAccessTier,
 					}, false),
 				},
 				Set: schema.HashString,

--- a/aws/resource_aws_s3_bucket_inventory_test.go
+++ b/aws/resource_aws_s3_bucket_inventory_test.go
@@ -44,8 +44,8 @@ func TestAccAWSS3BucketInventory_basic(t *testing.T) {
 
 					resource.TestCheckResourceAttr(resourceName, "destination.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "destination.0.bucket.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "destination.0.bucket.0.bucket_arn", "arn:aws:s3:::"+bucketName),
-					resource.TestCheckResourceAttrSet(resourceName, "destination.0.bucket.0.account_id"),
+					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "destination.0.bucket.0.bucket_arn", "s3", bucketName),
+					testAccCheckResourceAttrAccountID(resourceName, "destination.0.bucket.0.account_id"),
 					resource.TestCheckResourceAttr(resourceName, "destination.0.bucket.0.format", "ORC"),
 					resource.TestCheckResourceAttr(resourceName, "destination.0.bucket.0.prefix", "inventory"),
 				),
@@ -191,21 +191,20 @@ func testAccCheckAWSS3BucketInventoryDestroy(s *terraform.State) error {
 
 func testAccAWSS3BucketInventoryConfigBucket(name string) string {
 	return fmt.Sprintf(`
-resource "aws_s3_bucket" "bucket" {
-  bucket = "%s"
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
   acl    = "private"
 }
 `, name)
 }
 
 func testAccAWSS3BucketInventoryConfig(bucketName, inventoryName string) string {
-	return fmt.Sprintf(`
-%s
+	return testAccAWSS3BucketInventoryConfigBucket(bucketName) + fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 
 resource "aws_s3_bucket_inventory" "test" {
-  bucket = "${aws_s3_bucket.bucket.id}"
-  name   = "%s"
+  bucket = "${aws_s3_bucket.test.id}"
+  name   = %[1]q
 
   included_object_versions = "All"
 
@@ -225,21 +224,20 @@ resource "aws_s3_bucket_inventory" "test" {
   destination {
     bucket {
       format     = "ORC"
-      bucket_arn = "${aws_s3_bucket.bucket.arn}"
+      bucket_arn = "${aws_s3_bucket.test.arn}"
       account_id = "${data.aws_caller_identity.current.account_id}"
       prefix     = "inventory"
     }
   }
 }
-`, testAccAWSS3BucketInventoryConfigBucket(bucketName), inventoryName)
+`, inventoryName)
 }
 
 func testAccAWSS3BucketInventoryConfigEncryptWithSSES3(bucketName, inventoryName string) string {
-	return fmt.Sprintf(`
-%s
+	return testAccAWSS3BucketInventoryConfigBucket(bucketName) + fmt.Sprintf(`
 resource "aws_s3_bucket_inventory" "test" {
-  bucket = "${aws_s3_bucket.bucket.id}"
-  name   = "%s"
+  bucket = "${aws_s3_bucket.test.id}"
+  name   = %[1]q
 
   included_object_versions = "Current"
 
@@ -250,7 +248,7 @@ resource "aws_s3_bucket_inventory" "test" {
   destination {
     bucket {
       format     = "CSV"
-      bucket_arn = "${aws_s3_bucket.bucket.arn}"
+      bucket_arn = "${aws_s3_bucket.test.arn}"
 
       encryption {
         sse_s3 {}
@@ -258,20 +256,19 @@ resource "aws_s3_bucket_inventory" "test" {
     }
   }
 }
-`, testAccAWSS3BucketInventoryConfigBucket(bucketName), inventoryName)
+`, inventoryName)
 }
 
 func testAccAWSS3BucketInventoryConfigEncryptWithSSEKMS(bucketName, inventoryName string) string {
-	return fmt.Sprintf(`
-%s
-resource "aws_kms_key" "inventory" {
-  description             = "Terraform acc test S3 inventory SSE-KMS encryption: %s"
+	return testAccAWSS3BucketInventoryConfigBucket(bucketName) + fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  description             = "Terraform acc test S3 inventory SSE-KMS encryption: %[1]s"
   deletion_window_in_days = 7
 }
 
 resource "aws_s3_bucket_inventory" "test" {
-  bucket = "${aws_s3_bucket.bucket.id}"
-  name   = "%s"
+  bucket = "${aws_s3_bucket.test.id}"
+  name   = %[2]q
 
   included_object_versions = "Current"
 
@@ -282,15 +279,15 @@ resource "aws_s3_bucket_inventory" "test" {
   destination {
     bucket {
       format     = "Parquet"
-      bucket_arn = "${aws_s3_bucket.bucket.arn}"
+      bucket_arn = "${aws_s3_bucket.test.arn}"
 
       encryption {
         sse_kms {
-          key_id = "${aws_kms_key.inventory.arn}"
+          key_id = "${aws_kms_key.test.arn}"
         }
       }
     }
   }
 }
-`, testAccAWSS3BucketInventoryConfigBucket(bucketName), bucketName, inventoryName)
+`, bucketName, inventoryName)
 }

--- a/website/docs/r/s3_bucket_inventory.html.markdown
+++ b/website/docs/r/s3_bucket_inventory.html.markdown
@@ -80,22 +80,23 @@ resource "aws_s3_bucket_inventory" "test-prefix" {
 
 The following arguments are supported:
 
-* `bucket` - (Required) The name of the bucket to put inventory configuration.
+* `bucket` - (Required) The name of the bucket where the inventory configuration will be stored.
 * `name` - (Required) Unique identifier of the inventory configuration for the bucket.
-* `included_object_versions` - (Required) Object filtering that accepts a prefix (documented below). Can be `All` or `Current`.
-* `schedule` - (Required) Contains the frequency for generating inventory results (documented below).
-* `destination` - (Required) Destination bucket where inventory list files are written (documented below).
-* `enabled` - (Optional, Default: true) Specifies whether the inventory is enabled or disabled.
-* `filter` - (Optional) Object filtering that accepts a prefix (documented below).
-* `optional_fields` - (Optional) Contains the optional fields that are included in the inventory results.
+* `included_object_versions` - (Required) Object versions to include in the inventory list. Valid values: `All`, `Current`.
+* `schedule` - (Required) Specifies the schedule for generating inventory results (documented below).
+* `destination` - (Required) Contains information about where to publish the inventory results (documented below).
+* `enabled` - (Optional, Default: `true`) Specifies whether the inventory is enabled or disabled.
+* `filter` - (Optional) Specifies an inventory filter. The inventory only includes objects that meet the filter's criteria (documented below).
+* `optional_fields` - (Optional) List of optional fields that are included in the inventory results.
+Valid values: `Size`, `LastModifiedDate`, `StorageClass`, `ETag`, `IsMultipartUploaded`, `ReplicationStatus`, `EncryptionStatus`, `ObjectLockRetainUntilDate`, `ObjectLockMode`, `ObjectLockLegalHoldStatus`, `IntelligentTieringAccessTier`.
 
 The `filter` configuration supports the following:
 
-* `prefix` - (Optional) Object prefix for filtering (singular).
+* `prefix` - (Optional) The prefix that an object must have to be included in the inventory results.
 
 The `schedule` configuration supports the following:
 
-* `frequency` - (Required) Specifies how frequently inventory results are produced. Can be `Daily` or `Weekly`.
+* `frequency` - (Required) Specifies how frequently inventory results are produced. Valid values: `Daily`, `Weekly`.
 
 The `destination` configuration supports the following:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/10743.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_s3_bucket_inventory: Add `IntelligentTieringAccessTier` as valid value for `optional_fields` attribute
```

Output from acceptance testing:

```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSS3BucketInventory_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSS3BucketInventory_ -timeout 120m
=== RUN   TestAccAWSS3BucketInventory_basic
=== PAUSE TestAccAWSS3BucketInventory_basic
=== RUN   TestAccAWSS3BucketInventory_encryptWithSSES3
=== PAUSE TestAccAWSS3BucketInventory_encryptWithSSES3
=== RUN   TestAccAWSS3BucketInventory_encryptWithSSEKMS
=== PAUSE TestAccAWSS3BucketInventory_encryptWithSSEKMS
=== CONT  TestAccAWSS3BucketInventory_basic
=== CONT  TestAccAWSS3BucketInventory_encryptWithSSEKMS
=== CONT  TestAccAWSS3BucketInventory_encryptWithSSES3
--- PASS: TestAccAWSS3BucketInventory_encryptWithSSES3 (33.75s)
--- PASS: TestAccAWSS3BucketInventory_basic (34.30s)
--- PASS: TestAccAWSS3BucketInventory_encryptWithSSEKMS (54.83s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	54.876s
```
