### PR TITLE
update minimun storage capacity size to 32GiB in resource, test, doc

### DIFF
--- a/aws/resource_aws_fsx_windows_file_system.go
+++ b/aws/resource_aws_fsx_windows_file_system.go
@@ -143,7 +143,7 @@ func resourceAwsFsxWindowsFileSystem() *schema.Resource {
 				Type:         schema.TypeInt,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.IntBetween(300, 65536),
+				ValidateFunc: validation.IntBetween(32, 65536),
 			},
 			"subnet_ids": {
 				Type:     schema.TypeSet,

--- a/aws/resource_aws_fsx_windows_file_system_test.go
+++ b/aws/resource_aws_fsx_windows_file_system_test.go
@@ -95,7 +95,7 @@ func TestAccAWSFsxWindowsFileSystem_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "self_managed_active_directory.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "skip_final_backup", "true"),
-					resource.TestCheckResourceAttr(resourceName, "storage_capacity", "300"),
+					resource.TestCheckResourceAttr(resourceName, "storage_capacity", "32"),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "throughput_capacity", "8"),
@@ -372,10 +372,10 @@ func TestAccAWSFsxWindowsFileSystem_StorageCapacity(t *testing.T) {
 		CheckDestroy: testAccCheckFsxWindowsFileSystemDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsFsxWindowsFileSystemConfigStorageCapacity(301),
+				Config: testAccAwsFsxWindowsFileSystemConfigStorageCapacity(33),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFsxWindowsFileSystemExists(resourceName, &filesystem1),
-					resource.TestCheckResourceAttr(resourceName, "storage_capacity", "301"),
+					resource.TestCheckResourceAttr(resourceName, "storage_capacity", "33"),
 				),
 			},
 			{
@@ -388,11 +388,11 @@ func TestAccAWSFsxWindowsFileSystem_StorageCapacity(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccAwsFsxWindowsFileSystemConfigStorageCapacity(302),
+				Config: testAccAwsFsxWindowsFileSystemConfigStorageCapacity(34),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFsxWindowsFileSystemExists(resourceName, &filesystem2),
 					testAccCheckFsxWindowsFileSystemRecreated(&filesystem1, &filesystem2),
-					resource.TestCheckResourceAttr(resourceName, "storage_capacity", "302"),
+					resource.TestCheckResourceAttr(resourceName, "storage_capacity", "34"),
 				),
 			},
 		},
@@ -652,7 +652,7 @@ resource "aws_fsx_windows_file_system" "test" {
   active_directory_id             = "${aws_directory_service_directory.test.id}"
   automatic_backup_retention_days = %[1]d
   skip_final_backup               = true
-  storage_capacity                = 300
+  storage_capacity                = 32
   subnet_ids                      = ["${aws_subnet.test1.id}"]
   throughput_capacity             = 8
 }
@@ -665,7 +665,7 @@ resource "aws_fsx_windows_file_system" "test" {
   active_directory_id  = "${aws_directory_service_directory.test.id}"
   copy_tags_to_backups = %[1]t
   skip_final_backup    = true
-  storage_capacity     = 300
+  storage_capacity     = 32
   subnet_ids           = ["${aws_subnet.test1.id}"]
   throughput_capacity  = 8
 }
@@ -678,7 +678,7 @@ resource "aws_fsx_windows_file_system" "test" {
   active_directory_id               = "${aws_directory_service_directory.test.id}"
   daily_automatic_backup_start_time = %[1]q
   skip_final_backup                 = true
-  storage_capacity                  = 300
+  storage_capacity                  = 32
   subnet_ids                        = ["${aws_subnet.test1.id}"]
   throughput_capacity               = 8
 }
@@ -696,7 +696,7 @@ resource "aws_fsx_windows_file_system" "test" {
   active_directory_id = "${aws_directory_service_directory.test.id}"
   kms_key_id          = "${aws_kms_key.test1.arn}"
   skip_final_backup   = true
-  storage_capacity    = 300
+  storage_capacity    = 32
   subnet_ids          = ["${aws_subnet.test1.id}"]
   throughput_capacity = 8
 }
@@ -714,7 +714,7 @@ resource "aws_fsx_windows_file_system" "test" {
   active_directory_id = "${aws_directory_service_directory.test.id}"
   kms_key_id          = "${aws_kms_key.test2.arn}"
   skip_final_backup   = true
-  storage_capacity    = 300
+  storage_capacity    = 32
   subnet_ids          = ["${aws_subnet.test1.id}"]
   throughput_capacity = 8
 }
@@ -746,7 +746,7 @@ resource "aws_fsx_windows_file_system" "test" {
   active_directory_id  = "${aws_directory_service_directory.test.id}"
   security_group_ids   = ["${aws_security_group.test1.id}"]
   skip_final_backup    = true
-  storage_capacity     = 300
+  storage_capacity     = 32
   subnet_ids           = ["${aws_subnet.test1.id}"]
   throughput_capacity  = 8
 }
@@ -797,7 +797,7 @@ resource "aws_fsx_windows_file_system" "test" {
   active_directory_id  = "${aws_directory_service_directory.test.id}"
   security_group_ids   = ["${aws_security_group.test1.id}", "${aws_security_group.test2.id}"]
   skip_final_backup    = true
-  storage_capacity     = 300
+  storage_capacity     = 32
   subnet_ids           = ["${aws_subnet.test1.id}"]
   throughput_capacity  = 8
 }
@@ -808,7 +808,7 @@ func testAccAwsFsxWindowsFileSystemConfigSelfManagedActiveDirectory() string {
 	return testAccAwsFsxWindowsFileSystemConfigBase() + fmt.Sprintf(`
 resource "aws_fsx_windows_file_system" "test" {
   skip_final_backup   = true
-  storage_capacity    = 300
+  storage_capacity    = 32
   subnet_ids          = ["${aws_subnet.test1.id}"]
   throughput_capacity = 8
 
@@ -839,7 +839,7 @@ func testAccAwsFsxWindowsFileSystemConfigSubnetIds1() string {
 resource "aws_fsx_windows_file_system" "test" {
   active_directory_id = "${aws_directory_service_directory.test.id}"
   skip_final_backup   = true
-  storage_capacity    = 300
+  storage_capacity    = 32
   subnet_ids          = ["${aws_subnet.test1.id}"]
   throughput_capacity = 8
 }
@@ -851,7 +851,7 @@ func testAccAwsFsxWindowsFileSystemConfigTags1(tagKey1, tagValue1 string) string
 resource "aws_fsx_windows_file_system" "test" {
   active_directory_id = "${aws_directory_service_directory.test.id}"
   skip_final_backup   = true
-  storage_capacity    = 300
+  storage_capacity    = 32
   subnet_ids          = ["${aws_subnet.test1.id}"]
   throughput_capacity = 8
 
@@ -867,7 +867,7 @@ func testAccAwsFsxWindowsFileSystemConfigTags2(tagKey1, tagValue1, tagKey2, tagV
 resource "aws_fsx_windows_file_system" "test" {
   active_directory_id = "${aws_directory_service_directory.test.id}"
   skip_final_backup   = true
-  storage_capacity    = 300
+  storage_capacity    = 32
   subnet_ids          = ["${aws_subnet.test1.id}"]
   throughput_capacity = 8
 
@@ -884,7 +884,7 @@ func testAccAwsFsxWindowsFileSystemConfigThroughputCapacity(throughputCapacity i
 resource "aws_fsx_windows_file_system" "test" {
   active_directory_id = "${aws_directory_service_directory.test.id}"
   skip_final_backup   = true
-  storage_capacity    = 300
+  storage_capacity    = 32
   subnet_ids          = ["${aws_subnet.test1.id}"]
   throughput_capacity = %[1]d
 }
@@ -896,7 +896,7 @@ func testAccAwsFsxWindowsFileSystemConfigWeeklyMaintenanceStartTime(weeklyMainte
 resource "aws_fsx_windows_file_system" "test" {
   active_directory_id           = "${aws_directory_service_directory.test.id}"
   skip_final_backup             = true
-  storage_capacity              = 300
+  storage_capacity              = 32
   subnet_ids                    = ["${aws_subnet.test1.id}"]
   throughput_capacity           = 8
   weekly_maintenance_start_time = %[1]q

--- a/website/docs/r/fsx_windows_file_system.html.markdown
+++ b/website/docs/r/fsx_windows_file_system.html.markdown
@@ -52,7 +52,7 @@ resource "aws_fsx_windows_file_system" "example" {
 
 The following arguments are supported:
 
-* `storage_capacity` - (Required) Storage capacity (GiB) of the file system. Minimum of 300 and maximum of 65536.
+* `storage_capacity` - (Required) Storage capacity (GiB) of the file system. Minimum of 32 and maximum of 65536.
 * `subnet_ids` - (Required) A list of IDs for the subnets that the file system will be accessible from. File systems support only one subnet. The file server is also launched in that subnet's Availability Zone.
 * `throughput_capacity` - (Required) Throughput (megabytes per second) of the file system in power of 2 increments. Minimum of `8` and maximum of `2048`.
 * `active_directory_id` - (Optional) The ID for an existing Microsoft Active Directory instance that the file system should join when it's created. Cannot be specified with `self_managed_active_directory`.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #11247

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
Updates the storage_capacity minimum size from 300GiB to 32GiB, to reflect the current options available in the AWS console.
```

Output from acceptance testing:

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSFsxWindowsFileSystem'
...
--- PASS: TestAccAWSFsxWindowsFileSystem_DailyAutomaticBackupStartTime (2782.98s)
--- PASS: TestAccAWSFsxWindowsFileSystem_AutomaticBackupRetentionDays (2849.85s)
--- PASS: TestAccAWSFsxWindowsFileSystem_basic (2854.21s)
--- PASS: TestAccAWSFsxWindowsFileSystem_WeeklyMaintenanceStartTime (2903.37s)
--- PASS: TestAccAWSFsxWindowsFileSystem_SelfManagedActiveDirectory (2966.89s)
--- PASS: TestAccAWSFsxWindowsFileSystem_Tags (3095.36s)
--- PASS: TestAccAWSFsxWindowsFileSystem_disappears (3227.16s)
--- PASS: TestAccAWSFsxWindowsFileSystem_StorageCapacity (3928.28s)
--- PASS: TestAccAWSFsxWindowsFileSystem_CopyTagsToBackups (4046.48s)
--- PASS: TestAccAWSFsxWindowsFileSystem_SecurityGroupIds (4103.13s)
--- PASS: TestAccAWSFsxWindowsFileSystem_ThroughputCapacity (4273.32s)
--- PASS: TestAccAWSFsxWindowsFileSystem_KmsKeyId (4287.93s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	4288.049s
```
