### PR TITLE
added support in batch for the allocation_strategy attribute

### DIFF
--- a/aws/resource_aws_batch_compute_environment.go
+++ b/aws/resource_aws_batch_compute_environment.go
@@ -39,6 +39,11 @@ func resourceAwsBatchComputeEnvironment() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"allocation_strategy": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
 						"bid_percentage": {
 							Type:     schema.TypeInt,
 							Optional: true,
@@ -230,6 +235,9 @@ func resourceAwsBatchComputeEnvironmentCreate(d *schema.ResourceData, meta inter
 			Type:             aws.String(computeResourceType),
 		}
 
+		if v, ok := computeResource["allocation_strategy"]; ok {
+			input.ComputeResources.AllocationStrategy = aws.String(v.(string))
+		}
 		if v, ok := computeResource["bid_percentage"]; ok {
 			input.ComputeResources.BidPercentage = aws.Int64(int64(v.(int)))
 		}

--- a/aws/resource_aws_batch_compute_environment.go
+++ b/aws/resource_aws_batch_compute_environment.go
@@ -43,6 +43,10 @@ func resourceAwsBatchComputeEnvironment() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							ForceNew: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								batch.CRAllocationStrategyBestFit,
+								batch.CRAllocationStrategyBestFitProgressive,
+								batch.CRAllocationStrategySpotCapacityOptimized}, true),
 						},
 						"bid_percentage": {
 							Type:     schema.TypeInt,

--- a/aws/resource_aws_batch_compute_environment.go
+++ b/aws/resource_aws_batch_compute_environment.go
@@ -339,6 +339,7 @@ func flattenBatchComputeResources(computeResource *batch.ComputeResource) []map[
 	result := make([]map[string]interface{}, 0)
 	m := make(map[string]interface{})
 
+	m["allocation_strategy"] = aws.StringValue(computeResource.AllocationStrategy)
 	m["bid_percentage"] = int(aws.Int64Value(computeResource.BidPercentage))
 	m["desired_vcpus"] = int(aws.Int64Value(computeResource.DesiredvCpus))
 	m["ec2_key_pair"] = aws.StringValue(computeResource.Ec2KeyPair)

--- a/aws/resource_aws_batch_compute_environment_test.go
+++ b/aws/resource_aws_batch_compute_environment_test.go
@@ -337,6 +337,25 @@ func TestAccAWSBatchComputeEnvironment_UpdateLaunchTemplate(t *testing.T) {
 	})
 }
 
+func TestAccAWSBatchComputeEnvironment_createSpotWithAllocationStrategy(t *testing.T) {
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSBatchComputeEnvironmentConfigSpotWithAllocationStrategy(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBatchComputeEnvironmentExists(),
+					resource.TestCheckResourceAttr("aws_batch_compute_environment.ec2", "compute_resources.0.allocation_strategy", "BEST_FIT"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSBatchComputeEnvironment_createSpotWithoutBidPercentage(t *testing.T) {
 	rInt := acctest.RandInt()
 
@@ -802,6 +821,34 @@ resource "aws_batch_compute_environment" "unmanaged" {
   }
   service_role = "${aws_iam_role.aws_batch_service_role.arn}"
   type = "UNMANAGED"
+  depends_on = ["aws_iam_role_policy_attachment.aws_batch_service_role"]
+}
+`, rInt)
+}
+
+func testAccAWSBatchComputeEnvironmentConfigSpotWithAllocationStrategy(rInt int) string {
+	return testAccAWSBatchComputeEnvironmentConfigBase(rInt) + fmt.Sprintf(`
+resource "aws_batch_compute_environment" "ec2" {
+  compute_environment_name = "tf_acc_test_%d"
+  compute_resources {
+	allocation_strategy = "BEST_FIT"
+    instance_role = "${aws_iam_instance_profile.ecs_instance_role.arn}"
+    instance_type = [
+      "c4.large",
+    ]
+    max_vcpus = 16
+    min_vcpus = 0
+    security_group_ids = [
+      "${aws_security_group.test_acc.id}"
+	]
+	spot_iam_fleet_role = "${aws_iam_role.aws_ec2_spot_fleet_role.arn}"
+    subnets = [
+      "${aws_subnet.test_acc.id}"
+    ]
+    type = "SPOT"
+  }
+  service_role = "${aws_iam_role.aws_batch_service_role.arn}"
+  type = "MANAGED"
   depends_on = ["aws_iam_role_policy_attachment.aws_batch_service_role"]
 }
 `, rInt)

--- a/website/docs/r/batch_compute_environment.html.markdown
+++ b/website/docs/r/batch_compute_environment.html.markdown
@@ -135,6 +135,7 @@ resource "aws_batch_compute_environment" "sample" {
 * `bid_percentage` - (Optional) Integer of minimum percentage that a Spot Instance price must be when compared with the On-Demand price for that instance type before instances are launched. For example, if your bid percentage is 20% (`20`), then the Spot price must be below 20% of the current On-Demand price for that EC2 instance. This parameter is required for SPOT compute environments.
 * `desired_vcpus` - (Optional) The desired number of EC2 vCPUS in the compute environment.
 * `ec2_key_pair` - (Optional) The EC2 key pair that is used for instances launched in the compute environment.
+* `allocation_strategy` - (Optional) The allocation strategy to use for the compute resource in case not enough instances of the best fitting instance type can be allocated. Valid items are `BEST_FIT_PROGRESSIVE`, `SPOT_CAPACITY_OPTIMIZED` or `BEST_FIT`. Defaults to `BEST_FIT`.
 * `image_id` - (Optional) The Amazon Machine Image (AMI) ID used for instances launched in the compute environment.
 * `instance_role` - (Required) The Amazon ECS instance role applied to Amazon EC2 instances in a compute environment.
 * `instance_type` - (Required) A list of instance types that may be launched.

--- a/website/docs/r/batch_compute_environment.html.markdown
+++ b/website/docs/r/batch_compute_environment.html.markdown
@@ -132,10 +132,10 @@ resource "aws_batch_compute_environment" "sample" {
 
 **compute_resources** is a child block with a single argument:
 
+* `allocation_strategy` - (Optional) The allocation strategy to use for the compute resource in case not enough instances of the best fitting instance type can be allocated. Valid items are `BEST_FIT_PROGRESSIVE`, `SPOT_CAPACITY_OPTIMIZED` or `BEST_FIT`. Defaults to `BEST_FIT`. See [AWS docs](https://docs.aws.amazon.com/batch/latest/userguide/allocation-strategies.html) for details.
 * `bid_percentage` - (Optional) Integer of minimum percentage that a Spot Instance price must be when compared with the On-Demand price for that instance type before instances are launched. For example, if your bid percentage is 20% (`20`), then the Spot price must be below 20% of the current On-Demand price for that EC2 instance. This parameter is required for SPOT compute environments.
 * `desired_vcpus` - (Optional) The desired number of EC2 vCPUS in the compute environment.
 * `ec2_key_pair` - (Optional) The EC2 key pair that is used for instances launched in the compute environment.
-* `allocation_strategy` - (Optional) The allocation strategy to use for the compute resource in case not enough instances of the best fitting instance type can be allocated. Valid items are `BEST_FIT_PROGRESSIVE`, `SPOT_CAPACITY_OPTIMIZED` or `BEST_FIT`. Defaults to `BEST_FIT`.
 * `image_id` - (Optional) The Amazon Machine Image (AMI) ID used for instances launched in the compute environment.
 * `instance_role` - (Required) The Amazon ECS instance role applied to Amazon EC2 instances in a compute environment.
 * `instance_type` - (Required) A list of instance types that may be launched.
@@ -174,3 +174,4 @@ $ terraform import aws_batch_compute_environment.sample sample
 [1]: http://docs.aws.amazon.com/batch/latest/userguide/what-is-batch.html
 [2]: http://docs.aws.amazon.com/batch/latest/userguide/compute_environments.html
 [3]: http://docs.aws.amazon.com/batch/latest/userguide/troubleshooting.html
+[4]: https://docs.aws.amazon.com/batch/latest/userguide/allocation-strategies.html


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates support new attribute 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Added support for the allocation_strategy attribute for aws_batch_compute_environment resource
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSBatchComputeEnvironment_createSpotWithAllocationStrategy'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSBatchComputeEnvironment_createSpotWithAllocationStrategy -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSBatchComputeEnvironment_createSpotWithAllocationStrategy
=== PAUSE TestAccAWSBatchComputeEnvironment_createSpotWithAllocationStrategy
=== CONT  TestAccAWSBatchComputeEnvironment_createSpotWithAllocationStrategy
--- PASS: TestAccAWSBatchComputeEnvironment_createSpotWithAllocationStrategy (77.92s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       77.969s
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap      0.009s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags 0.016s [no tests to run]
```
