### PR TITLE
tests/provider: Provide helpful error when AWS_ALTERNATE_REGION partition does not match AWS_DEFAULT_REGION partition

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -222,6 +222,13 @@ func testAccGetPartition() string {
 	return "aws"
 }
 
+func testAccGetAlternateRegionPartition() string {
+	if partition, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), testAccGetAlternateRegion()); ok {
+		return partition.ID()
+	}
+	return "aws"
+}
+
 func testAccAlternateAccountPreCheck(t *testing.T) {
 	if os.Getenv("AWS_ALTERNATE_PROFILE") == "" && os.Getenv("AWS_ALTERNATE_ACCESS_KEY_ID") == "" {
 		t.Fatal("AWS_ALTERNATE_ACCESS_KEY_ID or AWS_ALTERNATE_PROFILE must be set for acceptance tests")
@@ -235,6 +242,10 @@ func testAccAlternateAccountPreCheck(t *testing.T) {
 func testAccAlternateRegionPreCheck(t *testing.T) {
 	if testAccGetRegion() == testAccGetAlternateRegion() {
 		t.Fatal("AWS_DEFAULT_REGION and AWS_ALTERNATE_REGION must be set to different values for acceptance tests")
+	}
+
+	if testAccGetPartition() != testAccGetAlternateRegionPartition() {
+		t.Fatalf("AWS_ALTERNATE_REGION partition (%s) does not match AWS_DEFAULT_REGION partition (%s)", testAccGetAlternateRegionPartition(), testAccGetPartition())
 	}
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Certain acceptance tests require multiple regions and when the `AWS_ALTERNATE_REGION` environment variable is omitted for testing outside AWS Commercial (e.g. AWS GovCloud (US)), previously testing could throw an initially cryptic error:

```console
$ export AWS_DEFAULT_REGION=us-gov-west-1
$ TF_ACC=1 go test ./aws -v -count 1 -timeout 120m -parallel 20 -run='TestAccAWSEbsSnapshotCopy_withRegions'
...
--- FAIL: TestAccAWSEbsSnapshotCopy_withRegions (4.70s)
    testing.go:635: Step 0 error: errors during refresh:

        Error: error using credentials to get account ID: error calling sts:GetCallerIdentity: InvalidClientTokenId: The security token included in the request is invalid.
```

This update allows us to return a custom error before provider initialization:

```
--- FAIL: TestAccAWSEbsSnapshotCopy_withRegions (2.06s)
    provider_test.go:248: AWS_ALTERNATE_REGION partition (aws) does not match AWS_DEFAULT_REGION partition (aws-us-gov)
```

When `AWS_ALTERNATE_REGION` is set correctly, testing passes as expected:

```console
$ export AWS_ALTERNATE_REGION=us-gov-east-1
$ TF_ACC=1 go test ./aws -v -count 1 -timeout 120m -parallel 20 -run='TestAccAWSEbsSnapshotCopy_withRegions'
...
--- PASS: TestAccAWSEbsSnapshotCopy_withRegions (67.50s)
```
