### PR TITLE
Replace dangerous use of string slicing

### DIFF
--- a/aws/resource_aws_cloudwatch_event_permission_test.go
+++ b/aws/resource_aws_cloudwatch_event_permission_test.go
@@ -251,7 +251,7 @@ func TestAccAWSCloudWatchEventPermission_Multiple(t *testing.T) {
 func TestAccAWSCloudWatchEventPermission_Disappears(t *testing.T) {
 	resourceName := "aws_cloudwatch_event_permission.test1"
 	principal := "111111111111"
-	statementID := acctest.RandomWithPrefix(t.Name())[:64]
+	statementID := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(52, acctest.CharSetAlphaNum)) // len = 64
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -89,7 +89,7 @@ func TestAccAWSElasticSearchDomain_basic(t *testing.T) {
 
 func TestAccAWSElasticSearchDomain_ClusterConfig_ZoneAwarenessConfig(t *testing.T) {
 	var domain1, domain2, domain3, domain4 elasticsearch.ElasticsearchDomainStatus
-	rName := acctest.RandomWithPrefix("tf-acc-test")[:28]
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(16, acctest.CharSetAlphaNum)) // len = 28
 	resourceName := "aws_elasticsearch_domain.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1630,7 +1630,7 @@ resource "aws_cognito_identity_pool" "example" {
 }
 
 resource "aws_iam_role" "example" {
-	name = "tf-test-%d" 
+	name = "tf-test-%d"
 	path = "/service-role/"
 	assume_role_policy = "${data.aws_iam_policy_document.assume-role-policy.json}"
 }
@@ -1640,14 +1640,14 @@ data "aws_iam_policy_document" "assume-role-policy" {
     sid     = ""
 		actions = ["sts:AssumeRole"]
 		effect  = "Allow"
-		
+
     principals {
       type        = "Service"
       identifiers = ["es.${data.aws_partition.current.dns_suffix}"]
     }
   }
 }
-	
+
 resource "aws_iam_role_policy_attachment" "example" {
 	role       = "${aws_iam_role.example.name}"
 	policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonESCognitoAccess"
@@ -1659,7 +1659,7 @@ resource "aws_elasticsearch_domain" "test" {
 	elasticsearch_version = "6.0"
 
 	%s
-	
+
   ebs_options {
     ebs_enabled = true
     volume_size = 10


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/11138.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make test
==> Checking that code complies with gofmt requirements...
go test ./... -timeout=30s -parallel=4
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
ok  	github.com/terraform-providers/terraform-provider-aws/aws	18.652s
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	(cached)
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.140s
```
