### PR TITLE
Fix validate docdb instance identifier limit

### DIFF
--- a/aws/validators.go
+++ b/aws/validators.go
@@ -288,11 +288,11 @@ func validateDbParamGroupNamePrefix(v interface{}, k string) (ws []string, error
 
 func validateDocDBIdentifier(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	if !regexp.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(value) {
+	if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"only lowercase alphanumeric characters and hyphens allowed in %q", k))
 	}
-	if !regexp.MustCompile(`^[A-Za-z]`).MatchString(value) {
+	if !regexp.MustCompile(`^[a-z]`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"first character of %q must be a letter", k))
 	}
@@ -306,7 +306,7 @@ func validateDocDBIdentifier(v interface{}, k string) (ws []string, errors []err
 	}
 	if len(value) > 63 {
 		errors = append(errors, fmt.Errorf(
-			"parameter group %q cannot be greater than 63 characters", k))
+			"%q cannot be greater than 63 characters", k))
 	}
 	return
 }

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -288,11 +288,11 @@ func validateDbParamGroupNamePrefix(v interface{}, k string) (ws []string, error
 
 func validateDocDBIdentifier(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
+	if !regexp.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"only lowercase alphanumeric characters and hyphens allowed in %q", k))
 	}
-	if !regexp.MustCompile(`^[a-z]`).MatchString(value) {
+	if !regexp.MustCompile(`^[A-Za-z]`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"first character of %q must be a letter", k))
 	}
@@ -303,6 +303,10 @@ func validateDocDBIdentifier(v interface{}, k string) (ws []string, errors []err
 	if regexp.MustCompile(`-$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"%q cannot end with a hyphen", k))
+	}
+	if len(value) > 63 {
+		errors = append(errors, fmt.Errorf(
+			"parameter group %q cannot be greater than 63 characters", k))
 	}
 	return
 }

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -1408,7 +1408,7 @@ func TestValidateDocDBIdentifier(t *testing.T) {
 		"a",
 		"hello-world",
 		"hello-world-0123456789",
-		strings.Repeat("W", 63),
+		strings.Repeat("w", 63),
 	}
 	for _, v := range validNames {
 		_, errors := validateDocDBIdentifier(v, "name")

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -1403,6 +1403,37 @@ func TestValidateApiGatewayUsagePlanQuotaSettings(t *testing.T) {
 	}
 }
 
+func TestValidateDocDBIdentifier(t *testing.T) {
+	validNames := []string{
+		"a",
+		"hello-world",
+		"hello-world-0123456789",
+	}
+	for _, v := range validNames {
+		_, errors := validateDocDBIdentifier(v, "name")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid DocDB Identifier: %q", v, errors)
+		}
+	}
+
+	invalidNames := []string{
+		"",
+		"special@character",
+		"slash/in-the-middle",
+		"dot.in-the-middle",
+		"two-hyphen--in-the-middle",
+		"0-first-numeric",
+		"-first-hyphen",
+		"end-hyphen-",
+	}
+	for _, v := range invalidNames {
+		_, errors := validateDocDBIdentifier(v, "name")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid DocDB Identifier", v)
+		}
+	}
+}
+
 func TestValidateElbName(t *testing.T) {
 	validNames := []string{
 		"tf-test-elb",

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -1408,6 +1408,7 @@ func TestValidateDocDBIdentifier(t *testing.T) {
 		"a",
 		"hello-world",
 		"hello-world-0123456789",
+		strings.Repeat("W", 63),
 	}
 	for _, v := range validNames {
 		_, errors := validateDocDBIdentifier(v, "name")
@@ -1425,6 +1426,7 @@ func TestValidateDocDBIdentifier(t *testing.T) {
 		"0-first-numeric",
 		"-first-hyphen",
 		"end-hyphen-",
+		strings.Repeat("W", 64),
 	}
 	for _, v := range invalidNames {
 		_, errors := validateDocDBIdentifier(v, "name")


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Changes proposed in this pull request:
- Changes were made because the restrictions described in https://docs.aws.amazon.com/documentdb/latest/developerguide/limits.html#limits.naming differ from the validation content


Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestValidateDocDBIdentifier'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestValidateDocDBIdentifier -timeout 120m
=== RUN   TestValidateDocDBIdentifier
--- PASS: TestValidateDocDBIdentifier (0.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	0.020s
```
