### PR TITLE
resource/aws_batch_compute_environment: Propose resource recreation when updating compute_resources configuration block tags argument

### DIFF
--- a/aws/resource_aws_batch_compute_environment.go
+++ b/aws/resource_aws_batch_compute_environment.go
@@ -114,7 +114,7 @@ func resourceAwsBatchComputeEnvironment() *schema.Resource {
 							ForceNew: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
-						"tags": tagsSchema(),
+						"tags": tagsSchemaForceNew(),
 						"type": {
 							Type:         schema.TypeString,
 							Required:     true,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2696
Reference: https://docs.aws.amazon.com/batch/latest/APIReference/API_UpdateComputeEnvironment.html

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_batch_compute_environment: Propose resource recreation when updating `compute_resources` configuration block `tags` argument
```

The upstream API does not support updating compute resource tags, therefore we update Terraform to propose resource recreation when they are modified instead of perpetually showing a difference.

Output from acceptance testing:

```
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources (20.68s)
--- PASS: TestAccAWSBatchComputeEnvironment_createSpotWithoutBidPercentage (23.28s)
--- PASS: TestAccAWSBatchComputeEnvironment_createUnmanaged (44.92s)
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2 (45.81s)
--- PASS: TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources (55.24s)
--- PASS: TestAccAWSBatchComputeEnvironment_launchTemplate (57.90s)
--- PASS: TestAccAWSBatchComputeEnvironment_createSpot (58.45s)
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2WithTags (60.50s)
--- PASS: TestAccAWSBatchComputeEnvironment_updateMaxvCpus (76.98s)
--- PASS: TestAccAWSBatchComputeEnvironment_updateState (77.05s)
--- PASS: TestAccAWSBatchComputeEnvironment_updateInstanceType (84.66s)
--- PASS: TestAccAWSBatchComputeEnvironment_updateComputeEnvironmentName (91.90s)
```

