### PR TITLE
EC2 Transit Gateway: Refactor tagging logic to keyvaluetags package

### DIFF
--- a/aws/data_source_aws_ec2_transit_gateway.go
+++ b/aws/data_source_aws_ec2_transit_gateway.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func dataSourceAwsEc2TransitGateway() *schema.Resource {
@@ -118,7 +119,7 @@ func dataSourceAwsEc2TransitGatewayRead(d *schema.ResourceData, meta interface{}
 	d.Set("owner_id", transitGateway.OwnerId)
 	d.Set("propagation_default_route_table_id", transitGateway.Options.PropagationDefaultRouteTableId)
 
-	if err := d.Set("tags", tagsToMap(transitGateway.Tags)); err != nil {
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(transitGateway.Tags).IgnoreAws().Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 

--- a/aws/data_source_aws_ec2_transit_gateway_dx_gateway_attachment.go
+++ b/aws/data_source_aws_ec2_transit_gateway_dx_gateway_attachment.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func dataSourceAwsEc2TransitGatewayDxGatewayAttachment() *schema.Resource {
@@ -65,7 +66,7 @@ func dataSourceAwsEc2TransitGatewayDxGatewayAttachmentRead(d *schema.ResourceDat
 
 	transitGatewayAttachment := output.TransitGatewayAttachments[0]
 
-	if err := d.Set("tags", tagsToMap(transitGatewayAttachment.Tags)); err != nil {
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(transitGatewayAttachment.Tags).IgnoreAws().Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 

--- a/aws/data_source_aws_ec2_transit_gateway_route_table.go
+++ b/aws/data_source_aws_ec2_transit_gateway_route_table.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func dataSourceAwsEc2TransitGatewayRouteTable() *schema.Resource {
@@ -74,7 +75,7 @@ func dataSourceAwsEc2TransitGatewayRouteTableRead(d *schema.ResourceData, meta i
 	d.Set("default_association_route_table", aws.BoolValue(transitGatewayRouteTable.DefaultAssociationRouteTable))
 	d.Set("default_propagation_route_table", aws.BoolValue(transitGatewayRouteTable.DefaultPropagationRouteTable))
 
-	if err := d.Set("tags", tagsToMap(transitGatewayRouteTable.Tags)); err != nil {
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(transitGatewayRouteTable.Tags).IgnoreAws().Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 

--- a/aws/data_source_aws_ec2_transit_gateway_vpc_attachment.go
+++ b/aws/data_source_aws_ec2_transit_gateway_vpc_attachment.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func dataSourceAwsEc2TransitGatewayVpcAttachment() *schema.Resource {
@@ -95,7 +96,7 @@ func dataSourceAwsEc2TransitGatewayVpcAttachmentRead(d *schema.ResourceData, met
 		return fmt.Errorf("error setting subnet_ids: %s", err)
 	}
 
-	if err := d.Set("tags", tagsToMap(transitGatewayVpcAttachment.Tags)); err != nil {
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(transitGatewayVpcAttachment.Tags).IgnoreAws().Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 

--- a/aws/data_source_aws_ec2_transit_gateway_vpn_attachment.go
+++ b/aws/data_source_aws_ec2_transit_gateway_vpn_attachment.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func dataSourceAwsEc2TransitGatewayVpnAttachment() *schema.Resource {
@@ -65,7 +66,7 @@ func dataSourceAwsEc2TransitGatewayVpnAttachmentRead(d *schema.ResourceData, met
 
 	transitGatewayAttachment := output.TransitGatewayAttachments[0]
 
-	if err := d.Set("tags", tagsToMap(transitGatewayAttachment.Tags)); err != nil {
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(transitGatewayAttachment.Tags).IgnoreAws().Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 

--- a/aws/ec2_transit_gateway.go
+++ b/aws/ec2_transit_gateway.go
@@ -394,19 +394,6 @@ func ec2TransitGatewayVpcAttachmentRefreshFunc(conn *ec2.EC2, transitGatewayAtta
 	}
 }
 
-func expandEc2TransitGatewayRouteTableTagSpecifications(m map[string]interface{}) []*ec2.TagSpecification {
-	if len(m) == 0 {
-		return nil
-	}
-
-	return []*ec2.TagSpecification{
-		{
-			ResourceType: aws.String("transit-gateway-route-table"),
-			Tags:         tagsFromMap(m),
-		},
-	}
-}
-
 func waitForEc2TransitGatewayCreation(conn *ec2.EC2, transitGatewayID string) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{ec2.TransitGatewayStatePending},

--- a/aws/ec2_transit_gateway.go
+++ b/aws/ec2_transit_gateway.go
@@ -394,19 +394,6 @@ func ec2TransitGatewayVpcAttachmentRefreshFunc(conn *ec2.EC2, transitGatewayAtta
 	}
 }
 
-func expandEc2TransitGatewayAttachmentTagSpecifications(m map[string]interface{}) []*ec2.TagSpecification {
-	if len(m) == 0 {
-		return nil
-	}
-
-	return []*ec2.TagSpecification{
-		{
-			ResourceType: aws.String("transit-gateway-attachment"),
-			Tags:         tagsFromMap(m),
-		},
-	}
-}
-
 func expandEc2TransitGatewayRouteTableTagSpecifications(m map[string]interface{}) []*ec2.TagSpecification {
 	if len(m) == 0 {
 		return nil

--- a/aws/ec2_transit_gateway.go
+++ b/aws/ec2_transit_gateway.go
@@ -394,19 +394,6 @@ func ec2TransitGatewayVpcAttachmentRefreshFunc(conn *ec2.EC2, transitGatewayAtta
 	}
 }
 
-func expandEc2TransitGatewayTagSpecifications(m map[string]interface{}) []*ec2.TagSpecification {
-	if len(m) == 0 {
-		return nil
-	}
-
-	return []*ec2.TagSpecification{
-		{
-			ResourceType: aws.String("transit-gateway"),
-			Tags:         tagsFromMap(m),
-		},
-	}
-}
-
 func expandEc2TransitGatewayAttachmentTagSpecifications(m map[string]interface{}) []*ec2.TagSpecification {
 	if len(m) == 0 {
 		return nil

--- a/aws/resource_aws_ec2_transit_gateway.go
+++ b/aws/resource_aws_ec2_transit_gateway.go
@@ -120,7 +120,7 @@ func resourceAwsEc2TransitGatewayCreate(d *schema.ResourceData, meta interface{}
 			DnsSupport:                   aws.String(d.Get("dns_support").(string)),
 			VpnEcmpSupport:               aws.String(d.Get("vpn_ecmp_support").(string)),
 		},
-		TagSpecifications: expandEc2TransitGatewayTagSpecifications(d.Get("tags").(map[string]interface{})),
+		TagSpecifications: ec2TagSpecificationsFromMap(d.Get("tags").(map[string]interface{}), ec2.ResourceTypeTransitGateway),
 	}
 
 	if v, ok := d.GetOk("amazon_side_asn"); ok {

--- a/aws/resource_aws_ec2_transit_gateway.go
+++ b/aws/resource_aws_ec2_transit_gateway.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsEc2TransitGateway() *schema.Resource {
@@ -90,11 +91,7 @@ func resourceAwsEc2TransitGateway() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
+			"tags": tagsSchema(),
 			"vpn_ecmp_support": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -188,7 +185,7 @@ func resourceAwsEc2TransitGatewayRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("owner_id", transitGateway.OwnerId)
 	d.Set("propagation_default_route_table_id", transitGateway.Options.PropagationDefaultRouteTableId)
 
-	if err := d.Set("tags", tagsToMap(transitGateway.Tags)); err != nil {
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(transitGateway.Tags).IgnoreAws().Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 
@@ -200,8 +197,12 @@ func resourceAwsEc2TransitGatewayRead(d *schema.ResourceData, meta interface{}) 
 func resourceAwsEc2TransitGatewayUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	if err := setTags(conn, d); err != nil {
-		return fmt.Errorf("error updating EC2 Transit Gateway (%s) tags: %s", d.Id(), err)
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.Ec2UpdateTags(conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("error updating EC2 Transit Gateway (%s) tags: %s", d.Id(), err)
+		}
 	}
 
 	return nil

--- a/aws/resource_aws_ec2_transit_gateway_route_table.go
+++ b/aws/resource_aws_ec2_transit_gateway_route_table.go
@@ -49,7 +49,7 @@ func resourceAwsEc2TransitGatewayRouteTableCreate(d *schema.ResourceData, meta i
 
 	input := &ec2.CreateTransitGatewayRouteTableInput{
 		TransitGatewayId:  aws.String(d.Get("transit_gateway_id").(string)),
-		TagSpecifications: expandEc2TransitGatewayRouteTableTagSpecifications(d.Get("tags").(map[string]interface{})),
+		TagSpecifications: ec2TagSpecificationsFromMap(d.Get("tags").(map[string]interface{}), ec2.ResourceTypeTransitGatewayRouteTable),
 	}
 
 	log.Printf("[DEBUG] Creating EC2 Transit Gateway Route Table: %s", input)

--- a/aws/resource_aws_ec2_transit_gateway_route_table.go
+++ b/aws/resource_aws_ec2_transit_gateway_route_table.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsEc2TransitGatewayRouteTable() *schema.Resource {
@@ -29,11 +30,7 @@ func resourceAwsEc2TransitGatewayRouteTable() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
-			"tags": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
+			"tags": tagsSchema(),
 			"transit_gateway_id": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -97,7 +94,7 @@ func resourceAwsEc2TransitGatewayRouteTableRead(d *schema.ResourceData, meta int
 	d.Set("default_association_route_table", aws.BoolValue(transitGatewayRouteTable.DefaultAssociationRouteTable))
 	d.Set("default_propagation_route_table", aws.BoolValue(transitGatewayRouteTable.DefaultPropagationRouteTable))
 
-	if err := d.Set("tags", tagsToMap(transitGatewayRouteTable.Tags)); err != nil {
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(transitGatewayRouteTable.Tags).IgnoreAws().Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 
@@ -109,8 +106,12 @@ func resourceAwsEc2TransitGatewayRouteTableRead(d *schema.ResourceData, meta int
 func resourceAwsEc2TransitGatewayRouteTableUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	if err := setTags(conn, d); err != nil {
-		return fmt.Errorf("error updating EC2 Transit Gateway Route Table (%s) tags: %s", d.Id(), err)
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.Ec2UpdateTags(conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("error updating EC2 Transit Gateway Route Table (%s) tags: %s", d.Id(), err)
+		}
 	}
 
 	return nil

--- a/aws/resource_aws_ec2_transit_gateway_vpc_attachment.go
+++ b/aws/resource_aws_ec2_transit_gateway_vpc_attachment.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsEc2TransitGatewayVpcAttachment() *schema.Resource {
@@ -45,11 +46,7 @@ func resourceAwsEc2TransitGatewayVpcAttachment() *schema.Resource {
 				MinItems: 1,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"tags": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
+			"tags": tagsSchema(),
 			"transit_gateway_default_route_table_association": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -197,7 +194,7 @@ func resourceAwsEc2TransitGatewayVpcAttachmentRead(d *schema.ResourceData, meta 
 		return fmt.Errorf("error setting subnet_ids: %s", err)
 	}
 
-	if err := d.Set("tags", tagsToMap(transitGatewayVpcAttachment.Tags)); err != nil {
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(transitGatewayVpcAttachment.Tags).IgnoreAws().Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 
@@ -269,7 +266,9 @@ func resourceAwsEc2TransitGatewayVpcAttachmentUpdate(d *schema.ResourceData, met
 	}
 
 	if d.HasChange("tags") {
-		if err := setTags(conn, d); err != nil {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.Ec2UpdateTags(conn, d.Id(), o, n); err != nil {
 			return fmt.Errorf("error updating EC2 Transit Gateway VPC Attachment (%s) tags: %s", d.Id(), err)
 		}
 	}

--- a/aws/resource_aws_ec2_transit_gateway_vpc_attachment.go
+++ b/aws/resource_aws_ec2_transit_gateway_vpc_attachment.go
@@ -92,7 +92,7 @@ func resourceAwsEc2TransitGatewayVpcAttachmentCreate(d *schema.ResourceData, met
 		},
 		SubnetIds:         expandStringSet(d.Get("subnet_ids").(*schema.Set)),
 		TransitGatewayId:  aws.String(transitGatewayID),
-		TagSpecifications: expandEc2TransitGatewayAttachmentTagSpecifications(d.Get("tags").(map[string]interface{})),
+		TagSpecifications: ec2TagSpecificationsFromMap(d.Get("tags").(map[string]interface{}), ec2.ResourceTypeTransitGatewayAttachment),
 		VpcId:             aws.String(d.Get("vpc_id").(string)),
 	}
 

--- a/aws/resource_aws_ec2_transit_gateway_vpc_attachment_accepter.go
+++ b/aws/resource_aws_ec2_transit_gateway_vpc_attachment_accepter.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsEc2TransitGatewayVpcAttachmentAccepter() *schema.Resource {
@@ -85,8 +86,10 @@ func resourceAwsEc2TransitGatewayVpcAttachmentAccepterCreate(d *schema.ResourceD
 		return fmt.Errorf("error waiting for EC2 Transit Gateway VPC Attachment (%s) availability: %s", d.Id(), err)
 	}
 
-	if err := setTags(conn, d); err != nil {
-		return fmt.Errorf("error updating EC2 Transit Gateway VPC Attachment (%s) tags: %s", d.Id(), err)
+	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
+		if err := keyvaluetags.Ec2UpdateTags(conn, d.Id(), nil, v); err != nil {
+			return fmt.Errorf("error updating EC2 Transit Gateway VPC Attachment (%s) tags: %s", d.Id(), err)
+		}
 	}
 
 	transitGateway, err := ec2DescribeTransitGateway(conn, transitGatewayID)
@@ -169,7 +172,7 @@ func resourceAwsEc2TransitGatewayVpcAttachmentAccepterRead(d *schema.ResourceDat
 		return fmt.Errorf("error setting subnet_ids: %s", err)
 	}
 
-	if err := d.Set("tags", tagsToMap(transitGatewayVpcAttachment.Tags)); err != nil {
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(transitGatewayVpcAttachment.Tags).IgnoreAws().Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 
@@ -212,7 +215,9 @@ func resourceAwsEc2TransitGatewayVpcAttachmentAccepterUpdate(d *schema.ResourceD
 	}
 
 	if d.HasChange("tags") {
-		if err := setTags(conn, d); err != nil {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.Ec2UpdateTags(conn, d.Id(), o, n); err != nil {
 			return fmt.Errorf("error updating EC2 Transit Gateway VPC Attachment (%s) tags: %s", d.Id(), err)
 		}
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10688.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEc2TransitGatewayDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEc2TransitGatewayDataSource_ -timeout 120m
=== RUN   TestAccAWSEc2TransitGatewayDataSource_Filter
=== PAUSE TestAccAWSEc2TransitGatewayDataSource_Filter
=== RUN   TestAccAWSEc2TransitGatewayDataSource_ID
=== PAUSE TestAccAWSEc2TransitGatewayDataSource_ID
=== CONT  TestAccAWSEc2TransitGatewayDataSource_Filter
=== CONT  TestAccAWSEc2TransitGatewayDataSource_ID
--- PASS: TestAccAWSEc2TransitGatewayDataSource_Filter (141.86s)
--- PASS: TestAccAWSEc2TransitGatewayDataSource_ID (141.90s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	141.937s
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEc2TransitGatewayRouteTableDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEc2TransitGatewayRouteTableDataSource_ -timeout 120m
=== RUN   TestAccAWSEc2TransitGatewayRouteTableDataSource_Filter
=== PAUSE TestAccAWSEc2TransitGatewayRouteTableDataSource_Filter
=== RUN   TestAccAWSEc2TransitGatewayRouteTableDataSource_ID
=== PAUSE TestAccAWSEc2TransitGatewayRouteTableDataSource_ID
=== CONT  TestAccAWSEc2TransitGatewayRouteTableDataSource_Filter
=== CONT  TestAccAWSEc2TransitGatewayRouteTableDataSource_ID
--- PASS: TestAccAWSEc2TransitGatewayRouteTableDataSource_ID (257.94s)
--- PASS: TestAccAWSEc2TransitGatewayRouteTableDataSource_Filter (257.94s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	257.985s
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_ -timeout 120m
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_Filter
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_Filter
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_ID
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_ID
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_Filter
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_ID
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_ID (312.80s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_Filter (312.81s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	312.836s
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEc2TransitGatewayVpnAttachmentDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEc2TransitGatewayVpnAttachmentDataSource_ -timeout 120m
=== RUN   TestAccAWSEc2TransitGatewayVpnAttachmentDataSource_TransitGatewayIdAndVpnConnectionId
=== PAUSE TestAccAWSEc2TransitGatewayVpnAttachmentDataSource_TransitGatewayIdAndVpnConnectionId
=== CONT  TestAccAWSEc2TransitGatewayVpnAttachmentDataSource_TransitGatewayIdAndVpnConnectionId
--- PASS: TestAccAWSEc2TransitGatewayVpnAttachmentDataSource_TransitGatewayIdAndVpnConnectionId (560.53s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	560.562s
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEc2TransitGatewayDxGatewayAttachmentDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEc2TransitGatewayDxGatewayAttachmentDataSource_ -timeout 120m
=== RUN   TestAccAWSEc2TransitGatewayDxGatewayAttachmentDataSource_TransitGatewayIdAndDxGatewayId
=== PAUSE TestAccAWSEc2TransitGatewayDxGatewayAttachmentDataSource_TransitGatewayIdAndDxGatewayId
=== CONT  TestAccAWSEc2TransitGatewayDxGatewayAttachmentDataSource_TransitGatewayIdAndDxGatewayId
--- PASS: TestAccAWSEc2TransitGatewayDxGatewayAttachmentDataSource_TransitGatewayIdAndDxGatewayId (715.40s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	715.431s
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEc2TransitGateway_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 2 -run=TestAccAWSEc2TransitGateway_ -timeout 120m
=== RUN   TestAccAWSEc2TransitGateway_basic
=== PAUSE TestAccAWSEc2TransitGateway_basic
=== RUN   TestAccAWSEc2TransitGateway_disappears
=== PAUSE TestAccAWSEc2TransitGateway_disappears
=== RUN   TestAccAWSEc2TransitGateway_AmazonSideASN
=== PAUSE TestAccAWSEc2TransitGateway_AmazonSideASN
=== RUN   TestAccAWSEc2TransitGateway_AutoAcceptSharedAttachments
=== PAUSE TestAccAWSEc2TransitGateway_AutoAcceptSharedAttachments
=== RUN   TestAccAWSEc2TransitGateway_DefaultRouteTableAssociationAndPropagationDisabled
=== PAUSE TestAccAWSEc2TransitGateway_DefaultRouteTableAssociationAndPropagationDisabled
=== RUN   TestAccAWSEc2TransitGateway_DefaultRouteTableAssociation
=== PAUSE TestAccAWSEc2TransitGateway_DefaultRouteTableAssociation
=== RUN   TestAccAWSEc2TransitGateway_DefaultRouteTablePropagation
=== PAUSE TestAccAWSEc2TransitGateway_DefaultRouteTablePropagation
=== RUN   TestAccAWSEc2TransitGateway_DnsSupport
=== PAUSE TestAccAWSEc2TransitGateway_DnsSupport
=== RUN   TestAccAWSEc2TransitGateway_VpnEcmpSupport
=== PAUSE TestAccAWSEc2TransitGateway_VpnEcmpSupport
=== RUN   TestAccAWSEc2TransitGateway_Description
=== PAUSE TestAccAWSEc2TransitGateway_Description
=== RUN   TestAccAWSEc2TransitGateway_Tags
=== PAUSE TestAccAWSEc2TransitGateway_Tags
=== CONT  TestAccAWSEc2TransitGateway_basic
=== CONT  TestAccAWSEc2TransitGateway_Tags
--- PASS: TestAccAWSEc2TransitGateway_basic (190.92s)
=== CONT  TestAccAWSEc2TransitGateway_Description
--- PASS: TestAccAWSEc2TransitGateway_Tags (231.16s)
=== CONT  TestAccAWSEc2TransitGateway_VpnEcmpSupport
--- PASS: TestAccAWSEc2TransitGateway_Description (353.64s)
=== CONT  TestAccAWSEc2TransitGateway_DnsSupport
--- PASS: TestAccAWSEc2TransitGateway_VpnEcmpSupport (320.32s)
=== CONT  TestAccAWSEc2TransitGateway_DefaultRouteTablePropagation
--- PASS: TestAccAWSEc2TransitGateway_DnsSupport (342.07s)
=== CONT  TestAccAWSEc2TransitGateway_DefaultRouteTableAssociation
--- PASS: TestAccAWSEc2TransitGateway_DefaultRouteTablePropagation (352.24s)
=== CONT  TestAccAWSEc2TransitGateway_DefaultRouteTableAssociationAndPropagationDisabled
--- PASS: TestAccAWSEc2TransitGateway_DefaultRouteTableAssociationAndPropagationDisabled (107.61s)
=== CONT  TestAccAWSEc2TransitGateway_AutoAcceptSharedAttachments
--- PASS: TestAccAWSEc2TransitGateway_DefaultRouteTableAssociation (300.26s)
=== CONT  TestAccAWSEc2TransitGateway_AmazonSideASN
--- PASS: TestAccAWSEc2TransitGateway_AutoAcceptSharedAttachments (321.18s)
=== CONT  TestAccAWSEc2TransitGateway_disappears
--- PASS: TestAccAWSEc2TransitGateway_AmazonSideASN (300.76s)
--- PASS: TestAccAWSEc2TransitGateway_disappears (164.06s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1496.612s
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEc2TransitGatewayRouteTable_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 2 -run=TestAccAWSEc2TransitGatewayRouteTable_ -timeout 120m
=== RUN   TestAccAWSEc2TransitGatewayRouteTable_basic
=== PAUSE TestAccAWSEc2TransitGatewayRouteTable_basic
=== RUN   TestAccAWSEc2TransitGatewayRouteTable_disappears
=== PAUSE TestAccAWSEc2TransitGatewayRouteTable_disappears
=== RUN   TestAccAWSEc2TransitGatewayRouteTable_disappears_TransitGateway
=== PAUSE TestAccAWSEc2TransitGatewayRouteTable_disappears_TransitGateway
=== RUN   TestAccAWSEc2TransitGatewayRouteTable_Tags
=== PAUSE TestAccAWSEc2TransitGatewayRouteTable_Tags
=== CONT  TestAccAWSEc2TransitGatewayRouteTable_basic
=== CONT  TestAccAWSEc2TransitGatewayRouteTable_Tags
--- PASS: TestAccAWSEc2TransitGatewayRouteTable_Tags (266.09s)
=== CONT  TestAccAWSEc2TransitGatewayRouteTable_disappears_TransitGateway
--- PASS: TestAccAWSEc2TransitGatewayRouteTable_basic (266.14s)
=== CONT  TestAccAWSEc2TransitGatewayRouteTable_disappears
--- PASS: TestAccAWSEc2TransitGatewayRouteTable_disappears_TransitGateway (149.66s)
--- PASS: TestAccAWSEc2TransitGatewayRouteTable_disappears (241.02s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	507.248s
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEc2TransitGatewayVpcAttachment_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 2 -run=TestAccAWSEc2TransitGatewayVpcAttachment_ -timeout 120m
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachment_basic
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachment_basic
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachment_disappears
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachment_disappears
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachment_DnsSupport
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachment_DnsSupport
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachment_Ipv6Support
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachment_Ipv6Support
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachment_SubnetIds
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachment_SubnetIds
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachment_Tags
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachment_Tags
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociation
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociation
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTablePropagation
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTablePropagation
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_basic
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_Tags
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_basic (302.01s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTablePropagation
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_Tags (408.11s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociation
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTablePropagation (359.95s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociation (500.03s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_Ipv6Support
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled (278.04s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_SubnetIds
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_Ipv6Support (361.82s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_DnsSupport
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_SubnetIds (502.97s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_disappears
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_DnsSupport (471.92s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_disappears (340.14s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1783.160s
$ AWS_ALTERNATE_ACCESS_KEY_ID=AAAAAAAAAAAAAAAAAAAA AWS_ALTERNATE_SECRET_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx make testacc TEST=./aws TESTARGS='-run=TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 2 -run=TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_ -timeout 120m
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_basic
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_basic
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_Tags
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_Tags
=== RUN   TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_TransitGatewayDefaultRouteTableAssociationAndPropagation
=== PAUSE TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_TransitGatewayDefaultRouteTableAssociationAndPropagation
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_basic
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_TransitGatewayDefaultRouteTableAssociationAndPropagation
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_basic (336.06s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_Tags
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_TransitGatewayDefaultRouteTableAssociationAndPropagation (531.59s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_Tags (320.51s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	656.654s
```
