### PR TITLE
[documentation] add cloudwatch monitoring for target group and NLB

### DIFF
--- a/website/docs/r/cloudwatch_metric_alarm.html.markdown
+++ b/website/docs/r/cloudwatch_metric_alarm.html.markdown
@@ -109,6 +109,30 @@ resource "aws_cloudwatch_metric_alarm" "foobar" {
 }
 ```
 
+## Example of monitoring Healthy Hosts on NLB using Target Group and NLB
+
+```hcl
+resource "aws_cloudwatch_metric_alarm" "xxx_nlb_healthyhosts" {
+  alarm_name          = "alarmname"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "HealthyHostCount"
+  namespace           = "AWS/NetworkELB"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = var.logstash_servers_count
+  alarm_description   = "Number of XXXX nodes healthy in Target Group"
+  actions_enabled     = "true"
+  alarm_actions       = [aws_sns_topic.sns.arn]
+  ok_actions          = [aws_sns_topic.sns.arn]
+  dimensions = {
+    TargetGroup  = "${aws_lb_target_group.lb-tg.arn_suffix}" 
+    LoadBalancer = "${aws_lb.lb.arn_suffix}"
+  }
+}
+
+```
+
 ~> **NOTE:**  You cannot create a metric alarm consisting of both `statistic` and `extended_statistic` parameters.
 You must choose one or the other
 


### PR DESCRIPTION
add cloudwatch for target group and load balancer.   I could only 1 find good example of how to do this using Google, so thought it would be good to add to the docs.
  dimensions = {
    TargetGroup  = ""
    LoadBalancer = ""
  }

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
