### PR TITLE
r/aws_efs_file_system: Fix crash on empty 'lifecycle_policy'

### DIFF
--- a/aws/resource_aws_efs_file_system.go
+++ b/aws/resource_aws_efs_file_system.go
@@ -103,7 +103,7 @@ func resourceAwsEfsFileSystem() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"transition_to_ia": {
 							Type:     schema.TypeString,
-							Optional: true,
+							Required: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								efs.TransitionToIARulesAfter14Days,
 								efs.TransitionToIARulesAfter30Days,
@@ -186,7 +186,7 @@ func resourceAwsEfsFileSystemCreate(d *schema.ResourceData, meta interface{}) er
 	if hasLifecyclePolicy {
 		_, err := conn.PutLifecycleConfiguration(&efs.PutLifecycleConfigurationInput{
 			FileSystemId:      aws.String(d.Id()),
-			LifecyclePolicies: resourceAwsEfsFileSystemLifecyclePolicy(d.Get("lifecycle_policy").([]interface{})),
+			LifecyclePolicies: expandEfsFileSystemLifecyclePolicies(d.Get("lifecycle_policy").([]interface{})),
 		})
 		if err != nil {
 			return fmt.Errorf("Error creating lifecycle policy for EFS file system %q: %s",
@@ -235,7 +235,7 @@ func resourceAwsEfsFileSystemUpdate(d *schema.ResourceData, meta interface{}) er
 	if d.HasChange("lifecycle_policy") {
 		_, err := conn.PutLifecycleConfiguration(&efs.PutLifecycleConfigurationInput{
 			FileSystemId:      aws.String(d.Id()),
-			LifecyclePolicies: resourceAwsEfsFileSystemLifecyclePolicy(d.Get("lifecycle_policy").([]interface{})),
+			LifecyclePolicies: expandEfsFileSystemLifecyclePolicies(d.Get("lifecycle_policy").([]interface{})),
 		})
 		if err != nil {
 			return fmt.Errorf("Error updating lifecycle policy for EFS file system %q: %s",
@@ -344,8 +344,8 @@ func resourceAwsEfsFileSystemRead(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error describing lifecycle configuration for EFS file system (%s): %s",
 			aws.StringValue(fs.FileSystemId), err)
 	}
-	if err := resourceAwsEfsFileSystemSetLifecyclePolicy(d, res.LifecyclePolicies); err != nil {
-		return err
+	if err := d.Set("lifecycle_policy", flattenEfsFileSystemLifecyclePolicies(res.LifecyclePolicies)); err != nil {
+		return fmt.Errorf("error setting lifecycle_policy: %s", err)
 	}
 
 	return nil
@@ -431,36 +431,38 @@ func resourceEfsFileSystemCreateUpdateRefreshFunc(id string, conn *efs.EFS) reso
 	}
 }
 
-func resourceAwsEfsFileSystemSetLifecyclePolicy(d *schema.ResourceData, lp []*efs.LifecyclePolicy) error {
-	log.Printf("[DEBUG] lifecycle pols: %s %d", lp, len(lp))
-	if len(lp) == 0 {
-		d.Set("lifecycle_policy", nil)
-		return nil
-	}
-	newLP := make([]*map[string]interface{}, len(lp))
+func expandEfsFileSystemLifecyclePolicies(vLifecyclePolicies []interface{}) []*efs.LifecyclePolicy {
+	lifecyclePolicies := []*efs.LifecyclePolicy{}
 
-	for i := 0; i < len(lp); i++ {
-		config := lp[i]
-		data := make(map[string]interface{})
-		newLP[i] = &data
-		if config.TransitionToIA != nil {
-			data["transition_to_ia"] = *config.TransitionToIA
+	for _, vLifecyclePolicy := range vLifecyclePolicies {
+		if vLifecyclePolicy == nil {
+			continue
 		}
-		log.Printf("[DEBUG] lp: %s", data)
+
+		lifecyclePolicy := &efs.LifecyclePolicy{}
+
+		mLifecyclePolicy := vLifecyclePolicy.(map[string]interface{})
+
+		if vTransitionToIA, ok := mLifecyclePolicy["transition_to_ia"].(string); ok && vTransitionToIA != "" {
+			lifecyclePolicy.TransitionToIA = aws.String(vTransitionToIA)
+		}
+
+		lifecyclePolicies = append(lifecyclePolicies, lifecyclePolicy)
 	}
 
-	if err := d.Set("lifecycle_policy", newLP); err != nil {
-		return fmt.Errorf("error setting lifecycle_policy: %s", err)
-	}
-	return nil
+	return lifecyclePolicies
 }
 
-func resourceAwsEfsFileSystemLifecyclePolicy(lcPol []interface{}) []*efs.LifecyclePolicy {
-	result := make([]*efs.LifecyclePolicy, len(lcPol))
+func flattenEfsFileSystemLifecyclePolicies(lifecyclePolicies []*efs.LifecyclePolicy) []interface{} {
+	vLifecyclePolicies := []interface{}{}
 
-	for i := 0; i < len(lcPol); i++ {
-		lp := lcPol[i].(map[string]interface{})
-		result[i] = &efs.LifecyclePolicy{TransitionToIA: aws.String(lp["transition_to_ia"].(string))}
+	for _, lifecyclePolicy := range lifecyclePolicies {
+		mLifecyclePolicy := map[string]interface{}{
+			"transition_to_ia": aws.StringValue(lifecyclePolicy.TransitionToIA),
+		}
+
+		vLifecyclePolicies = append(vLifecyclePolicies, mLifecyclePolicy)
 	}
-	return result
+
+	return vLifecyclePolicies
 }

--- a/aws/resource_aws_efs_file_system_test.go
+++ b/aws/resource_aws_efs_file_system_test.go
@@ -378,6 +378,21 @@ func TestAccAWSEFSFileSystem_lifecyclePolicy_removal(t *testing.T) {
 	})
 }
 
+// https://github.com/terraform-providers/terraform-provider-aws/issues/10146
+func TestAccAWSEFSFileSystem_emptyLifecyclePolicy(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckEfsFileSystemDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSEFSFileSystemConfigEmptyLifecyclePolicy,
+				ExpectError: regexp.MustCompile(regexp.QuoteMeta("The argument \"transition_to_ia\" is required, but no definition was found.")),
+			},
+		},
+	})
+}
+
 func testAccCheckEfsFileSystemDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).efsconn
 	for _, rs := range s.RootModule().Resources {
@@ -651,4 +666,10 @@ resource "aws_efs_file_system" "test" {
 
 const testAccAWSEFSFileSystemConfigRemovedLifecyclePolicy = `
 resource "aws_efs_file_system" "test" {}
+`
+
+const testAccAWSEFSFileSystemConfigEmptyLifecyclePolicy = `
+resource "aws_efs_file_system" "test" {
+  lifecycle_policy {}
+}
 `


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/10146.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_efs_file_system: Disallow empty `lifecycle_policy`
```

Output from acceptance testing:

```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEFSFileSystem_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEFSFileSystem_ -timeout 120m
=== RUN   TestAccAWSEFSFileSystem_basic
=== PAUSE TestAccAWSEFSFileSystem_basic
=== RUN   TestAccAWSEFSFileSystem_pagedTags
=== PAUSE TestAccAWSEFSFileSystem_pagedTags
=== RUN   TestAccAWSEFSFileSystem_kmsKey
=== PAUSE TestAccAWSEFSFileSystem_kmsKey
=== RUN   TestAccAWSEFSFileSystem_kmsConfigurationWithoutEncryption
=== PAUSE TestAccAWSEFSFileSystem_kmsConfigurationWithoutEncryption
=== RUN   TestAccAWSEFSFileSystem_ProvisionedThroughputInMibps
=== PAUSE TestAccAWSEFSFileSystem_ProvisionedThroughputInMibps
=== RUN   TestAccAWSEFSFileSystem_ThroughputMode
=== PAUSE TestAccAWSEFSFileSystem_ThroughputMode
=== RUN   TestAccAWSEFSFileSystem_lifecyclePolicy
=== PAUSE TestAccAWSEFSFileSystem_lifecyclePolicy
=== RUN   TestAccAWSEFSFileSystem_lifecyclePolicy_update
=== PAUSE TestAccAWSEFSFileSystem_lifecyclePolicy_update
=== RUN   TestAccAWSEFSFileSystem_lifecyclePolicy_removal
=== PAUSE TestAccAWSEFSFileSystem_lifecyclePolicy_removal
=== RUN   TestAccAWSEFSFileSystem_emptyLifecyclePolicy
=== PAUSE TestAccAWSEFSFileSystem_emptyLifecyclePolicy
=== CONT  TestAccAWSEFSFileSystem_basic
=== CONT  TestAccAWSEFSFileSystem_emptyLifecyclePolicy
=== CONT  TestAccAWSEFSFileSystem_lifecyclePolicy_removal
=== CONT  TestAccAWSEFSFileSystem_lifecyclePolicy_update
=== CONT  TestAccAWSEFSFileSystem_lifecyclePolicy
=== CONT  TestAccAWSEFSFileSystem_ThroughputMode
=== CONT  TestAccAWSEFSFileSystem_ProvisionedThroughputInMibps
=== CONT  TestAccAWSEFSFileSystem_kmsConfigurationWithoutEncryption
=== CONT  TestAccAWSEFSFileSystem_kmsKey
=== CONT  TestAccAWSEFSFileSystem_pagedTags
--- PASS: TestAccAWSEFSFileSystem_emptyLifecyclePolicy (2.99s)
--- PASS: TestAccAWSEFSFileSystem_kmsConfigurationWithoutEncryption (35.72s)
--- PASS: TestAccAWSEFSFileSystem_lifecyclePolicy_update (66.62s)
--- PASS: TestAccAWSEFSFileSystem_lifecyclePolicy (72.84s)
--- PASS: TestAccAWSEFSFileSystem_ProvisionedThroughputInMibps (83.46s)
--- PASS: TestAccAWSEFSFileSystem_ThroughputMode (84.15s)
--- PASS: TestAccAWSEFSFileSystem_kmsKey (86.75s)
--- PASS: TestAccAWSEFSFileSystem_pagedTags (93.72s)
--- PASS: TestAccAWSEFSFileSystem_lifecyclePolicy_removal (94.32s)
--- PASS: TestAccAWSEFSFileSystem_basic (110.86s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	110.901s
```
