### PR TITLE
Support for SFN activity as data source

### DIFF
--- a/aws/data_source_aws_sfn_activity.go
+++ b/aws/data_source_aws_sfn_activity.go
@@ -1,0 +1,108 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sfn"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAwsSfnActivity() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsSfnActivityRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+				ExactlyOneOf: []string{
+					"arn",
+					"name",
+				},
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+				ExactlyOneOf: []string{
+					"arn",
+					"name",
+				},
+			},
+			"creation_date": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsSfnActivityRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AWSClient)
+	conn := client.sfnconn
+	log.Print("[DEBUG] Reading Step Function Activity")
+
+	if nm, ok := d.GetOk("name"); ok {
+		name := nm.(string)
+		var acts []*sfn.ActivityListItem
+
+		err := conn.ListActivitiesPages(&sfn.ListActivitiesInput{}, func(page *sfn.ListActivitiesOutput, b bool) bool {
+			for _, a := range page.Activities {
+				if name == aws.StringValue(a.Name) {
+					acts = append(acts, a)
+				}
+			}
+			return true
+		})
+
+		if err != nil {
+			return fmt.Errorf("Error listing activities: %s", err)
+		}
+
+		if len(acts) == 0 {
+			return fmt.Errorf("No activity found with name %s in this region", name)
+		}
+
+		if len(acts) > 1 {
+			return fmt.Errorf("Found more than 1 activity with name %s in this region", name)
+		}
+
+		act := acts[0]
+
+		d.SetId(*act.ActivityArn)
+		d.Set("name", act.Name)
+		d.Set("arn", act.ActivityArn)
+		if err := d.Set("creation_date", act.CreationDate.Format(time.RFC3339)); err != nil {
+			log.Printf("[DEBUG] Error setting creation_date: %s", err)
+		}
+	}
+
+	if rnm, ok := d.GetOk("arn"); ok {
+		arn := rnm.(string)
+		params := &sfn.DescribeActivityInput{
+			ActivityArn: aws.String(arn),
+		}
+
+		act, err := conn.DescribeActivity(params)
+		if err != nil {
+			return fmt.Errorf("Error describing activities: %s", err)
+		}
+
+		if act == nil {
+			return fmt.Errorf("No activity found with arn %s in this region", arn)
+		}
+
+		d.SetId(*act.ActivityArn)
+		d.Set("name", act.Name)
+		d.Set("arn", act.ActivityArn)
+		if err := d.Set("creation_date", act.CreationDate.Format(time.RFC3339)); err != nil {
+			log.Printf("[DEBUG] Error setting creation_date: %s", err)
+		}
+	}
+
+	return nil
+}

--- a/aws/data_source_aws_sfn_activity_test.go
+++ b/aws/data_source_aws_sfn_activity_test.go
@@ -1,0 +1,60 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccAWSStepFunctionsActivityDataSource(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sfn_activity.test"
+	dataName := "data.aws_sfn_activity.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAWSStepFunctionsActivityDataSourceConfig_ActivityArn(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "id", dataName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "creation_date", dataName, "creation_date"),
+					resource.TestCheckResourceAttrPair(resourceName, "name", dataName, "name"),
+				),
+			},
+			{
+				Config: testAccCheckAWSStepFunctionsActivityDataSourceConfig_ActivityName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "id", dataName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "creation_date", dataName, "creation_date"),
+					resource.TestCheckResourceAttrPair(resourceName, "name", dataName, "name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSStepFunctionsActivityDataSourceConfig_ActivityArn(rName string) string {
+	return fmt.Sprintf(`
+resource aws_sfn_activity "test" {
+  name = "%s"
+}
+data aws_sfn_activity "test" {
+  arn = "${aws_sfn_activity.test.id}"
+}
+`, rName)
+}
+
+func testAccCheckAWSStepFunctionsActivityDataSourceConfig_ActivityName(rName string) string {
+	return fmt.Sprintf(`
+resource aws_sfn_activity "test" {
+  name = "%s"
+}
+data aws_sfn_activity "test" {
+  name = "${aws_sfn_activity.test.name}"
+}
+`, rName)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -281,6 +281,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_secretsmanager_secret_version":             dataSourceAwsSecretsManagerSecretVersion(),
 			"aws_servicequotas_service":                     dataSourceAwsServiceQuotasService(),
 			"aws_servicequotas_service_quota":               dataSourceAwsServiceQuotasServiceQuota(),
+			"aws_sfn_activity":                              dataSourceAwsSfnActivity(),
 			"aws_sfn_state_machine":                         dataSourceAwsSfnStateMachine(),
 			"aws_sns_topic":                                 dataSourceAwsSnsTopic(),
 			"aws_sqs_queue":                                 dataSourceAwsSqsQueue(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -2987,6 +2987,9 @@
                             <a href="#">Data Sources</a>
                             <ul class="nav nav-auto-expand">
                                 <li>
+                                    <a href="/docs/providers/aws/d/sfn_activity.html">aws_sfn_activity</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/aws/d/sfn_state_machine.html">aws_sfn_state_machine</a>
                                 </li>
                             </ul>

--- a/website/docs/d/sfn_activity.html.markdown
+++ b/website/docs/d/sfn_activity.html.markdown
@@ -1,0 +1,33 @@
+---
+subcategory: "SFN"
+layout: "aws"
+page_title: "AWS: aws_sfn_activity"
+description: |-
+  Use this data source to get information about a Step Functions Activity.
+---
+
+# Data Source: aws_sfn_activity
+
+Provides a Step Functions Activity data source
+
+## Example Usage
+
+```hcl
+data "aws_sfn_activity" "sfn_activity" {
+  name = "my-activity"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Optional) The name that identifies the activity.
+* `arn` - (Optional) The Amazon Resource Name (ARN) that identifies the activity.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The Amazon Resource Name (ARN) that identifies the activity.
+* `creation_date` - The date the activity was created.

--- a/website/docs/d/sfn_activity.html.markdown
+++ b/website/docs/d/sfn_activity.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "SFN"
+subcategory: "Step Function (SFN)"
 layout: "aws"
 page_title: "AWS: aws_sfn_activity"
 description: |-


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

This change allows users to reference Step Functions activities and state machines as data sources. This is useful when reusing activities and state machines across different Terraform projects. The change also means users can now reference these resources in Terraform code even if they are not Terraform-managed.

Example:

```
# project A

resource "aws_sfn_activity" "example" {
  name = "activity-A"
  ...
}
```

```
# project B

data "aws_sfn_activity" "activity_A" {
  name = "activity-A"
}
```

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```
Support for SFN activity as data source
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSStepFunctions.*DataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSStepFunctions.*DataSource -timeout 120m
=== RUN   TestAccAWSStepFunctionsActivityDataSource
=== PAUSE TestAccAWSStepFunctionsActivityDataSource
=== RUN   TestAccAWSStepFunctionsStateMachineDataSource
=== PAUSE TestAccAWSStepFunctionsStateMachineDataSource
=== CONT  TestAccAWSStepFunctionsActivityDataSource
=== CONT  TestAccAWSStepFunctionsStateMachineDataSource
--- PASS: TestAccAWSStepFunctionsActivityDataSource (73.50s)
--- PASS: TestAccAWSStepFunctionsStateMachineDataSource (106.55s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	107.101s
```
