### PR TITLE
Set default description for aws_service_discovery_public_dns_namespace

### DIFF
--- a/aws/resource_aws_athena_named_query.go
+++ b/aws/resource_aws_athena_named_query.go
@@ -44,6 +44,7 @@ func resourceAwsAthenaNamedQuery() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Default:  "Managed by Terraform",
 			},
 		},
 	}

--- a/aws/resource_aws_datapipeline_pipeline.go
+++ b/aws/resource_aws_datapipeline_pipeline.go
@@ -32,6 +32,7 @@ func resourceAwsDataPipelinePipeline() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Default:  "Managed by Terraform",
 			},
 
 			"tags": tagsSchema(),

--- a/aws/resource_aws_dax_parameter_group.go
+++ b/aws/resource_aws_dax_parameter_group.go
@@ -29,6 +29,7 @@ func resourceAwsDaxParameterGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Default:  "Managed by Terraform",
 			},
 			"parameters": {
 				Type:     schema.TypeSet,

--- a/aws/resource_aws_directory_service_directory.go
+++ b/aws/resource_aws_directory_service_directory.go
@@ -55,6 +55,7 @@ func resourceAwsDirectoryServiceDirectory() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Default:  "Managed by Terraform",
 			},
 			"short_name": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_ebs_snapshot.go
+++ b/aws/resource_aws_ebs_snapshot.go
@@ -32,6 +32,7 @@ func resourceAwsEbsSnapshot() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Default:  "Managed by Terraform",
 			},
 			"owner_id": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_ebs_snapshot_copy.go
+++ b/aws/resource_aws_ebs_snapshot_copy.go
@@ -26,6 +26,7 @@ func resourceAwsEbsSnapshotCopy() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Default:  "Managed by Terraform",
 			},
 			"owner_id": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_ec2_transit_gateway.go
+++ b/aws/resource_aws_ec2_transit_gateway.go
@@ -71,6 +71,7 @@ func resourceAwsEc2TransitGateway() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Default:  "Managed by Terraform",
 			},
 			"dns_support": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_elastic_transcoder_preset.go
+++ b/aws/resource_aws_elastic_transcoder_preset.go
@@ -103,6 +103,7 @@ func resourceAwsElasticTranscoderPreset() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Default:  "Managed by Terraform",
 			},
 
 			"name": {

--- a/aws/resource_aws_lambda_layer_version.go
+++ b/aws/resource_aws_lambda_layer_version.go
@@ -71,6 +71,7 @@ func resourceAwsLambdaLayerVersion() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Default:  "Managed by Terraform",
 			},
 			"license_info": {
 				Type:         schema.TypeString,

--- a/aws/resource_aws_msk_configuration.go
+++ b/aws/resource_aws_msk_configuration.go
@@ -28,6 +28,7 @@ func resourceAwsMskConfiguration() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Default:  "Managed by Terraform",
 			},
 			"kafka_versions": {
 				Type:     schema.TypeSet,

--- a/aws/resource_aws_redshift_snapshot_schedule.go
+++ b/aws/resource_aws_redshift_snapshot_schedule.go
@@ -45,6 +45,7 @@ func resourceAwsRedshiftSnapshotSchedule() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Default:  "Managed by Terraform",
 			},
 			"definitions": {
 				Type:     schema.TypeSet,

--- a/aws/resource_aws_service_discovery_http_namespace.go
+++ b/aws/resource_aws_service_discovery_http_namespace.go
@@ -31,6 +31,7 @@ func resourceAwsServiceDiscoveryHttpNamespace() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Default:  "Managed by Terraform",
 			},
 			"arn": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_service_discovery_private_dns_namespace.go
+++ b/aws/resource_aws_service_discovery_private_dns_namespace.go
@@ -25,6 +25,7 @@ func resourceAwsServiceDiscoveryPrivateDnsNamespace() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Default:  "Managed by Terraform",
 			},
 			"vpc": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_service_discovery_public_dns_namespace.go
+++ b/aws/resource_aws_service_discovery_public_dns_namespace.go
@@ -30,6 +30,7 @@ func resourceAwsServiceDiscoveryPublicDnsNamespace() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Default:  "Managed by Terraform",
 			},
 			"arn": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_ssm_activation.go
+++ b/aws/resource_aws_ssm_activation.go
@@ -28,6 +28,7 @@ func resourceAwsSsmActivation() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Default:  "Managed by Terraform",
 			},
 			"expired": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_swf_domain.go
+++ b/aws/resource_aws_swf_domain.go
@@ -40,6 +40,7 @@ func resourceAwsSwfDomain() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Default:  "Managed by Terraform",
 			},
 			"workflow_execution_retention_period_in_days": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
Unify description to match other resources https://github.com/terraform-providers/terraform-provider-aws/search?l=Go&q=%22Managed+by+Terraform%22 . 

I suppose AWS should review all Terraform resources for AWS and standardize the use of the "Description" field.

Copy of suraj-rajan/terraform-provider-aws#1
