### PR TITLE
resource/aws_s3_bucket: Retry GetBucketTagging API calls on NoSuchBucket errors due to eventual consistency

### DIFF
--- a/aws/s3_tags.go
+++ b/aws/s3_tags.go
@@ -14,17 +14,32 @@ import (
 // s3.GetBucketTagging, except returns an empty slice instead of an error when
 // there are no tags.
 func getTagSetS3Bucket(conn *s3.S3, bucket string) ([]*s3.Tag, error) {
-	resp, err := conn.GetBucketTagging(&s3.GetBucketTaggingInput{
+	input := &s3.GetBucketTaggingInput{
 		Bucket: aws.String(bucket),
+	}
+
+	// Retry due to S3 eventual consistency
+	outputRaw, err := retryOnAwsCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
+		return conn.GetBucketTagging(input)
 	})
+
+	// S3 API Reference (https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketTagging.html)
+	// lists the special error as NoSuchTagSetError, however the existing logic used NoSuchTagSet
+	// and the AWS Go SDK has neither as a constant.
+	if isAWSErr(err, "NoSuchTagSet", "") {
+		return nil, nil
+	}
+
 	if err != nil {
-		if isAWSErr(err, "NoSuchTagSet", "") {
-			return nil, nil
-		}
 		return nil, err
 	}
 
-	return resp.TagSet, nil
+	var tagSet []*s3.Tag
+	if output, ok := outputRaw.(*s3.GetBucketTaggingOutput); ok {
+		tagSet = output.TagSet
+	}
+
+	return tagSet, nil
 }
 
 // setTags is a helper to set the tags for a resource. It expects the


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10068

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_s3_bucket: Retry `GetBucketTagging` API calls on `NoSuchBucket` errors due to eventual consistency
```

Previously, our acceptance testing would report eventual consistency issues such as:

```
--- FAIL: TestAccAWSS3Bucket_tagsWithSystemTags (11.28s)
    testing.go:615: Step 0 error: errors during apply:

        Error: error getting S3 bucket tags: NoSuchBucket: The specified bucket does not exist

--- FAIL: TestAccAWSCodeBuildProject_Artifacts_ArtifactIdentifier (7.39s)
    testing.go:615: Step 0 error: errors during apply:

        Error: error getting S3 bucket tags: NoSuchBucket: The specified bucket does not exist
```

The `aws_s3_bucket` resource tends to call our `retryOnAwsCode()` helper function to deal with this type of eventual consistency issue so we also add that handling to this API call as well.

Output from acceptance testing (after retrying any failing tests due to other read-after-write eventual consistency issues):

```
--- PASS: TestAccAWSS3Bucket_acceleration (57.29s)
--- PASS: TestAccAWSS3Bucket_basic (32.63s)
--- PASS: TestAccAWSS3Bucket_Bucket_EmptyString (30.76s)
--- PASS: TestAccAWSS3Bucket_Cors_Delete (29.45s)
--- PASS: TestAccAWSS3Bucket_Cors_EmptyOrigin (32.09s)
--- PASS: TestAccAWSS3Bucket_Cors_Update (55.25s)
--- PASS: TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled (52.43s)
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed (30.94s)
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical (61.25s)
--- PASS: TestAccAWSS3Bucket_forceDestroy (26.03s)
--- PASS: TestAccAWSS3Bucket_forceDestroyWithEmptyPrefixes (26.81s)
--- PASS: TestAccAWSS3Bucket_forceDestroyWithObjectLockEnabled (33.29s)
--- PASS: TestAccAWSS3Bucket_generatedName (31.31s)
--- PASS: TestAccAWSS3Bucket_LifecycleBasic (78.75s)
--- PASS: TestAccAWSS3Bucket_LifecycleExpireMarkerOnly (52.02s)
--- PASS: TestAccAWSS3Bucket_Logging (49.71s)
--- PASS: TestAccAWSS3Bucket_namePrefix (30.67s)
--- PASS: TestAccAWSS3Bucket_objectLock (52.31s)
--- PASS: TestAccAWSS3Bucket_Policy (70.45s)
--- PASS: TestAccAWSS3Bucket_region (29.50s)
--- PASS: TestAccAWSS3Bucket_Replication (223.64s)
--- PASS: TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation (141.38s)
--- PASS: TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError (35.00s)
--- PASS: TestAccAWSS3Bucket_ReplicationSchemaV2 (231.22s)
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutPrefix (67.87s)
--- PASS: TestAccAWSS3Bucket_RequestPayer (53.47s)
--- PASS: TestAccAWSS3Bucket_shouldFailNotFound (13.40s)
--- PASS: TestAccAWSS3Bucket_tagsWithNoSystemTags (94.76s)
--- PASS: TestAccAWSS3Bucket_tagsWithSystemTags (144.59s)
--- PASS: TestAccAWSS3Bucket_UpdateAcl (53.37s)
--- PASS: TestAccAWSS3Bucket_WebsiteRedirect (77.20s)
--- PASS: TestAccAWSS3Bucket_WebsiteRoutingRules (57.40s)
```
