### PR TITLE
New Resource: aws_workspaces_directory

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -827,6 +827,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_wafregional_web_acl_association":                     resourceAwsWafRegionalWebAclAssociation(),
 			"aws_worklink_fleet":                                      resourceAwsWorkLinkFleet(),
 			"aws_worklink_website_certificate_authority_association":  resourceAwsWorkLinkWebsiteCertificateAuthorityAssociation(),
+			"aws_workspaces_directory":                                resourceAwsWorkspacesDirectory(),
 			"aws_batch_compute_environment":                           resourceAwsBatchComputeEnvironment(),
 			"aws_batch_job_definition":                                resourceAwsBatchJobDefinition(),
 			"aws_batch_job_queue":                                     resourceAwsBatchJobQueue(),

--- a/aws/resource_aws_workspaces_directory.go
+++ b/aws/resource_aws_workspaces_directory.go
@@ -106,9 +106,10 @@ func resourceAwsWorkspacesDirectoryCreate(d *schema.ResourceData, meta interface
 		Pending: []string{
 			workspaces.WorkspaceDirectoryStateRegistering,
 		},
-		Target:  []string{workspaces.WorkspaceDirectoryStateRegistered},
-		Refresh: workspacesDirectoryRefreshStateFunc(conn, directoryId),
-		Timeout: 10 * time.Minute,
+		Target:       []string{workspaces.WorkspaceDirectoryStateRegistered},
+		Refresh:      workspacesDirectoryRefreshStateFunc(conn, directoryId),
+		PollInterval: 30 * time.Second,
+		Timeout:      10 * time.Minute,
 	}
 
 	_, err = stateConf.WaitForState()
@@ -222,8 +223,9 @@ func resourceAwsWorkspacesDirectoryDelete(d *schema.ResourceData, meta interface
 		Target: []string{
 			workspaces.WorkspaceDirectoryStateDeregistered,
 		},
-		Refresh: workspacesDirectoryRefreshStateFunc(conn, d.Id()),
-		Timeout: 10 * time.Minute,
+		Refresh:      workspacesDirectoryRefreshStateFunc(conn, d.Id()),
+		PollInterval: 30 * time.Second,
+		Timeout:      10 * time.Minute,
 	}
 
 	_, err = stateConf.WaitForState()

--- a/aws/resource_aws_workspaces_directory.go
+++ b/aws/resource_aws_workspaces_directory.go
@@ -82,7 +82,6 @@ func resourceAwsWorkspacesDirectoryRead(d *schema.ResourceData, meta interface{}
 
 	resp, err := conn.DescribeWorkspaceDirectories(&workspaces.DescribeWorkspaceDirectoriesInput{
 		DirectoryIds: []*string{aws.String(d.Id())},
-		Limit:        aws.Int64(1),
 	})
 	if err != nil {
 		return err
@@ -134,7 +133,6 @@ func workspacesDirectoryRefreshStateFunc(conn *workspaces.WorkSpaces, directoryI
 	return func() (interface{}, string, error) {
 		resp, err := conn.DescribeWorkspaceDirectories(&workspaces.DescribeWorkspaceDirectoriesInput{
 			DirectoryIds: []*string{aws.String(directoryID)},
-			Limit:        aws.Int64(1),
 		})
 		if err != nil {
 			return nil, workspaces.WorkspaceDirectoryStateError, err

--- a/aws/resource_aws_workspaces_directory.go
+++ b/aws/resource_aws_workspaces_directory.go
@@ -27,7 +27,8 @@ func resourceAwsWorkspacesDirectory() *schema.Resource {
 				ForceNew: true,
 			},
 			"self_service_permissions": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
+				Computed: true,
 				Optional: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
@@ -45,12 +46,12 @@ func resourceAwsWorkspacesDirectory() *schema.Resource {
 						"rebuild_workspace": {
 							Type:     schema.TypeBool,
 							Optional: true,
-							Default:  false,
+							Default:  true,
 						},
 						"restart_workspace": {
 							Type:     schema.TypeBool,
 							Optional: true,
-							Default:  false,
+							Default:  true,
 						},
 						"switch_running_mode": {
 							Type:     schema.TypeBool,
@@ -109,16 +110,16 @@ func resourceAwsWorkspacesDirectoryCreate(d *schema.ResourceData, meta interface
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("workspaces directory was not registered: %s", err)
+		return fmt.Errorf("error registering directory: %s", err)
 	}
 
 	if v, ok := d.GetOk("self_service_permissions"); ok {
 		_, err := conn.ModifySelfservicePermissions(&workspaces.ModifySelfservicePermissionsInput{
 			ResourceId:             aws.String(directoryId),
-			SelfservicePermissions: expandSelfServicePermissions(v.(*schema.Set).List()),
+			SelfservicePermissions: expandSelfServicePermissions(v.([]interface{})),
 		})
 		if err != nil {
-			return fmt.Errorf("workspaces directory self service permissions was not set: %s", err)
+			return fmt.Errorf("error setting self service permissions: %s", err)
 		}
 	}
 
@@ -165,7 +166,7 @@ func resourceAwsWorkspacesDirectoryUpdate(d *schema.ResourceData, meta interface
 			SelfservicePermissions: expandSelfServicePermissions(permissions),
 		})
 		if err != nil {
-			return fmt.Errorf("workspaces directory self service permissions was not set: %s", err)
+			return fmt.Errorf("error updating self service permissions: %s", err)
 		}
 	}
 

--- a/aws/resource_aws_workspaces_directory.go
+++ b/aws/resource_aws_workspaces_directory.go
@@ -1,0 +1,145 @@
+package aws
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/workspaces"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAwsWorkspacesDirectory() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsWorkspacesDirectoryCreate,
+		Read:   resourceAwsWorkspacesDirectoryRead,
+		Update: resourceAwsWorkspacesDirectoryUpdate,
+		Delete: resourceAwsWorkspacesDirectoryDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"directory_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"subnet_ids": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func resourceAwsWorkspacesDirectoryCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).workspacesconn
+	directoryId := d.Get("directory_id").(string)
+
+	input := &workspaces.RegisterWorkspaceDirectoryInput{
+		DirectoryId:       aws.String(directoryId),
+		EnableSelfService: aws.Bool(false),
+		EnableWorkDocs:    aws.Bool(false),
+		Tenancy:           aws.String(workspaces.TenancyShared),
+	}
+
+	if v, ok := d.GetOk("subnet_ids"); ok {
+		subnetIdsSet := v.(*schema.Set)
+		for _, id := range subnetIdsSet.List() {
+			input.SubnetIds = append(input.SubnetIds, aws.String(id.(string)))
+		}
+	}
+
+	_, err := conn.RegisterWorkspaceDirectory(input)
+	if err != nil {
+		return err
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			workspaces.WorkspaceDirectoryStateRegistering,
+		},
+		Target:  []string{workspaces.WorkspaceDirectoryStateRegistered},
+		Refresh: workspacesDirectoryRefreshStateFunc(conn, directoryId),
+		Timeout: 10 * time.Minute,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("workspace directory was not registered: %s", err)
+	}
+
+	d.SetId(directoryId)
+
+	return resourceAwsWorkspacesDirectoryRead(d, meta)
+}
+
+func resourceAwsWorkspacesDirectoryRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).workspacesconn
+
+	resp, err := conn.DescribeWorkspaceDirectories(&workspaces.DescribeWorkspaceDirectoriesInput{
+		DirectoryIds: []*string{aws.String(d.Id())},
+		Limit:        aws.Int64(1),
+	})
+	if err != nil {
+		return err
+	}
+	dir := resp.Directories[0]
+
+	d.Set("directory_id", dir.DirectoryId)
+	d.Set("subnet_ids", dir.SubnetIds)
+
+	return nil
+}
+
+func resourceAwsWorkspacesDirectoryUpdate(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceAwsWorkspacesDirectoryDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).workspacesconn
+
+	_, err := conn.DeregisterWorkspaceDirectory(&workspaces.DeregisterWorkspaceDirectoryInput{
+		DirectoryId: aws.String(d.Id()),
+	})
+	if err != nil {
+		return err
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			workspaces.WorkspaceDirectoryStateRegistering,
+			workspaces.WorkspaceDirectoryStateRegistered,
+		},
+		Target: []string{
+			workspaces.WorkspaceDirectoryStateDeregistering,
+			workspaces.WorkspaceDirectoryStateDeregistered,
+		},
+		Refresh: workspacesDirectoryRefreshStateFunc(conn, d.Id()),
+		Timeout: 10 * time.Minute,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("directory was not deregistered: %s", err)
+	}
+
+	return nil
+}
+
+func workspacesDirectoryRefreshStateFunc(conn *workspaces.WorkSpaces, directoryID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := conn.DescribeWorkspaceDirectories(&workspaces.DescribeWorkspaceDirectoriesInput{
+			DirectoryIds: []*string{aws.String(directoryID)},
+			Limit:        aws.Int64(1),
+		})
+		if err != nil {
+			return nil, workspaces.WorkspaceDirectoryStateError, err
+		}
+		directory := resp.Directories[0]
+		return directory, *directory.State, nil
+	}
+}

--- a/aws/resource_aws_workspaces_directory.go
+++ b/aws/resource_aws_workspaces_directory.go
@@ -95,10 +95,6 @@ func resourceAwsWorkspacesDirectoryRead(d *schema.ResourceData, meta interface{}
 	return nil
 }
 
-func resourceAwsWorkspacesDirectoryUpdate(d *schema.ResourceData, meta interface{}) error {
-	return nil
-}
-
 func resourceAwsWorkspacesDirectoryDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).workspacesconn
 

--- a/aws/resource_aws_workspaces_directory.go
+++ b/aws/resource_aws_workspaces_directory.go
@@ -117,6 +117,8 @@ func resourceAwsWorkspacesDirectoryCreate(d *schema.ResourceData, meta interface
 	}
 	log.Printf("[DEBUG] Workspaces directory %q is registered", d.Id())
 
+	d.Partial(true)
+
 	log.Printf("[DEBUG] Modifying workspaces directory %q self-service permissions...", d.Id())
 	if v, ok := d.GetOk("self_service_permissions"); ok {
 		_, err := conn.ModifySelfservicePermissions(&workspaces.ModifySelfservicePermissionsInput{
@@ -126,8 +128,11 @@ func resourceAwsWorkspacesDirectoryCreate(d *schema.ResourceData, meta interface
 		if err != nil {
 			return fmt.Errorf("error setting self service permissions: %s", err)
 		}
+		d.SetPartial("self_service_permission")
 	}
 	log.Printf("[DEBUG] Workspaces directory %q self-sevice permissions are set", d.Id())
+
+	d.Partial(false)
 
 	return resourceAwsWorkspacesDirectoryRead(d, meta)
 }
@@ -162,6 +167,8 @@ func resourceAwsWorkspacesDirectoryRead(d *schema.ResourceData, meta interface{}
 func resourceAwsWorkspacesDirectoryUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).workspacesconn
 
+	d.Partial(true)
+
 	if d.HasChange("self_service_permissions") {
 		log.Printf("[DEBUG] Modifying workspaces directory %q self-service permissions...", d.Id())
 		permissions := d.Get("self_service_permissions").([]interface{})
@@ -174,6 +181,7 @@ func resourceAwsWorkspacesDirectoryUpdate(d *schema.ResourceData, meta interface
 			return fmt.Errorf("error updating self service permissions: %s", err)
 		}
 		log.Printf("[DEBUG] Workspaces directory %q self-sevice permissions are set", d.Id())
+		d.SetPartial("self_service_permission")
 	}
 
 	if d.HasChange("tags") {
@@ -183,7 +191,10 @@ func resourceAwsWorkspacesDirectoryUpdate(d *schema.ResourceData, meta interface
 			return fmt.Errorf("error updating tags: %s", err)
 		}
 		log.Printf("[DEBUG] Workspaces directory %q tags are modified", d.Id())
+		d.SetPartial("tags")
 	}
+
+	d.Partial(false)
 
 	return resourceAwsWorkspacesDirectoryRead(d, meta)
 }

--- a/aws/resource_aws_workspaces_directory.go
+++ b/aws/resource_aws_workspaces_directory.go
@@ -28,6 +28,7 @@ func resourceAwsWorkspacesDirectory() *schema.Resource {
 			"subnet_ids": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				ForceNew: true,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},

--- a/aws/resource_aws_workspaces_directory.go
+++ b/aws/resource_aws_workspaces_directory.go
@@ -137,7 +137,9 @@ func workspacesDirectoryRefreshStateFunc(conn *workspaces.WorkSpaces, directoryI
 		if err != nil {
 			return nil, workspaces.WorkspaceDirectoryStateError, err
 		}
-		directory := resp.Directories[0]
-		return directory, *directory.State, nil
+		if len(resp.Directories) == 0 {
+			return resp, workspaces.WorkspaceDirectoryStateDeregistered, nil
+		}
+		return resp, *resp.Directories[0].State, nil
 	}
 }

--- a/aws/resource_aws_workspaces_directory.go
+++ b/aws/resource_aws_workspaces_directory.go
@@ -130,7 +130,7 @@ func resourceAwsWorkspacesDirectoryCreate(d *schema.ResourceData, meta interface
 		}
 		d.SetPartial("self_service_permission")
 	}
-	log.Printf("[DEBUG] Workspaces directory %q self-sevice permissions are set", d.Id())
+	log.Printf("[DEBUG] Workspaces directory %q self-service permissions are set", d.Id())
 
 	d.Partial(false)
 
@@ -180,7 +180,7 @@ func resourceAwsWorkspacesDirectoryUpdate(d *schema.ResourceData, meta interface
 		if err != nil {
 			return fmt.Errorf("error updating self service permissions: %s", err)
 		}
-		log.Printf("[DEBUG] Workspaces directory %q self-sevice permissions are set", d.Id())
+		log.Printf("[DEBUG] Workspaces directory %q self-service permissions are set", d.Id())
 		d.SetPartial("self_service_permission")
 	}
 

--- a/aws/resource_aws_workspaces_directory.go
+++ b/aws/resource_aws_workspaces_directory.go
@@ -217,9 +217,9 @@ func resourceAwsWorkspacesDirectoryDelete(d *schema.ResourceData, meta interface
 		Pending: []string{
 			workspaces.WorkspaceDirectoryStateRegistering,
 			workspaces.WorkspaceDirectoryStateRegistered,
+			workspaces.WorkspaceDirectoryStateDeregistering,
 		},
 		Target: []string{
-			workspaces.WorkspaceDirectoryStateDeregistering,
 			workspaces.WorkspaceDirectoryStateDeregistered,
 		},
 		Refresh: workspacesDirectoryRefreshStateFunc(conn, d.Id()),

--- a/aws/resource_aws_workspaces_directory.go
+++ b/aws/resource_aws_workspaces_directory.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 	"log"
 	"time"
 
@@ -10,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/workspaces"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsWorkspacesDirectory() *schema.Resource {
@@ -188,7 +188,7 @@ func resourceAwsWorkspacesDirectoryUpdate(d *schema.ResourceData, meta interface
 	if d.HasChange("tags") {
 		log.Printf("[DEBUG] Modifying workspaces directory %q tags...", d.Id())
 		o, n := d.GetChange("tags")
-		if err := keyvaluetags.WorkspacesUpdateTags(conn, d.Id(), o, n); err != nil {
+		if err := WorkspacesUpdateTags(conn, d.Id(), o, n); err != nil {
 			return fmt.Errorf("error updating tags: %s", err)
 		}
 		log.Printf("[DEBUG] Workspaces directory %q tags are modified", d.Id())

--- a/aws/resource_aws_workspaces_directory.go
+++ b/aws/resource_aws_workspaces_directory.go
@@ -46,7 +46,7 @@ func resourceAwsWorkspacesDirectory() *schema.Resource {
 						"rebuild_workspace": {
 							Type:     schema.TypeBool,
 							Optional: true,
-							Default:  true,
+							Default:  false,
 						},
 						"restart_workspace": {
 							Type:     schema.TypeBool,
@@ -88,8 +88,7 @@ func resourceAwsWorkspacesDirectoryCreate(d *schema.ResourceData, meta interface
 	}
 
 	if v, ok := d.GetOk("subnet_ids"); ok {
-		subnetIdsSet := v.(*schema.Set)
-		for _, id := range subnetIdsSet.List() {
+		for _, id := range v.(*schema.Set).List() {
 			input.SubnetIds = append(input.SubnetIds, aws.String(id.(string)))
 		}
 	}
@@ -159,7 +158,7 @@ func resourceAwsWorkspacesDirectoryUpdate(d *schema.ResourceData, meta interface
 	conn := meta.(*AWSClient).workspacesconn
 
 	if d.HasChange("self_service_permissions") {
-		permissions := d.Get("self_service_permissions").(*schema.Set).List()
+		permissions := d.Get("self_service_permissions").([]interface{})
 
 		_, err := conn.ModifySelfservicePermissions(&workspaces.ModifySelfservicePermissionsInput{
 			ResourceId:             aws.String(d.Id()),
@@ -172,8 +171,6 @@ func resourceAwsWorkspacesDirectoryUpdate(d *schema.ResourceData, meta interface
 
 	if d.HasChange("tags") {
 		o, n := d.GetChange("tags")
-		fmt.Printf("%+v", o)
-		fmt.Printf("%+v", n)
 		if err := keyvaluetags.WorkspacesUpdateTags(conn, d.Id(), o, n); err != nil {
 			return fmt.Errorf("error updating tags: %s", err)
 		}

--- a/aws/resource_aws_workspaces_directory_test.go
+++ b/aws/resource_aws_workspaces_directory_test.go
@@ -321,7 +321,7 @@ func testAccWorkspacesDirectoryConfigA(booster string) string {
 	return fmt.Sprintf(`
 %s
 
-resource "aws_workspaces_directory" "test" {
+resource "aws_workspaces_directory" "main" {
   directory_id = "${aws_directory_service_directory.main.id}"
 
   tags = {

--- a/aws/resource_aws_workspaces_directory_test.go
+++ b/aws/resource_aws_workspaces_directory_test.go
@@ -132,6 +132,10 @@ data aws_iam_policy_document workspaces {
       type        = "Service"
       identifiers = ["workspaces.amazonaws.com"]
     }
+  tags = {
+    Name = "test"
+    Terraform = true
+    Directory = "tf-acctest.example.com"
   }
 }
 
@@ -233,6 +237,11 @@ resource "aws_workspaces_directory" "test" {
     restart_workspace = true
     switch_running_mode = true
   }
+
+  tags = {
+    Purpose   = "test"
+    Directory = "tf-acctest.example.com"
+  }
 }
 `
 
@@ -327,6 +336,10 @@ func TestAccAwsWorkspacesDirectory_basic(t *testing.T) {
 				Config: testAccWorkspaceConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsWorkspacesDirectoryExists("aws_workspaces_directory.test"),
+					resource.TestCheckResourceAttr("aws_workspaces_directory.test", "tags.%", "3"),
+					resource.TestCheckResourceAttr("aws_workspaces_directory.test", "tags.Name", "test"),
+					resource.TestCheckResourceAttr("aws_workspaces_directory.test", "tags.Terraform", "true"),
+					resource.TestCheckResourceAttr("aws_workspaces_directory.test", "tags.Directory", "tf-acctest.example.com"),
 				),
 			},
 			{
@@ -348,6 +361,9 @@ func TestAccAwsWorkspacesDirectory_subnetIds(t *testing.T) {
 				Config: testAccWorkspaceConfig_subnetIds,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsWorkspacesDirectoryExists("aws_workspaces_directory.test"),
+					resource.TestCheckResourceAttr("aws_workspaces_directory.test", "tags.%", "2"),
+					resource.TestCheckResourceAttr("aws_workspaces_directory.test", "tags.Directory", "tf-acctest.example.com"),
+					resource.TestCheckResourceAttr("aws_workspaces_directory.test", "tags.Purpose", "test"),
 				),
 			},
 			{

--- a/aws/resource_aws_workspaces_directory_test.go
+++ b/aws/resource_aws_workspaces_directory_test.go
@@ -16,7 +16,7 @@ func TestAccAwsWorkspacesDirectory_basic(t *testing.T) {
 	booster := acctest.RandString(8)
 	resourceName := "aws_workspaces_directory.main"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsWorkspacesDirectoryDestroy,
@@ -79,7 +79,7 @@ func TestAccAwsWorkspacesDirectory_subnetIds(t *testing.T) {
 	booster := acctest.RandString(8)
 	resourceName := "aws_workspaces_directory.main"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsWorkspacesDirectoryDestroy,

--- a/aws/resource_aws_workspaces_directory_test.go
+++ b/aws/resource_aws_workspaces_directory_test.go
@@ -67,6 +67,10 @@ func testAccCheckAwsWorkspacesDirectoryDestroy(s *terraform.State) error {
 			return err
 		}
 
+		if len(resp.Directories) == 0 {
+			return nil
+		}
+
 		dir := resp.Directories[0]
 		if *dir.State != workspaces.WorkspaceDirectoryStateDeregistering && *dir.State != workspaces.WorkspaceDirectoryStateDeregistered {
 			return fmt.Errorf("directory %q was not deregistered", rs.Primary.ID)

--- a/aws/resource_aws_workspaces_directory_test.go
+++ b/aws/resource_aws_workspaces_directory_test.go
@@ -318,9 +318,7 @@ resource "aws_iam_role_policy_attachment" "workspaces-default-self-service-acces
 }
 
 func testAccWorkspacesDirectoryConfigA(booster string) string {
-	return fmt.Sprintf(`
-%s
-
+	return testAccAwsWorkspacesDirectoryConfig_Prerequisites(booster) + fmt.Sprintf(`
 resource "aws_workspaces_directory" "main" {
   directory_id = "${aws_directory_service_directory.main.id}"
 
@@ -330,13 +328,11 @@ resource "aws_workspaces_directory" "main" {
     Directory = "tf-acctest.example.com"
   }
 }
-`, testAccAwsWorkspacesDirectoryConfig_Prerequisites(booster))
+`)
 }
 
 func testAccWorkspacesDirectoryConfigB(booster string) string {
-	return fmt.Sprintf(`
-%s
-
+	return testAccAwsWorkspacesDirectoryConfig_Prerequisites(booster) + fmt.Sprintf(`
 resource "aws_workspaces_directory" "main" {
   directory_id = "${aws_directory_service_directory.main.id}"
 
@@ -353,13 +349,11 @@ resource "aws_workspaces_directory" "main" {
     Directory = "tf-acctest.example.com"
   }
 }
-`, testAccAwsWorkspacesDirectoryConfig_Prerequisites(booster))
+`)
 }
 
 func testAccWorkspacesDirectoryConfigC(booster string) string {
-	return fmt.Sprintf(`
-%s
-
+	return testAccAwsWorkspacesDirectoryConfig_Prerequisites(booster) + fmt.Sprintf(`
 resource "aws_workspaces_directory" "main" {
   directory_id = "${aws_directory_service_directory.main.id}"
 
@@ -368,16 +362,14 @@ resource "aws_workspaces_directory" "main" {
     switch_running_mode = true
   }
 }
-`, testAccAwsWorkspacesDirectoryConfig_Prerequisites(booster))
+`)
 }
 
 func testAccWorkspacesDirectoryConfig_subnetIds(booster string) string {
-	return fmt.Sprintf(`
-%s
-
+	return testAccAwsWorkspacesDirectoryConfig_Prerequisites(booster) + fmt.Sprintf(`
 resource "aws_workspaces_directory" "main" {
   directory_id = "${aws_directory_service_directory.main.id}"
   subnet_ids = ["${aws_subnet.primary.id}","${aws_subnet.secondary.id}"]
 }
-`, testAccAwsWorkspacesDirectoryConfig_Prerequisites(booster))
+`)
 }

--- a/aws/resource_aws_workspaces_directory_test.go
+++ b/aws/resource_aws_workspaces_directory_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -98,10 +99,6 @@ locals {
   workspaces_az_ids = lookup(local.region_workspaces_az_ids, data.aws_region.current.name, data.aws_availability_zones.available.zone_ids)
 }
 
-data "aws_availability_zones" "available" {
-  state = "available"
-}
-
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 }
@@ -158,6 +155,86 @@ resource "aws_workspaces_directory" "test" {
   subnet_ids = ["${aws_subnet.primary.id}","${aws_subnet.secondary.id}"]
 }
 `
+
+	testAccWorkspaceConfig_selfServicePermissions = `
+data "aws_region" "current" {}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+  region_workspaces_az_ids = {
+    "us-east-1" = formatlist("use1-az%d", [2, 4, 6])
+  }
+
+  workspaces_az_ids = lookup(local.region_workspaces_az_ids, data.aws_region.current.name, data.aws_availability_zones.available.zone_ids)
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "primary" {
+  vpc_id = "${aws_vpc.test.id}"
+  availability_zone_id = "${local.workspaces_az_ids[0]}"
+  cidr_block = "10.0.1.0/24"
+}
+
+resource "aws_subnet" "secondary" {
+  vpc_id = "${aws_vpc.test.id}"
+  availability_zone_id = "${local.workspaces_az_ids[1]}"
+  cidr_block = "10.0.2.0/24"
+}
+resource "aws_directory_service_directory" "test" {
+  name = "tf-acctest.example.com"
+  password = "#S1ncerely"
+  size = "Small"
+  vpc_settings {
+    vpc_id = "${aws_vpc.test.id}"
+    subnet_ids = ["${aws_subnet.primary.id}","${aws_subnet.secondary.id}"]
+  }
+}
+
+data aws_iam_policy_document workspaces {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["workspaces.amazonaws.com"]
+    }
+  }
+}
+
+resource aws_iam_role workspaces-default {
+  name               = "workspaces_DefaultRole"
+  assume_role_policy = data.aws_iam_policy_document.workspaces.json
+}
+
+resource aws_iam_role_policy_attachment workspaces-default-service-access {
+  role       = aws_iam_role.workspaces-default.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonWorkSpacesServiceAccess"
+}
+
+resource aws_iam_role_policy_attachment workspaces-default-self-service-access {
+  role       = aws_iam_role.workspaces-default.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonWorkSpacesSelfServiceAccess"
+}
+
+resource "aws_workspaces_directory" "test" {
+  directory_id = "${aws_directory_service_directory.test.id}"
+  subnet_ids = ["${aws_subnet.primary.id}","${aws_subnet.secondary.id}"]
+
+  self_service_permissions {
+    change_compute_type = true
+    increase_volume_size = true
+    rebuild_workspace = true
+    restart_workspace = true
+    switch_running_mode = true
+  }
+}
+`
 )
 
 func TestAccAwsWorkspacesDirectory_basic(t *testing.T) {
@@ -189,6 +266,27 @@ func TestAccAwsWorkspacesDirectory_subnetIds(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccWorkspaceConfig_subnetIds,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsWorkspacesDirectoryExists("aws_workspaces_directory.test"),
+				),
+			},
+			{
+				ResourceName:      "aws_workspaces_directory.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsWorkspacesDirectory_selfServicePermissions(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsWorkspacesDirectoryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkspaceConfig_selfServicePermissions,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsWorkspacesDirectoryExists("aws_workspaces_directory.test"),
 				),
@@ -254,5 +352,83 @@ func testAccCheckAwsWorkspacesDirectoryExists(n string) resource.TestCheckFunc {
 		}
 
 		return fmt.Errorf("workspaces directory %q is not found", rs.Primary.ID)
+	}
+}
+
+func TestExpandSelfServicePermissions(t *testing.T) {
+	cases := []struct {
+		input    []interface{}
+		expected *workspaces.SelfservicePermissions
+	}{
+		// Empty
+		{
+			input:    []interface{}{},
+			expected: nil,
+		},
+		// Full
+		{
+			input: []interface{}{
+				map[string]interface{}{
+					"change_compute_type":  false,
+					"increase_volume_size": false,
+					"rebuild_workspace":    true,
+					"restart_workspace":    true,
+					"switch_running_mode":  true,
+				},
+			},
+			expected: &workspaces.SelfservicePermissions{
+				ChangeComputeType:  aws.String(workspaces.ReconnectEnumDisabled),
+				IncreaseVolumeSize: aws.String(workspaces.ReconnectEnumDisabled),
+				RebuildWorkspace:   aws.String(workspaces.ReconnectEnumEnabled),
+				RestartWorkspace:   aws.String(workspaces.ReconnectEnumEnabled),
+				SwitchRunningMode:  aws.String(workspaces.ReconnectEnumEnabled),
+			},
+		},
+	}
+
+	for _, c := range cases {
+		actual := expandSelfServicePermissions(c.input)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Fatalf("expected\n\n%#+v\n\ngot\n\n%#+v", c.expected, actual)
+		}
+	}
+}
+
+func TestFlattenSelfServicePermissions(t *testing.T) {
+	cases := []struct {
+		input    *workspaces.SelfservicePermissions
+		expected []interface{}
+	}{
+		// Empty
+		{
+			input:    nil,
+			expected: []interface{}{},
+		},
+		// Full
+		{
+			input: &workspaces.SelfservicePermissions{
+				ChangeComputeType:  aws.String(workspaces.ReconnectEnumDisabled),
+				IncreaseVolumeSize: aws.String(workspaces.ReconnectEnumDisabled),
+				RebuildWorkspace:   aws.String(workspaces.ReconnectEnumEnabled),
+				RestartWorkspace:   aws.String(workspaces.ReconnectEnumEnabled),
+				SwitchRunningMode:  aws.String(workspaces.ReconnectEnumEnabled),
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					"change_compute_type":  false,
+					"increase_volume_size": false,
+					"rebuild_workspace":    true,
+					"restart_workspace":    true,
+					"switch_running_mode":  true,
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		actual := flattenSelfServicePermissions(c.input)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Fatalf("expected\n\n%#+v\n\ngot\n\n%#+v", c.expected, actual)
+		}
 	}
 }

--- a/aws/resource_aws_workspaces_directory_test.go
+++ b/aws/resource_aws_workspaces_directory_test.go
@@ -42,6 +42,32 @@ resource "aws_directory_service_directory" "test" {
   }
 }
 
+data aws_iam_policy_document workspaces {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["workspaces.amazonaws.com"]
+    }
+  }
+}
+
+resource aws_iam_role workspaces-default {
+  name               = "workspaces_DefaultRole"
+  assume_role_policy = data.aws_iam_policy_document.workspaces.json
+}
+
+resource aws_iam_role_policy_attachment workspaces-default-service-access {
+  role       = aws_iam_role.workspaces-default.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonWorkSpacesServiceAccess"
+}
+
+resource aws_iam_role_policy_attachment workspaces-default-self-service-access {
+  role       = aws_iam_role.workspaces-default.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonWorkSpacesSelfServiceAccess"
+}
+
 resource "aws_workspaces_directory" "test" {
   directory_id = "${aws_directory_service_directory.test.id}"
 }
@@ -72,6 +98,32 @@ resource "aws_directory_service_directory" "test" {
     vpc_id = "${aws_vpc.test.id}"
     subnet_ids = ["${aws_subnet.test-a.id}","${aws_subnet.test-c.id}"]
   }
+}
+
+data aws_iam_policy_document workspaces {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["workspaces.amazonaws.com"]
+    }
+  }
+}
+
+resource aws_iam_role workspaces-default {
+  name               = "workspaces_DefaultRole"
+  assume_role_policy = data.aws_iam_policy_document.workspaces.json
+}
+
+resource aws_iam_role_policy_attachment workspaces-default-service-access {
+  role       = aws_iam_role.workspaces-default.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonWorkSpacesServiceAccess"
+}
+
+resource aws_iam_role_policy_attachment workspaces-default-self-service-access {
+  role       = aws_iam_role.workspaces-default.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonWorkSpacesSelfServiceAccess"
 }
 
 resource "aws_workspaces_directory" "test" {

--- a/aws/resource_aws_workspaces_directory_test.go
+++ b/aws/resource_aws_workspaces_directory_test.go
@@ -62,7 +62,6 @@ func testAccCheckAwsWorkspacesDirectoryDestroy(s *terraform.State) error {
 
 		resp, err := conn.DescribeWorkspaceDirectories(&workspaces.DescribeWorkspaceDirectoriesInput{
 			DirectoryIds: []*string{aws.String(rs.Primary.ID)},
-			Limit:        aws.Int64(1),
 		})
 		if err != nil {
 			return err
@@ -91,7 +90,6 @@ func testAccCheckAwsWorkspacesDirectoryExists(n string) resource.TestCheckFunc {
 		conn := testAccProvider.Meta().(*AWSClient).workspacesconn
 		resp, err := conn.DescribeWorkspaceDirectories(&workspaces.DescribeWorkspaceDirectoriesInput{
 			DirectoryIds: []*string{aws.String(rs.Primary.ID)},
-			Limit:        aws.Int64(1),
 		})
 		if err != nil {
 			return err

--- a/aws/resource_aws_workspaces_directory_test.go
+++ b/aws/resource_aws_workspaces_directory_test.go
@@ -156,7 +156,7 @@ resource "aws_workspaces_directory" "test" {
 }
 `
 
-	testAccWorkspaceConfig_selfServicePermissions = `
+	testAccWorkspaceConfig_selfServicePermissionsA = `
 data "aws_region" "current" {}
 
 data "aws_availability_zones" "available" {
@@ -235,6 +235,86 @@ resource "aws_workspaces_directory" "test" {
   }
 }
 `
+
+	testAccWorkspaceConfig_selfServicePermissionsB = `
+data "aws_region" "current" {}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+  region_workspaces_az_ids = {
+    "us-east-1" = formatlist("use1-az%d", [2, 4, 6])
+  }
+
+  workspaces_az_ids = lookup(local.region_workspaces_az_ids, data.aws_region.current.name, data.aws_availability_zones.available.zone_ids)
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "primary" {
+  vpc_id = "${aws_vpc.test.id}"
+  availability_zone_id = "${local.workspaces_az_ids[0]}"
+  cidr_block = "10.0.1.0/24"
+}
+
+resource "aws_subnet" "secondary" {
+  vpc_id = "${aws_vpc.test.id}"
+  availability_zone_id = "${local.workspaces_az_ids[1]}"
+  cidr_block = "10.0.2.0/24"
+}
+resource "aws_directory_service_directory" "test" {
+  name = "tf-acctest.example.com"
+  password = "#S1ncerely"
+  size = "Small"
+  vpc_settings {
+    vpc_id = "${aws_vpc.test.id}"
+    subnet_ids = ["${aws_subnet.primary.id}","${aws_subnet.secondary.id}"]
+  }
+}
+
+data aws_iam_policy_document workspaces {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["workspaces.amazonaws.com"]
+    }
+  }
+}
+
+resource aws_iam_role workspaces-default {
+  name               = "workspaces_DefaultRole"
+  assume_role_policy = data.aws_iam_policy_document.workspaces.json
+}
+
+resource aws_iam_role_policy_attachment workspaces-default-service-access {
+  role       = aws_iam_role.workspaces-default.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonWorkSpacesServiceAccess"
+}
+
+resource aws_iam_role_policy_attachment workspaces-default-self-service-access {
+  role       = aws_iam_role.workspaces-default.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonWorkSpacesSelfServiceAccess"
+}
+
+resource "aws_workspaces_directory" "test" {
+  directory_id = "${aws_directory_service_directory.test.id}"
+  subnet_ids = ["${aws_subnet.primary.id}","${aws_subnet.secondary.id}"]
+
+  self_service_permissions {
+    change_compute_type = false
+    increase_volume_size = true
+    rebuild_workspace = false
+    restart_workspace = true
+    switch_running_mode = false
+  }
+}
+`
 )
 
 func TestAccAwsWorkspacesDirectory_basic(t *testing.T) {
@@ -286,7 +366,18 @@ func TestAccAwsWorkspacesDirectory_selfServicePermissions(t *testing.T) {
 		CheckDestroy: testAccCheckAwsWorkspacesDirectoryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkspaceConfig_selfServicePermissions,
+				Config: testAccWorkspaceConfig_selfServicePermissionsA,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsWorkspacesDirectoryExists("aws_workspaces_directory.test"),
+				),
+			},
+			{
+				ResourceName:      "aws_workspaces_directory.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccWorkspaceConfig_selfServicePermissionsB,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsWorkspacesDirectoryExists("aws_workspaces_directory.test"),
 				),

--- a/aws/resource_aws_workspaces_directory_test.go
+++ b/aws/resource_aws_workspaces_directory_test.go
@@ -12,7 +12,85 @@ import (
 )
 
 const (
-	testAccWorkspaceConfig = `
+	testAccWorkspaceConfigA = `
+data "aws_region" "current" {}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+  region_workspaces_az_ids = {
+    "us-east-1" = formatlist("use1-az%d", [2, 4, 6])
+  }
+
+  workspaces_az_ids = lookup(local.region_workspaces_az_ids, data.aws_region.current.name, data.aws_availability_zones.available.zone_ids)
+}
+
+ resource "aws_vpc" "test" {
+   cidr_block = "10.0.0.0/16"
+ }
+ 
+ resource "aws_subnet" "primary" {
+   vpc_id = "${aws_vpc.test.id}"
+   availability_zone_id = "${local.workspaces_az_ids[0]}"
+   cidr_block = "10.0.1.0/24"
+ }
+ 
+ resource "aws_subnet" "secondary" {
+   vpc_id = "${aws_vpc.test.id}"
+   availability_zone_id = "${local.workspaces_az_ids[1]}"
+   cidr_block = "10.0.2.0/24"
+ }
+
+resource "aws_directory_service_directory" "test" {
+  name = "tf-acctest.example.com"
+  password = "#S1ncerely"
+  size = "Small"
+  vpc_settings {
+    vpc_id = "${aws_vpc.test.id}"
+    subnet_ids = ["${aws_subnet.primary.id}","${aws_subnet.secondary.id}"]
+  }
+}
+
+data aws_iam_policy_document workspaces {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["workspaces.amazonaws.com"]
+    }
+  }
+}
+
+# resource aws_iam_role workspaces-default {
+#   name               = "workspaces_DefaultRole"
+#   assume_role_policy = data.aws_iam_policy_document.workspaces.json
+# }
+# 
+# resource aws_iam_role_policy_attachment workspaces-default-service-access {
+#   role       = aws_iam_role.workspaces-default.name
+#   policy_arn = "arn:aws:iam::aws:policy/AmazonWorkSpacesServiceAccess"
+# }
+# 
+# resource aws_iam_role_policy_attachment workspaces-default-self-service-access {
+#   role       = aws_iam_role.workspaces-default.name
+#   policy_arn = "arn:aws:iam::aws:policy/AmazonWorkSpacesSelfServiceAccess"
+# }
+
+resource "aws_workspaces_directory" "test" {
+  directory_id = "${aws_directory_service_directory.test.id}"
+
+  tags = {
+    Name = "test"
+    Terraform = true
+    Directory = "tf-acctest.example.com"
+  }
+}
+`
+
+	testAccWorkspaceConfigB = `
 data "aws_region" "current" {}
 
 data "aws_availability_zones" "available" {
@@ -64,23 +142,36 @@ data aws_iam_policy_document workspaces {
   }
 }
 
-resource aws_iam_role workspaces-default {
-  name               = "workspaces_DefaultRole"
-  assume_role_policy = data.aws_iam_policy_document.workspaces.json
-}
-
-resource aws_iam_role_policy_attachment workspaces-default-service-access {
-  role       = aws_iam_role.workspaces-default.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonWorkSpacesServiceAccess"
-}
-
-resource aws_iam_role_policy_attachment workspaces-default-self-service-access {
-  role       = aws_iam_role.workspaces-default.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonWorkSpacesSelfServiceAccess"
-}
+# resource aws_iam_role workspaces-default {
+#   name               = "workspaces_DefaultRole"
+#   assume_role_policy = data.aws_iam_policy_document.workspaces.json
+# }
+# 
+# resource aws_iam_role_policy_attachment workspaces-default-service-access {
+#   role       = aws_iam_role.workspaces-default.name
+#   policy_arn = "arn:aws:iam::aws:policy/AmazonWorkSpacesServiceAccess"
+# }
+# 
+# resource aws_iam_role_policy_attachment workspaces-default-self-service-access {
+#   role       = aws_iam_role.workspaces-default.name
+#   policy_arn = "arn:aws:iam::aws:policy/AmazonWorkSpacesSelfServiceAccess"
+# }
 
 resource "aws_workspaces_directory" "test" {
   directory_id = "${aws_directory_service_directory.test.id}"
+
+  self_service_permissions {
+    change_compute_type = true
+    increase_volume_size = true
+    rebuild_workspace = true
+    restart_workspace = true
+    switch_running_mode = true
+  }
+
+  tags = {
+    Purpose   = "test"
+    Directory = "tf-acctest.example.com"
+  }
 }
 `
 
@@ -132,10 +223,6 @@ data aws_iam_policy_document workspaces {
       type        = "Service"
       identifiers = ["workspaces.amazonaws.com"]
     }
-  tags = {
-    Name = "test"
-    Terraform = true
-    Directory = "tf-acctest.example.com"
   }
 }
 
@@ -157,171 +244,6 @@ resource aws_iam_role_policy_attachment workspaces-default-self-service-access {
 resource "aws_workspaces_directory" "test" {
   directory_id = "${aws_directory_service_directory.test.id}"
   subnet_ids = ["${aws_subnet.primary.id}","${aws_subnet.secondary.id}"]
-}
-`
-
-	testAccWorkspaceConfig_selfServicePermissionsA = `
-data "aws_region" "current" {}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-}
-
-locals {
-  region_workspaces_az_ids = {
-    "us-east-1" = formatlist("use1-az%d", [2, 4, 6])
-  }
-
-  workspaces_az_ids = lookup(local.region_workspaces_az_ids, data.aws_region.current.name, data.aws_availability_zones.available.zone_ids)
-}
-
-resource "aws_vpc" "test" {
-  cidr_block = "10.0.0.0/16"
-}
-
-resource "aws_subnet" "primary" {
-  vpc_id = "${aws_vpc.test.id}"
-  availability_zone_id = "${local.workspaces_az_ids[0]}"
-  cidr_block = "10.0.1.0/24"
-}
-
-resource "aws_subnet" "secondary" {
-  vpc_id = "${aws_vpc.test.id}"
-  availability_zone_id = "${local.workspaces_az_ids[1]}"
-  cidr_block = "10.0.2.0/24"
-}
-resource "aws_directory_service_directory" "test" {
-  name = "tf-acctest.example.com"
-  password = "#S1ncerely"
-  size = "Small"
-  vpc_settings {
-    vpc_id = "${aws_vpc.test.id}"
-    subnet_ids = ["${aws_subnet.primary.id}","${aws_subnet.secondary.id}"]
-  }
-}
-
-data aws_iam_policy_document workspaces {
-  statement {
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["workspaces.amazonaws.com"]
-    }
-  }
-}
-
-resource aws_iam_role workspaces-default {
-  name               = "workspaces_DefaultRole"
-  assume_role_policy = data.aws_iam_policy_document.workspaces.json
-}
-
-resource aws_iam_role_policy_attachment workspaces-default-service-access {
-  role       = aws_iam_role.workspaces-default.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonWorkSpacesServiceAccess"
-}
-
-resource aws_iam_role_policy_attachment workspaces-default-self-service-access {
-  role       = aws_iam_role.workspaces-default.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonWorkSpacesSelfServiceAccess"
-}
-
-resource "aws_workspaces_directory" "test" {
-  directory_id = "${aws_directory_service_directory.test.id}"
-  subnet_ids = ["${aws_subnet.primary.id}","${aws_subnet.secondary.id}"]
-
-  self_service_permissions {
-    change_compute_type = true
-    increase_volume_size = true
-    rebuild_workspace = true
-    restart_workspace = true
-    switch_running_mode = true
-  }
-
-  tags = {
-    Purpose   = "test"
-    Directory = "tf-acctest.example.com"
-  }
-}
-`
-
-	testAccWorkspaceConfig_selfServicePermissionsB = `
-data "aws_region" "current" {}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-}
-
-locals {
-  region_workspaces_az_ids = {
-    "us-east-1" = formatlist("use1-az%d", [2, 4, 6])
-  }
-
-  workspaces_az_ids = lookup(local.region_workspaces_az_ids, data.aws_region.current.name, data.aws_availability_zones.available.zone_ids)
-}
-
-resource "aws_vpc" "test" {
-  cidr_block = "10.0.0.0/16"
-}
-
-resource "aws_subnet" "primary" {
-  vpc_id = "${aws_vpc.test.id}"
-  availability_zone_id = "${local.workspaces_az_ids[0]}"
-  cidr_block = "10.0.1.0/24"
-}
-
-resource "aws_subnet" "secondary" {
-  vpc_id = "${aws_vpc.test.id}"
-  availability_zone_id = "${local.workspaces_az_ids[1]}"
-  cidr_block = "10.0.2.0/24"
-}
-resource "aws_directory_service_directory" "test" {
-  name = "tf-acctest.example.com"
-  password = "#S1ncerely"
-  size = "Small"
-  vpc_settings {
-    vpc_id = "${aws_vpc.test.id}"
-    subnet_ids = ["${aws_subnet.primary.id}","${aws_subnet.secondary.id}"]
-  }
-}
-
-data aws_iam_policy_document workspaces {
-  statement {
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["workspaces.amazonaws.com"]
-    }
-  }
-}
-
-resource aws_iam_role workspaces-default {
-  name               = "workspaces_DefaultRole"
-  assume_role_policy = data.aws_iam_policy_document.workspaces.json
-}
-
-resource aws_iam_role_policy_attachment workspaces-default-service-access {
-  role       = aws_iam_role.workspaces-default.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonWorkSpacesServiceAccess"
-}
-
-resource aws_iam_role_policy_attachment workspaces-default-self-service-access {
-  role       = aws_iam_role.workspaces-default.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonWorkSpacesSelfServiceAccess"
-}
-
-resource "aws_workspaces_directory" "test" {
-  directory_id = "${aws_directory_service_directory.test.id}"
-  subnet_ids = ["${aws_subnet.primary.id}","${aws_subnet.secondary.id}"]
-
-  self_service_permissions {
-    change_compute_type = false
-    increase_volume_size = true
-    rebuild_workspace = false
-    restart_workspace = true
-    switch_running_mode = false
-  }
 }
 `
 )
@@ -333,9 +255,18 @@ func TestAccAwsWorkspacesDirectory_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAwsWorkspacesDirectoryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkspaceConfig,
+				Config: testAccWorkspaceConfigA,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsWorkspacesDirectoryExists("aws_workspaces_directory.test"),
+					resource.TestCheckResourceAttr("aws_workspaces_directory.test", "subnet_ids.#", "2"),
+					resource.TestCheckResourceAttrPair("aws_workspaces_directory.test", "subnet_ids.0.id", "aws_subnet.primary", "id"),
+					resource.TestCheckResourceAttrPair("aws_workspaces_directory.test", "subnet_ids.1.id", "aws_subnet.secondary", "id"),
+					resource.TestCheckResourceAttr("aws_workspaces_directory.test", "self_service_permissions.#", "1"),
+					resource.TestCheckResourceAttr("aws_workspaces_directory.test", "self_service_permissions.0.change_compute_type", "false"),
+					resource.TestCheckResourceAttr("aws_workspaces_directory.test", "self_service_permissions.0.increase_volume_size", "false"),
+					resource.TestCheckResourceAttr("aws_workspaces_directory.test", "self_service_permissions.0.rebuild_workspace", "true"),
+					resource.TestCheckResourceAttr("aws_workspaces_directory.test", "self_service_permissions.0.restart_workspace", "true"),
+					resource.TestCheckResourceAttr("aws_workspaces_directory.test", "self_service_permissions.0.switch_running_mode", "false"),
 					resource.TestCheckResourceAttr("aws_workspaces_directory.test", "tags.%", "3"),
 					resource.TestCheckResourceAttr("aws_workspaces_directory.test", "tags.Name", "test"),
 					resource.TestCheckResourceAttr("aws_workspaces_directory.test", "tags.Terraform", "true"),
@@ -346,6 +277,21 @@ func TestAccAwsWorkspacesDirectory_basic(t *testing.T) {
 				ResourceName:      "aws_workspaces_directory.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccWorkspaceConfigB,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsWorkspacesDirectoryExists("aws_workspaces_directory.test"),
+					resource.TestCheckResourceAttr("aws_workspaces_directory.test", "self_service_permissions.#", "1"),
+					resource.TestCheckResourceAttr("aws_workspaces_directory.test", "self_service_permissions.0.change_compute_type", "true"),
+					resource.TestCheckResourceAttr("aws_workspaces_directory.test", "self_service_permissions.0.increase_volume_size", "true"),
+					resource.TestCheckResourceAttr("aws_workspaces_directory.test", "self_service_permissions.0.rebuild_workspace", "true"),
+					resource.TestCheckResourceAttr("aws_workspaces_directory.test", "self_service_permissions.0.restart_workspace", "true"),
+					resource.TestCheckResourceAttr("aws_workspaces_directory.test", "self_service_permissions.0.switch_running_mode", "true"),
+					resource.TestCheckResourceAttr("aws_workspaces_directory.test", "tags.%", "2"),
+					resource.TestCheckResourceAttr("aws_workspaces_directory.test", "tags.Directory", "tf-acctest.example.com"),
+					resource.TestCheckResourceAttr("aws_workspaces_directory.test", "tags.Purpose", "test"),
+				),
 			},
 		},
 	})
@@ -359,41 +305,6 @@ func TestAccAwsWorkspacesDirectory_subnetIds(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccWorkspaceConfig_subnetIds,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsWorkspacesDirectoryExists("aws_workspaces_directory.test"),
-					resource.TestCheckResourceAttr("aws_workspaces_directory.test", "tags.%", "2"),
-					resource.TestCheckResourceAttr("aws_workspaces_directory.test", "tags.Directory", "tf-acctest.example.com"),
-					resource.TestCheckResourceAttr("aws_workspaces_directory.test", "tags.Purpose", "test"),
-				),
-			},
-			{
-				ResourceName:      "aws_workspaces_directory.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAwsWorkspacesDirectory_selfServicePermissions(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsWorkspacesDirectoryDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccWorkspaceConfig_selfServicePermissionsA,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsWorkspacesDirectoryExists("aws_workspaces_directory.test"),
-				),
-			},
-			{
-				ResourceName:      "aws_workspaces_directory.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccWorkspaceConfig_selfServicePermissionsB,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsWorkspacesDirectoryExists("aws_workspaces_directory.test"),
 				),

--- a/aws/resource_aws_workspaces_directory_test.go
+++ b/aws/resource_aws_workspaces_directory_test.go
@@ -1,0 +1,175 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/workspaces"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccAwsWorkspacesDirectory_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsWorkspacesDirectoryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkspaceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsWorkspacesDirectoryExists("aws_workspaces_directory.test"),
+				),
+			},
+			{
+				ResourceName:      "aws_workspaces_directory.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsWorkspacesDirectory_subnetIds(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsWorkspacesDirectoryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkspaceConfig_subnetIds(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsWorkspacesDirectoryExists("aws_workspaces_directory.test"),
+				),
+			},
+			{
+				ResourceName:      "aws_workspaces_directory.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAwsWorkspacesDirectoryDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).workspacesconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_workspaces_directory" {
+			continue
+		}
+
+		resp, err := conn.DescribeWorkspaceDirectories(&workspaces.DescribeWorkspaceDirectoriesInput{
+			DirectoryIds: []*string{aws.String(rs.Primary.ID)},
+			Limit:        aws.Int64(1),
+		})
+		if err != nil {
+			return err
+		}
+
+		dir := resp.Directories[0]
+		if *dir.State != workspaces.WorkspaceDirectoryStateDeregistering && *dir.State != workspaces.WorkspaceDirectoryStateDeregistered {
+			return fmt.Errorf("directory %q was not deregistered", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAwsWorkspacesDirectoryExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("workspaces directory resource is not found: %q", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("workspaces directory resource ID is not set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).workspacesconn
+		resp, err := conn.DescribeWorkspaceDirectories(&workspaces.DescribeWorkspaceDirectoriesInput{
+			DirectoryIds: []*string{aws.String(rs.Primary.ID)},
+			Limit:        aws.Int64(1),
+		})
+		if err != nil {
+			return err
+		}
+
+		if *resp.Directories[0].DirectoryId == rs.Primary.ID {
+			return nil
+		}
+
+		return fmt.Errorf("workspaces directory %q is not found", rs.Primary.ID)
+	}
+}
+
+func testAccWorkspaceConfig() string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "test-a" {
+  vpc_id = "${aws_vpc.test.id}"
+  availability_zone = "us-east-1a"
+  cidr_block = "10.0.1.0/24"
+}
+
+resource "aws_subnet" "test-c" {
+  vpc_id = "${aws_vpc.test.id}"
+  availability_zone = "us-east-1c"
+  cidr_block = "10.0.2.0/24"
+}
+
+resource "aws_directory_service_directory" "test" {
+  name = "tf-acctest.example.com"
+  password = "#S1ncerely"
+  size = "Small"
+  vpc_settings {
+    vpc_id = "${aws_vpc.test.id}"
+    subnet_ids = ["${aws_subnet.test-a.id}","${aws_subnet.test-c.id}"]
+  }
+}
+
+resource "aws_workspaces_directory" "test" {
+  directory_id = "${aws_directory_service_directory.test.id}"
+}
+`)
+}
+
+func testAccWorkspaceConfig_subnetIds() string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "test-a" {
+  vpc_id = "${aws_vpc.test.id}"
+  availability_zone = "us-east-1a"
+  cidr_block = "10.0.1.0/24"
+}
+
+resource "aws_subnet" "test-c" {
+  vpc_id = "${aws_vpc.test.id}"
+  availability_zone = "us-east-1c"
+  cidr_block = "10.0.2.0/24"
+}
+
+resource "aws_directory_service_directory" "test" {
+  name = "tf-acctest.example.com"
+  password = "#S1ncerely"
+  size = "Small"
+  vpc_settings {
+    vpc_id = "${aws_vpc.test.id}"
+    subnet_ids = ["${aws_subnet.test-a.id}","${aws_subnet.test-c.id}"]
+  }
+}
+
+resource "aws_workspaces_directory" "test" {
+  directory_id = "${aws_directory_service_directory.test.id}"
+  subnet_ids = ["${aws_subnet.test-a.id}","${aws_subnet.test-c.id}"]
+}
+`)
+}

--- a/aws/resource_aws_workspaces_ip_group.go
+++ b/aws/resource_aws_workspaces_ip_group.go
@@ -68,10 +68,6 @@ func resourceAwsWorkspacesIpGroupCreate(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	//if len(tags) > 0 {
-	//	params.Tags = tags
-	//}
-
 	d.SetId(*resp.GroupId)
 
 	return resourceAwsWorkspacesIpGroupRead(d, meta)

--- a/aws/tagsWorkspaces.go
+++ b/aws/tagsWorkspaces.go
@@ -1,0 +1,38 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/workspaces"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+// WorkspacesUpdateTags custom function, which updates workspaces service tags.
+// The identifier is typically the Amazon Resource Name (ARN), although
+// it may also be a different identifier depending on the service.
+func WorkspacesUpdateTags(conn *workspaces.WorkSpaces, identifier string, oldTagsMap interface{}, newTagsMap interface{}) error {
+	oldTags := keyvaluetags.New(oldTagsMap)
+	newTags := keyvaluetags.New(newTagsMap)
+
+	if len(newTags) == 0 {
+		input := &workspaces.DeleteTagsInput{
+			ResourceId: aws.String(identifier),
+			TagKeys:    aws.StringSlice(oldTags.Keys()),
+		}
+
+		if _, err := conn.DeleteTags(input); err != nil {
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
+		}
+	} else {
+		input := &workspaces.CreateTagsInput{
+			ResourceId: aws.String(identifier),
+			Tags:       newTags.IgnoreAws().WorkspacesTags(),
+		}
+
+		if _, err := conn.CreateTags(input); err != nil {
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
+		}
+	}
+
+	return nil
+}

--- a/examples/workspaces/main.tf
+++ b/examples/workspaces/main.tf
@@ -2,7 +2,38 @@ provider "aws" {
   region = "us-east-1"
 }
 
-resource "aws_workspaces_ip_group" "example" {
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "private-a" {
+  vpc_id            = "${aws_vpc.main.id}"
+  availability_zone = "us-east-1b"
+  cidr_block        = "10.0.1.0/24"
+}
+
+resource "aws_subnet" "private-b" {
+  vpc_id            = "${aws_vpc.main.id}"
+  availability_zone = "us-east-1b"
+  cidr_block        = "10.0.2.0/24"
+}
+
+resource "aws_directory_service_directory" "main" {
+  name     = "tf-acctest.example.com"
+  password = "#S1ncerely"
+  size     = "Small"
+  vpc_settings {
+    vpc_id     = "${aws_vpc.main.id}"
+    subnet_ids = ["${aws_subnet.private-a.id}", "${aws_subnet.private-b.id}"]
+  }
+}
+
+resource "aws_workspaces_directory" "main" {
+  directory_id = "${aws_directory_service_directory.main.id}"
+  subnet_ids   = ["${aws_subnet.private-a.id}", "${aws_subnet.private-b.id}"]
+}
+
+resource "aws_workspaces_ip_group" "main" {
   name        = "main"
   description = "Main IP access control group"
 

--- a/examples/workspaces/main.tf
+++ b/examples/workspaces/main.tf
@@ -8,7 +8,7 @@ resource "aws_vpc" "main" {
 
 resource "aws_subnet" "private-a" {
   vpc_id            = "${aws_vpc.main.id}"
-  availability_zone = "us-east-1b"
+  availability_zone = "us-east-1a"
   cidr_block        = "10.0.1.0/24"
 }
 

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/kubernetes-sigs/aws-iam-authenticator v0.3.1-0.20181019024009-82544ec86140
 	github.com/mitchellh/copystructure v1.0.0
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/pquerna/otp v1.2.0
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -351,6 +351,8 @@ github.com/mitchellh/reflectwalk v1.0.1 h1:FVzMWA5RllMAKIdUSC8mdWo3XtwoecrH79BY7
 github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -3387,6 +3387,9 @@
                             <a href="#">Resources</a>
                             <ul class="nav nav-auto-expand">
                                 <li>
+                                    <a href="/docs/providers/aws/r/workspaces_directory.html">aws_workspaces_directory</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/aws/r/workspaces_ip_group.html">aws_workspaces_ip_group</a>
                                 </li>
                             </ul>

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -3346,6 +3346,14 @@
                                 </li>
                             </ul>
                         </li>
+                        <li>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/workspaces_directory.html">aws_workspaces_directory</a>
+                                </li>
+                            </ul>
+                        </li>
                     </ul>
                 </li>
                 <li>

--- a/website/docs/r/workspaces_directory.html.markdown
+++ b/website/docs/r/workspaces_directory.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Workspaces"
 layout: "aws"
 page_title: "AWS: aws_workspaces_directory"
-sidebar_current: "docs-aws-resource-workspaces-directory"
 description: |-
   Provides a directory registration in AWS Workspaces Service.
 ---

--- a/website/docs/r/workspaces_directory.html.markdown
+++ b/website/docs/r/workspaces_directory.html.markdown
@@ -1,0 +1,67 @@
+---
+subcategory: "Workspaces"
+layout: "aws"
+page_title: "AWS: aws_workspaces_directory"
+sidebar_current: "docs-aws-resource-workspaces-directory"
+description: |-
+  Provides a directory registration in AWS Workspaces Service.
+---
+
+# Resource: aws_workspaces_directory
+
+Provides a directory registration in AWS Workspaces Service
+
+## Example Usage
+
+```hcl
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "private-a" {
+  vpc_id = "${aws_vpc.main.id}"
+  availability_zone = "us-east-1a"
+  cidr_block = "10.0.0.0/24"
+}
+
+resource "aws_subnet" "private-b" {
+  vpc_id = "${aws_vpc.main.id}"
+  availability_zone = "us-east-1b"
+  cidr_block = "10.0.1.0/24"
+}
+
+resource "aws_directory_service_directory" "main" {
+  name = "corp.example.com"
+  password = "#S1ncerely"
+  size = "Small"
+  vpc_settings {
+    vpc_id = "${aws_vpc.main.id}"
+    subnet_ids = ["${aws_subnet.private-a.id}","${aws_subnet.private-b.id}"]
+  }
+}
+
+resource "aws_workspaces_directory" "main" {
+  directory_id = "${aws_directory_service_directory.main.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `directory_id` - (Required) The directory identifier for registration in Workspaces service.
+* `subnet_ids` - (Optional) The identifiers of the subnets where the directory resides new workspaces.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The workspaces directory identifier.
+
+## Import
+
+Workspaces directory can be imported using the directory ID, e.g.
+
+```
+$ terraform import aws_workspaces_directory.main d-4444444444
+```

--- a/website/docs/r/workspaces_directory.html.markdown
+++ b/website/docs/r/workspaces_directory.html.markdown
@@ -42,6 +42,11 @@ resource "aws_directory_service_directory" "main" {
 
 resource "aws_workspaces_directory" "main" {
   directory_id = "${aws_directory_service_directory.main.id}"
+  
+  self_service_permissions = {
+    increase_volume_size = true
+    rebuild_workspace = true
+  }
 }
 ```
 

--- a/website/docs/r/workspaces_directory.html.markdown
+++ b/website/docs/r/workspaces_directory.html.markdown
@@ -51,6 +51,16 @@ The following arguments are supported:
 
 * `directory_id` - (Required) The directory identifier for registration in Workspaces service.
 * `subnet_ids` - (Optional) The identifiers of the subnets where the directory resides new workspaces.
+* `tags` – (Optional) A mapping of tags assigned to the workspaces directory.
+* `self_service_permissions` – (Optional) The permissions to enable or disable self-service capabilities.
+
+`self_service_permissions` supports the following:
+
+* `change_compute_type` – (Optional) Whether workspaces directory users can change the compute type (bundle) for their workspace. Default `false`.
+* `increase_volume_size` – (Optional) Whether workspaces directory users can increase the volume size of the drives on their workspace. Default `false`.
+* `rebuild_workspace` – (Optional) Whether workspaces directory users can rebuild the operating system of a workspace to its original state. Default `false`.
+* `restart_workspace` – (Optional) Whether workspaces directory users can restart their workspace. Default `true`.
+* `switch_running_mode` – (Optional) Whether workspaces directory users can switch the running mode of their workspace. Default `false`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

### Example

```hcl
resource "aws_vpc" "main" {
  cidr_block = "10.0.0.0/16"
}

resource "aws_subnet" "private-a" {
  vpc_id = "${aws_vpc.main.id}"
  availability_zone = "us-east-1a"
  cidr_block = "10.0.0.0/24"
}

resource "aws_subnet" "private-b" {
  vpc_id = "${aws_vpc.main.id}"
  availability_zone = "us-east-1b"
  cidr_block = "10.0.1.0/24"
}

resource "aws_directory_service_directory" "main" {
  name = "corp.example.com"
  password = "#S1ncerely"
  size = "Small"
  vpc_settings {
    vpc_id = "${aws_vpc.main.id}"
    subnet_ids = ["${aws_subnet.private-a.id}","${aws_subnet.private-b.id}"]
  }
}

resource "aws_workspaces_directory" "main" {
  directory_id = "${aws_directory_service_directory.main.id}"
}
```

### Test

Output from acceptance testing:

```
$ AWS_DEFAULT_REGION=us-east-1 make testacc TESTARGS='-run=TestAccAwsWorkspacesDirectory_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAwsWorkspacesDirectory_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
--- PASS: TestAccAwsWorkspacesDirectory_basic (557.79s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	561.184s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.307s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.234s [no tests to run]
```

### Notes

Workspaces API still lacks a lot of features support and is not consistent. However, this resource opens the doors to other Workspaces resource, check out #434. I've already requested a couple of AWS API features to support other attributes support and will add them to the resource as soon as it will be possible.

### References

- [AWS Workspaces RegisterWorkspaceDirectory](https://docs.aws.amazon.com/workspaces/latest/api/API_RegisterWorkspaceDirectory.html#API_RegisterWorkspaceDirectory_RequestSyntax)
- [AWS Workspaces DescribeWorkspaceDirectories](https://docs.aws.amazon.com/workspaces/latest/api/API_DescribeWorkspaceDirectories.html)
- [AWS Workspaces DeregisterWorkspaceDirectory](https://docs.aws.amazon.com/workspaces/latest/api/API_DeregisterWorkspaceDirectory.html)


### Questions

- Is it necessary to add sweeper?