### PR TITLE
resource/aws_ssm_parameter: Enable to change type from SecureString to String

### DIFF
--- a/aws/resource_aws_ssm_parameter.go
+++ b/aws/resource_aws_ssm_parameter.go
@@ -211,7 +211,7 @@ func resourceAwsSsmParameterPut(d *schema.ResourceData, meta interface{}) error 
 		paramInput.Description = aws.String(n.(string))
 	}
 
-	if keyID, ok := d.GetOk("key_id"); ok {
+	if keyID, ok := d.GetOk("key_id"); d.Get("type") == "SecureString" && ok {
 		log.Printf("[DEBUG] Setting key_id for SSM Parameter %v: %s", d.Get("name"), keyID)
 		paramInput.SetKeyId(keyID.(string))
 	}

--- a/aws/resource_aws_ssm_parameter_test.go
+++ b/aws/resource_aws_ssm_parameter_test.go
@@ -170,6 +170,36 @@ func TestAccAWSSSMParameter_updateTags(t *testing.T) {
 	})
 }
 
+func TestAccAWSSSMParameter_updateType(t *testing.T) {
+	var param ssm.Parameter
+	name := fmt.Sprintf("%s_%s", t.Name(), acctest.RandString(10))
+	resourceName := "aws_ssm_parameter.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMParameterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMParameterBasicConfig(name, "SecureString", "test2"),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"overwrite"},
+			},
+			{
+				Config: testAccAWSSSMParameterBasicConfigTypeUpdated(name, "String", "test2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMParameterExists(resourceName, &param),
+					resource.TestCheckResourceAttr(resourceName, "type", "String"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSSSMParameter_updateDescription(t *testing.T) {
 	var param ssm.Parameter
 	name := fmt.Sprintf("%s_%s", t.Name(), acctest.RandString(10))
@@ -481,6 +511,20 @@ resource "aws_ssm_parameter" "test" {
   tags = {
     Name       = "My Parameter Updated"
     AnotherTag = "AnotherTagValue"
+  }
+}
+`, rName, pType, value)
+}
+
+func testAccAWSSSMParameterBasicConfigTypeUpdated(rName, pType, value string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_parameter" "test" {
+  name  = "%s"
+  type  = "%s"
+  value = "%s"
+
+  tags = {
+    Name = "My Parameter"
   }
 }
 `, rName, pType, value)


### PR DESCRIPTION
Fix #9843. Enable to change ssm parameter `type` from `SecureString` to `String` .

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #9843

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_ssm_parameter: Enable to change type from SecureString to String
```

Output from acceptance testing:

```
❯ make testacc TEST=./aws TESTARGS='-run=TestAccAWSSSMParameter_updateType'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSSMParameter_updateType -timeout 120m
=== RUN   TestAccAWSSSMParameter_updateType
=== PAUSE TestAccAWSSSMParameter_updateType
=== CONT  TestAccAWSSSMParameter_updateType
--- PASS: TestAccAWSSSMParameter_updateType (60.92s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       60.964s
```
