### PR TITLE
Fix users attribute of iam_group data source 

### DIFF
--- a/aws/data_source_aws_iam_group.go
+++ b/aws/data_source_aws_iam_group.go
@@ -67,22 +67,31 @@ func dataSourceAwsIAMGroupRead(d *schema.ResourceData, meta interface{}) error {
 		GroupName: aws.String(groupName),
 	}
 
+	var users []*iam.User
+	var group *iam.Group
+
 	log.Printf("[DEBUG] Reading IAM Group: %s", req)
-	resp, err := iamconn.GetGroup(req)
+	err := iamconn.GetGroupPages(req, func(page *iam.GetGroupOutput, lastPage bool) bool {
+		if group == nil {
+			group = page.Group
+		}
+		for _, user := range page.Users {
+			users = append(users, user)
+		}
+		return !lastPage
+	})
 	if err != nil {
 		return fmt.Errorf("Error getting group: %s", err)
 	}
-	if resp == nil {
+	if group == nil {
 		return fmt.Errorf("no IAM group found")
 	}
-
-	group := resp.Group
 
 	d.SetId(*group.GroupId)
 	d.Set("arn", group.Arn)
 	d.Set("path", group.Path)
 	d.Set("group_id", group.GroupId)
-	if err := d.Set("users", dataSourceUsersRead(resp.Users)); err != nil {
+	if err := d.Set("users", dataSourceUsersRead(users)); err != nil {
 		return fmt.Errorf("error setting users: %s", err)
 	}
 

--- a/aws/data_source_aws_iam_group.go
+++ b/aws/data_source_aws_iam_group.go
@@ -75,9 +75,7 @@ func dataSourceAwsIAMGroupRead(d *schema.ResourceData, meta interface{}) error {
 		if group == nil {
 			group = page.Group
 		}
-		for _, user := range page.Users {
-			users = append(users, user)
-		}
+		users = append(users, page.Users...)
 		return !lastPage
 	})
 	if err != nil {

--- a/aws/data_source_aws_iam_group_test.go
+++ b/aws/data_source_aws_iam_group_test.go
@@ -32,23 +32,24 @@ func TestAccAWSDataSourceIAMGroup_users(t *testing.T) {
 	groupName := fmt.Sprintf("test-datasource-group-%d", acctest.RandInt())
 	userName := fmt.Sprintf("test-datasource-user-%d", acctest.RandInt())
 	groupMemberShipName := fmt.Sprintf("test-datasource-group-membership-%d", acctest.RandInt())
+	userCount := 101
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsIAMGroupConfigWithUser(groupName, userName, groupMemberShipName),
+				Config: testAccAwsIAMGroupConfigWithUser(groupName, userName, groupMemberShipName, userCount),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.aws_iam_group.test", "group_id"),
 					resource.TestCheckResourceAttr("data.aws_iam_group.test", "path", "/"),
 					resource.TestCheckResourceAttr("data.aws_iam_group.test", "group_name", groupName),
 					testAccCheckResourceAttrGlobalARN("data.aws_iam_group.test", "arn", "iam", fmt.Sprintf("group/%s", groupName)),
-					resource.TestCheckResourceAttr("data.aws_iam_group.test", "users.#", "1"),
-					resource.TestCheckResourceAttrPair("data.aws_iam_group.test", "users.0.arn", "aws_iam_user.user", "arn"),
-					resource.TestCheckResourceAttrPair("data.aws_iam_group.test", "users.0.user_id", "aws_iam_user.user", "unique_id"),
-					resource.TestCheckResourceAttrPair("data.aws_iam_group.test", "users.0.user_name", "aws_iam_user.user", "name"),
-					resource.TestCheckResourceAttrPair("data.aws_iam_group.test", "users.0.path", "aws_iam_user.user", "path"),
+					resource.TestCheckResourceAttr("data.aws_iam_group.test", "users.#", fmt.Sprint(userCount)),
+					resource.TestCheckResourceAttrSet("data.aws_iam_group.test", "users.0.arn"),
+					resource.TestCheckResourceAttrSet("data.aws_iam_group.test", "users.0.user_id"),
+					resource.TestCheckResourceAttrSet("data.aws_iam_group.test", "users.0.user_name"),
+					resource.TestCheckResourceAttrSet("data.aws_iam_group.test", "users.0.path"),
 				),
 			},
 		},
@@ -68,7 +69,7 @@ data "aws_iam_group" "test" {
 `, name)
 }
 
-func testAccAwsIAMGroupConfigWithUser(groupName, userName, membershipName string) string {
+func testAccAwsIAMGroupConfigWithUser(groupName, userName, membershipName string, userCount int) string {
 	return fmt.Sprintf(`
 resource "aws_iam_group" "group" {
 	name = "%s"
@@ -76,17 +77,18 @@ resource "aws_iam_group" "group" {
 }
 
 resource "aws_iam_user" "user" {
-	name = "%s"
+	name = "%s-${count.index}"
+	count = %d
 }
 
 resource "aws_iam_group_membership" "team" {
 	name = "%s"
-	users = ["${aws_iam_user.user.name}"]
+	users = "${aws_iam_user.user.*.name}"
 	group = "${aws_iam_group.group.name}"
 }
 
 data "aws_iam_group" "test" {
 	group_name = "${aws_iam_group_membership.team.group}"	
 }
-`, groupName, userName, membershipName)
+`, groupName, userName, userCount, membershipName)
 }


### PR DESCRIPTION
### Summary

The current implementation of the aws_iam_group data source only retrieves the first 100 users in an IAM group. This PR updates the code to page through the API response and return the full list of users.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7076 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add ability for aws_iam_group data source to retrieve more than 100 users
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDataSourceIAMGroup_users'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDataSourceIAMGroup_users -timeout 120m
=== RUN   TestAccAWSDataSourceIAMGroup_users
=== PAUSE TestAccAWSDataSourceIAMGroup_users
=== CONT  TestAccAWSDataSourceIAMGroup_users
--- PASS: TestAccAWSDataSourceIAMGroup_users (204.28s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       204.341s
```
