### PR TITLE
Add support for DynamoDB customer managed CMKs for server-side encryption

### DIFF
--- a/aws/data_source_aws_dynamodb_table.go
+++ b/aws/data_source_aws_dynamodb_table.go
@@ -178,6 +178,10 @@ func dataSourceAwsDynamoDbTable() *schema.Resource {
 							Type:     schema.TypeBool,
 							Computed: true,
 						},
+						"kms_key_arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/aws/data_source_aws_dynamodb_table_test.go
+++ b/aws/data_source_aws_dynamodb_table_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccDataSourceAwsDynamoDbTable_basic(t *testing.T) {
+	datasourceName := "data.aws_dynamodb_table.test"
 	tableName := fmt.Sprintf("testaccawsdynamodbtable-basic-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -18,21 +19,21 @@ func TestAccDataSourceAwsDynamoDbTable_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsDynamoDbTableConfigBasic(tableName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_dynamodb_table.dynamodb_table_test", "name", tableName),
-					resource.TestCheckResourceAttr("data.aws_dynamodb_table.dynamodb_table_test", "read_capacity", "20"),
-					resource.TestCheckResourceAttr("data.aws_dynamodb_table.dynamodb_table_test", "write_capacity", "20"),
-					resource.TestCheckResourceAttr("data.aws_dynamodb_table.dynamodb_table_test", "hash_key", "UserId"),
-					resource.TestCheckResourceAttr("data.aws_dynamodb_table.dynamodb_table_test", "range_key", "GameTitle"),
-					resource.TestCheckResourceAttr("data.aws_dynamodb_table.dynamodb_table_test", "attribute.#", "3"),
-					resource.TestCheckResourceAttr("data.aws_dynamodb_table.dynamodb_table_test", "global_secondary_index.#", "1"),
-					resource.TestCheckResourceAttr("data.aws_dynamodb_table.dynamodb_table_test", "ttl.#", "1"),
-					resource.TestCheckResourceAttr("data.aws_dynamodb_table.dynamodb_table_test", "tags.%", "2"),
-					resource.TestCheckResourceAttr("data.aws_dynamodb_table.dynamodb_table_test", "tags.Name", "dynamodb-table-1"),
-					resource.TestCheckResourceAttr("data.aws_dynamodb_table.dynamodb_table_test", "tags.Environment", "test"),
-					resource.TestCheckResourceAttr("data.aws_dynamodb_table.dynamodb_table_test", "server_side_encryption.#", "0"),
-					resource.TestCheckResourceAttr("data.aws_dynamodb_table.dynamodb_table_test", "billing_mode", "PROVISIONED"),
-					resource.TestCheckResourceAttr("data.aws_dynamodb_table.dynamodb_table_test", "point_in_time_recovery.#", "1"),
-					resource.TestCheckResourceAttr("data.aws_dynamodb_table.dynamodb_table_test", "point_in_time_recovery.0.enabled", "false"),
+					resource.TestCheckResourceAttr(datasourceName, "name", tableName),
+					resource.TestCheckResourceAttr(datasourceName, "read_capacity", "20"),
+					resource.TestCheckResourceAttr(datasourceName, "write_capacity", "20"),
+					resource.TestCheckResourceAttr(datasourceName, "hash_key", "UserId"),
+					resource.TestCheckResourceAttr(datasourceName, "range_key", "GameTitle"),
+					resource.TestCheckResourceAttr(datasourceName, "attribute.#", "3"),
+					resource.TestCheckResourceAttr(datasourceName, "global_secondary_index.#", "1"),
+					resource.TestCheckResourceAttr(datasourceName, "ttl.#", "1"),
+					resource.TestCheckResourceAttr(datasourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(datasourceName, "tags.Name", "dynamodb-table-1"),
+					resource.TestCheckResourceAttr(datasourceName, "tags.Environment", "test"),
+					resource.TestCheckResourceAttr(datasourceName, "server_side_encryption.#", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "billing_mode", "PROVISIONED"),
+					resource.TestCheckResourceAttr(datasourceName, "point_in_time_recovery.#", "1"),
+					resource.TestCheckResourceAttr(datasourceName, "point_in_time_recovery.0.enabled", "false"),
 				),
 			},
 		},
@@ -41,7 +42,7 @@ func TestAccDataSourceAwsDynamoDbTable_basic(t *testing.T) {
 
 func testAccDataSourceAwsDynamoDbTableConfigBasic(tableName string) string {
 	return fmt.Sprintf(`
-resource "aws_dynamodb_table" "dynamodb_table_test" {
+resource "aws_dynamodb_table" "test" {
   name           = "%s"
   read_capacity  = 20
   write_capacity = 20
@@ -79,8 +80,8 @@ resource "aws_dynamodb_table" "dynamodb_table_test" {
   }
 }
 
-data "aws_dynamodb_table" "dynamodb_table_test" {
-  name = "${aws_dynamodb_table.dynamodb_table_test.name}"
+data "aws_dynamodb_table" "test" {
+  name = "${aws_dynamodb_table.test.name}"
 }
 `, tableName)
 }

--- a/aws/resource_aws_dynamodb_table.go
+++ b/aws/resource_aws_dynamodb_table.go
@@ -254,7 +254,12 @@ func resourceAwsDynamoDbTable() *schema.Resource {
 						"enabled": {
 							Type:     schema.TypeBool,
 							Required: true,
-							ForceNew: true,
+						},
+						"kms_key_arn": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validateArn,
 						},
 					},
 				},
@@ -345,13 +350,7 @@ func resourceAwsDynamoDbTableCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if v, ok := d.GetOk("server_side_encryption"); ok {
-		options := v.([]interface{})
-		if options[0] == nil {
-			return fmt.Errorf("At least one field is expected inside server_side_encryption")
-		}
-
-		s := options[0].(map[string]interface{})
-		req.SSESpecification = expandDynamoDbEncryptAtRestOptions(s)
+		req.SSESpecification = expandDynamoDbEncryptAtRestOptions(v.([]interface{}))
 	}
 
 	var output *dynamodb.CreateTableOutput
@@ -559,6 +558,21 @@ func resourceAwsDynamoDbTableUpdate(d *schema.ResourceData, meta interface{}) er
 
 		if err := waitForDynamoDbGSIToBeActive(d.Id(), idxName, d.Timeout(schema.TimeoutUpdate), conn); err != nil {
 			return fmt.Errorf("error waiting for DynamoDB Table (%s) Global Secondary Index (%s) creation: %s", d.Id(), idxName, err)
+		}
+	}
+
+	if d.HasChange("server_side_encryption") {
+		// "ValidationException: One or more parameter values were invalid: Server-Side Encryption modification must be the only operation in the request".
+		_, err := conn.UpdateTable(&dynamodb.UpdateTableInput{
+			TableName:        aws.String(d.Id()),
+			SSESpecification: expandDynamoDbEncryptAtRestOptions(d.Get("server_side_encryption").([]interface{})),
+		})
+		if err != nil {
+			return fmt.Errorf("error updating DynamoDB Table (%s) SSE: %s", d.Id(), err)
+		}
+
+		if err := waitForDynamoDbSSEUpdateToBeCompleted(d.Id(), d.Timeout(schema.TimeoutUpdate), conn); err != nil {
+			return fmt.Errorf("error waiting for DynamoDB Table (%s) SSE update: %s", d.Id(), err)
 		}
 	}
 
@@ -969,6 +983,38 @@ func waitForDynamoDbTtlUpdateToBeCompleted(tableName string, toEnable bool, conn
 	}
 
 	_, err := stateConf.WaitForState()
+	return err
+}
+
+func waitForDynamoDbSSEUpdateToBeCompleted(tableName string, timeout time.Duration, conn *dynamodb.DynamoDB) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			dynamodb.SSEStatusDisabling,
+			dynamodb.SSEStatusEnabling,
+			dynamodb.SSEStatusUpdating,
+		},
+		Target: []string{
+			dynamodb.SSEStatusDisabled,
+			dynamodb.SSEStatusEnabled,
+		},
+		Timeout: timeout,
+		Refresh: func() (interface{}, string, error) {
+			result, err := conn.DescribeTable(&dynamodb.DescribeTableInput{
+				TableName: aws.String(tableName),
+			})
+			if err != nil {
+				return 42, "", err
+			}
+
+			// Disabling SSE returns null SSEDescription.
+			if result.Table.SSEDescription == nil {
+				return result, dynamodb.SSEStatusDisabled, nil
+			}
+			return result, aws.StringValue(result.Table.SSEDescription.Status), nil
+		},
+	}
+	_, err := stateConf.WaitForState()
+
 	return err
 }
 

--- a/aws/resource_aws_dynamodb_table_test.go
+++ b/aws/resource_aws_dynamodb_table_test.go
@@ -473,8 +473,8 @@ func TestAccAWSDynamoDbTable_enablePitr(t *testing.T) {
 }
 
 func TestAccAWSDynamoDbTable_BillingMode_PayPerRequestToProvisioned(t *testing.T) {
-	rName := acctest.RandomWithPrefix("TerraformTestTable-")
 	resourceName := "aws_dynamodb_table.test"
+	rName := acctest.RandomWithPrefix("TerraformTestTable-")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -503,8 +503,8 @@ func TestAccAWSDynamoDbTable_BillingMode_PayPerRequestToProvisioned(t *testing.T
 }
 
 func TestAccAWSDynamoDbTable_BillingMode_ProvisionedToPayPerRequest(t *testing.T) {
-	rName := acctest.RandomWithPrefix("TerraformTestTable-")
 	resourceName := "aws_dynamodb_table.test"
+	rName := acctest.RandomWithPrefix("TerraformTestTable-")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -533,8 +533,8 @@ func TestAccAWSDynamoDbTable_BillingMode_ProvisionedToPayPerRequest(t *testing.T
 }
 
 func TestAccAWSDynamoDbTable_BillingMode_GSI_PayPerRequestToProvisioned(t *testing.T) {
-	rName := acctest.RandomWithPrefix("TerraformTestTable-")
 	resourceName := "aws_dynamodb_table.test"
+	rName := acctest.RandomWithPrefix("TerraformTestTable-")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -563,8 +563,8 @@ func TestAccAWSDynamoDbTable_BillingMode_GSI_PayPerRequestToProvisioned(t *testi
 }
 
 func TestAccAWSDynamoDbTable_BillingMode_GSI_ProvisionedToPayPerRequest(t *testing.T) {
-	rName := acctest.RandomWithPrefix("TerraformTestTable-")
 	resourceName := "aws_dynamodb_table.test"
+	rName := acctest.RandomWithPrefix("TerraformTestTable-")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -675,8 +675,8 @@ func TestAccAWSDynamoDbTable_tags(t *testing.T) {
 // https://github.com/hashicorp/terraform/issues/13243
 func TestAccAWSDynamoDbTable_gsiUpdateCapacity(t *testing.T) {
 	var conf dynamodb.DescribeTableOutput
-	name := acctest.RandString(10)
 	resourceName := "aws_dynamodb_table.test"
+	name := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -720,8 +720,8 @@ func TestAccAWSDynamoDbTable_gsiUpdateCapacity(t *testing.T) {
 
 func TestAccAWSDynamoDbTable_gsiUpdateOtherAttributes(t *testing.T) {
 	var conf dynamodb.DescribeTableOutput
-	name := acctest.RandString(10)
 	resourceName := "aws_dynamodb_table.test"
+	name := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -797,8 +797,8 @@ func TestAccAWSDynamoDbTable_gsiUpdateOtherAttributes(t *testing.T) {
 // https://github.com/terraform-providers/terraform-provider-aws/issues/566
 func TestAccAWSDynamoDbTable_gsiUpdateNonKeyAttributes(t *testing.T) {
 	var conf dynamodb.DescribeTableOutput
-	name := acctest.RandString(10)
 	resourceName := "aws_dynamodb_table.test"
+	name := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -877,8 +877,8 @@ func TestAccAWSDynamoDbTable_gsiUpdateNonKeyAttributes(t *testing.T) {
 // ValidationException: Time to live has been modified multiple times within a fixed interval
 func TestAccAWSDynamoDbTable_Ttl_Enabled(t *testing.T) {
 	var table dynamodb.DescribeTableOutput
-	rName := acctest.RandomWithPrefix("TerraformTestTable-")
 	resourceName := "aws_dynamodb_table.test"
+	rName := acctest.RandomWithPrefix("TerraformTestTable-")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -906,8 +906,8 @@ func TestAccAWSDynamoDbTable_Ttl_Enabled(t *testing.T) {
 // ValidationException: Time to live has been modified multiple times within a fixed interval
 func TestAccAWSDynamoDbTable_Ttl_Disabled(t *testing.T) {
 	var table dynamodb.DescribeTableOutput
-	rName := acctest.RandomWithPrefix("TerraformTestTable-")
 	resourceName := "aws_dynamodb_table.test"
+	rName := acctest.RandomWithPrefix("TerraformTestTable-")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1003,9 +1003,11 @@ func TestAccAWSDynamoDbTable_attributeUpdateValidation(t *testing.T) {
 }
 
 func TestAccAWSDynamoDbTable_encryption(t *testing.T) {
-	var confEncEnabled, confEncDisabled, confBasic dynamodb.DescribeTableOutput
+	var confBYOK, confEncEnabled, confEncDisabled dynamodb.DescribeTableOutput
 	resourceName := "aws_dynamodb_table.test"
 	rName := acctest.RandomWithPrefix("TerraformTestTable-")
+	kmsKeyResourceName := "aws_kms_key.test"
+	kmsAliasDatasourceName := "data.aws_kms_alias.dynamodb"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1013,11 +1015,12 @@ func TestAccAWSDynamoDbTable_encryption(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDynamoDbTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDynamoDbConfigInitialStateWithEncryption(rName, true),
+				Config: testAccAWSDynamoDbConfigInitialStateWithEncryptionBYOK(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInitialAWSDynamoDbTableExists(resourceName, &confEncEnabled),
+					testAccCheckInitialAWSDynamoDbTableExists(resourceName, &confBYOK),
 					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.enabled", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "server_side_encryption.0.kms_key_arn", kmsKeyResourceName, "arn"),
 				),
 			},
 			{
@@ -1026,26 +1029,28 @@ func TestAccAWSDynamoDbTable_encryption(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSDynamoDbConfigInitialStateWithEncryption(rName, false),
+				Config: testAccAWSDynamoDbConfigInitialStateWithEncryptionAmazonCMK(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInitialAWSDynamoDbTableExists(resourceName, &confEncDisabled),
 					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.#", "0"),
 					func(s *terraform.State) error {
-						if confEncDisabled.Table.CreationDateTime.Equal(*confEncEnabled.Table.CreationDateTime) {
-							return fmt.Errorf("DynamoDB table not recreated when changing SSE")
+						if !confEncDisabled.Table.CreationDateTime.Equal(*confBYOK.Table.CreationDateTime) {
+							return fmt.Errorf("DynamoDB table recreated when changing SSE")
 						}
 						return nil
 					},
 				),
 			},
 			{
-				Config: testAccAWSDynamoDbConfig_basic(rName),
+				Config: testAccAWSDynamoDbConfigInitialStateWithEncryptionAmazonCMK(rName, true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInitialAWSDynamoDbTableExists(resourceName, &confBasic),
-					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.#", "0"),
+					testAccCheckInitialAWSDynamoDbTableExists(resourceName, &confEncEnabled),
+					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.enabled", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "server_side_encryption.0.kms_key_arn", kmsAliasDatasourceName, "target_key_arn"),
 					func(s *terraform.State) error {
-						if !confBasic.Table.CreationDateTime.Equal(*confEncDisabled.Table.CreationDateTime) {
-							return fmt.Errorf("DynamoDB table was recreated unexpectedly")
+						if !confEncEnabled.Table.CreationDateTime.Equal(*confEncDisabled.Table.CreationDateTime) {
+							return fmt.Errorf("DynamoDB table recreated when changing SSE")
 						}
 						return nil
 					},
@@ -1569,8 +1574,16 @@ resource "aws_dynamodb_table" "test" {
 `, rName)
 }
 
-func testAccAWSDynamoDbConfigInitialStateWithEncryption(rName string, enabled bool) string {
+func testAccAWSDynamoDbConfigInitialStateWithEncryptionAmazonCMK(rName string, enabled bool) string {
 	return fmt.Sprintf(`
+data "aws_kms_alias" "dynamodb" {
+  name = "alias/aws/dynamodb"
+}
+
+resource "aws_kms_key" "test" {
+  description = "DynamoDbTest"
+}
+
 resource "aws_dynamodb_table" "test" {
   name           = "%s"
   read_capacity  = 1
@@ -1587,6 +1600,31 @@ resource "aws_dynamodb_table" "test" {
   }
 }
 `, rName, enabled)
+}
+
+func testAccAWSDynamoDbConfigInitialStateWithEncryptionBYOK(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  description = "DynamoDbTest"
+}
+
+resource "aws_dynamodb_table" "test" {
+  name           = "%s"
+  read_capacity  = 2
+  write_capacity = 2
+  hash_key       = "TestTableHashKey"
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+  server_side_encryption {
+	enabled     = true
+	kms_key_arn = "${aws_kms_key.test.arn}"
+  }
+}
+`, rName)
 }
 
 func testAccAWSDynamoDbConfigAddSecondaryGSI(rName string) string {

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -4351,10 +4351,11 @@ func flattenAwsDynamoDbTableResource(d *schema.ResourceData, table *dynamodb.Tab
 	}
 
 	sseOptions := []map[string]interface{}{}
-	if table.SSEDescription != nil {
-		m := map[string]interface{}{}
-		m["enabled"] = aws.StringValue(table.SSEDescription.Status) == dynamodb.SSEStatusEnabled
-		sseOptions = []map[string]interface{}{m}
+	if sseDescription := table.SSEDescription; sseDescription != nil {
+		sseOptions = []map[string]interface{}{{
+			"enabled":     aws.StringValue(sseDescription.Status) == dynamodb.SSEStatusEnabled,
+			"kms_key_arn": aws.StringValue(sseDescription.KMSMasterKeyArn),
+		}}
 	}
 	err = d.Set("server_side_encryption", sseOptions)
 	if err != nil {
@@ -4478,14 +4479,24 @@ func expandDynamoDbKeySchema(data map[string]interface{}) []*dynamodb.KeySchemaE
 	return keySchema
 }
 
-func expandDynamoDbEncryptAtRestOptions(m map[string]interface{}) *dynamodb.SSESpecification {
-	options := dynamodb.SSESpecification{}
+func expandDynamoDbEncryptAtRestOptions(vOptions []interface{}) *dynamodb.SSESpecification {
+	options := &dynamodb.SSESpecification{}
 
-	if v, ok := m["enabled"]; ok {
-		options.Enabled = aws.Bool(v.(bool))
+	enabled := false
+	if len(vOptions) > 0 {
+		mOptions := vOptions[0].(map[string]interface{})
+
+		enabled = mOptions["enabled"].(bool)
+		if enabled {
+			if vKmsKeyArn, ok := mOptions["kms_key_arn"].(string); ok && vKmsKeyArn != "" {
+				options.KMSMasterKeyId = aws.String(vKmsKeyArn)
+				options.SSEType = aws.String(dynamodb.SSETypeKms)
+			}
+		}
 	}
+	options.Enabled = aws.Bool(enabled)
 
-	return &options
+	return options
 }
 
 func expandDynamoDbTableItemAttributes(input string) (map[string]*dynamodb.AttributeValue, error) {

--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -134,9 +134,12 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 
 #### `server_side_encryption`
 
-* `enabled` - (Required) Whether or not to enable encryption at rest using an AWS managed Customer Master Key.
+* `enabled` - (Required) Whether or not to enable encryption at rest using an AWS managed KMS customer master key (CMK).
+* `kms_key_arn` - (Optional) The ARN of the CMK that should be used for the AWS KMS encryption.
+This attribute should only be specified if the key is different from the default DynamoDB CMK, `alias/aws/dynamodb`.
+
 If `enabled` is `false` then server-side encryption is set to AWS owned CMK (shown as `DEFAULT` in the AWS console).
-If `enabled` is `true` then server-side encryption is set to AWS managed CMK (shown as `KMS` in the AWS console).
+If `enabled` is `true` and no `kms_master_key_id` is specified then server-side encryption is set to AWS managed CMK (shown as `KMS` in the AWS console).
 The [AWS KMS documentation](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html) explains the difference between AWS owned and AWS managed CMKs.
 
 #### `point_in_time_recovery`


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/8137.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_dynamodb_table: Support for customer managed CMKs for server-side encryption. Add `kms_key_arn` attribute. Updating `server_side_encryption` attribute no longer recreates the DynamoDB table.
data-source/aws_dynamodb_table: Add `kms_key_arn` attribute.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsDynamoDbTable_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsDynamoDbTable_ -timeout 120m
=== RUN   TestAccDataSourceAwsDynamoDbTable_basic
=== PAUSE TestAccDataSourceAwsDynamoDbTable_basic
=== CONT  TestAccDataSourceAwsDynamoDbTable_basic
--- PASS: TestAccDataSourceAwsDynamoDbTable_basic (49.51s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	49.551s
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDynamoDbTable_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDynamoDbTable_ -timeout 120m
=== RUN   TestAccAWSDynamoDbTable_basic
=== PAUSE TestAccAWSDynamoDbTable_basic
=== RUN   TestAccAWSDynamoDbTable_disappears
=== PAUSE TestAccAWSDynamoDbTable_disappears
=== RUN   TestAccAWSDynamoDbTable_disappears_PayPerRequestWithGSI
=== PAUSE TestAccAWSDynamoDbTable_disappears_PayPerRequestWithGSI
=== RUN   TestAccAWSDynamoDbTable_extended
=== PAUSE TestAccAWSDynamoDbTable_extended
=== RUN   TestAccAWSDynamoDbTable_enablePitr
=== PAUSE TestAccAWSDynamoDbTable_enablePitr
=== RUN   TestAccAWSDynamoDbTable_BillingMode_PayPerRequestToProvisioned
=== PAUSE TestAccAWSDynamoDbTable_BillingMode_PayPerRequestToProvisioned
=== RUN   TestAccAWSDynamoDbTable_BillingMode_ProvisionedToPayPerRequest
=== PAUSE TestAccAWSDynamoDbTable_BillingMode_ProvisionedToPayPerRequest
=== RUN   TestAccAWSDynamoDbTable_BillingMode_GSI_PayPerRequestToProvisioned
=== PAUSE TestAccAWSDynamoDbTable_BillingMode_GSI_PayPerRequestToProvisioned
=== RUN   TestAccAWSDynamoDbTable_BillingMode_GSI_ProvisionedToPayPerRequest
=== PAUSE TestAccAWSDynamoDbTable_BillingMode_GSI_ProvisionedToPayPerRequest
=== RUN   TestAccAWSDynamoDbTable_streamSpecification
=== PAUSE TestAccAWSDynamoDbTable_streamSpecification
=== RUN   TestAccAWSDynamoDbTable_streamSpecificationValidation
=== PAUSE TestAccAWSDynamoDbTable_streamSpecificationValidation
=== RUN   TestAccAWSDynamoDbTable_tags
=== PAUSE TestAccAWSDynamoDbTable_tags
=== RUN   TestAccAWSDynamoDbTable_gsiUpdateCapacity
=== PAUSE TestAccAWSDynamoDbTable_gsiUpdateCapacity
=== RUN   TestAccAWSDynamoDbTable_gsiUpdateOtherAttributes
=== PAUSE TestAccAWSDynamoDbTable_gsiUpdateOtherAttributes
=== RUN   TestAccAWSDynamoDbTable_gsiUpdateNonKeyAttributes
=== PAUSE TestAccAWSDynamoDbTable_gsiUpdateNonKeyAttributes
=== RUN   TestAccAWSDynamoDbTable_Ttl_Enabled
=== PAUSE TestAccAWSDynamoDbTable_Ttl_Enabled
=== RUN   TestAccAWSDynamoDbTable_Ttl_Disabled
=== PAUSE TestAccAWSDynamoDbTable_Ttl_Disabled
=== RUN   TestAccAWSDynamoDbTable_attributeUpdate
=== PAUSE TestAccAWSDynamoDbTable_attributeUpdate
=== RUN   TestAccAWSDynamoDbTable_attributeUpdateValidation
=== PAUSE TestAccAWSDynamoDbTable_attributeUpdateValidation
=== RUN   TestAccAWSDynamoDbTable_encryption
=== PAUSE TestAccAWSDynamoDbTable_encryption
=== CONT  TestAccAWSDynamoDbTable_basic
=== CONT  TestAccAWSDynamoDbTable_encryption
=== CONT  TestAccAWSDynamoDbTable_attributeUpdateValidation
=== CONT  TestAccAWSDynamoDbTable_attributeUpdate
=== CONT  TestAccAWSDynamoDbTable_Ttl_Disabled
=== CONT  TestAccAWSDynamoDbTable_Ttl_Enabled
=== CONT  TestAccAWSDynamoDbTable_gsiUpdateNonKeyAttributes
=== CONT  TestAccAWSDynamoDbTable_gsiUpdateOtherAttributes
=== CONT  TestAccAWSDynamoDbTable_gsiUpdateCapacity
=== CONT  TestAccAWSDynamoDbTable_tags
=== CONT  TestAccAWSDynamoDbTable_streamSpecificationValidation
=== CONT  TestAccAWSDynamoDbTable_streamSpecification
=== CONT  TestAccAWSDynamoDbTable_BillingMode_GSI_ProvisionedToPayPerRequest
=== CONT  TestAccAWSDynamoDbTable_BillingMode_GSI_PayPerRequestToProvisioned
=== CONT  TestAccAWSDynamoDbTable_BillingMode_ProvisionedToPayPerRequest
=== CONT  TestAccAWSDynamoDbTable_BillingMode_PayPerRequestToProvisioned
=== CONT  TestAccAWSDynamoDbTable_enablePitr
=== CONT  TestAccAWSDynamoDbTable_extended
=== CONT  TestAccAWSDynamoDbTable_disappears_PayPerRequestWithGSI
=== CONT  TestAccAWSDynamoDbTable_disappears
--- PASS: TestAccAWSDynamoDbTable_streamSpecificationValidation (10.27s)
--- PASS: TestAccAWSDynamoDbTable_attributeUpdateValidation (12.52s)
--- PASS: TestAccAWSDynamoDbTable_disappears (31.36s)
--- PASS: TestAccAWSDynamoDbTable_Ttl_Enabled (38.19s)
--- PASS: TestAccAWSDynamoDbTable_basic (39.48s)
--- PASS: TestAccAWSDynamoDbTable_Ttl_Disabled (59.29s)
--- PASS: TestAccAWSDynamoDbTable_BillingMode_PayPerRequestToProvisioned (60.45s)
--- PASS: TestAccAWSDynamoDbTable_BillingMode_GSI_PayPerRequestToProvisioned (74.05s)
--- PASS: TestAccAWSDynamoDbTable_streamSpecification (76.44s)
--- PASS: TestAccAWSDynamoDbTable_disappears_PayPerRequestWithGSI (82.10s)
--- PASS: TestAccAWSDynamoDbTable_tags (83.56s)
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateCapacity (109.24s)
--- PASS: TestAccAWSDynamoDbTable_enablePitr (110.97s)
--- PASS: TestAccAWSDynamoDbTable_encryption (179.90s)
--- PASS: TestAccAWSDynamoDbTable_extended (190.07s)
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateNonKeyAttributes (192.59s)
--- PASS: TestAccAWSDynamoDbTable_attributeUpdate (472.80s)
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateOtherAttributes (507.40s)
--- PASS: TestAccAWSDynamoDbTable_BillingMode_GSI_ProvisionedToPayPerRequest (616.38s)
--- PASS: TestAccAWSDynamoDbTable_BillingMode_ProvisionedToPayPerRequest (740.41s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	740.482s
```
