### PR TITLE
add support for ca_cert_identifier parameter for docdb

### DIFF
--- a/aws/resource_aws_docdb_cluster_instance.go
+++ b/aws/resource_aws_docdb_cluster_instance.go
@@ -159,6 +159,12 @@ func resourceAwsDocDBClusterInstance() *schema.Resource {
 				Computed: true,
 			},
 
+			"ca_cert_identifier": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
 			"tags": tagsSchema(),
 
 			"writer": {
@@ -306,6 +312,7 @@ func resourceAwsDocDBClusterInstanceRead(d *schema.ResourceData, meta interface{
 	d.Set("promotion_tier", db.PromotionTier)
 	d.Set("publicly_accessible", db.PubliclyAccessible)
 	d.Set("storage_encrypted", db.StorageEncrypted)
+	d.Set("ca_cert_identifier", db.CACertificateIdentifier)
 
 	if err := saveTagsDocDB(conn, d, aws.StringValue(db.DBInstanceArn)); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
@@ -343,6 +350,12 @@ func resourceAwsDocDBClusterInstanceUpdate(d *schema.ResourceData, meta interfac
 	if d.HasChange("promotion_tier") {
 		d.SetPartial("promotion_tier")
 		req.PromotionTier = aws.Int64(int64(d.Get("promotion_tier").(int)))
+		requestUpdate = true
+	}
+
+	if d.HasChange("ca_cert_identifier") {
+		d.SetPartial("ca_cert_identifier")
+		req.CACertificateIdentifier = aws.String(d.Get("ca_cert_identifier").(string))
 		requestUpdate = true
 	}
 

--- a/aws/resource_aws_docdb_cluster_instance_test.go
+++ b/aws/resource_aws_docdb_cluster_instance_test.go
@@ -37,6 +37,7 @@ func TestAccAWSDocDBClusterInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "dbi_resource_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "availability_zone"),
 					resource.TestCheckResourceAttrSet(resourceName, "engine_version"),
+					resource.TestCheckResourceAttrSet(resourceName, "ca_cert_identifier"),
 					resource.TestCheckResourceAttr(resourceName, "engine", "docdb"),
 				),
 			},

--- a/website/docs/r/docdb_cluster_instance.html.markdown
+++ b/website/docs/r/docdb_cluster_instance.html.markdown
@@ -77,6 +77,7 @@ In addition to all arguments above, the following attributes are exported:
 * `preferred_backup_window` - The daily time range during which automated backups are created if automated backups are enabled.
 * `storage_encrypted` - Specifies whether the DB cluster is encrypted.
 * `writer` – Boolean indicating if this instance is writable. `False` indicates this instance is a read replica.
+* `ca_cert_identifier` - (Optional) The identifier of the CA certificate for the DB instance.
 
 [1]: /docs/providers/aws/r/docdb_cluster.html
 [2]: https://docs.aws.amazon.com/documentdb/latest/developerguide/db-cluster-manage-performance.html#db-cluster-manage-scaling-instance


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
add support for ca_cert_identifier parameter for docdb
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSDocDBClusterInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDocDBClusterInstance_basic -timeout 120m
=== RUN   TestAccAWSDocDBClusterInstance_basic
=== PAUSE TestAccAWSDocDBClusterInstance_basic
=== CONT  TestAccAWSDocDBClusterInstance_basic
--- PASS: TestAccAWSDocDBClusterInstance_basic (1429.78s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1429.834s
...
```
