### PR TITLE
Add `ca_cert_identifier` field to `aws_rds_cluster_instance`

### DIFF
--- a/website/docs/r/rds_cluster_instance.html.markdown
+++ b/website/docs/r/rds_cluster_instance.html.markdown
@@ -87,6 +87,7 @@ what IAM permissions are needed to allow Enhanced Monitoring for RDS Instances.
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - Amazon Resource Name (ARN) of cluster instance
+* `ca_cert_identifier` - Indicates the certificate that needs to be associated with the instance
 * `cluster_identifier` - The RDS Cluster Identifier
 * `identifier` - The Instance identifier
 * `id` - The Instance identifier


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #11142

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_rds_cluster_instance: Add `ca_cert_identifier` argument
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$  make testacc TEST=./aws TESTARGS='-run=TestAccAWSRDSClusterInstance_CACertificateIdentifier'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSRDSClusterInstance_CACertificateIdentifier -timeout 120m
=== RUN   TestAccAWSRDSClusterInstance_CACertificateIdentifier
=== PAUSE TestAccAWSRDSClusterInstance_CACertificateIdentifier
=== CONT  TestAccAWSRDSClusterInstance_CACertificateIdentifier
--- PASS: TestAccAWSRDSClusterInstance_CACertificateIdentifier (1810.16s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       1810.198s
```
