### PR TITLE
Adds test/docs to confirm current behavior re iam_role name omission

### DIFF
--- a/aws/resource_aws_iam_role_test.go
+++ b/aws/resource_aws_iam_role_test.go
@@ -252,6 +252,29 @@ func TestAccAWSIAMRole_testNameChange(t *testing.T) {
 	})
 }
 
+func TestAccAWSIAMRole_testNameOmission(t *testing.T) {
+	rName := acctest.RandString(10)
+	resourceName := "aws_iam_role.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				ResourceName: resourceName,
+				Config:       testAccAWSIAMRoleConfigNameSupplied(rName),
+			},
+			{
+				ResourceName:       resourceName,
+				Config:             testAccAWSIAMRoleConfigNameOmitted(),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 func TestAccAWSIAMRole_badJSON(t *testing.T) {
 	rName := acctest.RandString(10)
 
@@ -636,6 +659,23 @@ resource "aws_iam_role" "test" {
   assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"ec2.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
 }
 `, rName)
+}
+
+func testAccAWSIAMRoleConfigNameSupplied(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+	name               = "test-role-%s"
+	assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"ec2.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
+}
+`, rName)
+}
+
+func testAccAWSIAMRoleConfigNameOmitted() string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"ec2.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
+}
+`)
 }
 
 func testAccAWSIAMRoleConfigWithDescription(rName string) string {

--- a/website/docs/r/iam_role.html.markdown
+++ b/website/docs/r/iam_role.html.markdown
@@ -44,7 +44,7 @@ EOF
 
 The following arguments are supported:
 
-* `name` - (Optional, Forces new resource) The name of the role. If omitted, Terraform will assign a random, unique name.
+* `name` - (Optional, Forces new resource) The name of the role. If omitted and a new resource, Terraform will assign a random, unique name. If omitted and an existing resource, Terraform will ignore this attribute.
 * `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `assume_role_policy` - (Required) The policy that grants an entity permission to assume the role.
 


### PR DESCRIPTION
It was my expectation that removing the name from an aws_iam_role resource would result in terraform generating a new random name for this resource and forcing a replacement of this resource. This test confirms that this is not the case currently. Whether this is desired behavior or not, I don't know. I can only add this test in an effort to preserve this behavior.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
NONE
```

Output from acceptance testing:

```
$ AWS_PROFILE=jpd make testacc TEST=./aws TESTARGS='-run=TestAccAWSIAMRole_testNameOmission'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSIAMRole_testNameOmission -timeout 120m
=== RUN   TestAccAWSIAMRole_testNameOmission
=== PAUSE TestAccAWSIAMRole_testNameOmission
=== CONT  TestAccAWSIAMRole_testNameOmission
--- PASS: TestAccAWSIAMRole_testNameOmission (19.16s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	20.815s
```
