### PR TITLE
Update vendored AppStream service client to latest (v1.25.49)

### DIFF
--- a/vendor/github.com/aws/aws-sdk-go/service/appstream/service.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/appstream/service.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/client/metadata"
 	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/aws/signer/v4"
+	v4 "github.com/aws/aws-sdk-go/aws/signer/v4"
 	"github.com/aws/aws-sdk-go/private/protocol/jsonrpc"
 )
 
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "appstream2" // Name of service.
 	EndpointsID = ServiceName  // ID to lookup a service endpoint with.
-	ServiceID   = "AppStream"  // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "AppStream"  // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the AppStream client with a session.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Relates #6508

Update vendored service client for AWS AppStream 2.0. Extremely minor update but we are starting to work on implementing the appstream resources and wanted to start with this before we start submitting PRs for appstream resources.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
n/a
```
