### PR TITLE
aws_vpc_endpoint_service - Use Filter instead of ServiceNames

### DIFF
--- a/aws/data_source_aws_vpc_endpoint_service.go
+++ b/aws/data_source_aws_vpc_endpoint_service.go
@@ -86,7 +86,7 @@ func dataSourceAwsVpcEndpointServiceRead(d *schema.ResourceData, meta interface{
 	}
 
 	req := &ec2.DescribeVpcEndpointServicesInput{
-		ServiceNames: aws.StringSlice([]string{serviceName}),
+		Filters: []*Filter{Name: "service-name", Values: aws.StringSlice(string{serviceName})},
 	}
 
 	log.Printf("[DEBUG] Reading VPC Endpoint Service: %s", req)

--- a/aws/data_source_aws_vpc_endpoint_service.go
+++ b/aws/data_source_aws_vpc_endpoint_service.go
@@ -85,9 +85,12 @@ func dataSourceAwsVpcEndpointServiceRead(d *schema.ResourceData, meta interface{
 			"One of ['service', 'service_name'] must be set to query VPC Endpoint Services")
 	}
 
-	req := &ec2.DescribeVpcEndpointServicesInput{
-		Filters: []*Filter{Name: "service-name", Values: aws.StringSlice(string{serviceName})},
-	}
+	req := &ec2.DescribeVpcEndpointServicesInput{}
+	req.Filters = buildEC2AttributeFilterList(
+		map[string]string{
+			"service-name": serviceName,
+		},
+	)
 
 	log.Printf("[DEBUG] Reading VPC Endpoint Service: %s", req)
 	resp, err := conn.DescribeVpcEndpointServices(req)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
aws_vpc_endpoint_service - Query via Filters for service-names instead of ServiceNames
```

us-east-1 currently fails to have the `s3` service endpoint returned when used in this fashion. This switches the code to using filters which works in us-east-1 and the other regions. 

As of 6:26:30 PM EST on Tuesday, November 12, 2019:
```
❯ aws ec2 describe-vpc-endpoint-services --service-names "com.amazonaws.us-east-1.s3"

An error occurred (InvalidServiceName) when calling the DescribeVpcEndpointServices operation: The Vpc Endpoint Service 'com.amazonaws.us-east-1.s3' does not exist
```

Whereas the filter expression works:
```
❯ aws ec2 describe-vpc-endpoint-services --filter "Name=service-name,Values=com.amazonaws.us-east-1.s3"
{
    "ServiceDetails": [
        {
            "ServiceName": "com.amazonaws.us-east-1.s3",
            "ServiceId": "vpce-svc-1234567890",
            "ServiceType": [
                {
                    "ServiceType": "Gateway"
                }
            ],
            "AvailabilityZones": [
                "us-east-1a",
                "us-east-1b",
                "us-east-1c",
                "us-east-1d",
                "us-east-1e",
                "us-east-1f"
            ],
            "Owner": "amazon",
            "BaseEndpointDnsNames": [
                "s3.us-east-1.amazonaws.com"
            ],
            "VpcEndpointPolicySupported": true,
            "AcceptanceRequired": false,
            "ManagesVpcEndpoints": false,
            "Tags": []
        }
    ],
    "ServiceNames": [
        "com.amazonaws.us-east-1.s3"
    ]
}
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
TODO
```
