### PR TITLE
data-source/aws_iam_policy_document: support multiple princiapls in iam policy document without dropping some

### DIFF
--- a/aws/data_source_aws_iam_policy_document_test.go
+++ b/aws/data_source_aws_iam_policy_document_test.go
@@ -162,6 +162,24 @@ func TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_Strin
 	})
 }
 
+// Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/10777
+func TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_MultiplePrincipals(t *testing.T) {
+	dataSourceName := "data.aws_iam_policy_document.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSIAMPolicyDocumentConfigStatementPrincipalIdentifiersMultiplePrincipals,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "json", testAccAWSIAMPolicyDocumentExpectedJSONStatementPrincipalIdentifiersMultiplePrincipals),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSDataSourceIAMPolicyDocument_Version_20081017(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -858,6 +876,57 @@ var testAccAWSIAMPolicyDocumentExpectedJSONStatementPrincipalIdentifiersStringAn
           "arn:aws:iam::111111111111:root",
           "arn:aws:iam::333333333333:root",
           "arn:aws:iam::222222222222:root"
+        ]
+      }
+    }
+  ]
+}`
+
+var testAccAWSIAMPolicyDocumentConfigStatementPrincipalIdentifiersMultiplePrincipals = `
+data "aws_iam_policy_document" "test" {
+  statement {
+    actions   = ["*"]
+    resources = ["*"]
+    sid       = "StatementPrincipalIdentifiersStringAndSlice"
+
+    principals {
+      identifiers = [
+        "arn:aws:iam::111111111111:root",
+        "arn:aws:iam::222222222222:root",
+      ]
+      type = "AWS"
+    }
+    principals {
+      identifiers = [
+        "arn:aws:iam::333333333333:root",
+      ]
+      type = "AWS"
+    }
+    principals {
+      identifiers = [
+        "arn:aws:iam::444444444444:root",
+      ]
+      type = "AWS"
+    }
+
+  }
+}
+`
+
+var testAccAWSIAMPolicyDocumentExpectedJSONStatementPrincipalIdentifiersMultiplePrincipals = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "StatementPrincipalIdentifiersStringAndSlice",
+      "Effect": "Allow",
+      "Action": "*",
+      "Resource": "*",
+      "Principal": {
+        "AWS": [
+          "arn:aws:iam::333333333333:root",
+          "arn:aws:iam::444444444444:root",
+          "arn:aws:iam::222222222222:root",
+          "arn:aws:iam::111111111111:root"
         ]
       }
     }

--- a/aws/iam_policy_model.go
+++ b/aws/iam_policy_model.go
@@ -105,7 +105,17 @@ func (ps IAMPolicyStatementPrincipalSet) MarshalJSON() ([]byte, error) {
 			sort.Sort(sort.Reverse(sort.StringSlice(i)))
 			raw[p.Type] = append(raw[p.Type].([]string), i...)
 		case string:
-			raw[p.Type] = i
+			switch v := raw[p.Type].(type) {
+			case nil:
+				raw[p.Type] = i
+			case string:
+				// Convert to []string to stop drop of principals
+				raw[p.Type] = make([]string, 0, 2)
+				raw[p.Type] = append(raw[p.Type].([]string), v)
+				raw[p.Type] = append(raw[p.Type].([]string), i)
+			case []string:
+				raw[p.Type] = append(raw[p.Type].([]string), i)
+			}
 		default:
 			return []byte{}, fmt.Errorf("Unsupported data type %T for IAMPolicyStatementPrincipalSet", i)
 		}


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request


This is a continuation of #10780

```release-note
* data-source/aws_iam_policy_document: Prevent providers from being slightly omitted when multiple principal blocks are set.

```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDataSourceIAMPolicyDocument'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDataSourceIAMPolicyDocument -timeout 120m
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_basic
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_basic
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_source
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_source
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_sourceConflicting
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_sourceConflicting
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_override
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_override
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_noStatementMerge
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_noStatementMerge
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_noStatementOverride
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_noStatementOverride
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_duplicateSid
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_duplicateSid
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_StringAndSlice
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_StringAndSlice
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_MultiplePrincipals
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_MultiplePrincipals
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_Version_20081017
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_Version_20081017
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_basic
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_duplicateSid
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_MultiplePrincipals
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_source
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_override
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_noStatementOverride
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_StringAndSlice
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_noStatementMerge
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_Version_20081017
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_sourceConflicting
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_noStatementOverride (23.40s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_sourceConflicting (23.43s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_MultiplePrincipals (23.50s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_basic (23.51s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_StringAndSlice (23.57s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_noStatementMerge (23.61s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_override (23.62s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_duplicateSid (25.57s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_Version_20081017 (34.58s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_source (37.92s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	37.997s


...
```
