### PR TITLE
aws_ebs_volume: Refactor tagging logic to keyvaluetags package

### DIFF
--- a/aws/data_source_aws_ebs_volume.go
+++ b/aws/data_source_aws_ebs_volume.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func dataSourceAwsEbsVolume() *schema.Resource {
@@ -141,6 +142,9 @@ func volumeDescriptionAttributes(d *schema.ResourceData, client *AWSClient, volu
 	d.Set("snapshot_id", volume.SnapshotId)
 	d.Set("volume_type", volume.VolumeType)
 
-	err := d.Set("tags", tagsToMap(volume.Tags))
-	return err
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(volume.Tags).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
 }

--- a/aws/resource_aws_ebs_volume.go
+++ b/aws/resource_aws_ebs_volume.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsEbsVolume() *schema.Resource {
@@ -80,7 +81,8 @@ func resourceAwsEbsVolumeCreate(d *schema.ResourceData, meta interface{}) error 
 	conn := meta.(*AWSClient).ec2conn
 
 	request := &ec2.CreateVolumeInput{
-		AvailabilityZone: aws.String(d.Get("availability_zone").(string)),
+		AvailabilityZone:  aws.String(d.Get("availability_zone").(string)),
+		TagSpecifications: ec2TagSpecificationsFromMap(d.Get("tags").(map[string]interface{}), ec2.ResourceTypeVolume),
 	}
 	if value, ok := d.GetOk("encrypted"); ok {
 		request.Encrypted = aws.Bool(value.(bool))
@@ -93,14 +95,6 @@ func resourceAwsEbsVolumeCreate(d *schema.ResourceData, meta interface{}) error 
 	}
 	if value, ok := d.GetOk("snapshot_id"); ok {
 		request.SnapshotId = aws.String(value.(string))
-	}
-	if value, ok := d.GetOk("tags"); ok {
-		request.TagSpecifications = []*ec2.TagSpecification{
-			{
-				ResourceType: aws.String(ec2.ResourceTypeVolume),
-				Tags:         tagsFromMap(value.(map[string]interface{})),
-			},
-		}
 	}
 
 	// IOPs are only valid, and required for, storage type io1. The current minimu
@@ -154,11 +148,6 @@ func resourceAwsEbsVolumeCreate(d *schema.ResourceData, meta interface{}) error 
 
 func resourceAWSEbsVolumeUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
-	if _, ok := d.GetOk("tags"); ok {
-		if err := setTags(conn, d); err != nil {
-			return fmt.Errorf("Error updating tags for EBS Volume: %s", err)
-		}
-	}
 
 	requestUpdate := false
 	params := &ec2.ModifyVolumeInput{
@@ -200,6 +189,14 @@ func resourceAWSEbsVolumeUpdate(d *schema.ResourceData, meta interface{}) error 
 			return fmt.Errorf(
 				"Error waiting for Volume (%s) to become available: %s",
 				*result.VolumeModification.VolumeId, err)
+		}
+	}
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.Ec2UpdateTags(conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("error updating tags: %s", err)
 		}
 	}
 
@@ -268,7 +265,7 @@ func resourceAwsEbsVolumeRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("size", aws.Int64Value(volume.Size))
 	d.Set("snapshot_id", aws.StringValue(volume.SnapshotId))
 
-	if err := d.Set("tags", tagsToMap(volume.Tags)); err != nil {
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(volume.Tags).IgnoreAws().Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10688.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEbsVolumeDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEbsVolumeDataSource_ -timeout 120m
=== RUN   TestAccAWSEbsVolumeDataSource_basic
=== PAUSE TestAccAWSEbsVolumeDataSource_basic
=== RUN   TestAccAWSEbsVolumeDataSource_multipleFilters
=== PAUSE TestAccAWSEbsVolumeDataSource_multipleFilters
=== CONT  TestAccAWSEbsVolumeDataSource_multipleFilters
=== CONT  TestAccAWSEbsVolumeDataSource_basic
--- PASS: TestAccAWSEbsVolumeDataSource_basic (30.45s)
--- PASS: TestAccAWSEbsVolumeDataSource_multipleFilters (30.88s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	30.931s
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEBSVolume_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEBSVolume_ -timeout 120m
=== RUN   TestAccAWSEBSVolume_basic
=== PAUSE TestAccAWSEBSVolume_basic
=== RUN   TestAccAWSEBSVolume_updateAttachedEbsVolume
=== PAUSE TestAccAWSEBSVolume_updateAttachedEbsVolume
=== RUN   TestAccAWSEBSVolume_updateSize
=== PAUSE TestAccAWSEBSVolume_updateSize
=== RUN   TestAccAWSEBSVolume_updateType
=== PAUSE TestAccAWSEBSVolume_updateType
=== RUN   TestAccAWSEBSVolume_updateIops
=== PAUSE TestAccAWSEBSVolume_updateIops
=== RUN   TestAccAWSEBSVolume_kmsKey
=== PAUSE TestAccAWSEBSVolume_kmsKey
=== RUN   TestAccAWSEBSVolume_NoIops
=== PAUSE TestAccAWSEBSVolume_NoIops
=== RUN   TestAccAWSEBSVolume_withTags
=== PAUSE TestAccAWSEBSVolume_withTags
=== CONT  TestAccAWSEBSVolume_basic
=== CONT  TestAccAWSEBSVolume_kmsKey
=== CONT  TestAccAWSEBSVolume_updateIops
=== CONT  TestAccAWSEBSVolume_withTags
=== CONT  TestAccAWSEBSVolume_updateType
=== CONT  TestAccAWSEBSVolume_NoIops
=== CONT  TestAccAWSEBSVolume_updateSize
=== CONT  TestAccAWSEBSVolume_updateAttachedEbsVolume
--- PASS: TestAccAWSEBSVolume_withTags (31.58s)
--- PASS: TestAccAWSEBSVolume_NoIops (32.07s)
--- PASS: TestAccAWSEBSVolume_basic (32.43s)
--- PASS: TestAccAWSEBSVolume_updateIops (56.35s)
--- PASS: TestAccAWSEBSVolume_updateType (56.58s)
--- PASS: TestAccAWSEBSVolume_updateSize (56.62s)
--- PASS: TestAccAWSEBSVolume_kmsKey (59.69s)
--- PASS: TestAccAWSEBSVolume_updateAttachedEbsVolume (179.52s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	179.550s
```
