### PR TITLE
Add SigV4 for SES SMTP passwords

### DIFF
--- a/aws/resource_aws_iam_access_key.go
+++ b/aws/resource_aws_iam_access_key.go
@@ -142,7 +142,7 @@ func resourceAwsIamAccessKeyCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	// AWS SigV2
-	sesSMTPPassword, err := sesSmtpPasswordFromSecretKeyV2(createResp.AccessKey.SecretAccessKey)
+	sesSMTPPassword, err := sesSmtpPasswordFromSecretKeySigV2(createResp.AccessKey.SecretAccessKey)
 	if err != nil {
 		return fmt.Errorf("error getting SES SMTP Password from Secret Access Key: %s", err)
 	}
@@ -153,7 +153,7 @@ func resourceAwsIamAccessKeyCreate(d *schema.ResourceData, meta interface{}) err
 		var sesSmtpPasswords []map[string]string
 
 		for _, region := range v.([]interface{}) {
-			password, err := sesSmtpPasswordFromSecretKeyV4(createResp.AccessKey.SecretAccessKey, region.(string))
+			password, err := sesSmtpPasswordFromSecretKeySigV4(createResp.AccessKey.SecretAccessKey, region.(string))
 			if err != nil {
 				return fmt.Errorf("error getting SES SMTP Password from Secret Access Key: %s", err)
 			}
@@ -263,7 +263,7 @@ func hmacSignature(key []byte, value []byte) ([]byte, error) {
 	return h.Sum(nil), nil
 }
 
-func sesSmtpPasswordFromSecretKeyV4(key *string, region string) (string, error) {
+func sesSmtpPasswordFromSecretKeySigV4(key *string, region string) (string, error) {
 	if key == nil {
 		return "", nil
 	}
@@ -297,7 +297,7 @@ func sesSmtpPasswordFromSecretKeyV4(key *string, region string) (string, error) 
 	return base64.StdEncoding.EncodeToString(versionedSig), nil
 }
 
-func sesSmtpPasswordFromSecretKeyV2(key *string) (string, error) {
+func sesSmtpPasswordFromSecretKeySigV2(key *string) (string, error) {
 	if key == nil {
 		return "", nil
 	}

--- a/aws/resource_aws_iam_access_key.go
+++ b/aws/resource_aws_iam_access_key.go
@@ -273,7 +273,7 @@ func sesSmtpPasswordFromSecretKeySigV4(key *string, region string) (string, erro
 	terminal := []byte("aws4_request")
 	message := []byte("SendRawEmail")
 
-	rawSig, err := hmacSignature([]byte("AWS4"+*key), []byte(date))
+	rawSig, err := hmacSignature([]byte("AWS4"+*key), date)
 	if err != nil {
 		return "", err
 	}

--- a/aws/resource_aws_iam_access_key_test.go
+++ b/aws/resource_aws_iam_access_key_test.go
@@ -234,7 +234,7 @@ resource "aws_iam_access_key" "a_key" {
 `, rName)
 }
 
-func TestSesSmtpPasswordFromSecretKeyV4(t *testing.T) {
+func TestSesSmtpPasswordFromSecretKeySigV4(t *testing.T) {
 	cases := []struct {
 		Region   string
 		Input    string
@@ -247,7 +247,7 @@ func TestSesSmtpPasswordFromSecretKeyV4(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		actual, err := sesSmtpPasswordFromSecretKeyV4(&tc.Input, tc.Region)
+		actual, err := sesSmtpPasswordFromSecretKeySigV4(&tc.Input, tc.Region)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -257,7 +257,7 @@ func TestSesSmtpPasswordFromSecretKeyV4(t *testing.T) {
 	}
 }
 
-func TestSesSmtpPasswordFromSecretKeyV2(t *testing.T) {
+func TestSesSmtpPasswordFromSecretKeySigV2(t *testing.T) {
 	cases := []struct {
 		Input    string
 		Expected string
@@ -267,7 +267,7 @@ func TestSesSmtpPasswordFromSecretKeyV2(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		actual, err := sesSmtpPasswordFromSecretKeyV2(&tc.Input)
+		actual, err := sesSmtpPasswordFromSecretKeySigV2(&tc.Input)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}

--- a/aws/resource_aws_iam_access_key_test.go
+++ b/aws/resource_aws_iam_access_key_test.go
@@ -234,7 +234,30 @@ resource "aws_iam_access_key" "a_key" {
 `, rName)
 }
 
-func TestSesSmtpPasswordFromSecretKey(t *testing.T) {
+func TestSesSmtpPasswordFromSecretKeyV4(t *testing.T) {
+	cases := []struct {
+		Region   string
+		Input    string
+		Expected string
+	}{
+		{"eu-central-1", "some+secret+key", "BMXhUYlu5Z3gSXVQORxlVa7XPaz91aGWdfHxvkOZdWZ2"},
+		{"eu-central-1", "another+secret+key", "BBbphbrQmrKMx42d1N6+C7VINYEBGI5v9VsZeTxwskfh"},
+		{"us-west-1", "some+secret+key", "BH+jbMzper5WwlwUar9E1ySBqHa9whi0GPo+sJ0mVYJj"},
+		{"us-west-1", "another+secret+key", "BKVmjjMDFk/qqw8EROW99bjCS65PF8WKvK5bSr4Y6EqF"},
+	}
+
+	for _, tc := range cases {
+		actual, err := sesSmtpPasswordFromSecretKeyV4(&tc.Input, tc.Region)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if actual != tc.Expected {
+			t.Fatalf("%q: expected %q, got %q", tc.Input, tc.Expected, actual)
+		}
+	}
+}
+
+func TestSesSmtpPasswordFromSecretKeyV2(t *testing.T) {
 	cases := []struct {
 		Input    string
 		Expected string
@@ -244,7 +267,7 @@ func TestSesSmtpPasswordFromSecretKey(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		actual, err := sesSmtpPasswordFromSecretKey(&tc.Input)
+		actual, err := sesSmtpPasswordFromSecretKeyV2(&tc.Input)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}

--- a/website/docs/r/iam_access_key.html.markdown
+++ b/website/docs/r/iam_access_key.html.markdown
@@ -56,12 +56,10 @@ resource "aws_iam_user" "test" {
 
 resource "aws_iam_access_key" "test" {
   user             = aws_iam_user.test.name
-  ses_smtp_regions = ["eu-central-1", "us-east-1"]
 }
 
-output "aws_iam_smtp_password_eu_central_1" {
-  value = [for ses_smtp_password in aws_iam_access_key.test.ses_smtp_passwords :
-  ses_smtp_password.secret if ses_smtp_password.region == "eu-central-1"][0]
+output "aws_iam_smtp_password_v4" {
+  value = aws_iam_access_key.test.ses_smtp_password_v4
 }
 ```
 
@@ -75,10 +73,6 @@ The following arguments are supported:
   in the `encrypted_secret` output attribute.
 * `status` - (Optional) The access key status to apply. Defaults to `Active`.
 Valid values are `Active` and `Inactive`.
-* `ses_smtp_regions` - The availability regions for the key should be converted into an SES SMTP
-  passwords by applying [AWS's documented Sigv4 conversion
-  algorithm](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-credentials.html#smtp-credentials-convert).
-  Valid values are `ap-south-1`, `ap-southeast-2`, `eu-central-1`, `eu-west-1`, `us-east-1` and `us-west-2`. See current [AWS SES regions](https://docs.aws.amazon.com/general/latest/gr/rande.html#ses_region)
 
 ## Attributes Reference
 
@@ -98,6 +92,7 @@ the use of the secret key in automation.
    for example: `terraform output encrypted_secret | base64 --decode | keybase pgp decrypt`.
 * `ses_smtp_password` - **DEPRECATED** The secret access key converted into an SES SMTP
   password by applying AWS's SigV2 conversion algorithm
-* `ses_smtp_passwords` - The secret access key converted into an SES SMTP
-  passwords for given `ses_smtp_regions` by applying [AWS's documented Sigv4 conversion
+* `ses_smtp_password_v4` - The secret access key converted into an SES SMTP
+  password by applying [AWS's documented Sigv4 conversion
   algorithm](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-credentials.html#smtp-credentials-convert).
+  As SigV4 is region specific, valid Provider regions are `ap-south-1`, `ap-southeast-2`, `eu-central-1`, `eu-west-1`, `us-east-1` and `us-west-2`. See current [AWS SES regions](https://docs.aws.amazon.com/general/latest/gr/rande.html#ses_region)

--- a/website/docs/r/iam_access_key.html.markdown
+++ b/website/docs/r/iam_access_key.html.markdown
@@ -75,7 +75,7 @@ The following arguments are supported:
   in the `encrypted_secret` output attribute.
 * `status` - (Optional) The access key status to apply. Defaults to `Active`.
 Valid values are `Active` and `Inactive`.
-* `ses_smtp_regions` - The availablity regions for the key should be converted into an SES SMTP
+* `ses_smtp_regions` - The availability regions for the key should be converted into an SES SMTP
   passwords by applying [AWS's documented Sigv4 conversion
   algorithm](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-credentials.html#smtp-credentials-convert).
   Valid values are `ap-south-1`, `ap-southeast-2`, `eu-central-1`, `eu-west-1`, `us-east-1` and `us-west-2`. See current [AWS SES regions](https://docs.aws.amazon.com/general/latest/gr/rande.html#ses_region)

--- a/website/docs/r/iam_access_key.html.markdown
+++ b/website/docs/r/iam_access_key.html.markdown
@@ -48,6 +48,23 @@ output "secret" {
 }
 ```
 
+```hcl
+resource "aws_iam_user" "test" {
+  name = "test"
+  path = "/test/"
+}
+
+resource "aws_iam_access_key" "test" {
+  user             = aws_iam_user.test.name
+  ses_smtp_regions = ["eu-central-1", "us-east-1"]
+}
+
+output "aws_iam_smtp_password_eu_central_1" {
+  value = [for ses_smtp_password in aws_iam_access_key.test.ses_smtp_passwords :
+  ses_smtp_password.secret if ses_smtp_password.region == "eu-central-1"][0]
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -58,6 +75,10 @@ The following arguments are supported:
   in the `encrypted_secret` output attribute.
 * `status` - (Optional) The access key status to apply. Defaults to `Active`.
 Valid values are `Active` and `Inactive`.
+* `ses_smtp_regions` - The availablity regions for the key should be converted into an SES SMTP
+  passwords by applying [AWS's documented Sigv4 conversion
+  algorithm](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-credentials.html#smtp-credentials-convert).
+  Valid values are `ap-south-1`, `ap-southeast-2`, `eu-central-1`, `eu-west-1`, `us-east-1` and `us-west-2`. See current [AWS SES regions](https://docs.aws.amazon.com/general/latest/gr/rande.html#ses_region)
 
 ## Attributes Reference
 
@@ -75,6 +96,8 @@ the use of the secret key in automation.
 * `encrypted_secret` - The encrypted secret, base64 encoded, if `pgp_key` was specified.
 ~> **NOTE:** The encrypted secret may be decrypted using the command line,
    for example: `terraform output encrypted_secret | base64 --decode | keybase pgp decrypt`.
-* `ses_smtp_password` - The secret access key converted into an SES SMTP
-  password by applying [AWS's documented conversion
+* `ses_smtp_password` - **DEPRECATED** The secret access key converted into an SES SMTP
+  password by applying AWS's SigV2 conversion algorithm
+* `ses_smtp_passwords` - The secret access key converted into an SES SMTP
+  passwords for given `ses_smtp_regions` by applying [AWS's documented Sigv4 conversion
   algorithm](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-credentials.html#smtp-credentials-convert).


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Closes #10903
Closes #11143
Closes #11930 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
* resource/aws_iam_access_key: add provider region specific attribute `ses_smtp_password_v4` for SigV4 support ([#11143](https://github.com/terraform-providers/terraform-provider-aws/issues/11143))

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestSesSmtpPasswordFromSecretKeySigV4'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestSesSmtpPasswordFromSecretKeySigV4 -timeout 120m
=== RUN   TestSesSmtpPasswordFromSecretKeySigV4
--- PASS: TestSesSmtpPasswordFromSecretKeySigV4 (0.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	0.024s
```
