### PR TITLE
Recreate batch_compute_environment when updating launch_template

### DIFF
--- a/aws/resource_aws_batch_compute_environment.go
+++ b/aws/resource_aws_batch_compute_environment.go
@@ -75,15 +75,18 @@ func resourceAwsBatchComputeEnvironment() *schema.Resource {
 										Type:          schema.TypeString,
 										Optional:      true,
 										ConflictsWith: []string{"compute_resources.0.launch_template.0.launch_template_name"},
+										ForceNew:      true,
 									},
 									"launch_template_name": {
 										Type:          schema.TypeString,
 										Optional:      true,
 										ConflictsWith: []string{"compute_resources.0.launch_template.0.launch_template_id"},
+										ForceNew:      true,
 									},
 									"version": {
 										Type:     schema.TypeString,
 										Optional: true,
+										ForceNew: true,
 									},
 								},
 							},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11012 
Forces to recreate a new batch_compute_environment when the associated launch_template is updated.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSBatchComputeEnvironment_UpdateLaunchTemplate'

=== RUN   TestAccAWSBatchComputeEnvironment_UpdateLaunchTemplate
=== PAUSE TestAccAWSBatchComputeEnvironment_UpdateLaunchTemplate
=== CONT  TestAccAWSBatchComputeEnvironment_UpdateLaunchTemplate
--- PASS: TestAccAWSBatchComputeEnvironment_UpdateLaunchTemplate (135.79s)
PASS
...
```
