### PR TITLE
resource/aws_api_gateway_usage_plan: Add tags argument and arn attribute

### DIFF
--- a/aws/resource_aws_api_gateway_usage_plan.go
+++ b/aws/resource_aws_api_gateway_usage_plan.go
@@ -7,10 +7,12 @@ import (
 	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/apigateway"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsApiGatewayUsagePlan() *schema.Resource {
@@ -107,6 +109,11 @@ func resourceAwsApiGatewayUsagePlan() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"tags": tagsSchema(),
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -197,6 +204,10 @@ func resourceAwsApiGatewayUsagePlanCreate(d *schema.ResourceData, meta interface
 		params.Throttle = ts
 	}
 
+	if v, ok := d.GetOk("tags"); ok {
+		params.Tags = keyvaluetags.New(v.(map[string]interface{})).IgnoreAws().ApigatewayTags()
+	}
+
 	up, err := conn.CreateUsagePlan(params)
 	if err != nil {
 		return fmt.Errorf("Error creating API Gateway Usage Plan: %s", err)
@@ -242,6 +253,18 @@ func resourceAwsApiGatewayUsagePlanRead(d *schema.ResourceData, meta interface{}
 		}
 		return err
 	}
+
+	if err := d.Set("tags", keyvaluetags.ApigatewayKeyValueTags(up.Tags).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Service:   "apigateway",
+		Region:    meta.(*AWSClient).region,
+		Resource:  fmt.Sprintf("/usageplans/%s", d.Id()),
+	}.String()
+	d.Set("arn", arn)
 
 	d.Set("name", up.Name)
 	d.Set("description", up.Description)
@@ -443,6 +466,13 @@ func resourceAwsApiGatewayUsagePlanUpdate(d *schema.ResourceData, meta interface
 					Value: aws.String(d["period"].(string)),
 				})
 			}
+		}
+	}
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+		if err := keyvaluetags.ApigatewayUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating tags: %s", err)
 		}
 	}
 

--- a/aws/resource_aws_api_gateway_usage_plan_test.go
+++ b/aws/resource_aws_api_gateway_usage_plan_test.go
@@ -55,6 +55,47 @@ func TestAccAWSAPIGatewayUsagePlan_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSAPIGatewayUsagePlan_tags(t *testing.T) {
+	var conf apigateway.UsagePlan
+	name := acctest.RandString(10)
+	resourceName := "aws_api_gateway_usage_plan.main"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayUsagePlanDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSApiGatewayUsagePlanBasicTags1(name, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				Config: testAccAWSApiGatewayUsagePlanBasicTags2(name, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSApiGatewayUsagePlanBasicTags1(name, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSAPIGatewayUsagePlan_description(t *testing.T) {
 	var conf apigateway.UsagePlan
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(10))
@@ -495,6 +536,31 @@ resource "aws_api_gateway_usage_plan" "test" {
   name = "%s"
 }
 `, rName)
+}
+
+func testAccAWSApiGatewayUsagePlanBasicTags1(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(testAccAWSAPIGatewayUsagePlanConfig(rName)+`
+resource "aws_api_gateway_usage_plan" "main" {
+  name = "%s"
+
+  tags = {
+	%q = %q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccAWSApiGatewayUsagePlanBasicTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(testAccAWSAPIGatewayUsagePlanConfig(rName)+`
+resource "aws_api_gateway_usage_plan" "main" {
+  name = "%s"
+
+  tags = {
+	%q = %q
+	%q = %q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
 func testAccAWSApiGatewayUsagePlanDescriptionConfig(rName string) string {

--- a/website/docs/r/api_gateway_usage_plan.html.markdown
+++ b/website/docs/r/api_gateway_usage_plan.html.markdown
@@ -69,6 +69,7 @@ The API Gateway Usage Plan argument layout is a structure composed of several su
 * `quota_settings` - (Optional) The [quota settings](#quota-settings-arguments) of the usage plan.
 * `throttle_settings` - (Optional) The [throttling limits](#throttling-settings-arguments) of the usage plan.
 * `product_code` - (Optional) The AWS Markeplace product identifier to associate with the usage plan as a SaaS product on AWS Marketplace.
+* `tags` - (Optional) Key-value mapping of resource tags
 
 #### Api Stages arguments
 
@@ -97,6 +98,7 @@ In addition to all arguments above, the following attributes are exported:
 * `quota_settings` - The quota of the usage plan.
 * `throttle_settings` - The throttling limits of the usage plan.
 * `product_code` - The AWS Markeplace product identifier to associate with the usage plan as a SaaS product on AWS Marketplace.
+* `arn` - Amazon Resource Name (ARN)
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/10566/commits/60418c6d18d1200f4617811b61fa557f5f5779c0
Closes #11146 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_api_gateway_usage_plan: Add `tags` argument and `arn` attribute
```

When performing the Squash and Merge operation on pull request #10566, GitHub silently did not add commit 60418c6d18d1200f4617811b61fa557f5f5779c0. This commit contained the actual tagging implementation for the `aws_api_gateway_usage_plan` resource.

Since @DrFaust92's fork still has the commit, I have cherry picked it on top of master and handled all merge conflicts. I had previously approved this pull request so when CI passes (acceptance testing already verified and shown below), will go ahead and merge it (for real this time, we hope).

Output from acceptance testing:

```
--- PASS: TestAccAWSAPIGatewayUsagePlan_basic (81.96s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_apiStages (147.42s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_throttlingInitialRateLimit (159.19s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_throttling (206.28s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_tags (273.42s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_quota (306.13s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_productCode (340.96s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_description (419.08s)
```
