### PR TITLE
resource/aws_eks_node_group: Ensure testing and documentation includes necessary IAM Role permissions depends_on configuration

### DIFF
--- a/aws/resource_aws_eks_node_group_test.go
+++ b/aws/resource_aws_eks_node_group_test.go
@@ -754,6 +754,12 @@ resource "aws_eks_node_group" "test" {
     max_size     = 1
     min_size     = 1
   }
+
+  depends_on = [
+    "aws_iam_role_policy_attachment.node-AmazonEKSWorkerNodePolicy",
+    "aws_iam_role_policy_attachment.node-AmazonEKS_CNI_Policy",
+    "aws_iam_role_policy_attachment.node-AmazonEC2ContainerRegistryReadOnly",
+  ]
 }
 `, rName, amiType)
 }
@@ -772,6 +778,12 @@ resource "aws_eks_node_group" "test" {
     max_size     = 1
     min_size     = 1
   }
+
+  depends_on = [
+    "aws_iam_role_policy_attachment.node-AmazonEKSWorkerNodePolicy",
+    "aws_iam_role_policy_attachment.node-AmazonEKS_CNI_Policy",
+    "aws_iam_role_policy_attachment.node-AmazonEC2ContainerRegistryReadOnly",
+  ]
 }
 `, rName, diskSize)
 }
@@ -790,6 +802,12 @@ resource "aws_eks_node_group" "test" {
     max_size     = 1
     min_size     = 1
   }
+
+  depends_on = [
+    "aws_iam_role_policy_attachment.node-AmazonEKSWorkerNodePolicy",
+    "aws_iam_role_policy_attachment.node-AmazonEKS_CNI_Policy",
+    "aws_iam_role_policy_attachment.node-AmazonEC2ContainerRegistryReadOnly",
+  ]
 }
 `, rName, instanceType1)
 }
@@ -811,6 +829,12 @@ resource "aws_eks_node_group" "test" {
     max_size     = 1
     min_size     = 1
   }
+
+  depends_on = [
+    "aws_iam_role_policy_attachment.node-AmazonEKSWorkerNodePolicy",
+    "aws_iam_role_policy_attachment.node-AmazonEKS_CNI_Policy",
+    "aws_iam_role_policy_attachment.node-AmazonEC2ContainerRegistryReadOnly",
+  ]
 }
 `, rName, labelKey1, labelValue1)
 }
@@ -833,6 +857,12 @@ resource "aws_eks_node_group" "test" {
     max_size     = 1
     min_size     = 1
   }
+
+  depends_on = [
+    "aws_iam_role_policy_attachment.node-AmazonEKSWorkerNodePolicy",
+    "aws_iam_role_policy_attachment.node-AmazonEKS_CNI_Policy",
+    "aws_iam_role_policy_attachment.node-AmazonEC2ContainerRegistryReadOnly",
+  ]
 }
 `, rName, labelKey1, labelValue1, labelKey2, labelValue2)
 }
@@ -851,6 +881,12 @@ resource "aws_eks_node_group" "test" {
     max_size     = 1
     min_size     = 1
   }
+
+  depends_on = [
+    "aws_iam_role_policy_attachment.node-AmazonEKSWorkerNodePolicy",
+    "aws_iam_role_policy_attachment.node-AmazonEKS_CNI_Policy",
+    "aws_iam_role_policy_attachment.node-AmazonEC2ContainerRegistryReadOnly",
+  ]
 }
 `, rName, releaseVersion)
 }
@@ -877,6 +913,12 @@ resource "aws_eks_node_group" "test" {
     max_size     = 1
     min_size     = 1
   }
+
+  depends_on = [
+    "aws_iam_role_policy_attachment.node-AmazonEKSWorkerNodePolicy",
+    "aws_iam_role_policy_attachment.node-AmazonEKS_CNI_Policy",
+    "aws_iam_role_policy_attachment.node-AmazonEC2ContainerRegistryReadOnly",
+  ]
 }
 `, rName)
 }
@@ -904,6 +946,12 @@ resource "aws_eks_node_group" "test" {
     max_size     = 1
     min_size     = 1
   }
+
+  depends_on = [
+    "aws_iam_role_policy_attachment.node-AmazonEKSWorkerNodePolicy",
+    "aws_iam_role_policy_attachment.node-AmazonEKS_CNI_Policy",
+    "aws_iam_role_policy_attachment.node-AmazonEC2ContainerRegistryReadOnly",
+  ]
 }
 `, rName)
 }
@@ -921,6 +969,12 @@ resource "aws_eks_node_group" "test" {
     max_size     = %[3]d
     min_size     = %[4]d
   }
+
+  depends_on = [
+    "aws_iam_role_policy_attachment.node-AmazonEKSWorkerNodePolicy",
+    "aws_iam_role_policy_attachment.node-AmazonEKS_CNI_Policy",
+    "aws_iam_role_policy_attachment.node-AmazonEC2ContainerRegistryReadOnly",
+  ]
 }
 `, rName, desiredSize, maxSize, minSize)
 }
@@ -942,6 +996,12 @@ resource "aws_eks_node_group" "test" {
     max_size     = 1
     min_size     = 1
   }
+
+  depends_on = [
+    "aws_iam_role_policy_attachment.node-AmazonEKSWorkerNodePolicy",
+    "aws_iam_role_policy_attachment.node-AmazonEKS_CNI_Policy",
+    "aws_iam_role_policy_attachment.node-AmazonEC2ContainerRegistryReadOnly",
+  ]
 }
 `, rName, tagKey1, tagValue1)
 }
@@ -964,6 +1024,12 @@ resource "aws_eks_node_group" "test" {
     max_size     = 1
     min_size     = 1
   }
+
+  depends_on = [
+    "aws_iam_role_policy_attachment.node-AmazonEKSWorkerNodePolicy",
+    "aws_iam_role_policy_attachment.node-AmazonEKS_CNI_Policy",
+    "aws_iam_role_policy_attachment.node-AmazonEC2ContainerRegistryReadOnly",
+  ]
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
@@ -982,6 +1048,12 @@ resource "aws_eks_node_group" "test" {
     max_size     = 1
     min_size     = 1
   }
+
+  depends_on = [
+    "aws_iam_role_policy_attachment.node-AmazonEKSWorkerNodePolicy",
+    "aws_iam_role_policy_attachment.node-AmazonEKS_CNI_Policy",
+    "aws_iam_role_policy_attachment.node-AmazonEC2ContainerRegistryReadOnly",
+  ]
 }
 `, rName, version)
 }

--- a/website/docs/r/eks_node_group.html.markdown
+++ b/website/docs/r/eks_node_group.html.markdown
@@ -24,6 +24,14 @@ resource "aws_eks_node_group" "example" {
     max_size     = 1
     min_size     = 1
   }
+
+  # Ensure that IAM Role permissions are created before and deleted after EKS Node Group handling.
+  # Otherwise, EKS will not be able to properly delete EC2 Instances and Elastic Network Interfaces.
+  depends_on = [
+    aws_iam_role_policy_attachment.example-AmazonEKSWorkerNodePolicy,
+    aws_iam_role_policy_attachment.example-AmazonEKS_CNI_Policy,
+    aws_iam_role_policy_attachment.example-AmazonEC2ContainerRegistryReadOnly,
+  ]
 }
 ```
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10934
Reference: ENIs currently stuck in-use in main testing account us-west-2
Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/5904
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/4426

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Otherwise, EC2 ENIs managed by EKS can be left dangling on destroy. In the future, we can help reduce the need for explicit Terraform dependencies such as these via supporting the management of attached IAM Role policies directly in the `aws_iam_role` resource (e.g. #5904).

Output from acceptance testing:

```
--- PASS: TestAccAWSEksNodeGroup_Version (1449.66s)
--- PASS: TestAccAWSEksNodeGroup_AmiType (1462.03s)
--- PASS: TestAccAWSEksNodeGroup_DiskSize (1510.26s)
--- PASS: TestAccAWSEksNodeGroup_ReleaseVersion (1575.37s)
--- PASS: TestAccAWSEksNodeGroup_RemoteAccess_SourceSecurityGroupIds (1584.41s)
--- PASS: TestAccAWSEksNodeGroup_RemoteAccess_Ec2SshKey (1597.61s)
--- PASS: TestAccAWSEksNodeGroup_ScalingConfig_MinSize (1624.95s)
--- PASS: TestAccAWSEksNodeGroup_basic (1644.52s)
--- PASS: TestAccAWSEksNodeGroup_InstanceTypes (1646.77s)
--- PASS: TestAccAWSEksNodeGroup_disappears (1652.94s)
--- PASS: TestAccAWSEksNodeGroup_Labels (1655.54s)
--- PASS: TestAccAWSEksNodeGroup_ScalingConfig_DesiredSize (1702.82s)
--- PASS: TestAccAWSEksNodeGroup_ScalingConfig_MaxSize (1764.88s)
--- PASS: TestAccAWSEksNodeGroup_Tags (1768.71s)
```
