### PR TITLE
r/aws_ec2_fleet: Refactor tagging logic to keyvaluetags package

### DIFF
--- a/aws/resource_aws_ec2_fleet.go
+++ b/aws/resource_aws_ec2_fleet.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsEc2Fleet() *schema.Resource {
@@ -192,12 +193,7 @@ func resourceAwsEc2Fleet() *schema.Resource {
 					},
 				},
 			},
-			"tags": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
+			"tags": tagsSchema(),
 			"target_capacity_specification": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -312,7 +308,7 @@ func resourceAwsEc2FleetCreate(d *schema.ResourceData, meta interface{}) error {
 		SpotOptions:                      expandEc2SpotOptionsRequest(d.Get("spot_options").([]interface{})),
 		TargetCapacitySpecification:      expandEc2TargetCapacitySpecificationRequest(d.Get("target_capacity_specification").([]interface{})),
 		TerminateInstancesWithExpiration: aws.Bool(d.Get("terminate_instances_with_expiration").(bool)),
-		TagSpecifications:                expandEc2TagSpecifications(d.Get("tags").(map[string]interface{})),
+		TagSpecifications:                ec2TagSpecificationsFromMap(d.Get("tags").(map[string]interface{}), ec2.ResourceTypeFleet),
 		Type:                             aws.String(d.Get("type").(string)),
 	}
 
@@ -435,7 +431,7 @@ func resourceAwsEc2FleetRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("terminate_instances_with_expiration", fleet.TerminateInstancesWithExpiration)
 	d.Set("type", fleet.Type)
 
-	if err := d.Set("tags", tagsToMap(fleet.Tags)); err != nil {
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(fleet.Tags).IgnoreAws().Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 
@@ -473,6 +469,14 @@ func resourceAwsEc2FleetUpdate(d *schema.ResourceData, meta interface{}) error {
 	_, err = stateConf.WaitForState()
 	if err != nil {
 		return fmt.Errorf("error waiting for EC2 Fleet (%s) modification: %s", d.Id(), err)
+	}
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.Ec2UpdateTags(conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("error updating tags: %s", err)
+		}
 	}
 
 	return resourceAwsEc2FleetRead(d, meta)
@@ -691,19 +695,6 @@ func expandEc2SpotOptionsRequest(l []interface{}) *ec2.SpotOptionsRequest {
 	}
 
 	return spotOptionsRequest
-}
-
-func expandEc2TagSpecifications(m map[string]interface{}) []*ec2.TagSpecification {
-	if len(m) == 0 {
-		return nil
-	}
-
-	return []*ec2.TagSpecification{
-		{
-			ResourceType: aws.String("fleet"),
-			Tags:         tagsFromMap(m),
-		},
-	}
 }
 
 func expandEc2TargetCapacitySpecificationRequest(l []interface{}) *ec2.TargetCapacitySpecificationRequest {

--- a/aws/resource_aws_ec2_fleet_test.go
+++ b/aws/resource_aws_ec2_fleet_test.go
@@ -783,7 +783,6 @@ func TestAccAWSEc2Fleet_Tags(t *testing.T) {
 				Config: testAccAWSEc2FleetConfig_Tags(rName, "key1", "value1updated"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEc2FleetExists(resourceName, &fleet2),
-					testAccCheckAWSEc2FleetRecreated(&fleet1, &fleet2),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
 				),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/terraform-providers/terraform-provider-aws/issues/10688.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_ec2_fleet: Updating `tags` no longer recreates the resource
```

Output from acceptance testing:

```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEc2Fleet_Tags'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEc2Fleet_Tags -timeout 120m
=== RUN   TestAccAWSEc2Fleet_Tags
=== PAUSE TestAccAWSEc2Fleet_Tags
=== CONT  TestAccAWSEc2Fleet_Tags
--- PASS: TestAccAWSEc2Fleet_Tags (109.13s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	109.174s
```
