### PR TITLE
fix to use keyvaluetags in aws_route53_resolver_endpoint and aws_rout…

### DIFF
--- a/aws/resource_aws_route53_resolver_endpoint.go
+++ b/aws/resource_aws_route53_resolver_endpoint.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 const (
@@ -115,7 +116,7 @@ func resourceAwsRoute53ResolverEndpointCreate(d *schema.ResourceData, meta inter
 		req.Name = aws.String(v.(string))
 	}
 	if v, ok := d.GetOk("tags"); ok && len(v.(map[string]interface{})) > 0 {
-		req.Tags = tagsFromMapRoute53Resolver(v.(map[string]interface{}))
+		req.Tags = keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().Route53resolverTags()
 	}
 
 	log.Printf("[DEBUG] Creating Route53 Resolver endpoint: %#v", req)
@@ -179,8 +180,14 @@ func resourceAwsRoute53ResolverEndpointRead(d *schema.ResourceData, meta interfa
 		return err
 	}
 
-	if err := getTagsRoute53Resolver(conn, d); err != nil {
-		return fmt.Errorf("error getting Route53 Resolver endpoint (%s) tags: %s", d.Id(), err)
+	tags, err := keyvaluetags.Route53resolverListTags(conn, d.Get("arn").(string))
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for Route53 Resolver endpoint (%s): %s", d.Get("arn").(string), err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
 	}
 
 	return nil
@@ -257,10 +264,13 @@ func resourceAwsRoute53ResolverEndpointUpdate(d *schema.ResourceData, meta inter
 		d.SetPartial("ip_address")
 	}
 
-	if err := setTagsRoute53Resolver(conn, d); err != nil {
-		return fmt.Errorf("error setting Route53 Resolver endpoint (%s) tags: %s", d.Id(), err)
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+		if err := keyvaluetags.Route53resolverUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating Route53 Resolver endpoint (%s) tags: %s", d.Get("arn").(string), err)
+		}
+		d.SetPartial("tags")
 	}
-	d.SetPartial("tags")
 
 	d.Partial(false)
 	return resourceAwsRoute53ResolverEndpointRead(d, meta)

--- a/aws/resource_aws_route53_resolver_rule.go
+++ b/aws/resource_aws_route53_resolver_rule.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"bytes"
 	"fmt"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 	"log"
 	"time"
 
@@ -126,7 +127,7 @@ func resourceAwsRoute53ResolverRuleCreate(d *schema.ResourceData, meta interface
 		req.TargetIps = expandRoute53ResolverRuleTargetIps(v.(*schema.Set))
 	}
 	if v, ok := d.GetOk("tags"); ok && len(v.(map[string]interface{})) > 0 {
-		req.Tags = tagsFromMapRoute53Resolver(v.(map[string]interface{}))
+		req.Tags = keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().Route53resolverTags()
 	}
 
 	log.Printf("[DEBUG] Creating Route 53 Resolver rule: %s", req)
@@ -172,9 +173,14 @@ func resourceAwsRoute53ResolverRuleRead(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	err = getTagsRoute53Resolver(conn, d)
+	tags, err := keyvaluetags.Route53resolverListTags(conn, d.Get("arn").(string))
+
 	if err != nil {
-		return fmt.Errorf("Error reading Route 53 Resolver rule tags %s: %s", d.Id(), err)
+		return fmt.Errorf("error listing tags for Route53 Resolver rule (%s): %s", d.Get("arn").(string), err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
 	}
 
 	return nil
@@ -217,10 +223,13 @@ func resourceAwsRoute53ResolverRuleUpdate(d *schema.ResourceData, meta interface
 		d.SetPartial("target_ip")
 	}
 
-	if err := setTagsRoute53Resolver(conn, d); err != nil {
-		return fmt.Errorf("error setting Route53 Resolver rule (%s) tags: %s", d.Id(), err)
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+		if err := keyvaluetags.Route53resolverUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating Route53 Resolver rule (%s) tags: %s", d.Get("arn").(string), err)
+		}
+		d.SetPartial("tags")
 	}
-	d.SetPartial("tags")
 
 	d.Partial(false)
 	return resourceAwsRoute53ResolverRuleRead(d, meta)

--- a/aws/tagsRoute53Resolver.go
+++ b/aws/tagsRoute53Resolver.go
@@ -37,46 +37,6 @@ func getTagsRoute53Resolver(conn *route53resolver.Route53Resolver, d *schema.Res
 	return nil
 }
 
-// setTags is a helper to set the tags for a resource. It expects the
-// tags field to be named "tags" and the ARN field to be named "arn".
-func setTagsRoute53Resolver(conn *route53resolver.Route53Resolver, d *schema.ResourceData) error {
-	if d.HasChange("tags") {
-		oraw, nraw := d.GetChange("tags")
-		o := oraw.(map[string]interface{})
-		n := nraw.(map[string]interface{})
-		create, remove := diffTagsRoute53Resolver(tagsFromMapRoute53Resolver(o), tagsFromMapRoute53Resolver(n))
-
-		// Set tags
-		if len(remove) > 0 {
-			log.Printf("[DEBUG] Removing tags: %#v", remove)
-			k := make([]*string, len(remove))
-			for i, t := range remove {
-				k[i] = t.Key
-			}
-
-			_, err := conn.UntagResource(&route53resolver.UntagResourceInput{
-				ResourceArn: aws.String(d.Get("arn").(string)),
-				TagKeys:     k,
-			})
-			if err != nil {
-				return err
-			}
-		}
-		if len(create) > 0 {
-			log.Printf("[DEBUG] Creating tags: %#v", create)
-			_, err := conn.TagResource(&route53resolver.TagResourceInput{
-				ResourceArn: aws.String(d.Get("arn").(string)),
-				Tags:        create,
-			})
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
 // diffTags takes our tags locally and the ones remotely and returns
 // the set of tags that must be created, and the set of tags that must
 // be destroyed.


### PR DESCRIPTION
### Community Note
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request
 
Relates #10688
 
Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
 
```
NONE
```

Output from acceptance testing:

* `aws_route53_resolver_endpoint`

```
-> % make testacc TEST=./aws TESTARGS='-run=TestAccAwsRoute53ResolverEndpoint_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsRoute53ResolverEndpoint_ -timeout 120m
=== RUN   TestAccAwsRoute53ResolverEndpoint_basicInbound
=== PAUSE TestAccAwsRoute53ResolverEndpoint_basicInbound
=== RUN   TestAccAwsRoute53ResolverEndpoint_updateOutbound
=== PAUSE TestAccAwsRoute53ResolverEndpoint_updateOutbound
=== CONT  TestAccAwsRoute53ResolverEndpoint_basicInbound
=== CONT  TestAccAwsRoute53ResolverEndpoint_updateOutbound
--- PASS: TestAccAwsRoute53ResolverEndpoint_basicInbound (110.35s)
--- PASS: TestAccAwsRoute53ResolverEndpoint_updateOutbound (431.22s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	431.276s
```

* `aws_route53_resolver_rule`

```
-> % make testacc TEST=./aws TESTARGS='-run=TestAccAwsRoute53ResolverRule_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsRoute53ResolverRule_ -timeout 120m
=== RUN   TestAccAwsRoute53ResolverRule_basic
=== PAUSE TestAccAwsRoute53ResolverRule_basic
=== RUN   TestAccAwsRoute53ResolverRule_tags
=== PAUSE TestAccAwsRoute53ResolverRule_tags
=== RUN   TestAccAwsRoute53ResolverRule_updateName
=== PAUSE TestAccAwsRoute53ResolverRule_updateName
=== RUN   TestAccAwsRoute53ResolverRule_forward
=== PAUSE TestAccAwsRoute53ResolverRule_forward
=== RUN   TestAccAwsRoute53ResolverRule_forwardEndpointRecreate
=== PAUSE TestAccAwsRoute53ResolverRule_forwardEndpointRecreate
=== CONT  TestAccAwsRoute53ResolverRule_basic
=== CONT  TestAccAwsRoute53ResolverRule_forward
=== CONT  TestAccAwsRoute53ResolverRule_updateName
=== CONT  TestAccAwsRoute53ResolverRule_tags
=== CONT  TestAccAwsRoute53ResolverRule_forwardEndpointRecreate
--- PASS: TestAccAwsRoute53ResolverRule_basic (58.61s)
--- PASS: TestAccAwsRoute53ResolverRule_updateName (93.64s)
--- PASS: TestAccAwsRoute53ResolverRule_tags (107.47s)
--- PASS: TestAccAwsRoute53ResolverRule_forward (372.85s)
--- PASS: TestAccAwsRoute53ResolverRule_forwardEndpointRecreate (477.22s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	477.299s
```


