### PR TITLE
Change example instance to r5.large as r4 is no longer valid

### DIFF
--- a/website/docs/r/docdb_cluster_instance.html.markdown
+++ b/website/docs/r/docdb_cluster_instance.html.markdown
@@ -24,7 +24,7 @@ resource "aws_docdb_cluster_instance" "cluster_instances" {
   count              = 2
   identifier         = "docdb-cluster-demo-${count.index}"
   cluster_identifier = "${aws_docdb_cluster.default.id}"
-  instance_class     = "db.r4.large"
+  instance_class     = "db.r5.large"
 }
 
 resource "aws_docdb_cluster" "default" {


### PR DESCRIPTION
Was trying to create one and wondered why it wasn't working, then I found out it's not a valid instance type.
Simply fixing to use the minimum valid instance type

Closes #11166
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
