### PR TITLE
resource/aws_iam_user: Delete a user's virtual MFA devices when force_destroy is enabled

### DIFF
--- a/aws/resource_aws_iam_user.go
+++ b/aws/resource_aws_iam_user.go
@@ -233,7 +233,11 @@ func resourceAwsIamUserDelete(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("error removing IAM User (%s) SSH keys: %s", d.Id(), err)
 		}
 
-		if err := deleteAwsIamUserMFADevices(iamconn, d.Id()); err != nil {
+		if err := deleteAwsIamUserVirtualMFADevices(iamconn, d.Id()); err != nil {
+			return fmt.Errorf("error removing IAM User (%s) Virtual MFA devices: %s", d.Id(), err)
+		}
+
+		if err := deactivateAwsIamUserMFADevices(iamconn, d.Id()); err != nil {
 			return fmt.Errorf("error removing IAM User (%s) MFA devices: %s", d.Id(), err)
 		}
 
@@ -326,7 +330,45 @@ func deleteAwsIamUserSSHKeys(svc *iam.IAM, username string) error {
 	return nil
 }
 
-func deleteAwsIamUserMFADevices(svc *iam.IAM, username string) error {
+func deleteAwsIamUserVirtualMFADevices(svc *iam.IAM, username string) error {
+	var VirtualMFADevices []string
+	var err error
+
+	listVirtualMFADevices := &iam.ListVirtualMFADevicesInput{
+		AssignmentStatus: aws.String("Assigned"),
+	}
+	pageOfVirtualMFADevices := func(page *iam.ListVirtualMFADevicesOutput, lastPage bool) (shouldContinue bool) {
+		for _, m := range page.VirtualMFADevices {
+			if *m.User.UserName == username {
+				VirtualMFADevices = append(VirtualMFADevices, *m.SerialNumber)
+			}
+		}
+		return !lastPage
+	}
+	err = svc.ListVirtualMFADevicesPages(listVirtualMFADevices, pageOfVirtualMFADevices)
+	if err != nil {
+		return fmt.Errorf("Error removing Virtual MFA devices of user %s: %s", username, err)
+	}
+	for _, m := range VirtualMFADevices {
+		_, err := svc.DeactivateMFADevice(&iam.DeactivateMFADeviceInput{
+			UserName:     aws.String(username),
+			SerialNumber: aws.String(m),
+		})
+		if err != nil {
+			return fmt.Errorf("Error deactivating Virtual MFA device %s: %s", m, err)
+		}
+		_, err = svc.DeleteVirtualMFADevice(&iam.DeleteVirtualMFADeviceInput{
+			SerialNumber: aws.String(m),
+		})
+		if err != nil {
+			return fmt.Errorf("Error deleting Virtual MFA device %s: %s", m, err)
+		}
+	}
+
+	return nil
+}
+
+func deactivateAwsIamUserMFADevices(svc *iam.IAM, username string) error {
 	var MFADevices []string
 	var err error
 

--- a/aws/resource_aws_iam_user_test.go
+++ b/aws/resource_aws_iam_user_test.go
@@ -139,7 +139,11 @@ func testSweepIamUsers(region string) error {
 			return fmt.Errorf("error removing IAM User (%s) SSH keys: %s", username, err)
 		}
 
-		if err := deleteAwsIamUserMFADevices(conn, username); err != nil {
+		if err := deleteAwsIamUserVirtualMFADevices(conn, username); err != nil {
+			return fmt.Errorf("error removing IAM User (%s) virtual MFA devices: %s", username, err)
+		}
+
+		if err := deactivateAwsIamUserMFADevices(conn, username); err != nil {
 			return fmt.Errorf("error removing IAM User (%s) MFA devices: %s", username, err)
 		}
 


### PR DESCRIPTION
Fully removing a virtual MFA device requires first deactivating then deleting it. Currently the resource `aws_am_user` with `force_destroy = true` implements only the deactivation step and results in dissociated virtual MFA devices being left behind. This can cause issues should a future user - likely one with the same name as the deleted user - attempt to enable virtual MFA with the same path.

This PR implements the deletion step for virtual MFA devices. It also renames the prior function `deleteAwsIamUserMFADevices` to `deactivateAwsIamUserMFADevices` in order to reflect what's actually happening to non-virtual MFA devices.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
resource/aws_iam_user: Delete a user's virtual MFA devices when `force_destroy` is enabled
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSUser_ForceDestroy_MFADevice'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSUser_ForceDestroy_MFADevice -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSUser_ForceDestroy_MFADevice
=== PAUSE TestAccAWSUser_ForceDestroy_MFADevice
=== CONT  TestAccAWSUser_ForceDestroy_MFADevice
--- PASS: TestAccAWSUser_ForceDestroy_MFADevice (22.34s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	23.867s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.258s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.118s [no tests to run]'
```
