### PR TITLE
d/api_gateway_rest_api - add attributes

### DIFF
--- a/aws/data_source_aws_api_gateway_rest_api.go
+++ b/aws/data_source_aws_api_gateway_rest_api.go
@@ -27,6 +27,53 @@ func dataSourceAwsApiGatewayRestApi() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"policy": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"api_key_source": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"minimum_compression_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"binary_media_types": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"endpoint_configuration": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"types": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"vpc_endpoint_ids": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"execution_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"tags": tagsSchemaComputed(),
 		},
 	}
@@ -69,10 +116,34 @@ func dataSourceAwsApiGatewayRestApiRead(d *schema.ResourceData, meta interface{}
 		Resource:  fmt.Sprintf("/restapis/%s", d.Id()),
 	}.String()
 	d.Set("arn", restApiArn)
+	d.Set("version", match.Version)
+	d.Set("description", match.Description)
+	d.Set("policy", match.Policy)
+	d.Set("api_key_source", match.ApiKeySource)
+	d.Set("binary_media_types", match.BinaryMediaTypes)
+
+	if match.MinimumCompressionSize == nil {
+		d.Set("minimum_compression_size", -1)
+	} else {
+		d.Set("minimum_compression_size", match.MinimumCompressionSize)
+	}
+
+	if err := d.Set("endpoint_configuration", flattenApiGatewayEndpointConfiguration(match.EndpointConfiguration)); err != nil {
+		return fmt.Errorf("error setting endpoint_configuration: %s", err)
+	}
 
 	if err := d.Set("tags", keyvaluetags.ApigatewayKeyValueTags(match.Tags).IgnoreAws().Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
+
+	executionArn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Service:   "execute-api",
+		Region:    meta.(*AWSClient).region,
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  d.Id(),
+	}.String()
+	d.Set("execution_arn", executionArn)
 
 	resourceParams := &apigateway.GetResourcesInput{
 		RestApiId: aws.String(d.Id()),

--- a/aws/data_source_aws_api_gateway_rest_api.go
+++ b/aws/data_source_aws_api_gateway_rest_api.go
@@ -27,10 +27,6 @@ func dataSourceAwsApiGatewayRestApi() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"version": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"description": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -116,7 +112,6 @@ func dataSourceAwsApiGatewayRestApiRead(d *schema.ResourceData, meta interface{}
 		Resource:  fmt.Sprintf("/restapis/%s", d.Id()),
 	}.String()
 	d.Set("arn", restApiArn)
-	d.Set("version", match.Version)
 	d.Set("description", match.Description)
 	d.Set("policy", match.Policy)
 	d.Set("api_key_source", match.ApiKeySource)

--- a/aws/data_source_aws_api_gateway_rest_api_test.go
+++ b/aws/data_source_aws_api_gateway_rest_api_test.go
@@ -22,46 +22,20 @@ func TestAccDataSourceAwsApiGatewayRestApi(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "root_resource_id", resourceName, "root_resource_id"),
-					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags", resourceName, "tags"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "version", resourceName, "version"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "policy", resourceName, "policy"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "api_key_source", resourceName, "api_key_source"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "minimum_compression_size", resourceName, "minimum_compression_size"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "binary_media_types", resourceName, "binary_media_types"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "endpoint_configuration", resourceName, "endpoint_configuration"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "execution_arn", resourceName, "execution_arn"),
 				),
 			},
 		},
 	})
 }
-
-//func testAccDataSourceAwsApiGatewayRestApiCheck(name string) resource.TestCheckFunc {
-//	return func(s *terraform.State) error {
-//		resources, ok := s.RootModule().Resources[name]
-//		if !ok {
-//			return fmt.Errorf("root module has no resource called %s", name)
-//		}
-//
-//		apiGatewayRestApiResources, ok := s.RootModule().Resources["aws_api_gateway_rest_api.tf_test"]
-//		if !ok {
-//			return fmt.Errorf("can't find aws_api_gateway_rest_api.tf_test in state")
-//		}
-//
-//		attr := resources.Primary.Attributes
-//
-//		if attr["name"] != apiGatewayRestApiResources.Primary.Attributes["name"] {
-//			return fmt.Errorf(
-//				"name is %s; want %s",
-//				attr["name"],
-//				apiGatewayRestApiResources.Primary.Attributes["name"],
-//			)
-//		}
-//
-//		if attr["root_resource_id"] != apiGatewayRestApiResources.Primary.Attributes["root_resource_id"] {
-//			return fmt.Errorf(
-//				"root_resource_id is %s; want %s",
-//				attr["root_resource_id"],
-//				apiGatewayRestApiResources.Primary.Attributes["root_resource_id"],
-//			)
-//		}
-//
-//		return nil
-//	}
-//}
 
 func testAccDataSourceAwsApiGatewayRestApiConfig(r string) string {
 	return fmt.Sprintf(`

--- a/aws/data_source_aws_api_gateway_rest_api_test.go
+++ b/aws/data_source_aws_api_gateway_rest_api_test.go
@@ -6,11 +6,12 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func TestAccDataSourceAwsApiGatewayRestApi(t *testing.T) {
 	rName := acctest.RandString(8)
+	dataSourceName := "data.aws_api_gateway_rest_api.test"
+	resourceName := "resource.aws_api_gateway_rest_api.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -18,63 +19,58 @@ func TestAccDataSourceAwsApiGatewayRestApi(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsApiGatewayRestApiConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceAwsApiGatewayRestApiCheck("data.aws_api_gateway_rest_api.by_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "root_resource_id", resourceName, "root_resource_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceAwsApiGatewayRestApiCheck(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		resources, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("root module has no resource called %s", name)
-		}
-
-		apiGatewayRestApiResources, ok := s.RootModule().Resources["aws_api_gateway_rest_api.tf_test"]
-		if !ok {
-			return fmt.Errorf("can't find aws_api_gateway_rest_api.tf_test in state")
-		}
-
-		attr := resources.Primary.Attributes
-
-		if attr["name"] != apiGatewayRestApiResources.Primary.Attributes["name"] {
-			return fmt.Errorf(
-				"name is %s; want %s",
-				attr["name"],
-				apiGatewayRestApiResources.Primary.Attributes["name"],
-			)
-		}
-
-		if attr["root_resource_id"] != apiGatewayRestApiResources.Primary.Attributes["root_resource_id"] {
-			return fmt.Errorf(
-				"root_resource_id is %s; want %s",
-				attr["root_resource_id"],
-				apiGatewayRestApiResources.Primary.Attributes["root_resource_id"],
-			)
-		}
-
-		return nil
-	}
-}
+//func testAccDataSourceAwsApiGatewayRestApiCheck(name string) resource.TestCheckFunc {
+//	return func(s *terraform.State) error {
+//		resources, ok := s.RootModule().Resources[name]
+//		if !ok {
+//			return fmt.Errorf("root module has no resource called %s", name)
+//		}
+//
+//		apiGatewayRestApiResources, ok := s.RootModule().Resources["aws_api_gateway_rest_api.tf_test"]
+//		if !ok {
+//			return fmt.Errorf("can't find aws_api_gateway_rest_api.tf_test in state")
+//		}
+//
+//		attr := resources.Primary.Attributes
+//
+//		if attr["name"] != apiGatewayRestApiResources.Primary.Attributes["name"] {
+//			return fmt.Errorf(
+//				"name is %s; want %s",
+//				attr["name"],
+//				apiGatewayRestApiResources.Primary.Attributes["name"],
+//			)
+//		}
+//
+//		if attr["root_resource_id"] != apiGatewayRestApiResources.Primary.Attributes["root_resource_id"] {
+//			return fmt.Errorf(
+//				"root_resource_id is %s; want %s",
+//				attr["root_resource_id"],
+//				apiGatewayRestApiResources.Primary.Attributes["root_resource_id"],
+//			)
+//		}
+//
+//		return nil
+//	}
+//}
 
 func testAccDataSourceAwsApiGatewayRestApiConfig(r string) string {
 	return fmt.Sprintf(`
-resource "aws_api_gateway_rest_api" "tf_wrong1" {
-  name = "%s_wrong1"
+resource "aws_api_gateway_rest_api" "test" {
+  name = "%[1]s"
 }
 
-resource "aws_api_gateway_rest_api" "tf_test" {
-  name = "%s_correct"
+data "aws_api_gateway_rest_api" "test" {
+  name = "${aws_api_gateway_rest_api.test.name}"
 }
-
-resource "aws_api_gateway_rest_api" "tf_wrong2" {
-  name = "%s_wrong1"
-}
-
-data "aws_api_gateway_rest_api" "by_name" {
-  name = "${aws_api_gateway_rest_api.tf_test.name}"
-}
-`, r, r, r)
+`, r)
 }

--- a/aws/data_source_aws_api_gateway_rest_api_test.go
+++ b/aws/data_source_aws_api_gateway_rest_api_test.go
@@ -11,7 +11,7 @@ import (
 func TestAccDataSourceAwsApiGatewayRestApi(t *testing.T) {
 	rName := acctest.RandString(8)
 	dataSourceName := "data.aws_api_gateway_rest_api.test"
-	resourceName := "resource.aws_api_gateway_rest_api.test"
+	resourceName := "aws_api_gateway_rest_api.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,

--- a/aws/data_source_aws_api_gateway_rest_api_test.go
+++ b/aws/data_source_aws_api_gateway_rest_api_test.go
@@ -23,7 +23,6 @@ func TestAccDataSourceAwsApiGatewayRestApi(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "root_resource_id", resourceName, "root_resource_id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "tags", resourceName, "tags"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "version", resourceName, "version"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "policy", resourceName, "policy"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "api_key_source", resourceName, "api_key_source"),

--- a/website/docs/d/api_gateway_rest_api.html.markdown
+++ b/website/docs/d/api_gateway_rest_api.html.markdown
@@ -23,12 +23,18 @@ data "aws_api_gateway_rest_api" "my_rest_api" {
 
 ## Argument Reference
 
- * `name` - (Required) The name of the REST API to look up. If no REST API is found with this name, an error will be returned. 
- If multiple REST APIs are found with this name, an error will be returned.
+* `name` - (Required) The name of the REST API to look up. If no REST API is found with this name, an error will be returned. If multiple REST APIs are found with this name, an error will be returned.
 
 ## Attributes Reference
 
- * `id` - Set to the ID of the found REST API.
- * `arn` - The ARN of the REST API
- * `root_resource_id` - Set to the ID of the API Gateway Resource on the found REST API where the route matches '/'.
- * `tags` - Key-value mapping of resource tags
+* `id` - Set to the ID of the found REST API.
+* `arn` - The ARN of the REST API.
+* `root_resource_id` - Set to the ID of the API Gateway Resource on the found REST API where the route matches '/'.
+* `description` - The description of the REST API.
+* `api_key_source` - The source of the API key for requests.
+* `policy` - JSON formatted policy document that controls access to the API Gateway.
+* `minimum_compression_size` - Minimum response size to compress for the REST API.
+* `binary_media_types` - The list of binary media types supported by the REST API.
+* `endpoint_configuration` - The endpoint configuration of this RestApi showing the endpoint types of the API.
+* `tags` - Key-value mapping of resource tags.
+ 

--- a/website/docs/d/api_gateway_rest_api.html.markdown
+++ b/website/docs/d/api_gateway_rest_api.html.markdown
@@ -29,4 +29,6 @@ data "aws_api_gateway_rest_api" "my_rest_api" {
 ## Attributes Reference
 
  * `id` - Set to the ID of the found REST API.
+ * `arn` - The ARN of the REST API
  * `root_resource_id` - Set to the ID of the API Gateway Resource on the found REST API where the route matches '/'.
+ * `tags` - Key-value mapping of resource tags


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10688

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
- data/data_source_api_gateway_rest_api: Add `tags`, `arn`, `description`, `policy`, `api_key_source`, `minimum_compression_size`, `binary_media_types`, `endpoint_configuration` and `execution_arn` attributes
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccDataSourceAwsApiGatewayRestApi'
--- PASS: TestAccDataSourceAwsApiGatewayRestApi (111.73s)
```
