### PR TITLE
resource/aws_datasync_location_s3: Retry creation for IAM eventual consistency errors

### DIFF
--- a/aws/resource_aws_datasync_location_s3.go
+++ b/aws/resource_aws_datasync_location_s3.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/datasync"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
@@ -87,7 +89,35 @@ func resourceAwsDataSyncLocationS3Create(d *schema.ResourceData, meta interface{
 	}
 
 	log.Printf("[DEBUG] Creating DataSync Location S3: %s", input)
-	output, err := conn.CreateLocationS3(input)
+
+	var output *datasync.CreateLocationS3Output
+	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+		var err error
+		output, err = conn.CreateLocationS3(input)
+
+		// Retry for IAM eventual consistency on error:
+		// InvalidRequestException: Unable to assume role. Reason: Access denied when calling sts:AssumeRole
+		if isAWSErr(err, datasync.ErrCodeInvalidRequestException, "Unable to assume role") {
+			return resource.RetryableError(err)
+		}
+
+		// Retry for IAM eventual consistency on error:
+		// InvalidRequestException: DataSync location access test failed: could not perform s3:ListObjectsV2 on bucket
+		if isAWSErr(err, datasync.ErrCodeInvalidRequestException, "access test failed") {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if isResourceTimeoutError(err) {
+		output, err = conn.CreateLocationS3(input)
+	}
+
 	if err != nil {
 		return fmt.Errorf("error creating DataSync Location S3: %s", err)
 	}

--- a/aws/resource_aws_datasync_location_s3_test.go
+++ b/aws/resource_aws_datasync_location_s3_test.go
@@ -282,6 +282,25 @@ resource "aws_iam_role" "test" {
 POLICY
 }
 
+resource "aws_iam_role_policy" "test" {
+  role   = aws_iam_role.test.id
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Action": [
+      "s3:*"
+    ],
+    "Effect": "Allow",
+    "Resource": [
+      "${aws_s3_bucket.test.arn}",
+      "${aws_s3_bucket.test.arn}/*"
+    ]
+  }]
+}
+POLICY
+}
+
 resource "aws_s3_bucket" "test" {
   bucket        = %q
   force_destroy = true
@@ -298,6 +317,8 @@ resource "aws_datasync_location_s3" "test" {
   s3_config {
     bucket_access_role_arn = "${aws_iam_role.test.arn}"
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 `)
 }
@@ -315,6 +336,8 @@ resource "aws_datasync_location_s3" "test" {
   tags = {
     %q = %q
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 `, key1, value1)
 }
@@ -333,6 +356,8 @@ resource "aws_datasync_location_s3" "test" {
     %q = %q
     %q = %q
   }
+
+  depends_on = [aws_iam_role_policy.test]
 }
 `, key1, value1, key2, value2)
 }

--- a/aws/resource_aws_datasync_task_test.go
+++ b/aws/resource_aws_datasync_task_test.go
@@ -630,6 +630,25 @@ resource "aws_s3_bucket" "destination" {
   force_destroy = true
 }
 
+resource "aws_iam_role_policy" "destination" {
+  role   = aws_iam_role.destination.id
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Action": [
+      "s3:*"
+    ],
+    "Effect": "Allow",
+    "Resource": [
+      "${aws_s3_bucket.destination.arn}",
+      "${aws_s3_bucket.destination.arn}/*"
+    ]
+  }]
+}
+POLICY
+}
+
 resource "aws_datasync_location_s3" "destination" {
   s3_bucket_arn = "${aws_s3_bucket.destination.arn}"
   subdirectory  = "/destination"
@@ -637,6 +656,8 @@ resource "aws_datasync_location_s3" "destination" {
   s3_config {
     bucket_access_role_arn = "${aws_iam_role.destination.arn}"
   }
+
+  depends_on = [aws_iam_role_policy.destination]
 }
 `, rName, rName)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_datasync_location_s3: Automatically retry creation for IAM errors due to eventual consistency
```

Starting around November 17, 2019, the DataSync API in AWS Commercial regions began performing additional validation for CreateLocationS3 API calls to ensure the DataSync service has valid permissions to the S3 Bucket. This can be seen in our acceptance testing via these new errors:

```
--- FAIL: TestAccAWSDataSyncLocationS3_basic (8.51s)
    testing.go:635: Step 0 error: errors during apply:

        Error: error creating DataSync Location S3: InvalidRequestException: Unable to assume role. Reason: Access denied when calling sts:AssumeRole; roleName=tf-acc-test-1957308096022085996, roleArn=arn:aws:iam::*******:role/tf-acc-test-1957308096022085996

--- FAIL: TestAccAWSDataSyncLocationS3_basic (24.43s)
    testing.go:635: Step 0 error: errors during apply:

        Error: error creating DataSync Location S3: InvalidRequestException: DataSync location access test failed: could not perform s3:ListObjectsV2 on bucket tf-acc-test-4479739578378504845. Access denied. Ensure bucket access role has s3:ListBucket permission.

--- FAIL: TestAccAWSDataSyncTask_basic (175.57s)
    testing.go:635: Step 0 error: errors during apply:

        Error: error creating DataSync Location S3: InvalidRequestException: Unable to assume role. Reason: Access denied when calling sts:AssumeRole; roleName=tf-acc-test-3325424455551081900destination, roleArn=arn:aws:iam::*******:role/tf-acc-test-3325424455551081900destination
```

To handle these eventual consistency issues even when providing Terraform with fully correct dependency ordering, we introduce our typical strategy of retries for specific error messaging relating to IAM to allow time for propagation of permissions across AWS services.

Output from acceptance testing:

```
--- PASS: TestAccAWSDataSyncLocationS3_disappears (53.03s)
--- PASS: TestAccAWSDataSyncLocationS3_basic (57.20s)
--- PASS: TestAccAWSDataSyncLocationS3_Tags (102.21s)

--- PASS: TestAccAWSDataSyncTask_basic (521.34s)
```
