### PR TITLE
d/aws_ebs_snapshot - refactor to use keyvaluetags

### DIFF
--- a/aws/data_source_aws_ebs_snapshot.go
+++ b/aws/data_source_aws_ebs_snapshot.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func dataSourceAwsEbsSnapshot() *schema.Resource {
@@ -150,6 +151,9 @@ func snapshotDescriptionAttributes(d *schema.ResourceData, snapshot *ec2.Snapsho
 	d.Set("owner_id", snapshot.OwnerId)
 	d.Set("owner_alias", snapshot.OwnerAlias)
 
-	err := d.Set("tags", tagsToMap(snapshot.Tags))
-	return err
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(snapshot.Tags).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10688

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEbsSnapshotDataSource_'
=== RUN   TestAccAWSEbsSnapshotDataSource_basic
=== PAUSE TestAccAWSEbsSnapshotDataSource_basic
=== CONT  TestAccAWSEbsSnapshotDataSource_basic
--- PASS: TestAccAWSEbsSnapshotDataSource_basic (89.50s)
=== RUN   TestAccAWSEbsSnapshotDataSource_Filter
=== PAUSE TestAccAWSEbsSnapshotDataSource_Filter
=== CONT  TestAccAWSEbsSnapshotDataSource_Filter
--- PASS: TestAccAWSEbsSnapshotDataSource_Filter (116.74s)
=== RUN   TestAccAWSEbsSnapshotDataSource_MostRecent
=== PAUSE TestAccAWSEbsSnapshotDataSource_MostRecent
=== CONT  TestAccAWSEbsSnapshotDataSource_MostRecent
--- PASS: TestAccAWSEbsSnapshotDataSource_MostRecent (202.77s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	212.556s

...
```
