### PR TITLE
Make 'profiler' a valid CloudWatch log export type for DocumentDB.

### DIFF
--- a/aws/resource_aws_docdb_cluster.go
+++ b/aws/resource_aws_docdb_cluster.go
@@ -231,6 +231,7 @@ func resourceAwsDocDBCluster() *schema.Resource {
 					Type: schema.TypeString,
 					ValidateFunc: validation.StringInSlice([]string{
 						"audit",
+						"profiler",
 					}, false),
 				},
 			},

--- a/aws/resource_aws_docdb_cluster_test.go
+++ b/aws/resource_aws_docdb_cluster_test.go
@@ -41,6 +41,8 @@ func TestAccAWSDocDBCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "hosted_zone_id"),
 					resource.TestCheckResourceAttr(resourceName,
 						"enabled_cloudwatch_logs_exports.0", "audit"),
+					resource.TestCheckResourceAttr(resourceName,
+						"enabled_cloudwatch_logs_exports.1", "profiler"),
 				),
 			},
 			{
@@ -556,6 +558,7 @@ resource "aws_docdb_cluster" "default" {
 
   enabled_cloudwatch_logs_exports = [
     "audit",
+    "profiler",
   ]
 }
 `, n)

--- a/website/docs/r/docdb_cluster.html.markdown
+++ b/website/docs/r/docdb_cluster.html.markdown
@@ -53,7 +53,7 @@ The following arguments are supported:
 * `db_subnet_group_name` - (Optional) A DB subnet group to associate with this DB instance.
 * `db_cluster_parameter_group_name` - (Optional) A cluster parameter group to associate with the cluster.
 * `enabled_cloudwatch_logs_exports` - (Optional) List of log types to export to cloudwatch. If omitted, no logs will be exported.
-   The following log types are supported: `audit`.
+   The following log types are supported: `audit`, `profiler`.
 * `engine_version` - (Optional) The database engine version. Updating this argument results in an outage.
 * `engine` - (Optional) The name of the database engine to be used for this DB cluster. Defaults to `docdb`. Valid Values: `docdb`
 * `final_snapshot_identifier` - (Optional) The name of your final DB snapshot


### PR DESCRIPTION
Enabling the `profiler` feature in a DocumentDB parameter group requires adding the `profiler` logtype to `enabled_cloudwatch_logs_exports` on the `aws_docdb_cluster` resource. Add `profiler` to the list of allowed values for `enabled_cloudwatch_logs_exports` so that this becomes possible.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10953

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add support for the `profiler` CloudWatch log type in `enabled_cloudwatch_logs_exports` for DocumentDB clusters [GH-10953]
```

Output from acceptance testing:

```
$ export AWS_DEFAULT_REGION=us-west-2
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDocDBCluster_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDocDBCluster_basic -timeout 120m
=== RUN   TestAccAWSDocDBCluster_basic
=== PAUSE TestAccAWSDocDBCluster_basic
=== CONT  TestAccAWSDocDBCluster_basic
--- PASS: TestAccAWSDocDBCluster_basic (147.21s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	147.264s
$ 
```