### PR TITLE
docs - Minor copy style fixes on acm_certificate

### DIFF
--- a/website/docs/r/acm_certificate.html.markdown
+++ b/website/docs/r/acm_certificate.html.markdown
@@ -20,7 +20,7 @@ Most commonly, this resource is used to together with [`aws_route53_record`](rou
 [`aws_acm_certificate_validation`](acm_certificate_validation.html) to request a DNS validated certificate,
 deploy the required validation records and wait for validation to complete.
 
-Domain validation through E-Mail is also supported but should be avoided as it requires a manual step outside
+Domain validation through e-mail is also supported but should be avoided as it requires a manual step outside
 of Terraform.
 
 It's recommended to specify `create_before_destroy = true` in a [lifecycle][1] block to replace a certificate
@@ -45,7 +45,7 @@ resource "aws_acm_certificate" "cert" {
 }
 ```
 
-### Importation of existing certificate
+### Importing an existing certificate
 
 ```hcl
 resource "tls_private_key" "example" {

--- a/website/docs/r/acm_certificate.html.markdown
+++ b/website/docs/r/acm_certificate.html.markdown
@@ -20,7 +20,7 @@ Most commonly, this resource is used to together with [`aws_route53_record`](rou
 [`aws_acm_certificate_validation`](acm_certificate_validation.html) to request a DNS validated certificate,
 deploy the required validation records and wait for validation to complete.
 
-Domain validation through e-mail is also supported but should be avoided as it requires a manual step outside
+Domain validation through email is also supported but should be avoided as it requires a manual step outside
 of Terraform.
 
 It's recommended to specify `create_before_destroy = true` in a [lifecycle][1] block to replace a certificate


### PR DESCRIPTION
Looking at the [docs](https://www.terraform.io/docs/providers/aws/r/acm_certificate.html) found a couple of small style suggestions I wanted to make:

- `e-mail` is [more commonly styled](https://en.wikipedia.org/wiki/Email#Terminology) lowercase
- `Importation of` refers to goods crossing borders, let's use `Importing a` instead 

Hope it's okay I'm not posting acceptance testing results, doing this from a computer with an old go version I'm currently unable to change.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
update aws_acm_certificate documentation
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
aws/internal/keyvaluetags/update_tags_gen.go:2892:11: Errorf format %w has unknown verb w
...
many of the above
...
# github.com/terraform-providers/terraform-provider-aws/aws
aws/awserr.go:18:5: undefined: errors.As
note: module requires Go 1.13
...
```
