### PR TITLE
scaling config values are not required

### DIFF
--- a/aws/resource_aws_eks_node_group.go
+++ b/aws/resource_aws_eks_node_group.go
@@ -143,17 +143,17 @@ func resourceAwsEksNodeGroup() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"desired_size": {
 							Type:         schema.TypeInt,
-							Required:     false,
+							Optional:     true,
 							ValidateFunc: validation.IntAtLeast(1),
 						},
 						"max_size": {
 							Type:         schema.TypeInt,
-							Required:     false,
+							Optional:     true,
 							ValidateFunc: validation.IntAtLeast(1),
 						},
 						"min_size": {
 							Type:         schema.TypeInt,
-							Required:     false,
+							Optional:     true,
 							ValidateFunc: validation.IntAtLeast(1),
 						},
 					},

--- a/aws/resource_aws_eks_node_group.go
+++ b/aws/resource_aws_eks_node_group.go
@@ -143,17 +143,17 @@ func resourceAwsEksNodeGroup() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"desired_size": {
 							Type:         schema.TypeInt,
-							Required:     true,
+							Required:     false,
 							ValidateFunc: validation.IntAtLeast(1),
 						},
 						"max_size": {
 							Type:         schema.TypeInt,
-							Required:     true,
+							Required:     false,
 							ValidateFunc: validation.IntAtLeast(1),
 						},
 						"min_size": {
 							Type:         schema.TypeInt,
-							Required:     true,
+							Required:     false,
 							ValidateFunc: validation.IntAtLeast(1),
 						},
 					},


### PR DESCRIPTION
These attributes are not required in the API. In particular, I don't want to put `desired_size` in my template because then every `apply` would force the cluster back to a static size.

https://docs.aws.amazon.com/eks/latest/APIReference/API_NodegroupScalingConfig.html

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Change `scaling_config` attributes of `eks_node_group` to be not required to match API.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```