### PR TITLE
cognito user pool - refactor to use keyvaluetags

### DIFF
--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -796,15 +796,6 @@ func resourceAwsCognitoUserPoolRead(d *schema.ResourceData, meta interface{}) er
 func resourceAwsCognitoUserPoolUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).cognitoidpconn
 
-	arn := d.Get("arn").(string)
-	if d.HasChange("tags") {
-		o, n := d.GetChange("tags")
-
-		if err := keyvaluetags.CognitoidentityproviderUpdateTags(conn, arn, o, n); err != nil {
-			return fmt.Errorf("error updating Cognito Identity Pool (%s) tags: %s", arn, err)
-		}
-	}
-
 	params := &cognitoidentityprovider.UpdateUserPoolInput{
 		UserPoolId: aws.String(d.Id()),
 	}
@@ -936,6 +927,10 @@ func resourceAwsCognitoUserPoolUpdate(d *schema.ResourceData, meta interface{}) 
 
 	if v, ok := d.GetOk("sms_verification_message"); ok {
 		params.SmsVerificationMessage = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("tags"); ok {
+		params.UserPoolTags = keyvaluetags.New(v.(map[string]interface{})).IgnoreAws().CognitoidentityproviderTags()
 	}
 
 	log.Printf("[DEBUG] Updating Cognito User Pool: %s", params)

--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsCognitoUserPool() *schema.Resource {
@@ -653,7 +654,7 @@ func resourceAwsCognitoUserPoolCreate(d *schema.ResourceData, meta interface{}) 
 	}
 
 	if v, ok := d.GetOk("tags"); ok {
-		params.UserPoolTags = tagsFromMapGeneric(v.(map[string]interface{}))
+		params.UserPoolTags = keyvaluetags.New(v.(map[string]interface{})).IgnoreAws().CognitoidentityproviderTags()
 	}
 	log.Printf("[DEBUG] Creating Cognito User Pool: %s", params)
 
@@ -663,11 +664,11 @@ func resourceAwsCognitoUserPoolCreate(d *schema.ResourceData, meta interface{}) 
 	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		var err error
 		resp, err = conn.CreateUserPool(params)
-		if isAWSErr(err, "InvalidSmsRoleTrustRelationshipException", "Role does not have a trust relationship allowing Cognito to assume the role") {
+		if isAWSErr(err, cognitoidentityprovider.ErrCodeInvalidSmsRoleTrustRelationshipException, "Role does not have a trust relationship allowing Cognito to assume the role") {
 			log.Printf("[DEBUG] Received %s, retrying CreateUserPool", err)
 			return resource.RetryableError(err)
 		}
-		if isAWSErr(err, "InvalidSmsRoleAccessPolicyException", "Role does not have permission to publish with SNS") {
+		if isAWSErr(err, cognitoidentityprovider.ErrCodeInvalidSmsRoleAccessPolicyException, "Role does not have permission to publish with SNS") {
 			log.Printf("[DEBUG] Received %s, retrying CreateUserPool", err)
 			return resource.RetryableError(err)
 		}
@@ -698,7 +699,7 @@ func resourceAwsCognitoUserPoolRead(d *schema.ResourceData, meta interface{}) er
 	resp, err := conn.DescribeUserPool(params)
 
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "ResourceNotFoundException" {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == cognitoidentityprovider.ErrCodeResourceNotFoundException {
 			log.Printf("[WARN] Cognito User Pool %s is already gone", d.Id())
 			d.SetId("")
 			return nil
@@ -785,13 +786,24 @@ func resourceAwsCognitoUserPoolRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("creation_date", resp.UserPool.CreationDate.Format(time.RFC3339))
 	d.Set("last_modified_date", resp.UserPool.LastModifiedDate.Format(time.RFC3339))
 	d.Set("name", resp.UserPool.Name)
-	d.Set("tags", tagsToMapGeneric(resp.UserPool.UserPoolTags))
+	if err := d.Set("tags", keyvaluetags.CognitoidentityKeyValueTags(resp.UserPool.UserPoolTags).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
 
 	return nil
 }
 
 func resourceAwsCognitoUserPoolUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).cognitoidpconn
+
+	arn := d.Get("arn").(string)
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.CognitoidentityproviderUpdateTags(conn, arn, o, n); err != nil {
+			return fmt.Errorf("error updating Cognito Identity Pool (%s) tags: %s", arn, err)
+		}
+	}
 
 	params := &cognitoidentityprovider.UpdateUserPoolInput{
 		UserPoolId: aws.String(d.Id()),
@@ -926,10 +938,6 @@ func resourceAwsCognitoUserPoolUpdate(d *schema.ResourceData, meta interface{}) 
 		params.SmsVerificationMessage = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("tags"); ok {
-		params.UserPoolTags = tagsFromMapGeneric(v.(map[string]interface{}))
-	}
-
 	log.Printf("[DEBUG] Updating Cognito User Pool: %s", params)
 
 	// IAM roles & policies can take some time to propagate and be attached
@@ -937,11 +945,11 @@ func resourceAwsCognitoUserPoolUpdate(d *schema.ResourceData, meta interface{}) 
 	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		var err error
 		_, err = conn.UpdateUserPool(params)
-		if isAWSErr(err, "InvalidSmsRoleTrustRelationshipException", "Role does not have a trust relationship allowing Cognito to assume the role") {
+		if isAWSErr(err, cognitoidentityprovider.ErrCodeInvalidSmsRoleTrustRelationshipException, "Role does not have a trust relationship allowing Cognito to assume the role") {
 			log.Printf("[DEBUG] Received %s, retrying UpdateUserPool", err)
 			return resource.RetryableError(err)
 		}
-		if isAWSErr(err, "InvalidSmsRoleAccessPolicyException", "Role does not have permission to publish with SNS") {
+		if isAWSErr(err, cognitoidentityprovider.ErrCodeInvalidSmsRoleAccessPolicyException, "Role does not have permission to publish with SNS") {
 			log.Printf("[DEBUG] Received %s, retrying UpdateUserPool", err)
 			return resource.RetryableError(err)
 		}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10688

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCognitoUserPool_'
=== RUN   TestAccAWSCognitoUserPool_basic
=== PAUSE TestAccAWSCognitoUserPool_basic
=== CONT  TestAccAWSCognitoUserPool_basic
--- PASS: TestAccAWSCognitoUserPool_basic (41.45s)
=== RUN   TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration
=== PAUSE TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration
=== CONT  TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration
--- PASS: TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration (62.36s)
=== RUN   TestAccAWSCognitoUserPool_withAdvancedSecurityMode
=== PAUSE TestAccAWSCognitoUserPool_withAdvancedSecurityMode
=== CONT  TestAccAWSCognitoUserPool_withAdvancedSecurityMode
--- PASS: TestAccAWSCognitoUserPool_withAdvancedSecurityMode (84.89s)
=== RUN   TestAccAWSCognitoUserPool_withDeviceConfiguration
=== PAUSE TestAccAWSCognitoUserPool_withDeviceConfiguration
=== CONT  TestAccAWSCognitoUserPool_withDeviceConfiguration
--- PASS: TestAccAWSCognitoUserPool_withDeviceConfiguration (63.15s)
=== RUN   TestAccAWSCognitoUserPool_withEmailVerificationMessage
=== PAUSE TestAccAWSCognitoUserPool_withEmailVerificationMessage
=== CONT  TestAccAWSCognitoUserPool_withEmailVerificationMessage
--- PASS: TestAccAWSCognitoUserPool_withEmailVerificationMessage (62.89s)
=== RUN   TestAccAWSCognitoUserPool_withSmsVerificationMessage
=== PAUSE TestAccAWSCognitoUserPool_withSmsVerificationMessage
=== CONT  TestAccAWSCognitoUserPool_withSmsVerificationMessage
--- PASS: TestAccAWSCognitoUserPool_withSmsVerificationMessage (61.02s)
=== RUN   TestAccAWSCognitoUserPool_withEmailConfiguration
--- SKIP: TestAccAWSCognitoUserPool_withEmailConfiguration (0.00s)
    resource_aws_cognito_user_pool_test.go:293: 'TEST_AWS_SES_VERIFIED_EMAIL_ARN' not set, skipping test.

Test ignored.
=== RUN   TestAccAWSCognitoUserPool_withSmsConfiguration
=== PAUSE TestAccAWSCognitoUserPool_withSmsConfiguration
=== CONT  TestAccAWSCognitoUserPool_withSmsConfiguration
--- PASS: TestAccAWSCognitoUserPool_withSmsConfiguration (61.24s)
=== RUN   TestAccAWSCognitoUserPool_withSmsConfigurationUpdated
=== PAUSE TestAccAWSCognitoUserPool_withSmsConfigurationUpdated
=== CONT  TestAccAWSCognitoUserPool_withSmsConfigurationUpdated
--- PASS: TestAccAWSCognitoUserPool_withSmsConfigurationUpdated (86.01s)
=== RUN   TestAccAWSCognitoUserPool_withTags
=== PAUSE TestAccAWSCognitoUserPool_withTags
=== CONT  TestAccAWSCognitoUserPool_withTags
--- PASS: TestAccAWSCognitoUserPool_withTags (90.67s)
=== RUN   TestAccAWSCognitoUserPool_withAliasAttributes
=== PAUSE TestAccAWSCognitoUserPool_withAliasAttributes
=== CONT  TestAccAWSCognitoUserPool_withAliasAttributes
--- PASS: TestAccAWSCognitoUserPool_withAliasAttributes (65.88s)
=== RUN   TestAccAWSCognitoUserPool_withPasswordPolicy
=== PAUSE TestAccAWSCognitoUserPool_withPasswordPolicy
=== CONT  TestAccAWSCognitoUserPool_withPasswordPolicy
--- PASS: TestAccAWSCognitoUserPool_withPasswordPolicy (62.59s)
=== RUN   TestAccAWSCognitoUserPool_withLambdaConfig
=== PAUSE TestAccAWSCognitoUserPool_withLambdaConfig
=== CONT  TestAccAWSCognitoUserPool_withLambdaConfig
--- PASS: TestAccAWSCognitoUserPool_withLambdaConfig (108.54s)
=== RUN   TestAccAWSCognitoUserPool_withSchemaAttributes
=== PAUSE TestAccAWSCognitoUserPool_withSchemaAttributes
=== CONT  TestAccAWSCognitoUserPool_withSchemaAttributes
--- PASS: TestAccAWSCognitoUserPool_withSchemaAttributes (68.63s)
=== RUN   TestAccAWSCognitoUserPool_withVerificationMessageTemplate
=== PAUSE TestAccAWSCognitoUserPool_withVerificationMessageTemplate
=== CONT  TestAccAWSCognitoUserPool_withVerificationMessageTemplate
--- PASS: TestAccAWSCognitoUserPool_withVerificationMessageTemplate (61.93s)
=== RUN   TestAccAWSCognitoUserPool_update
=== PAUSE TestAccAWSCognitoUserPool_update
=== CONT  TestAccAWSCognitoUserPool_update
--- PASS: TestAccAWSCognitoUserPool_update (115.21s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	308.015s

...
```
