### PR TITLE
Glue workflow

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -538,6 +538,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_glue_job":                                            resourceAwsGlueJob(),
 			"aws_glue_security_configuration":                         resourceAwsGlueSecurityConfiguration(),
 			"aws_glue_trigger":                                        resourceAwsGlueTrigger(),
+			"aws_glue_workflow":                                       resourceAwsGlueWorkflow(),
 			"aws_guardduty_detector":                                  resourceAwsGuardDutyDetector(),
 			"aws_guardduty_invite_accepter":                           resourceAwsGuardDutyInviteAccepter(),
 			"aws_guardduty_ipset":                                     resourceAwsGuardDutyIpset(),

--- a/aws/resource_aws_glue_trigger.go
+++ b/aws/resource_aws_glue_trigger.go
@@ -126,6 +126,11 @@ func resourceAwsGlueTrigger() *schema.Resource {
 					glue.TriggerTypeScheduled,
 				}, false),
 			},
+			"workflow_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -155,6 +160,10 @@ func resourceAwsGlueTriggerCreate(d *schema.ResourceData, meta interface{}) erro
 
 	if d.Get("enabled").(bool) && triggerType != glue.TriggerTypeOnDemand {
 		input.StartOnCreation = aws.Bool(true)
+	}
+
+	if v, ok := d.GetOk("workflow_name"); ok {
+		input.WorkflowName = aws.String(v.(string))
 	}
 
 	log.Printf("[DEBUG] Creating Glue Trigger: %s", input)
@@ -234,6 +243,7 @@ func resourceAwsGlueTriggerRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("name", trigger.Name)
 	d.Set("schedule", trigger.Schedule)
 	d.Set("type", trigger.Type)
+	d.Set("workflow_name", trigger.WorkflowName)
 
 	return nil
 }

--- a/aws/resource_aws_glue_trigger_test.go
+++ b/aws/resource_aws_glue_trigger_test.go
@@ -36,7 +36,7 @@ func testSweepGlueTriggers(region string) error {
 			name := aws.StringValue(trigger.Name)
 
 			log.Printf("[INFO] Deleting Glue Trigger: %s", name)
-			err := deleteGlueJob(conn, name)
+			err := deleteGlueTrigger(conn, name)
 			if err != nil {
 				log.Printf("[ERROR] Failed to delete Glue Trigger %s: %s", name, err)
 			}
@@ -71,6 +71,40 @@ func TestAccAWSGlueTrigger_Basic(t *testing.T) {
 					testAccCheckAWSGlueTriggerExists(resourceName, &trigger),
 					resource.TestCheckResourceAttr(resourceName, "actions.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "actions.0.job_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "predicate.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "schedule", ""),
+					resource.TestCheckResourceAttr(resourceName, "type", "ON_DEMAND"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSGlueTrigger_Crawler(t *testing.T) {
+	var trigger glue.Trigger
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "aws_glue_trigger.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueTriggerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGlueTriggerConfig_Crawler(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueTriggerExists(resourceName, &trigger),
+					resource.TestCheckResourceAttr(resourceName, "actions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.crawler_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -375,6 +409,21 @@ resource "aws_glue_trigger" "test" {
   }
 }
 `, testAccAWSGlueJobConfig_Required(rName), rName)
+}
+
+func testAccAWSGlueTriggerConfig_Crawler(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "aws_glue_trigger" "test" {
+  name = "%s"
+  type = "ON_DEMAND"
+
+  actions {
+    crawler_name = "${aws_glue_crawler.test.name}"
+  }
+}
+`, testAccGlueCrawlerConfig_DynamodbTarget(rName, "table1"), rName)
 }
 
 func testAccAWSGlueTriggerConfig_Predicate(rName, state string) string {

--- a/aws/resource_aws_glue_workflow.go
+++ b/aws/resource_aws_glue_workflow.go
@@ -1,0 +1,160 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/glue"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"log"
+)
+
+func resourceAwsGlueWorkflow() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsGlueWorkflowCreate,
+		Read:   resourceAwsGlueWorkflowRead,
+		Update: resourceAwsGlueWorkflowUpdate,
+		Delete: resourceAwsGlueWorkflowDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"default_run_properties": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     schema.TypeString,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+		},
+	}
+}
+
+func resourceAwsGlueWorkflowCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).glueconn
+	name := d.Get("name").(string)
+
+	input := &glue.CreateWorkflowInput{
+		Name: aws.String(name),
+	}
+
+	if kv, ok := d.GetOk("default_run_properties"); ok {
+		defaultRunPropertiesMap := make(map[string]string)
+		for k, v := range kv.(map[string]interface{}) {
+			defaultRunPropertiesMap[k] = v.(string)
+		}
+		input.DefaultRunProperties = aws.StringMap(defaultRunPropertiesMap)
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		input.Description = aws.String(v.(string))
+	}
+
+	log.Printf("[DEBUG] Creating Glue Workflow: %s", input)
+	_, err := conn.CreateWorkflow(input)
+	if err != nil {
+		return fmt.Errorf("error creating Glue Trigger (%s): %s", name, err)
+	}
+	d.SetId(name)
+
+	return resourceAwsGlueWorkflowRead(d, meta)
+}
+
+func resourceAwsGlueWorkflowRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).glueconn
+
+	input := &glue.GetWorkflowInput{
+		Name: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Reading Glue Workflow: %s", input)
+	output, err := conn.GetWorkflow(input)
+	if err != nil {
+		if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
+			log.Printf("[WARN] Glue Workflow (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("error reading Glue Workflow (%s): %s", d.Id(), err)
+	}
+
+	workflow := output.Workflow
+	if workflow == nil {
+		log.Printf("[WARN] Glue Workflow (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err := d.Set("default_run_properties", aws.StringValueMap(workflow.DefaultRunProperties)); err != nil {
+		return fmt.Errorf("error setting default_run_properties: %s", err)
+	}
+	d.Set("description", workflow.Description)
+	d.Set("name", workflow.Name)
+
+	return nil
+}
+
+func resourceAwsGlueWorkflowUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).glueconn
+
+	input := &glue.UpdateWorkflowInput{
+		Name: aws.String(d.Get("name").(string)),
+	}
+
+	if kv, ok := d.GetOk("default_run_properties"); ok {
+		defaultRunPropertiesMap := make(map[string]string)
+		for k, v := range kv.(map[string]interface{}) {
+			defaultRunPropertiesMap[k] = v.(string)
+		}
+		input.DefaultRunProperties = aws.StringMap(defaultRunPropertiesMap)
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		input.Description = aws.String(v.(string))
+	}
+
+	log.Printf("[DEBUG] Updating Glue Workflow: %s", input)
+	_, err := conn.UpdateWorkflow(input)
+	if err != nil {
+		return fmt.Errorf("error updating Glue Workflow (%s): %s", d.Id(), err)
+	}
+
+	return resourceAwsGlueWorkflowRead(d, meta)
+}
+
+func resourceAwsGlueWorkflowDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).glueconn
+
+	log.Printf("[DEBUG] Deleting Glue Workflow: %s", d.Id())
+	err := deleteWorkflow(conn, d.Id())
+	if err != nil {
+		return fmt.Errorf("error deleting Glue Workflow (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func deleteWorkflow(conn *glue.Glue, name string) error {
+	input := &glue.DeleteWorkflowInput{
+		Name: aws.String(name),
+	}
+
+	_, err := conn.DeleteWorkflow(input)
+	if err != nil {
+		if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}

--- a/aws/resource_aws_glue_workflow_test.go
+++ b/aws/resource_aws_glue_workflow_test.go
@@ -1,0 +1,229 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/glue"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_glue_workflow", &resource.Sweeper{
+		Name: "aws_glue_workflow",
+		F:    testSweepGlueWorkflow,
+	})
+}
+
+func testSweepGlueWorkflow(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).glueconn
+
+	listWorkflowInput := &glue.ListWorkflowsInput{}
+
+	listOutput, err := conn.ListWorkflows(listWorkflowInput)
+	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Glue Workflow sweep for %s: %s", region, err)
+			return nil
+		}
+		return fmt.Errorf("Error retrieving Glue Workflow: %s", err)
+	}
+	for _, workflowName := range listOutput.Workflows {
+		err := deleteWorkflow(conn, *workflowName)
+		if err != nil {
+			log.Printf("[ERROR] Failed to delete Glue Workflow %s: %s", *workflowName, err)
+		}
+	}
+	return nil
+}
+
+func TestAccAWSGlueWorkflow_Basic(t *testing.T) {
+	var workflow glue.Workflow
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "aws_glue_workflow.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueWorkflowDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGlueWorkflowConfig_Required(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueWorkflowExists(resourceName, &workflow),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSGlueWorkflow_DefaultRunProperties(t *testing.T) {
+	var workflow glue.Workflow
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "aws_glue_workflow.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueWorkflowDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGlueWorkflowConfig_DefaultRunProperties(rName, "firstPropValue", "secondPropValue"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueWorkflowExists(resourceName, &workflow),
+					resource.TestCheckResourceAttr(resourceName, "default_run_properties.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "default_run_properties.--run-prop1", "firstPropValue"),
+					resource.TestCheckResourceAttr(resourceName, "default_run_properties.--run-prop2", "secondPropValue"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSGlueWorkflow_Description(t *testing.T) {
+	var workflow glue.Workflow
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "aws_glue_workflow.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueWorkflowDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGlueWorkflowConfig_Description(rName, "First Description"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueWorkflowExists(resourceName, &workflow),
+					resource.TestCheckResourceAttr(resourceName, "description", "First Description"),
+				),
+			},
+			{
+				Config: testAccAWSGlueWorkflowConfig_Description(rName, "Second Description"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueWorkflowExists(resourceName, &workflow),
+					resource.TestCheckResourceAttr(resourceName, "description", "Second Description"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSGlueWorkflowExists(resourceName string, workflow *glue.Workflow) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Glue Workflow ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).glueconn
+
+		output, err := conn.GetWorkflow(&glue.GetWorkflowInput{
+			Name: aws.String(rs.Primary.ID),
+		})
+		if err != nil {
+			return err
+		}
+
+		if output.Workflow == nil {
+			return fmt.Errorf("Glue Workflow (%s) not found", rs.Primary.ID)
+		}
+
+		if aws.StringValue(output.Workflow.Name) == rs.Primary.ID {
+			*workflow = *output.Workflow
+			return nil
+		}
+
+		return fmt.Errorf("Glue Workflow (%s) not found", rs.Primary.ID)
+	}
+}
+
+func testAccCheckAWSGlueWorkflowDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_glue_workflow" {
+			continue
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).glueconn
+
+		output, err := conn.GetWorkflow(&glue.GetWorkflowInput{
+			Name: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
+				return nil
+			}
+
+		}
+
+		workflow := output.Workflow
+		if workflow != nil && aws.StringValue(workflow.Name) == rs.Primary.ID {
+			return fmt.Errorf("Glue Workflow %s still exists", rs.Primary.ID)
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func testAccAWSGlueWorkflowConfig_DefaultRunProperties(rName, firstPropValue, secondPropValue string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_workflow" "test" {
+ name               = "%s"
+
+ default_run_properties = {
+   "--run-prop1" = "%s"
+   "--run-prop2" = "%s"
+ }
+}
+`, rName, firstPropValue, secondPropValue)
+}
+
+func testAccAWSGlueWorkflowConfig_Description(rName, description string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_workflow" "test" {
+ description        = "%s"
+ name               = "%s"
+}
+`, description, rName)
+}
+
+func testAccAWSGlueWorkflowConfig_Required(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_workflow" "test" {
+ name               = "%s"
+}
+`, rName)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1596,6 +1596,9 @@
                                 <li>
                                     <a href="/docs/providers/aws/r/glue_trigger.html">aws_glue_trigger</a>
                                 </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/glue_workflow.html">aws_glue_workflow</a>
+                                </li>
                             </ul>
                         </li>
                     </ul>

--- a/website/docs/r/glue_trigger.html.markdown
+++ b/website/docs/r/glue_trigger.html.markdown
@@ -75,7 +75,8 @@ The following arguments are supported:
 ### actions Argument Reference
 
 * `arguments` - (Optional) Arguments to be passed to the job. You can specify arguments here that your own job-execution script consumes, as well as arguments that AWS Glue itself consumes.
-* `job_name` - (Required) The name of a job to be executed.
+* `crawler_name` - (Optional) The name of the crawler to be executed. Conflicts with `job_name`.
+* `job_name` - (Optional) The name of a job to be executed. Conflicts with `crawler_name`.
 * `timeout` - (Optional) The job run timeout in minutes. It overrides the timeout value of the job.
 
 ### predicate Argument Reference

--- a/website/docs/r/glue_trigger.html.markdown
+++ b/website/docs/r/glue_trigger.html.markdown
@@ -16,8 +16,8 @@ Manages a Glue Trigger resource.
 
 ```hcl
 resource "aws_glue_trigger" "example" {
-  name = "example"
-  type = "CONDITIONAL"
+  name          = "example"
+  type          = "CONDITIONAL"
 
   actions {
     job_name = "${aws_glue_job.example1.name}"
@@ -70,6 +70,7 @@ The following arguments are supported:
 * `predicate` – (Optional) A predicate to specify when the new trigger should fire. Required when trigger type is `CONDITIONAL`. Defined below.
 * `schedule` – (Optional) A cron expression used to specify the schedule. [Time-Based Schedules for Jobs and Crawlers](https://docs.aws.amazon.com/glue/latest/dg/monitor-data-warehouse-schedule.html)
 * `type` – (Required) The type of trigger. Valid values are `CONDITIONAL`, `ON_DEMAND`, and `SCHEDULED`.
+* `workflow_name` - (Optional) A workflow to which the trigger should be associated to. Every workflow graph (DAG) needs a starting trigger (`ON_DEMAND` or `SCHEDULED`) and can contain multiple additional `CONDITIONAL` triggers.
 
 ### actions Argument Reference
 

--- a/website/docs/r/glue_workflow.html.markdown
+++ b/website/docs/r/glue_workflow.html.markdown
@@ -1,0 +1,70 @@
+---
+subcategory: "Glue"
+layout: "aws"
+page_title: "AWS: aws_glue_workflow"
+description: |-
+  Provides an Glue Workflow resource.
+---
+
+# Resource: aws_glue_workflow
+
+Provides a Glue Workflow resource.
+The workflow graph (DAG) can be build using the `aws_glue_trigger` resource. 
+See the example below for creating a graph with four nodes (two triggers and two jobs). 
+
+## Example Usage
+
+```hcl
+resource "aws_glue_workflow" "example" {
+  name = "example"
+}
+
+resource "aws_glue_trigger" "example-start" {
+  name = "trigger-start"
+  type = "ON_DEMAND"
+  workflow_name = "${aws_glue_workflow.example.name}"
+
+  actions {
+    job_name = "example-job"
+  }
+}
+
+resource "aws_glue_trigger" "example-inner" {
+  name = "trigger-inner"
+  type = "CONDITIONAL"
+  workflow_name = "${aws_glue_workflow.example.name}"
+
+  predicate {
+    conditions {
+      job_name = "example-job"
+      state = "SUCCEEDED"
+    }
+  }
+
+  actions {
+    job_name = "another-example-job"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `default_run_properties` – (Optional) A map of default run properties for this workflow. These properties are passed to all jobs associated to the workflow.
+* `description` – (Optional) Description of the workflow.
+* `name` – (Required) The name you assign to this workflow.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Workflow name
+
+## Import
+
+Glue Workflows can be imported using `name`, e.g.
+
+```
+$ terraform import aws_glue_workflow.MyWorkflow MyWorkflow
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10116

Right now the Glue Crawler can't be used in the workflow graph. Probably the trigger's action must be extended by the 'crawler_name' field.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_glue_workflow: Add glue workflow resource
resource/aws_glue_trigger: Add 'workflow_name' attribute, add 'crawler_name' attribute to 'action'
```

Output from acceptance testing:
```
$ make testacc TESTARGS='-run=TestAccAWSGlueWorkflow*'
=== RUN   TestAccAWSGlueWorkflow_Basic
=== PAUSE TestAccAWSGlueWorkflow_Basic
=== RUN   TestAccAWSGlueWorkflow_DefaultRunProperties
=== PAUSE TestAccAWSGlueWorkflow_DefaultRunProperties
=== RUN   TestAccAWSGlueWorkflow_Description
=== PAUSE TestAccAWSGlueWorkflow_Description
=== CONT  TestAccAWSGlueWorkflow_Basic
=== CONT  TestAccAWSGlueWorkflow_Description
=== CONT  TestAccAWSGlueWorkflow_DefaultRunProperties
--- PASS: TestAccAWSGlueWorkflow_DefaultRunProperties (29.23s)
--- PASS: TestAccAWSGlueWorkflow_Basic (29.39s)
--- PASS: TestAccAWSGlueWorkflow_Description (46.62s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       47.858s

$ make testacc TESTARGS='-run=TestAccAWSGlueTrigger*'
=== RUN   TestAccAWSGlueTrigger_Basic
=== PAUSE TestAccAWSGlueTrigger_Basic
=== RUN   TestAccAWSGlueTrigger_Crawler
=== PAUSE TestAccAWSGlueTrigger_Crawler
=== RUN   TestAccAWSGlueTrigger_Description
=== PAUSE TestAccAWSGlueTrigger_Description
=== RUN   TestAccAWSGlueTrigger_Enabled
=== PAUSE TestAccAWSGlueTrigger_Enabled
=== RUN   TestAccAWSGlueTrigger_Predicate
=== PAUSE TestAccAWSGlueTrigger_Predicate
=== RUN   TestAccAWSGlueTrigger_Schedule
=== PAUSE TestAccAWSGlueTrigger_Schedule
=== RUN   TestAccAWSGlueTrigger_WorkflowName
=== PAUSE TestAccAWSGlueTrigger_WorkflowName
=== CONT  TestAccAWSGlueTrigger_Basic
=== CONT  TestAccAWSGlueTrigger_Predicate
=== CONT  TestAccAWSGlueTrigger_Crawler
=== CONT  TestAccAWSGlueTrigger_WorkflowName
=== CONT  TestAccAWSGlueTrigger_Description
=== CONT  TestAccAWSGlueTrigger_Enabled
=== CONT  TestAccAWSGlueTrigger_Schedule
--- PASS: TestAccAWSGlueTrigger_WorkflowName (48.18s)
--- PASS: TestAccAWSGlueTrigger_Basic (56.47s)
--- PASS: TestAccAWSGlueTrigger_Crawler (66.11s)
--- PASS: TestAccAWSGlueTrigger_Description (67.95s)
--- PASS: TestAccAWSGlueTrigger_Predicate (98.46s)
--- PASS: TestAccAWSGlueTrigger_Schedule (104.25s)
--- PASS: TestAccAWSGlueTrigger_Enabled (132.27s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       133.497s
```