### PR TITLE
r/aws_codebuild_project add queued_timeout optional argument

### DIFF
--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -531,6 +531,12 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 				Default:      "60",
 				ValidateFunc: validation.IntBetween(5, 480),
 			},
+			"queued_timeout": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      "480",
+				ValidateFunc: validation.IntBetween(5, 480),
+			},
 			"badge_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -635,6 +641,10 @@ func resourceAwsCodeBuildProjectCreate(d *schema.ResourceData, meta interface{})
 
 	if v, ok := d.GetOk("build_timeout"); ok {
 		params.TimeoutInMinutes = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("queued_timeout"); ok {
+		params.QueuedTimeoutInMinutes = aws.Int64(int64(v.(int)))
 	}
 
 	if v, ok := d.GetOk("vpc_config"); ok {
@@ -1066,6 +1076,7 @@ func resourceAwsCodeBuildProjectRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("name", project.Name)
 	d.Set("service_role", project.ServiceRole)
 	d.Set("build_timeout", project.TimeoutInMinutes)
+	d.Set("queued_timeout", project.QueuedTimeoutInMinutes)
 	if project.Badge != nil {
 		d.Set("badge_enabled", project.Badge.BadgeEnabled)
 		d.Set("badge_url", project.Badge.BadgeRequestUrl)
@@ -1146,6 +1157,10 @@ func resourceAwsCodeBuildProjectUpdate(d *schema.ResourceData, meta interface{})
 
 	if d.HasChange("build_timeout") {
 		params.TimeoutInMinutes = aws.Int64(int64(d.Get("build_timeout").(int)))
+	}
+
+	if d.HasChange("queued_timeout") {
+		params.QueuedTimeoutInMinutes = aws.Int64(int64(d.Get("queued_timeout").(int)))
 	}
 
 	if d.HasChange("badge_enabled") {

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -57,6 +57,7 @@ func TestAccAWSCodeBuildProject_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "artifacts.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "badge_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "build_timeout", "60"),
+					resource.TestCheckResourceAttr(resourceName, "queued_timeout", "480"),
 					resource.TestCheckResourceAttr(resourceName, "cache.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "cache.0.type", "NO_CACHE"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
@@ -145,6 +146,39 @@ func TestAccAWSCodeBuildProject_BuildTimeout(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "build_timeout", "240"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeBuildProject_QueuedTimeout(t *testing.T) {
+	var project codebuild.Project
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_codebuild_project.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCodeBuild(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeBuildProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodeBuildProjectConfig_QueuedTimeout(rName, 120),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
+					resource.TestCheckResourceAttr(resourceName, "queued_timeout", "120"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSCodeBuildProjectConfig_QueuedTimeout(rName, 240),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
+					resource.TestCheckResourceAttr(resourceName, "queued_timeout", "240"),
 				),
 			},
 		},
@@ -2017,6 +2051,31 @@ func testAccAWSCodeBuildProjectConfig_BuildTimeout(rName string, buildTimeout in
 	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   build_timeout = %d
+  name          = "%s"
+  service_role  = "${aws_iam_role.test.arn}"
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = "2"
+    type         = "LINUX_CONTAINER"
+  }
+
+  source {
+    type     = "GITHUB"
+    location = "https://github.com/hashicorp/packer.git"
+  }
+}
+`, buildTimeout, rName)
+}
+
+func testAccAWSCodeBuildProjectConfig_QueuedTimeout(rName string, queuedTimeout int) string {
+	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+resource "aws_codebuild_project" "test" {
+  queued_timeout = %d
   name          = "%s"
   service_role  = "${aws_iam_role.test.arn}"
 

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -2094,7 +2094,7 @@ resource "aws_codebuild_project" "test" {
     location = "https://github.com/hashicorp/packer.git"
   }
 }
-`, buildTimeout, rName)
+`, queuedTimeout, rName)
 }
 
 func testAccAWSCodeBuildProjectConfig_Cache(rName, cacheLocation, cacheType string) string {

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -222,7 +222,7 @@ The following arguments are supported:
 * `source` - (Required) Information about the project's input source code. Source blocks are documented below.
 * `badge_enabled` - (Optional) Generates a publicly-accessible URL for the projects build badge. Available as `badge_url` attribute when enabled.
 * `build_timeout` - (Optional) How long in minutes, from 5 to 480 (8 hours), for AWS CodeBuild to wait until timing out any related build that does not get marked as completed. The default is 60 minutes.
-* `queued_timeout` - (Optional) The number of minutes, from 5 to 480 (8 hours), a build is allowed to be queued before it times out. The default is 8 hours.
+* `queued_timeout` - (Optional) How long in minutes, from 5 to 480 (8 hours), a build is allowed to be queued before it times out. The default is 8 hours.
 * `cache` - (Optional) Information about the cache storage for the project. Cache blocks are documented below.
 * `description` - (Optional) A short description of the project.
 * `encryption_key` - (Optional) The AWS Key Management Service (AWS KMS) customer master key (CMK) to be used for encrypting the build project's build output artifacts.

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -172,9 +172,11 @@ resource "aws_codebuild_project" "example" {
 }
 
 resource "aws_codebuild_project" "project-with-cache" {
-  name          = "test-project-cache"
-  description   = "test_codebuild_project_cache"
-  build_timeout = "5"
+  name           = "test-project-cache"
+  description    = "test_codebuild_project_cache"
+  build_timeout  = "5"
+  queued_timeout = "5"
+  
   service_role  = "${aws_iam_role.example.arn}"
 
   artifacts {
@@ -220,6 +222,7 @@ The following arguments are supported:
 * `source` - (Required) Information about the project's input source code. Source blocks are documented below.
 * `badge_enabled` - (Optional) Generates a publicly-accessible URL for the projects build badge. Available as `badge_url` attribute when enabled.
 * `build_timeout` - (Optional) How long in minutes, from 5 to 480 (8 hours), for AWS CodeBuild to wait until timing out any related build that does not get marked as completed. The default is 60 minutes.
+* `queued_timeout` - (Optional) The number of minutes, from 5 to 480 (8 hours), a build is allowed to be queued before it times out. The default is 8 hours.
 * `cache` - (Optional) Information about the cache storage for the project. Cache blocks are documented below.
 * `description` - (Optional) A short description of the project.
 * `encryption_key` - (Optional) The AWS Key Management Service (AWS KMS) customer master key (CMK) to be used for encrypting the build project's build output artifacts.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11213

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_codebuild_project: Add queued_timeout option on resource (#11213)
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCodeBuildProject'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCodeBuildProject -timeout 120m
=== RUN   TestAccAWSCodeBuildProject_basic
=== PAUSE TestAccAWSCodeBuildProject_basic
=== RUN   TestAccAWSCodeBuildProject_BadgeEnabled
=== PAUSE TestAccAWSCodeBuildProject_BadgeEnabled
=== RUN   TestAccAWSCodeBuildProject_BuildTimeout
=== PAUSE TestAccAWSCodeBuildProject_BuildTimeout
=== RUN   TestAccAWSCodeBuildProject_QueuedTimeout
=== PAUSE TestAccAWSCodeBuildProject_QueuedTimeout
=== RUN   TestAccAWSCodeBuildProject_Cache
=== PAUSE TestAccAWSCodeBuildProject_Cache
=== RUN   TestAccAWSCodeBuildProject_Description
=== PAUSE TestAccAWSCodeBuildProject_Description
=== RUN   TestAccAWSCodeBuildProject_EncryptionKey
=== PAUSE TestAccAWSCodeBuildProject_EncryptionKey
=== RUN   TestAccAWSCodeBuildProject_Environment_EnvironmentVariable
=== PAUSE TestAccAWSCodeBuildProject_Environment_EnvironmentVariable
=== RUN   TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type
=== PAUSE TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type
=== RUN   TestAccAWSCodeBuildProject_Environment_Certificate
=== PAUSE TestAccAWSCodeBuildProject_Environment_Certificate
=== RUN   TestAccAWSCodeBuildProject_LogsConfig_CloudWatchLogs
=== PAUSE TestAccAWSCodeBuildProject_LogsConfig_CloudWatchLogs
=== RUN   TestAccAWSCodeBuildProject_LogsConfig_S3Logs
=== PAUSE TestAccAWSCodeBuildProject_LogsConfig_S3Logs
=== RUN   TestAccAWSCodeBuildProject_Source_Auth
=== PAUSE TestAccAWSCodeBuildProject_Source_Auth
=== RUN   TestAccAWSCodeBuildProject_Source_GitCloneDepth
=== PAUSE TestAccAWSCodeBuildProject_Source_GitCloneDepth
=== RUN   TestAccAWSCodeBuildProject_Source_InsecureSSL
=== PAUSE TestAccAWSCodeBuildProject_Source_InsecureSSL
=== RUN   TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket
=== PAUSE TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket
=== RUN   TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub
=== PAUSE TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub
=== RUN   TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise
=== PAUSE TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise
=== RUN   TestAccAWSCodeBuildProject_Source_Type_Bitbucket
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_Bitbucket
=== RUN   TestAccAWSCodeBuildProject_Source_Type_CodeCommit
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_CodeCommit
=== RUN   TestAccAWSCodeBuildProject_Source_Type_CodePipeline
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_CodePipeline
=== RUN   TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise
=== RUN   TestAccAWSCodeBuildProject_Source_Type_S3
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_S3
=== RUN   TestAccAWSCodeBuildProject_Source_Type_NoSource
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_NoSource
=== RUN   TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid
=== RUN   TestAccAWSCodeBuildProject_Tags
=== PAUSE TestAccAWSCodeBuildProject_Tags
=== RUN   TestAccAWSCodeBuildProject_VpcConfig
=== PAUSE TestAccAWSCodeBuildProject_VpcConfig
=== RUN   TestAccAWSCodeBuildProject_WindowsContainer
=== PAUSE TestAccAWSCodeBuildProject_WindowsContainer
=== RUN   TestAccAWSCodeBuildProject_ARMContainer
=== PAUSE TestAccAWSCodeBuildProject_ARMContainer
=== RUN   TestAccAWSCodeBuildProject_Artifacts_ArtifactIdentifier
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_ArtifactIdentifier
=== RUN   TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled
=== RUN   TestAccAWSCodeBuildProject_Artifacts_Location
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_Location
=== RUN   TestAccAWSCodeBuildProject_Artifacts_Name
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_Name
=== RUN   TestAccAWSCodeBuildProject_Artifacts_NamespaceType
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_NamespaceType
=== RUN   TestAccAWSCodeBuildProject_Artifacts_OverrideArtifactName
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_OverrideArtifactName
=== RUN   TestAccAWSCodeBuildProject_Artifacts_Packaging
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_Packaging
=== RUN   TestAccAWSCodeBuildProject_Artifacts_Path
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_Path
=== RUN   TestAccAWSCodeBuildProject_Artifacts_Type
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_Type
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_ArtifactIdentifier
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_ArtifactIdentifier
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_OverrideArtifactName
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_OverrideArtifactName
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_EncryptionDisabled
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_EncryptionDisabled
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_Location
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_Location
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_Name
--- SKIP: TestAccAWSCodeBuildProject_SecondaryArtifacts_Name (0.00s)
    resource_aws_codebuild_project_test.go:1566: Currently no solution to allow updates on name attribute
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_NamespaceType
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_NamespaceType
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_Packaging
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_Packaging
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_Path
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_Path
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_Type
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_Type
=== RUN   TestAccAWSCodeBuildProject_SecondarySources_CodeCommit
=== PAUSE TestAccAWSCodeBuildProject_SecondarySources_CodeCommit
=== RUN   TestAccAWSCodeBuildProject_Environment_RegistryCredential
=== PAUSE TestAccAWSCodeBuildProject_Environment_RegistryCredential
=== CONT  TestAccAWSCodeBuildProject_basic
=== CONT  TestAccAWSCodeBuildProject_Tags
=== CONT  TestAccAWSCodeBuildProject_Source_Type_CodePipeline
=== CONT  TestAccAWSCodeBuildProject_Source_Type_Bitbucket
=== CONT  TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid
=== CONT  TestAccAWSCodeBuildProject_Source_Type_NoSource
=== CONT  TestAccAWSCodeBuildProject_Source_Type_S3
=== CONT  TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise
=== CONT  TestAccAWSCodeBuildProject_Environment_EnvironmentVariable
=== CONT  TestAccAWSCodeBuildProject_Source_Auth
=== CONT  TestAccAWSCodeBuildProject_LogsConfig_S3Logs
=== CONT  TestAccAWSCodeBuildProject_LogsConfig_CloudWatchLogs
=== CONT  TestAccAWSCodeBuildProject_Environment_Certificate
=== CONT  TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts
=== CONT  TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise
=== CONT  TestAccAWSCodeBuildProject_Source_Type_CodeCommit
=== CONT  TestAccAWSCodeBuildProject_Environment_RegistryCredential
=== CONT  TestAccAWSCodeBuildProject_SecondarySources_CodeCommit
=== CONT  TestAccAWSCodeBuildProject_Source_GitCloneDepth
--- FAIL: TestAccAWSCodeBuildProject_Source_Auth (14.85s)
    testing.go:635: Step 1 error: errors during apply:

        Error: Error creating CodeBuild project: InvalidInputException: No Access token found, please visit AWS CodeBuild console to connect to GitHub
                status code: 400, request id: 43ffbe5c-f653-447b-9172-cba0d1d25534

          on /tmp/tf-test094521274/main.tf line 64:
          (source code not available)


=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_Type
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid (20.21s)
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_Path
--- PASS: TestAccAWSCodeBuildProject_Environment_Certificate (48.58s)
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_Packaging
--- PASS: TestAccAWSCodeBuildProject_Source_Type_Bitbucket (49.15s)
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_NamespaceType
--- PASS: TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise (51.86s)
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_Location
--- PASS: TestAccAWSCodeBuildProject_Source_Type_S3 (53.88s)
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_EncryptionDisabled
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodeCommit (58.00s)
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_OverrideArtifactName
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts (60.52s)
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_ArtifactIdentifier
--- PASS: TestAccAWSCodeBuildProject_Tags (62.36s)
=== CONT  TestAccAWSCodeBuildProject_Cache
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Type (52.24s)
=== CONT  TestAccAWSCodeBuildProject_EncryptionKey
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_CodeCommit (67.14s)
=== CONT  TestAccAWSCodeBuildProject_Description
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSource (72.31s)
=== CONT  TestAccAWSCodeBuildProject_Artifacts_Packaging
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type (77.08s)
=== CONT  TestAccAWSCodeBuildProject_Artifacts_Type
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise (89.41s)
=== CONT  TestAccAWSCodeBuildProject_Artifacts_Path
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Path (77.42s)
=== CONT  TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket
--- PASS: TestAccAWSCodeBuildProject_Source_GitCloneDepth (99.89s)
=== CONT  TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub
--- PASS: TestAccAWSCodeBuildProject_LogsConfig_CloudWatchLogs (103.25s)
=== CONT  TestAccAWSCodeBuildProject_Source_InsecureSSL
--- PASS: TestAccAWSCodeBuildProject_Environment_RegistryCredential (106.68s)
=== CONT  TestAccAWSCodeBuildProject_Artifacts_OverrideArtifactName
--- PASS: TestAccAWSCodeBuildProject_LogsConfig_S3Logs (122.75s)
=== CONT  TestAccAWSCodeBuildProject_BuildTimeout
--- PASS: TestAccAWSCodeBuildProject_Description (67.73s)
=== CONT  TestAccAWSCodeBuildProject_QueuedTimeout
--- PASS: TestAccAWSCodeBuildProject_basic (134.90s)
=== CONT  TestAccAWSCodeBuildProject_Artifacts_Name
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_OverrideArtifactName (77.02s)
=== CONT  TestAccAWSCodeBuildProject_BadgeEnabled
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_NamespaceType (85.89s)
=== CONT  TestAccAWSCodeBuildProject_Artifacts_NamespaceType
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_ArtifactIdentifier (74.53s)
=== CONT  TestAccAWSCodeBuildProject_Artifacts_ArtifactIdentifier
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Location (83.99s)
=== CONT  TestAccAWSCodeBuildProject_Artifacts_Location
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Packaging (79.45s)
=== CONT  TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_EncryptionDisabled (103.65s)
=== CONT  TestAccAWSCodeBuildProject_WindowsContainer
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodePipeline (163.04s)
=== CONT  TestAccAWSCodeBuildProject_VpcConfig


--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub (246.59s)
=== CONT  TestAccAWSCodeBuildProject_ARMContainer
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Type (269.42s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket (248.92s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Path (257.39s)
--- PASS: TestAccAWSCodeBuildProject_BadgeEnabled (221.14s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Packaging (312.59s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable (361.82s)
--- PASS: TestAccAWSCodeBuildProject_WindowsContainer (204.64s)
--- PASS: TestAccAWSCodeBuildProject_Source_InsecureSSL (262.11s)
--- PASS: TestAccAWSCodeBuildProject_BuildTimeout (242.79s)
--- PASS: TestAccAWSCodeBuildProject_QueuedTimeout (235.16s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_OverrideArtifactName (267.29s)
--- PASS: TestAccAWSCodeBuildProject_ARMContainer (45.42s)
--- PASS: TestAccAWSCodeBuildProject_EncryptionKey (324.88s)
--- PASS: TestAccAWSCodeBuildProject_Cache (331.85s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_NamespaceType (261.38s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_ArtifactIdentifier (263.16s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled (250.80s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Location (267.42s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Name (270.46s)
--- PASS: TestAccAWSCodeBuildProject_VpcConfig (253.66s)
...
```
