### PR TITLE
Set `secret` and `ses_smtp_password` to sensitive

### DIFF
--- a/aws/resource_aws_iam_access_key.go
+++ b/aws/resource_aws_iam_access_key.go
@@ -38,13 +38,14 @@ func resourceAwsIamAccessKey() *schema.Resource {
 				}, false),
 			},
 			"secret": {
-				Type:       schema.TypeString,
-				Computed:   true,
-				Deprecated: "Please use a PGP key to encrypt",
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 			"ses_smtp_password": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 			"pgp_key": {
 				Type:     schema.TypeString,

--- a/website/docs/r/iam_access_key.html.markdown
+++ b/website/docs/r/iam_access_key.html.markdown
@@ -54,7 +54,8 @@ The following arguments are supported:
 
 * `user` - (Required) The IAM user to associate with this access key.
 * `pgp_key` - (Optional) Either a base-64 encoded PGP public key, or a
-  keybase username in the form `keybase:some_person_that_exists`.
+  keybase username in the form `keybase:some_person_that_exists`, for use
+  in the `encrypted_secret` output attribute.
 * `status` - (Optional) The access key status to apply. Defaults to `Active`.
 Valid values are `Active` and `Inactive`.
 
@@ -67,9 +68,11 @@ In addition to all arguments above, the following attributes are exported:
 * `key_fingerprint` - The fingerprint of the PGP key used to encrypt
   the secret
 * `secret` - The secret access key. Note that this will be written
-to the state file. Please supply a `pgp_key` instead, which will prevent the
-secret from being stored in plain text
-* `encrypted_secret` - The encrypted secret, base64 encoded.
+to the state file. If you use this, please protect your backend state file
+judiciously. Alternatively, you may supply a `pgp_key` instead, which will
+prevent the secret from being stored in plaintext, at the cost of preventing
+the use of the secret key in automation.
+* `encrypted_secret` - The encrypted secret, base64 encoded, if `pgp_key` was specified.
 ~> **NOTE:** The encrypted secret may be decrypted using the command line,
    for example: `terraform output encrypted_secret | base64 --decode | keybase pgp decrypt`.
 * `ses_smtp_password` - The secret access key converted into an SES SMTP


### PR DESCRIPTION
According to [article](https://www.terraform.io/docs/extend/best-practices/sensitive-state.html), we should stop focusing efforts on encrypting state values with PGP keys and instead mark fields as sensitive. According to the article, the effort should be spent instead on protecting state buckets and our team intends to move in this direction.

Therefore, I've gone and set both attributes to sensitive and removed the deprecation notice recommending using the `pgp_key` technique.

Since people may disagree, I haven't gone so far as to remove the `pgp_key` support. I think it should remain for as long as the maintainers want to promote people using this feature and as long as it doesn't seem contrarian compared to official Hashicorp doctrine.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Un-deprecated the `secret` output attribute of `aws_iam_access_key`, and marked
the `secret` and `ses_smtp_password` attributes as `sensitive` instead, according
to [Terraform best practice](https://www.terraform.io/docs/extend/best-practices/sensitive-state.html).
`pgp_key` attribute remains usable and will continue to have the same behavior.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
▶ make testacc TESTARGS='-run=TestAccAWSAccess*'                   
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSAccess* -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSAccessKey_basic
=== PAUSE TestAccAWSAccessKey_basic
=== RUN   TestAccAWSAccessKey_encrypted
=== PAUSE TestAccAWSAccessKey_encrypted
=== RUN   TestAccAWSAccessKey_inactive
=== PAUSE TestAccAWSAccessKey_inactive
=== CONT  TestAccAWSAccessKey_basic
=== CONT  TestAccAWSAccessKey_inactive
=== CONT  TestAccAWSAccessKey_encrypted
--- PASS: TestAccAWSAccessKey_basic (15.29s)
--- PASS: TestAccAWSAccessKey_encrypted (15.33s)
--- PASS: TestAccAWSAccessKey_inactive (26.03s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	27.965s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.352s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.223s [no tests to run]
...
```
