### PR TITLE
resource/aws_appautoscaling_policy: Prevent state removal at creation

### DIFF
--- a/aws/resource_aws_appautoscaling_policy.go
+++ b/aws/resource_aws_appautoscaling_policy.go
@@ -304,6 +304,9 @@ func resourceAwsAppautoscalingPolicyRead(d *schema.ResourceData, meta interface{
 			}
 			return resource.NonRetryableError(err)
 		}
+		if d.IsNewResource() && p == nil {
+			return resource.RetryableError(&resource.NotFoundError{})
+		}
 		return nil
 	})
 	if isResourceTimeoutError(err) {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10549

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_appautoscaling_policy: Prevent state removal of resource immediately after creation due to eventual consistency ([#10549](https://github.com/terraform-providers/terraform-provider-aws/issues/10549))
```

The AWS application-autoscaling service has eventual consistency considerations. The `aws_appautoscaling_policy` resource immediately tries to read a scaling policy after creation. If the policy is not found, the application-autoscaling service returns a 200 OK with an
empty list of scaling policies. Since no scaling policy is present, the `aws_appautoscaling_policy` resource removes the created resource from state, leading to a "produced an unexpected new value for was present, but now absent" error.

With the changes in this commit, the empty list of scaling policies in the response for the newly created resource will result in a NotFoundError being returned and a retry of the read request. A
subsequent retry should hopefully be successful, leading to the state being preserved.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAppautoScalingPolicy_'
...
--- PASS: TestAccAWSAppautoScalingPolicy_multiplePoliciesSameName (34.27s)
--- PASS: TestAccAWSAppautoScalingPolicy_dynamoDb (36.59s)
--- PASS: TestAccAWSAppautoScalingPolicy_multiplePoliciesSameResource (37.73s)
--- PASS: TestAccAWSAppautoScalingPolicy_disappears (68.94s)
--- PASS: TestAccAWSAppautoScalingPolicy_basic (72.25s)
--- PASS: TestAccAWSAppautoScalingPolicy_scaleOutAndIn (74.31s)
--- PASS: TestAccAWSAppautoScalingPolicy_spotFleetRequest (77.85s)
--- PASS: TestAccAWSAppautoScalingPolicy_ResourceId_ForceNew (88.97s)
```