### PR TITLE
data-source/data_source_aws_iam_group: Retrieve users that are associated to the group 

### DIFF
--- a/aws/data_source_aws_iam_group_test.go
+++ b/aws/data_source_aws_iam_group_test.go
@@ -10,34 +10,52 @@ import (
 )
 
 func TestAccAWSDataSourceIAMGroup_basic(t *testing.T) {
-	groupName := fmt.Sprintf("test-datasource-user-%d", acctest.RandInt())
+	groupName := fmt.Sprintf("test-datasource-group-%d", acctest.RandInt())
+	userName := fmt.Sprintf("test-datasource-user-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsIAMGroupConfig(groupName),
+				Config: testAccAwsIAMGroupConfig(groupName, userName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.aws_iam_group.test", "group_id"),
 					resource.TestCheckResourceAttr("data.aws_iam_group.test", "path", "/"),
 					resource.TestCheckResourceAttr("data.aws_iam_group.test", "group_name", groupName),
 					resource.TestMatchResourceAttr("data.aws_iam_group.test", "arn", regexp.MustCompile("^arn:aws:iam::[0-9]{12}:group/"+groupName)),
+					resource.TestCheckResourceAttr("data.aws_iam_group.test", "users.#", "1"),
 				),
 			},
 		},
 	})
 }
 
-func testAccAwsIAMGroupConfig(name string) string {
+func testAccAwsIAMGroupConfig(groupname string, username string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_group" "group" {
   name = "%s"
   path = "/"
 }
 
-data "aws_iam_group" "test" {
-  group_name = "${aws_iam_group.group.name}"
+resource "aws_iam_user" "user" {
+	name = "%s"
 }
-`, name)
+
+resource "aws_iam_user_group_membership" "user_membership" {
+	user = "${aws_iam_user.user.name}"
+
+	groups = [
+		"${aws_iam_group.group.name}",
+	]
+}
+
+data "aws_iam_group" "test" {
+  /*
+  Getting the group_name from the aws_iam_user_group_membership
+  enforce an implicit dependency which is needed for the test
+  */
+  group_name = "${element(tolist(aws_iam_user_group_membership.user_membership.groups), 0)}"
+}
+`, groupname, username)
 }

--- a/website/docs/d/iam_group.html.markdown
+++ b/website/docs/d/iam_group.html.markdown
@@ -31,3 +31,8 @@ data "aws_iam_group" "example" {
 * `path` - The path to the group.
 
 * `group_id` - The stable and unique string identifying the group.
+
+* `users` - The list of users associated to this group.
+  * `users.#.Arn` - The Amazon Resource Name (ARN) specifying the user.
+  * `users.#.UserId` - The unique identifier for the user.
+  * `users.#.UserName` - The "friendly name" for the user.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Motivation

It is often handy to have access to the mapping between IAM Groups and IAM Users, especially when you can't directly use the group.

For example, you can't give permissions to a group in a S3 Bucket Policy. You need to explicitly give all the ARNs or UserIDs of the users.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10652

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* data-source/data_source_aws_iam_group: Retrieve users that are associated to the group
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDataSourceIAMGroup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDataSourceIAMGroup_basic -timeout 120m
=== RUN   TestAccAWSDataSourceIAMGroup_basic
=== PAUSE TestAccAWSDataSourceIAMGroup_basic
=== CONT  TestAccAWSDataSourceIAMGroup_basic
--- PASS: TestAccAWSDataSourceIAMGroup_basic (22.98s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       23.004s
...
```