### PR TITLE
Adding support for password_policy.temporary_password_validity_days

### DIFF
--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -65,11 +65,11 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 							},
 						},
 						"unused_account_validity_days": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							Default:      7,
-							Deprecated:   "Use password_policy.temporary_password_validity_days instead",
-							ValidateFunc: validation.IntBetween(0, 90),
+							Type:          schema.TypeInt,
+							Optional:      true,
+							Deprecated:    "Use password_policy.temporary_password_validity_days instead",
+							ValidateFunc:  validation.IntBetween(0, 90),
+							ConflictsWith: []string{"password_policy.0.temporary_password_validity_days"},
 						},
 					},
 				},
@@ -297,9 +297,10 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 							Optional: true,
 						},
 						"temporary_password_validity_days": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							ValidateFunc: validation.IntBetween(0, 365),
+							Type:          schema.TypeInt,
+							Optional:      true,
+							ValidateFunc:  validation.IntBetween(0, 365),
+							ConflictsWith: []string{"admin_create_user_config.0.unused_account_validity_days"},
 						},
 					},
 				},
@@ -676,11 +677,6 @@ func resourceAwsCognitoUserPoolCreate(d *schema.ResourceData, meta interface{}) 
 		}
 		if isAWSErr(err, cognitoidentityprovider.ErrCodeInvalidSmsRoleAccessPolicyException, "Role does not have permission to publish with SNS") {
 			log.Printf("[DEBUG] Received %s, retrying CreateUserPool", err)
-			return resource.RetryableError(err)
-		}
-		if isAWSErr(err, cognitoidentityprovider.ErrCodeInvalidParameterException, "Please use TemporaryPasswordValidityDays in PasswordPolicy instead of UnusedAccountValidityDays") {
-			log.Printf("[DEBUG] Received %s, retrying UpdateUserPool without UnusedAccountValidityDays", err)
-			params.AdminCreateUserConfig.UnusedAccountValidityDays = nil
 			return resource.RetryableError(err)
 		}
 

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -484,6 +484,7 @@ func TestAccAWSCognitoUserPool_withPasswordPolicy(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "password_policy.0.require_numbers", "false"),
 					resource.TestCheckResourceAttr(resourceName, "password_policy.0.require_symbols", "true"),
 					resource.TestCheckResourceAttr(resourceName, "password_policy.0.require_uppercase", "false"),
+					resource.TestCheckResourceAttr(resourceName, "password_policy.0.temporary_password_validity_days", "7"),
 				),
 			},
 			{
@@ -500,6 +501,7 @@ func TestAccAWSCognitoUserPool_withPasswordPolicy(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "password_policy.0.require_numbers", "true"),
 					resource.TestCheckResourceAttr(resourceName, "password_policy.0.require_symbols", "false"),
 					resource.TestCheckResourceAttr(resourceName, "password_policy.0.require_uppercase", "true"),
+					resource.TestCheckResourceAttr(resourceName, "password_policy.0.temporary_password_validity_days", "14"),
 				),
 			},
 		},
@@ -872,6 +874,11 @@ resource "aws_cognito_user_pool" "test" {
       sms_message   = "Your username is {username} and temporary password is {####}."
     }
   }
+
+  password_policy {
+    minimum_length                   = 6
+    temporary_password_validity_days = 6
+  }
 }
 `, name)
 }
@@ -890,6 +897,11 @@ resource "aws_cognito_user_pool" "test" {
       email_subject = "Foo{####}BaBaz"
       sms_message   = "Your username is {username} and constant password is {####}."
     }
+  }
+
+  password_policy {
+    minimum_length                   = 6
+    temporary_password_validity_days = 7
   }
 }
 `, name)
@@ -1086,11 +1098,12 @@ resource "aws_cognito_user_pool" "test" {
   name = "terraform-test-pool-%s"
 
   password_policy {
-    minimum_length    = 7
-    require_lowercase = true
-    require_numbers   = false
-    require_symbols   = true
-    require_uppercase = false
+    minimum_length                   = 7
+    require_lowercase                = true
+    require_numbers                  = false
+    require_symbols                  = true
+    require_uppercase                = false
+    temporary_password_validity_days = 7
   }
 }
 `, name)
@@ -1102,11 +1115,12 @@ resource "aws_cognito_user_pool" "test" {
   name = "terraform-test-pool-%s"
 
   password_policy {
-    minimum_length    = 9
-    require_lowercase = false
-    require_numbers   = true
-    require_symbols   = false
-    require_uppercase = true
+    minimum_length                   = 9
+    require_lowercase                = false
+    require_numbers                  = true
+    require_symbols                  = false
+    require_uppercase                = true
+    temporary_password_validity_days = 14
   }
 }
 `, name)

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -128,7 +128,7 @@ func TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration(t *testing.T) {
 			{
 				Config: testAccAWSCognitoUserPoolConfig_withAdminCreateUserConfigurationUpdated(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.unused_account_validity_days", "7"),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.unused_account_validity_days", "6"),
 					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.allow_admin_create_user_only", "false"),
 					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.email_message", "Your username is {username} and constant password is {####}. "),
 					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.email_subject", "Foo{####}BaBaz"),
@@ -874,11 +874,6 @@ resource "aws_cognito_user_pool" "test" {
       sms_message   = "Your username is {username} and temporary password is {####}."
     }
   }
-
-  password_policy {
-    minimum_length                   = 6
-    temporary_password_validity_days = 6
-  }
 }
 `, name)
 }
@@ -890,18 +885,13 @@ resource "aws_cognito_user_pool" "test" {
 
   admin_create_user_config {
     allow_admin_create_user_only = false
-    unused_account_validity_days = 7
+    unused_account_validity_days = 6
 
     invite_message_template {
       email_message = "Your username is {username} and constant password is {####}. "
       email_subject = "Foo{####}BaBaz"
       sms_message   = "Your username is {username} and constant password is {####}."
     }
-  }
-
-  password_policy {
-    minimum_length                   = 6
-    temporary_password_validity_days = 7
   }
 }
 `, name)

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -126,6 +126,17 @@ func TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
+				Config: testAccAWSCognitoUserPoolConfig_withAdminCreateUserConfigurationUpdatedError(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.unused_account_validity_days", "6"),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.allow_admin_create_user_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.email_message", "Your username is {username} and constant password is {####}. "),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.email_subject", "Foo{####}BaBaz"),
+					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.invite_message_template.0.sms_message", "Your username is {username} and constant password is {####}."),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
 				Config: testAccAWSCognitoUserPoolConfig_withAdminCreateUserConfigurationUpdated(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "admin_create_user_config.0.unused_account_validity_days", "6"),
@@ -872,6 +883,25 @@ resource "aws_cognito_user_pool" "test" {
       email_message = "Your username is {username} and temporary password is {####}. "
       email_subject = "FooBar {####}"
       sms_message   = "Your username is {username} and temporary password is {####}."
+    }
+  }
+}
+`, name)
+}
+
+func testAccAWSCognitoUserPoolConfig_withAdminCreateUserConfigurationUpdatedError(name string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  name = "terraform-test-pool-%s"
+
+  admin_create_user_config {
+    allow_admin_create_user_only = false
+    unused_account_validity_days = 7
+
+    invite_message_template {
+      email_message = "Your username is {username} and constant password is {####}. "
+      email_subject = "Foo{####}BaBaz"
+      sms_message   = "Your username is {username} and constant password is {####}."
     }
   }
 }

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -2721,6 +2721,10 @@ func expandCognitoUserPoolPasswordPolicy(config map[string]interface{}) *cognito
 		configs.RequireUppercase = aws.Bool(v.(bool))
 	}
 
+	if v, ok := config["temporary_password_validity_days"]; ok {
+		configs.TemporaryPasswordValidityDays = aws.Int64(int64(v.(int)))
+	}
+
 	return configs
 }
 
@@ -2991,6 +2995,10 @@ func flattenCognitoUserPoolPasswordPolicy(s *cognitoidentityprovider.PasswordPol
 
 	if s.RequireUppercase != nil {
 		m["require_uppercase"] = *s.RequireUppercase
+	}
+
+	if s.TemporaryPasswordValidityDays != nil {
+		m["temporary_password_validity_days"] = *s.TemporaryPasswordValidityDays
 	}
 
 	if len(m) > 0 {

--- a/website/docs/r/cognito_user_pool.markdown
+++ b/website/docs/r/cognito_user_pool.markdown
@@ -48,7 +48,7 @@ The following arguments are supported:
 
   * `allow_admin_create_user_only` (Optional) - Set to True if only the administrator is allowed to create user profiles. Set to False if users can sign themselves up via an app.
   * `invite_message_template` (Optional) - The [invite message template structure](#invite-message-template).
-  * `unused_account_validity_days` (Optional) - The user account expiration limit, in days, after which the account is no longer usable.
+  * `unused_account_validity_days` (Optional) - **DEPRECATED** Use password_policy.temporary_password_validity_days instead - The user account expiration limit, in days, after which the account is no longer usable.
 
 ##### Invite Message template
 
@@ -87,6 +87,7 @@ The following arguments are supported:
   * `require_numbers` (Optional) - Whether you have required users to use at least one number in their password.
   * `require_symbols` (Optional) - Whether you have required users to use at least one symbol in their password.
   * `require_uppercase` (Optional) - Whether you have required users to use at least one uppercase letter in their password.
+  * `temporary_password_validity_days` (Optional) - In the password policy you have set, refers to the number of days a temporary password is valid. If the user does not sign-in during this time, their password will need to be reset by an administrator.
 
 #### Schema Attributes
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #8827

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`admin_create_user_config.0.unused_account_validity_days` has been deprecated, added support for 
 `password_policy.0.temporary_password_validity_days`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCognitoUserPool'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 10 -run=TestAccAWSCognitoUserPool -timeout 120m
=== RUN   TestAccAWSCognitoUserPoolClient_basic
=== PAUSE TestAccAWSCognitoUserPoolClient_basic
=== RUN   TestAccAWSCognitoUserPoolClient_RefreshTokenValidity
=== PAUSE TestAccAWSCognitoUserPoolClient_RefreshTokenValidity
=== RUN   TestAccAWSCognitoUserPoolClient_Name
=== PAUSE TestAccAWSCognitoUserPoolClient_Name
=== RUN   TestAccAWSCognitoUserPoolClient_allFields
=== PAUSE TestAccAWSCognitoUserPoolClient_allFields
=== RUN   TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField
=== PAUSE TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField
=== RUN   TestAccAWSCognitoUserPoolDomain_basic
=== PAUSE TestAccAWSCognitoUserPoolDomain_basic
=== RUN   TestAccAWSCognitoUserPoolDomain_custom
--- SKIP: TestAccAWSCognitoUserPoolDomain_custom (0.00s)
    resource_aws_cognito_user_pool_domain_test.go:56: Environment variable AWS_COGNITO_USER_POOL_DOMAIN_ROOT_DOMAIN is not set. This environment variable must be set to the fqdn of an ISSUED ACM certificate in us-east-1 to enable this test.
=== RUN   TestAccAWSCognitoUserPool_basic
=== PAUSE TestAccAWSCognitoUserPool_basic
=== RUN   TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration
=== PAUSE TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration
=== RUN   TestAccAWSCognitoUserPool_withAdvancedSecurityMode
=== PAUSE TestAccAWSCognitoUserPool_withAdvancedSecurityMode
=== RUN   TestAccAWSCognitoUserPool_withDeviceConfiguration
=== PAUSE TestAccAWSCognitoUserPool_withDeviceConfiguration
=== RUN   TestAccAWSCognitoUserPool_withEmailVerificationMessage
=== PAUSE TestAccAWSCognitoUserPool_withEmailVerificationMessage
=== RUN   TestAccAWSCognitoUserPool_withSmsVerificationMessage
=== PAUSE TestAccAWSCognitoUserPool_withSmsVerificationMessage
=== RUN   TestAccAWSCognitoUserPool_withEmailConfiguration
--- SKIP: TestAccAWSCognitoUserPool_withEmailConfiguration (0.00s)
    resource_aws_cognito_user_pool_test.go:304: 'TEST_AWS_SES_VERIFIED_EMAIL_ARN' not set, skipping test.
=== RUN   TestAccAWSCognitoUserPool_withSmsConfiguration
=== PAUSE TestAccAWSCognitoUserPool_withSmsConfiguration
=== RUN   TestAccAWSCognitoUserPool_withSmsConfigurationUpdated
=== PAUSE TestAccAWSCognitoUserPool_withSmsConfigurationUpdated
=== RUN   TestAccAWSCognitoUserPool_withTags
=== PAUSE TestAccAWSCognitoUserPool_withTags
=== RUN   TestAccAWSCognitoUserPool_withAliasAttributes
=== PAUSE TestAccAWSCognitoUserPool_withAliasAttributes
=== RUN   TestAccAWSCognitoUserPool_withPasswordPolicy
=== PAUSE TestAccAWSCognitoUserPool_withPasswordPolicy
=== RUN   TestAccAWSCognitoUserPool_withLambdaConfig
=== PAUSE TestAccAWSCognitoUserPool_withLambdaConfig
=== RUN   TestAccAWSCognitoUserPool_withSchemaAttributes
=== PAUSE TestAccAWSCognitoUserPool_withSchemaAttributes
=== RUN   TestAccAWSCognitoUserPool_withVerificationMessageTemplate
=== PAUSE TestAccAWSCognitoUserPool_withVerificationMessageTemplate
=== RUN   TestAccAWSCognitoUserPool_update
=== PAUSE TestAccAWSCognitoUserPool_update
=== CONT  TestAccAWSCognitoUserPoolClient_basic
=== CONT  TestAccAWSCognitoUserPool_basic
=== CONT  TestAccAWSCognitoUserPool_withSmsVerificationMessage
=== CONT  TestAccAWSCognitoUserPool_withVerificationMessageTemplate
=== CONT  TestAccAWSCognitoUserPool_withSchemaAttributes
=== CONT  TestAccAWSCognitoUserPool_withLambdaConfig
=== CONT  TestAccAWSCognitoUserPool_withPasswordPolicy
=== CONT  TestAccAWSCognitoUserPool_update
=== CONT  TestAccAWSCognitoUserPool_withTags
=== CONT  TestAccAWSCognitoUserPool_withAliasAttributes
--- PASS: TestAccAWSCognitoUserPool_basic (34.67s)
=== CONT  TestAccAWSCognitoUserPool_withSmsConfigurationUpdated
--- PASS: TestAccAWSCognitoUserPoolClient_basic (39.40s)
=== CONT  TestAccAWSCognitoUserPool_withSmsConfiguration
--- PASS: TestAccAWSCognitoUserPool_withSmsVerificationMessage (54.44s)
=== CONT  TestAccAWSCognitoUserPoolClient_allFields
--- PASS: TestAccAWSCognitoUserPool_withVerificationMessageTemplate (54.44s)
=== CONT  TestAccAWSCognitoUserPoolDomain_basic
--- PASS: TestAccAWSCognitoUserPool_withAliasAttributes (55.41s)
=== CONT  TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField
--- PASS: TestAccAWSCognitoUserPool_withPasswordPolicy (56.14s)
=== CONT  TestAccAWSCognitoUserPool_withDeviceConfiguration
--- PASS: TestAccAWSCognitoUserPool_withSchemaAttributes (58.23s)
=== CONT  TestAccAWSCognitoUserPool_withEmailVerificationMessage
--- PASS: TestAccAWSCognitoUserPool_withTags (77.46s)
=== CONT  TestAccAWSCognitoUserPoolClient_Name
--- PASS: TestAccAWSCognitoUserPool_withSmsConfiguration (49.83s)
=== CONT  TestAccAWSCognitoUserPoolClient_RefreshTokenValidity
--- PASS: TestAccAWSCognitoUserPoolClient_allFields (37.53s)
=== CONT  TestAccAWSCognitoUserPool_withAdvancedSecurityMode
--- PASS: TestAccAWSCognitoUserPool_withLambdaConfig (93.05s)
=== CONT  TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration
--- PASS: TestAccAWSCognitoUserPoolDomain_basic (39.21s)
--- PASS: TestAccAWSCognitoUserPool_update (104.76s)
--- PASS: TestAccAWSCognitoUserPool_withSmsConfigurationUpdated (70.37s)
--- PASS: TestAccAWSCognitoUserPool_withDeviceConfiguration (52.87s)
--- PASS: TestAccAWSCognitoUserPool_withEmailVerificationMessage (53.27s)
--- PASS: TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField (58.13s)
--- PASS: TestAccAWSCognitoUserPoolClient_Name (60.39s)
--- PASS: TestAccAWSCognitoUserPoolClient_RefreshTokenValidity (58.94s)
--- PASS: TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration (71.57s)
--- PASS: TestAccAWSCognitoUserPool_withAdvancedSecurityMode (75.25s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	168.608s
```
