### PR TITLE
aws_instance: Refactor tagging logic to keyvaluetags package

### DIFF
--- a/aws/data_source_aws_instance.go
+++ b/aws/data_source_aws_instance.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func dataSourceAwsInstance() *schema.Resource {
@@ -307,9 +308,7 @@ func dataSourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		params.InstanceIds = []*string{aws.String(instanceID.(string))}
 	}
 	if tagsOk {
-		params.Filters = append(params.Filters, buildEC2TagFilterList(
-			tagsFromMap(tags.(map[string]interface{})),
-		)...)
+		params.Filters = append(params.Filters, ec2TagFiltersFromMap(tags.(map[string]interface{}))...)
 	}
 
 	log.Printf("[DEBUG] Reading IAM Instance: %s", params)
@@ -424,7 +423,9 @@ func instanceDescriptionAttributes(d *schema.ResourceData, instance *ec2.Instanc
 		d.Set("monitoring", monitoringState == "enabled" || monitoringState == "pending")
 	}
 
-	d.Set("tags", tagsToMap(instance.Tags))
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(instance.Tags).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
 
 	// Security Groups
 	if err := readSecurityGroups(d, instance, conn); err != nil {

--- a/aws/data_source_aws_instance_test.go
+++ b/aws/data_source_aws_instance_test.go
@@ -173,13 +173,14 @@ func TestAccAWSInstanceDataSource_rootInstanceStore(t *testing.T) {
 func TestAccAWSInstanceDataSource_privateIP(t *testing.T) {
 	resourceName := "aws_instance.test"
 	datasourceName := "data.aws_instance.test"
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceDataSourceConfig_privateIP,
+				Config: testAccInstanceDataSourceConfig_privateIP(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "ami", resourceName, "ami"),
 					resource.TestCheckResourceAttrPair(datasourceName, "instance_type", resourceName, "instance_type"),
@@ -215,13 +216,14 @@ func TestAccAWSInstanceDataSource_keyPair(t *testing.T) {
 func TestAccAWSInstanceDataSource_VPC(t *testing.T) {
 	resourceName := "aws_instance.test"
 	datasourceName := "data.aws_instance.test"
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceDataSourceConfig_VPC,
+				Config: testAccInstanceDataSourceConfig_VPC(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "ami", resourceName, "ami"),
 					resource.TestCheckResourceAttrPair(datasourceName, "instance_type", resourceName, "instance_type"),
@@ -350,27 +352,28 @@ func TestAccAWSInstanceDataSource_getPasswordData_falseToTrue(t *testing.T) {
 
 func TestAccAWSInstanceDataSource_GetUserData(t *testing.T) {
 	datasourceName := "data.aws_instance.test"
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceDataSourceConfigGetUserData(true),
+				Config: testAccInstanceDataSourceConfigGetUserData(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "get_user_data", "true"),
 					resource.TestCheckResourceAttr(datasourceName, "user_data_base64", "IyEvYmluL2Jhc2gKCmVjaG8gImhlbGxvIHdvcmxkIgo="),
 				),
 			},
 			{
-				Config: testAccInstanceDataSourceConfigGetUserData(false),
+				Config: testAccInstanceDataSourceConfigGetUserData(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "get_user_data", "false"),
 					resource.TestCheckNoResourceAttr(datasourceName, "user_data_base64"),
 				),
 			},
 			{
-				Config: testAccInstanceDataSourceConfigGetUserData(true),
+				Config: testAccInstanceDataSourceConfigGetUserData(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "get_user_data", "true"),
 					resource.TestCheckResourceAttr(datasourceName, "user_data_base64", "IyEvYmluL2Jhc2gKCmVjaG8gImhlbGxvIHdvcmxkIgo="),
@@ -383,13 +386,14 @@ func TestAccAWSInstanceDataSource_GetUserData(t *testing.T) {
 func TestAccAWSInstanceDataSource_GetUserData_NoUserData(t *testing.T) {
 	resourceName := "aws_instance.test"
 	datasourceName := "data.aws_instance.test"
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceDataSourceConfigGetUserDataNoUserData(true),
+				Config: testAccInstanceDataSourceConfigGetUserDataNoUserData(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "get_user_data", "true"),
 					resource.TestCheckNoResourceAttr(datasourceName, "user_data_base64"),
@@ -397,7 +401,7 @@ func TestAccAWSInstanceDataSource_GetUserData_NoUserData(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstanceDataSourceConfigGetUserDataNoUserData(false),
+				Config: testAccInstanceDataSourceConfigGetUserDataNoUserData(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "get_user_data", "false"),
 					resource.TestCheckNoResourceAttr(datasourceName, "user_data_base64"),
@@ -405,7 +409,7 @@ func TestAccAWSInstanceDataSource_GetUserData_NoUserData(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstanceDataSourceConfigGetUserDataNoUserData(true),
+				Config: testAccInstanceDataSourceConfigGetUserDataNoUserData(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "get_user_data", "true"),
 					resource.TestCheckNoResourceAttr(datasourceName, "user_data_base64"),
@@ -419,6 +423,7 @@ func TestAccAWSInstanceDataSource_GetUserData_NoUserData(t *testing.T) {
 func TestAccAWSInstanceDataSource_creditSpecification(t *testing.T) {
 	resourceName := "aws_instance.test"
 	datasourceName := "data.aws_instance.test"
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -426,7 +431,7 @@ func TestAccAWSInstanceDataSource_creditSpecification(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 
-				Config: testAccInstanceDataSourceConfig_creditSpecification,
+				Config: testAccInstanceDataSourceConfig_creditSpecification(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "instance_type", resourceName, "instance_type"),
 					resource.TestCheckResourceAttrPair(datasourceName, "credit_specification.#", resourceName, "credit_specification.#"),
@@ -615,49 +620,84 @@ data "aws_instance" "test" {
 }
 `
 
-const testAccInstanceDataSourceConfig_privateIP = `
+func testAccInstanceDataSourceConfig_privateIP(rName string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "current" {
+  blacklisted_names = ["us-west-2d"]
+}
+
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
+
   tags = {
-    Name = "terraform-testacc-instance-ds-private-ip"
+    Name = %[1]q
   }
 }
 
 resource "aws_subnet" "test" {
-  cidr_block = "10.1.1.0/24"
-  vpc_id = "${aws_vpc.test.id}"
+  cidr_block        = "10.1.1.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.current.names[0]}"
+
   tags = {
-    Name = "tf-acc-instance-ds-private-ip"
+    Name = %[1]q
+  }
+}
+
+data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name = "name"
+    values = ["amzn-ami-minimal-hvm-*"]
+  }
+
+  filter {
+    name = "root-device-type"
+    values = ["ebs"]
   }
 }
 
 resource "aws_instance" "test" {
-  ami = "ami-c5eabbf5"
+  ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   instance_type = "t2.micro"
-  subnet_id = "${aws_subnet.test.id}"
-  private_ip = "10.1.1.42"
+  subnet_id     = "${aws_subnet.test.id}"
+  private_ip    = "10.1.1.42"
 }
 
 data "aws_instance" "test" {
   instance_id = "${aws_instance.test.id}"
 }
-`
+`, rName)
+}
 
 func testAccInstanceDataSourceConfig_keyPair(rName string) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
+data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name = "name"
+    values = ["amzn-ami-minimal-hvm-*"]
+  }
+
+  filter {
+    name = "root-device-type"
+    values = ["ebs"]
+  }
 }
 
-resource "aws_key_pair" "debugging" {
-  key_name   = "%s"
+resource "aws_key_pair" "test" {
+  key_name   = %[1]q
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
 resource "aws_instance" "test" {
-  ami           = "ami-408c7f28"
+  ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   instance_type = "t1.micro"
-  key_name      = "${aws_key_pair.debugging.key_name}"
+  key_name      = "${aws_key_pair.test.key_name}"
 
   tags = {
     Name = "testAccInstanceDataSourceConfigKeyPair_TestAMI"
@@ -678,37 +718,60 @@ data "aws_instance" "test" {
 `, rName)
 }
 
-const testAccInstanceDataSourceConfig_VPC = `
+func testAccInstanceDataSourceConfig_VPC(rName string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "current" {
+  blacklisted_names = ["us-west-2d"]
+}
+
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
+
   tags = {
-    Name = "terraform-testacc-instance-data-source-vpc"
+    Name = %[1]q
   }
 }
 
 resource "aws_subnet" "test" {
-  cidr_block = "10.1.1.0/24"
-  vpc_id = "${aws_vpc.test.id}"
+  cidr_block        = "10.1.1.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.current.names[0]}"
+
   tags = {
-   Name = "tf-acc-instance-data-source-vpc"
+    Name = %[1]q
+  }
+}
+
+data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name = "name"
+    values = ["amzn-ami-minimal-hvm-*"]
+  }
+
+  filter {
+    name = "root-device-type"
+    values = ["ebs"]
   }
 }
 
 resource "aws_instance" "test" {
-  # us-west-2
-  ami = "ami-4fccb37f"
-  instance_type = "m1.small"
-  subnet_id = "${aws_subnet.test.id}"
+  ami                         = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type               = "m1.small"
+  subnet_id                   = "${aws_subnet.test.id}"
   associate_public_ip_address = true
-  tenancy = "dedicated"
+  tenancy                     = "dedicated"
   # pre-encoded base64 data
-  user_data = "3dc39dda39be1205215e776bad998da361a5955d"
+  user_data                   = "3dc39dda39be1205215e776bad998da361a5955d"
 }
 
 data "aws_instance" "test" {
   instance_id = "${aws_instance.test.id}"
 }
-`
+`, rName)
+}
 
 func testAccInstanceDataSourceConfig_PlacementGroup(rStr string) string {
 	return fmt.Sprintf(`
@@ -787,7 +850,7 @@ data "aws_instance" "test" {
 const testAccInstanceDataSourceConfig_VPCSecurityGroups = `
 resource "aws_internet_gateway" "gw" {
   vpc_id = "${aws_vpc.foo.id}"
- 
+
   tags = {
     Name = "terraform-testacc-instance-data-source-vpc-sgs"
   }
@@ -840,7 +903,7 @@ func testAccInstanceDataSourceConfig_getPasswordData(val bool, rInt int) string 
 data "aws_ami" "win2016core" {
   most_recent = true
   owners      = ["amazon"]
-  
+
   filter {
     name   = "name"
     values = ["Windows_Server-2016-English-Core-Base-*"]
@@ -860,43 +923,48 @@ resource "aws_instance" "test" {
 
 data "aws_instance" "test" {
   instance_id = "${aws_instance.test.id}"
- 
+
   get_password_data = %t
 }
 `, rInt, val)
 }
 
-func testAccInstanceDataSourceConfigGetUserData(getUserData bool) string {
+func testAccInstanceDataSourceConfigGetUserData(rName string, getUserData bool) string {
 	return fmt.Sprintf(`
 data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
   most_recent = true
   owners      = ["amazon"]
-  
+
   filter {
     name   = "name"
     values = ["amzn-ami-minimal-hvm-*"]
   }
-  
+
   filter {
     name   = "root-device-type"
     values = ["ebs"]
   }
 }
 
+data "aws_availability_zones" "current" {
+  blacklisted_names = ["us-west-2d"]
+}
+
 resource "aws_vpc" "test" {
   cidr_block = "172.16.0.0/16"
 
   tags = {
-    Name = "tf-acc-test-instance-datasource-get-user-data"
+    Name = %[1]q
   }
 }
 
 resource "aws_subnet" "test" {
-  cidr_block = "172.16.0.0/24"
-  vpc_id     = "${aws_vpc.test.id}"
+  cidr_block        = "172.16.0.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.current.names[0]}"
 
   tags = {
-    Name = "tf-acc-test-instance-datasource-get-user-data"
+    Name = %[1]q
   }
 }
 
@@ -904,7 +972,7 @@ resource "aws_instance" "test" {
   ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   instance_type = "t2.micro"
   subnet_id     = "${aws_subnet.test.id}"
- 
+
   user_data = <<EUD
 #!/bin/bash
 
@@ -913,18 +981,18 @@ EUD
 }
 
 data "aws_instance" "test" {
-  get_user_data = %t
+  get_user_data = %[2]t
   instance_id   = "${aws_instance.test.id}"
 }
-`, getUserData)
+`, rName, getUserData)
 }
 
-func testAccInstanceDataSourceConfigGetUserDataNoUserData(getUserData bool) string {
+func testAccInstanceDataSourceConfigGetUserDataNoUserData(rName string, getUserData bool) string {
 	return fmt.Sprintf(`
 data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
   most_recent = true
   owners      = ["amazon"]
-  
+
   filter {
     name   = "name"
     values = ["amzn-ami-minimal-hvm-*"]
@@ -936,20 +1004,25 @@ data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
   }
 }
 
+data "aws_availability_zones" "current" {
+  blacklisted_names = ["us-west-2d"]
+}
+
 resource "aws_vpc" "test" {
   cidr_block = "172.16.0.0/16"
 
   tags = {
-    Name = "tf-acc-test-instance-datasource-get-user-data"
+    Name = %[1]q
   }
 }
 
 resource "aws_subnet" "test" {
-  cidr_block = "172.16.0.0/24"
-  vpc_id     = "${aws_vpc.test.id}"
+  cidr_block        = "172.16.0.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.current.names[0]}"
 
   tags = {
-    Name = "tf-acc-test-instance-datasource-get-user-data"
+    Name = %[1]q
   }
 }
 
@@ -960,26 +1033,56 @@ resource "aws_instance" "test" {
 }
 
 data "aws_instance" "test" {
-  get_user_data = %t
+  get_user_data = %[2]t
   instance_id   = "${aws_instance.test.id}"
 }
-`, getUserData)
+`, rName, getUserData)
 }
 
-const testAccInstanceDataSourceConfig_creditSpecification = `
-resource "aws_vpc" "foo" {
+func testAccInstanceDataSourceConfig_creditSpecification(rName string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "current" {
+  blacklisted_names = ["us-west-2d"]
+}
+
+resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
-resource "aws_subnet" "foo" {
-  cidr_block = "10.1.1.0/24"
-  vpc_id = "${aws_vpc.foo.id}"
+resource "aws_subnet" "test" {
+  cidr_block        = "10.1.1.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.current.names[0]}"
+
+  tags = {
+    Name = %[1]q
+  }
 }
+
+data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
+	most_recent = true
+	owners      = ["amazon"]
+
+	filter {
+	  name = "name"
+	  values = ["amzn-ami-minimal-hvm-*"]
+	}
+
+	filter {
+	  name = "root-device-type"
+	  values = ["ebs"]
+	}
+  }
 
 resource "aws_instance" "test" {
-  ami = "ami-bf4193c7"
+  ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   instance_type = "t2.micro"
-  subnet_id = "${aws_subnet.foo.id}"
+  subnet_id     = "${aws_subnet.test.id}"
+
   credit_specification {
     cpu_credits = "unlimited"
   }
@@ -988,4 +1091,5 @@ resource "aws_instance" "test" {
 data "aws_instance" "test" {
   instance_id = "${aws_instance.test.id}"
 }
-`
+`, rName)
+}

--- a/aws/ec2_filters.go
+++ b/aws/ec2_filters.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 // buildEC2AttributeFilterList takes a flat map of scalar attributes (most
@@ -85,6 +86,49 @@ func buildEC2TagFilterList(tags []*ec2.Tag) []*ec2.Filter {
 			Name:   aws.String(fmt.Sprintf("tag:%s", *tag.Key)),
 			Values: []*string{tag.Value},
 		}
+	}
+
+	return filters
+}
+
+// ec2AttributeFiltersFromMultimap returns an array of EC2 Filter objects to be used when listing resources.
+//
+// The keys of the specified map are the resource attributes names used in the filter - see the documentation
+// for the relevant "Describe" action for a list of the valid names. The resource must match all the filters
+// to be included in the result.
+// The values of the specified map are lists of resource attribute values used in the filter. The resource can
+// match any of the filter values to be included in the result.
+// See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html#Filtering_Resources_CLI for more details.
+func ec2AttributeFiltersFromMultimap(m map[string][]string) []*ec2.Filter {
+	if len(m) == 0 {
+		return nil
+	}
+
+	filters := []*ec2.Filter{}
+	for k, v := range m {
+		filters = append(filters, &ec2.Filter{
+			Name:   aws.String(k),
+			Values: aws.StringSlice(v),
+		})
+	}
+
+	return filters
+}
+
+// ec2TagFiltersFromMap returns an array of EC2 Filter objects to be used when listing resources.
+//
+// The filters represent exact matches for all the resource tags in the given key/value map.
+func ec2TagFiltersFromMap(m map[string]interface{}) []*ec2.Filter {
+	if len(m) == 0 {
+		return nil
+	}
+
+	filters := []*ec2.Filter{}
+	for _, tag := range keyvaluetags.New(m).IgnoreAws().Ec2Tags() {
+		filters = append(filters, &ec2.Filter{
+			Name:   aws.String(fmt.Sprintf("tag:%s", aws.StringValue(tag.Key))),
+			Values: []*string{tag.Value},
+		})
 	}
 
 	return filters

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -147,9 +147,9 @@ func TestFetchRootDevice(t *testing.T) {
 }
 
 func TestAccAWSInstance_inDefaultVpcBySgName(t *testing.T) {
-	resourceName := "aws_instance.test"
-	rInt := acctest.RandInt()
 	var v ec2.Instance
+	resourceName := "aws_instance.test"
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -157,7 +157,7 @@ func TestAccAWSInstance_inDefaultVpcBySgName(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigInDefaultVpcBySgName(rInt),
+				Config: testAccInstanceConfigInDefaultVpcBySgName(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(
 						resourceName, &v),
@@ -173,9 +173,9 @@ func TestAccAWSInstance_inDefaultVpcBySgName(t *testing.T) {
 }
 
 func TestAccAWSInstance_inDefaultVpcBySgId(t *testing.T) {
-	resourceName := "aws_instance.test"
-	rInt := acctest.RandInt()
 	var v ec2.Instance
+	resourceName := "aws_instance.test"
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -183,7 +183,7 @@ func TestAccAWSInstance_inDefaultVpcBySgId(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigInDefaultVpcBySgId(rInt),
+				Config: testAccInstanceConfigInDefaultVpcBySgId(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(
 						resourceName, &v),
@@ -800,6 +800,7 @@ func TestAccAWSInstance_sourceDestCheck(t *testing.T) {
 func TestAccAWSInstance_disableApiTermination(t *testing.T) {
 	var v ec2.Instance
 	resourceName := "aws_instance.test"
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	checkDisableApiTermination := func(expected bool) resource.TestCheckFunc {
 		return func(*terraform.State) error {
@@ -826,7 +827,7 @@ func TestAccAWSInstance_disableApiTermination(t *testing.T) {
 		CheckDestroy:  testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigDisableAPITermination(true),
+				Config: testAccInstanceConfigDisableAPITermination(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					checkDisableApiTermination(true),
@@ -838,7 +839,7 @@ func TestAccAWSInstance_disableApiTermination(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccInstanceConfigDisableAPITermination(false),
+				Config: testAccInstanceConfigDisableAPITermination(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					checkDisableApiTermination(false),
@@ -883,8 +884,8 @@ func TestAccAWSInstance_vpc(t *testing.T) {
 
 func TestAccAWSInstance_placementGroup(t *testing.T) {
 	var v ec2.Instance
-	rStr := acctest.RandString(5)
 	resourceName := "aws_instance.test"
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
@@ -894,14 +895,14 @@ func TestAccAWSInstance_placementGroup(t *testing.T) {
 		CheckDestroy:    testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigPlacementGroup(rStr),
+				Config: testAccInstanceConfigPlacementGroup(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(
 						resourceName, &v),
 					resource.TestCheckResourceAttr(
 						resourceName,
 						"placement_group",
-						fmt.Sprintf("testAccInstanceConfigPlacementGroup_%s", rStr)),
+						rName),
 				),
 			},
 			{
@@ -916,6 +917,7 @@ func TestAccAWSInstance_placementGroup(t *testing.T) {
 func TestAccAWSInstance_ipv6_supportAddressCount(t *testing.T) {
 	var v ec2.Instance
 	resourceName := "aws_instance.test"
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -923,7 +925,7 @@ func TestAccAWSInstance_ipv6_supportAddressCount(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigIpv6Support,
+				Config: testAccInstanceConfigIpv6Support(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(
 						resourceName, &v),
@@ -943,6 +945,7 @@ func TestAccAWSInstance_ipv6_supportAddressCount(t *testing.T) {
 }
 
 func TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError(t *testing.T) {
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -950,7 +953,7 @@ func TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError(t *testing.T
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccInstanceConfigIpv6ErrorConfig,
+				Config:      testAccInstanceConfigIpv6ErrorConfig(rName),
 				ExpectError: regexp.MustCompile("Only 1 of `ipv6_address_count` or `ipv6_addresses` can be specified"),
 			},
 		},
@@ -960,6 +963,7 @@ func TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError(t *testing.T
 func TestAccAWSInstance_ipv6_supportAddressCountWithIpv4(t *testing.T) {
 	var v ec2.Instance
 	resourceName := "aws_instance.test"
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -967,7 +971,7 @@ func TestAccAWSInstance_ipv6_supportAddressCountWithIpv4(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigIpv6SupportWithIpv4,
+				Config: testAccInstanceConfigIpv6SupportWithIpv4(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(
 						resourceName, &v),
@@ -1015,7 +1019,7 @@ func TestAccAWSInstance_multipleRegions(t *testing.T) {
 func TestAccAWSInstance_NetworkInstanceSecurityGroups(t *testing.T) {
 	var v ec2.Instance
 	resourceName := "aws_instance.test"
-	rInt := acctest.RandInt()
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
@@ -1025,7 +1029,7 @@ func TestAccAWSInstance_NetworkInstanceSecurityGroups(t *testing.T) {
 		CheckDestroy:    testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceNetworkInstanceSecurityGroups(rInt),
+				Config: testAccInstanceNetworkInstanceSecurityGroups(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(
 						resourceName, &v),
@@ -1232,8 +1236,8 @@ func TestAccAWSInstance_volumeTagsComputed(t *testing.T) {
 
 func TestAccAWSInstance_instanceProfileChange(t *testing.T) {
 	var v ec2.Instance
-	rName := acctest.RandString(5)
 	resourceName := "aws_instance.test"
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	testCheckInstanceProfile := func() resource.TestCheckFunc {
 		return func(*terraform.State) error {
@@ -1275,8 +1279,8 @@ func TestAccAWSInstance_instanceProfileChange(t *testing.T) {
 
 func TestAccAWSInstance_withIamInstanceProfile(t *testing.T) {
 	var v ec2.Instance
-	rName := acctest.RandString(5)
 	resourceName := "aws_instance.test"
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	testCheckInstanceProfile := func() resource.TestCheckFunc {
 		return func(*terraform.State) error {
@@ -1350,6 +1354,7 @@ func TestAccAWSInstance_privateIP(t *testing.T) {
 func TestAccAWSInstance_associatePublicIPAndPrivateIP(t *testing.T) {
 	var v ec2.Instance
 	resourceName := "aws_instance.test"
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	testCheckPrivateIP := func() resource.TestCheckFunc {
 		return func(*terraform.State) error {
@@ -1369,7 +1374,7 @@ func TestAccAWSInstance_associatePublicIPAndPrivateIP(t *testing.T) {
 		CheckDestroy:    testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigAssociatePublicIPAndPrivateIP,
+				Config: testAccInstanceConfigAssociatePublicIPAndPrivateIP(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					testCheckPrivateIP(),
@@ -1389,6 +1394,7 @@ func TestAccAWSInstance_associatePublicIPAndPrivateIP(t *testing.T) {
 func TestAccAWSInstance_keyPairCheck(t *testing.T) {
 	var v ec2.Instance
 	resourceName := "aws_instance.test"
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	testCheckKeyPair := func(keyName string) resource.TestCheckFunc {
 		return func(*terraform.State) error {
@@ -1403,8 +1409,6 @@ func TestAccAWSInstance_keyPairCheck(t *testing.T) {
 		}
 	}
 
-	keyPairName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
 		IDRefreshName:   resourceName,
@@ -1413,10 +1417,10 @@ func TestAccAWSInstance_keyPairCheck(t *testing.T) {
 		CheckDestroy:    testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigKeyPair(keyPairName),
+				Config: testAccInstanceConfigKeyPair(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
-					testCheckKeyPair(keyPairName),
+					testCheckKeyPair(rName),
 				),
 			},
 		},
@@ -1529,8 +1533,10 @@ func TestAccAWSInstance_changeInstanceType(t *testing.T) {
 
 func TestAccAWSInstance_primaryNetworkInterface(t *testing.T) {
 	var instance ec2.Instance
-	var ini ec2.NetworkInterface
+	var eni ec2.NetworkInterface
 	resourceName := "aws_instance.test"
+	eniResourceName := "aws_network_interface.test"
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1538,10 +1544,10 @@ func TestAccAWSInstance_primaryNetworkInterface(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigPrimaryNetworkInterface,
+				Config: testAccInstanceConfigPrimaryNetworkInterface(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &instance),
-					testAccCheckAWSENIExists("aws_network_interface.test", &ini),
+					testAccCheckAWSENIExists(eniResourceName, &eni),
 					resource.TestCheckResourceAttr(resourceName, "network_interface.#", "1"),
 				),
 			},
@@ -1557,8 +1563,10 @@ func TestAccAWSInstance_primaryNetworkInterface(t *testing.T) {
 
 func TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck(t *testing.T) {
 	var instance ec2.Instance
-	var ini ec2.NetworkInterface
+	var eni ec2.NetworkInterface
 	resourceName := "aws_instance.test"
+	eniResourceName := "aws_network_interface.test"
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1566,10 +1574,10 @@ func TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigPrimaryNetworkInterfaceSourceDestCheck,
+				Config: testAccInstanceConfigPrimaryNetworkInterfaceSourceDestCheck(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &instance),
-					testAccCheckAWSENIExists("aws_network_interface.test", &ini),
+					testAccCheckAWSENIExists(eniResourceName, &eni),
 					resource.TestCheckResourceAttr(resourceName, "source_dest_check", "false"),
 				),
 			},
@@ -1586,9 +1594,12 @@ func TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck(t *testing.T) {
 func TestAccAWSInstance_addSecondaryInterface(t *testing.T) {
 	var before ec2.Instance
 	var after ec2.Instance
-	var iniPrimary ec2.NetworkInterface
-	var iniSecondary ec2.NetworkInterface
+	var eniPrimary ec2.NetworkInterface
+	var eniSecondary ec2.NetworkInterface
 	resourceName := "aws_instance.test"
+	eniPrimaryResourceName := "aws_network_interface.primary"
+	eniSecondaryResourceName := "aws_network_interface.secondary"
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1596,10 +1607,10 @@ func TestAccAWSInstance_addSecondaryInterface(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigAddSecondaryNetworkInterfaceBefore,
+				Config: testAccInstanceConfigAddSecondaryNetworkInterfaceBefore(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &before),
-					testAccCheckAWSENIExists("aws_network_interface.primary", &iniPrimary),
+					testAccCheckAWSENIExists(eniPrimaryResourceName, &eniPrimary),
 					resource.TestCheckResourceAttr(resourceName, "network_interface.#", "1"),
 				),
 			},
@@ -1610,10 +1621,10 @@ func TestAccAWSInstance_addSecondaryInterface(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"network_interface"},
 			},
 			{
-				Config: testAccInstanceConfigAddSecondaryNetworkInterfaceAfter,
+				Config: testAccInstanceConfigAddSecondaryNetworkInterfaceAfter(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &after),
-					testAccCheckAWSENIExists("aws_network_interface.secondary", &iniSecondary),
+					testAccCheckAWSENIExists(eniSecondaryResourceName, &eniSecondary),
 					resource.TestCheckResourceAttr(resourceName, "network_interface.#", "1"),
 				),
 			},
@@ -1626,6 +1637,7 @@ func TestAccAWSInstance_addSecurityGroupNetworkInterface(t *testing.T) {
 	var before ec2.Instance
 	var after ec2.Instance
 	resourceName := "aws_instance.test"
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1633,7 +1645,7 @@ func TestAccAWSInstance_addSecurityGroupNetworkInterface(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigAddSecurityGroupBefore,
+				Config: testAccInstanceConfigAddSecurityGroupBefore(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "vpc_security_group_ids.#", "1"),
@@ -1645,7 +1657,7 @@ func TestAccAWSInstance_addSecurityGroupNetworkInterface(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccInstanceConfigAddSecurityGroupAfter,
+				Config: testAccInstanceConfigAddSecurityGroupAfter(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "vpc_security_group_ids.#", "2"),
@@ -1657,9 +1669,9 @@ func TestAccAWSInstance_addSecurityGroupNetworkInterface(t *testing.T) {
 
 // https://github.com/terraform-providers/terraform-provider-aws/issues/227
 func TestAccAWSInstance_associatePublic_defaultPrivate(t *testing.T) {
-	var before ec2.Instance
+	var v ec2.Instance
 	resourceName := "aws_instance.test"
-	rInt := acctest.RandInt()
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1667,9 +1679,9 @@ func TestAccAWSInstance_associatePublic_defaultPrivate(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_associatePublic_defaultPrivate(rInt),
+				Config: testAccInstanceConfig_associatePublic_defaultPrivate(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(resourceName, &before),
+					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "associate_public_ip_address", "false"),
 					resource.TestCheckResourceAttr(resourceName, "public_ip", ""),
 				),
@@ -1685,9 +1697,9 @@ func TestAccAWSInstance_associatePublic_defaultPrivate(t *testing.T) {
 
 // https://github.com/terraform-providers/terraform-provider-aws/issues/227
 func TestAccAWSInstance_associatePublic_defaultPublic(t *testing.T) {
-	var before ec2.Instance
+	var v ec2.Instance
 	resourceName := "aws_instance.test"
-	rInt := acctest.RandInt()
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1695,9 +1707,9 @@ func TestAccAWSInstance_associatePublic_defaultPublic(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_associatePublic_defaultPublic(rInt),
+				Config: testAccInstanceConfig_associatePublic_defaultPublic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(resourceName, &before),
+					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "associate_public_ip_address", "true"),
 					resource.TestCheckResourceAttrSet(resourceName, "public_ip"),
 				),
@@ -1713,9 +1725,9 @@ func TestAccAWSInstance_associatePublic_defaultPublic(t *testing.T) {
 
 // https://github.com/terraform-providers/terraform-provider-aws/issues/227
 func TestAccAWSInstance_associatePublic_explicitPublic(t *testing.T) {
-	var before ec2.Instance
+	var v ec2.Instance
 	resourceName := "aws_instance.test"
-	rInt := acctest.RandInt()
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1723,9 +1735,9 @@ func TestAccAWSInstance_associatePublic_explicitPublic(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_associatePublic_explicitPublic(rInt),
+				Config: testAccInstanceConfig_associatePublic_explicitPublic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(resourceName, &before),
+					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "associate_public_ip_address", "true"),
 					resource.TestCheckResourceAttrSet(resourceName, "public_ip"),
 				),
@@ -1741,9 +1753,9 @@ func TestAccAWSInstance_associatePublic_explicitPublic(t *testing.T) {
 
 // https://github.com/terraform-providers/terraform-provider-aws/issues/227
 func TestAccAWSInstance_associatePublic_explicitPrivate(t *testing.T) {
-	var before ec2.Instance
+	var v ec2.Instance
 	resourceName := "aws_instance.test"
-	rInt := acctest.RandInt()
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1751,9 +1763,9 @@ func TestAccAWSInstance_associatePublic_explicitPrivate(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_associatePublic_explicitPrivate(rInt),
+				Config: testAccInstanceConfig_associatePublic_explicitPrivate(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(resourceName, &before),
+					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "associate_public_ip_address", "false"),
 					resource.TestCheckResourceAttr(resourceName, "public_ip", ""),
 				),
@@ -1769,9 +1781,9 @@ func TestAccAWSInstance_associatePublic_explicitPrivate(t *testing.T) {
 
 // https://github.com/terraform-providers/terraform-provider-aws/issues/227
 func TestAccAWSInstance_associatePublic_overridePublic(t *testing.T) {
-	var before ec2.Instance
+	var v ec2.Instance
 	resourceName := "aws_instance.test"
-	rInt := acctest.RandInt()
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1779,9 +1791,9 @@ func TestAccAWSInstance_associatePublic_overridePublic(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_associatePublic_overridePublic(rInt),
+				Config: testAccInstanceConfig_associatePublic_overridePublic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(resourceName, &before),
+					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "associate_public_ip_address", "true"),
 					resource.TestCheckResourceAttrSet(resourceName, "public_ip"),
 				),
@@ -1797,9 +1809,9 @@ func TestAccAWSInstance_associatePublic_overridePublic(t *testing.T) {
 
 // https://github.com/terraform-providers/terraform-provider-aws/issues/227
 func TestAccAWSInstance_associatePublic_overridePrivate(t *testing.T) {
-	var before ec2.Instance
+	var v ec2.Instance
 	resourceName := "aws_instance.test"
-	rInt := acctest.RandInt()
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1807,9 +1819,9 @@ func TestAccAWSInstance_associatePublic_overridePrivate(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_associatePublic_overridePrivate(rInt),
+				Config: testAccInstanceConfig_associatePublic_overridePrivate(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(resourceName, &before),
+					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "associate_public_ip_address", "false"),
 					resource.TestCheckResourceAttr(resourceName, "public_ip", ""),
 				),
@@ -1826,7 +1838,7 @@ func TestAccAWSInstance_associatePublic_overridePrivate(t *testing.T) {
 func TestAccAWSInstance_getPasswordData_falseToTrue(t *testing.T) {
 	var before, after ec2.Instance
 	resourceName := "aws_instance.test"
-	rInt := acctest.RandInt()
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1834,7 +1846,7 @@ func TestAccAWSInstance_getPasswordData_falseToTrue(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_getPasswordData(false, rInt),
+				Config: testAccInstanceConfig_getPasswordData(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "get_password_data", "false"),
@@ -1847,7 +1859,7 @@ func TestAccAWSInstance_getPasswordData_falseToTrue(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccInstanceConfig_getPasswordData(true, rInt),
+				Config: testAccInstanceConfig_getPasswordData(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &after),
 					testAccCheckInstanceNotRecreated(t, &before, &after),
@@ -1862,7 +1874,7 @@ func TestAccAWSInstance_getPasswordData_falseToTrue(t *testing.T) {
 func TestAccAWSInstance_getPasswordData_trueToFalse(t *testing.T) {
 	var before, after ec2.Instance
 	resourceName := "aws_instance.test"
-	rInt := acctest.RandInt()
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1870,7 +1882,7 @@ func TestAccAWSInstance_getPasswordData_trueToFalse(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_getPasswordData(true, rInt),
+				Config: testAccInstanceConfig_getPasswordData(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "get_password_data", "true"),
@@ -1884,7 +1896,7 @@ func TestAccAWSInstance_getPasswordData_trueToFalse(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"password_data", "get_password_data"},
 			},
 			{
-				Config: testAccInstanceConfig_getPasswordData(false, rInt),
+				Config: testAccInstanceConfig_getPasswordData(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &after),
 					testAccCheckInstanceNotRecreated(t, &before, &after),
@@ -1897,9 +1909,9 @@ func TestAccAWSInstance_getPasswordData_trueToFalse(t *testing.T) {
 }
 
 func TestAccAWSInstance_CreditSpecification_Empty_NonBurstable(t *testing.T) {
-	var instance ec2.Instance
+	var v ec2.Instance
 	resourceName := "aws_instance.test"
-	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1909,7 +1921,7 @@ func TestAccAWSInstance_CreditSpecification_Empty_NonBurstable(t *testing.T) {
 			{
 				Config: testAccInstanceConfig_CreditSpecification_Empty_NonBurstable(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(resourceName, &instance),
+					testAccCheckInstanceExists(resourceName, &v),
 				),
 			},
 			{
@@ -1926,7 +1938,7 @@ func TestAccAWSInstance_CreditSpecification_Empty_NonBurstable(t *testing.T) {
 func TestAccAWSInstance_CreditSpecification_UnspecifiedToEmpty_NonBurstable(t *testing.T) {
 	var instance ec2.Instance
 	resourceName := "aws_instance.test"
-	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1955,9 +1967,9 @@ func TestAccAWSInstance_CreditSpecification_UnspecifiedToEmpty_NonBurstable(t *t
 }
 
 func TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard(t *testing.T) {
-	var instance ec2.Instance
+	var v ec2.Instance
 	resourceName := "aws_instance.test"
-	rInt := acctest.RandInt()
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1965,9 +1977,9 @@ func TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard(t *tes
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_creditSpecification_unspecified(rInt),
+				Config: testAccInstanceConfig_creditSpecification_unspecified(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(resourceName, &instance),
+					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.0.cpu_credits", "standard"),
 				),
@@ -1984,7 +1996,7 @@ func TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard(t *tes
 func TestAccAWSInstance_creditSpecification_standardCpuCredits(t *testing.T) {
 	var first, second ec2.Instance
 	resourceName := "aws_instance.test"
-	rInt := acctest.RandInt()
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1992,7 +2004,7 @@ func TestAccAWSInstance_creditSpecification_standardCpuCredits(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_creditSpecification_standardCpuCredits(rInt),
+				Config: testAccInstanceConfig_creditSpecification_standardCpuCredits(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &first),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -2005,7 +2017,7 @@ func TestAccAWSInstance_creditSpecification_standardCpuCredits(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccInstanceConfig_creditSpecification_unspecified(rInt),
+				Config: testAccInstanceConfig_creditSpecification_unspecified(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &second),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -2019,7 +2031,7 @@ func TestAccAWSInstance_creditSpecification_standardCpuCredits(t *testing.T) {
 func TestAccAWSInstance_creditSpecification_unlimitedCpuCredits(t *testing.T) {
 	var first, second ec2.Instance
 	resourceName := "aws_instance.test"
-	rInt := acctest.RandInt()
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -2027,7 +2039,7 @@ func TestAccAWSInstance_creditSpecification_unlimitedCpuCredits(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_creditSpecification_unlimitedCpuCredits(rInt),
+				Config: testAccInstanceConfig_creditSpecification_unlimitedCpuCredits(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &first),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -2040,7 +2052,7 @@ func TestAccAWSInstance_creditSpecification_unlimitedCpuCredits(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccInstanceConfig_creditSpecification_unspecified(rInt),
+				Config: testAccInstanceConfig_creditSpecification_unspecified(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &second),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -2052,9 +2064,9 @@ func TestAccAWSInstance_creditSpecification_unlimitedCpuCredits(t *testing.T) {
 }
 
 func TestAccAWSInstance_creditSpecification_unknownCpuCredits_t2(t *testing.T) {
-	var instance ec2.Instance
-	rInt := acctest.RandInt()
+	var v ec2.Instance
 	resourceName := "aws_instance.test"
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -2062,9 +2074,9 @@ func TestAccAWSInstance_creditSpecification_unknownCpuCredits_t2(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_creditSpecification_unknownCpuCredits(rInt, "t2.micro"),
+				Config: testAccInstanceConfig_creditSpecification_unknownCpuCredits(rName, "t2.micro"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(resourceName, &instance),
+					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.0.cpu_credits", "standard"),
 				),
@@ -2079,9 +2091,9 @@ func TestAccAWSInstance_creditSpecification_unknownCpuCredits_t2(t *testing.T) {
 }
 
 func TestAccAWSInstance_creditSpecification_unknownCpuCredits_t3(t *testing.T) {
-	var instance ec2.Instance
-	rInt := acctest.RandInt()
+	var v ec2.Instance
 	resourceName := "aws_instance.test"
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -2089,9 +2101,9 @@ func TestAccAWSInstance_creditSpecification_unknownCpuCredits_t3(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_creditSpecification_unknownCpuCredits(rInt, "t3.micro"),
+				Config: testAccInstanceConfig_creditSpecification_unknownCpuCredits(rName, "t3.micro"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(resourceName, &instance),
+					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.0.cpu_credits", "unlimited"),
 				),
@@ -2108,7 +2120,7 @@ func TestAccAWSInstance_creditSpecification_unknownCpuCredits_t3(t *testing.T) {
 func TestAccAWSInstance_creditSpecification_updateCpuCredits(t *testing.T) {
 	var first, second, third ec2.Instance
 	resourceName := "aws_instance.test"
-	rInt := acctest.RandInt()
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -2116,7 +2128,7 @@ func TestAccAWSInstance_creditSpecification_updateCpuCredits(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_creditSpecification_standardCpuCredits(rInt),
+				Config: testAccInstanceConfig_creditSpecification_standardCpuCredits(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &first),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -2129,7 +2141,7 @@ func TestAccAWSInstance_creditSpecification_updateCpuCredits(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccInstanceConfig_creditSpecification_unlimitedCpuCredits(rInt),
+				Config: testAccInstanceConfig_creditSpecification_unlimitedCpuCredits(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &second),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -2137,7 +2149,7 @@ func TestAccAWSInstance_creditSpecification_updateCpuCredits(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstanceConfig_creditSpecification_standardCpuCredits(rInt),
+				Config: testAccInstanceConfig_creditSpecification_standardCpuCredits(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &third),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -2149,9 +2161,9 @@ func TestAccAWSInstance_creditSpecification_updateCpuCredits(t *testing.T) {
 }
 
 func TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable(t *testing.T) {
-	var instance ec2.Instance
+	var v ec2.Instance
 	resourceName := "aws_instance.test"
-	rInt := acctest.RandInt()
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -2159,9 +2171,9 @@ func TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable(t *testin
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_creditSpecification_isNotAppliedToNonBurstable(rInt),
+				Config: testAccInstanceConfig_creditSpecification_isNotAppliedToNonBurstable(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(resourceName, &instance),
+					testAccCheckInstanceExists(resourceName, &v),
 				),
 			},
 			{
@@ -2175,9 +2187,9 @@ func TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable(t *testin
 }
 
 func TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited(t *testing.T) {
-	var instance ec2.Instance
+	var v ec2.Instance
 	resourceName := "aws_instance.test"
-	rInt := acctest.RandInt()
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -2185,9 +2197,9 @@ func TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited(t *
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_creditSpecification_unspecified_t3(rInt),
+				Config: testAccInstanceConfig_creditSpecification_unspecified_t3(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(resourceName, &instance),
+					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.0.cpu_credits", "unlimited"),
 				),
@@ -2204,7 +2216,7 @@ func TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited(t *
 func TestAccAWSInstance_creditSpecificationT3_standardCpuCredits(t *testing.T) {
 	var first, second ec2.Instance
 	resourceName := "aws_instance.test"
-	rInt := acctest.RandInt()
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -2212,7 +2224,7 @@ func TestAccAWSInstance_creditSpecificationT3_standardCpuCredits(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_creditSpecification_standardCpuCredits_t3(rInt),
+				Config: testAccInstanceConfig_creditSpecification_standardCpuCredits_t3(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &first),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -2225,7 +2237,7 @@ func TestAccAWSInstance_creditSpecificationT3_standardCpuCredits(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccInstanceConfig_creditSpecification_unspecified_t3(rInt),
+				Config: testAccInstanceConfig_creditSpecification_unspecified_t3(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &second),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -2239,7 +2251,7 @@ func TestAccAWSInstance_creditSpecificationT3_standardCpuCredits(t *testing.T) {
 func TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits(t *testing.T) {
 	var first, second ec2.Instance
 	resourceName := "aws_instance.test"
-	rInt := acctest.RandInt()
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -2247,7 +2259,7 @@ func TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits(t *testing.T) 
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_creditSpecification_unlimitedCpuCredits_t3(rInt),
+				Config: testAccInstanceConfig_creditSpecification_unlimitedCpuCredits_t3(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &first),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -2260,7 +2272,7 @@ func TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits(t *testing.T) 
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccInstanceConfig_creditSpecification_unspecified_t3(rInt),
+				Config: testAccInstanceConfig_creditSpecification_unspecified_t3(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &second),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -2274,7 +2286,7 @@ func TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits(t *testing.T) 
 func TestAccAWSInstance_creditSpecificationT3_updateCpuCredits(t *testing.T) {
 	var first, second, third ec2.Instance
 	resourceName := "aws_instance.test"
-	rInt := acctest.RandInt()
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -2282,7 +2294,7 @@ func TestAccAWSInstance_creditSpecificationT3_updateCpuCredits(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_creditSpecification_standardCpuCredits_t3(rInt),
+				Config: testAccInstanceConfig_creditSpecification_standardCpuCredits_t3(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &first),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -2295,7 +2307,7 @@ func TestAccAWSInstance_creditSpecificationT3_updateCpuCredits(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccInstanceConfig_creditSpecification_unlimitedCpuCredits_t3(rInt),
+				Config: testAccInstanceConfig_creditSpecification_unlimitedCpuCredits_t3(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &second),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -2303,7 +2315,7 @@ func TestAccAWSInstance_creditSpecificationT3_updateCpuCredits(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstanceConfig_creditSpecification_standardCpuCredits_t3(rInt),
+				Config: testAccInstanceConfig_creditSpecification_standardCpuCredits_t3(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &third),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -2317,7 +2329,7 @@ func TestAccAWSInstance_creditSpecificationT3_updateCpuCredits(t *testing.T) {
 func TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint(t *testing.T) {
 	var before, after ec2.Instance
 	resourceName := "aws_instance.test"
-	rInt := acctest.RandInt()
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -2325,7 +2337,7 @@ func TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint(t *te
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_creditSpecification_standardCpuCredits(rInt),
+				Config: testAccInstanceConfig_creditSpecification_standardCpuCredits(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -2338,7 +2350,7 @@ func TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint(t *te
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccInstanceConfig_creditSpecification_standardCpuCredits_t3(rInt),
+				Config: testAccInstanceConfig_creditSpecification_standardCpuCredits_t3(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -2353,7 +2365,7 @@ func TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint(t *te
 func TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint(t *testing.T) {
 	var before, after ec2.Instance
 	resourceName := "aws_instance.test"
-	rInt := acctest.RandInt()
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -2361,7 +2373,7 @@ func TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint(t *t
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_creditSpecification_unlimitedCpuCredits(rInt),
+				Config: testAccInstanceConfig_creditSpecification_unlimitedCpuCredits(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -2374,7 +2386,7 @@ func TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint(t *t
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccInstanceConfig_creditSpecification_unlimitedCpuCredits_t3(rInt),
+				Config: testAccInstanceConfig_creditSpecification_unlimitedCpuCredits_t3(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
@@ -2409,9 +2421,9 @@ func TestAccAWSInstance_disappears(t *testing.T) {
 }
 
 func TestAccAWSInstance_UserData_EmptyStringToUnspecified(t *testing.T) {
-	var instance ec2.Instance
-	rInt := acctest.RandInt()
+	var v ec2.Instance
 	resourceName := "aws_instance.test"
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -2419,9 +2431,9 @@ func TestAccAWSInstance_UserData_EmptyStringToUnspecified(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_UserData_EmptyString(rInt),
+				Config: testAccInstanceConfig_UserData_EmptyString(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(resourceName, &instance),
+					testAccCheckInstanceExists(resourceName, &v),
 				),
 			},
 			{
@@ -2432,7 +2444,7 @@ func TestAccAWSInstance_UserData_EmptyStringToUnspecified(t *testing.T) {
 			},
 			// Switching should show no difference
 			{
-				Config:             testAccInstanceConfig_UserData_Unspecified(rInt),
+				Config:             testAccInstanceConfig_UserData_Unspecified(rName),
 				ExpectNonEmptyPlan: false,
 				PlanOnly:           true,
 			},
@@ -2441,9 +2453,9 @@ func TestAccAWSInstance_UserData_EmptyStringToUnspecified(t *testing.T) {
 }
 
 func TestAccAWSInstance_UserData_UnspecifiedToEmptyString(t *testing.T) {
-	var instance ec2.Instance
-	rInt := acctest.RandInt()
+	var v ec2.Instance
 	resourceName := "aws_instance.test"
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -2451,9 +2463,9 @@ func TestAccAWSInstance_UserData_UnspecifiedToEmptyString(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_UserData_Unspecified(rInt),
+				Config: testAccInstanceConfig_UserData_Unspecified(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(resourceName, &instance),
+					testAccCheckInstanceExists(resourceName, &v),
 				),
 			},
 			{
@@ -2463,7 +2475,7 @@ func TestAccAWSInstance_UserData_UnspecifiedToEmptyString(t *testing.T) {
 			},
 			// Switching should show no difference
 			{
-				Config:             testAccInstanceConfig_UserData_EmptyString(rInt),
+				Config:             testAccInstanceConfig_UserData_EmptyString(rName),
 				ExpectNonEmptyPlan: false,
 				PlanOnly:           true,
 			},
@@ -2648,76 +2660,56 @@ func driftTags(instance *ec2.Instance) resource.TestCheckFunc {
 	}
 }
 
-func testAccInstanceConfigInDefaultVpcBySgName(rInt int) string {
-	return fmt.Sprintf(`
-data "aws_ami" "ubuntu" {
-  most_recent = true
-
-  filter {
-    name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  owners = ["099720109477"] # Canonical
+func testAccInstanceConfigInDefaultVpcBySgName(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
+data "aws_availability_zones" "current" {
+  # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
+  blacklisted_zone_ids = ["usw2-az4"]
 }
 
 data "aws_vpc" "default" {
   default = true
 }
 
-resource "aws_security_group" "sg" {
-  name        = "tf_acc_test_%d"
-  description = "Test security group"
+resource "aws_security_group" "test" {
+  name        = %[1]q
+  description = %[1]q
   vpc_id      = "${data.aws_vpc.default.id}"
 }
 
 resource "aws_instance" "test" {
-  ami             = "${data.aws_ami.ubuntu.id}"
-  instance_type   = "t2.micro"
-  security_groups = ["${aws_security_group.sg.name}"]
+  ami               = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type     = "t2.micro"
+  security_groups   = ["${aws_security_group.test.name}"]
+  availability_zone = "${data.aws_availability_zones.current.names[0]}"
 }
-`, rInt)
+`, rName)
 }
 
-func testAccInstanceConfigInDefaultVpcBySgId(rInt int) string {
-	return fmt.Sprintf(`
-data "aws_ami" "ubuntu" {
-  most_recent = true
-
-  filter {
-    name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  owners = ["099720109477"] # Canonical
+func testAccInstanceConfigInDefaultVpcBySgId(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
+data "aws_availability_zones" "current" {
+  # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
+  blacklisted_zone_ids = ["usw2-az4"]
 }
 
 data "aws_vpc" "default" {
   default = true
 }
 
-resource "aws_security_group" "sg" {
-  name        = "tf_acc_test_%d"
-  description = "Test security group"
+resource "aws_security_group" "test" {
+  name        = %[1]q
+  description = %[1]q
   vpc_id      = "${data.aws_vpc.default.id}"
 }
 
 resource "aws_instance" "test" {
-  ami                    = "${data.aws_ami.ubuntu.id}"
+  ami                    = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   instance_type          = "t2.micro"
-  vpc_security_group_ids = ["${aws_security_group.sg.id}"]
+  vpc_security_group_ids = ["${aws_security_group.test.id}"]
+  availability_zone      = "${data.aws_availability_zones.current.names[0]}"
 }
-`, rInt)
+`, rName)
 }
 
 func testAccInstanceConfigInEc2Classic(rInt int) string {
@@ -2929,7 +2921,7 @@ resource "aws_instance" "test" {
 `
 
 func testAccInstanceConfigSourceDestEnable(rName string) string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName) + fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   instance_type = "m1.small"
@@ -2939,7 +2931,7 @@ resource "aws_instance" "test" {
 }
 
 func testAccInstanceConfigSourceDestDisable(rName string) string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName) + fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami               = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   instance_type     = "m1.small"
@@ -2949,37 +2941,19 @@ resource "aws_instance" "test" {
 `)
 }
 
-func testAccInstanceConfigDisableAPITermination(val bool) string {
-	return fmt.Sprintf(`
-resource "aws_vpc" "test" {
-  cidr_block = "10.1.0.0/16"
-
-  tags = {
-    Name = "terraform-testacc-instance-disable-api-termination"
-  }
-}
-
-resource "aws_subnet" "test" {
-  cidr_block = "10.1.1.0/24"
-  vpc_id     = "${aws_vpc.test.id}"
-
-  tags = {
-    Name = "tf-acc-instance-disable-api-termination"
-  }
-}
-
+func testAccInstanceConfigDisableAPITermination(rName string, val bool) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + fmt.Sprintf(`
 resource "aws_instance" "test" {
-  # us-west-2
-  ami                     = "ami-4fccb37f"
+  ami                     = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   instance_type           = "m1.small"
   subnet_id               = "${aws_subnet.test.id}"
-  disable_api_termination = %t
+  disable_api_termination = %[1]t
 }
 `, val)
 }
 
 func testAccInstanceConfigVPC(rName string) string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName) + fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami                         = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   instance_type               = "m1.small"
@@ -2992,34 +2966,16 @@ resource "aws_instance" "test" {
 `)
 }
 
-func testAccInstanceConfigPlacementGroup(rStr string) string {
-	return fmt.Sprintf(`
-resource "aws_vpc" "test" {
-  cidr_block = "10.1.0.0/16"
-
-  tags = {
-    Name = "terraform-testacc-instance-placement-group"
-  }
-}
-
-resource "aws_subnet" "test" {
-  cidr_block = "10.1.1.0/24"
-  vpc_id     = "${aws_vpc.test.id}"
-
-  tags = {
-    Name = "tf-acc-instance-placement-group"
-  }
-}
-
+func testAccInstanceConfigPlacementGroup(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + fmt.Sprintf(`
 resource "aws_placement_group" "test" {
-  name     = "testAccInstanceConfigPlacementGroup_%s"
+  name     = %[1]q
   strategy = "cluster"
 }
 
 # Limitations: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html#concepts-placement-groups
 resource "aws_instance" "test" {
-  # us-west-2
-  ami                         = "ami-55a7ea65"
+  ami                         = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   instance_type               = "c3.large"
   subnet_id                   = "${aws_subnet.test.id}"
   associate_public_ip_address = true
@@ -3028,102 +2984,55 @@ resource "aws_instance" "test" {
   # pre-encoded base64 data
   user_data = "3dc39dda39be1205215e776bad998da361a5955d"
 }
-`, rStr)
+`, rName)
 }
 
-const testAccInstanceConfigIpv6ErrorConfig = `
-resource "aws_vpc" "test" {
-	cidr_block = "10.1.0.0/16"
-	assign_generated_ipv6_cidr_block = true
-	tags = {
-		Name = "terraform-testacc-instance-ipv6-err"
-	}
-}
-
-resource "aws_subnet" "test" {
-	cidr_block = "10.1.1.0/24"
-	vpc_id = "${aws_vpc.test.id}"
-	ipv6_cidr_block = "${cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)}"
-	tags = {
-		Name = "tf-acc-instance-ipv6-err"
-	}
-}
-
+func testAccInstanceConfigIpv6ErrorConfig(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcIpv6Config(rName) + fmt.Sprintf(`
 resource "aws_instance" "test" {
-	# us-west-2
-	ami = "ami-c5eabbf5"
-	instance_type = "t2.micro"
-	subnet_id = "${aws_subnet.test.id}"
-	ipv6_addresses = ["2600:1f14:bb2:e501::10"]
-	ipv6_address_count = 1
-	tags = {
-		Name = "tf-ipv6-instance-acc-test"
-	}
-}
-`
+  ami                = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type      = "t2.micro"
+  subnet_id          = "${aws_subnet.test.id}"
+  ipv6_addresses     = ["2600:1f14:bb2:e501::10"]
+  ipv6_address_count = 1
 
-const testAccInstanceConfigIpv6Support = `
-resource "aws_vpc" "test" {
-	cidr_block = "10.1.0.0/16"
-	assign_generated_ipv6_cidr_block = true
-	tags = {
-		Name = "terraform-testacc-instance-ipv6-support"
-	}
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName)
 }
 
-resource "aws_subnet" "test" {
-	cidr_block = "10.1.1.0/24"
-	vpc_id = "${aws_vpc.test.id}"
-	ipv6_cidr_block = "${cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)}"
-	tags = {
-		Name = "tf-acc-instance-ipv6-support"
-	}
-}
-
+func testAccInstanceConfigIpv6Support(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcIpv6Config(rName) + fmt.Sprintf(`
 resource "aws_instance" "test" {
-	# us-west-2
-	ami = "ami-c5eabbf5"
-	instance_type = "t2.micro"
-	subnet_id = "${aws_subnet.test.id}"
+  ami                = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type      = "t2.micro"
+  subnet_id          = "${aws_subnet.test.id}"
+  ipv6_address_count = 1
 
-	ipv6_address_count = 1
-	tags = {
-		Name = "tf-ipv6-instance-acc-test"
-	}
+  tags = {
+    Name = %[1]q
+  }
 }
-`
-
-const testAccInstanceConfigIpv6SupportWithIpv4 = `
-resource "aws_vpc" "test" {
-	cidr_block = "10.1.0.0/16"
-	assign_generated_ipv6_cidr_block = true
-	tags = {
-		Name = "terraform-testacc-instance-ipv6-support-with-ipv4"
-	}
+`, rName)
 }
 
-resource "aws_subnet" "test" {
-	cidr_block = "10.1.1.0/24"
-	vpc_id = "${aws_vpc.test.id}"
-	ipv6_cidr_block = "${cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)}"
-	tags = {
-		Name = "tf-acc-instance-ipv6-support-with-ipv4"
-	}
-}
-
+func testAccInstanceConfigIpv6SupportWithIpv4(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcIpv6Config(rName) + fmt.Sprintf(`
 resource "aws_instance" "test" {
-	# us-west-2
-	ami = "ami-c5eabbf5"
-	instance_type = "t2.micro"
-	subnet_id = "${aws_subnet.test.id}"
+  ami                         = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type               = "t2.micro"
+  subnet_id                   = "${aws_subnet.test.id}"
+  associate_public_ip_address = true
+  ipv6_address_count          = 1
 
-	associate_public_ip_address = true
-	ipv6_address_count = 1
-	tags = {
-		Name = "tf-ipv6-instance-acc-test"
-	}
+  tags = {
+    Name = %[1]q
+  }
 }
-`
+`, rName)
+}
 
 const testAccInstanceConfigMultipleRegions = `
 provider "aws" {
@@ -3406,49 +3315,49 @@ resource "aws_instance" "test" {
 `
 
 func testAccInstanceConfigWithoutInstanceProfile(rName string) string {
-	return fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
 resource "aws_iam_role" "test" {
-  name               = "test-%s"
+  name               = %[1]q
   assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"ec2.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
 }
 
 resource "aws_instance" "test" {
-  ami           = "ami-4fccb37f"
+  ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   instance_type = "m1.small"
 
   tags = {
-    test = "test3"
+    Name = %[1]q
   }
 }
 `, rName)
 }
 
 func testAccInstanceConfigWithInstanceProfile(rName string) string {
-	return fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
 resource "aws_iam_role" "test" {
-  name               = "test-%s"
+  name               = %[1]q
   assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"ec2.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
 }
 
 resource "aws_iam_instance_profile" "test" {
-  name  = "test-%s"
+  name  = %[1]q
   roles = ["${aws_iam_role.test.name}"]
 }
 
 resource "aws_instance" "test" {
-  ami                  = "ami-4fccb37f"
+  ami                  = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   instance_type        = "m1.small"
   iam_instance_profile = "${aws_iam_instance_profile.test.name}"
 
   tags = {
-    test = "test3"
+    Name = %[1]q
   }
 }
-`, rName, rName)
+`, rName)
 }
 
 func testAccInstanceConfigPrivateIP(rName string) string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName) + fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   instance_type = "t2.micro"
@@ -3458,107 +3367,45 @@ resource "aws_instance" "test" {
 `)
 }
 
-const testAccInstanceConfigAssociatePublicIPAndPrivateIP = `
-resource "aws_vpc" "test" {
-	cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-instance-public-ip-and-private-ip"
-	}
-}
-
-resource "aws_subnet" "test" {
-	cidr_block = "10.1.1.0/24"
-	vpc_id = "${aws_vpc.test.id}"
-	tags = {
-		Name = "tf-acc-instance-public-ip-and-private-ip"
-	}
-}
-
+func testAccInstanceConfigAssociatePublicIPAndPrivateIP(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + fmt.Sprintf(`
 resource "aws_instance" "test" {
-	ami = "ami-c5eabbf5"
-	instance_type = "t2.micro"
-	subnet_id = "${aws_subnet.test.id}"
-	associate_public_ip_address = true
-	private_ip = "10.1.1.42"
+  ami                         = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type               = "t2.micro"
+  subnet_id                   = "${aws_subnet.test.id}"
+  associate_public_ip_address = true
+  private_ip                  = "10.1.1.42"
 }
-`
-
-func testAccInstanceNetworkInstanceSecurityGroups(rInt int) string {
-	return fmt.Sprintf(`
-resource "aws_internet_gateway" "gw" {
-  vpc_id = "${aws_vpc.test.id}"
+`)
 }
 
-resource "aws_vpc" "test" {
-  cidr_block = "10.1.0.0/16"
-
-  tags = {
-    Name = "terraform-testacc-instance-network-security-groups"
-  }
-}
-
-resource "aws_security_group" "test" {
-  name        = "tf_test_%d"
-  description = "test"
-  vpc_id      = "${aws_vpc.test.id}"
-
-  ingress {
-    protocol    = "icmp"
-    from_port   = -1
-    to_port     = -1
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}
-
-resource "aws_subnet" "test" {
-  cidr_block = "10.1.1.0/24"
-  vpc_id     = "${aws_vpc.test.id}"
-
-  tags = {
-    Name = "tf-acc-instance-network-security-groups"
-  }
-}
-
+func testAccInstanceNetworkInstanceSecurityGroups(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() +
+		testAccAwsInstanceVpcConfig(rName, false) +
+		testAccAwsInstanceVpcSecurityGroupConfig(rName) +
+		fmt.Sprintf(`
 resource "aws_instance" "test" {
-  ami                         = "ami-21f78e11"
+  ami                         = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   instance_type               = "t1.micro"
   vpc_security_group_ids      = ["${aws_security_group.test.id}"]
   subnet_id                   = "${aws_subnet.test.id}"
   associate_public_ip_address = true
-  depends_on                  = ["aws_internet_gateway.gw"]
+  depends_on                  = ["aws_internet_gateway.test"]
 }
 
-resource "aws_eip" "test_eip" {
+resource "aws_eip" "test" {
   instance   = "${aws_instance.test.id}"
   vpc        = true
-  depends_on = ["aws_internet_gateway.gw"]
+  depends_on = ["aws_internet_gateway.test"]
 }
-`, rInt)
+`)
 }
 
 func testAccInstanceNetworkInstanceVPCSecurityGroupIDs(rName string) string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName) + fmt.Sprintf(`
-resource "aws_internet_gateway" "test" {
-  vpc_id = "${aws_vpc.test.id}"
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_security_group" "test" {
-  name        = %[1]q
-  description = "test"
-  vpc_id      = "${aws_vpc.test.id}"
-
-  ingress {
-    protocol    = "icmp"
-    from_port   = -1
-    to_port     = -1
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}
-
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() +
+		testAccAwsInstanceVpcConfig(rName, false) +
+		testAccAwsInstanceVpcSecurityGroupConfig(rName) +
+		fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami                    = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   instance_type          = "t1.micro"
@@ -3572,32 +3419,14 @@ resource "aws_eip" "test" {
   vpc        = true
   depends_on = ["aws_internet_gateway.test"]
 }
-`, rName)
+`)
 }
 
 func testAccInstanceNetworkInstanceVPCRemoveSecurityGroupIDs(rName string) string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName) + fmt.Sprintf(`
-resource "aws_internet_gateway" "test" {
-  vpc_id = "${aws_vpc.test.id}"
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_security_group" "test" {
-  name        = %[1]q
-  description = "test"
-  vpc_id      = "${aws_vpc.test.id}"
-
-  ingress {
-    protocol    = "icmp"
-    from_port   = -1
-    to_port     = -1
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}
-
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() +
+		testAccAwsInstanceVpcConfig(rName, false) +
+		testAccAwsInstanceVpcSecurityGroupConfig(rName) +
+		fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami                    = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   instance_type          = "t1.micro"
@@ -3611,33 +3440,30 @@ resource "aws_eip" "test" {
   vpc        = true
   depends_on = ["aws_internet_gateway.test"]
 }
+`)
+}
+
+func testAccInstanceConfigKeyPair(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
+resource "aws_key_pair" "test" {
+  key_name   = %[1]q
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+}
+
+resource "aws_instance" "test" {
+  ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type = "t1.micro"
+  key_name      = "${aws_key_pair.test.key_name}"
+
+  tags = {
+    Name = %[1]q
+  }
+}
 `, rName)
 }
 
-func testAccInstanceConfigKeyPair(keyPairName string) string {
-	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
-resource "aws_key_pair" "debugging" {
-  key_name   = "%s"
-  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
-}
-resource "aws_instance" "test" {
-  ami           = "ami-408c7f28"
-  instance_type = "t1.micro"
-  key_name      = "${aws_key_pair.debugging.key_name}"
-
-  tags = {
-    Name = "testAccInstanceConfigKeyPair_TestAMI"
-  }
-}
-`, keyPairName)
-}
-
 func testAccInstanceConfigRootBlockDeviceMismatch(rName string) string {
-	return testAccAwsInstanceVpcConfig(rName) + fmt.Sprintf(`
+	return testAccAwsInstanceVpcConfig(rName, false) + fmt.Sprintf(`
 resource "aws_instance" "test" {
   // This is an AMI with RootDeviceName: "/dev/sda1"; actual root: "/dev/sda"
   ami           = "ami-ef5b69df"
@@ -3652,7 +3478,7 @@ resource "aws_instance" "test" {
 }
 
 func testAccInstanceConfigForceNewAndTagsDrift(rName string) string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName) + fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   instance_type = "t2.nano"
@@ -3662,7 +3488,7 @@ resource "aws_instance" "test" {
 }
 
 func testAccInstanceConfigForceNewAndTagsDrift_Update(rName string) string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName) + fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   instance_type = "t2.micro"
@@ -3671,560 +3497,345 @@ resource "aws_instance" "test" {
 `)
 }
 
-const testAccInstanceConfigPrimaryNetworkInterface = `
-resource "aws_vpc" "test" {
-  cidr_block = "172.16.0.0/16"
-  tags = {
-    Name = "terraform-testacc-instance-primary-network-iface"
-  }
-}
-
-resource "aws_subnet" "test" {
-  vpc_id = "${aws_vpc.test.id}"
-  cidr_block = "172.16.10.0/24"
-  availability_zone = "us-west-2a"
-  tags = {
-    Name = "tf-acc-instance-primary-network-iface"
-  }
-}
-
+func testAccInstanceConfigPrimaryNetworkInterface(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + fmt.Sprintf(`
 resource "aws_network_interface" "test" {
-  subnet_id = "${aws_subnet.test.id}"
-  private_ips = ["172.16.10.100"]
-  tags = {
-    Name = "primary_network_interface"
-  }
-}
-
-resource "aws_instance" "test" {
-	ami = "ami-22b9a343"
-	instance_type = "t2.micro"
-	network_interface {
-	 network_interface_id = "${aws_network_interface.test.id}"
-	 device_index = 0
-  }
-}
-`
-
-const testAccInstanceConfigPrimaryNetworkInterfaceSourceDestCheck = `
-resource "aws_vpc" "test" {
-  cidr_block = "172.16.0.0/16"
-  tags = {
-    Name = "terraform-testacc-instance-primary-network-iface-source-dest-check"
-  }
-}
-
-resource "aws_subnet" "test" {
-  vpc_id = "${aws_vpc.test.id}"
-  cidr_block = "172.16.10.0/24"
-  availability_zone = "us-west-2a"
-  tags = {
-    Name = "tf-acc-instance-primary-network-iface-source-dest-check"
-  }
-}
-
-resource "aws_network_interface" "test" {
-  subnet_id = "${aws_subnet.test.id}"
-  private_ips = ["172.16.10.100"]
-  source_dest_check = false
-  tags = {
-    Name = "primary_network_interface"
-  }
-}
-
-resource "aws_instance" "test" {
-	ami = "ami-22b9a343"
-	instance_type = "t2.micro"
-	network_interface {
-	 network_interface_id = "${aws_network_interface.test.id}"
-	 device_index = 0
-  }
-}
-`
-
-const testAccInstanceConfigAddSecondaryNetworkInterfaceBefore = `
-resource "aws_vpc" "test" {
-  cidr_block = "172.16.0.0/16"
-  tags = {
-    Name = "terraform-testacc-instance-add-secondary-network-iface"
-  }
-}
-
-resource "aws_subnet" "test" {
-  vpc_id = "${aws_vpc.test.id}"
-  cidr_block = "172.16.10.0/24"
-  availability_zone = "us-west-2a"
-  tags = {
-    Name = "tf-acc-instance-add-secondary-network-iface"
-  }
-}
-
-resource "aws_network_interface" "primary" {
-  subnet_id = "${aws_subnet.test.id}"
-  private_ips = ["172.16.10.100"]
-  tags = {
-    Name = "primary_network_interface"
-  }
-}
-
-resource "aws_network_interface" "secondary" {
-  subnet_id = "${aws_subnet.test.id}"
-  private_ips = ["172.16.10.101"]
-  tags = {
-    Name = "secondary_network_interface"
-  }
-}
-
-resource "aws_instance" "test" {
-	ami = "ami-22b9a343"
-	instance_type = "t2.micro"
-	network_interface {
-	 network_interface_id = "${aws_network_interface.primary.id}"
-	 device_index = 0
-  }
-}
-`
-
-const testAccInstanceConfigAddSecondaryNetworkInterfaceAfter = `
-resource "aws_vpc" "test" {
-  cidr_block = "172.16.0.0/16"
-  tags = {
-    Name = "terraform-testacc-instance-add-secondary-network-iface"
-  }
-}
-
-resource "aws_subnet" "test" {
-  vpc_id = "${aws_vpc.test.id}"
-  cidr_block = "172.16.10.0/24"
-  availability_zone = "us-west-2a"
-  tags = {
-    Name = "tf-acc-instance-add-secondary-network-iface"
-  }
-}
-
-resource "aws_network_interface" "primary" {
-  subnet_id = "${aws_subnet.test.id}"
-  private_ips = ["172.16.10.100"]
-  tags = {
-    Name = "primary_network_interface"
-  }
-}
-
-// Attach previously created network interface, observe no state diff on instance resource
-resource "aws_network_interface" "secondary" {
-  subnet_id = "${aws_subnet.test.id}"
-  private_ips = ["172.16.10.101"]
-  tags = {
-    Name = "secondary_network_interface"
-  }
-  attachment {
-    instance = "${aws_instance.test.id}"
-    device_index = 1
-  }
-}
-
-resource "aws_instance" "test" {
-	ami = "ami-22b9a343"
-	instance_type = "t2.micro"
-	network_interface {
-	 network_interface_id = "${aws_network_interface.primary.id}"
-	 device_index = 0
-  }
-}
-`
-
-const testAccInstanceConfigAddSecurityGroupBefore = `
-resource "aws_vpc" "test" {
-    cidr_block = "172.16.0.0/16"
-  tags = {
-        Name = "terraform-testacc-instance-add-security-group"
-    }
-}
-
-resource "aws_subnet" "test" {
-    vpc_id = "${aws_vpc.test.id}"
-    cidr_block = "172.16.10.0/24"
-    availability_zone = "us-west-2a"
-  tags = {
-        Name = "tf-acc-instance-add-security-group-test"
-    }
-}
-
-resource "aws_subnet" "test2" {
-    vpc_id = "${aws_vpc.test.id}"
-    cidr_block = "172.16.11.0/24"
-    availability_zone = "us-west-2a"
-  tags = {
-        Name = "tf-acc-instance-add-security-group-test2"
-    }
-}
-
-resource "aws_security_group" "test" {
-  vpc_id = "${aws_vpc.test.id}"
-  description = "test"
-  name = "test"
-}
-
-resource "aws_security_group" "test2" {
-  vpc_id = "${aws_vpc.test.id}"
-  description = "test2"
-  name = "test2"
-}
-
-resource "aws_instance" "test" {
-    ami = "ami-c5eabbf5"
-    instance_type = "t2.micro"
-    subnet_id = "${aws_subnet.test.id}"
-    associate_public_ip_address = false
-    vpc_security_group_ids = [
-      "${aws_security_group.test.id}"
-    ]
-  tags = {
-        Name = "test-instance-sg-add-test"
-    }
-}
-
-resource "aws_network_interface" "test" {
-    subnet_id = "${aws_subnet.test.id}"
-    private_ips = ["172.16.10.100"]
-    security_groups = ["${aws_security_group.test.id}"]
-    attachment {
-        instance = "${aws_instance.test.id}"
-        device_index = 1
-    }
-  tags = {
-        Name = "test_interface"
-    }
-}
-`
-
-const testAccInstanceConfigAddSecurityGroupAfter = `
-resource "aws_vpc" "test" {
-    cidr_block = "172.16.0.0/16"
-  tags = {
-        Name = "terraform-testacc-instance-add-security-group"
-    }
-}
-
-resource "aws_subnet" "test" {
-    vpc_id = "${aws_vpc.test.id}"
-    cidr_block = "172.16.10.0/24"
-    availability_zone = "us-west-2a"
-  tags = {
-        Name = "tf-acc-instance-add-security-group-test"
-    }
-}
-
-resource "aws_subnet" "test2" {
-    vpc_id = "${aws_vpc.test.id}"
-    cidr_block = "172.16.11.0/24"
-    availability_zone = "us-west-2a"
-  tags = {
-        Name = "tf-acc-instance-add-security-group-test"
-    }
-}
-
-resource "aws_security_group" "test" {
-  vpc_id = "${aws_vpc.test.id}"
-  description = "test"
-  name = "test"
-}
-
-resource "aws_security_group" "test2" {
-  vpc_id = "${aws_vpc.test.id}"
-  description = "test2"
-  name = "test2"
-}
-
-resource "aws_instance" "test" {
-    ami = "ami-c5eabbf5"
-    instance_type = "t2.micro"
-    subnet_id = "${aws_subnet.test.id}"
-    associate_public_ip_address = false
-    vpc_security_group_ids = [
-      "${aws_security_group.test.id}",
-      "${aws_security_group.test2.id}"
-    ]
-  tags = {
-        Name = "test-instance-sg-add-test"
-    }
-}
-
-resource "aws_network_interface" "test" {
-    subnet_id = "${aws_subnet.test.id}"
-    private_ips = ["172.16.10.100"]
-    security_groups = ["${aws_security_group.test.id}"]
-    attachment {
-        instance = "${aws_instance.test.id}"
-        device_index = 1
-    }
-  tags = {
-        Name = "test_interface"
-    }
-}
-`
-
-func testAccInstanceConfig_associatePublic_defaultPrivate(rInt int) string {
-	return fmt.Sprintf(`
-resource "aws_vpc" "my_vpc" {
-  cidr_block = "172.16.0.0/16"
-
-  tags = {
-    Name = "terraform-testacc-instance-associate-public-default-private"
-  }
-}
-
-resource "aws_subnet" "public_subnet" {
-  vpc_id                  = "${aws_vpc.my_vpc.id}"
-  cidr_block              = "172.16.20.0/24"
-  availability_zone       = "us-west-2a"
-  map_public_ip_on_launch = false
-
-  tags = {
-    Name = "tf-acc-instance-associate-public-default-private"
-  }
-}
-
-resource "aws_instance" "test" {
-  ami           = "ami-22b9a343"                   # us-west-2
-  instance_type = "t2.micro"
-  subnet_id     = "${aws_subnet.public_subnet.id}"
-
-  tags = {
-    Name = "tf-acctest-%d"
-  }
-}
-`, rInt)
-}
-
-func testAccInstanceConfig_associatePublic_defaultPublic(rInt int) string {
-	return fmt.Sprintf(`
-resource "aws_vpc" "my_vpc" {
-  cidr_block = "172.16.0.0/16"
-
-  tags = {
-    Name = "terraform-testacc-instance-associate-public-default-public"
-  }
-}
-
-resource "aws_subnet" "public_subnet" {
-  vpc_id                  = "${aws_vpc.my_vpc.id}"
-  cidr_block              = "172.16.20.0/24"
-  availability_zone       = "us-west-2a"
-  map_public_ip_on_launch = true
-
-  tags = {
-    Name = "tf-acc-instance-associate-public-default-public"
-  }
-}
-
-resource "aws_instance" "test" {
-  ami           = "ami-22b9a343"                   # us-west-2
-  instance_type = "t2.micro"
-  subnet_id     = "${aws_subnet.public_subnet.id}"
-
-  tags = {
-    Name = "tf-acctest-%d"
-  }
-}
-`, rInt)
-}
-
-func testAccInstanceConfig_associatePublic_explicitPublic(rInt int) string {
-	return fmt.Sprintf(`
-resource "aws_vpc" "my_vpc" {
-  cidr_block = "172.16.0.0/16"
-
-  tags = {
-    Name = "terraform-testacc-instance-associate-public-explicit-public"
-  }
-}
-
-resource "aws_subnet" "public_subnet" {
-  vpc_id                  = "${aws_vpc.my_vpc.id}"
-  cidr_block              = "172.16.20.0/24"
-  availability_zone       = "us-west-2a"
-  map_public_ip_on_launch = true
-
-  tags = {
-    Name = "tf-acc-instance-associate-public-explicit-public"
-  }
-}
-
-resource "aws_instance" "test" {
-  ami                         = "ami-22b9a343"                   # us-west-2
-  instance_type               = "t2.micro"
-  subnet_id                   = "${aws_subnet.public_subnet.id}"
-  associate_public_ip_address = true
-
-  tags = {
-    Name = "tf-acctest-%d"
-  }
-}
-`, rInt)
-}
-
-func testAccInstanceConfig_associatePublic_explicitPrivate(rInt int) string {
-	return fmt.Sprintf(`
-resource "aws_vpc" "my_vpc" {
-  cidr_block = "172.16.0.0/16"
-
-  tags = {
-    Name = "terraform-testacc-instance-associate-public-explicit-private"
-  }
-}
-
-resource "aws_subnet" "public_subnet" {
-  vpc_id                  = "${aws_vpc.my_vpc.id}"
-  cidr_block              = "172.16.20.0/24"
-  availability_zone       = "us-west-2a"
-  map_public_ip_on_launch = false
-
-  tags = {
-    Name = "tf-acc-instance-associate-public-explicit-private"
-  }
-}
-
-resource "aws_instance" "test" {
-  ami                         = "ami-22b9a343"                   # us-west-2
-  instance_type               = "t2.micro"
-  subnet_id                   = "${aws_subnet.public_subnet.id}"
-  associate_public_ip_address = false
-
-  tags = {
-    Name = "tf-acctest-%d"
-  }
-}
-`, rInt)
-}
-
-func testAccInstanceConfig_associatePublic_overridePublic(rInt int) string {
-	return fmt.Sprintf(`
-resource "aws_vpc" "my_vpc" {
-  cidr_block = "172.16.0.0/16"
-
-  tags = {
-    Name = "terraform-testacc-instance-associate-public-override-public"
-  }
-}
-
-resource "aws_subnet" "public_subnet" {
-  vpc_id                  = "${aws_vpc.my_vpc.id}"
-  cidr_block              = "172.16.20.0/24"
-  availability_zone       = "us-west-2a"
-  map_public_ip_on_launch = false
-
-  tags = {
-    Name = "tf-acc-instance-associate-public-override-public"
-  }
-}
-
-resource "aws_instance" "test" {
-  ami                         = "ami-22b9a343"                   # us-west-2
-  instance_type               = "t2.micro"
-  subnet_id                   = "${aws_subnet.public_subnet.id}"
-  associate_public_ip_address = true
-
-  tags = {
-    Name = "tf-acctest-%d"
-  }
-}
-`, rInt)
-}
-
-func testAccInstanceConfig_associatePublic_overridePrivate(rInt int) string {
-	return fmt.Sprintf(`
-resource "aws_vpc" "my_vpc" {
-  cidr_block = "172.16.0.0/16"
-
-  tags = {
-    Name = "terraform-testacc-instance-associate-public-override-private"
-  }
-}
-
-resource "aws_subnet" "public_subnet" {
-  vpc_id                  = "${aws_vpc.my_vpc.id}"
-  cidr_block              = "172.16.20.0/24"
-  availability_zone       = "us-west-2a"
-  map_public_ip_on_launch = true
-
-  tags = {
-    Name = "tf-acc-instance-associate-public-override-private"
-  }
-}
-
-resource "aws_instance" "test" {
-  ami                         = "ami-22b9a343"                   # us-west-2
-  instance_type               = "t2.micro"
-  subnet_id                   = "${aws_subnet.public_subnet.id}"
-  associate_public_ip_address = false
-
-  tags = {
-    Name = "tf-acctest-%d"
-  }
-}
-`, rInt)
-}
-
-func testAccInstanceConfig_getPasswordData(val bool, rInt int) string {
-	return fmt.Sprintf(`
-# Find latest Microsoft Windows Server 2016 Core image (Amazon deletes old ones)
-data "aws_ami" "win2016core" {
-  most_recent = true
-  owners      = ["amazon"]
-
-  filter {
-    name   = "name"
-    values = ["Windows_Server-2016-English-Core-Base-*"]
-  }
-}
-
-resource "aws_key_pair" "test" {
-  key_name   = "tf-acctest-%d"
-  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEAq6U3HQYC4g8WzU147gZZ7CKQH8TgYn3chZGRPxaGmHW1RUwsyEs0nmombmIhwxudhJ4ehjqXsDLoQpd6+c7BuLgTMvbv8LgE9LX53vnljFe1dsObsr/fYLvpU9LTlo8HgHAqO5ibNdrAUvV31ronzCZhms/Gyfdaue88Fd0/YnsZVGeOZPayRkdOHSpqme2CBrpa8myBeL1CWl0LkDG4+YCURjbaelfyZlIApLYKy3FcCan9XQFKaL32MJZwCgzfOvWIMtYcU8QtXMgnA3/I3gXk8YDUJv5P4lj0s/PJXuTM8DygVAUtebNwPuinS7wwonm5FXcWMuVGsVpG5K7FGQ== tf-acc-winpasswordtest"
-}
-
-resource "aws_instance" "test" {
-  ami           = "${data.aws_ami.win2016core.id}"
-  instance_type = "t2.medium"
-  key_name      = "${aws_key_pair.test.key_name}"
-
-  get_password_data = %t
-}
-`, rInt, val)
-}
-
-func testAccInstanceConfig_CreditSpecification_Empty_NonBurstable(rName string) string {
-	return fmt.Sprintf(`
-data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
-  most_recent = true
-  owners      = ["amazon"]
-
-  filter {
-    name   = "name"
-    values = ["amzn-ami-minimal-hvm-*"]
-  }
-
-  filter {
-    name   = "root-device-type"
-    values = ["ebs"]
-  }
-}
-
-
-resource "aws_vpc" "test" {
-  cidr_block = "172.16.0.0/16"
+  subnet_id   = "${aws_subnet.test.id}"
+  private_ips = ["10.1.1.42"]
 
   tags = {
     Name = %[1]q
   }
 }
 
-resource "aws_subnet" "test" {
-  cidr_block = "172.16.0.0/24"
-  vpc_id     = "${aws_vpc.test.id}"
+resource "aws_instance" "test" {
+  ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type = "t2.micro"
+
+  network_interface {
+    network_interface_id = "${aws_network_interface.test.id}"
+    device_index         = 0
+  }
+}
+`, rName)
 }
 
+func testAccInstanceConfigPrimaryNetworkInterfaceSourceDestCheck(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + fmt.Sprintf(`
+resource "aws_network_interface" "test" {
+  subnet_id         = "${aws_subnet.test.id}"
+  private_ips       = ["10.1.1.42"]
+  source_dest_check = false
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_instance" "test" {
+  ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type = "t2.micro"
+
+  network_interface {
+    network_interface_id = "${aws_network_interface.test.id}"
+    device_index         = 0
+  }
+}
+`, rName)
+}
+
+func testAccInstanceConfigAddSecondaryNetworkInterfaceBefore(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + fmt.Sprintf(`
+resource "aws_network_interface" "primary" {
+  subnet_id   = "${aws_subnet.test.id}"
+  private_ips = ["10.1.1.42"]
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_network_interface" "secondary" {
+  subnet_id   = "${aws_subnet.test.id}"
+  private_ips = ["10.1.1.43"]
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_instance" "test" {
+  ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type = "t2.micro"
+
+  network_interface {
+    network_interface_id = "${aws_network_interface.primary.id}"
+    device_index         = 0
+  }
+}
+`, rName)
+}
+
+func testAccInstanceConfigAddSecondaryNetworkInterfaceAfter(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + fmt.Sprintf(`
+resource "aws_network_interface" "primary" {
+  subnet_id   = "${aws_subnet.test.id}"
+  private_ips = ["10.1.1.42"]
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+// Attach previously created network interface, observe no state diff on instance resource
+resource "aws_network_interface" "secondary" {
+  subnet_id   = "${aws_subnet.test.id}"
+  private_ips = ["10.1.1.43"]
+
+  tags = {
+    Name = %[1]q
+  }
+
+  attachment {
+    instance     = "${aws_instance.test.id}"
+    device_index = 1
+  }
+}
+
+resource "aws_instance" "test" {
+  ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type = "t2.micro"
+
+  network_interface {
+    network_interface_id = "${aws_network_interface.primary.id}"
+    device_index         = 0
+  }
+}
+`, rName)
+}
+
+func testAccInstanceConfigAddSecurityGroupBefore(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + fmt.Sprintf(`
+resource "aws_subnet" "test2" {
+  cidr_block        = "10.1.2.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.current.names[0]}"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_security_group" "test" {
+  vpc_id      = "${aws_vpc.test.id}"
+  description = "%[1]s_1"
+  name        = "%[1]s_1"
+}
+
+resource "aws_security_group" "test2" {
+  vpc_id      = "${aws_vpc.test.id}"
+  description = "%[1]s_2"
+  name        = "%[1]s_2"
+}
+
+resource "aws_instance" "test" {
+  ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type = "t2.micro"
+  subnet_id     = "${aws_subnet.test.id}"
+
+  associate_public_ip_address = false
+
+  vpc_security_group_ids = [
+    "${aws_security_group.test.id}",
+  ]
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_network_interface" "test" {
+  subnet_id       = "${aws_subnet.test.id}"
+  private_ips     = ["10.1.1.42"]
+  security_groups = ["${aws_security_group.test.id}"]
+
+  attachment {
+    instance     = "${aws_instance.test.id}"
+    device_index = 1
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName)
+}
+
+func testAccInstanceConfigAddSecurityGroupAfter(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + fmt.Sprintf(`
+resource "aws_subnet" "test2" {
+  cidr_block        = "10.1.2.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.current.names[0]}"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_security_group" "test" {
+  vpc_id      = "${aws_vpc.test.id}"
+  description = "%[1]s_1"
+  name        = "%[1]s_1"
+}
+
+resource "aws_security_group" "test2" {
+  vpc_id      = "${aws_vpc.test.id}"
+  description = "%[1]s_2"
+  name        = "%[1]s_2"
+}
+
+resource "aws_instance" "test" {
+  ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type = "t2.micro"
+  subnet_id     = "${aws_subnet.test.id}"
+
+  associate_public_ip_address = false
+
+  vpc_security_group_ids = [
+    "${aws_security_group.test.id}",
+    "${aws_security_group.test2.id}",
+  ]
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_network_interface" "test" {
+  subnet_id       = "${aws_subnet.test.id}"
+  private_ips     = ["10.1.1.42"]
+  security_groups = ["${aws_security_group.test.id}"]
+
+  attachment {
+    instance     = "${aws_instance.test.id}"
+    device_index = 1
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName)
+}
+
+func testAccInstanceConfig_associatePublic_defaultPrivate(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + fmt.Sprintf(`
+resource "aws_instance" "test" {
+  ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type = "t2.micro"
+  subnet_id     = "${aws_subnet.test.id}"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName)
+}
+
+func testAccInstanceConfig_associatePublic_defaultPublic(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, true) + fmt.Sprintf(`
+resource "aws_instance" "test" {
+  ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type = "t2.micro"
+  subnet_id     = "${aws_subnet.test.id}"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName)
+}
+
+func testAccInstanceConfig_associatePublic_explicitPublic(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, true) + fmt.Sprintf(`
+resource "aws_instance" "test" {
+  ami                         = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type               = "t2.micro"
+  subnet_id                   = "${aws_subnet.test.id}"
+  associate_public_ip_address = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName)
+}
+
+func testAccInstanceConfig_associatePublic_explicitPrivate(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, true) + fmt.Sprintf(`
+resource "aws_instance" "test" {
+  ami                         = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type               = "t2.micro"
+  subnet_id                   = "${aws_subnet.test.id}"
+  associate_public_ip_address = false
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName)
+}
+
+func testAccInstanceConfig_associatePublic_overridePublic(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + fmt.Sprintf(`
+resource "aws_instance" "test" {
+  ami                         = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type               = "t2.micro"
+  subnet_id                   = "${aws_subnet.test.id}"
+  associate_public_ip_address = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName)
+}
+
+func testAccInstanceConfig_associatePublic_overridePrivate(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, true) + fmt.Sprintf(`
+resource "aws_instance" "test" {
+  ami                         = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type               = "t2.micro"
+  subnet_id                   = "${aws_subnet.test.id}"
+  associate_public_ip_address = false
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName)
+}
+
+func testAccInstanceConfig_getPasswordData(rName string, val bool) string {
+	return testAccLatestWindowsServer2016CoreAmiConfig() + fmt.Sprintf(`
+resource "aws_key_pair" "test" {
+  key_name   = %[1]q
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEAq6U3HQYC4g8WzU147gZZ7CKQH8TgYn3chZGRPxaGmHW1RUwsyEs0nmombmIhwxudhJ4ehjqXsDLoQpd6+c7BuLgTMvbv8LgE9LX53vnljFe1dsObsr/fYLvpU9LTlo8HgHAqO5ibNdrAUvV31ronzCZhms/Gyfdaue88Fd0/YnsZVGeOZPayRkdOHSpqme2CBrpa8myBeL1CWl0LkDG4+YCURjbaelfyZlIApLYKy3FcCan9XQFKaL32MJZwCgzfOvWIMtYcU8QtXMgnA3/I3gXk8YDUJv5P4lj0s/PJXuTM8DygVAUtebNwPuinS7wwonm5FXcWMuVGsVpG5K7FGQ== tf-acc-winpasswordtest"
+}
+
+resource "aws_instance" "test" {
+  ami           = "${data.aws_ami.win2016core-ami.id}"
+  instance_type = "t2.medium"
+  key_name      = "${aws_key_pair.test.key_name}"
+
+  get_password_data = %[2]t
+}
+`, rName, val)
+}
+
+func testAccInstanceConfig_CreditSpecification_Empty_NonBurstable(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   instance_type = "m5.large"
@@ -4232,318 +3843,141 @@ resource "aws_instance" "test" {
 
   credit_specification {}
 }
-`, rName)
+`)
 }
 
 func testAccInstanceConfig_CreditSpecification_Unspecified_NonBurstable(rName string) string {
-	return fmt.Sprintf(`
-data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
-  most_recent = true
-  owners      = ["amazon"]
-
-  filter {
-    name   = "name"
-    values = ["amzn-ami-minimal-hvm-*"]
-  }
-
-  filter {
-    name   = "root-device-type"
-    values = ["ebs"]
-  }
-}
-
-resource "aws_vpc" "test" {
-  cidr_block = "172.16.0.0/16"
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_subnet" "test" {
-  cidr_block = "172.16.0.0/24"
-  vpc_id     = "${aws_vpc.test.id}"
-}
-
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   instance_type = "m5.large"
   subnet_id     = "${aws_subnet.test.id}"
 }
-`, rName)
+`)
 }
 
-func testAccInstanceConfig_creditSpecification_unspecified(rInt int) string {
-	return fmt.Sprintf(`
-resource "aws_vpc" "my_vpc" {
-  cidr_block = "172.16.0.0/16"
-
-  tags = {
-    Name = "tf-acctest-%d"
-  }
-}
-
-resource "aws_subnet" "my_subnet" {
-  vpc_id            = "${aws_vpc.my_vpc.id}"
-  cidr_block        = "172.16.20.0/24"
-  availability_zone = "us-west-2a"
-}
-
-resource "aws_instance" "test" {
-  ami           = "ami-22b9a343"               # us-west-2
-  instance_type = "t2.micro"
-  subnet_id     = "${aws_subnet.my_subnet.id}"
-}
-`, rInt)
-}
-
-func testAccInstanceConfig_creditSpecification_unspecified_t3(rInt int) string {
-	return fmt.Sprintf(`
-resource "aws_vpc" "my_vpc" {
-  cidr_block = "172.16.0.0/16"
-
-  tags = {
-    Name = "tf-acctest-%d"
-  }
-}
-
-resource "aws_subnet" "my_subnet" {
-  vpc_id            = "${aws_vpc.my_vpc.id}"
-  cidr_block        = "172.16.20.0/24"
-  availability_zone = "us-west-2a"
-}
-
-resource "aws_instance" "test" {
-  ami           = "ami-51537029"               # us-west-2
-  instance_type = "t3.micro"
-  subnet_id     = "${aws_subnet.my_subnet.id}"
-
-}
-`, rInt)
-}
-
-func testAccInstanceConfig_creditSpecification_standardCpuCredits(rInt int) string {
-	return fmt.Sprintf(`
-resource "aws_vpc" "my_vpc" {
-  cidr_block = "172.16.0.0/16"
-
-  tags = {
-    Name = "tf-acctest-%d"
-  }
-}
-
-resource "aws_subnet" "my_subnet" {
-  vpc_id            = "${aws_vpc.my_vpc.id}"
-  cidr_block        = "172.16.20.0/24"
-  availability_zone = "us-west-2a"
-}
-
-resource "aws_instance" "test" {
-  ami           = "ami-22b9a343"               # us-west-2
-  instance_type = "t2.micro"
-  subnet_id     = "${aws_subnet.my_subnet.id}"
-
-  credit_specification {
-    cpu_credits = "standard"
-  }
-}
-`, rInt)
-}
-
-func testAccInstanceConfig_creditSpecification_standardCpuCredits_t3(rInt int) string {
-	return fmt.Sprintf(`
-resource "aws_vpc" "my_vpc" {
-  cidr_block = "172.16.0.0/16"
-
-  tags = {
-    Name = "tf-acctest-%d"
-  }
-}
-
-resource "aws_subnet" "my_subnet" {
-  vpc_id            = "${aws_vpc.my_vpc.id}"
-  cidr_block        = "172.16.20.0/24"
-  availability_zone = "us-west-2a"
-}
-
-resource "aws_instance" "test" {
-  ami           = "ami-51537029"               # us-west-2
-  instance_type = "t3.micro"
-  subnet_id     = "${aws_subnet.my_subnet.id}"
-
-  credit_specification {
-    cpu_credits = "standard"
-  }
-}
-`, rInt)
-}
-
-func testAccInstanceConfig_creditSpecification_unlimitedCpuCredits(rInt int) string {
-	return fmt.Sprintf(`
-resource "aws_vpc" "my_vpc" {
-  cidr_block = "172.16.0.0/16"
-
-  tags = {
-    Name = "tf-acctest-%d"
-  }
-}
-
-resource "aws_subnet" "my_subnet" {
-  vpc_id            = "${aws_vpc.my_vpc.id}"
-  cidr_block        = "172.16.20.0/24"
-  availability_zone = "us-west-2a"
-}
-
-resource "aws_instance" "test" {
-  ami           = "ami-22b9a343"               # us-west-2
-  instance_type = "t2.micro"
-  subnet_id     = "${aws_subnet.my_subnet.id}"
-
-  credit_specification {
-    cpu_credits = "unlimited"
-  }
-}
-`, rInt)
-}
-
-func testAccInstanceConfig_creditSpecification_unlimitedCpuCredits_t3(rInt int) string {
-	return fmt.Sprintf(`
-resource "aws_vpc" "my_vpc" {
-  cidr_block = "172.16.0.0/16"
-
-  tags = {
-    Name = "tf-acctest-%d"
-  }
-}
-
-resource "aws_subnet" "my_subnet" {
-  vpc_id            = "${aws_vpc.my_vpc.id}"
-  cidr_block        = "172.16.20.0/24"
-  availability_zone = "us-west-2a"
-}
-
-resource "aws_instance" "test" {
-  ami           = "ami-51537029"               # us-west-2
-  instance_type = "t3.micro"
-  subnet_id     = "${aws_subnet.my_subnet.id}"
-
-  credit_specification {
-    cpu_credits = "unlimited"
-  }
-}
-`, rInt)
-}
-
-func testAccInstanceConfig_creditSpecification_isNotAppliedToNonBurstable(rInt int) string {
-	return fmt.Sprintf(`
-resource "aws_vpc" "my_vpc" {
-  cidr_block = "172.16.0.0/16"
-
-  tags = {
-    Name = "tf-acctest-%d"
-  }
-}
-
-resource "aws_subnet" "my_subnet" {
-  vpc_id            = "${aws_vpc.my_vpc.id}"
-  cidr_block        = "172.16.20.0/24"
-  availability_zone = "us-west-2a"
-}
-
-resource "aws_instance" "test" {
-  ami           = "ami-22b9a343"               # us-west-2
-  instance_type = "m1.small"
-  subnet_id     = "${aws_subnet.my_subnet.id}"
-
-  credit_specification {
-    cpu_credits = "standard"
-  }
-}
-`, rInt)
-}
-
-func testAccInstanceConfig_creditSpecification_unknownCpuCredits(rInt int, instanceType string) string {
-	return fmt.Sprintf(`
-resource "aws_vpc" "my_vpc" {
-  cidr_block = "172.16.0.0/16"
-
-  tags = {
-    Name = "tf-acctest-%d"
-  }
-}
-
-resource "aws_subnet" "my_subnet" {
-  vpc_id            = "${aws_vpc.my_vpc.id}"
-  cidr_block        = "172.16.20.0/24"
-  availability_zone = "us-west-2a"
-}
-
-resource "aws_instance" "test" {
-  ami           = "ami-51537029"               # us-west-2
-  instance_type = %q
-  subnet_id     = "${aws_subnet.my_subnet.id}"
-
-  credit_specification {
-  }
-}
-`, rInt, instanceType)
-}
-
-func testAccInstanceConfig_UserData_Base(rInt int) string {
-	return fmt.Sprintf(`
-data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
-  most_recent = true
-  owners      = ["amazon"]
-
-  filter {
-    name   = "name"
-    values = ["amzn-ami-minimal-hvm-*"]
-  }
-
-  filter {
-    name   = "root-device-type"
-    values = ["ebs"]
-  }
-}
-
-resource "aws_vpc" "test" {
-  cidr_block = "172.16.0.0/16"
-
-  tags = {
-    Name = "tf-acctest-%d"
-  }
-}
-
-resource "aws_subnet" "test" {
-  vpc_id     = "${aws_vpc.test.id}"
-  cidr_block = "172.16.0.0/24"
-
-  tags = {
-    Name = "tf-acctest-%d"
-  }
-}
-`, rInt, rInt)
-}
-
-func testAccInstanceConfig_UserData_Unspecified(rInt int) string {
-	return testAccInstanceConfig_UserData_Base(rInt) + `
+func testAccInstanceConfig_creditSpecification_unspecified(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   instance_type = "t2.micro"
   subnet_id     = "${aws_subnet.test.id}"
 }
-`
+`)
 }
 
-func testAccInstanceConfig_UserData_EmptyString(rInt int) string {
-	return testAccInstanceConfig_UserData_Base(rInt) + `
+func testAccInstanceConfig_creditSpecification_unspecified_t3(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + fmt.Sprintf(`
+resource "aws_instance" "test" {
+  ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type = "t3.micro"
+  subnet_id     = "${aws_subnet.test.id}"
+
+}
+`)
+}
+
+func testAccInstanceConfig_creditSpecification_standardCpuCredits(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + fmt.Sprintf(`
+resource "aws_instance" "test" {
+  ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type = "t2.micro"
+  subnet_id     = "${aws_subnet.test.id}"
+
+  credit_specification {
+    cpu_credits = "standard"
+  }
+}
+`)
+}
+
+func testAccInstanceConfig_creditSpecification_standardCpuCredits_t3(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + fmt.Sprintf(`
+resource "aws_instance" "test" {
+  ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type = "t3.micro"
+  subnet_id     = "${aws_subnet.test.id}"
+
+  credit_specification {
+    cpu_credits = "standard"
+  }
+}
+`)
+}
+
+func testAccInstanceConfig_creditSpecification_unlimitedCpuCredits(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + fmt.Sprintf(`
+resource "aws_instance" "test" {
+  ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type = "t2.micro"
+  subnet_id     = "${aws_subnet.test.id}"
+
+  credit_specification {
+    cpu_credits = "unlimited"
+  }
+}
+`)
+}
+
+func testAccInstanceConfig_creditSpecification_unlimitedCpuCredits_t3(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + fmt.Sprintf(`
+resource "aws_instance" "test" {
+  ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type = "t3.micro"
+  subnet_id     = "${aws_subnet.test.id}"
+
+  credit_specification {
+    cpu_credits = "unlimited"
+  }
+}
+`)
+}
+
+func testAccInstanceConfig_creditSpecification_isNotAppliedToNonBurstable(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + fmt.Sprintf(`
+resource "aws_instance" "test" {
+  ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type = "m1.small"
+  subnet_id     = "${aws_subnet.test.id}"
+
+  credit_specification {
+    cpu_credits = "standard"
+  }
+}
+`)
+}
+
+func testAccInstanceConfig_creditSpecification_unknownCpuCredits(rName, instanceType string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + fmt.Sprintf(`
+resource "aws_instance" "test" {
+  ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type = %[1]q
+  subnet_id     = "${aws_subnet.test.id}"
+
+  credit_specification {}
+}
+`, instanceType)
+}
+
+func testAccInstanceConfig_UserData_Unspecified(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + fmt.Sprintf(`
+resource "aws_instance" "test" {
+  ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type = "t2.micro"
+  subnet_id     = "${aws_subnet.test.id}"
+}
+`)
+}
+
+func testAccInstanceConfig_UserData_EmptyString(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   instance_type = "t2.micro"
   subnet_id     = "${aws_subnet.test.id}"
   user_data     = ""
 }
-`
+`)
 }
 
 // testAccLatestAmazonLinuxHvmEbsAmiConfig returns the configuration for a data source that
@@ -4556,12 +3990,12 @@ data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
   owners      = ["amazon"]
 
   filter {
-    name = "name"
+    name   = "name"
     values = ["amzn-ami-minimal-hvm-*"]
   }
 
   filter {
-    name = "root-device-type"
+    name   = "root-device-type"
     values = ["ebs"]
   }
 }
@@ -4579,12 +4013,12 @@ data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
   owners      = ["amazon"]
 
   filter {
-    name = "name"
+    name   = "name"
     values = ["amzn-ami-minimal-pv-*"]
   }
 
   filter {
-    name = "root-device-type"
+    name   = "root-device-type"
     values = ["ebs"]
   }
 }
@@ -4592,9 +4026,28 @@ data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
 }
 */
 
-// testAccAwsInstanceVpcConfig returns the configuration for resources that create a VPC and subnet in that the VPC.
+// testAccLatestWindowsServer2016CoreAmiConfig returns the configuration for a data source that
+// describes the latest Microsoft Windows Server 2016 Core AMI.
+// The data source is named 'win2016core-ami'.
+func testAccLatestWindowsServer2016CoreAmiConfig() string {
+	return fmt.Sprintf(`
+data "aws_ami" "win2016core-ami" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["Windows_Server-2016-English-Core-Base-*"]
+  }
+}
+`)
+}
+
+// testAccAwsInstanceVpcConfig returns the configuration for tests that create
+//   1) a VPC with IPv6 support
+//   2) a subnet in the VPC
 // The resources are named 'test'.
-func testAccAwsInstanceVpcConfig(rName string) string {
+func testAccAwsInstanceVpcConfig(rName string, mapPublicIpOnLaunch bool) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "current" {
   # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
@@ -4610,9 +4063,77 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
+  cidr_block              = "10.1.1.0/24"
+  vpc_id                  = "${aws_vpc.test.id}"
+  availability_zone       = "${data.aws_availability_zones.current.names[0]}"
+  map_public_ip_on_launch = %[2]t
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName, mapPublicIpOnLaunch)
+}
+
+// testAccAwsInstanceVpcSecurityGroupConfig returns the configuration for tests that create
+//   1) a VPC security group
+//   2) an internet gateway in the VPC
+// The resources are named 'test'.
+func testAccAwsInstanceVpcSecurityGroupConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_internet_gateway" "test" {
+  vpc_id = "${aws_vpc.test.id}"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_security_group" "test" {
+  name        = %[1]q
+  description = "test"
+  vpc_id      = "${aws_vpc.test.id}"
+
+  ingress {
+    protocol    = "icmp"
+    from_port   = -1
+    to_port     = -1
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName)
+}
+
+// testAccAwsInstanceVpcIpv6Config returns the configuration for tests that create
+//   1) a VPC with IPv6 support
+//   2) a subnet in the VPC
+// The resources are named 'test'.
+func testAccAwsInstanceVpcIpv6Config(rName string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "current" {
+  # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
+  blacklisted_zone_ids = ["usw2-az4"]
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  assign_generated_ipv6_cidr_block = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
   cidr_block        = "10.1.1.0/24"
   vpc_id            = "${aws_vpc.test.id}"
   availability_zone = "${data.aws_availability_zones.current.names[0]}"
+  ipv6_cidr_block   = "${cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)}"
 
   tags = {
     Name = %[1]q

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -746,6 +746,7 @@ func TestAccAWSInstance_noAMIEphemeralDevices(t *testing.T) {
 func TestAccAWSInstance_sourceDestCheck(t *testing.T) {
 	var v ec2.Instance
 	resourceName := "aws_instance.test"
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	testCheck := func(enabled bool) resource.TestCheckFunc {
 		return func(*terraform.State) error {
@@ -767,7 +768,7 @@ func TestAccAWSInstance_sourceDestCheck(t *testing.T) {
 		CheckDestroy:  testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigSourceDestDisable,
+				Config: testAccInstanceConfigSourceDestDisable(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					testCheck(false),
@@ -779,14 +780,14 @@ func TestAccAWSInstance_sourceDestCheck(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccInstanceConfigSourceDestEnable,
+				Config: testAccInstanceConfigSourceDestEnable(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					testCheck(true),
 				),
 			},
 			{
-				Config: testAccInstanceConfigSourceDestDisable,
+				Config: testAccInstanceConfigSourceDestDisable(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					testCheck(false),
@@ -850,6 +851,7 @@ func TestAccAWSInstance_disableApiTermination(t *testing.T) {
 func TestAccAWSInstance_vpc(t *testing.T) {
 	var v ec2.Instance
 	resourceName := "aws_instance.test"
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
@@ -859,7 +861,7 @@ func TestAccAWSInstance_vpc(t *testing.T) {
 		CheckDestroy:    testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigVPC,
+				Config: testAccInstanceConfigVPC(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(
 						resourceName, &v),
@@ -1041,7 +1043,7 @@ func TestAccAWSInstance_NetworkInstanceSecurityGroups(t *testing.T) {
 func TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups(t *testing.T) {
 	var v ec2.Instance
 	resourceName := "aws_instance.test"
-	rInt := acctest.RandInt()
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -1050,7 +1052,7 @@ func TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups(t *testing.T) {
 		CheckDestroy:  testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceNetworkInstanceVPCSecurityGroupIDs(rInt),
+				Config: testAccInstanceNetworkInstanceVPCSecurityGroupIDs(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(
 						resourceName, &v),
@@ -1066,7 +1068,7 @@ func TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccInstanceNetworkInstanceVPCRemoveSecurityGroupIDs(rInt),
+				Config: testAccInstanceNetworkInstanceVPCRemoveSecurityGroupIDs(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(
 						resourceName, &v),
@@ -1084,7 +1086,7 @@ func TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups(t *testing.T) {
 func TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs(t *testing.T) {
 	var v ec2.Instance
 	resourceName := "aws_instance.test"
-	rInt := acctest.RandInt()
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -1093,7 +1095,7 @@ func TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs(t *testing.T) {
 		CheckDestroy:  testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceNetworkInstanceVPCSecurityGroupIDs(rInt),
+				Config: testAccInstanceNetworkInstanceVPCSecurityGroupIDs(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(
 						resourceName, &v),
@@ -1311,6 +1313,7 @@ func TestAccAWSInstance_withIamInstanceProfile(t *testing.T) {
 func TestAccAWSInstance_privateIP(t *testing.T) {
 	var v ec2.Instance
 	resourceName := "aws_instance.test"
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	testCheckPrivateIP := func() resource.TestCheckFunc {
 		return func(*terraform.State) error {
@@ -1329,7 +1332,7 @@ func TestAccAWSInstance_privateIP(t *testing.T) {
 		CheckDestroy:  testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigPrivateIP,
+				Config: testAccInstanceConfigPrivateIP(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					testCheckPrivateIP(),
@@ -1423,6 +1426,7 @@ func TestAccAWSInstance_keyPairCheck(t *testing.T) {
 func TestAccAWSInstance_rootBlockDeviceMismatch(t *testing.T) {
 	var v ec2.Instance
 	resourceName := "aws_instance.test"
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1430,7 +1434,7 @@ func TestAccAWSInstance_rootBlockDeviceMismatch(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigRootBlockDeviceMismatch,
+				Config: testAccInstanceConfigRootBlockDeviceMismatch(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
@@ -1459,6 +1463,7 @@ func TestAccAWSInstance_rootBlockDeviceMismatch(t *testing.T) {
 func TestAccAWSInstance_forceNewAndTagsDrift(t *testing.T) {
 	var v ec2.Instance
 	resourceName := "aws_instance.test"
+	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -1467,7 +1472,7 @@ func TestAccAWSInstance_forceNewAndTagsDrift(t *testing.T) {
 		CheckDestroy:  testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigForceNewAndTagsDrift,
+				Config: testAccInstanceConfigForceNewAndTagsDrift(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					driftTags(&v),
@@ -1475,7 +1480,7 @@ func TestAccAWSInstance_forceNewAndTagsDrift(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config: testAccInstanceConfigForceNewAndTagsDrift_Update,
+				Config: testAccInstanceConfigForceNewAndTagsDrift_Update(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 				),
@@ -2923,54 +2928,26 @@ resource "aws_instance" "test" {
 }
 `
 
-const testAccInstanceConfigSourceDestEnable = `
-resource "aws_vpc" "test" {
-	cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-instance-source-dest-enable"
-	}
-}
-
-resource "aws_subnet" "test" {
-	cidr_block = "10.1.1.0/24"
-	vpc_id = "${aws_vpc.test.id}"
-	tags = {
-		Name = "tf-acc-instance-source-dest-enable"
-	}
-}
-
+func testAccInstanceConfigSourceDestEnable(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName) + fmt.Sprintf(`
 resource "aws_instance" "test" {
-	# us-west-2
-	ami = "ami-4fccb37f"
-	instance_type = "m1.small"
-	subnet_id = "${aws_subnet.test.id}"
+  ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type = "m1.small"
+  subnet_id     = "${aws_subnet.test.id}"
 }
-`
-
-const testAccInstanceConfigSourceDestDisable = `
-resource "aws_vpc" "test" {
-	cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-instance-source-dest-disable"
-	}
+`)
 }
 
-resource "aws_subnet" "test" {
-	cidr_block = "10.1.1.0/24"
-	vpc_id = "${aws_vpc.test.id}"
-	tags = {
-		Name = "tf-acc-instance-source-dest-disable"
-	}
-}
-
+func testAccInstanceConfigSourceDestDisable(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName) + fmt.Sprintf(`
 resource "aws_instance" "test" {
-	# us-west-2
-	ami = "ami-4fccb37f"
-	instance_type = "m1.small"
-	subnet_id = "${aws_subnet.test.id}"
-	source_dest_check = false
+  ami               = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type     = "m1.small"
+  subnet_id         = "${aws_subnet.test.id}"
+  source_dest_check = false
 }
-`
+`)
+}
 
 func testAccInstanceConfigDisableAPITermination(val bool) string {
 	return fmt.Sprintf(`
@@ -3001,33 +2978,19 @@ resource "aws_instance" "test" {
 `, val)
 }
 
-const testAccInstanceConfigVPC = `
-resource "aws_vpc" "test" {
-	cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-instance-vpc"
-	}
-}
-
-resource "aws_subnet" "test" {
-	cidr_block = "10.1.1.0/24"
-	vpc_id = "${aws_vpc.test.id}"
-	tags = {
-		Name = "tf-acc-instance-vpc"
-	}
-}
-
+func testAccInstanceConfigVPC(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName) + fmt.Sprintf(`
 resource "aws_instance" "test" {
-	# us-west-2
-	ami = "ami-4fccb37f"
-	instance_type = "m1.small"
-	subnet_id = "${aws_subnet.test.id}"
-	associate_public_ip_address = true
-	tenancy = "dedicated"
-	# pre-encoded base64 data
-	user_data = "3dc39dda39be1205215e776bad998da361a5955d"
+  ami                         = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type               = "m1.small"
+  subnet_id                   = "${aws_subnet.test.id}"
+  associate_public_ip_address = true
+  tenancy                     = "dedicated"
+  # pre-encoded base64 data
+  user_data                   = "3dc39dda39be1205215e776bad998da361a5955d"
 }
-`
+`)
+}
 
 func testAccInstanceConfigPlacementGroup(rStr string) string {
 	return fmt.Sprintf(`
@@ -3484,29 +3447,16 @@ resource "aws_instance" "test" {
 `, rName, rName)
 }
 
-const testAccInstanceConfigPrivateIP = `
-resource "aws_vpc" "test" {
-	cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-instance-private-ip"
-	}
-}
-
-resource "aws_subnet" "test" {
-	cidr_block = "10.1.1.0/24"
-	vpc_id = "${aws_vpc.test.id}"
-	tags = {
-		Name = "tf-acc-instance-private-ip"
-	}
-}
-
+func testAccInstanceConfigPrivateIP(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName) + fmt.Sprintf(`
 resource "aws_instance" "test" {
-	ami = "ami-c5eabbf5"
-	instance_type = "t2.micro"
-	subnet_id = "${aws_subnet.test.id}"
-	private_ip = "10.1.1.42"
+  ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type = "t2.micro"
+  subnet_id     = "${aws_subnet.test.id}"
+  private_ip    = "10.1.1.42"
 }
-`
+`)
+}
 
 const testAccInstanceConfigAssociatePublicIPAndPrivateIP = `
 resource "aws_vpc" "test" {
@@ -3586,22 +3536,18 @@ resource "aws_eip" "test_eip" {
 `, rInt)
 }
 
-func testAccInstanceNetworkInstanceVPCSecurityGroupIDs(rInt int) string {
-	return fmt.Sprintf(`
-resource "aws_internet_gateway" "gw" {
+func testAccInstanceNetworkInstanceVPCSecurityGroupIDs(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName) + fmt.Sprintf(`
+resource "aws_internet_gateway" "test" {
   vpc_id = "${aws_vpc.test.id}"
-}
-
-resource "aws_vpc" "test" {
-  cidr_block = "10.1.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-instance-network-vpc-sg-ids"
+    Name = %[1]q
   }
 }
 
-resource "aws_security_group" "tf_test_test" {
-  name        = "tf_test_%d"
+resource "aws_security_group" "test" {
+  name        = %[1]q
   description = "test"
   vpc_id      = "${aws_vpc.test.id}"
 
@@ -3613,47 +3559,34 @@ resource "aws_security_group" "tf_test_test" {
   }
 }
 
-resource "aws_subnet" "test" {
-  cidr_block = "10.1.1.0/24"
-  vpc_id     = "${aws_vpc.test.id}"
-
-  tags = {
-    Name = "tf-acc-instance-network-vpc-sg-ids"
-  }
-}
-
 resource "aws_instance" "test" {
-  ami                    = "ami-21f78e11"
+  ami                    = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   instance_type          = "t1.micro"
-  vpc_security_group_ids = ["${aws_security_group.tf_test_test.id}"]
+  vpc_security_group_ids = ["${aws_security_group.test.id}"]
   subnet_id              = "${aws_subnet.test.id}"
-  depends_on             = ["aws_internet_gateway.gw"]
+  depends_on             = ["aws_internet_gateway.test"]
 }
 
-resource "aws_eip" "test_eip" {
+resource "aws_eip" "test" {
   instance   = "${aws_instance.test.id}"
   vpc        = true
-  depends_on = ["aws_internet_gateway.gw"]
+  depends_on = ["aws_internet_gateway.test"]
 }
-`, rInt)
+`, rName)
 }
 
-func testAccInstanceNetworkInstanceVPCRemoveSecurityGroupIDs(rInt int) string {
-	return fmt.Sprintf(`
-resource "aws_internet_gateway" "gw" {
+func testAccInstanceNetworkInstanceVPCRemoveSecurityGroupIDs(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName) + fmt.Sprintf(`
+resource "aws_internet_gateway" "test" {
   vpc_id = "${aws_vpc.test.id}"
-}
-
-resource "aws_vpc" "test" {
-  cidr_block = "10.1.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-instance-network-vpc-sg-ids"
+    Name = %[1]q
   }
 }
 
-resource "aws_security_group" "tf_test_test" {
-  name        = "tf_test_%d"
+resource "aws_security_group" "test" {
+  name        = %[1]q
   description = "test"
   vpc_id      = "${aws_vpc.test.id}"
 
@@ -3665,29 +3598,20 @@ resource "aws_security_group" "tf_test_test" {
   }
 }
 
-resource "aws_subnet" "test" {
-  cidr_block = "10.1.1.0/24"
-  vpc_id     = "${aws_vpc.test.id}"
-
-  tags = {
-    Name = "tf-acc-instance-network-vpc-sg-ids"
-  }
-}
-
 resource "aws_instance" "test" {
-  ami                    = "ami-21f78e11"
+  ami                    = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   instance_type          = "t1.micro"
   vpc_security_group_ids = []
   subnet_id              = "${aws_subnet.test.id}"
-  depends_on             = ["aws_internet_gateway.gw"]
+  depends_on             = ["aws_internet_gateway.test"]
 }
 
-resource "aws_eip" "test_eip" {
+resource "aws_eip" "test" {
   instance   = "${aws_instance.test.id}"
   vpc        = true
-  depends_on = ["aws_internet_gateway.gw"]
+  depends_on = ["aws_internet_gateway.test"]
 }
-`, rInt)
+`, rName)
 }
 
 func testAccInstanceConfigKeyPair(keyPairName string) string {
@@ -3704,7 +3628,7 @@ resource "aws_instance" "test" {
   ami           = "ami-408c7f28"
   instance_type = "t1.micro"
   key_name      = "${aws_key_pair.debugging.key_name}"
-  
+
   tags = {
     Name = "testAccInstanceConfigKeyPair_TestAMI"
   }
@@ -3712,78 +3636,40 @@ resource "aws_instance" "test" {
 `, keyPairName)
 }
 
-const testAccInstanceConfigRootBlockDeviceMismatch = `
-resource "aws_vpc" "test" {
-	cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-instance-root-block-device-mismatch"
-	}
-}
-
-resource "aws_subnet" "test" {
-	cidr_block = "10.1.1.0/24"
-	vpc_id = "${aws_vpc.test.id}"
-	tags = {
-		Name = "tf-acc-instance-root-block-device-mismatch"
-	}
-}
-
+func testAccInstanceConfigRootBlockDeviceMismatch(rName string) string {
+	return testAccAwsInstanceVpcConfig(rName) + fmt.Sprintf(`
 resource "aws_instance" "test" {
-	// This is an AMI with RootDeviceName: "/dev/sda1"; actual root: "/dev/sda"
-	ami = "ami-ef5b69df"
-	instance_type = "t1.micro"
-	subnet_id = "${aws_subnet.test.id}"
-	root_block_device {
-		volume_size = 13
-	}
-}
-`
+  // This is an AMI with RootDeviceName: "/dev/sda1"; actual root: "/dev/sda"
+  ami           = "ami-ef5b69df"
+  instance_type = "t1.micro"
+  subnet_id     = "${aws_subnet.test.id}"
 
-const testAccInstanceConfigForceNewAndTagsDrift = `
-resource "aws_vpc" "test" {
-	cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-instance-force-new-and-tags-drift"
-	}
+  root_block_device {
+    volume_size = 13
+  }
+}
+`)
 }
 
-resource "aws_subnet" "test" {
-	cidr_block = "10.1.1.0/24"
-	vpc_id = "${aws_vpc.test.id}"
-	tags = {
-		Name = "tf-acc-instance-force-new-and-tags-drift"
-	}
-}
-
+func testAccInstanceConfigForceNewAndTagsDrift(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName) + fmt.Sprintf(`
 resource "aws_instance" "test" {
-	ami = "ami-22b9a343"
-	instance_type = "t2.nano"
-	subnet_id = "${aws_subnet.test.id}"
+  ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type = "t2.nano"
+  subnet_id     = "${aws_subnet.test.id}"
 }
-`
-
-const testAccInstanceConfigForceNewAndTagsDrift_Update = `
-resource "aws_vpc" "test" {
-	cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-instance-force-new-and-tags-drift"
-	}
+`)
 }
 
-resource "aws_subnet" "test" {
-	cidr_block = "10.1.1.0/24"
-	vpc_id = "${aws_vpc.test.id}"
-	tags = {
-		Name = "tf-acc-instance-force-new-and-tags-drift"
-	}
-}
-
+func testAccInstanceConfigForceNewAndTagsDrift_Update(rName string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName) + fmt.Sprintf(`
 resource "aws_instance" "test" {
-	ami = "ami-22b9a343"
-	instance_type = "t2.micro"
-	subnet_id = "${aws_subnet.test.id}"
+  ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type = "t2.micro"
+  subnet_id     = "${aws_subnet.test.id}"
 }
-`
+`)
+}
 
 const testAccInstanceConfigPrimaryNetworkInterface = `
 resource "aws_vpc" "test" {
@@ -4658,4 +4544,79 @@ resource "aws_instance" "test" {
   user_data     = ""
 }
 `
+}
+
+// testAccLatestAmazonLinuxHvmEbsAmiConfig returns the configuration for a data source that
+// describes the latest Amazon Linux AMI using HVM virtualization and an EBS root device.
+// The data source is named 'amzn-ami-minimal-hvm-ebs'.
+func testAccLatestAmazonLinuxHvmEbsAmiConfig() string {
+	return fmt.Sprintf(`
+data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name = "name"
+    values = ["amzn-ami-minimal-hvm-*"]
+  }
+
+  filter {
+    name = "root-device-type"
+    values = ["ebs"]
+  }
+}
+`)
+}
+
+// testAccLatestAmazonLinuxPvEbsAmiConfig returns the configuration for a data source that
+// describes the latest Amazon Linux AMI using PV virtualization and an EBS root device.
+// The data source is named 'amzn-ami-minimal-pv-ebs'.
+/*
+func testAccLatestAmazonLinuxPvEbsAmiConfig() string {
+	return fmt.Sprintf(`
+data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name = "name"
+    values = ["amzn-ami-minimal-pv-*"]
+  }
+
+  filter {
+    name = "root-device-type"
+    values = ["ebs"]
+  }
+}
+`)
+}
+*/
+
+// testAccAwsInstanceVpcConfig returns the configuration for resources that create a VPC and subnet in that the VPC.
+// The resources are named 'test'.
+func testAccAwsInstanceVpcConfig(rName string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "current" {
+  # Exclude us-west-2d as it has limited instance types.
+  blacklisted_names = ["us-west-2d"]
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block        = "10.1.1.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.current.names[0]}"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName)
 }

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -4597,8 +4597,8 @@ data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
 func testAccAwsInstanceVpcConfig(rName string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "current" {
-  # Exclude us-west-2d as it has limited instance types.
-  blacklisted_names = ["us-west-2d"]
+  # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
+  blacklisted_zone_ids = ["usw2-az4"]
 }
 
 resource "aws_vpc" "test" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10688.

Rather a bigger change than I thought on starting it. Most of the changes are in the acceptance tests to remove hard-coded AMIs and ensure that the AZ supports the required instance types, part of https://github.com/terraform-providers/terraform-provider-aws/issues/4987.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSInstanceDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 1 -run=TestAccAWSInstanceDataSource_ -timeout 120m
=== RUN   TestAccAWSInstanceDataSource_basic
=== PAUSE TestAccAWSInstanceDataSource_basic
=== RUN   TestAccAWSInstanceDataSource_tags
=== PAUSE TestAccAWSInstanceDataSource_tags
=== RUN   TestAccAWSInstanceDataSource_AzUserData
=== PAUSE TestAccAWSInstanceDataSource_AzUserData
=== RUN   TestAccAWSInstanceDataSource_gp2IopsDevice
=== PAUSE TestAccAWSInstanceDataSource_gp2IopsDevice
=== RUN   TestAccAWSInstanceDataSource_blockDevices
=== PAUSE TestAccAWSInstanceDataSource_blockDevices
=== RUN   TestAccAWSInstanceDataSource_EbsBlockDevice_KmsKeyId
=== PAUSE TestAccAWSInstanceDataSource_EbsBlockDevice_KmsKeyId
=== RUN   TestAccAWSInstanceDataSource_RootBlockDevice_KmsKeyId
=== PAUSE TestAccAWSInstanceDataSource_RootBlockDevice_KmsKeyId
=== RUN   TestAccAWSInstanceDataSource_rootInstanceStore
=== PAUSE TestAccAWSInstanceDataSource_rootInstanceStore
=== RUN   TestAccAWSInstanceDataSource_privateIP
=== PAUSE TestAccAWSInstanceDataSource_privateIP
=== RUN   TestAccAWSInstanceDataSource_keyPair
=== PAUSE TestAccAWSInstanceDataSource_keyPair
=== RUN   TestAccAWSInstanceDataSource_VPC
=== PAUSE TestAccAWSInstanceDataSource_VPC
=== RUN   TestAccAWSInstanceDataSource_PlacementGroup
=== PAUSE TestAccAWSInstanceDataSource_PlacementGroup
=== RUN   TestAccAWSInstanceDataSource_SecurityGroups
=== PAUSE TestAccAWSInstanceDataSource_SecurityGroups
=== RUN   TestAccAWSInstanceDataSource_VPCSecurityGroups
=== PAUSE TestAccAWSInstanceDataSource_VPCSecurityGroups
=== RUN   TestAccAWSInstanceDataSource_getPasswordData_trueToFalse
=== PAUSE TestAccAWSInstanceDataSource_getPasswordData_trueToFalse
=== RUN   TestAccAWSInstanceDataSource_getPasswordData_falseToTrue
=== PAUSE TestAccAWSInstanceDataSource_getPasswordData_falseToTrue
=== RUN   TestAccAWSInstanceDataSource_GetUserData
=== PAUSE TestAccAWSInstanceDataSource_GetUserData
=== RUN   TestAccAWSInstanceDataSource_GetUserData_NoUserData
=== PAUSE TestAccAWSInstanceDataSource_GetUserData_NoUserData
=== RUN   TestAccAWSInstanceDataSource_creditSpecification
=== PAUSE TestAccAWSInstanceDataSource_creditSpecification
=== CONT  TestAccAWSInstanceDataSource_tags
--- PASS: TestAccAWSInstanceDataSource_tags (122.12s)
=== CONT  TestAccAWSInstanceDataSource_creditSpecification
--- PASS: TestAccAWSInstanceDataSource_creditSpecification (104.13s)
=== CONT  TestAccAWSInstanceDataSource_GetUserData_NoUserData
--- PASS: TestAccAWSInstanceDataSource_GetUserData_NoUserData (170.82s)
=== CONT  TestAccAWSInstanceDataSource_GetUserData
--- PASS: TestAccAWSInstanceDataSource_GetUserData (169.50s)
=== CONT  TestAccAWSInstanceDataSource_getPasswordData_falseToTrue
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_falseToTrue (184.59s)
=== CONT  TestAccAWSInstanceDataSource_getPasswordData_trueToFalse
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_trueToFalse (183.23s)
=== CONT  TestAccAWSInstanceDataSource_VPCSecurityGroups
--- PASS: TestAccAWSInstanceDataSource_VPCSecurityGroups (99.12s)
=== CONT  TestAccAWSInstanceDataSource_SecurityGroups
--- PASS: TestAccAWSInstanceDataSource_SecurityGroups (220.05s)
=== CONT  TestAccAWSInstanceDataSource_PlacementGroup
--- PASS: TestAccAWSInstanceDataSource_PlacementGroup (99.34s)
=== CONT  TestAccAWSInstanceDataSource_VPC
--- PASS: TestAccAWSInstanceDataSource_VPC (104.72s)
=== CONT  TestAccAWSInstanceDataSource_keyPair
--- PASS: TestAccAWSInstanceDataSource_keyPair (87.66s)
=== CONT  TestAccAWSInstanceDataSource_privateIP
--- PASS: TestAccAWSInstanceDataSource_privateIP (114.26s)
=== CONT  TestAccAWSInstanceDataSource_rootInstanceStore
--- PASS: TestAccAWSInstanceDataSource_rootInstanceStore (89.61s)
=== CONT  TestAccAWSInstanceDataSource_RootBlockDevice_KmsKeyId
--- PASS: TestAccAWSInstanceDataSource_RootBlockDevice_KmsKeyId (131.69s)
=== CONT  TestAccAWSInstanceDataSource_EbsBlockDevice_KmsKeyId
--- PASS: TestAccAWSInstanceDataSource_EbsBlockDevice_KmsKeyId (121.11s)
=== CONT  TestAccAWSInstanceDataSource_blockDevices
--- PASS: TestAccAWSInstanceDataSource_blockDevices (92.22s)
=== CONT  TestAccAWSInstanceDataSource_gp2IopsDevice
--- PASS: TestAccAWSInstanceDataSource_gp2IopsDevice (93.03s)
=== CONT  TestAccAWSInstanceDataSource_AzUserData
--- PASS: TestAccAWSInstanceDataSource_AzUserData (247.33s)
=== CONT  TestAccAWSInstanceDataSource_basic
--- PASS: TestAccAWSInstanceDataSource_basic (236.45s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2671.037s
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSInstance_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 1 -run=TestAccAWSInstance_ -timeout 600m
=== RUN   TestAccAWSInstance_inDefaultVpcBySgName
=== PAUSE TestAccAWSInstance_inDefaultVpcBySgName
=== RUN   TestAccAWSInstance_inDefaultVpcBySgId
=== PAUSE TestAccAWSInstance_inDefaultVpcBySgId
=== RUN   TestAccAWSInstance_basic
=== PAUSE TestAccAWSInstance_basic
=== RUN   TestAccAWSInstance_EbsBlockDevice_KmsKeyArn
=== PAUSE TestAccAWSInstance_EbsBlockDevice_KmsKeyArn
=== RUN   TestAccAWSInstance_RootBlockDevice_KmsKeyArn
=== PAUSE TestAccAWSInstance_RootBlockDevice_KmsKeyArn
=== RUN   TestAccAWSInstance_userDataBase64
=== PAUSE TestAccAWSInstance_userDataBase64
=== RUN   TestAccAWSInstance_GP2IopsDevice
=== PAUSE TestAccAWSInstance_GP2IopsDevice
=== RUN   TestAccAWSInstance_GP2WithIopsValue
=== PAUSE TestAccAWSInstance_GP2WithIopsValue
=== RUN   TestAccAWSInstance_blockDevices
=== PAUSE TestAccAWSInstance_blockDevices
=== RUN   TestAccAWSInstance_rootInstanceStore
=== PAUSE TestAccAWSInstance_rootInstanceStore
=== RUN   TestAccAWSInstance_noAMIEphemeralDevices
=== PAUSE TestAccAWSInstance_noAMIEphemeralDevices
=== RUN   TestAccAWSInstance_sourceDestCheck
=== PAUSE TestAccAWSInstance_sourceDestCheck
=== RUN   TestAccAWSInstance_disableApiTermination
=== PAUSE TestAccAWSInstance_disableApiTermination
=== RUN   TestAccAWSInstance_vpc
=== PAUSE TestAccAWSInstance_vpc
=== RUN   TestAccAWSInstance_placementGroup
=== PAUSE TestAccAWSInstance_placementGroup
=== RUN   TestAccAWSInstance_ipv6_supportAddressCount
=== PAUSE TestAccAWSInstance_ipv6_supportAddressCount
=== RUN   TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError
=== PAUSE TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError
=== RUN   TestAccAWSInstance_ipv6_supportAddressCountWithIpv4
=== PAUSE TestAccAWSInstance_ipv6_supportAddressCountWithIpv4
=== RUN   TestAccAWSInstance_multipleRegions
=== PAUSE TestAccAWSInstance_multipleRegions
=== RUN   TestAccAWSInstance_NetworkInstanceSecurityGroups
=== PAUSE TestAccAWSInstance_NetworkInstanceSecurityGroups
=== RUN   TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups
=== PAUSE TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups
=== RUN   TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs
=== PAUSE TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs
=== RUN   TestAccAWSInstance_tags
=== PAUSE TestAccAWSInstance_tags
=== RUN   TestAccAWSInstance_volumeTags
=== PAUSE TestAccAWSInstance_volumeTags
=== RUN   TestAccAWSInstance_volumeTagsComputed
=== PAUSE TestAccAWSInstance_volumeTagsComputed
=== RUN   TestAccAWSInstance_instanceProfileChange
=== PAUSE TestAccAWSInstance_instanceProfileChange
=== RUN   TestAccAWSInstance_withIamInstanceProfile
=== PAUSE TestAccAWSInstance_withIamInstanceProfile
=== RUN   TestAccAWSInstance_privateIP
=== PAUSE TestAccAWSInstance_privateIP
=== RUN   TestAccAWSInstance_associatePublicIPAndPrivateIP
=== PAUSE TestAccAWSInstance_associatePublicIPAndPrivateIP
=== RUN   TestAccAWSInstance_keyPairCheck
=== PAUSE TestAccAWSInstance_keyPairCheck
=== RUN   TestAccAWSInstance_rootBlockDeviceMismatch
=== PAUSE TestAccAWSInstance_rootBlockDeviceMismatch
=== RUN   TestAccAWSInstance_forceNewAndTagsDrift
=== PAUSE TestAccAWSInstance_forceNewAndTagsDrift
=== RUN   TestAccAWSInstance_changeInstanceType
=== PAUSE TestAccAWSInstance_changeInstanceType
=== RUN   TestAccAWSInstance_primaryNetworkInterface
=== PAUSE TestAccAWSInstance_primaryNetworkInterface
=== RUN   TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck
=== PAUSE TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck
=== RUN   TestAccAWSInstance_addSecondaryInterface
=== PAUSE TestAccAWSInstance_addSecondaryInterface
=== RUN   TestAccAWSInstance_addSecurityGroupNetworkInterface
=== PAUSE TestAccAWSInstance_addSecurityGroupNetworkInterface
=== RUN   TestAccAWSInstance_associatePublic_defaultPrivate
=== PAUSE TestAccAWSInstance_associatePublic_defaultPrivate
=== RUN   TestAccAWSInstance_associatePublic_defaultPublic
=== PAUSE TestAccAWSInstance_associatePublic_defaultPublic
=== RUN   TestAccAWSInstance_associatePublic_explicitPublic
=== PAUSE TestAccAWSInstance_associatePublic_explicitPublic
=== RUN   TestAccAWSInstance_associatePublic_explicitPrivate
=== PAUSE TestAccAWSInstance_associatePublic_explicitPrivate
=== RUN   TestAccAWSInstance_associatePublic_overridePublic
=== PAUSE TestAccAWSInstance_associatePublic_overridePublic
=== RUN   TestAccAWSInstance_associatePublic_overridePrivate
=== PAUSE TestAccAWSInstance_associatePublic_overridePrivate
=== RUN   TestAccAWSInstance_getPasswordData_falseToTrue
=== PAUSE TestAccAWSInstance_getPasswordData_falseToTrue
=== RUN   TestAccAWSInstance_getPasswordData_trueToFalse
=== PAUSE TestAccAWSInstance_getPasswordData_trueToFalse
=== RUN   TestAccAWSInstance_CreditSpecification_Empty_NonBurstable
=== PAUSE TestAccAWSInstance_CreditSpecification_Empty_NonBurstable
=== RUN   TestAccAWSInstance_CreditSpecification_UnspecifiedToEmpty_NonBurstable
=== PAUSE TestAccAWSInstance_CreditSpecification_UnspecifiedToEmpty_NonBurstable
=== RUN   TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard
=== PAUSE TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard
=== RUN   TestAccAWSInstance_creditSpecification_standardCpuCredits
=== PAUSE TestAccAWSInstance_creditSpecification_standardCpuCredits
=== RUN   TestAccAWSInstance_creditSpecification_unlimitedCpuCredits
=== PAUSE TestAccAWSInstance_creditSpecification_unlimitedCpuCredits
=== RUN   TestAccAWSInstance_creditSpecification_unknownCpuCredits_t2
=== PAUSE TestAccAWSInstance_creditSpecification_unknownCpuCredits_t2
=== RUN   TestAccAWSInstance_creditSpecification_unknownCpuCredits_t3
=== PAUSE TestAccAWSInstance_creditSpecification_unknownCpuCredits_t3
=== RUN   TestAccAWSInstance_creditSpecification_updateCpuCredits
=== PAUSE TestAccAWSInstance_creditSpecification_updateCpuCredits
=== RUN   TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable
=== PAUSE TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable
=== RUN   TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited
=== PAUSE TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited
=== RUN   TestAccAWSInstance_creditSpecificationT3_standardCpuCredits
=== PAUSE TestAccAWSInstance_creditSpecificationT3_standardCpuCredits
=== RUN   TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits
=== PAUSE TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits
=== RUN   TestAccAWSInstance_creditSpecificationT3_updateCpuCredits
=== PAUSE TestAccAWSInstance_creditSpecificationT3_updateCpuCredits
=== RUN   TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint
=== PAUSE TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint
=== RUN   TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint
=== PAUSE TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint
=== RUN   TestAccAWSInstance_disappears
=== PAUSE TestAccAWSInstance_disappears
=== RUN   TestAccAWSInstance_UserData_EmptyStringToUnspecified
=== PAUSE TestAccAWSInstance_UserData_EmptyStringToUnspecified
=== RUN   TestAccAWSInstance_UserData_UnspecifiedToEmptyString
=== PAUSE TestAccAWSInstance_UserData_UnspecifiedToEmptyString
=== CONT  TestAccAWSInstance_inDefaultVpcBySgName
--- PASS: TestAccAWSInstance_inDefaultVpcBySgName (89.15s)
=== CONT  TestAccAWSInstance_changeInstanceType
--- PASS: TestAccAWSInstance_changeInstanceType (142.76s)
=== CONT  TestAccAWSInstance_UserData_UnspecifiedToEmptyString
--- PASS: TestAccAWSInstance_UserData_UnspecifiedToEmptyString (133.13s)
=== CONT  TestAccAWSInstance_UserData_EmptyStringToUnspecified
--- PASS: TestAccAWSInstance_UserData_EmptyStringToUnspecified (121.92s)
=== CONT  TestAccAWSInstance_disappears
--- PASS: TestAccAWSInstance_disappears (229.26s)
=== CONT  TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint (208.14s)
=== CONT  TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint (416.24s)
=== CONT  TestAccAWSInstance_creditSpecificationT3_updateCpuCredits
--- PASS: TestAccAWSInstance_creditSpecificationT3_updateCpuCredits (131.04s)
=== CONT  TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits
--- PASS: TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits (108.67s)
=== CONT  TestAccAWSInstance_creditSpecificationT3_standardCpuCredits
--- PASS: TestAccAWSInstance_creditSpecificationT3_standardCpuCredits (161.90s)
=== CONT  TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited
--- PASS: TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited (138.11s)
=== CONT  TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable
--- PASS: TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable (126.30s)        
=== CONT  TestAccAWSInstance_creditSpecification_updateCpuCredits
--- PASS: TestAccAWSInstance_creditSpecification_updateCpuCredits (161.72s)
=== CONT  TestAccAWSInstance_creditSpecification_unknownCpuCredits_t3
--- PASS: TestAccAWSInstance_creditSpecification_unknownCpuCredits_t3 (96.69s)
=== CONT  TestAccAWSInstance_creditSpecification_unknownCpuCredits_t2
--- PASS: TestAccAWSInstance_creditSpecification_unknownCpuCredits_t2 (127.22s)
=== CONT  TestAccAWSInstance_creditSpecification_unlimitedCpuCredits
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits (129.89s)
=== CONT  TestAccAWSInstance_creditSpecification_standardCpuCredits
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits (129.85s)
=== CONT  TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard
--- PASS: TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard (106.37s)
=== CONT  TestAccAWSInstance_CreditSpecification_UnspecifiedToEmpty_NonBurstable
--- PASS: TestAccAWSInstance_CreditSpecification_UnspecifiedToEmpty_NonBurstable (125.71s)
=== CONT  TestAccAWSInstance_CreditSpecification_Empty_NonBurstable
--- PASS: TestAccAWSInstance_CreditSpecification_Empty_NonBurstable (107.08s)
=== CONT  TestAccAWSInstance_getPasswordData_trueToFalse
--- PASS: TestAccAWSInstance_getPasswordData_trueToFalse (202.66s)
=== CONT  TestAccAWSInstance_getPasswordData_falseToTrue
--- PASS: TestAccAWSInstance_getPasswordData_falseToTrue (150.58s)
=== CONT  TestAccAWSInstance_associatePublic_overridePrivate
--- PASS: TestAccAWSInstance_associatePublic_overridePrivate (107.44s)
=== CONT  TestAccAWSInstance_associatePublic_overridePublic
--- PASS: TestAccAWSInstance_associatePublic_overridePublic (106.61s)
=== CONT  TestAccAWSInstance_associatePublic_explicitPrivate
--- PASS: TestAccAWSInstance_associatePublic_explicitPrivate (106.48s)
=== CONT  TestAccAWSInstance_associatePublic_explicitPublic
--- PASS: TestAccAWSInstance_associatePublic_explicitPublic (117.63s)
=== CONT  TestAccAWSInstance_associatePublic_defaultPublic
--- PASS: TestAccAWSInstance_associatePublic_defaultPublic (107.49s)
=== CONT  TestAccAWSInstance_associatePublic_defaultPrivate
--- PASS: TestAccAWSInstance_associatePublic_defaultPrivate (221.53s)
=== CONT  TestAccAWSInstance_addSecurityGroupNetworkInterface
--- PASS: TestAccAWSInstance_addSecurityGroupNetworkInterface (263.83s)
=== CONT  TestAccAWSInstance_addSecondaryInterface
--- PASS: TestAccAWSInstance_addSecondaryInterface (140.43s)
=== CONT  TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck
--- PASS: TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck (112.45s)
=== CONT  TestAccAWSInstance_primaryNetworkInterface
--- PASS: TestAccAWSInstance_primaryNetworkInterface (91.09s)
=== CONT  TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError
--- PASS: TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError (20.32s)
=== CONT  TestAccAWSInstance_forceNewAndTagsDrift
--- PASS: TestAccAWSInstance_forceNewAndTagsDrift (169.74s)
=== CONT  TestAccAWSInstance_rootBlockDeviceMismatch
--- PASS: TestAccAWSInstance_rootBlockDeviceMismatch (97.97s)
=== CONT  TestAccAWSInstance_keyPairCheck
--- PASS: TestAccAWSInstance_keyPairCheck (73.54s)
=== CONT  TestAccAWSInstance_associatePublicIPAndPrivateIP
--- PASS: TestAccAWSInstance_associatePublicIPAndPrivateIP (117.32s)
=== CONT  TestAccAWSInstance_privateIP
--- PASS: TestAccAWSInstance_privateIP (110.03s)
=== CONT  TestAccAWSInstance_withIamInstanceProfile
--- PASS: TestAccAWSInstance_withIamInstanceProfile (264.89s)
=== CONT  TestAccAWSInstance_instanceProfileChange
--- PASS: TestAccAWSInstance_instanceProfileChange (146.05s)
=== CONT  TestAccAWSInstance_volumeTagsComputed
--- PASS: TestAccAWSInstance_volumeTagsComputed (156.04s)
=== CONT  TestAccAWSInstance_volumeTags
--- PASS: TestAccAWSInstance_volumeTags (133.04s)
=== CONT  TestAccAWSInstance_tags
--- PASS: TestAccAWSInstance_tags (145.19s)
=== CONT  TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs
--- PASS: TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs (112.95s)
=== CONT  TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups
--- PASS: TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups (126.19s)
=== CONT  TestAccAWSInstance_NetworkInstanceSecurityGroups
--- PASS: TestAccAWSInstance_NetworkInstanceSecurityGroups (110.34s)
=== CONT  TestAccAWSInstance_multipleRegions
--- PASS: TestAccAWSInstance_multipleRegions (246.21s)
=== CONT  TestAccAWSInstance_ipv6_supportAddressCountWithIpv4
--- PASS: TestAccAWSInstance_ipv6_supportAddressCountWithIpv4 (108.16s)
=== CONT  TestAccAWSInstance_blockDevices
--- PASS: TestAccAWSInstance_blockDevices (89.08s)
=== CONT  TestAccAWSInstance_ipv6_supportAddressCount
--- PASS: TestAccAWSInstance_ipv6_supportAddressCount (107.31s)
=== CONT  TestAccAWSInstance_placementGroup
--- PASS: TestAccAWSInstance_placementGroup (94.99s)
=== CONT  TestAccAWSInstance_vpc
--- PASS: TestAccAWSInstance_vpc (108.28s)
=== CONT  TestAccAWSInstance_disableApiTermination
--- PASS: TestAccAWSInstance_disableApiTermination (161.05s)
=== CONT  TestAccAWSInstance_sourceDestCheck
--- PASS: TestAccAWSInstance_sourceDestCheck (183.65s)
=== CONT  TestAccAWSInstance_noAMIEphemeralDevices
--- PASS: TestAccAWSInstance_noAMIEphemeralDevices (72.68s)
=== CONT  TestAccAWSInstance_rootInstanceStore
--- PASS: TestAccAWSInstance_rootInstanceStore (86.07s)
=== CONT  TestAccAWSInstance_RootBlockDevice_KmsKeyArn
--- PASS: TestAccAWSInstance_RootBlockDevice_KmsKeyArn (184.65s)
=== CONT  TestAccAWSInstance_GP2WithIopsValue
--- PASS: TestAccAWSInstance_GP2WithIopsValue (99.96s)
=== CONT  TestAccAWSInstance_GP2IopsDevice
--- PASS: TestAccAWSInstance_GP2IopsDevice (78.77s)
=== CONT  TestAccAWSInstance_userDataBase64
--- PASS: TestAccAWSInstance_userDataBase64 (237.78s)
=== CONT  TestAccAWSInstance_basic
--- PASS: TestAccAWSInstance_basic (161.16s)
=== CONT  TestAccAWSInstance_EbsBlockDevice_KmsKeyArn
--- PASS: TestAccAWSInstance_EbsBlockDevice_KmsKeyArn (113.28s)
=== CONT  TestAccAWSInstance_inDefaultVpcBySgId
--- PASS: TestAccAWSInstance_inDefaultVpcBySgId (99.16s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	8735.398s
```

Acceptance tests run with `-parallel 1` to avoid any eventual consistency errors.
