### PR TITLE
resource/aws_autoscaling_group: implement max_instance_lifetime

### DIFF
--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -231,6 +231,7 @@ Note that if you suspend either the `Launch` or `Terminate` process types, it ca
    autoscaling group will not select instances with this setting for terminination
    during scale in events.
 * `service_linked_role_arn` (Optional) The ARN of the service-linked role that the ASG will use to call other AWS services
+* `max_instance_lifetime` (Optional) The maximum amount of time, in seconds, that an instance can be in service
 
 ### launch_template
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10956 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Implementing `MaxInstanceLifetime` for `aws_autoscaling_groups`

```

Output from acceptance testing:


```
$ ./terraform-provider-aws make testacc TEST=./aws TESTARGS='-run=TestAccAWSAutoScalingGroup_MaxInstanceLifetime'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAutoScalingGroup_MaxInstanceLifetime -timeout 120m
=== RUN   TestAccAWSAutoScalingGroup_MaxInstanceLifetime
=== PAUSE TestAccAWSAutoScalingGroup_MaxInstanceLifetime
=== CONT  TestAccAWSAutoScalingGroup_MaxInstanceLifetime
--- PASS: TestAccAWSAutoScalingGroup_MaxInstanceLifetime (50.12s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	51.642s

```
