### PR TITLE
r/aws_ec2_capacity_reservation: Refactor tagging logic to keyvaluetags package

### DIFF
--- a/aws/resource_aws_ec2_capacity_reservation.go
+++ b/aws/resource_aws_ec2_capacity_reservation.go
@@ -9,6 +9,12 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+const (
+	// There is no constant in the SDK for this resource type
+	ec2ResourceTypeCapacityReservation = "capacity-reservation"
 )
 
 func resourceAwsEc2CapacityReservation() *schema.Resource {
@@ -106,11 +112,12 @@ func resourceAwsEc2CapacityReservationCreate(d *schema.ResourceData, meta interf
 	conn := meta.(*AWSClient).ec2conn
 
 	opts := &ec2.CreateCapacityReservationInput{
-		AvailabilityZone: aws.String(d.Get("availability_zone").(string)),
-		EndDateType:      aws.String(d.Get("end_date_type").(string)),
-		InstanceCount:    aws.Int64(int64(d.Get("instance_count").(int))),
-		InstancePlatform: aws.String(d.Get("instance_platform").(string)),
-		InstanceType:     aws.String(d.Get("instance_type").(string)),
+		AvailabilityZone:  aws.String(d.Get("availability_zone").(string)),
+		EndDateType:       aws.String(d.Get("end_date_type").(string)),
+		InstanceCount:     aws.Int64(int64(d.Get("instance_count").(int))),
+		InstancePlatform:  aws.String(d.Get("instance_platform").(string)),
+		InstanceType:      aws.String(d.Get("instance_type").(string)),
+		TagSpecifications: ec2TagSpecificationsFromMap(d.Get("tags").(map[string]interface{}), ec2ResourceTypeCapacityReservation),
 	}
 
 	if v, ok := d.GetOk("ebs_optimized"); ok {
@@ -135,16 +142,6 @@ func resourceAwsEc2CapacityReservationCreate(d *schema.ResourceData, meta interf
 
 	if v, ok := d.GetOk("tenancy"); ok {
 		opts.Tenancy = aws.String(v.(string))
-	}
-
-	if v, ok := d.GetOk("tags"); ok && len(v.(map[string]interface{})) > 0 {
-		opts.TagSpecifications = []*ec2.TagSpecification{
-			{
-				// There is no constant in the SDK for this resource type
-				ResourceType: aws.String("capacity-reservation"),
-				Tags:         tagsFromMap(v.(map[string]interface{})),
-			},
-		}
 	}
 
 	log.Printf("[DEBUG] Capacity reservation: %s", opts)
@@ -200,7 +197,7 @@ func resourceAwsEc2CapacityReservationRead(d *schema.ResourceData, meta interfac
 	d.Set("instance_platform", reservation.InstancePlatform)
 	d.Set("instance_type", reservation.InstanceType)
 
-	if err := d.Set("tags", tagsToMap(reservation.Tags)); err != nil {
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(reservation.Tags).IgnoreAws().Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 
@@ -211,18 +208,6 @@ func resourceAwsEc2CapacityReservationRead(d *schema.ResourceData, meta interfac
 
 func resourceAwsEc2CapacityReservationUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
-
-	d.Partial(true)
-
-	if d.HasChange("tags") {
-		if err := setTags(conn, d); err != nil {
-			return err
-		} else {
-			d.SetPartial("tags")
-		}
-	}
-
-	d.Partial(false)
 
 	opts := &ec2.ModifyCapacityReservationInput{
 		CapacityReservationId: aws.String(d.Id()),
@@ -244,6 +229,15 @@ func resourceAwsEc2CapacityReservationUpdate(d *schema.ResourceData, meta interf
 	if err != nil {
 		return fmt.Errorf("Error modifying EC2 Capacity Reservation: %s", err)
 	}
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.Ec2UpdateTags(conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("error updating tags: %s", err)
+		}
+	}
+
 	return resourceAwsEc2CapacityReservationRead(d, meta)
 }
 

--- a/aws/resource_aws_ec2_capacity_reservation_test.go
+++ b/aws/resource_aws_ec2_capacity_reservation_test.go
@@ -162,6 +162,7 @@ func TestAccAWSEc2CapacityReservation_endDate(t *testing.T) {
 
 func TestAccAWSEc2CapacityReservation_endDateType(t *testing.T) {
 	var cr ec2.CapacityReservation
+	endDate := time.Now().UTC().Add(12 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_ec2_capacity_reservation.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -182,10 +183,10 @@ func TestAccAWSEc2CapacityReservation_endDateType(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccEc2CapacityReservationConfig_endDate("2019-10-31T07:39:57Z"),
+				Config: testAccEc2CapacityReservationConfig_endDate(endDate),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEc2CapacityReservationExists(resourceName, &cr),
-					resource.TestCheckResourceAttr(resourceName, "end_date", "2019-10-31T07:39:57Z"),
+					resource.TestCheckResourceAttr(resourceName, "end_date", endDate),
 					resource.TestCheckResourceAttr(resourceName, "end_date_type", "limited"),
 				),
 			},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10688.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEc2CapacityReservation_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEc2CapacityReservation_ -timeout 120m
=== RUN   TestAccAWSEc2CapacityReservation_basic
=== PAUSE TestAccAWSEc2CapacityReservation_basic
=== RUN   TestAccAWSEc2CapacityReservation_ebsOptimized
=== PAUSE TestAccAWSEc2CapacityReservation_ebsOptimized
=== RUN   TestAccAWSEc2CapacityReservation_endDate
=== PAUSE TestAccAWSEc2CapacityReservation_endDate
=== RUN   TestAccAWSEc2CapacityReservation_endDateType
=== PAUSE TestAccAWSEc2CapacityReservation_endDateType
=== RUN   TestAccAWSEc2CapacityReservation_ephemeralStorage
=== PAUSE TestAccAWSEc2CapacityReservation_ephemeralStorage
=== RUN   TestAccAWSEc2CapacityReservation_instanceCount
=== PAUSE TestAccAWSEc2CapacityReservation_instanceCount
=== RUN   TestAccAWSEc2CapacityReservation_instanceMatchCriteria
=== PAUSE TestAccAWSEc2CapacityReservation_instanceMatchCriteria
=== RUN   TestAccAWSEc2CapacityReservation_instanceType
=== PAUSE TestAccAWSEc2CapacityReservation_instanceType
=== RUN   TestAccAWSEc2CapacityReservation_tags
=== PAUSE TestAccAWSEc2CapacityReservation_tags
=== RUN   TestAccAWSEc2CapacityReservation_tenancy
--- SKIP: TestAccAWSEc2CapacityReservation_tenancy (0.00s)
    resource_aws_ec2_capacity_reservation_test.go:363: EC2 Capacity Reservations do not currently support dedicated tenancy.
=== CONT  TestAccAWSEc2CapacityReservation_basic
=== CONT  TestAccAWSEc2CapacityReservation_tags
=== CONT  TestAccAWSEc2CapacityReservation_instanceType
=== CONT  TestAccAWSEc2CapacityReservation_instanceMatchCriteria
=== CONT  TestAccAWSEc2CapacityReservation_instanceCount
=== CONT  TestAccAWSEc2CapacityReservation_ephemeralStorage
=== CONT  TestAccAWSEc2CapacityReservation_endDateType
=== CONT  TestAccAWSEc2CapacityReservation_endDate
=== CONT  TestAccAWSEc2CapacityReservation_ebsOptimized
--- PASS: TestAccAWSEc2CapacityReservation_ebsOptimized (21.29s)
--- PASS: TestAccAWSEc2CapacityReservation_ephemeralStorage (21.32s)
--- PASS: TestAccAWSEc2CapacityReservation_instanceMatchCriteria (21.43s)
--- PASS: TestAccAWSEc2CapacityReservation_basic (21.70s)
--- PASS: TestAccAWSEc2CapacityReservation_instanceCount (35.18s)
--- PASS: TestAccAWSEc2CapacityReservation_endDate (35.47s)
--- PASS: TestAccAWSEc2CapacityReservation_instanceType (36.33s)
--- PASS: TestAccAWSEc2CapacityReservation_endDateType (46.01s)
--- PASS: TestAccAWSEc2CapacityReservation_tags (47.22s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	47.276s
```
