### PR TITLE
refactor tagging code to use keyvaluetags for aws rds cluster resources

### DIFF
--- a/aws/resource_aws_rds_cluster_instance.go
+++ b/aws/resource_aws_rds_cluster_instance.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsRDSClusterInstance() *schema.Resource {
@@ -213,7 +214,6 @@ func resourceAwsRDSClusterInstance() *schema.Resource {
 
 func resourceAwsRDSClusterInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).rdsconn
-	tags := tagsFromMapRDS(d.Get("tags").(map[string]interface{}))
 
 	createOpts := &rds.CreateDBInstanceInput{
 		DBInstanceClass:         aws.String(d.Get("instance_class").(string)),
@@ -223,7 +223,7 @@ func resourceAwsRDSClusterInstanceCreate(d *schema.ResourceData, meta interface{
 		PubliclyAccessible:      aws.Bool(d.Get("publicly_accessible").(bool)),
 		PromotionTier:           aws.Int64(int64(d.Get("promotion_tier").(int))),
 		AutoMinorVersionUpgrade: aws.Bool(d.Get("auto_minor_version_upgrade").(bool)),
-		Tags:                    tags,
+		Tags:                    keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().RdsTags(),
 	}
 
 	if attr, ok := d.GetOk("availability_zone"); ok {
@@ -396,8 +396,12 @@ func resourceAwsRDSClusterInstanceRead(d *schema.ResourceData, meta interface{})
 		d.Set("db_parameter_group_name", db.DBParameterGroups[0].DBParameterGroupName)
 	}
 
-	if err := saveTagsRDS(conn, d, aws.StringValue(db.DBInstanceArn)); err != nil {
-		log.Printf("[WARN] Failed to save tags for RDS Cluster Instance (%s): %s", *db.DBClusterIdentifier, err)
+	tags, err := keyvaluetags.RdsListTags(conn, aws.StringValue(db.DBInstanceArn))
+	if err != nil {
+		return fmt.Errorf("error listing tags for RDS Cluster Instance (%s): %s", d.Id(), err)
+	}
+	if err := d.Set("tags", tags.IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
 	}
 
 	return nil
@@ -520,8 +524,12 @@ func resourceAwsRDSClusterInstanceUpdate(d *schema.ResourceData, meta interface{
 
 	}
 
-	if err := setTagsRDS(conn, d, d.Get("arn").(string)); err != nil {
-		return err
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.RdsUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating RDS Cluster Instance (%s) tags: %s", d.Id(), err)
+		}
 	}
 
 	return resourceAwsRDSClusterInstanceRead(d, meta)

--- a/aws/resource_aws_rds_cluster_parameter_group.go
+++ b/aws/resource_aws_rds_cluster_parameter_group.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 const rdsClusterParameterGroupMaxParamsBulkEdit = 20
@@ -88,7 +89,6 @@ func resourceAwsRDSClusterParameterGroup() *schema.Resource {
 
 func resourceAwsRDSClusterParameterGroupCreate(d *schema.ResourceData, meta interface{}) error {
 	rdsconn := meta.(*AWSClient).rdsconn
-	tags := tagsFromMapRDS(d.Get("tags").(map[string]interface{}))
 
 	var groupName string
 	if v, ok := d.GetOk("name"); ok {
@@ -103,7 +103,7 @@ func resourceAwsRDSClusterParameterGroupCreate(d *schema.ResourceData, meta inte
 		DBClusterParameterGroupName: aws.String(groupName),
 		DBParameterGroupFamily:      aws.String(d.Get("family").(string)),
 		Description:                 aws.String(d.Get("description").(string)),
-		Tags:                        tags,
+		Tags:                        keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().RdsTags(),
 	}
 
 	log.Printf("[DEBUG] Create DB Cluster Parameter Group: %#v", createOpts)
@@ -170,11 +170,9 @@ func resourceAwsRDSClusterParameterGroupRead(d *schema.ResourceData, meta interf
 		log.Printf("[DEBUG] Error retrieving tags for ARN: %s", arn)
 	}
 
-	var dt []*rds.Tag
-	if len(resp.TagList) > 0 {
-		dt = resp.TagList
+	if err := d.Set("tags", keyvaluetags.RdsKeyValueTags(resp.TagList).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
 	}
-	d.Set("tags", tagsToMapRDS(dt))
 
 	return nil
 }
@@ -228,9 +226,12 @@ func resourceAwsRDSClusterParameterGroupUpdate(d *schema.ResourceData, meta inte
 		}
 	}
 
-	if err := setTagsRDS(rdsconn, d, d.Get("arn").(string)); err != nil {
-		return err
-	} else {
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.RdsUpdateTags(rdsconn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating RDS Cluster Parameter Group (%s) tags: %s", d.Id(), err)
+		}
 		d.SetPartial("tags")
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10688

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

- `aws_rds_cluster_instance`

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSRDSClusterInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSRDSClusterInstance_basic -timeout 120m
=== RUN   TestAccAWSRDSClusterInstance_basic
=== PAUSE TestAccAWSRDSClusterInstance_basic
=== CONT  TestAccAWSRDSClusterInstance_basic
--- PASS: TestAccAWSRDSClusterInstance_basic (1137.77s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1137.856s
```

- `aws_rds_cluster_parameter_group`

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDBClusterParameterGroup_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDBClusterParameterGroup_ -timeout 120m
=== RUN   TestAccAWSDBClusterParameterGroup_basic
=== PAUSE TestAccAWSDBClusterParameterGroup_basic
=== RUN   TestAccAWSDBClusterParameterGroup_withApplyMethod
=== PAUSE TestAccAWSDBClusterParameterGroup_withApplyMethod
=== RUN   TestAccAWSDBClusterParameterGroup_namePrefix
=== PAUSE TestAccAWSDBClusterParameterGroup_namePrefix
=== RUN   TestAccAWSDBClusterParameterGroup_namePrefix_Parameter
=== PAUSE TestAccAWSDBClusterParameterGroup_namePrefix_Parameter
=== RUN   TestAccAWSDBClusterParameterGroup_generatedName
=== PAUSE TestAccAWSDBClusterParameterGroup_generatedName
=== RUN   TestAccAWSDBClusterParameterGroup_generatedName_Parameter
=== PAUSE TestAccAWSDBClusterParameterGroup_generatedName_Parameter
=== RUN   TestAccAWSDBClusterParameterGroup_disappears
=== PAUSE TestAccAWSDBClusterParameterGroup_disappears
=== RUN   TestAccAWSDBClusterParameterGroup_only
=== PAUSE TestAccAWSDBClusterParameterGroup_only
=== CONT  TestAccAWSDBClusterParameterGroup_basic
=== CONT  TestAccAWSDBClusterParameterGroup_generatedName_Parameter
=== CONT  TestAccAWSDBClusterParameterGroup_only
=== CONT  TestAccAWSDBClusterParameterGroup_disappears
=== CONT  TestAccAWSDBClusterParameterGroup_namePrefix_Parameter
=== CONT  TestAccAWSDBClusterParameterGroup_generatedName
=== CONT  TestAccAWSDBClusterParameterGroup_namePrefix
=== CONT  TestAccAWSDBClusterParameterGroup_withApplyMethod
--- PASS: TestAccAWSDBClusterParameterGroup_disappears (29.47s)
--- PASS: TestAccAWSDBClusterParameterGroup_only (38.25s)
--- PASS: TestAccAWSDBClusterParameterGroup_generatedName (38.63s)
--- PASS: TestAccAWSDBClusterParameterGroup_namePrefix (39.50s)
--- PASS: TestAccAWSDBClusterParameterGroup_generatedName_Parameter (39.62s)
--- PASS: TestAccAWSDBClusterParameterGroup_namePrefix_Parameter (39.91s)
--- PASS: TestAccAWSDBClusterParameterGroup_withApplyMethod (41.82s)
--- PASS: TestAccAWSDBClusterParameterGroup_basic (65.17s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	65.279s
```