### PR TITLE
Add greengrass service to keyvaluetags

### DIFF
--- a/aws/internal/keyvaluetags/generators/listtags/main.go
+++ b/aws/internal/keyvaluetags/generators/listtags/main.go
@@ -56,6 +56,7 @@ var serviceNames = []string{
 	"fsx",
 	"glue",
 	"guardduty",
+	"greengrass",
 	"inspector",
 	"iot",
 	"iotanalytics",

--- a/aws/internal/keyvaluetags/generators/servicetags/main.go
+++ b/aws/internal/keyvaluetags/generators/servicetags/main.go
@@ -107,6 +107,7 @@ var mapServiceNames = []string{
 	"glacier",
 	"glue",
 	"guardduty",
+	"greengrass",
 	"kafka",
 	"lambda",
 	"mediaconnect",

--- a/aws/internal/keyvaluetags/generators/updatetags/main.go
+++ b/aws/internal/keyvaluetags/generators/updatetags/main.go
@@ -61,6 +61,7 @@ var serviceNames = []string{
 	"fsx",
 	"glue",
 	"guardduty",
+	"greengrass",
 	"iot",
 	"iotanalytics",
 	"iotevents",

--- a/aws/internal/keyvaluetags/list_tags_gen.go
+++ b/aws/internal/keyvaluetags/list_tags_gen.go
@@ -42,6 +42,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/firehose"
 	"github.com/aws/aws-sdk-go/service/fsx"
 	"github.com/aws/aws-sdk-go/service/glue"
+	"github.com/aws/aws-sdk-go/service/greengrass"
 	"github.com/aws/aws-sdk-go/service/guardduty"
 	"github.com/aws/aws-sdk-go/service/inspector"
 	"github.com/aws/aws-sdk-go/service/iot"
@@ -723,6 +724,23 @@ func GlueListTags(conn *glue.Glue, identifier string) (KeyValueTags, error) {
 	}
 
 	return GlueKeyValueTags(output.Tags), nil
+}
+
+// GreengrassListTags lists greengrass service tags.
+// The identifier is typically the Amazon Resource Name (ARN), although
+// it may also be a different identifier depending on the service.
+func GreengrassListTags(conn *greengrass.Greengrass, identifier string) (KeyValueTags, error) {
+	input := &greengrass.ListTagsForResourceInput{
+		ResourceArn: aws.String(identifier),
+	}
+
+	output, err := conn.ListTagsForResource(input)
+
+	if err != nil {
+		return New(nil), err
+	}
+
+	return GreengrassKeyValueTags(output.Tags), nil
 }
 
 // GuarddutyListTags lists guardduty service tags.

--- a/aws/internal/keyvaluetags/service_generation_customizations.go
+++ b/aws/internal/keyvaluetags/service_generation_customizations.go
@@ -51,6 +51,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/firehose"
 	"github.com/aws/aws-sdk-go/service/fsx"
 	"github.com/aws/aws-sdk-go/service/glue"
+	"github.com/aws/aws-sdk-go/service/greengrass"
 	"github.com/aws/aws-sdk-go/service/guardduty"
 	"github.com/aws/aws-sdk-go/service/inspector"
 	"github.com/aws/aws-sdk-go/service/iot"
@@ -193,6 +194,8 @@ func ServiceClientType(serviceName string) string {
 		funcType = reflect.TypeOf(glue.New)
 	case "guardduty":
 		funcType = reflect.TypeOf(guardduty.New)
+	case "greengrass":
+		funcType = reflect.TypeOf(greengrass.New)
 	case "inspector":
 		funcType = reflect.TypeOf(inspector.New)
 	case "iot":

--- a/aws/internal/keyvaluetags/service_tags_gen.go
+++ b/aws/internal/keyvaluetags/service_tags_gen.go
@@ -226,6 +226,16 @@ func GlueKeyValueTags(tags map[string]*string) KeyValueTags {
 	return New(tags)
 }
 
+// GreengrassTags returns greengrass service tags.
+func (tags KeyValueTags) GreengrassTags() map[string]*string {
+	return aws.StringMap(tags.Map())
+}
+
+// GreengrassKeyValueTags creates KeyValueTags from greengrass service tags.
+func GreengrassKeyValueTags(tags map[string]*string) KeyValueTags {
+	return New(tags)
+}
+
 // GuarddutyTags returns guardduty service tags.
 func (tags KeyValueTags) GuarddutyTags() map[string]*string {
 	return aws.StringMap(tags.Map())


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #11017 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->
Add support for greengrass service in keyvaluetags
```release-note
Add support for greengrass service in keyvaluetags
```

Output from testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
go test
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.010s
```
