### PR TITLE
RDS Cluster Endpoint tagging support

### DIFF
--- a/aws/resource_aws_rds_cluster_endpoint.go
+++ b/aws/resource_aws_rds_cluster_endpoint.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 const (
@@ -70,6 +71,7 @@ func resourceAwsRDSClusterEndpoint() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -85,6 +87,7 @@ func resourceAwsRDSClusterEndpointCreate(d *schema.ResourceData, meta interface{
 		DBClusterIdentifier:         aws.String(clusterId),
 		DBClusterEndpointIdentifier: aws.String(endpointId),
 		EndpointType:                aws.String(endpointType),
+		Tags:                        keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().RdsTags(),
 	}
 
 	if v := d.Get("static_members"); v != nil {
@@ -140,9 +143,10 @@ func resourceAwsRDSClusterEndpointRead(d *schema.ResourceData, meta interface{})
 		return nil
 	}
 
+	arn := clusterEp.DBClusterEndpointArn
 	d.Set("cluster_endpoint_identifier", clusterEp.DBClusterEndpointIdentifier)
 	d.Set("cluster_identifier", clusterEp.DBClusterIdentifier)
-	d.Set("arn", clusterEp.DBClusterEndpointArn)
+	d.Set("arn", arn)
 	d.Set("endpoint", clusterEp.Endpoint)
 	d.Set("custom_endpoint_type", clusterEp.CustomEndpointType)
 
@@ -154,6 +158,16 @@ func resourceAwsRDSClusterEndpointRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("error setting static_members: %s", err)
 	}
 
+	tags, err := keyvaluetags.RdsListTags(conn, *arn)
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for RDS Cluster Endpoint (%s): %s", *arn, err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
 	return nil
 }
 
@@ -161,6 +175,14 @@ func resourceAwsRDSClusterEndpointUpdate(d *schema.ResourceData, meta interface{
 	conn := meta.(*AWSClient).rdsconn
 	input := &rds.ModifyDBClusterEndpointInput{
 		DBClusterEndpointIdentifier: aws.String(d.Id()),
+	}
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.RdsUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating RDS Cluster Endpoint (%s) tags: %s", d.Get("arn").(string), err)
+		}
 	}
 
 	if v, ok := d.GetOk("custom_endpoint_type"); ok {

--- a/aws/resource_aws_rds_cluster_endpoint_test.go
+++ b/aws/resource_aws_rds_cluster_endpoint_test.go
@@ -38,6 +38,8 @@ func TestAccAWSRDSClusterEndpoint_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(readerResourceName, "endpoint"),
 					testAccMatchResourceAttrRegionalARN(defaultResourceName, "arn", "rds", regexp.MustCompile(`cluster-endpoint:.+`)),
 					resource.TestCheckResourceAttrSet(defaultResourceName, "endpoint"),
+					resource.TestCheckResourceAttr(defaultResourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(readerResourceName, "tags.%", "0"),
 				),
 			},
 			{
@@ -50,6 +52,50 @@ func TestAccAWSRDSClusterEndpoint_basic(t *testing.T) {
 				ResourceName:      "aws_rds_cluster_endpoint.default",
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSRDSClusterEndpoint_tags(t *testing.T) {
+	rInt := acctest.RandInt()
+	var customReaderEndpoint rds.DBClusterEndpoint
+	resourceName := "aws_rds_cluster_endpoint.reader"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSClusterEndpointConfigTags1(rInt, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRDSClusterEndpointExists(resourceName, &customReaderEndpoint),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSClusterEndpointConfigTags2(rInt, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRDSClusterEndpointExists(resourceName, &customReaderEndpoint),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSClusterEndpointConfigTags1(rInt, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRDSClusterEndpointExists(resourceName, &customReaderEndpoint),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
 			},
 		},
 	})
@@ -160,10 +206,10 @@ func testAccCheckAWSRDSClusterEndpointExistsWithProvider(resourceName string, en
 	}
 }
 
-func testAccAWSClusterEndpointConfig(n int) string {
+func testAccAWSClusterEndpointConfigBase(n int) string {
 	return fmt.Sprintf(`
 resource "aws_rds_cluster" "default" {
-  cluster_identifier              = "tf-aurora-cluster-%d"
+  cluster_identifier              = "tf-aurora-cluster-%[1]d"
   availability_zones              = ["us-west-2a", "us-west-2b", "us-west-2c"]
   database_name                   = "mydb"
   master_username                 = "foo"
@@ -175,20 +221,24 @@ resource "aws_rds_cluster" "default" {
 resource "aws_rds_cluster_instance" "test1" {
   apply_immediately  = true
   cluster_identifier = "${aws_rds_cluster.default.id}"
-  identifier         = "tf-aurora-cluster-instance-test1-%d"
+  identifier         = "tf-aurora-cluster-instance-test1-%[1]d"
   instance_class     = "db.t2.small"
 }
 
 resource "aws_rds_cluster_instance" "test2" {
   apply_immediately  = true
   cluster_identifier = "${aws_rds_cluster.default.id}"
-  identifier         = "tf-aurora-cluster-instance-test2-%d"
+  identifier         = "tf-aurora-cluster-instance-test2-%[1]d"
   instance_class     = "db.t2.small"
 }
+`, n)
+}
 
+func testAccAWSClusterEndpointConfig(n int) string {
+	return testAccAWSClusterEndpointConfigBase(n) + fmt.Sprintf(`
 resource "aws_rds_cluster_endpoint" "reader" {
   cluster_identifier          = "${aws_rds_cluster.default.id}"
-  cluster_endpoint_identifier = "reader-%d"
+  cluster_endpoint_identifier = "reader-%[1]d"
   custom_endpoint_type        = "READER"
 
   static_members = ["${aws_rds_cluster_instance.test2.id}"]
@@ -196,10 +246,43 @@ resource "aws_rds_cluster_endpoint" "reader" {
 
 resource "aws_rds_cluster_endpoint" "default" {
   cluster_identifier          = "${aws_rds_cluster.default.id}"
-  cluster_endpoint_identifier = "default-%d"
+  cluster_endpoint_identifier = "default-%[1]d"
   custom_endpoint_type        = "ANY"
 
   excluded_members = ["${aws_rds_cluster_instance.test2.id}"]
 }
-`, n, n, n, n, n)
+`, n)
+}
+
+func testAccAWSClusterEndpointConfigTags1(n int, tagKey1, tagValue1 string) string {
+	return testAccAWSClusterEndpointConfigBase(n) + fmt.Sprintf(`
+resource "aws_rds_cluster_endpoint" "reader" {
+  cluster_identifier          = "${aws_rds_cluster.default.id}"
+  cluster_endpoint_identifier = "reader-%[1]d"
+  custom_endpoint_type        = "READER"
+
+  static_members = ["${aws_rds_cluster_instance.test2.id}"]
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, n, tagKey1, tagValue1)
+}
+
+func testAccAWSClusterEndpointConfigTags2(n int, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return testAccAWSClusterEndpointConfigBase(n) + fmt.Sprintf(`
+resource "aws_rds_cluster_endpoint" "reader" {
+  cluster_identifier          = "${aws_rds_cluster.default.id}"
+  cluster_endpoint_identifier = "reader-%[1]d"
+  custom_endpoint_type        = "READER"
+
+  static_members = ["${aws_rds_cluster_instance.test2.id}"]
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, n, tagKey1, tagValue1, tagKey2, tagValue2)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11043

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/rds_cluster_endpoint: Add `tags` argument.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSRDSClusterEndpoint_'
=== RUN   TestAccAWSRDSClusterEndpoint_basic
=== PAUSE TestAccAWSRDSClusterEndpoint_basic
=== CONT  TestAccAWSRDSClusterEndpoint_basic
--- PASS: TestAccAWSRDSClusterEndpoint_basic (1638.48s)
=== RUN   TestAccAWSRDSClusterEndpoint_tags
=== PAUSE TestAccAWSRDSClusterEndpoint_tags
=== CONT  TestAccAWSRDSClusterEndpoint_tags
--- PASS: TestAccAWSRDSClusterEndpoint_tags (2120.47s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2148.207s

...
```
