### PR TITLE
add missing `multi_az` param to aws_db_instance data source

### DIFF
--- a/aws/data_source_aws_db_instance.go
+++ b/aws/data_source_aws_db_instance.go
@@ -281,6 +281,7 @@ func dataSourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("master_username", dbInstance.MasterUsername)
 	d.Set("monitoring_interval", dbInstance.MonitoringInterval)
 	d.Set("monitoring_role_arn", dbInstance.MonitoringRoleArn)
+	d.Set("multi_az", dbInstance.MultiAZ)
 	d.Set("address", dbInstance.Endpoint.Address)
 	d.Set("port", dbInstance.Endpoint.Port)
 	d.Set("hosted_zone_id", dbInstance.Endpoint.HostedZoneId)

--- a/aws/data_source_aws_db_instance_test.go
+++ b/aws/data_source_aws_db_instance_test.go
@@ -28,6 +28,7 @@ func TestAccAWSDbInstanceDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.aws_db_instance.bar", "hosted_zone_id"),
 					resource.TestCheckResourceAttrSet("data.aws_db_instance.bar", "master_username"),
 					resource.TestCheckResourceAttrSet("data.aws_db_instance.bar", "port"),
+					resource.TestCheckResourceAttrSet("data.aws_db_instance.bar", "multi_az"),
 					resource.TestCheckResourceAttrSet("data.aws_db_instance.bar", "enabled_cloudwatch_logs_exports.0"),
 					resource.TestCheckResourceAttrSet("data.aws_db_instance.bar", "enabled_cloudwatch_logs_exports.1"),
 					resource.TestCheckResourceAttrPair("data.aws_db_instance.bar", "resource_id", "aws_db_instance.bar", "resource_id"),


### PR DESCRIPTION
The `aws_db_instance` data source was missing this field even though the documentation already states it should be included on the data source. Adds the field + test for the field

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
