### PR TITLE
New Resource: aws_eks_node_group

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -499,6 +499,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_eip":                                                 resourceAwsEip(),
 			"aws_eip_association":                                     resourceAwsEipAssociation(),
 			"aws_eks_cluster":                                         resourceAwsEksCluster(),
+			"aws_eks_node_group":                                      resourceAwsEksNodeGroup(),
 			"aws_elasticache_cluster":                                 resourceAwsElasticacheCluster(),
 			"aws_elasticache_parameter_group":                         resourceAwsElasticacheParameterGroup(),
 			"aws_elasticache_replication_group":                       resourceAwsElasticacheReplicationGroup(),

--- a/aws/resource_aws_eks_node_group.go
+++ b/aws/resource_aws_eks_node_group.go
@@ -1,0 +1,692 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+func resourceAwsEksNodeGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsEksNodeGroupCreate,
+		Read:   resourceAwsEksNodeGroupRead,
+		Update: resourceAwsEksNodeGroupUpdate,
+		Delete: resourceAwsEksNodeGroupDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+			Update: schema.DefaultTimeout(60 * time.Minute),
+			Delete: schema.DefaultTimeout(60 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"ami_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					eks.AMITypesAl2X8664,
+					eks.AMITypesAl2X8664Gpu,
+				}, false),
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cluster_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"disk_size": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_types": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				// Multiple instance types returns an API error currently:
+				// InvalidParameterException: Instance type list not valid, only one instance type is supported!
+				MaxItems: 1,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"labels": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"node_group_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"node_role_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"release_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"remote_access": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ec2_ssh_key": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"source_security_group_ids": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							ForceNew: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"resources": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"autoscaling_groups": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"remote_access_security_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"scaling_config": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"desired_size": {
+							Type:         schema.TypeInt,
+							Required:     true,
+							ValidateFunc: validation.IntAtLeast(1),
+						},
+						"max_size": {
+							Type:         schema.TypeInt,
+							Required:     true,
+							ValidateFunc: validation.IntAtLeast(1),
+						},
+						"min_size": {
+							Type:         schema.TypeInt,
+							Required:     true,
+							ValidateFunc: validation.IntAtLeast(1),
+						},
+					},
+				},
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"subnet_ids": {
+				Type:     schema.TypeSet,
+				Required: true,
+				ForceNew: true,
+				MinItems: 1,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"tags": tagsSchema(),
+			"version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsEksNodeGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).eksconn
+	clusterName := d.Get("cluster_name").(string)
+	nodeGroupName := d.Get("node_group_name").(string)
+
+	input := &eks.CreateNodegroupInput{
+		ClientRequestToken: aws.String(resource.UniqueId()),
+		ClusterName:        aws.String(clusterName),
+		NodegroupName:      aws.String(nodeGroupName),
+		NodeRole:           aws.String(d.Get("node_role_arn").(string)),
+		Subnets:            expandStringSet(d.Get("subnet_ids").(*schema.Set)),
+	}
+
+	if v, ok := d.GetOk("ami_type"); ok {
+		input.AmiType = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("disk_size"); ok {
+		input.DiskSize = aws.Int64(int64(v.(int)))
+	}
+
+	if v := d.Get("instance_types").(*schema.Set); v.Len() > 0 {
+		input.InstanceTypes = expandStringSet(v)
+	}
+
+	if v := d.Get("labels").(map[string]interface{}); len(v) > 0 {
+		input.Labels = stringMapToPointers(v)
+	}
+
+	if v, ok := d.GetOk("release_version"); ok {
+		input.ReleaseVersion = aws.String(v.(string))
+	}
+
+	if v := d.Get("remote_access").([]interface{}); len(v) > 0 {
+		input.RemoteAccess = expandEksRemoteAccessConfig(v)
+	}
+
+	if v := d.Get("scaling_config").([]interface{}); len(v) > 0 {
+		input.ScalingConfig = expandEksNodegroupScalingConfig(v)
+	}
+
+	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
+		input.Tags = keyvaluetags.New(v).IgnoreAws().EksTags()
+	}
+
+	if v, ok := d.GetOk("version"); ok {
+		input.Version = aws.String(v.(string))
+	}
+
+	_, err := conn.CreateNodegroup(input)
+
+	id := fmt.Sprintf("%s:%s", clusterName, nodeGroupName)
+
+	if err != nil {
+		return fmt.Errorf("error creating EKS Node Group (%s): %s", id, err)
+	}
+
+	d.SetId(id)
+
+	stateConf := resource.StateChangeConf{
+		Pending: []string{eks.NodegroupStatusCreating},
+		Target:  []string{eks.NodegroupStatusActive},
+		Timeout: d.Timeout(schema.TimeoutCreate),
+		Refresh: refreshEksNodeGroupStatus(conn, clusterName, nodeGroupName),
+	}
+
+	if _, err := stateConf.WaitForState(); err != nil {
+		return fmt.Errorf("error waiting for EKS Node Group (%s) creation: %s", d.Id(), err)
+	}
+
+	return resourceAwsEksNodeGroupRead(d, meta)
+}
+
+func resourceAwsEksNodeGroupRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).eksconn
+
+	clusterName, nodeGroupName, err := resourceAwsEksNodeGroupParseId(d.Id())
+	if err != nil {
+		return err
+	}
+
+	input := &eks.DescribeNodegroupInput{
+		ClusterName:   aws.String(clusterName),
+		NodegroupName: aws.String(nodeGroupName),
+	}
+
+	output, err := conn.DescribeNodegroup(input)
+
+	if isAWSErr(err, eks.ErrCodeResourceNotFoundException, "") {
+		log.Printf("[WARN] EKS Node Group (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading EKS Node Group (%s): %s", d.Id(), err)
+	}
+
+	nodeGroup := output.Nodegroup
+	if nodeGroup == nil {
+		log.Printf("[WARN] EKS Node Group (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("ami_type", nodeGroup.AmiType)
+	d.Set("arn", nodeGroup.NodegroupArn)
+	d.Set("cluster_name", nodeGroup.ClusterName)
+	d.Set("disk_size", nodeGroup.DiskSize)
+
+	if err := d.Set("instance_types", aws.StringValueSlice(nodeGroup.InstanceTypes)); err != nil {
+		return fmt.Errorf("error setting instance_types: %s", err)
+	}
+
+	if err := d.Set("labels", aws.StringValueMap(nodeGroup.Labels)); err != nil {
+		return fmt.Errorf("error setting labels: %s", err)
+	}
+
+	d.Set("node_group_name", nodeGroup.NodegroupName)
+	d.Set("node_role_arn", nodeGroup.NodeRole)
+	d.Set("release_version", nodeGroup.ReleaseVersion)
+
+	if err := d.Set("remote_access", flattenEksRemoteAccessConfig(nodeGroup.RemoteAccess)); err != nil {
+		return fmt.Errorf("error setting remote_access: %s", err)
+	}
+
+	if err := d.Set("resources", flattenEksNodeGroupResources(nodeGroup.Resources)); err != nil {
+		return fmt.Errorf("error setting resources: %s", err)
+	}
+
+	if err := d.Set("scaling_config", flattenEksNodeGroupScalingConfig(nodeGroup.ScalingConfig)); err != nil {
+		return fmt.Errorf("error setting scaling_config: %s", err)
+	}
+
+	d.Set("status", nodeGroup.Status)
+
+	if err := d.Set("subnet_ids", aws.StringValueSlice(nodeGroup.Subnets)); err != nil {
+		return fmt.Errorf("error setting subnets: %s", err)
+	}
+
+	if err := d.Set("tags", keyvaluetags.EksKeyValueTags(nodeGroup.Tags).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	d.Set("version", nodeGroup.Version)
+
+	return nil
+}
+
+func resourceAwsEksNodeGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).eksconn
+
+	clusterName, nodeGroupName, err := resourceAwsEksNodeGroupParseId(d.Id())
+	if err != nil {
+		return err
+	}
+
+	if d.HasChange("labels") || d.HasChange("scaling_config") {
+		oldLabelsRaw, newLabelsRaw := d.GetChange("labels")
+
+		input := &eks.UpdateNodegroupConfigInput{
+			ClientRequestToken: aws.String(resource.UniqueId()),
+			ClusterName:        aws.String(clusterName),
+			Labels:             expandEksUpdateLabelsPayload(oldLabelsRaw, newLabelsRaw),
+			NodegroupName:      aws.String(nodeGroupName),
+		}
+
+		if v := d.Get("scaling_config").([]interface{}); len(v) > 0 {
+			input.ScalingConfig = expandEksNodegroupScalingConfig(v)
+		}
+
+		output, err := conn.UpdateNodegroupConfig(input)
+
+		if err != nil {
+			return fmt.Errorf("error updating EKS Node Group (%s) config: %s", d.Id(), err)
+		}
+
+		if output == nil || output.Update == nil || output.Update.Id == nil {
+			return fmt.Errorf("error determining EKS Node Group (%s) config update ID: empty response", d.Id())
+		}
+
+		updateID := aws.StringValue(output.Update.Id)
+
+		err = waitForEksNodeGroupUpdate(conn, clusterName, nodeGroupName, updateID, d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return fmt.Errorf("error waiting for EKS Node Group (%s) config update (%s): %s", d.Id(), updateID, err)
+		}
+	}
+
+	if d.HasChange("release_version") || d.HasChange("version") {
+		input := &eks.UpdateNodegroupVersionInput{
+			ClientRequestToken: aws.String(resource.UniqueId()),
+			ClusterName:        aws.String(clusterName),
+			Force:              aws.Bool(false),
+			NodegroupName:      aws.String(nodeGroupName),
+		}
+
+		if v, ok := d.GetOk("release_version"); ok {
+			input.ReleaseVersion = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("version"); ok {
+			input.Version = aws.String(v.(string))
+		}
+
+		output, err := conn.UpdateNodegroupVersion(input)
+
+		if err != nil {
+			return fmt.Errorf("error updating EKS Node Group (%s) version: %s", d.Id(), err)
+		}
+
+		if output == nil || output.Update == nil || output.Update.Id == nil {
+			return fmt.Errorf("error determining EKS Node Group (%s) version update ID: empty response", d.Id())
+		}
+
+		updateID := aws.StringValue(output.Update.Id)
+
+		err = waitForEksNodeGroupUpdate(conn, clusterName, nodeGroupName, updateID, d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return fmt.Errorf("error waiting for EKS Node Group (%s) version update (%s): %s", d.Id(), updateID, err)
+		}
+	}
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+		if err := keyvaluetags.EksUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating tags: %s", err)
+		}
+	}
+
+	return resourceAwsEksNodeGroupRead(d, meta)
+}
+
+func resourceAwsEksNodeGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).eksconn
+
+	clusterName, nodeGroupName, err := resourceAwsEksNodeGroupParseId(d.Id())
+	if err != nil {
+		return err
+	}
+
+	input := &eks.DeleteNodegroupInput{
+		ClusterName:   aws.String(clusterName),
+		NodegroupName: aws.String(nodeGroupName),
+	}
+
+	_, err = conn.DeleteNodegroup(input)
+
+	if isAWSErr(err, eks.ErrCodeResourceNotFoundException, "") {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting EKS Node Group (%s): %s", d.Id(), err)
+	}
+
+	if err := waitForEksNodeGroupDeletion(conn, clusterName, nodeGroupName, d.Timeout(schema.TimeoutDelete)); err != nil {
+		return fmt.Errorf("error waiting for EKS Node Group (%s) deletion: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func expandEksNodegroupScalingConfig(l []interface{}) *eks.NodegroupScalingConfig {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	config := &eks.NodegroupScalingConfig{}
+
+	if v, ok := m["desired_size"].(int); ok && v != 0 {
+		config.DesiredSize = aws.Int64(int64(v))
+	}
+
+	if v, ok := m["max_size"].(int); ok && v != 0 {
+		config.MaxSize = aws.Int64(int64(v))
+	}
+
+	if v, ok := m["min_size"].(int); ok && v != 0 {
+		config.MinSize = aws.Int64(int64(v))
+	}
+
+	return config
+}
+
+func expandEksRemoteAccessConfig(l []interface{}) *eks.RemoteAccessConfig {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	config := &eks.RemoteAccessConfig{}
+
+	if v, ok := m["ec2_ssh_key"].(string); ok && v != "" {
+		config.Ec2SshKey = aws.String(v)
+	}
+
+	if v, ok := m["source_security_group_ids"].(*schema.Set); ok && v.Len() > 0 {
+		config.SourceSecurityGroups = expandStringSet(v)
+	}
+
+	return config
+}
+
+func expandEksUpdateLabelsPayload(oldLabelsMap, newLabelsMap interface{}) *eks.UpdateLabelsPayload {
+	// EKS Labels operate similarly to keyvaluetags
+	oldLabels := keyvaluetags.New(oldLabelsMap)
+	newLabels := keyvaluetags.New(newLabelsMap)
+
+	removedLabels := oldLabels.Removed(newLabels)
+	updatedLabels := oldLabels.Updated(newLabels)
+
+	if len(removedLabels) == 0 && len(updatedLabels) == 0 {
+		return nil
+	}
+
+	updateLabelsPayload := &eks.UpdateLabelsPayload{}
+
+	if len(removedLabels) > 0 {
+		updateLabelsPayload.RemoveLabels = aws.StringSlice(removedLabels.Keys())
+	}
+
+	if len(updatedLabels) > 0 {
+		updateLabelsPayload.AddOrUpdateLabels = aws.StringMap(updatedLabels.Map())
+	}
+
+	return updateLabelsPayload
+}
+
+func flattenEksAutoScalingGroups(autoScalingGroups []*eks.AutoScalingGroup) []map[string]interface{} {
+	if len(autoScalingGroups) == 0 {
+		return []map[string]interface{}{}
+	}
+
+	l := make([]map[string]interface{}, 0, len(autoScalingGroups))
+
+	for _, autoScalingGroup := range autoScalingGroups {
+		m := map[string]interface{}{
+			"name": aws.StringValue(autoScalingGroup.Name),
+		}
+
+		l = append(l, m)
+	}
+
+	return l
+}
+
+func flattenEksNodeGroupResources(resources *eks.NodegroupResources) []map[string]interface{} {
+	if resources == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"autoscaling_groups":              flattenEksAutoScalingGroups(resources.AutoScalingGroups),
+		"remote_access_security_group_id": aws.StringValue(resources.RemoteAccessSecurityGroup),
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func flattenEksNodeGroupScalingConfig(config *eks.NodegroupScalingConfig) []map[string]interface{} {
+	if config == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"desired_size": aws.Int64Value(config.DesiredSize),
+		"max_size":     aws.Int64Value(config.MaxSize),
+		"min_size":     aws.Int64Value(config.MinSize),
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func flattenEksRemoteAccessConfig(config *eks.RemoteAccessConfig) []map[string]interface{} {
+	if config == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"ec2_ssh_key":               aws.StringValue(config.Ec2SshKey),
+		"source_security_group_ids": aws.StringValueSlice(config.SourceSecurityGroups),
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func refreshEksNodeGroupStatus(conn *eks.EKS, clusterName string, nodeGroupName string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		input := &eks.DescribeNodegroupInput{
+			ClusterName:   aws.String(clusterName),
+			NodegroupName: aws.String(nodeGroupName),
+		}
+
+		output, err := conn.DescribeNodegroup(input)
+
+		if err != nil {
+			return "", "", err
+		}
+
+		nodeGroup := output.Nodegroup
+
+		if nodeGroup == nil {
+			return nodeGroup, "", fmt.Errorf("EKS Node Group (%s:%s) missing", clusterName, nodeGroupName)
+		}
+
+		status := aws.StringValue(nodeGroup.Status)
+
+		// Return enhanced error messaging if available, instead of:
+		// unexpected state 'CREATE_FAILED', wanted target 'ACTIVE'. last error: %!s(<nil>)
+		if status == eks.NodegroupStatusCreateFailed || status == eks.NodegroupStatusDeleteFailed {
+			if nodeGroup.Health == nil || len(nodeGroup.Health.Issues) == 0 || nodeGroup.Health.Issues[0] == nil {
+				return nodeGroup, status, fmt.Errorf("unable to find additional information about %s status, check EKS Node Group (%s:%s) health", status, clusterName, nodeGroupName)
+			}
+
+			issue := nodeGroup.Health.Issues[0]
+
+			return nodeGroup, status, fmt.Errorf("%s: %s. Resource IDs: %v", aws.StringValue(issue.Code), aws.StringValue(issue.Message), aws.StringValueSlice(issue.ResourceIds))
+		}
+
+		return nodeGroup, status, nil
+	}
+}
+
+func refreshEksNodeGroupUpdateStatus(conn *eks.EKS, clusterName string, nodeGroupName string, updateID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		input := &eks.DescribeUpdateInput{
+			Name:          aws.String(clusterName),
+			NodegroupName: aws.String(nodeGroupName),
+			UpdateId:      aws.String(updateID),
+		}
+
+		output, err := conn.DescribeUpdate(input)
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		if output == nil || output.Update == nil {
+			return nil, "", fmt.Errorf("EKS Node Group (%s:%s) update (%s) missing", clusterName, nodeGroupName, updateID)
+		}
+
+		return output.Update, aws.StringValue(output.Update.Status), nil
+	}
+}
+
+func waitForEksNodeGroupDeletion(conn *eks.EKS, clusterName string, nodeGroupName string, timeout time.Duration) error {
+	stateConf := resource.StateChangeConf{
+		Pending: []string{
+			eks.NodegroupStatusActive,
+			eks.NodegroupStatusDeleting,
+		},
+		Target:  []string{""},
+		Timeout: timeout,
+		Refresh: refreshEksNodeGroupStatus(conn, clusterName, nodeGroupName),
+	}
+
+	_, err := stateConf.WaitForState()
+
+	if isAWSErr(err, eks.ErrCodeResourceNotFoundException, "") {
+		return nil
+	}
+
+	return err
+}
+
+func waitForEksNodeGroupUpdate(conn *eks.EKS, clusterName, nodeGroupName string, updateID string, timeout time.Duration) error {
+	stateConf := resource.StateChangeConf{
+		Pending: []string{eks.UpdateStatusInProgress},
+		Target: []string{
+			eks.UpdateStatusCancelled,
+			eks.UpdateStatusFailed,
+			eks.UpdateStatusSuccessful,
+		},
+		Timeout: timeout,
+		Refresh: refreshEksNodeGroupUpdateStatus(conn, clusterName, nodeGroupName, updateID),
+	}
+
+	updateRaw, err := stateConf.WaitForState()
+
+	if err != nil {
+		return err
+	}
+
+	update := updateRaw.(*eks.Update)
+
+	if aws.StringValue(update.Status) == eks.UpdateStatusSuccessful {
+		return nil
+	}
+
+	var detailedErrors []string
+	for i, updateError := range update.Errors {
+		detailedErrors = append(detailedErrors, fmt.Sprintf("Error %d: Code: %s / Message: %s", i+1, aws.StringValue(updateError.ErrorCode), aws.StringValue(updateError.ErrorMessage)))
+	}
+
+	return fmt.Errorf("EKS Node Group (%s) update (%s) status (%s) not successful: Errors:\n%s", clusterName, updateID, aws.StringValue(update.Status), strings.Join(detailedErrors, "\n"))
+}
+
+func resourceAwsEksNodeGroupParseId(id string) (string, string, error) {
+	parts := strings.Split(id, ":")
+
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("unexpected format of ID (%s), expected cluster-name:node-group-name", id)
+	}
+
+	return parts[0], parts[1], nil
+}

--- a/aws/resource_aws_eks_node_group_test.go
+++ b/aws/resource_aws_eks_node_group_test.go
@@ -1,0 +1,987 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccAWSEksNodeGroup_basic(t *testing.T) {
+	var nodeGroup eks.Nodegroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	eksClusterResourceName := "aws_eks_cluster.test"
+	iamRoleResourceName := "aws_iam_role.node"
+	resourceName := "aws_eks_node_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEksNodeGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEksNodeGroupConfigNodeGroupName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup),
+					resource.TestCheckResourceAttr(resourceName, "ami_type", eks.AMITypesAl2X8664),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "eks", regexp.MustCompile(fmt.Sprintf("nodegroup/%[1]s/%[1]s/.+", rName))),
+					resource.TestCheckResourceAttrPair(resourceName, "cluster_name", eksClusterResourceName, "name"),
+					resource.TestCheckResourceAttr(resourceName, "disk_size", "20"),
+					resource.TestCheckResourceAttr(resourceName, "instance_types.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "labels.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "node_group_name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "node_role_arn", iamRoleResourceName, "arn"),
+					resource.TestMatchResourceAttr(resourceName, "release_version", regexp.MustCompile(`^\d+\.\d+\.\d+-\d{8}$`)),
+					resource.TestCheckResourceAttr(resourceName, "remote_access.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "resources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "resources.0.autoscaling_groups.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.desired_size", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.max_size", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.min_size", "1"),
+					resource.TestCheckResourceAttr(resourceName, "status", eks.NodegroupStatusActive),
+					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttrPair(resourceName, "version", eksClusterResourceName, "version"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSEksNodeGroup_disappears(t *testing.T) {
+	var nodeGroup eks.Nodegroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_eks_node_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEksNodeGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEksNodeGroupConfigNodeGroupName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup),
+					testAccCheckAWSEksNodeGroupDisappears(&nodeGroup),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSEksNodeGroup_AmiType(t *testing.T) {
+	var nodeGroup1 eks.Nodegroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_eks_node_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEksNodeGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEksNodeGroupConfigAmiType(rName, eks.AMITypesAl2X8664Gpu),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup1),
+					resource.TestCheckResourceAttr(resourceName, "ami_type", eks.AMITypesAl2X8664Gpu),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSEksNodeGroup_DiskSize(t *testing.T) {
+	var nodeGroup1 eks.Nodegroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_eks_node_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEksNodeGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEksNodeGroupConfigDiskSize(rName, 21),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup1),
+					resource.TestCheckResourceAttr(resourceName, "disk_size", "21"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSEksNodeGroup_InstanceTypes(t *testing.T) {
+	var nodeGroup1 eks.Nodegroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_eks_node_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEksNodeGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEksNodeGroupConfigInstanceTypes1(rName, "t3.large"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup1),
+					resource.TestCheckResourceAttr(resourceName, "instance_types.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSEksNodeGroup_Labels(t *testing.T) {
+	var nodeGroup1, nodeGroup2, nodeGroup3 eks.Nodegroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_eks_node_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEksNodeGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEksNodeGroupConfigLabels1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup1),
+					resource.TestCheckResourceAttr(resourceName, "labels.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "labels.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSEksNodeGroupConfigLabels2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup2),
+					resource.TestCheckResourceAttr(resourceName, "labels.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "labels.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "labels.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSEksNodeGroupConfigLabels1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup3),
+					resource.TestCheckResourceAttr(resourceName, "labels.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "labels.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEksNodeGroup_ReleaseVersion(t *testing.T) {
+	var nodeGroup1 eks.Nodegroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_eks_node_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEksNodeGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEksNodeGroupConfigReleaseVersion(rName, "1.14.7-20190927"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup1),
+					resource.TestCheckResourceAttr(resourceName, "release_version", "1.14.7-20190927"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSEksNodeGroup_RemoteAccess_Ec2SshKey(t *testing.T) {
+	var nodeGroup1 eks.Nodegroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_eks_node_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEksNodeGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEksNodeGroupConfigRemoteAccessEc2SshKey(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup1),
+					resource.TestCheckResourceAttr(resourceName, "remote_access.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "remote_access.0.ec2_ssh_key", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSEksNodeGroup_RemoteAccess_SourceSecurityGroupIds(t *testing.T) {
+	var nodeGroup1 eks.Nodegroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_eks_node_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEksNodeGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEksNodeGroupConfigRemoteAccessSourceSecurityGroupIds1(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup1),
+					resource.TestCheckResourceAttr(resourceName, "remote_access.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "remote_access.0.source_security_group_ids.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSEksNodeGroup_ScalingConfig_DesiredSize(t *testing.T) {
+	var nodeGroup1, nodeGroup2 eks.Nodegroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_eks_node_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEksNodeGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEksNodeGroupConfigScalingConfigSizes(rName, 2, 2, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup1),
+					resource.TestCheckResourceAttr(resourceName, "scaling_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.desired_size", "2"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.max_size", "2"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.min_size", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSEksNodeGroupConfigScalingConfigSizes(rName, 1, 2, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup2),
+					resource.TestCheckResourceAttr(resourceName, "scaling_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.desired_size", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.max_size", "2"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.min_size", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEksNodeGroup_ScalingConfig_MaxSize(t *testing.T) {
+	var nodeGroup1, nodeGroup2 eks.Nodegroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_eks_node_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEksNodeGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEksNodeGroupConfigScalingConfigSizes(rName, 1, 2, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup1),
+					resource.TestCheckResourceAttr(resourceName, "scaling_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.desired_size", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.max_size", "2"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.min_size", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSEksNodeGroupConfigScalingConfigSizes(rName, 1, 1, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup2),
+					resource.TestCheckResourceAttr(resourceName, "scaling_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.desired_size", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.max_size", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.min_size", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEksNodeGroup_ScalingConfig_MinSize(t *testing.T) {
+	var nodeGroup1, nodeGroup2 eks.Nodegroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_eks_node_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEksNodeGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEksNodeGroupConfigScalingConfigSizes(rName, 2, 2, 2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup1),
+					resource.TestCheckResourceAttr(resourceName, "scaling_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.desired_size", "2"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.max_size", "2"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.min_size", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSEksNodeGroupConfigScalingConfigSizes(rName, 2, 2, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup2),
+					resource.TestCheckResourceAttr(resourceName, "scaling_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.desired_size", "2"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.max_size", "2"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.min_size", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEksNodeGroup_Tags(t *testing.T) {
+	var nodeGroup1, nodeGroup2, nodeGroup3 eks.Nodegroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_eks_node_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEksNodeGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEksNodeGroupConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup1),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSEksNodeGroupConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup2),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSEksNodeGroupConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup3),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEksNodeGroup_Version(t *testing.T) {
+	var nodeGroup1 eks.Nodegroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_eks_node_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEksNodeGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEksNodeGroupConfigVersion(rName, "1.14"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup1),
+					resource.TestCheckResourceAttr(resourceName, "version", "1.14"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSEksNodeGroupExists(resourceName string, nodeGroup *eks.Nodegroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No EKS Node Group ID is set")
+		}
+
+		clusterName, nodeGroupName, err := resourceAwsEksNodeGroupParseId(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).eksconn
+
+		input := &eks.DescribeNodegroupInput{
+			ClusterName:   aws.String(clusterName),
+			NodegroupName: aws.String(nodeGroupName),
+		}
+
+		output, err := conn.DescribeNodegroup(input)
+
+		if err != nil {
+			return err
+		}
+
+		if output == nil || output.Nodegroup == nil {
+			return fmt.Errorf("EKS Node Group (%s) not found", rs.Primary.ID)
+		}
+
+		if aws.StringValue(output.Nodegroup.NodegroupName) != nodeGroupName {
+			return fmt.Errorf("EKS Node Group (%s) not found", rs.Primary.ID)
+		}
+
+		if got, want := aws.StringValue(output.Nodegroup.Status), eks.NodegroupStatusActive; got != want {
+			return fmt.Errorf("EKS Node Group (%s) not in %s status, got: %s", rs.Primary.ID, want, got)
+		}
+
+		*nodeGroup = *output.Nodegroup
+
+		return nil
+	}
+}
+
+func testAccCheckAWSEksNodeGroupDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).eksconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_eks_node_group" {
+			continue
+		}
+
+		clusterName, nodeGroupName, err := resourceAwsEksNodeGroupParseId(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		input := &eks.DescribeNodegroupInput{
+			ClusterName:   aws.String(clusterName),
+			NodegroupName: aws.String(nodeGroupName),
+		}
+
+		output, err := conn.DescribeNodegroup(input)
+
+		if isAWSErr(err, eks.ErrCodeResourceNotFoundException, "") {
+			continue
+		}
+
+		if output != nil && output.Nodegroup != nil && aws.StringValue(output.Nodegroup.NodegroupName) == nodeGroupName {
+			return fmt.Errorf("EKS Node Group (%s) still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAWSEksNodeGroupDisappears(nodeGroup *eks.Nodegroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).eksconn
+
+		input := &eks.DeleteNodegroupInput{
+			ClusterName:   nodeGroup.ClusterName,
+			NodegroupName: nodeGroup.NodegroupName,
+		}
+
+		_, err := conn.DeleteNodegroup(input)
+
+		if isAWSErr(err, eks.ErrCodeResourceNotFoundException, "") {
+			return nil
+		}
+
+		if err != nil {
+			return err
+		}
+
+		return waitForEksNodeGroupDeletion(conn, aws.StringValue(nodeGroup.ClusterName), aws.StringValue(nodeGroup.NodegroupName), 60*time.Minute)
+	}
+}
+
+func testAccAWSEksNodeGroupConfigBase(rName string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "cluster" {
+  name = "%[1]s-cluster"
+
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = {
+        Service = [
+          "eks.${data.aws_partition.current.dns_suffix}",
+          "eks-nodegroup.${data.aws_partition.current.dns_suffix}",
+        ]
+      }
+    }]
+    Version = "2012-10-17"
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "cluster-AmazonEKSClusterPolicy" {
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKSClusterPolicy"
+  role       = aws_iam_role.cluster.name
+}
+
+resource "aws_iam_role_policy_attachment" "cluster-AmazonEKSServicePolicy" {
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKSServicePolicy"
+  role       = aws_iam_role.cluster.name
+}
+
+resource "aws_iam_role" "node" {
+  name = "%[1]s-node"
+  
+  assume_role_policy = jsonencode({
+    Statement = [{
+    Action    = "sts:AssumeRole"
+    Effect    = "Allow"
+    Principal = {
+      Service = "ec2.${data.aws_partition.current.dns_suffix}"
+    }
+    }]
+    Version = "2012-10-17"
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "node-AmazonEKSWorkerNodePolicy" {
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.node.name
+}
+
+resource "aws_iam_role_policy_attachment" "node-AmazonEKS_CNI_Policy" {
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.node.name
+}
+
+resource "aws_iam_role_policy_attachment" "node-AmazonEC2ContainerRegistryReadOnly" {
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.node.name
+}
+
+resource "aws_vpc" "test" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name                          = "tf-acc-test-eks-node-group"
+    "kubernetes.io/cluster/%[1]s" = "shared"
+  }
+}
+
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.test.id
+  }
+}
+
+resource "aws_main_route_table_association" "test" {
+  route_table_id = aws_route_table.test.id
+  vpc_id         = aws_vpc.test.id
+}
+
+resource "aws_security_group" "test" {
+  name   = %[1]q
+  vpc_id = aws_vpc.test.id
+
+  egress {
+    cidr_blocks = ["0.0.0.0/0"]
+    from_port   = 0
+    protocol    = -1
+    to_port     = 0
+  }
+
+  ingress {
+    cidr_blocks = [aws_vpc.test.cidr_block]
+    from_port   = 0
+    protocol    = -1
+    to_port     = 0
+  }
+}
+
+resource "aws_subnet" "test" {
+  count = 2
+
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
+  vpc_id            = aws_vpc.test.id
+
+  tags = {
+    Name                          = "tf-acc-test-eks-node-group"
+    "kubernetes.io/cluster/%[1]s" = "shared"
+  }
+}
+
+resource "aws_eks_cluster" "test" {
+  name     = %[1]q
+  role_arn = aws_iam_role.cluster.arn
+
+  vpc_config {
+    subnet_ids = aws_subnet.test[*].id
+  }
+
+  depends_on = [
+    "aws_iam_role_policy_attachment.cluster-AmazonEKSClusterPolicy",
+    "aws_iam_role_policy_attachment.cluster-AmazonEKSServicePolicy",
+    "aws_main_route_table_association.test",
+  ]
+}
+`, rName)
+}
+
+func testAccAWSEksNodeGroupConfigNodeGroupName(rName string) string {
+	return testAccAWSEksNodeGroupConfigBase(rName) + fmt.Sprintf(`
+resource "aws_eks_node_group" "test" {
+  cluster_name    = aws_eks_cluster.test.name
+  node_group_name = %[1]q
+  node_role_arn   = aws_iam_role.node.arn
+  subnet_ids      = aws_subnet.test[*].id
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+
+  depends_on = [
+    "aws_iam_role_policy_attachment.node-AmazonEKSWorkerNodePolicy",
+    "aws_iam_role_policy_attachment.node-AmazonEKS_CNI_Policy",
+    "aws_iam_role_policy_attachment.node-AmazonEC2ContainerRegistryReadOnly",
+  ]
+}
+`, rName)
+}
+
+func testAccAWSEksNodeGroupConfigAmiType(rName, amiType string) string {
+	return testAccAWSEksNodeGroupConfigBase(rName) + fmt.Sprintf(`
+resource "aws_eks_node_group" "test" {
+  ami_type        = %[2]q
+  cluster_name    = aws_eks_cluster.test.name
+  node_group_name = %[1]q
+  node_role_arn   = aws_iam_role.node.arn
+  subnet_ids      = aws_subnet.test[*].id
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+}
+`, rName, amiType)
+}
+
+func testAccAWSEksNodeGroupConfigDiskSize(rName string, diskSize int) string {
+	return testAccAWSEksNodeGroupConfigBase(rName) + fmt.Sprintf(`
+resource "aws_eks_node_group" "test" {
+  cluster_name    = aws_eks_cluster.test.name
+  disk_size       = %[2]d
+  node_group_name = %[1]q
+  node_role_arn   = aws_iam_role.node.arn
+  subnet_ids      = aws_subnet.test[*].id
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+}
+`, rName, diskSize)
+}
+
+func testAccAWSEksNodeGroupConfigInstanceTypes1(rName, instanceType1 string) string {
+	return testAccAWSEksNodeGroupConfigBase(rName) + fmt.Sprintf(`
+resource "aws_eks_node_group" "test" {
+  cluster_name    = aws_eks_cluster.test.name
+  instance_types  = [%[2]q]
+  node_group_name = %[1]q
+  node_role_arn   = aws_iam_role.node.arn
+  subnet_ids      = aws_subnet.test[*].id
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+}
+`, rName, instanceType1)
+}
+
+func testAccAWSEksNodeGroupConfigLabels1(rName, labelKey1, labelValue1 string) string {
+	return testAccAWSEksNodeGroupConfigBase(rName) + fmt.Sprintf(`
+resource "aws_eks_node_group" "test" {
+  cluster_name    = aws_eks_cluster.test.name
+  node_group_name = %[1]q
+  node_role_arn   = aws_iam_role.node.arn
+  subnet_ids      = aws_subnet.test[*].id
+
+  labels = {
+    %[2]q = %[3]q
+  }
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+}
+`, rName, labelKey1, labelValue1)
+}
+
+func testAccAWSEksNodeGroupConfigLabels2(rName, labelKey1, labelValue1, labelKey2, labelValue2 string) string {
+	return testAccAWSEksNodeGroupConfigBase(rName) + fmt.Sprintf(`
+resource "aws_eks_node_group" "test" {
+  cluster_name    = aws_eks_cluster.test.name
+  node_group_name = %[1]q
+  node_role_arn   = aws_iam_role.node.arn
+  subnet_ids      = aws_subnet.test[*].id
+
+  labels = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+}
+`, rName, labelKey1, labelValue1, labelKey2, labelValue2)
+}
+
+func testAccAWSEksNodeGroupConfigReleaseVersion(rName, releaseVersion string) string {
+	return testAccAWSEksNodeGroupConfigBase(rName) + fmt.Sprintf(`
+resource "aws_eks_node_group" "test" {
+  cluster_name    = aws_eks_cluster.test.name
+  node_group_name = %[1]q
+  node_role_arn   = aws_iam_role.node.arn
+  release_version = %[2]q
+  subnet_ids      = aws_subnet.test[*].id
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+}
+`, rName, releaseVersion)
+}
+
+func testAccAWSEksNodeGroupConfigRemoteAccessEc2SshKey(rName string) string {
+	return testAccAWSEksNodeGroupConfigBase(rName) + fmt.Sprintf(`
+resource "aws_key_pair" "test" {
+  key_name   = %[1]q
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 example@example.com"
+}
+
+resource "aws_eks_node_group" "test" {
+  cluster_name    = aws_eks_cluster.test.name
+  node_group_name = %[1]q
+  node_role_arn   = aws_iam_role.node.arn
+  subnet_ids      = aws_subnet.test[*].id
+
+  remote_access {
+    ec2_ssh_key = aws_key_pair.test.key_name
+  }
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+}
+`, rName)
+}
+
+func testAccAWSEksNodeGroupConfigRemoteAccessSourceSecurityGroupIds1(rName string) string {
+	return testAccAWSEksNodeGroupConfigBase(rName) + fmt.Sprintf(`
+resource "aws_key_pair" "test" {
+  key_name   = %[1]q
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 example@example.com"
+}
+
+resource "aws_eks_node_group" "test" {
+  cluster_name    = aws_eks_cluster.test.name
+  node_group_name = %[1]q
+  node_role_arn   = aws_iam_role.node.arn
+  subnet_ids      = aws_subnet.test[*].id
+
+  remote_access {
+    ec2_ssh_key               = aws_key_pair.test.key_name
+    source_security_group_ids = [aws_security_group.test.id]
+  }
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+}
+`, rName)
+}
+
+func testAccAWSEksNodeGroupConfigScalingConfigSizes(rName string, desiredSize, maxSize, minSize int) string {
+	return testAccAWSEksNodeGroupConfigBase(rName) + fmt.Sprintf(`
+resource "aws_eks_node_group" "test" {
+  cluster_name    = aws_eks_cluster.test.name
+  node_group_name = %[1]q
+  node_role_arn   = aws_iam_role.node.arn
+  subnet_ids      = aws_subnet.test[*].id
+
+  scaling_config {
+    desired_size = %[2]d
+    max_size     = %[3]d
+    min_size     = %[4]d
+  }
+}
+`, rName, desiredSize, maxSize, minSize)
+}
+
+func testAccAWSEksNodeGroupConfigTags1(rName, tagKey1, tagValue1 string) string {
+	return testAccAWSEksNodeGroupConfigBase(rName) + fmt.Sprintf(`
+resource "aws_eks_node_group" "test" {
+  cluster_name    = aws_eks_cluster.test.name
+  node_group_name = %[1]q
+  node_role_arn   = aws_iam_role.node.arn
+  subnet_ids      = aws_subnet.test[*].id
+
+  tags = {
+    %[2]q = %[3]q
+  }
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccAWSEksNodeGroupConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return testAccAWSEksNodeGroupConfigBase(rName) + fmt.Sprintf(`
+resource "aws_eks_node_group" "test" {
+  cluster_name    = aws_eks_cluster.test.name
+  node_group_name = %[1]q
+  node_role_arn   = aws_iam_role.node.arn
+  subnet_ids      = aws_subnet.test[*].id
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}
+
+func testAccAWSEksNodeGroupConfigVersion(rName, version string) string {
+	return testAccAWSEksNodeGroupConfigBase(rName) + fmt.Sprintf(`
+resource "aws_eks_node_group" "test" {
+  cluster_name    = aws_eks_cluster.test.name
+  node_group_name = %[1]q
+  node_role_arn   = aws_iam_role.node.arn
+  subnet_ids      = aws_subnet.test[*].id
+  version         = %[2]q
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+}
+`, rName, version)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1235,6 +1235,9 @@
                                 <li>
                                     <a href="/docs/providers/aws/r/eks_cluster.html">aws_eks_cluster</a>
                                 </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/eks_node_group.html">aws_eks_node_group</a>
+                                </li>
                             </ul>
                         </li>
                     </ul>

--- a/website/docs/r/eks_node_group.html.markdown
+++ b/website/docs/r/eks_node_group.html.markdown
@@ -1,0 +1,143 @@
+---
+subcategory: "EKS"
+layout: "aws"
+page_title: "AWS: aws_eks_node_group"
+description: |-
+  Manages an EKS Node Group
+---
+
+# Resource: aws_eks_node_group
+
+Manages an EKS Node Group, which can provision and optionally update an Auto Scaling Group of Kubernetes worker nodes compatible with EKS. Additional documentation about this functionality can be found in the [EKS User Guide](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html).
+
+## Example Usage
+
+```hcl
+resource "aws_eks_node_group" "example" {
+  cluster_name    = aws_eks_cluster.example.name
+  node_group_name = "example"
+  node_role_arn   = aws_iam_role.example.arn
+  subnet_ids      = aws_subnet.example[*].id
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+}
+```
+
+### Example IAM Role for EKS Node Group
+
+```hcl
+resource "aws_iam_role" "example" {
+  name = "eks-node-group-example"
+  
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = {
+        Service = "ec2.amazonaws.com"
+      }
+    }]
+    Version = "2012-10-17"
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "example-AmazonEKSWorkerNodePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.example.name
+}
+
+resource "aws_iam_role_policy_attachment" "example-AmazonEKS_CNI_Policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.example.name
+}
+
+resource "aws_iam_role_policy_attachment" "example-AmazonEC2ContainerRegistryReadOnly" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.example.name
+}
+```
+
+### Example Subnets for EKS Node Group
+
+```hcl
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+resource "aws_subnet" "example" {
+  count = 2
+
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  cidr_block        = cidrsubnet(aws_vpc.example.cidr_block, 8, count.index)
+  vpc_id            = aws_vpc.example.id
+
+  tags = {
+    "kubernetes.io/cluster/${aws_eks_cluster.example.name}" = "shared"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `cluster_name` – (Required) Name of the EKS Cluster.
+* `node_group_name` – (Required) Name of the EKS Node Group.
+* `node_role_arn` – (Required) Amazon Resource Name (ARN) of the IAM Role that provides permissions for the EKS Node Group.
+* `scaling_config` - (Required) Configuration block with scaling settings. Detailed below.
+* `subnet_ids` – (Required) Identifiers of EC2 Subnets to associate with the EKS Node Group. These subnets must have the following resource tag: `kubernetes.io/cluster/CLUSTER_NAME` (where `CLUSTER_NAME` is replaced with the name of the EKS Cluster).
+
+The following arguments are optional:
+
+* `ami_type` - (Optional) Type of Amazon Machine Image (AMI) associated with the EKS Node Group. Defaults to `AL2_x86_64`. Valid values: `AL2_x86_64`, `AL2_x86_64_GPU`. Terraform will only perform drift detection if a configuration value is provided.
+* `disk_size` - (Optional) Disk size in GiB for worker nodes. Defaults to `20`. Terraform will only perform drift detection if a configuration value is provided.
+* `instance_types` - (Optional) Set of instance types associated with the EKS Node Group. Defaults to `["t3.medium"]`. Terraform will only perform drift detection if a configuration value is provided.
+* `labels` - (Optional) Key-value mapping of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed.
+* `release_version` – (Optional) AMI version of the EKS Node Group. Defaults to latest version for Kubernetes version.
+* `remote_access` - (Optional) Configuration block with remote access settings. Detailed below.
+* `tags` - (Optional) Key-value mapping of resource tags.
+* `version` – (Optional) Kubernetes version. Defaults to EKS Cluster Kubernetes version. Terraform will only perform drift detection if a configuration value is provided.
+
+### remote_access Configuration Block
+
+* `ec2_ssh_key` - (Optional) EC2 Key Pair name that provides access for SSH communication with the worker nodes in the EKS Node Group. If you specify this configuration, but do not specify `source_security_group_ids` when you create an EKS Node Group, port 22 on the worker nodes is opened to the Internet (0.0.0.0/0).
+* `source_security_group_ids` - (Optional) Set of EC2 Security Group IDs to allow SSH access (port 22) from on the worker nodes. If you specify `ec2_ssh_key`, but do not specify this configuration when you create an EKS Node Group, port 22 on the worker nodes is opened to the Internet (0.0.0.0/0).
+
+### scaling_config Configuration Block
+
+* `desired_size` - (Required) Desired number of worker nodes.
+* `max_size` - (Required) Maximum number of worker nodes.
+* `min_size` - (Required) Minimum number of worker nodes.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - Amazon Resource Name (ARN) of the EKS Node Group.
+* `id` - EKS Cluster name and EKS Node Group name separated by a colon (`:`).
+* `resources` - List of objects containing information about underlying resources.
+  * `autoscaling_groups` - List of objects containing information about AutoScaling Groups.
+    * `name` - Name of the AutoScaling Group.
+  * `remote_access_security_group_id` - Identifier of the remote access EC2 Security Group.
+* `status` - Status of the EKS Node Group.
+
+## Timeouts
+
+`aws_eks_node_group` provides the following
+[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+* `create` - (Default `60 minutes`) How long to wait for the EKS Node Group to be created.
+* `update` - (Default `60 minutes`) How long to wait for the EKS Node Group to be updated. Note that the `update` timeout is used separately for both configuration and version update operations.
+* `delete` - (Default `60 minutes`) How long to wait for the EKS Node Group to be deleted.
+
+## Import
+
+EKS Node Groups can be imported using the `cluster_name` and `node_group_name` separated by a colon (`:`), e.g.
+
+```
+$ terraform import aws_eks_node_group.my_node_group my_cluster:my_node_group
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10915

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* **New Resource:** `aws_eks_node_group`
```

Output from acceptance testing:

```
--- PASS: TestAccAWSEksNodeGroup_AmiType (1541.19s)
--- PASS: TestAccAWSEksNodeGroup_basic (1592.90s)
--- PASS: TestAccAWSEksNodeGroup_disappears (1474.40s)
--- PASS: TestAccAWSEksNodeGroup_DiskSize (1509.60s)
--- PASS: TestAccAWSEksNodeGroup_InstanceTypes (1718.96s)
--- PASS: TestAccAWSEksNodeGroup_Labels (1674.47s)
--- PASS: TestAccAWSEksNodeGroup_ReleaseVersion (1473.09s)
--- PASS: TestAccAWSEksNodeGroup_RemoteAccess_Ec2SshKey (1572.12s)
--- PASS: TestAccAWSEksNodeGroup_RemoteAccess_SourceSecurityGroupIds (1579.61s)
--- PASS: TestAccAWSEksNodeGroup_ScalingConfig_DesiredSize (1695.85s)
--- PASS: TestAccAWSEksNodeGroup_ScalingConfig_MaxSize (1644.41s)
--- PASS: TestAccAWSEksNodeGroup_ScalingConfig_MinSize (1622.42s)
--- PASS: TestAccAWSEksNodeGroup_Tags (1614.55s)
--- PASS: TestAccAWSEksNodeGroup_Version (1721.66s)
```
