### PR TITLE
examples/eks-getting-started: Update for new EKS Node Group functionality

### DIFF
--- a/examples/eks-getting-started/eks-cluster.tf
+++ b/examples/eks-getting-started/eks-cluster.tf
@@ -51,16 +51,6 @@ resource "aws_security_group" "demo-cluster" {
   }
 }
 
-resource "aws_security_group_rule" "demo-cluster-ingress-node-https" {
-  description              = "Allow pods to communicate with the cluster API Server"
-  from_port                = 443
-  protocol                 = "tcp"
-  security_group_id        = "${aws_security_group.demo-cluster.id}"
-  source_security_group_id = "${aws_security_group.demo-node.id}"
-  to_port                  = 443
-  type                     = "ingress"
-}
-
 resource "aws_security_group_rule" "demo-cluster-ingress-workstation-https" {
   cidr_blocks       = ["${local.workstation-external-cidr}"]
   description       = "Allow workstation to communicate with the cluster API Server"

--- a/examples/eks-getting-started/eks-worker-nodes.tf
+++ b/examples/eks-getting-started/eks-worker-nodes.tf
@@ -1,10 +1,7 @@
 #
 # EKS Worker Nodes Resources
 #  * IAM role allowing Kubernetes actions to access other AWS services
-#  * EC2 Security Group to allow networking traffic
-#  * Data source to fetch latest EKS worker AMI
-#  * AutoScaling Launch Configuration to configure worker instances
-#  * AutoScaling Group to launch worker instances
+#  * EKS Node Group to launch worker nodes
 #
 
 resource "aws_iam_role" "demo-node" {
@@ -41,105 +38,21 @@ resource "aws_iam_role_policy_attachment" "demo-node-AmazonEC2ContainerRegistryR
   role       = "${aws_iam_role.demo-node.name}"
 }
 
-resource "aws_iam_instance_profile" "demo-node" {
-  name = "terraform-eks-demo"
-  role = "${aws_iam_role.demo-node.name}"
-}
+resource "aws_eks_node_group" "demo" {
+  cluster_name    = "${aws_eks_cluster.demo.name}"
+  node_group_name = "demo"
+  node_role_arn   = "${aws_iam_role.demo-node.arn}"
+  subnet_ids      = "${aws_subnet.demo[*].id}"
 
-resource "aws_security_group" "demo-node" {
-  name        = "terraform-eks-demo-node"
-  description = "Security group for all nodes in the cluster"
-  vpc_id      = "${aws_vpc.demo.id}"
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
   }
 
-  tags = "${
-    map(
-     "Name", "terraform-eks-demo-node",
-     "kubernetes.io/cluster/${var.cluster-name}", "owned",
-    )
-  }"
-}
-
-resource "aws_security_group_rule" "demo-node-ingress-self" {
-  description              = "Allow node to communicate with each other"
-  from_port                = 0
-  protocol                 = "-1"
-  security_group_id        = "${aws_security_group.demo-node.id}"
-  source_security_group_id = "${aws_security_group.demo-node.id}"
-  to_port                  = 65535
-  type                     = "ingress"
-}
-
-resource "aws_security_group_rule" "demo-node-ingress-cluster" {
-  description              = "Allow worker Kubelets and pods to receive communication from the cluster control plane"
-  from_port                = 1025
-  protocol                 = "tcp"
-  security_group_id        = "${aws_security_group.demo-node.id}"
-  source_security_group_id = "${aws_security_group.demo-cluster.id}"
-  to_port                  = 65535
-  type                     = "ingress"
-}
-
-data "aws_ami" "eks-worker" {
-  filter {
-    name   = "name"
-    values = ["amazon-eks-node-${aws_eks_cluster.demo.version}-v*"]
-  }
-
-  most_recent = true
-  owners      = ["602401143452"] # Amazon EKS AMI Account ID
-}
-
-# EKS currently documents this required userdata for EKS worker nodes to
-# properly configure Kubernetes applications on the EC2 instance.
-# We utilize a Terraform local here to simplify Base64 encoding this
-# information into the AutoScaling Launch Configuration.
-# More information: https://docs.aws.amazon.com/eks/latest/userguide/launch-workers.html
-locals {
-  demo-node-userdata = <<USERDATA
-#!/bin/bash
-set -o xtrace
-/etc/eks/bootstrap.sh --apiserver-endpoint '${aws_eks_cluster.demo.endpoint}' --b64-cluster-ca '${aws_eks_cluster.demo.certificate_authority.0.data}' '${var.cluster-name}'
-USERDATA
-}
-
-resource "aws_launch_configuration" "demo" {
-  associate_public_ip_address = true
-  iam_instance_profile        = "${aws_iam_instance_profile.demo-node.name}"
-  image_id                    = "${data.aws_ami.eks-worker.id}"
-  instance_type               = "m4.large"
-  name_prefix                 = "terraform-eks-demo"
-  security_groups             = ["${aws_security_group.demo-node.id}"]
-  user_data_base64            = "${base64encode(local.demo-node-userdata)}"
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "aws_autoscaling_group" "demo" {
-  desired_capacity     = 2
-  launch_configuration = "${aws_launch_configuration.demo.id}"
-  max_size             = 2
-  min_size             = 1
-  name                 = "terraform-eks-demo"
-  vpc_zone_identifier  = "${aws_subnet.demo[*].id}"
-
-  tag {
-    key                 = "Name"
-    value               = "terraform-eks-demo"
-    propagate_at_launch = true
-  }
-
-  tag {
-    key                 = "kubernetes.io/cluster/${var.cluster-name}"
-    value               = "owned"
-    propagate_at_launch = true
-  }
+  depends_on = [
+    "aws_iam_role_policy_attachment.demo-node-AmazonEKSWorkerNodePolicy",
+    "aws_iam_role_policy_attachment.demo-node-AmazonEKS_CNI_Policy",
+    "aws_iam_role_policy_attachment.demo-node-AmazonEC2ContainerRegistryReadOnly",
+  ]
 }

--- a/examples/eks-getting-started/providers.tf
+++ b/examples/eks-getting-started/providers.tf
@@ -3,7 +3,8 @@
 #
 
 provider "aws" {
-  region = "us-west-2"
+  region  = "us-west-2"
+  version = ">= 2.38.0"
 }
 
 # Using these data sources allows the configuration to be


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://aws.amazon.com/blogs/containers/eks-managed-node-groups/
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/10915

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing: N/A

Example output:

```
$ terraform apply
...
Apply complete! Resources: 18 added, 0 changed, 0 destroyed.
$ aws eks update-kubeconfig --name terraform-eks-demo
$ kubectl get nodes
NAME                                       STATUS   ROLES    AGE     VERSION
ip-10-0-0-133.us-west-2.compute.internal   Ready    <none>   6m40s   v1.14.7-eks-1861c5
```
