### PR TITLE
Add missing required argument `subnet_id`

### DIFF
--- a/website/docs/r/eip.html.markdown
+++ b/website/docs/r/eip.html.markdown
@@ -97,6 +97,7 @@ resource "aws_eip" "byoip-ip" {
 
 The following arguments are supported:
 
+* `subnet_id` - (Required) The VPC subnet ID.
 * `vpc` - (Optional) Boolean if the EIP is in a VPC or not.
 * `instance` - (Optional) EC2 instance ID.
 * `network_interface` - (Optional) Network interface ID to associate with.


### PR DESCRIPTION
Document update.

# Detail

I saw below error.

```
 % terraform apply

Error: Missing required argument

  on all.tf line 58, in resource "aws_nat_gateway" "eks":
  58: resource "aws_nat_gateway" "eks" {

The argument "subnet_id" is required, but no definition was found.

 %
```

and by [test code](https://github.com/terraform-providers/terraform-provider-aws/blob/0321db117feaac9f2e48fafef1a6d651b443ffa8/aws/resource_aws_eip_test.go), I guess subnet_id is required certainly.