### PR TITLE
Add 7 missing IP range values to documentation

### DIFF
--- a/website/docs/d/ip_ranges.html.markdown
+++ b/website/docs/d/ip_ranges.html.markdown
@@ -43,7 +43,10 @@ omitted). Valid items are `global` (for `cloudfront`) as well as all AWS regions
 (e.g. `eu-central-1`)
 
 * `services` - (Required) Filter IP ranges by services. Valid items are `amazon`
-(for amazon.com), `cloudfront`, `codebuild`, `ec2`, `route53`, `route53_healthchecks` and `S3`.
+(for amazon.com), `amazon_connect`, `api_gateway`, `cloud9`, `cloudfront`,
+`codebuild`, `dynamodb`, `ec2`, `ec2_instance_connect`, `globalaccelerator`,
+`route53`, `route53_healthchecks`, `s3` and `workspaces_gateways`. See the
+[`service` attribute][2] documentation for other possible values.
 
 ~> **NOTE:** If the specified combination of regions and services does not yield any
 CIDR blocks, Terraform will fail.
@@ -59,3 +62,4 @@ CIDR blocks, Terraform will fail.
   (e.g. `1470267965`).
 
 [1]: https://docs.aws.amazon.com/general/latest/gr/aws-ip-ranges.html
+[2]: https://docs.aws.amazon.com/general/latest/gr/aws-ip-ranges.html#aws-ip-syntax


### PR DESCRIPTION
Also update docs to point to the list used by AWS to maintain freshness.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #2301

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Update aws_ip_ranges documentation to indicate support for 7 additional services
```
