### PR TITLE
Feature/refactor tagging code to use keyvaluetags for aws eip resource

### DIFF
--- a/aws/resource_aws_eip.go
+++ b/aws/resource_aws_eip.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsEip() *schema.Resource {
@@ -141,9 +142,9 @@ func resourceAwsEipCreate(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[INFO] EIP ID: %s (domain: %v)", d.Id(), *allocResp.Domain)
 
-	if _, ok := d.GetOk("tags"); ok {
-		if err := setTags(ec2conn, d); err != nil {
-			return fmt.Errorf("Error creating EIP tags: %s", err)
+	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
+		if err := keyvaluetags.Ec2UpdateTags(ec2conn, d.Id(), nil, v); err != nil {
+			return fmt.Errorf("error adding tags: %s", err)
 		}
 	}
 
@@ -272,7 +273,9 @@ func resourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 		d.SetId(*address.AllocationId)
 	}
 
-	d.Set("tags", tagsToMap(address.Tags))
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(address.Tags).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
 
 	return nil
 }
@@ -355,9 +358,10 @@ func resourceAwsEipUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	if _, ok := d.GetOk("tags"); ok {
-		if err := setTags(ec2conn, d); err != nil {
-			return fmt.Errorf("Error updating EIP tags: %s", err)
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+		if err := keyvaluetags.Ec2UpdateTags(ec2conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("error updating EIP (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/aws/resource_aws_eip_test.go
+++ b/aws/resource_aws_eip_test.go
@@ -912,6 +912,10 @@ resource "aws_eip" "test" {
 `
 
 const testAccAWSEIPNetworkInterfaceConfig = `
+data "aws_availability_zones" "available" {
+	state = "available"
+}
+
 resource "aws_vpc" "test" {
 	cidr_block = "10.0.0.0/24"
 	tags = {
@@ -925,7 +929,7 @@ resource "aws_internet_gateway" "test" {
 
 resource "aws_subnet" "test" {
   vpc_id = "${aws_vpc.test.id}"
-  availability_zone = "us-west-2a"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
   cidr_block = "10.0.0.0/24"
   tags = {
 	Name = "tf-acc-eip-network-interface"
@@ -946,6 +950,10 @@ resource "aws_eip" "test" {
 `
 
 const testAccAWSEIPMultiNetworkInterfaceConfig = `
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+  
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/24"
 	tags = {
@@ -959,7 +967,7 @@ resource "aws_internet_gateway" "test" {
 
 resource "aws_subnet" "test" {
   vpc_id            = "${aws_vpc.test.id}"
-  availability_zone = "us-west-2a"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
   cidr_block        = "10.0.0.0/24"
   tags = {
 	Name = "tf-acc-eip-multi-network-interface"
@@ -1011,6 +1019,10 @@ data "aws_ami" "amzn-ami-minimal-pv" {
   }
 }
 
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_eip" "test" {
   count    = "${var.server_count}"
   instance = "${element(aws_instance.example.*.id, count.index)}"
@@ -1023,8 +1035,8 @@ resource "aws_instance" "example" {
   ami                         = "${data.aws_ami.amzn-ami-minimal-pv.id}"
   instance_type               = "m1.small"
   associate_public_ip_address = true
-  subnet_id                   = "${aws_subnet.us-east-1b-public.id}"
-  availability_zone           = "${aws_subnet.us-east-1b-public.availability_zone}"
+  subnet_id                   = "${aws_subnet.us-east-1-0-public.id}"
+  availability_zone           = "${aws_subnet.us-east-1-0-public.availability_zone}"
 
   tags = {
     Name = "testAccAWSEIP_classic_disassociate"
@@ -1046,11 +1058,11 @@ resource "aws_internet_gateway" "example" {
   vpc_id = "${aws_vpc.example.id}"
 }
 
-resource "aws_subnet" "us-east-1b-public" {
+resource "aws_subnet" "us-east-1-0-public" {
   vpc_id = "${aws_vpc.example.id}"
 
   cidr_block        = "10.0.0.0/24"
-  availability_zone = "us-east-1b"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
   tags = {
     Name = "tf-acc-eip-classic-disassociate"
   }
@@ -1065,8 +1077,8 @@ resource "aws_route_table" "us-east-1-public" {
   }
 }
 
-resource "aws_route_table_association" "us-east-1b-public" {
-  subnet_id      = "${aws_subnet.us-east-1b-public.id}"
+resource "aws_route_table_association" "us-east-1-0-public" {
+  subnet_id      = "${aws_subnet.us-east-1-0-public.id}"
   route_table_id = "${aws_route_table.us-east-1-public.id}"
 }
 `, rootDeviceType)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10688

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEIP_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEIP_ -timeout 120m
=== RUN   TestAccAWSEIP_Ec2Classic
=== PAUSE TestAccAWSEIP_Ec2Classic
=== RUN   TestAccAWSEIP_basic
=== PAUSE TestAccAWSEIP_basic
=== RUN   TestAccAWSEIP_instance
=== PAUSE TestAccAWSEIP_instance
=== RUN   TestAccAWSEIP_networkInterface
=== PAUSE TestAccAWSEIP_networkInterface
=== RUN   TestAccAWSEIP_twoEIPsOneNetworkInterface
=== PAUSE TestAccAWSEIP_twoEIPsOneNetworkInterface
=== RUN   TestAccAWSEIP_associated_user_private_ip
=== PAUSE TestAccAWSEIP_associated_user_private_ip
=== RUN   TestAccAWSEIP_classic_disassociate
=== PAUSE TestAccAWSEIP_classic_disassociate
=== RUN   TestAccAWSEIP_disappears
=== PAUSE TestAccAWSEIP_disappears
=== RUN   TestAccAWSEIP_tags
=== PAUSE TestAccAWSEIP_tags
=== RUN   TestAccAWSEIP_PublicIpv4Pool_default
=== PAUSE TestAccAWSEIP_PublicIpv4Pool_default
=== RUN   TestAccAWSEIP_PublicIpv4Pool_custom
--- SKIP: TestAccAWSEIP_PublicIpv4Pool_custom (0.00s)
    resource_aws_eip_test.go:439: Environment variable AWS_EC2_EIP_PUBLIC_IPV4_POOL is not set
=== CONT  TestAccAWSEIP_Ec2Classic
=== CONT  TestAccAWSEIP_classic_disassociate
=== CONT  TestAccAWSEIP_associated_user_private_ip
=== CONT  TestAccAWSEIP_twoEIPsOneNetworkInterface
=== CONT  TestAccAWSEIP_basic
=== CONT  TestAccAWSEIP_networkInterface
=== CONT  TestAccAWSEIP_instance
=== CONT  TestAccAWSEIP_PublicIpv4Pool_default
=== CONT  TestAccAWSEIP_tags
=== CONT  TestAccAWSEIP_disappears
--- SKIP: TestAccAWSEIP_Ec2Classic (7.48s)
    provider_test.go:234: This test can only run in EC2 Classic, platforms available in us-east-1: ["VPC"]
--- SKIP: TestAccAWSEIP_classic_disassociate (7.49s)
    provider_test.go:234: This test can only run in EC2 Classic, platforms available in us-east-1: ["VPC"]
--- PASS: TestAccAWSEIP_disappears (28.16s)
--- PASS: TestAccAWSEIP_basic (37.29s)
--- PASS: TestAccAWSEIP_PublicIpv4Pool_default (37.28s)
--- PASS: TestAccAWSEIP_tags (58.16s)
--- PASS: TestAccAWSEIP_networkInterface (88.12s)
--- PASS: TestAccAWSEIP_twoEIPsOneNetworkInterface (89.46s)
--- PASS: TestAccAWSEIP_instance (202.75s)
--- PASS: TestAccAWSEIP_associated_user_private_ip (239.78s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	239.896s
```
