### PR TITLE
New Resource: aws_workspaces_ip_group

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -837,6 +837,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_pinpoint_gcm_channel":                                resourceAwsPinpointGCMChannel(),
 			"aws_pinpoint_sms_channel":                                resourceAwsPinpointSMSChannel(),
 			"aws_xray_sampling_rule":                                  resourceAwsXraySamplingRule(),
+			"aws_workspaces_ip_group":                                 resourceAwsWorkspacesIpGroup(),
 
 			// ALBs are actually LBs because they can be type `network` or `application`
 			// To avoid regressions, we will add a new resource for each and they both point

--- a/aws/resource_aws_workspaces_ip_group.go
+++ b/aws/resource_aws_workspaces_ip_group.go
@@ -1,0 +1,177 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/workspaces"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"log"
+)
+
+func resourceAwsWorkspacesIpGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsWorkspacesIpGroupCreate,
+		Read:   resourceAwsWorkspacesIpGroupRead,
+		Update: resourceAwsWorkspacesIpGroupUpdate,
+		Delete: resourceAwsWorkspacesIpGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"rules": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"source": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsWorkspacesIpGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).workspacesconn
+
+	rules := d.Get("rules").(*schema.Set).List()
+
+	tags := keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().WorkspacesTags()
+
+	resp, err := conn.CreateIpGroup(&workspaces.CreateIpGroupInput{
+		GroupName: aws.String(d.Get("name").(string)),
+		GroupDesc: aws.String(d.Get("description").(string)),
+		UserRules: expandIpGroupRules(rules),
+		Tags:      tags,
+	})
+	if err != nil {
+		return err
+	}
+
+	//if len(tags) > 0 {
+	//	params.Tags = tags
+	//}
+
+	d.SetId(*resp.GroupId)
+
+	return resourceAwsWorkspacesIpGroupRead(d, meta)
+}
+
+func resourceAwsWorkspacesIpGroupRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).workspacesconn
+
+	resp, err := conn.DescribeIpGroups(&workspaces.DescribeIpGroupsInput{
+		GroupIds: []*string{aws.String(d.Id())},
+	})
+	if err != nil {
+		if len(resp.Result) == 0 {
+			log.Printf("[WARN] Workspaces Ip Group (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		return err
+	}
+
+	d.Set("name", resp.Result[0].GroupName)
+	d.Set("description", resp.Result[0].GroupDesc)
+	d.Set("rules", flattenIpGroupRules(resp.Result[0].UserRules))
+
+	tags, err := keyvaluetags.WorkspacesListTags(conn, d.Id())
+	if err != nil {
+		return fmt.Errorf("error listing tags for Workspaces IP Group (%q): %s", d.Id(), err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsWorkspacesIpGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).workspacesconn
+
+	if d.HasChange("rules") {
+		rules := d.Get("rules").(*schema.Set).List()
+
+		log.Printf("[INFO] Updating Workspaces IP Group Rules")
+		_, err := conn.UpdateRulesOfIpGroup(&workspaces.UpdateRulesOfIpGroupInput{
+			GroupId:   aws.String(d.Id()),
+			UserRules: expandIpGroupRules(rules),
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+		if err := keyvaluetags.WorkspacesUpdateTags(conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("error updating tags: %s", err)
+		}
+	}
+
+	return resourceAwsWorkspacesIpGroupRead(d, meta)
+}
+
+func resourceAwsWorkspacesIpGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).workspacesconn
+
+	log.Printf("[INFO] Deleting Workspaces IP Group")
+	_, err := conn.DeleteIpGroup(&workspaces.DeleteIpGroupInput{
+		GroupId: aws.String(d.Id()),
+	})
+	if err != nil {
+		return fmt.Errorf("Error Deleting Workspaces IP Group: %s", err)
+	}
+
+	return nil
+}
+
+func expandIpGroupRules(rules []interface{}) []*workspaces.IpRuleItem {
+	var result []*workspaces.IpRuleItem
+	for _, rule := range rules {
+		r := rule.(map[string]interface{})
+
+		result = append(result, &workspaces.IpRuleItem{
+			IpRule:   aws.String(r["source"].(string)),
+			RuleDesc: aws.String(r["description"].(string)),
+		})
+	}
+	return result
+}
+
+func flattenIpGroupRules(rules []*workspaces.IpRuleItem) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(rules))
+	for _, rule := range rules {
+		r := map[string]interface{}{
+			"source": *rule.IpRule,
+		}
+		if rule.RuleDesc != nil {
+			r["description"] = *rule.RuleDesc
+		}
+		result = append(result, r)
+	}
+	return result
+}

--- a/aws/resource_aws_workspaces_ip_group_test.go
+++ b/aws/resource_aws_workspaces_ip_group_test.go
@@ -1,0 +1,164 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/workspaces"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAwsWorkspacesIpGroup_basic(t *testing.T) {
+	var wipg workspaces.IpGroup
+	ipGroupName := fmt.Sprintf("terraform-acctest-%s", acctest.RandString(10))
+	ipGroupNewName := fmt.Sprintf("terraform-acctest-new-%s", acctest.RandString(10))
+	ipGroupDescription := fmt.Sprintf("Terraform Acceptance Test %s", strings.Title(acctest.RandString(20)))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsWorkspacesIpGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsWorkspacesIpGroupConfigA(ipGroupName, ipGroupDescription),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccWorkspacesIpGroupConfigExists("aws_workspaces_ip_group.test", &wipg),
+					resource.TestCheckResourceAttr(
+						"aws_workspaces_ip_group.test", "name", ipGroupName),
+					resource.TestCheckResourceAttr(
+						"aws_workspaces_ip_group.test", "description", ipGroupDescription),
+					resource.TestCheckResourceAttr(
+						"aws_workspaces_ip_group.test", "rules.#", "2"),
+				),
+			},
+			{
+				ResourceName:      "aws_workspaces_ip_group.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAwsWorkspacesIpGroupConfigB(ipGroupNewName, ipGroupDescription),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccWorkspacesIpGroupConfigExists("aws_workspaces_ip_group.test", &wipg),
+					resource.TestCheckResourceAttr(
+						"aws_workspaces_ip_group.test", "name", ipGroupNewName),
+					resource.TestCheckResourceAttr(
+						"aws_workspaces_ip_group.test", "description", ipGroupDescription),
+					resource.TestCheckResourceAttr(
+						"aws_workspaces_ip_group.test", "rules.#", "1"),
+				),
+			},
+			{
+				ResourceName:      "aws_workspaces_ip_group.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAwsWorkspacesIpGroupDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_workspaces_ip_group" {
+			continue
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).workspacesconn
+		resp, err := conn.DescribeIpGroups(&workspaces.DescribeIpGroupsInput{
+			GroupIds: []*string{aws.String(rs.Primary.ID)},
+		})
+
+		if err != nil {
+			return fmt.Errorf("Error Describing Workspaces IP Group: %s", err)
+		}
+
+		// Return nil if the IP Group is already destroyed (does not exist)
+		if len(resp.Result) == 0 {
+			return nil
+		}
+
+		if *resp.Result[0].GroupId == rs.Primary.ID {
+			return fmt.Errorf("Workspaces IP Group %s still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccWorkspacesIpGroupConfigExists(n string, wipg *workspaces.IpGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Workpsaces IP Group ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).workspacesconn
+		resp, err := conn.DescribeIpGroups(&workspaces.DescribeIpGroupsInput{
+			GroupIds: []*string{aws.String(rs.Primary.ID)},
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if *resp.Result[0].GroupId == rs.Primary.ID {
+			wipg = &workspaces.IpGroup{
+				GroupId:   resp.Result[0].GroupId,
+				GroupName: resp.Result[0].GroupName,
+				GroupDesc: resp.Result[0].GroupDesc,
+			}
+			return nil
+		}
+
+		return fmt.Errorf("Workspaces IP Group (%s) not found", rs.Primary.ID)
+	}
+}
+
+func testAccAwsWorkspacesIpGroupConfigA(name, description string) string {
+	return fmt.Sprintf(`
+resource "aws_workspaces_ip_group" "test" {
+  name        = "%s"
+  description = "%s"
+
+  rules {
+    source = "10.0.0.0/16"
+  }
+
+  rules {
+    source      = "10.0.0.1/16"
+    description = "Home" 
+  }
+
+  tags = {
+    Name = "Home IP Group"
+  }
+}
+`, name, description)
+}
+
+func testAccAwsWorkspacesIpGroupConfigB(name, description string) string {
+	return fmt.Sprintf(`
+resource "aws_workspaces_ip_group" "test" {
+  name        = "%s"
+  description = "%s"
+
+  rules {
+    source      = "10.0.0.1/16"
+    description = "Home" 
+  }
+
+  tags = {
+    Owner = "Andrew"
+  }
+}
+`, name, description)
+}

--- a/examples/workspaces/main.tf
+++ b/examples/workspaces/main.tf
@@ -1,0 +1,17 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_workspaces_ip_group" "example" {
+  name        = "main"
+  description = "Main IP access control group"
+
+  rules {
+    source = "10.10.10.10/16"
+  }
+
+  rules {
+    source      = "11.11.11.11/16"
+    description = "Contractors"
+  }
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -3340,6 +3340,14 @@
                                 </li>
                             </ul>
                         </li>
+                        <li>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/workspaces_ip_group.html">aws_workspaces_ip_group</a>
+                                </li>
+                            </ul>
+                        </li>
                     </ul>
                 </li>
                 <li>

--- a/website/docs/r/workspaces_ip_group.html.markdown
+++ b/website/docs/r/workspaces_ip_group.html.markdown
@@ -1,0 +1,53 @@
+---
+subcategory: "Workspaces"
+layout: "aws"
+page_title: "AWS: aws_workspaces_ip_group"
+sidebar_current: "docs-aws-resource-workspaces-ip-group"
+description: |-
+  Provides an IP access control group in AWS Workspaces Service.
+---
+
+# Resource: aws_workspaces_ip_group
+
+Provides an IP access control group in AWS Workspaces Service
+
+## Example Usage
+
+```hcl
+resource "aws_workspaces_ip_group" "contractors" {
+  name = "Contractors"
+  description = "Contractors IP access control group"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the IP group.
+* `description` - (Optional) The description of the IP group.
+* `rules` - (Optional) One or more pairs specifying the IP group rule (in CIDR format) from which web requests originate.
+
+## Nested Blocks
+
+### `rules`
+
+#### Arguments
+
+* `source` - (Required) The IP address range, in CIDR notation, e.g. `10.0.0.0/16`
+* `description` - (Optional) The description.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The IP group identifier.
+
+## Import
+
+Workspaces IP groups can be imported using their GroupID, e.g.
+
+```
+$ terraform import aws_workspaces_ip_group.example wsipg-488lrtl3k
+```
+


### PR DESCRIPTION
Relates to #434

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
**New Resource:** `aws_workspaces_ip_group`
```

### Example

```hcl
resource "aws_workspaces_ip_group" "example" {
  name = "main"
  description = "Main IP access control group"

  rules {
    source = "10.10.10.10/16"
  }

  rules {
    source = "11.11.11.11/16"
    description = "Contractors"
  }
}
```

### Test

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAwsWorkspacesIpGroup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAwsWorkspacesIpGroup_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAwsWorkspacesIpGroup_basic
=== PAUSE TestAccAwsWorkspacesIpGroup_basic
=== CONT  TestAccAwsWorkspacesIpGroup_basic
--- PASS: TestAccAwsWorkspacesIpGroup_basic (50.25s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	52.266s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.026s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.053s [no tests to run]
```

### Notes

This is my first contribution here, please don't hesitate to criticize the PR. I'm eager to make it perfect 🙂
❗️ **I need the help to understand the hashing approach for `TypeSet` values, like `rules`** [Documentation](https://www.terraform.io/docs/extend/schemas/schema-types.html#typeset) doesn't cover how to digest the hash of the set. During [HashiCorp Kyiv Meetup #8: Adding new resources to a Terraform Provider](https://www.meetup.com/Kyiv-HashiCorp-User-Group/events/263949486/) @tombuildsstuff suggested to leave all attributes verification to the intermediate import test step. I've done this way, however, I don't like implicit test and do believe explicit one should be more sustainable.

### References

- [AWS Workspaces DescribeIpGroups](https://docs.aws.amazon.com/workspaces/latest/api/API_DescribeIpGroups.html)
- [AWS Workspaces CreateIpGroup](https://docs.aws.amazon.com/workspaces/latest/api/API_CreateIpGroup.html)
- [AWS Workspaces UpdateRulesOfIpGroup](https://docs.aws.amazon.com/workspaces/latest/api/API_UpdateRulesOfIpGroup.html)
- [AWS Workspaces DeleteIpGroup](https://docs.aws.amazon.com/workspaces/latest/api/API_DeleteIpGroup.html)
- [AWS Workspaces AuthorizeIpRules](https://docs.aws.amazon.com/workspaces/latest/api/API_AuthorizeIpRules.html) (have no idea why it could be useful if `UpdateRulesOfIpGroup` exists)
