### PR TITLE
r/egress_only_internet_gateway: Add support for 'terraform import'

### DIFF
--- a/aws/resource_aws_egress_only_internet_gateway_test.go
+++ b/aws/resource_aws_egress_only_internet_gateway_test.go
@@ -63,6 +63,8 @@ func testSweepEc2EgressOnlyInternetGateways(region string) error {
 
 func TestAccAWSEgressOnlyInternetGateway_basic(t *testing.T) {
 	var igw ec2.EgressOnlyInternetGateway
+	resourceName := "aws_egress_only_internet_gateway.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -71,8 +73,13 @@ func TestAccAWSEgressOnlyInternetGateway_basic(t *testing.T) {
 			{
 				Config: testAccAWSEgressOnlyInternetGatewayConfig_basic,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSEgressOnlyInternetGatewayExists("aws_egress_only_internet_gateway.foo", &igw),
+					testAccCheckAWSEgressOnlyInternetGatewayExists(resourceName, &igw),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -132,15 +139,16 @@ func testAccCheckAWSEgressOnlyInternetGatewayExists(n string, igw *ec2.EgressOnl
 }
 
 const testAccAWSEgressOnlyInternetGatewayConfig_basic = `
-resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
-	assign_generated_ipv6_cidr_block = true
-	tags = {
-		Name = "terraform-testacc-egress-only-igw-basic"
-	}
+resource "aws_vpc" "test" {
+  cidr_block                       = "10.1.0.0/16"
+  assign_generated_ipv6_cidr_block = true
+
+  tags = {
+    Name = "terraform-testacc-egress-only-igw-basic"
+  }
 }
 
-resource "aws_egress_only_internet_gateway" "foo" {
-  	vpc_id = "${aws_vpc.foo.id}"
+resource "aws_egress_only_internet_gateway" "test" {
+  vpc_id = "${aws_vpc.test.id}"
 }
 `

--- a/website/docs/r/egress_only_internet_gateway.html.markdown
+++ b/website/docs/r/egress_only_internet_gateway.html.markdown
@@ -3,7 +3,7 @@ subcategory: "VPC"
 layout: "aws"
 page_title: "AWS: aws_egress_only_internet_gateway"
 description: |-
-  Provides a resource to create a VPC Egress Only Internet Gateway.
+  Provides a resource to create an egress-only Internet gateway.
 ---
 
 # Resource: aws_egress_only_internet_gateway
@@ -16,13 +16,13 @@ outside of your VPC from initiating an IPv6 connection with your instance.
 ## Example Usage
 
 ```hcl
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "example" {
   cidr_block                       = "10.1.0.0/16"
   assign_generated_ipv6_cidr_block = true
 }
 
-resource "aws_egress_only_internet_gateway" "foo" {
-  vpc_id = "${aws_vpc.foo.id}"
+resource "aws_egress_only_internet_gateway" "example" {
+  vpc_id = "${aws_vpc.example.id}"
 }
 ```
 
@@ -36,4 +36,12 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The ID of the Egress Only Internet Gateway.
+* `id` - The ID of the egress-only Internet gateway.
+
+## Import
+
+Egress-only Internet gateways can be imported using the `id`, e.g.
+
+```
+$ terraform import aws_egress_only_internet_gateway.example eigw-015e0e244e24dfe8a
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/1319.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/egress_only_internet_gateway:  Support resource import
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEgressOnlyInternetGateway_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEgressOnlyInternetGateway_basic -timeout 120m
=== RUN   TestAccAWSEgressOnlyInternetGateway_basic
=== PAUSE TestAccAWSEgressOnlyInternetGateway_basic
=== CONT  TestAccAWSEgressOnlyInternetGateway_basic
--- PASS: TestAccAWSEgressOnlyInternetGateway_basic (36.58s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	36.614s
```
