### PR TITLE
resource/aws_datasync_agent: Update deletion error to match updated API deletion error

### DIFF
--- a/aws/resource_aws_datasync_agent.go
+++ b/aws/resource_aws_datasync_agent.go
@@ -150,7 +150,7 @@ func resourceAwsDataSyncAgentCreate(d *schema.ResourceData, meta interface{}) er
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		_, err := conn.DescribeAgent(descAgentInput)
 
-		if isAWSErr(err, "InvalidRequestException", "not found") {
+		if isAWSErr(err, "InvalidRequestException", "does not exist") {
 			return resource.RetryableError(err)
 		}
 
@@ -180,7 +180,7 @@ func resourceAwsDataSyncAgentRead(d *schema.ResourceData, meta interface{}) erro
 	log.Printf("[DEBUG] Reading DataSync Agent: %s", input)
 	output, err := conn.DescribeAgent(input)
 
-	if isAWSErr(err, "InvalidRequestException", "not found") {
+	if isAWSErr(err, "InvalidRequestException", "does not exist") {
 		log.Printf("[WARN] DataSync Agent %q not found - removing from state", d.Id())
 		d.SetId("")
 		return nil
@@ -269,7 +269,7 @@ func resourceAwsDataSyncAgentDelete(d *schema.ResourceData, meta interface{}) er
 	log.Printf("[DEBUG] Deleting DataSync Agent: %s", input)
 	_, err := conn.DeleteAgent(input)
 
-	if isAWSErr(err, "InvalidRequestException", "not found") {
+	if isAWSErr(err, "InvalidRequestException", "does not exist") {
 		return nil
 	}
 

--- a/aws/resource_aws_datasync_agent_test.go
+++ b/aws/resource_aws_datasync_agent_test.go
@@ -56,7 +56,7 @@ func testSweepDataSyncAgents(region string) error {
 
 			_, err := conn.DeleteAgent(input)
 
-			if isAWSErr(err, "InvalidRequestException", "not found") {
+			if isAWSErr(err, "InvalidRequestException", "does not exist") {
 				continue
 			}
 
@@ -219,7 +219,7 @@ func testAccCheckAWSDataSyncAgentDestroy(s *terraform.State) error {
 
 		_, err := conn.DescribeAgent(input)
 
-		if isAWSErr(err, "InvalidRequestException", "not found") {
+		if isAWSErr(err, "InvalidRequestException", "does not exist") {
 			return nil
 		}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_datasync_agent: Trigger resource recreation on updated `InvalidRequestException` error for agents deleted outside Terraform
```

Starting around November 19, 2019 the DataSync API in AWS Commercial regions changed the error messaging for non-existent hosts from including "not found" to this new message:

```
--- FAIL: TestAccAWSDataSyncAgent_basic (158.82s)
    testing.go:696: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: Check failed: InvalidRequestException: host-0c61c0944a13c5fda does not exist or has been deleted.

--- FAIL: TestAccAWSDataSyncAgent_disappears (116.35s)
    testing.go:635: Step 0 error: errors during follow-up refresh:

        Error: error reading DataSync Agent (arn:aws:datasync:us-west-2:*******:agent/agent-027e5766a4963f977): InvalidRequestException: host-027e5766a4963f977 does not exist or has been deleted.
```

It would be better if the API used a special error code instead so we did not need to rely on the contents of the generic InvalidRequestException error code message.

Output from acceptance testing:

```
--- PASS: TestAccAWSDataSyncAgent_basic (185.94s)
--- PASS: TestAccAWSDataSyncAgent_disappears (217.60s)
--- PASS: TestAccAWSDataSyncAgent_AgentName (234.13s)
--- PASS: TestAccAWSDataSyncAgent_Tags (286.51s)
```
