### PR TITLE
interpolated tags - correct syntax tf 0.12.12

### DIFF
--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -158,13 +158,13 @@ resource "aws_autoscaling_group" "bar" {
     },
   ]
 
-  tags = ["${concat(
+  tags = "${concat(
     list(
       map("key", "interpolation1", "value", "value3", "propagate_at_launch", true),
       map("key", "interpolation2", "value", "value4", "propagate_at_launch", true)
     ),
     var.extra_tags)
-  }"]
+  }"
 }
 ```
 


### PR DESCRIPTION
Error: Incorrect attribute value type

  on terraform-aws-bastion/main.tf line 265, in resource "aws_autoscaling_group" "bastion_auto_scaling_group":
 265:   tags = ["${concat(

Inappropriate value for attribute "tags": element 0: map ofstring required.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8950 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
