### PR TITLE
resource/aws_appautoscaling_policy: Support importing policies for DynamoDB table indexes

### DIFF
--- a/aws/resource_aws_appautoscaling_policy.go
+++ b/aws/resource_aws_appautoscaling_policy.go
@@ -445,9 +445,16 @@ func validateAppautoscalingPolicyImportInput(id string) ([]string, error) {
 	switch idParts[0] {
 	case "dynamodb":
 		serviceNamespace = idParts[0]
-		resourceId = strings.Join(idParts[1:3], "/")
-		scalableDimension = idParts[3]
-		policyName = strings.Join(idParts[4:], "/")
+
+		dimensionIx := 3
+		// DynamoDB resource ID can be "/table/tableName" or "/table/tableName/index/indexName"
+		if idParts[dimensionIx] == "index" {
+			dimensionIx = 5
+		}
+
+		resourceId = strings.Join(idParts[1:dimensionIx], "/")
+		scalableDimension = idParts[dimensionIx]
+		policyName = strings.Join(idParts[dimensionIx+1:], "/")
 	default:
 		serviceNamespace = idParts[0]
 		resourceId = strings.Join(idParts[1:len(idParts)-2], "/")

--- a/aws/resource_aws_appautoscaling_policy_test.go
+++ b/aws/resource_aws_appautoscaling_policy_test.go
@@ -31,6 +31,11 @@ func TestValidateAppautoscalingPolicyImportInput(t *testing.T) {
 			errorExpected: false,
 		},
 		{
+			input:         "dynamodb/table/tableName/index/indexName/dynamodb:table:ReadCapacityUnits/DynamoDBReadCapacityUtilization:table/tableName",
+			expected:      []string{"dynamodb", "table/tableName/index/indexName", "dynamodb:table:ReadCapacityUnits", "DynamoDBReadCapacityUtilization:table/tableName"},
+			errorExpected: false,
+		},
+		{
 			input:         "ec2/spot-fleet-request/sfr-d77c6508-1c1d-4e79-8789-fc019ee44c96/ec2:spot-fleet-request:TargetCapacity/test-appautoscaling-policy-ruuhd",
 			expected:      []string{"ec2", "spot-fleet-request/sfr-d77c6508-1c1d-4e79-8789-fc019ee44c96", "ec2:spot-fleet-request:TargetCapacity", "test-appautoscaling-policy-ruuhd"},
 			errorExpected: false,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
<!--- Relates OR Closes #0000 --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_appautoscaling_policy: Fix error when attempting to import a policy for a DynamoDB table index
```

The code that splits up a DynamoDB resource ID when importing an `aws_appautoscaling_policy` doesn't account for resource IDs of table indexes, resulting in an error from the AWS API when the `/index/` segment is interpreted as the scaling dimension:
```
* import aws_appautoscaling_policy.dynamodb_read_policy result: query/dynamodb:index:ReadCapacityUnits/DynamoDBReadCapacityUtilization:table/MyTable/index/MyIndex: aws_appautoscaling_policy.dynamodb_read_policy: Failed to read scaling policy: Error retrieving scaling policies: ValidationException: 1 validation error detected: Value 'index' at 'scalableDimension' failed to satisfy constraint: Member must satisfy enum value set: [dynamodb:table:ReadCapacityUnits, dynamodb:index:ReadCapacityUnits, rds:cluster:ReadReplicaCount, comprehend:document-classifier-endpoint:DesiredInferenceUnits, elasticmapreduce:instancefleet:SpotCapacity, lambda:function:ProvisionedConcurrency, appstream:fleet:DesiredCapacity, dynamodb:index:WriteCapacityUnits, elasticmapreduce:instancefleet:OnDemandCapacity, rds:cluster:Capacity, dynamodb:table:WriteCapacityUnits, custom-resource:ResourceType:Property, sagemaker:variant:DesiredInstanceCount, ec2:spot-fleet-request:TargetCapacity, elasticmapreduce:instancegroup:InstanceCount, ecs:service:DesiredCount]
        status code: 400, request id: 223fb266-1b98-11ea-a615-c57387cdd7b8
```

This PR changes the import validation code to detect when a resource ID appears to be an index ID and handle this case correctly.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS="-run=TestAccAWSAppautoScalingPolicy_dynamoDb"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSAppautoScalingPolicy_dynamoDb -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSAppautoScalingPolicy_dynamoDb
=== PAUSE TestAccAWSAppautoScalingPolicy_dynamoDb
=== CONT  TestAccAWSAppautoScalingPolicy_dynamoDb
--- PASS: TestAccAWSAppautoScalingPolicy_dynamoDb (31.01s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       31.992s
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap      0.032s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags 0.078s [no tests to run]
...
```
