### PR TITLE
resource/aws_lambda_function: Support waiting for State on CreateFunction and LastUpdatedStatus on UpdateFunctionConfiguration

### DIFF
--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -447,6 +447,10 @@ func resourceAwsLambdaFunctionCreate(d *schema.ResourceData, meta interface{}) e
 
 	d.SetId(d.Get("function_name").(string))
 
+	if err := waitForLambdaFunctionCreation(conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
+		return fmt.Errorf("error waiting for Lambda Function (%s) creation: %s", d.Id(), err)
+	}
+
 	if reservedConcurrentExecutions >= 0 {
 
 		log.Printf("[DEBUG] Setting Concurrency to %d for the Lambda Function %s", reservedConcurrentExecutions, functionName)
@@ -819,6 +823,10 @@ func resourceAwsLambdaFunctionUpdate(d *schema.ResourceData, meta interface{}) e
 			}
 		}
 
+		if err := waitForLambdaFunctionUpdate(conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return fmt.Errorf("error waiting for Lambda Function (%s) update: %s", d.Id(), err)
+		}
+
 		d.SetPartial("description")
 		d.SetPartial("handler")
 		d.SetPartial("memory_size")
@@ -932,4 +940,84 @@ func lambdaFunctionInvokeArn(functionArn string, meta interface{}) string {
 		AccountID: "lambda",
 		Resource:  fmt.Sprintf("path/2015-03-31/functions/%s/invocations", functionArn),
 	}.String()
+}
+
+func refreshLambdaFunctionLastUpdateStatus(conn *lambda.Lambda, functionName string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		input := &lambda.GetFunctionInput{
+			FunctionName: aws.String(functionName),
+		}
+
+		output, err := conn.GetFunction(input)
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		if output == nil || output.Configuration == nil {
+			return nil, "", nil
+		}
+
+		lastUpdateStatus := aws.StringValue(output.Configuration.LastUpdateStatus)
+
+		if lastUpdateStatus == lambda.LastUpdateStatusFailed {
+			return output.Configuration, lastUpdateStatus, fmt.Errorf("%s: %s", aws.StringValue(output.Configuration.LastUpdateStatusReasonCode), aws.StringValue(output.Configuration.LastUpdateStatusReason))
+		}
+
+		return output.Configuration, lastUpdateStatus, nil
+	}
+}
+
+func refreshLambdaFunctionState(conn *lambda.Lambda, functionName string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		input := &lambda.GetFunctionInput{
+			FunctionName: aws.String(functionName),
+		}
+
+		output, err := conn.GetFunction(input)
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		if output == nil || output.Configuration == nil {
+			return nil, "", nil
+		}
+
+		state := aws.StringValue(output.Configuration.State)
+
+		if state == lambda.StateFailed {
+			return output.Configuration, state, fmt.Errorf("%s: %s", aws.StringValue(output.Configuration.StateReasonCode), aws.StringValue(output.Configuration.StateReason))
+		}
+
+		return output.Configuration, state, nil
+	}
+}
+
+func waitForLambdaFunctionCreation(conn *lambda.Lambda, functionName string, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{lambda.StatePending},
+		Target:  []string{lambda.StateActive},
+		Refresh: refreshLambdaFunctionState(conn, functionName),
+		Timeout: timeout,
+		Delay:   5 * time.Second,
+	}
+
+	_, err := stateConf.WaitForState()
+
+	return err
+}
+
+func waitForLambdaFunctionUpdate(conn *lambda.Lambda, functionName string, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{lambda.LastUpdateStatusInProgress},
+		Target:  []string{lambda.LastUpdateStatusSuccessful},
+		Refresh: refreshLambdaFunctionLastUpdateStatus(conn, functionName),
+		Timeout: timeout,
+		Delay:   5 * time.Second,
+	}
+
+	_, err := stateConf.WaitForState()
+
+	return err
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_lambda_function: Support waiting for function creation and configuration updates
```

Output from acceptance testing:

```
--- PASS: TestAccAWSLambdaFunction_basic (70.19s)
--- PASS: TestAccAWSLambdaFunction_concurrency (211.45s)
--- PASS: TestAccAWSLambdaFunction_concurrencyCycle (534.73s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfig (521.90s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfigUpdated (523.26s)
--- PASS: TestAccAWSLambdaFunction_EmptyVpcConfig (123.36s)
--- PASS: TestAccAWSLambdaFunction_encryptedEnvVariables (532.25s)
--- PASS: TestAccAWSLambdaFunction_envVariables (577.05s)
--- PASS: TestAccAWSLambdaFunction_expectFilenameAndS3Attributes (22.88s)
--- PASS: TestAccAWSLambdaFunction_KmsKeyArn_NoEnvironmentVariables (524.97s)
--- PASS: TestAccAWSLambdaFunction_Layers (389.18s)
--- PASS: TestAccAWSLambdaFunction_LayersUpdate (162.39s)
--- PASS: TestAccAWSLambdaFunction_localUpdate (579.02s)
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (467.24s)
--- PASS: TestAccAWSLambdaFunction_nilDeadLetterConfig (46.34s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_java11 (109.79s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_java8 (89.46s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_NodeJs10x (417.73s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_NodeJs12x (501.40s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_NodeJs810 (503.90s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_noRuntime (1.18s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_provided (76.07s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python27 (57.04s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python36 (63.71s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python37 (101.66s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python38 (82.66s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_ruby25 (96.18s)
--- PASS: TestAccAWSLambdaFunction_s3 (48.57s)
--- PASS: TestAccAWSLambdaFunction_s3Update_basic (70.87s)
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (71.77s)
--- PASS: TestAccAWSLambdaFunction_tags (153.01s)
--- PASS: TestAccAWSLambdaFunction_tracingConfig (521.15s)
--- PASS: TestAccAWSLambdaFunction_updateRuntime (525.56s)
--- PASS: TestAccAWSLambdaFunction_versioned (262.52s)
--- PASS: TestAccAWSLambdaFunction_versionedUpdate (502.87s)
--- PASS: TestAccAWSLambdaFunction_VPC (1810.83s)
--- PASS: TestAccAWSLambdaFunction_VPC_withInvocation (1667.42s)
--- PASS: TestAccAWSLambdaFunction_VpcConfig_ProperIamDependencies (1378.09s)
--- PASS: TestAccAWSLambdaFunction_VPCRemoval (3110.44s)
--- PASS: TestAccAWSLambdaFunction_VPCUpdate (2027.87s)
```
