### PR TITLE
Closes #10921

### DIFF
--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsEMRCluster() *schema.Resource {
@@ -84,6 +85,10 @@ func resourceAwsEMRCluster() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				ForceNew: true,
@@ -802,6 +807,7 @@ func resourceAwsEMRClusterCreate(d *schema.ResourceData, meta interface{}) error
 		ReleaseLabel:      aws.String(d.Get("release_label").(string)),
 		ServiceRole:       aws.String(d.Get("service_role").(string)),
 		VisibleToAllUsers: aws.Bool(d.Get("visible_to_all_users").(bool)),
+		Tags:              keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().EmrTags(),
 	}
 
 	if v, ok := d.GetOk("additional_info"); ok {
@@ -847,10 +853,6 @@ func resourceAwsEMRClusterCreate(d *schema.ResourceData, meta interface{}) error
 	if v, ok := d.GetOk("step"); ok {
 		steps := v.([]interface{})
 		params.Steps = expandEmrStepConfigs(steps)
-	}
-	if v, ok := d.GetOk("tags"); ok {
-		tagsIn := v.(map[string]interface{})
-		params.Tags = expandTags(tagsIn)
 	}
 	if v, ok := d.GetOk("configurations"); ok {
 		confUrl := v.(string)
@@ -974,6 +976,8 @@ func resourceAwsEMRClusterRead(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		d.Set("cluster_state", state)
+
+		d.Set("arn", aws.StringValue(cluster.ClusterArn))
 	}
 
 	instanceGroups, err := fetchAllEMRInstanceGroups(emrconn, d.Id())
@@ -1020,6 +1024,10 @@ func resourceAwsEMRClusterRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error setting master_instance_group: %s", err)
 	}
 
+	if err := d.Set("tags", keyvaluetags.EmrKeyValueTags(cluster.Tags).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error settings tags: %s", err)
+	}
+
 	d.Set("name", cluster.Name)
 
 	d.Set("service_role", cluster.ServiceRole)
@@ -1029,7 +1037,6 @@ func resourceAwsEMRClusterRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("log_uri", cluster.LogUri)
 	d.Set("master_public_dns", cluster.MasterPublicDnsName)
 	d.Set("visible_to_all_users", cluster.VisibleToAllUsers)
-	d.Set("tags", tagsToMapEMR(cluster.Tags))
 	d.Set("ebs_root_volume_size", cluster.EbsRootVolumeSize)
 	d.Set("scale_down_behavior", cluster.ScaleDownBehavior)
 	d.Set("termination_protection", cluster.TerminationProtected)
@@ -1324,10 +1331,12 @@ func resourceAwsEMRClusterUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	if err := setTagsEMR(conn, d); err != nil {
-		return err
-	} else {
-		d.SetPartial("tags")
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.EmrUpdateTags(conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("error updating EMR Cluster (%s) tags: %s", d.Id(), err)
+		}
 	}
 
 	d.Partial(false)
@@ -1736,85 +1745,6 @@ func emrCoreInstanceGroup(grps []*emr.InstanceGroup) *emr.InstanceGroup {
 			return grp
 		}
 	}
-	return nil
-}
-
-func expandTags(m map[string]interface{}) []*emr.Tag {
-	var result []*emr.Tag
-	for k, v := range m {
-		result = append(result, &emr.Tag{
-			Key:   aws.String(k),
-			Value: aws.String(v.(string)),
-		})
-	}
-
-	return result
-}
-
-func tagsToMapEMR(ts []*emr.Tag) map[string]string {
-	result := make(map[string]string)
-	for _, t := range ts {
-		result[*t.Key] = *t.Value
-	}
-
-	return result
-}
-
-func diffTagsEMR(oldTags, newTags []*emr.Tag) ([]*emr.Tag, []*emr.Tag) {
-	// First, we're creating everything we have
-	create := make(map[string]interface{})
-	for _, t := range newTags {
-		create[*t.Key] = *t.Value
-	}
-
-	// Build the list of what to remove
-	var remove []*emr.Tag
-	for _, t := range oldTags {
-		old, ok := create[*t.Key]
-		if !ok || old != *t.Value {
-			// Delete it!
-			remove = append(remove, t)
-		}
-	}
-
-	return expandTags(create), remove
-}
-
-func setTagsEMR(conn *emr.EMR, d *schema.ResourceData) error {
-	if d.HasChange("tags") {
-		oraw, nraw := d.GetChange("tags")
-		o := oraw.(map[string]interface{})
-		n := nraw.(map[string]interface{})
-		create, remove := diffTagsEMR(expandTags(o), expandTags(n))
-
-		// Set tags
-		if len(remove) > 0 {
-			log.Printf("[DEBUG] Removing tags: %s", remove)
-			k := make([]*string, len(remove))
-			for i, t := range remove {
-				k[i] = t.Key
-			}
-
-			_, err := conn.RemoveTags(&emr.RemoveTagsInput{
-				ResourceId: aws.String(d.Id()),
-				TagKeys:    k,
-			})
-			if err != nil {
-				return err
-			}
-		}
-		if len(create) > 0 {
-			log.Printf("[DEBUG] Creating tags: %s", create)
-			_, err := conn.AddTags(&emr.AddTagsInput{
-				ResourceId: aws.String(d.Id()),
-				Tags:       create,
-			})
-			if err != nil {
-				return err
-			}
-		}
-	}
-
 	return nil
 }
 

--- a/aws/resource_aws_emr_cluster_test.go
+++ b/aws/resource_aws_emr_cluster_test.go
@@ -91,6 +91,7 @@ func TestAccAWSEMRCluster_basic(t *testing.T) {
 					testAccCheckAWSEmrClusterExists("aws_emr_cluster.tf-test-cluster", &cluster),
 					resource.TestCheckResourceAttr("aws_emr_cluster.tf-test-cluster", "scale_down_behavior", "TERMINATE_AT_TASK_COMPLETION"),
 					resource.TestCheckResourceAttr("aws_emr_cluster.tf-test-cluster", "step.#", "0"),
+					resource.TestCheckResourceAttrSet("aws_emr_cluster.tf-test-cluster", "arn"),
 				),
 			},
 			{

--- a/website/docs/r/emr_cluster.html.markdown
+++ b/website/docs/r/emr_cluster.html.markdown
@@ -383,6 +383,7 @@ Attributes for Hadoop job step configuration
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn`- The ARN of the cluster.
 * `id` - The ID of the EMR Cluster
 * `name` - The name of the cluster.
 * `release_label` - The release label for the Amazon EMR release.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10921
Relates #10688 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_emr_cluster: Makes `arn` of cluster available as resource attribute. [GH-10921]
```

Output from acceptance testing:
_Note:_ I tested in us-east-1 because of a mismatch in us-west-2 AZ's in my account and the available compute instance types. Specifically, when I tried us-west-2, I saw all sorts of these types of errors like:
``` 
Error: Error waiting for EMR Cluster state to be "WAITING" or "RUNNING": TERMINATED_WITH_ERRORS: VALIDATION_ERROR: The requested instance type r4.xlarge is not supported in the requested availability zone. Learn more at https://docs.aws.amazon.com/console/elasticmapreduce/ERROR_noinstancetype
```

I assume :point_up: should not affect this PR's acceptance. Also, I ran the larger suite of `aws_emr_cluster` tests because I also changed the tagging in accordance with #10688 
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
root@b99c1799daa8:/go/src/github.com/terraform-providers/terraform-provider-aws# AWS_DEFAULT_REGION=us-east-1 AWS_PROFILE=default make testacc TEST=./aws TESTARGS='-run=TestAccAWSEMRCluster_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEMRCluster_ -timeout 120m
=== RUN   TestAccAWSEMRCluster_basic
=== PAUSE TestAccAWSEMRCluster_basic
=== RUN   TestAccAWSEMRCluster_additionalInfo
=== PAUSE TestAccAWSEMRCluster_additionalInfo
=== RUN   TestAccAWSEMRCluster_disappears
=== PAUSE TestAccAWSEMRCluster_disappears
=== RUN   TestAccAWSEMRCluster_configurationsJson
=== PAUSE TestAccAWSEMRCluster_configurationsJson
=== RUN   TestAccAWSEMRCluster_CoreInstanceGroup_AutoscalingPolicy
=== PAUSE TestAccAWSEMRCluster_CoreInstanceGroup_AutoscalingPolicy
=== RUN   TestAccAWSEMRCluster_CoreInstanceGroup_BidPrice
=== PAUSE TestAccAWSEMRCluster_CoreInstanceGroup_BidPrice
=== RUN   TestAccAWSEMRCluster_CoreInstanceGroup_InstanceCount
=== PAUSE TestAccAWSEMRCluster_CoreInstanceGroup_InstanceCount
=== RUN   TestAccAWSEMRCluster_CoreInstanceGroup_InstanceType
=== PAUSE TestAccAWSEMRCluster_CoreInstanceGroup_InstanceType
=== RUN   TestAccAWSEMRCluster_CoreInstanceGroup_Migration_CoreInstanceType
=== PAUSE TestAccAWSEMRCluster_CoreInstanceGroup_Migration_CoreInstanceType
=== RUN   TestAccAWSEMRCluster_CoreInstanceGroup_Migration_InstanceGroup
=== PAUSE TestAccAWSEMRCluster_CoreInstanceGroup_Migration_InstanceGroup
=== RUN   TestAccAWSEMRCluster_CoreInstanceGroup_Name
=== PAUSE TestAccAWSEMRCluster_CoreInstanceGroup_Name
=== RUN   TestAccAWSEMRCluster_instance_group
=== PAUSE TestAccAWSEMRCluster_instance_group
=== RUN   TestAccAWSEMRCluster_instance_group_names
=== PAUSE TestAccAWSEMRCluster_instance_group_names
=== RUN   TestAccAWSEMRCluster_instance_group_update
=== PAUSE TestAccAWSEMRCluster_instance_group_update
=== RUN   TestAccAWSEMRCluster_instance_group_EBSVolumeType_st1
=== PAUSE TestAccAWSEMRCluster_instance_group_EBSVolumeType_st1
=== RUN   TestAccAWSEMRCluster_updateAutoScalingPolicy
=== PAUSE TestAccAWSEMRCluster_updateAutoScalingPolicy
=== RUN   TestAccAWSEMRCluster_Kerberos_ClusterDedicatedKdc
=== PAUSE TestAccAWSEMRCluster_Kerberos_ClusterDedicatedKdc
=== RUN   TestAccAWSEMRCluster_MasterInstanceGroup_BidPrice
=== PAUSE TestAccAWSEMRCluster_MasterInstanceGroup_BidPrice
=== RUN   TestAccAWSEMRCluster_MasterInstanceGroup_InstanceCount
=== PAUSE TestAccAWSEMRCluster_MasterInstanceGroup_InstanceCount
=== RUN   TestAccAWSEMRCluster_MasterInstanceGroup_InstanceType
=== PAUSE TestAccAWSEMRCluster_MasterInstanceGroup_InstanceType
=== RUN   TestAccAWSEMRCluster_MasterInstanceGroup_Migration_InstanceGroup
=== PAUSE TestAccAWSEMRCluster_MasterInstanceGroup_Migration_InstanceGroup
=== RUN   TestAccAWSEMRCluster_MasterInstanceGroup_Migration_MasterInstanceType
=== PAUSE TestAccAWSEMRCluster_MasterInstanceGroup_Migration_MasterInstanceType
=== RUN   TestAccAWSEMRCluster_MasterInstanceGroup_Name
=== PAUSE TestAccAWSEMRCluster_MasterInstanceGroup_Name
=== RUN   TestAccAWSEMRCluster_security_config
=== PAUSE TestAccAWSEMRCluster_security_config
=== RUN   TestAccAWSEMRCluster_Step_Basic
=== PAUSE TestAccAWSEMRCluster_Step_Basic
=== RUN   TestAccAWSEMRCluster_Step_ConfigMode
=== PAUSE TestAccAWSEMRCluster_Step_ConfigMode
=== RUN   TestAccAWSEMRCluster_Step_Multiple
=== PAUSE TestAccAWSEMRCluster_Step_Multiple
=== RUN   TestAccAWSEMRCluster_bootstrap_ordering
=== PAUSE TestAccAWSEMRCluster_bootstrap_ordering
=== RUN   TestAccAWSEMRCluster_terminationProtected
=== PAUSE TestAccAWSEMRCluster_terminationProtected
=== RUN   TestAccAWSEMRCluster_keepJob
=== PAUSE TestAccAWSEMRCluster_keepJob
=== RUN   TestAccAWSEMRCluster_visibleToAllUsers
=== PAUSE TestAccAWSEMRCluster_visibleToAllUsers
=== RUN   TestAccAWSEMRCluster_s3Logging
=== PAUSE TestAccAWSEMRCluster_s3Logging
=== RUN   TestAccAWSEMRCluster_tags
=== PAUSE TestAccAWSEMRCluster_tags
=== RUN   TestAccAWSEMRCluster_root_volume_size
=== PAUSE TestAccAWSEMRCluster_root_volume_size
=== RUN   TestAccAWSEMRCluster_custom_ami_id
=== PAUSE TestAccAWSEMRCluster_custom_ami_id
=== CONT  TestAccAWSEMRCluster_basic
=== CONT  TestAccAWSEMRCluster_MasterInstanceGroup_InstanceCount
=== CONT  TestAccAWSEMRCluster_CoreInstanceGroup_BidPrice
=== CONT  TestAccAWSEMRCluster_CoreInstanceGroup_Migration_CoreInstanceType
=== CONT  TestAccAWSEMRCluster_CoreInstanceGroup_InstanceType
=== CONT  TestAccAWSEMRCluster_CoreInstanceGroup_Migration_InstanceGroup
=== CONT  TestAccAWSEMRCluster_MasterInstanceGroup_BidPrice
=== CONT  TestAccAWSEMRCluster_Kerberos_ClusterDedicatedKdc
=== CONT  TestAccAWSEMRCluster_updateAutoScalingPolicy
=== CONT  TestAccAWSEMRCluster_instance_group_EBSVolumeType_st1
=== CONT  TestAccAWSEMRCluster_instance_group_update
=== CONT  TestAccAWSEMRCluster_instance_group_names
=== CONT  TestAccAWSEMRCluster_instance_group
=== CONT  TestAccAWSEMRCluster_CoreInstanceGroup_InstanceCount
=== CONT  TestAccAWSEMRCluster_bootstrap_ordering
=== CONT  TestAccAWSEMRCluster_custom_ami_id
=== CONT  TestAccAWSEMRCluster_root_volume_size
=== CONT  TestAccAWSEMRCluster_tags
=== CONT  TestAccAWSEMRCluster_s3Logging
=== CONT  TestAccAWSEMRCluster_CoreInstanceGroup_Name
--- PASS: TestAccAWSEMRCluster_bootstrap_ordering (462.66s)
=== CONT  TestAccAWSEMRCluster_visibleToAllUsers
--- PASS: TestAccAWSEMRCluster_instance_group (485.44s)
=== CONT  TestAccAWSEMRCluster_keepJob
--- PASS: TestAccAWSEMRCluster_custom_ami_id (563.78s)
=== CONT  TestAccAWSEMRCluster_terminationProtected
--- PASS: TestAccAWSEMRCluster_instance_group_names (563.85s)
=== CONT  TestAccAWSEMRCluster_configurationsJson
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_InstanceCount (566.28s)
=== CONT  TestAccAWSEMRCluster_CoreInstanceGroup_AutoscalingPolicy
--- PASS: TestAccAWSEMRCluster_basic (568.91s)
=== CONT  TestAccAWSEMRCluster_security_config
--- PASS: TestAccAWSEMRCluster_Kerberos_ClusterDedicatedKdc (570.97s)
=== CONT  TestAccAWSEMRCluster_Step_Multiple
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_Migration_InstanceGroup (624.29s)
=== CONT  TestAccAWSEMRCluster_Step_ConfigMode
--- PASS: TestAccAWSEMRCluster_instance_group_update (627.04s)
=== CONT  TestAccAWSEMRCluster_Step_Basic
--- PASS: TestAccAWSEMRCluster_instance_group_EBSVolumeType_st1 (631.95s)
=== CONT  TestAccAWSEMRCluster_disappears
--- PASS: TestAccAWSEMRCluster_updateAutoScalingPolicy (633.16s)
=== CONT  TestAccAWSEMRCluster_additionalInfo
--- PASS: TestAccAWSEMRCluster_s3Logging (666.60s)
=== CONT  TestAccAWSEMRCluster_MasterInstanceGroup_Name
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_Migration_CoreInstanceType (738.59s)
=== CONT  TestAccAWSEMRCluster_MasterInstanceGroup_Migration_MasterInstanceType
--- PASS: TestAccAWSEMRCluster_tags (906.46s)
=== CONT  TestAccAWSEMRCluster_MasterInstanceGroup_Migration_InstanceGroup
--- PASS: TestAccAWSEMRCluster_keepJob (459.45s)
=== CONT  TestAccAWSEMRCluster_MasterInstanceGroup_InstanceType
--- PASS: TestAccAWSEMRCluster_additionalInfo (388.20s)
--- PASS: TestAccAWSEMRCluster_terminationProtected (466.61s)
--- PASS: TestAccAWSEMRCluster_configurationsJson (476.68s)
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_BidPrice (1061.94s)
--- PASS: TestAccAWSEMRCluster_disappears (454.72s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_AutoscalingPolicy (561.98s)
--- PASS: TestAccAWSEMRCluster_root_volume_size (1130.29s)
--- PASS: TestAccAWSEMRCluster_Step_Basic (542.90s)
--- PASS: TestAccAWSEMRCluster_Step_Multiple (606.19s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_Name (1179.35s)
--- PASS: TestAccAWSEMRCluster_security_config (620.31s)
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_InstanceCount (1190.97s)
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_Migration_MasterInstanceType (468.27s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_InstanceType (1236.30s)
--- PASS: TestAccAWSEMRCluster_visibleToAllUsers (837.63s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_BidPrice (1341.56s)
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_Migration_InstanceGroup (447.72s)
--- PASS: TestAccAWSEMRCluster_Step_ConfigMode (841.25s)
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_Name (838.47s)
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_InstanceType (748.52s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1693.494s
root@b99c1799daa8:/go/src/github.com/terraform-providers/terraform-provider-aws# 
```


ʕ •ᴥ•ʔ
