### PR TITLE
resource/servicecatalog portfolio refactor to use keyvaluetags

### DIFF
--- a/aws/resource_aws_servicecatalog_portfolio.go
+++ b/aws/resource_aws_servicecatalog_portfolio.go
@@ -151,12 +151,7 @@ func resourceAwsServiceCatalogPortfolioUpdate(d *schema.ResourceData, meta inter
 		o, n := d.GetChange("tags")
 
 		input.AddTags = keyvaluetags.New(n).IgnoreAws().ServicecatalogTags()
-
-		var tagsToRemove []*string
-		for k := range keyvaluetags.New(o).IgnoreAws().Map() {
-			tagsToRemove = append(tagsToRemove, aws.String(k))
-		}
-		input.RemoveTags = tagsToRemove
+		input.RemoveTags = aws.StringSlice(keyvaluetags.New(o).IgnoreAws().Keys())
 	}
 
 	log.Printf("[DEBUG] Update Service Catalog Portfolio: %#v", input)

--- a/aws/resource_aws_servicecatalog_portfolio.go
+++ b/aws/resource_aws_servicecatalog_portfolio.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsServiceCatalogPortfolio() *schema.Resource {
@@ -65,6 +66,7 @@ func resourceAwsServiceCatalogPortfolioCreate(d *schema.ResourceData, meta inter
 		AcceptLanguage:   aws.String("en"),
 		DisplayName:      aws.String(d.Get("name").(string)),
 		IdempotencyToken: aws.String(resource.UniqueId()),
+		Tags:             keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().ServicecatalogTags(),
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -73,19 +75,6 @@ func resourceAwsServiceCatalogPortfolioCreate(d *schema.ResourceData, meta inter
 
 	if v, ok := d.GetOk("provider_name"); ok {
 		input.ProviderName = aws.String(v.(string))
-	}
-
-	if v, ok := d.GetOk("tags"); ok {
-		tags := []*servicecatalog.Tag{}
-		t := v.(map[string]interface{})
-		for k, v := range t {
-			tag := servicecatalog.Tag{
-				Key:   aws.String(k),
-				Value: aws.String(v.(string)),
-			}
-			tags = append(tags, &tag)
-		}
-		input.Tags = tags
 	}
 
 	log.Printf("[DEBUG] Creating Service Catalog Portfolio: %#v", input)
@@ -123,11 +112,11 @@ func resourceAwsServiceCatalogPortfolioRead(d *schema.ResourceData, meta interfa
 	d.Set("description", portfolioDetail.Description)
 	d.Set("name", portfolioDetail.DisplayName)
 	d.Set("provider_name", portfolioDetail.ProviderName)
-	tags := map[string]string{}
-	for _, tag := range resp.Tags {
-		tags[*tag.Key] = *tag.Value
+
+	if err := d.Set("tags", keyvaluetags.ServicecatalogKeyValueTags(resp.Tags).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
 	}
-	d.Set("tags", tags)
+
 	return nil
 }
 
@@ -159,14 +148,14 @@ func resourceAwsServiceCatalogPortfolioUpdate(d *schema.ResourceData, meta inter
 	}
 
 	if d.HasChange("tags") {
-		currentTags, requiredTags := d.GetChange("tags")
-		log.Printf("[DEBUG] Current Tags: %#v", currentTags)
-		log.Printf("[DEBUG] Required Tags: %#v", requiredTags)
+		o, n := d.GetChange("tags")
 
-		tagsToAdd, tagsToRemove := tagUpdates(requiredTags.(map[string]interface{}), currentTags.(map[string]interface{}))
-		log.Printf("[DEBUG] Tags To Add: %#v", tagsToAdd)
-		log.Printf("[DEBUG] Tags To Remove: %#v", tagsToRemove)
-		input.AddTags = tagsToAdd
+		input.AddTags = keyvaluetags.New(n).IgnoreAws().ServicecatalogTags()
+
+		var tagsToRemove []*string
+		for k := range keyvaluetags.New(o).IgnoreAws().Map() {
+			tagsToRemove = append(tagsToRemove, aws.String(k))
+		}
 		input.RemoveTags = tagsToRemove
 	}
 
@@ -176,38 +165,6 @@ func resourceAwsServiceCatalogPortfolioUpdate(d *schema.ResourceData, meta inter
 		return fmt.Errorf("Updating Service Catalog Portfolio '%s' failed: %s", *input.Id, err.Error())
 	}
 	return resourceAwsServiceCatalogPortfolioRead(d, meta)
-}
-
-func tagUpdates(requriedTags, currentTags map[string]interface{}) ([]*servicecatalog.Tag, []*string) {
-	var tagsToAdd []*servicecatalog.Tag
-	var tagsToRemove []*string
-
-	for rk, rv := range requriedTags {
-		addTag := true
-		for ck, cv := range currentTags {
-			if (rk == ck) && (rv.(string) == cv.(string)) {
-				addTag = false
-			}
-		}
-		if addTag {
-			tag := &servicecatalog.Tag{Key: aws.String(rk), Value: aws.String(rv.(string))}
-			tagsToAdd = append(tagsToAdd, tag)
-		}
-	}
-
-	for ck, cv := range currentTags {
-		removeTag := true
-		for rk, rv := range requriedTags {
-			if (rk == ck) && (rv.(string) == cv.(string)) {
-				removeTag = false
-			}
-		}
-		if removeTag {
-			tagsToRemove = append(tagsToRemove, aws.String(ck))
-		}
-	}
-
-	return tagsToAdd, tagsToRemove
 }
 
 func resourceAwsServiceCatalogPortfolioDelete(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_servicecatalog_portfolio_test.go
+++ b/aws/resource_aws_servicecatalog_portfolio_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/servicecatalog"
@@ -24,49 +25,21 @@ func TestAccAWSServiceCatalogPortfolio_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckServiceCatlaogPortfolioDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAwsServiceCatalogPortfolioResourceConfigBasic1(name),
+				Config: testAccCheckAwsServiceCatalogPortfolioResourceConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPortfolio(resourceName, &dpo),
-					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "catalog", regexp.MustCompile(`portfolio/.+`)),
 					resource.TestCheckResourceAttrSet(resourceName, "created_time"),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "description", "test-2"),
 					resource.TestCheckResourceAttr(resourceName, "provider_name", "test-3"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "Value One"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-			},
-			{
-				Config: testAccCheckAwsServiceCatalogPortfolioResourceConfigBasic2(name),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPortfolio(resourceName, &dpo),
-					resource.TestCheckResourceAttrSet(resourceName, "arn"),
-					resource.TestCheckResourceAttrSet(resourceName, "created_time"),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "description", "test-b"),
-					resource.TestCheckResourceAttr(resourceName, "provider_name", "test-c"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "Value 1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "Value Two"),
-				),
-			},
-			{
-				Config: testAccCheckAwsServiceCatalogPortfolioResourceConfigBasic3(name),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPortfolio(resourceName, &dpo),
-					resource.TestCheckResourceAttrSet(resourceName, "arn"),
-					resource.TestCheckResourceAttrSet(resourceName, "created_time"),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "description", "test-only-change-me"),
-					resource.TestCheckResourceAttr(resourceName, "provider_name", "test-c"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Key3", "Value Three"),
-				),
 			},
 		},
 	})
@@ -83,12 +56,59 @@ func TestAccAWSServiceCatalogPortfolio_Disappears(t *testing.T) {
 		CheckDestroy: testAccCheckServiceCatlaogPortfolioDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAwsServiceCatalogPortfolioResourceConfigBasic1(name),
+				Config: testAccCheckAwsServiceCatalogPortfolioResourceConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPortfolio(resourceName, &dpo),
 					testAccCheckServiceCatlaogPortfolioDisappears(&dpo),
 				),
 				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSServiceCatalogPortfolio_Tags(t *testing.T) {
+	resourceName := "aws_servicecatalog_portfolio.test"
+	name := acctest.RandString(5)
+	var dpo servicecatalog.DescribePortfolioOutput
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceCatlaogPortfolioDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsServiceCatalogPortfolioResourceConfigTags1(name, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPortfolio(resourceName, &dpo),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccCheckAwsServiceCatalogPortfolioResourceConfigTags2(name, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPortfolio(resourceName, &dpo),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccCheckAwsServiceCatalogPortfolioResourceConfigTags1(name, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPortfolio(resourceName, &dpo),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
 			},
 		},
 	})
@@ -150,45 +170,41 @@ func testAccCheckServiceCatlaogPortfolioDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAwsServiceCatalogPortfolioResourceConfigBasic1(name string) string {
+func testAccCheckAwsServiceCatalogPortfolioResourceConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "aws_servicecatalog_portfolio" "test" {
   name          = "%s"
   description   = "test-2"
   provider_name = "test-3"
-
-  tags = {
-    Key1 = "Value One"
-  }
 }
 `, name)
 }
 
-func testAccCheckAwsServiceCatalogPortfolioResourceConfigBasic2(name string) string {
+func testAccCheckAwsServiceCatalogPortfolioResourceConfigTags1(name, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_servicecatalog_portfolio" "test" {
-  name          = "%s"
+  name          = %[1]q
   description   = "test-b"
   provider_name = "test-c"
 
   tags = {
-    Key1 = "Value 1"
-    Key2 = "Value Two"
+    %[2]q = %[3]q
   }
 }
-`, name)
+`, name, tagKey1, tagValue1)
 }
 
-func testAccCheckAwsServiceCatalogPortfolioResourceConfigBasic3(name string) string {
+func testAccCheckAwsServiceCatalogPortfolioResourceConfigTags2(name, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_servicecatalog_portfolio" "test" {
-  name          = "%s"
+  name          = %[1]q
   description   = "test-only-change-me"
   provider_name = "test-c"
 
   tags = {
-    Key3 = "Value Three"
+    %[2]q = %[3]q
+    %[4]q = %[5]q
   }
 }
-`, name)
+`, name, tagKey1, tagValue1, tagKey2, tagValue2)
 }


### PR DESCRIPTION
refactor tests to check tags case separately
check format arn

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10688

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSServiceCatalogPortfolio_'
--- PASS: TestAccAWSServiceCatalogPortfolio_Basic (35.65s)
--- PASS: TestAccAWSServiceCatalogPortfolio_Disappears (29.21s)
--- PASS: TestAccAWSServiceCatalogPortfolio_Tags (99.85s)
...
```
