### PR TITLE
Added ca_cert_identifier for aws_rds_cluster_instance

### DIFF
--- a/website/docs/r/rds_cluster_instance.html.markdown
+++ b/website/docs/r/rds_cluster_instance.html.markdown
@@ -80,6 +80,7 @@ what IAM permissions are needed to allow Enhanced Monitoring for RDS Instances.
 * `performance_insights_enabled` - (Optional) Specifies whether Performance Insights is enabled or not.
 * `performance_insights_kms_key_id` - (Optional) The ARN for the KMS key to encrypt Performance Insights data. When specifying `performance_insights_kms_key_id`, `performance_insights_enabled` needs to be set to true.
 * `copy_tags_to_snapshot` – (Optional, boolean) Indicates whether to copy all of the user-defined tags from the DB instance to snapshots of the DB instance. Default `false`.
+* `ca_cert_identifier` - (Optional) The identifier of the CA certificate for the DB instance.
 * `tags` - (Optional) A mapping of tags to assign to the instance.
 
 ## Attributes Reference


### PR DESCRIPTION
Allows updating ca_cert_identifier for aws_rds_cluster_instance resource

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10467 #10517
Relates #10417

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Allow updating ca_cert_identifier for aws_rds_cluster_instance
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTARGS='-run=TestAccAWSRDSClusterInstance_CACertificateIdentifier'
==> Checking that code complies with gofmt requirements...

TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSRDSClusterInstance_CACertificateIdentifier -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]

=== RUN   TestAccAWSRDSClusterInstance_CACertificateIdentifier
=== PAUSE TestAccAWSRDSClusterInstance_CACertificateIdentifier
=== CONT  TestAccAWSRDSClusterInstance_CACertificateIdentifier
--- PASS: TestAccAWSRDSClusterInstance_CACertificateIdentifier (828.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	828.047s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.010s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.018s [no tests to run]
...
```
