### PR TITLE
backup vault - refactor to use keyvaluetags

### DIFF
--- a/aws/resource_aws_backup_vault.go
+++ b/aws/resource_aws_backup_vault.go
@@ -5,11 +5,11 @@ import (
 	"log"
 	"regexp"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/backup"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsBackupVault() *schema.Resource {
@@ -29,11 +29,7 @@ func resourceAwsBackupVault() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9\-\_\.]{1,50}$`), "must consist of lowercase letters, numbers, and hyphens."),
 			},
-			"tags": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
+			"tags": tagsSchema(),
 			"kms_key_arn": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -58,10 +54,7 @@ func resourceAwsBackupVaultCreate(d *schema.ResourceData, meta interface{}) erro
 
 	input := &backup.CreateBackupVaultInput{
 		BackupVaultName: aws.String(d.Get("name").(string)),
-	}
-
-	if v, ok := d.GetOk("tags"); ok {
-		input.BackupVaultTags = tagsFromMapGeneric(v.(map[string]interface{}))
+		BackupVaultTags: keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().BackupTags(),
 	}
 
 	if v, ok := d.GetOk("kms_key_arn"); ok {
@@ -99,15 +92,11 @@ func resourceAwsBackupVaultRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("arn", resp.BackupVaultArn)
 	d.Set("recovery_points", resp.NumberOfRecoveryPoints)
 
-	tresp, err := conn.ListTags(&backup.ListTagsInput{
-		ResourceArn: aws.String(*resp.BackupVaultArn),
-	})
-
+	tags, err := keyvaluetags.BackupListTags(conn, d.Get("arn").(string))
 	if err != nil {
-		return fmt.Errorf("error retrieving Backup Vault (%s) tags: %s", aws.StringValue(resp.BackupVaultArn), err)
+		return fmt.Errorf("error listing tags for Backup Vault (%s): %s", d.Id(), err)
 	}
-
-	if err := d.Set("tags", tagsToMapGeneric(tresp.Tags)); err != nil {
+	if err := d.Set("tags", tags.IgnoreAws().Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 
@@ -118,44 +107,9 @@ func resourceAwsBackupVaultUpdate(d *schema.ResourceData, meta interface{}) erro
 	conn := meta.(*AWSClient).backupconn
 
 	if d.HasChange("tags") {
-		resourceArn := d.Get("arn").(string)
-		oraw, nraw := d.GetChange("tags")
-		create, remove := diffTagsGeneric(oraw.(map[string]interface{}), nraw.(map[string]interface{}))
-
-		if len(remove) > 0 {
-			log.Printf("[DEBUG] Removing tags: %#v", remove)
-			keys := make([]*string, 0, len(remove))
-			for k := range remove {
-				keys = append(keys, aws.String(k))
-			}
-
-			_, err := conn.UntagResource(&backup.UntagResourceInput{
-				ResourceArn: aws.String(resourceArn),
-				TagKeyList:  keys,
-			})
-			if isAWSErr(err, backup.ErrCodeResourceNotFoundException, "") {
-				log.Printf("[WARN] Backup Vault %s not found, removing from state", d.Id())
-				d.SetId("")
-				return nil
-			}
-			if err != nil {
-				return fmt.Errorf("Error removing tags for (%s): %s", d.Id(), err)
-			}
-		}
-		if len(create) > 0 {
-			log.Printf("[DEBUG] Creating tags: %#v", create)
-			_, err := conn.TagResource(&backup.TagResourceInput{
-				ResourceArn: aws.String(resourceArn),
-				Tags:        create,
-			})
-			if isAWSErr(err, backup.ErrCodeResourceNotFoundException, "") {
-				log.Printf("[WARN] Backup Vault %s not found, removing from state", d.Id())
-				d.SetId("")
-				return nil
-			}
-			if err != nil {
-				return fmt.Errorf("Error setting tags for (%s): %s", d.Id(), err)
-			}
+		o, n := d.GetChange("tags")
+		if err := keyvaluetags.BackupUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating tags for Backup Vault (%s): %s", d.Id(), err)
 		}
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10688

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsBackupVault_'
--- PASS: TestAccAwsBackupVault_basic (42.33s)
--- PASS: TestAccAwsBackupVault_withKmsKey (83.98s)
--- PASS: TestAccAwsBackupVault_withTags (91.57s)
...
```
