### PR TITLE
KMS asymmetric keys

### DIFF
--- a/aws/data_source_aws_kms_key.go
+++ b/aws/data_source_aws_kms_key.go
@@ -63,6 +63,10 @@ func dataSourceAwsKmsKey() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"customer_master_key_spec": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"origin": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -103,6 +107,7 @@ func dataSourceAwsKmsKeyRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("key_manager", output.KeyMetadata.KeyManager)
 	d.Set("key_state", output.KeyMetadata.KeyState)
 	d.Set("key_usage", output.KeyMetadata.KeyUsage)
+	d.Set("customer_master_key_spec", output.KeyMetadata.CustomerMasterKeySpec)
 	d.Set("origin", output.KeyMetadata.Origin)
 	if output.KeyMetadata.ValidTo != nil {
 		d.Set("valid_to", aws.TimeValue(output.KeyMetadata.ValidTo).Format(time.RFC3339))

--- a/aws/data_source_aws_kms_key_test.go
+++ b/aws/data_source_aws_kms_key_test.go
@@ -2,31 +2,36 @@ package aws
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func TestAccDataSourceAwsKmsKey_basic(t *testing.T) {
+	resourceName := "aws_kms_key.test"
+	datasourceName := "data.aws_kms_key.test"
+	rName := fmt.Sprintf("tf-testacc-kms-key-%s", acctest.RandStringFromCharSet(13, acctest.CharSetAlphaNum))
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsKmsKeyConfig,
+				Config: testAccDataSourceAwsKmsKeyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceAwsKmsKeyCheck("data.aws_kms_key.arbitrary"),
-					resource.TestMatchResourceAttr("data.aws_kms_key.arbitrary", "arn", regexp.MustCompile("^arn:[^:]+:kms:[^:]+:[^:]+:key/.+")),
-					resource.TestCheckResourceAttrSet("data.aws_kms_key.arbitrary", "aws_account_id"),
-					resource.TestCheckResourceAttrSet("data.aws_kms_key.arbitrary", "creation_date"),
-					resource.TestCheckResourceAttr("data.aws_kms_key.arbitrary", "description", "Terraform acc test"),
-					resource.TestCheckResourceAttr("data.aws_kms_key.arbitrary", "enabled", "true"),
-					resource.TestCheckResourceAttrSet("data.aws_kms_key.arbitrary", "key_manager"),
-					resource.TestCheckResourceAttrSet("data.aws_kms_key.arbitrary", "key_state"),
-					resource.TestCheckResourceAttr("data.aws_kms_key.arbitrary", "key_usage", "ENCRYPT_DECRYPT"),
-					resource.TestCheckResourceAttrSet("data.aws_kms_key.arbitrary", "origin"),
+					testAccDataSourceAwsKmsKeyCheck(datasourceName),
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "customer_master_key_spec", resourceName, "customer_master_key_spec"),
+					resource.TestCheckResourceAttrPair(datasourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(datasourceName, "enabled", resourceName, "is_enabled"),
+					resource.TestCheckResourceAttrPair(datasourceName, "key_usage", resourceName, "key_usage"),
+					resource.TestCheckResourceAttrSet(datasourceName, "aws_account_id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "creation_date"),
+					resource.TestCheckResourceAttrSet(datasourceName, "key_manager"),
+					resource.TestCheckResourceAttrSet(datasourceName, "key_state"),
+					resource.TestCheckResourceAttrSet(datasourceName, "origin"),
 				),
 			},
 		},
@@ -35,41 +40,23 @@ func TestAccDataSourceAwsKmsKey_basic(t *testing.T) {
 
 func testAccDataSourceAwsKmsKeyCheck(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		_, ok := s.RootModule().Resources[name]
 		if !ok {
 			return fmt.Errorf("root module has no resource called %s", name)
-		}
-
-		kmsKeyRs, ok := s.RootModule().Resources["aws_kms_key.arbitrary"]
-		if !ok {
-			return fmt.Errorf("can't find aws_kms_key.arbitrary in state")
-		}
-
-		attr := rs.Primary.Attributes
-
-		checkProperties := []string{"arn", "key_usage", "description"}
-
-		for _, p := range checkProperties {
-			if attr[p] != kmsKeyRs.Primary.Attributes[p] {
-				return fmt.Errorf(
-					"%s is %s; want %s",
-					p,
-					attr[p],
-					kmsKeyRs.Primary.Attributes[p],
-				)
-			}
 		}
 
 		return nil
 	}
 }
 
-const testAccDataSourceAwsKmsKeyConfig = `
-resource "aws_kms_key" "arbitrary" {
-    description = "Terraform acc test"
-    deletion_window_in_days = 7
+func testAccDataSourceAwsKmsKeyConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  description             = %[1]q
+  deletion_window_in_days = 7
 }
 
-data "aws_kms_key" "arbitrary" {
-  key_id = "${aws_kms_key.arbitrary.key_id}"
-}`
+data "aws_kms_key" "test" {
+  key_id = "${aws_kms_key.test.key_id}"
+}`, rName)
+}

--- a/aws/resource_aws_kms_key.go
+++ b/aws/resource_aws_kms_key.go
@@ -44,11 +44,27 @@ func resourceAwsKmsKey() *schema.Resource {
 			"key_usage": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
+				Default:  kms.KeyUsageTypeEncryptDecrypt,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					"",
 					kms.KeyUsageTypeEncryptDecrypt,
+					kms.KeyUsageTypeSignVerify,
+				}, false),
+			},
+			"customer_master_key_spec": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  kms.CustomerMasterKeySpecSymmetricDefault,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					kms.CustomerMasterKeySpecSymmetricDefault,
+					kms.CustomerMasterKeySpecRsa2048,
+					kms.CustomerMasterKeySpecRsa3072,
+					kms.CustomerMasterKeySpecRsa4096,
+					kms.CustomerMasterKeySpecEccNistP256,
+					kms.CustomerMasterKeySpecEccNistP384,
+					kms.CustomerMasterKeySpecEccNistP521,
+					kms.CustomerMasterKeySpecEccSecgP256k1,
 				}, false),
 			},
 			"policy": {
@@ -82,12 +98,12 @@ func resourceAwsKmsKeyCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).kmsconn
 
 	// Allow aws to chose default values if we don't pass them
-	var req kms.CreateKeyInput
+	req := &kms.CreateKeyInput{
+		CustomerMasterKeySpec: aws.String(d.Get("customer_master_key_spec").(string)),
+		KeyUsage:              aws.String(d.Get("key_usage").(string)),
+	}
 	if v, exists := d.GetOk("description"); exists {
 		req.Description = aws.String(v.(string))
-	}
-	if v, exists := d.GetOk("key_usage"); exists {
-		req.KeyUsage = aws.String(v.(string))
 	}
 	if v, exists := d.GetOk("policy"); exists {
 		req.Policy = aws.String(v.(string))
@@ -103,20 +119,20 @@ func resourceAwsKmsKeyCreate(d *schema.ResourceData, meta interface{}) error {
 	// http://docs.aws.amazon.com/kms/latest/APIReference/API_CreateKey.html
 	err := resource.Retry(30*time.Second, func() *resource.RetryError {
 		var err error
-		resp, err = conn.CreateKey(&req)
-		if isAWSErr(err, "MalformedPolicyDocumentException", "") {
+		resp, err = conn.CreateKey(req)
+		if isAWSErr(err, kms.ErrCodeMalformedPolicyDocumentException, "") {
 			return resource.RetryableError(err)
 		}
 		return resource.NonRetryableError(err)
 	})
 	if isResourceTimeoutError(err) {
-		resp, err = conn.CreateKey(&req)
+		resp, err = conn.CreateKey(req)
 	}
 	if err != nil {
 		return err
 	}
 
-	d.SetId(*resp.KeyMetadata.KeyId)
+	d.SetId(aws.StringValue(resp.KeyMetadata.KeyId))
 	d.Set("key_id", resp.KeyMetadata.KeyId)
 
 	return resourceAwsKmsKeyUpdate(d, meta)
@@ -133,7 +149,7 @@ func resourceAwsKmsKeyRead(d *schema.ResourceData, meta interface{}) error {
 	var err error
 	if d.IsNewResource() {
 		var out interface{}
-		out, err = retryOnAwsCode("NotFoundException", func() (interface{}, error) {
+		out, err = retryOnAwsCode(kms.ErrCodeNotFoundException, func() (interface{}, error) {
 			return conn.DescribeKey(req)
 		})
 		resp, _ = out.(*kms.DescribeKeyOutput)
@@ -145,23 +161,22 @@ func resourceAwsKmsKeyRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	metadata := resp.KeyMetadata
 
-	if *metadata.KeyState == "PendingDeletion" {
+	if aws.StringValue(metadata.KeyState) == kms.KeyStatePendingDeletion {
 		log.Printf("[WARN] Removing KMS key %s because it's already gone", d.Id())
 		d.SetId("")
 		return nil
 	}
 
-	d.SetId(*metadata.KeyId)
-
 	d.Set("arn", metadata.Arn)
 	d.Set("key_id", metadata.KeyId)
 	d.Set("description", metadata.Description)
 	d.Set("key_usage", metadata.KeyUsage)
+	d.Set("customer_master_key_spec", metadata.CustomerMasterKeySpec)
 	d.Set("is_enabled", metadata.Enabled)
 
-	pOut, err := retryOnAwsCode("NotFoundException", func() (interface{}, error) {
+	pOut, err := retryOnAwsCode(kms.ErrCodeNotFoundException, func() (interface{}, error) {
 		return conn.GetKeyPolicy(&kms.GetKeyPolicyInput{
-			KeyId:      metadata.KeyId,
+			KeyId:      aws.String(d.Id()),
 			PolicyName: aws.String("default"),
 		})
 	})
@@ -176,9 +191,9 @@ func resourceAwsKmsKeyRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.Set("policy", policy)
 
-	out, err := retryOnAwsCode("NotFoundException", func() (interface{}, error) {
+	out, err := retryOnAwsCode(kms.ErrCodeNotFoundException, func() (interface{}, error) {
 		return conn.GetKeyRotationStatus(&kms.GetKeyRotationStatusInput{
-			KeyId: metadata.KeyId,
+			KeyId: aws.String(d.Id()),
 		})
 	})
 	if err != nil {
@@ -459,8 +474,8 @@ func resourceAwsKmsKeyDelete(d *schema.ResourceData, meta interface{}) error {
 
 	// Wait for propagation since KMS is eventually consistent
 	wait := resource.StateChangeConf{
-		Pending:                   []string{"Enabled", "Disabled"},
-		Target:                    []string{"PendingDeletion"},
+		Pending:                   []string{kms.KeyStateEnabled, kms.KeyStateDisabled},
+		Target:                    []string{kms.KeyStatePendingDeletion},
 		Timeout:                   20 * time.Minute,
 		MinTimeout:                2 * time.Second,
 		ContinuousTargetOccurence: 10,

--- a/aws/resource_aws_kms_key_test.go
+++ b/aws/resource_aws_kms_key_test.go
@@ -68,40 +68,8 @@ func testSweepKmsKeys(region string) error {
 }
 
 func TestAccAWSKmsKey_basic(t *testing.T) {
-	var keyBefore, keyAfter kms.KeyMetadata
-	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	resourceName := "aws_kms_key.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSKmsKeyDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSKmsKey(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsKeyExists(resourceName, &keyBefore),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"deletion_window_in_days"},
-			},
-			{
-				Config: testAccAWSKmsKey_removedPolicy(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsKeyExists(resourceName, &keyAfter),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSKmsKey_disappears(t *testing.T) {
 	var key kms.KeyMetadata
-	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	rName := fmt.Sprintf("tf-testacc-kms-key-%s", acctest.RandStringFromCharSet(13, acctest.CharSetAlphaNum))
 	resourceName := "aws_kms_key.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -113,11 +81,58 @@ func TestAccAWSKmsKey_disappears(t *testing.T) {
 				Config: testAccAWSKmsKey(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSKmsKeyExists(resourceName, &key),
+					resource.TestCheckResourceAttr(resourceName, "customer_master_key_spec", "SYMMETRIC_DEFAULT"),
+					resource.TestCheckResourceAttr(resourceName, "key_usage", "ENCRYPT_DECRYPT"),
 				),
 			},
 			{
-				Config:             testAccAWSKmsKey_other_region(rName),
-				PlanOnly:           true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_window_in_days"},
+			},
+		},
+	})
+}
+
+func TestAccAWSKmsKey_asymmetricKey(t *testing.T) {
+	var key kms.KeyMetadata
+	rName := fmt.Sprintf("tf-testacc-kms-key-%s", acctest.RandStringFromCharSet(13, acctest.CharSetAlphaNum))
+	resourceName := "aws_kms_key.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSKmsKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSKmsKey_asymmetric(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSKmsKeyExists(resourceName, &key),
+					resource.TestCheckResourceAttr(resourceName, "customer_master_key_spec", "ECC_NIST_P384"),
+					resource.TestCheckResourceAttr(resourceName, "key_usage", "SIGN_VERIFY"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSKmsKey_disappears(t *testing.T) {
+	var key kms.KeyMetadata
+	rName := fmt.Sprintf("tf-testacc-kms-key-%s", acctest.RandStringFromCharSet(13, acctest.CharSetAlphaNum))
+	resourceName := "aws_kms_key.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSKmsKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSKmsKey(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSKmsKeyExists(resourceName, &key),
+					testAccCheckAWSKmsKeyDisappears(&key),
+				),
 				ExpectNonEmptyPlan: true,
 			},
 		},
@@ -126,7 +141,7 @@ func TestAccAWSKmsKey_disappears(t *testing.T) {
 
 func TestAccAWSKmsKey_policy(t *testing.T) {
 	var key kms.KeyMetadata
-	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	rName := fmt.Sprintf("tf-testacc-kms-key-%s", acctest.RandStringFromCharSet(13, acctest.CharSetAlphaNum))
 	resourceName := "aws_kms_key.test"
 	expectedPolicyText := `{"Version":"2012-10-17","Id":"kms-tf-1","Statement":[{"Sid":"Enable IAM User Permissions","Effect":"Allow","Principal":{"AWS":"*"},"Action":"kms:*","Resource":"*"}]}`
 
@@ -136,7 +151,7 @@ func TestAccAWSKmsKey_policy(t *testing.T) {
 		CheckDestroy: testAccCheckAWSKmsKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSKmsKey(rName),
+				Config: testAccAWSKmsKey_policy(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSKmsKeyExists(resourceName, &key),
 					testAccCheckAWSKmsKeyHasPolicy(resourceName, expectedPolicyText),
@@ -148,13 +163,19 @@ func TestAccAWSKmsKey_policy(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"deletion_window_in_days"},
 			},
+			{
+				Config: testAccAWSKmsKey_removedPolicy(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSKmsKeyExists(resourceName, &key),
+				),
+			},
 		},
 	})
 }
 
 func TestAccAWSKmsKey_isEnabled(t *testing.T) {
 	var key1, key2, key3 kms.KeyMetadata
-	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	rName := fmt.Sprintf("tf-testacc-kms-key-%s", acctest.RandStringFromCharSet(13, acctest.CharSetAlphaNum))
 	resourceName := "aws_kms_key.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -165,8 +186,8 @@ func TestAccAWSKmsKey_isEnabled(t *testing.T) {
 			{
 				Config: testAccAWSKmsKey_enabledRotation(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsKeyExists("aws_kms_key.test", &key1),
-					resource.TestCheckResourceAttr("aws_kms_key.test", "is_enabled", "true"),
+					testAccCheckAWSKmsKeyExists(resourceName, &key1),
+					resource.TestCheckResourceAttr(resourceName, "is_enabled", "true"),
 					testAccCheckAWSKmsKeyIsEnabled(&key1, true),
 					resource.TestCheckResourceAttr("aws_kms_key.test", "enable_key_rotation", "true"),
 				),
@@ -180,19 +201,19 @@ func TestAccAWSKmsKey_isEnabled(t *testing.T) {
 			{
 				Config: testAccAWSKmsKey_disabled(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsKeyExists("aws_kms_key.test", &key2),
-					resource.TestCheckResourceAttr("aws_kms_key.test", "is_enabled", "false"),
+					testAccCheckAWSKmsKeyExists(resourceName, &key2),
+					resource.TestCheckResourceAttr(resourceName, "is_enabled", "false"),
 					testAccCheckAWSKmsKeyIsEnabled(&key2, false),
-					resource.TestCheckResourceAttr("aws_kms_key.test", "enable_key_rotation", "false"),
+					resource.TestCheckResourceAttr(resourceName, "enable_key_rotation", "false"),
 				),
 			},
 			{
 				Config: testAccAWSKmsKey_enabled(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsKeyExists("aws_kms_key.test", &key3),
-					resource.TestCheckResourceAttr("aws_kms_key.test", "is_enabled", "true"),
+					testAccCheckAWSKmsKeyExists(resourceName, &key3),
+					resource.TestCheckResourceAttr(resourceName, "is_enabled", "true"),
 					testAccCheckAWSKmsKeyIsEnabled(&key3, true),
-					resource.TestCheckResourceAttr("aws_kms_key.test", "enable_key_rotation", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enable_key_rotation", "true"),
 				),
 			},
 		},
@@ -200,8 +221,8 @@ func TestAccAWSKmsKey_isEnabled(t *testing.T) {
 }
 
 func TestAccAWSKmsKey_tags(t *testing.T) {
-	var keyBefore kms.KeyMetadata
-	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	var key kms.KeyMetadata
+	rName := fmt.Sprintf("tf-testacc-kms-key-%s", acctest.RandStringFromCharSet(13, acctest.CharSetAlphaNum))
 	resourceName := "aws_kms_key.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -212,7 +233,7 @@ func TestAccAWSKmsKey_tags(t *testing.T) {
 			{
 				Config: testAccAWSKmsKey_tags(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsKeyExists(resourceName, &keyBefore),
+					testAccCheckAWSKmsKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
 				),
 			},
@@ -221,6 +242,13 @@ func TestAccAWSKmsKey_tags(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"deletion_window_in_days"},
+			},
+			{
+				Config: testAccAWSKmsKey(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSKmsKeyExists(resourceName, &key),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
 			},
 		},
 	})
@@ -328,45 +356,44 @@ func testAccCheckAWSKmsKeyIsEnabled(key *kms.KeyMetadata, isEnabled bool) resour
 	}
 }
 
+func testAccCheckAWSKmsKeyDisappears(key *kms.KeyMetadata) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).kmsconn
+
+		_, err := conn.ScheduleKeyDeletion(&kms.ScheduleKeyDeletionInput{
+			KeyId:               key.KeyId,
+			PendingWindowInDays: aws.Int64(int64(7)),
+		})
+
+		return err
+	}
+}
+
 func testAccAWSKmsKey(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description             = "Terraform acc test %s"
+  description             = %[1]q
   deletion_window_in_days = 7
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Id": "kms-tf-1",
-  "Statement": [
-    {
-      "Sid": "Enable IAM User Permissions",
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "*"
-      },
-      "Action": "kms:*",
-      "Resource": "*"
-    }
-  ]
 }
-POLICY
-
-  tags = {
-    Name = "tf-acc-test-kms-key-%s"
-  }
-}
-`, rName, rName)
+`, rName)
 }
 
-func testAccAWSKmsKey_other_region(rName string) string {
+func testAccAWSKmsKey_asymmetric(rName string) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
+resource "aws_kms_key" "test" {
+  description             = %[1]q
+  deletion_window_in_days = 7
+
+  key_usage                = "SIGN_VERIFY"
+  customer_master_key_spec = "ECC_NIST_P384"
+}
+`, rName)
 }
 
+func testAccAWSKmsKey_policy(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description             = "Terraform acc test %s"
+  description             = %[1]q
   deletion_window_in_days = 7
 
   policy = <<POLICY
@@ -386,81 +413,77 @@ resource "aws_kms_key" "test" {
   ]
 }
 POLICY
-
-  tags = {
-    Name = "tf-acc-test-kms-key-%s"
-  }
 }
-`, rName, rName)
+`, rName)
 }
 
 func testAccAWSKmsKey_removedPolicy(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description             = "Terraform acc test %s"
+  description             = %[1]q
   deletion_window_in_days = 7
 
   tags = {
-    Name = "tf-acc-test-kms-key-%s"
+    Name = %[1]q
   }
 }
-`, rName, rName)
+`, rName)
 }
 
 func testAccAWSKmsKey_enabledRotation(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description             = "Terraform acc test is_enabled %s"
+  description             = %[1]q
   deletion_window_in_days = 7
   enable_key_rotation     = true
 
   tags = {
-    Name = "tf-acc-test-kms-key-%s"
+    Name = %[1]q
   }
 }
-`, rName, rName)
+`, rName)
 }
 
 func testAccAWSKmsKey_disabled(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description             = "Terraform acc test is_enabled %s"
+  description             = %[1]q
   deletion_window_in_days = 7
   enable_key_rotation     = false
   is_enabled              = false
 
   tags = {
-    Name = "tf-acc-test-kms-key-%s"
+    Name = %[1]q
   }
 }
-`, rName, rName)
+`, rName)
 }
 
 func testAccAWSKmsKey_enabled(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description             = "Terraform acc test is_enabled %s"
+  description             = %[1]q
   deletion_window_in_days = 7
   enable_key_rotation     = true
   is_enabled              = true
 
   tags = {
-    Name = "tf-acc-test-kms-key-%s"
+    Name = %[1]q
   }
 }
-`, rName, rName)
+`, rName)
 }
 
 func testAccAWSKmsKey_tags(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = "Terraform acc test %s"
+  description = %[1]q
 
   tags = {
-    Name        = "tf-acc-test-kms-key-%s"
+    Name        = %[1]q
     Key1        = "Value One"
     Description = "Very interesting"
   }
 }
-`, rName, rName)
+`, rName)
 }

--- a/website/docs/d/kms_key.html.markdown
+++ b/website/docs/d/kms_key.html.markdown
@@ -8,9 +8,9 @@ description: |-
 
 # aws_kms_key
 
-Use this data source to get detailed information about 
-the specified KMS Key with flexible key id input. 
-This can be useful to reference key alias 
+Use this data source to get detailed information about
+the specified KMS Key with flexible key id input.
+This can be useful to reference key alias
 without having to hard code the ARN as input.
 
 ## Example Usage
@@ -54,6 +54,7 @@ data "aws_kms_key" "foo" {
 * `expiration_model`: Specifies whether the Key's key material expires. This value is present only when `origin` is `EXTERNAL`, otherwise this value is empty
 * `key_manager`: The key's manager
 * `key_state`: The state of the key
-* `key_usage`: Currently the only allowed value is `ENCRYPT_DECRYPT`
+* `key_usage`: Specifies the intended use of the key
+* `customer_master_key_spec`: Specifies whether the key contains a symmetric key or an asymmetric key pair and the encryption algorithms or signing algorithms that the key supports
 * `origin`: When this value is `AWS_KMS`, AWS KMS created the key material. When this value is `EXTERNAL`, the key material was imported from your existing key management infrastructure or the CMK lacks key material
 * `valid_to`: The time at which the imported key material expires. This value is present only when `origin` is `EXTERNAL` and whose `expiration_model` is `KEY_MATERIAL_EXPIRES`, otherwise this value is 0

--- a/website/docs/r/kms_key.html.markdown
+++ b/website/docs/r/kms_key.html.markdown
@@ -24,8 +24,10 @@ resource "aws_kms_key" "a" {
 The following arguments are supported:
 
 * `description` - (Optional) The description of the key as viewed in AWS console.
-* `key_usage` - (Optional) Specifies the intended use of the key.
-	Defaults to ENCRYPT_DECRYPT, and only symmetric encryption and decryption are supported.
+* `key_usage` - (Optional) Specifies the intended use of the key. Valid values: `ENCRYPT_DECRYPT` or `SIGN_VERIFY`.
+Defaults to `ENCRYPT_DECRYPT`.
+* `customer_master_key_spec` - (Optional) Specifies whether the key contains a symmetric key or an asymmetric key pair and the encryption algorithms or signing algorithms that the key supports.
+Valid values: `SYMMETRIC_DEFAULT`,  `RSA_2048`, `RSA_3072`, `RSA_4096`, `ECC_NIST_P256`, `ECC_NIST_P384`, `ECC_NIST_P521`, or `ECC_SECG_P256K1`. Defaults to `SYMMETRIC_DEFAULT`. For help with choosing a key spec, see the [AWS KMS Developer Guide](https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-choose.html).
 * `policy` - (Optional) A valid policy JSON document. For more information about building AWS IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://learn.hashicorp.com/terraform/aws/iam-policy).
 * `deletion_window_in_days` - (Optional) Duration in days after which the key is deleted
 	after destruction of the resource, must be between 7 and 30 days. Defaults to 30 days.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/11042.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data-source/aws_kms_key: Add `customer_master_key_spec` attribute
resource/aws_kms_key: Add support for asymmetric keys with `customer_master_key_spec` attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsKmsKey_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsKmsKey_ -timeout 120m
=== RUN   TestAccDataSourceAwsKmsKey_basic
=== PAUSE TestAccDataSourceAwsKmsKey_basic
=== CONT  TestAccDataSourceAwsKmsKey_basic
--- PASS: TestAccDataSourceAwsKmsKey_basic (51.46s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	51.485s
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSKmsKey_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSKmsKey_ -timeout 120m
=== RUN   TestAccAWSKmsKey_basic
=== PAUSE TestAccAWSKmsKey_basic
=== RUN   TestAccAWSKmsKey_asymmetricKey
=== PAUSE TestAccAWSKmsKey_asymmetricKey
=== RUN   TestAccAWSKmsKey_disappears
=== PAUSE TestAccAWSKmsKey_disappears
=== RUN   TestAccAWSKmsKey_policy
=== PAUSE TestAccAWSKmsKey_policy
=== RUN   TestAccAWSKmsKey_isEnabled
=== PAUSE TestAccAWSKmsKey_isEnabled
=== RUN   TestAccAWSKmsKey_tags
=== PAUSE TestAccAWSKmsKey_tags
=== CONT  TestAccAWSKmsKey_basic
=== CONT  TestAccAWSKmsKey_isEnabled
=== CONT  TestAccAWSKmsKey_tags
=== CONT  TestAccAWSKmsKey_disappears
=== CONT  TestAccAWSKmsKey_policy
=== CONT  TestAccAWSKmsKey_asymmetricKey
--- PASS: TestAccAWSKmsKey_disappears (18.90s)
--- PASS: TestAccAWSKmsKey_asymmetricKey (46.80s)
--- PASS: TestAccAWSKmsKey_basic (51.43s)
--- PASS: TestAccAWSKmsKey_tags (70.11s)
--- PASS: TestAccAWSKmsKey_policy (70.43s)
--- PASS: TestAccAWSKmsKey_isEnabled (395.66s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	395.715s
```
