### PR TITLE
resource/aws_eks_cluster: Handle additional error during creation for IAM eventual consistency

### DIFF
--- a/aws/resource_aws_eks_cluster.go
+++ b/aws/resource_aws_eks_cluster.go
@@ -192,6 +192,10 @@ func resourceAwsEksClusterCreate(d *schema.ResourceData, meta interface{}) error
 			if isAWSErr(err, eks.ErrCodeInvalidParameterException, "does not exist") {
 				return resource.RetryableError(err)
 			}
+			// InvalidParameterException: Error in role params
+			if isAWSErr(err, eks.ErrCodeInvalidParameterException, "Error in role params") {
+				return resource.RetryableError(err)
+			}
 			if isAWSErr(err, eks.ErrCodeInvalidParameterException, "Role could not be assumed because the trusted entity is not correct") {
 				return resource.RetryableError(err)
 			}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-aws-modules/terraform-aws-eks/issues/192
Reference: https://github.com/pulumi/pulumi-eks/issues/203

Also found via unrelated acceptance testing today:

```
--- FAIL: TestAccAWSEksFargateProfile_Selector_Labels (45.33s)
    testing.go:635: Step 0 error: errors during apply:

        Error: error creating EKS Cluster (tf-acc-test-2159167537533521597): InvalidParameterException: Error in role params
        	status code: 400, request id: 8aa9f973-d1a2-42d3-8148-285f2d4477d8
```

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_eks_cluster: Handle additional `InvalidParameterException: Error in role params` error during creation for IAM eventual consistency
```

Output from acceptance testing:

```
--- PASS: TestAccAWSEksCluster_VpcConfig_SecurityGroupIds (1158.86s)
--- PASS: TestAccAWSEksCluster_basic (1199.02s)
--- PASS: TestAccAWSEksCluster_Logging (1303.33s)
--- PASS: TestAccAWSEksCluster_Tags (1303.96s)
--- PASS: TestAccAWSEksCluster_VpcConfig_EndpointPublicAccess (1662.25s)
--- PASS: TestAccAWSEksCluster_VpcConfig_EndpointPrivateAccess (2223.33s)
--- PASS: TestAccAWSEksCluster_Version (2332.93s)

--- PASS: TestAccAWSEksFargateProfile_Selector_Labels (1511.68s)
--- PASS: TestAccAWSEksFargateProfile_basic (1599.46s)
--- PASS: TestAccAWSEksFargateProfile_disappears (1663.86s)
--- PASS: TestAccAWSEksFargateProfile_Tags (1810.36s)
```
