### PR TITLE
Check for `nil` UserName for Virtual MFA devices

### DIFF
--- a/aws/resource_aws_iam_user.go
+++ b/aws/resource_aws_iam_user.go
@@ -339,7 +339,8 @@ func deleteAwsIamUserVirtualMFADevices(svc *iam.IAM, username string) error {
 	}
 	pageOfVirtualMFADevices := func(page *iam.ListVirtualMFADevicesOutput, lastPage bool) (shouldContinue bool) {
 		for _, m := range page.VirtualMFADevices {
-			if *m.User.UserName == username {
+			// UserName is `nil` for the root user
+			if m.User.UserName != nil && *m.User.UserName == username {
 				VirtualMFADevices = append(VirtualMFADevices, *m.SerialNumber)
 			}
 		}


### PR DESCRIPTION
Checking for Virtual MFA Devices in an account where the root user has an MFA device causes a crash. This is because the root user has no "friendly" user name in the record returned by the AWS API.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Relates #11040

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
NONE
```
No CHANGELOG entry because this is an unreleased bug, introduced in #11040

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAcc\(AWSUser_ForceDestroy_\|AWSIAMPolicyAttachment_Users_RenamedUser\|AWSUserLoginProfile_\|AWSUserGroupMembership_basic\)'

--- PASS: TestAccAWSUserLoginProfile_keybaseDoesntExist (21.78s)
--- PASS: TestAccAWSUser_ForceDestroy_AccessKey (24.89s)
--- PASS: TestAccAWSUser_ForceDestroy_LoginProfile (26.31s)
--- PASS: TestAccAWSUser_ForceDestroy_MFADevice (26.52s)
--- PASS: TestAccAWSUser_ForceDestroy_SSHKey (27.08s)
--- PASS: TestAccAWSUserLoginProfile_PasswordLength (27.38s)
--- PASS: TestAccAWSUserLoginProfile_notAKey (28.31s)
--- PASS: TestAccAWSUserLoginProfile_keybase (30.40s)
--- PASS: TestAccAWSUserLoginProfile_basic (37.46s)
--- PASS: TestAccAWSIAMPolicyAttachment_Users_RenamedUser (50.23s)
--- PASS: TestAccAWSUserGroupMembership_basic (108.67s)
```
