### PR TITLE
Change name to id in the aws_lightsail_static_ip_attachment example

### DIFF
--- a/website/docs/r/lightsail_static_ip_attachment.html.markdown
+++ b/website/docs/r/lightsail_static_ip_attachment.html.markdown
@@ -16,8 +16,8 @@ Provides a static IP address attachment - relationship between a Lightsail stati
 
 ```hcl
 resource "aws_lightsail_static_ip_attachment" "test" {
-  static_ip_name = "${aws_lightsail_static_ip.test.name}"
-  instance_name  = "${aws_lightsail_instance.test.name}"
+  static_ip_name = "${aws_lightsail_static_ip.test.id}"
+  instance_name  = "${aws_lightsail_instance.test.id}"
 }
 
 resource "aws_lightsail_static_ip" "test" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Change the example from name to id, in the current example if the instance or static ip gets recreated the static ip attachment doesn't get marked for recreation and requires a second run. ID is equal to name but is generated so it works better.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

N/A