### PR TITLE
r/aws_rds_cluster: Allow enable/disable Data API Aurora Serverless

### DIFF
--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -403,7 +403,7 @@ func resourceAwsRDSCluster() *schema.Resource {
 					}, false),
 				},
 			},
-			"data_api_enabled": {
+			"enable_http_endpoint": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
@@ -780,7 +780,7 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 			createOpts.MasterUsername = aws.String(v.(string))
 		}
 
-		if v, ok := d.GetOk("data_api_enabled"); ok {
+		if v, ok := d.GetOk("enable_http_endpoint"); ok {
 			createOpts.EnableHttpEndpoint = aws.Bool(v.(bool))
 		}
 		// Need to check value > 0 due to:
@@ -1032,7 +1032,7 @@ func resourceAwsRDSClusterRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("storage_encrypted", dbc.StorageEncrypted)
-	d.Set("data_api_enabled", dbc.HttpEndpointEnabled)
+	d.Set("enable_http_endpoint", dbc.HttpEndpointEnabled)
 
 	var vpcg []string
 	for _, g := range dbc.VpcSecurityGroups {
@@ -1149,9 +1149,9 @@ func resourceAwsRDSClusterUpdate(d *schema.ResourceData, meta interface{}) error
 		requestUpdate = true
 	}
 
-	if d.HasChange("data_api_enabled") {
-		d.SetPartial("data_api_enabled")
-		req.EnableHttpEndpoint = aws.Bool(d.Get("data_api_enabled").(bool))
+	if d.HasChange("enable_http_endpoint") {
+		d.SetPartial("enable_http_endpoint")
+		req.EnableHttpEndpoint = aws.Bool(d.Get("enable_http_endpoint").(bool))
 		requestUpdate = true
 	}
 

--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -2060,7 +2060,7 @@ func testAccCheckAWSClusterRecreated(i, j *rds.DBCluster) resource.TestCheckFunc
 	}
 }
 
-func TestAccAWSRDSCluster_DataApiEnabled(t *testing.T) {
+func TestAccAWSRDSCluster_EnableHttpEndpoint(t *testing.T) {
 	var dbCluster rds.DBCluster
 
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -2072,10 +2072,10 @@ func TestAccAWSRDSCluster_DataApiEnabled(t *testing.T) {
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSRDSClusterConfig_DataApiEnabled(rName, true),
+				Config: testAccAWSRDSClusterConfig_EnableHttpEndpoint(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterExists(resourceName, &dbCluster),
-					resource.TestCheckResourceAttr(resourceName, "data_api_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enable_http_endpoint", "true"),
 				),
 			},
 			{
@@ -2091,10 +2091,10 @@ func TestAccAWSRDSCluster_DataApiEnabled(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccAWSRDSClusterConfig_DataApiEnabled(rName, false),
+				Config: testAccAWSRDSClusterConfig_EnableHttpEndpoint(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterExists(resourceName, &dbCluster),
-					resource.TestCheckResourceAttr(resourceName, "data_api_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "enable_http_endpoint", "false"),
 				),
 			},
 		},
@@ -3362,15 +3362,15 @@ resource "aws_rds_cluster" "test" {
 `, n, f)
 }
 
-func testAccAWSRDSClusterConfig_DataApiEnabled(rName string, dataApiEnabled bool) string {
+func testAccAWSRDSClusterConfig_EnableHttpEndpoint(rName string, enableHttpEndpoint bool) string {
 	return fmt.Sprintf(`
 resource "aws_rds_cluster" "test" {
-  cluster_identifier  = %q
-  engine_mode         = "serverless"
-  master_password     = "barbarbarbar"
-  master_username     = "foo"
-  skip_final_snapshot = true
-  data_api_enabled    = %t
+  cluster_identifier    = %q
+  engine_mode           = "serverless"
+  master_password       = "barbarbarbar"
+  master_username       = "foo"
+  skip_final_snapshot   = true
+  enable_http_endpoint  = %t
 
   scaling_configuration {
     auto_pause               = false
@@ -3380,5 +3380,5 @@ resource "aws_rds_cluster" "test" {
     timeout_action           = "RollbackCapacityChange"
   }
 }
-`, rName, dataApiEnabled)
+`, rName, enableHttpEndpoint)
 }

--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -137,7 +137,7 @@ Default: A 30-minute window selected at random from an 8-hour block of time per 
 * `enabled_cloudwatch_logs_exports` - (Optional) List of log types to export to cloudwatch. If omitted, no logs will be exported.
    The following log types are supported: `audit`, `error`, `general`, `slowquery`, `postgresql` (PostgreSQL).
 * `scaling_configuration` - (Optional) Nested attribute with scaling properties. Only valid when `engine_mode` is set to `serverless`. More details below.
-* `data_api_enabled` - (Optional) Enable data API. Only valid when `engine_mode` is set to `serverless`.
+* `enable_http_endpoint` - (Optional) Enable HTTP endpoint (data API). Only valid when `engine_mode` is set to `serverless`.
 * `tags` - (Optional) A mapping of tags to assign to the DB cluster.
 
 ### S3 Import Options

--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -137,6 +137,7 @@ Default: A 30-minute window selected at random from an 8-hour block of time per 
 * `enabled_cloudwatch_logs_exports` - (Optional) List of log types to export to cloudwatch. If omitted, no logs will be exported.
    The following log types are supported: `audit`, `error`, `general`, `slowquery`, `postgresql` (PostgreSQL).
 * `scaling_configuration` - (Optional) Nested attribute with scaling properties. Only valid when `engine_mode` is set to `serverless`. More details below.
+* `data_api_enabled` - (Optional) Enable data API. Only valid when `engine_mode` is set to `serverless`.
 * `tags` - (Optional) A mapping of tags to assign to the DB cluster.
 
 ### S3 Import Options


### PR DESCRIPTION
Add option to enable Data API  for aurora serverless

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10026

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_rds_cluster: Allow enable/disable Aurora Serverless HTTP endpoint (Data API) with `enable_http_endpoint` 
```
Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
± make testacc TEST=./aws TESTARGS='-run=TestAccAWSRDSCluster_EnableHttpEndpoint'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSRDSCluster_EnableHttpEndpoint -timeout 120m
=== RUN   TestAccAWSRDSCluster_EnableHttpEndpoint
=== PAUSE TestAccAWSRDSCluster_EnableHttpEndpoint
=== CONT  TestAccAWSRDSCluster_EnableHttpEndpoint
--- PASS: TestAccAWSRDSCluster_EnableHttpEndpoint (388.47s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	388.525s
...
```
