### PR TITLE
Add aws_s3_access_point resource

### DIFF
--- a/aws/data_source_aws_s3_bucket_objects_test.go
+++ b/aws/data_source_aws_s3_bucket_objects_test.go
@@ -34,6 +34,31 @@ func TestAccDataSourceAWSS3BucketObjects_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAWSS3BucketObjects_basicViaAccessPoint(t *testing.T) {
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                  func() { testAccPreCheck(t) },
+		Providers:                 testAccProviders,
+		PreventPostDestroyRefresh: true,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDataSourceS3ObjectsConfigResourcesPlusAccessPoint(rInt), // NOTE: contains no data source
+				// Does not need Check
+			},
+			{
+				Config: testAccAWSDataSourceS3ObjectsConfigBasicViaAccessPoint(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsS3ObjectsDataSourceExists("data.aws_s3_bucket_objects.yesh"),
+					resource.TestCheckResourceAttr("data.aws_s3_bucket_objects.yesh", "keys.#", "2"),
+					resource.TestCheckResourceAttr("data.aws_s3_bucket_objects.yesh", "keys.0", "arch/navajo/north_window"),
+					resource.TestCheckResourceAttr("data.aws_s3_bucket_objects.yesh", "keys.1", "arch/navajo/sand_dune"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDataSourceAWSS3BucketObjects_all(t *testing.T) {
 	rInt := acctest.RandInt()
 
@@ -256,6 +281,15 @@ resource "aws_s3_bucket_object" "object7" {
 `, randInt)
 }
 
+func testAccAWSDataSourceS3ObjectsConfigResourcesPlusAccessPoint(randInt int) string {
+	return testAccAWSDataSourceS3ObjectsConfigResources(randInt) + fmt.Sprintf(`
+resource "aws_s3_access_point" "test" {
+  bucket = "${aws_s3_bucket.objects_bucket.bucket}"
+  name   = "tf-objects-test-access-point-%[1]d"
+}
+`, randInt)
+}
+
 func testAccAWSDataSourceS3ObjectsConfigBasic(randInt int) string {
 	return fmt.Sprintf(`
 %s
@@ -266,6 +300,16 @@ data "aws_s3_bucket_objects" "yesh" {
   delimiter = "/"
 }
 `, testAccAWSDataSourceS3ObjectsConfigResources(randInt))
+}
+
+func testAccAWSDataSourceS3ObjectsConfigBasicViaAccessPoint(randInt int) string {
+	return testAccAWSDataSourceS3ObjectsConfigResourcesPlusAccessPoint(randInt) + fmt.Sprintf(`
+data "aws_s3_bucket_objects" "yesh" {
+  bucket    = "${aws_s3_access_point.test.arn}"
+  prefix    = "arch/navajo/"
+  delimiter = "/"
+}
+`)
 }
 
 func testAccAWSDataSourceS3ObjectsConfigAll(randInt int) string {

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -717,6 +717,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_ses_event_destination":                               resourceAwsSesEventDestination(),
 			"aws_ses_identity_notification_topic":                     resourceAwsSesNotificationTopic(),
 			"aws_ses_template":                                        resourceAwsSesTemplate(),
+			"aws_s3_access_point":                                     resourceAwsS3AccessPoint(),
 			"aws_s3_account_public_access_block":                      resourceAwsS3AccountPublicAccessBlock(),
 			"aws_s3_bucket":                                           resourceAwsS3Bucket(),
 			"aws_s3_bucket_policy":                                    resourceAwsS3BucketPolicy(),

--- a/aws/resource_aws_s3_access_point.go
+++ b/aws/resource_aws_s3_access_point.go
@@ -1,0 +1,359 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/s3control"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func resourceAwsS3AccessPoint() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsS3AccessPointCreate,
+		Read:   resourceAwsS3AccessPointRead,
+		Update: resourceAwsS3AccessPointUpdate,
+		Delete: resourceAwsS3AccessPointDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"account_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAwsAccountId,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"bucket": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"domain_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"has_public_access_policy": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"network_origin": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"policy": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
+			},
+			"public_access_block_configuration": {
+				Type:             schema.TypeList,
+				Optional:         true,
+				ForceNew:         true,
+				MinItems:         0,
+				MaxItems:         1,
+				DiffSuppressFunc: suppressMissingOptionalConfigurationBlock,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"block_public_acls": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+							ForceNew: true,
+						},
+						"block_public_policy": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+							ForceNew: true,
+						},
+						"ignore_public_acls": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+							ForceNew: true,
+						},
+						"restrict_public_buckets": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
+			"vpc_configuration": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MinItems: 0,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"vpc_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsS3AccessPointCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).s3controlconn
+
+	accountId := meta.(*AWSClient).accountid
+	if v, ok := d.GetOk("account_id"); ok {
+		accountId = v.(string)
+	}
+	name := d.Get("name").(string)
+
+	input := &s3control.CreateAccessPointInput{
+		AccountId:                      aws.String(accountId),
+		Bucket:                         aws.String(d.Get("bucket").(string)),
+		Name:                           aws.String(name),
+		PublicAccessBlockConfiguration: expandS3AccessPointPublicAccessBlockConfiguration(d.Get("public_access_block_configuration").([]interface{})),
+		VpcConfiguration:               expandS3AccessPointVpcConfiguration(d.Get("vpc_configuration").([]interface{})),
+	}
+
+	log.Printf("[DEBUG] Creating S3 Access Point: %s", input)
+	_, err := conn.CreateAccessPoint(input)
+	if err != nil {
+		return fmt.Errorf("error creating S3 Access Point: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("%s:%s", accountId, name))
+
+	if v, ok := d.GetOk("policy"); ok {
+		log.Printf("[DEBUG] Putting S3 Access Point policy: %s", d.Id())
+		_, err := conn.PutAccessPointPolicy(&s3control.PutAccessPointPolicyInput{
+			AccountId: aws.String(accountId),
+			Name:      aws.String(name),
+			Policy:    aws.String(v.(string)),
+		})
+
+		if err != nil {
+			return fmt.Errorf("error putting S3 Access Point (%s) policy: %s", d.Id(), err)
+		}
+	}
+
+	return resourceAwsS3AccessPointRead(d, meta)
+}
+
+func resourceAwsS3AccessPointRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).s3controlconn
+
+	accountId, name, err := s3AccessPointParseId(d.Id())
+	if err != nil {
+		return err
+	}
+
+	output, err := conn.GetAccessPoint(&s3control.GetAccessPointInput{
+		AccountId: aws.String(accountId),
+		Name:      aws.String(name),
+	})
+
+	if isAWSErr(err, "NoSuchAccessPoint", "") {
+		log.Printf("[WARN] S3 Access Point (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading S3 Access Point (%s): %s", d.Id(), err)
+	}
+
+	name = aws.StringValue(output.Name)
+	arn := arn.ARN{
+		AccountID: accountId,
+		Partition: meta.(*AWSClient).partition,
+		Region:    meta.(*AWSClient).region,
+		Resource:  fmt.Sprintf("accesspoint/%s", name),
+		Service:   "s3",
+	}
+	d.Set("account_id", accountId)
+	d.Set("arn", arn.String())
+	d.Set("bucket", output.Bucket)
+	d.Set("domain_name", fmt.Sprintf("%s-%s.s3-accesspoint.%s.amazonaws.com", name, accountId, meta.(*AWSClient).region))
+	d.Set("name", name)
+	d.Set("network_origin", output.NetworkOrigin)
+	if err := d.Set("public_access_block_configuration", flattenS3AccessPointPublicAccessBlockConfiguration(output.PublicAccessBlockConfiguration)); err != nil {
+		return fmt.Errorf("error setting public_access_block_configuration: %s", err)
+	}
+	if err := d.Set("vpc_configuration", flattenS3AccessPointVpcConfiguration(output.VpcConfiguration)); err != nil {
+		return fmt.Errorf("error setting vpc_configuration: %s", err)
+	}
+
+	policyOutput, err := conn.GetAccessPointPolicy(&s3control.GetAccessPointPolicyInput{
+		AccountId: aws.String(accountId),
+		Name:      aws.String(name),
+	})
+
+	if isAWSErr(err, "NoSuchAccessPointPolicy", "") {
+		d.Set("policy", "")
+	} else {
+		if err != nil {
+			return fmt.Errorf("error reading S3 Access Point (%s) policy: %s", d.Id(), err)
+		}
+
+		d.Set("policy", policyOutput.Policy)
+	}
+
+	policyStatusOutput, err := conn.GetAccessPointPolicyStatus(&s3control.GetAccessPointPolicyStatusInput{
+		AccountId: aws.String(accountId),
+		Name:      aws.String(name),
+	})
+
+	if isAWSErr(err, "NoSuchAccessPointPolicy", "") {
+		d.Set("has_public_access_policy", false)
+	} else {
+		if err != nil {
+			return fmt.Errorf("error reading S3 Access Point (%s) policy status: %s", d.Id(), err)
+		}
+
+		d.Set("has_public_access_policy", policyStatusOutput.PolicyStatus.IsPublic)
+	}
+
+	return nil
+}
+
+func resourceAwsS3AccessPointUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).s3controlconn
+
+	accountId, name, err := s3AccessPointParseId(d.Id())
+	if err != nil {
+		return err
+	}
+
+	if d.HasChange("policy") {
+		if v, ok := d.GetOk("policy"); ok {
+			log.Printf("[DEBUG] Putting S3 Access Point policy: %s", d.Id())
+			_, err := conn.PutAccessPointPolicy(&s3control.PutAccessPointPolicyInput{
+				AccountId: aws.String(accountId),
+				Name:      aws.String(name),
+				Policy:    aws.String(v.(string)),
+			})
+
+			if err != nil {
+				return fmt.Errorf("error putting S3 Access Point (%s) policy: %s", d.Id(), err)
+			}
+		} else {
+			log.Printf("[DEBUG] Deleting S3 Access Point policy: %s", d.Id())
+			_, err := conn.DeleteAccessPointPolicy(&s3control.DeleteAccessPointPolicyInput{
+				AccountId: aws.String(accountId),
+				Name:      aws.String(name),
+			})
+
+			if err != nil {
+				return fmt.Errorf("error deleting S3 Access Point (%s) policy: %s", d.Id(), err)
+			}
+		}
+	}
+
+	return resourceAwsS3AccessPointRead(d, meta)
+}
+
+func resourceAwsS3AccessPointDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).s3controlconn
+
+	accountId, name, err := s3AccessPointParseId(d.Id())
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Deleting S3 Access Point: %s", d.Id())
+	_, err = conn.DeleteAccessPoint(&s3control.DeleteAccessPointInput{
+		AccountId: aws.String(accountId),
+		Name:      aws.String(name),
+	})
+
+	if isAWSErr(err, "NoSuchAccessPoint", "") {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting S3 Access Point (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func s3AccessPointParseId(id string) (string, string, error) {
+	parts := strings.SplitN(id, ":", 2)
+
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("unexpected format of ID (%s), expected ACCOUNT_ID:NAME", id)
+	}
+
+	return parts[0], parts[1], nil
+}
+
+func expandS3AccessPointVpcConfiguration(vConfig []interface{}) *s3control.VpcConfiguration {
+	if len(vConfig) == 0 || vConfig[0] == nil {
+		return nil
+	}
+
+	mConfig := vConfig[0].(map[string]interface{})
+
+	return &s3control.VpcConfiguration{
+		VpcId: aws.String(mConfig["vpc_id"].(string)),
+	}
+}
+
+func flattenS3AccessPointVpcConfiguration(config *s3control.VpcConfiguration) []interface{} {
+	if config == nil {
+		return []interface{}{}
+	}
+
+	return []interface{}{map[string]interface{}{
+		"vpc_id": aws.StringValue(config.VpcId),
+	}}
+}
+
+func expandS3AccessPointPublicAccessBlockConfiguration(vConfig []interface{}) *s3control.PublicAccessBlockConfiguration {
+	if len(vConfig) == 0 || vConfig[0] == nil {
+		return nil
+	}
+
+	mConfig := vConfig[0].(map[string]interface{})
+
+	return &s3control.PublicAccessBlockConfiguration{
+		BlockPublicAcls:       aws.Bool(mConfig["block_public_acls"].(bool)),
+		BlockPublicPolicy:     aws.Bool(mConfig["block_public_policy"].(bool)),
+		IgnorePublicAcls:      aws.Bool(mConfig["ignore_public_acls"].(bool)),
+		RestrictPublicBuckets: aws.Bool(mConfig["restrict_public_buckets"].(bool)),
+	}
+}
+
+func flattenS3AccessPointPublicAccessBlockConfiguration(config *s3control.PublicAccessBlockConfiguration) []interface{} {
+	if config == nil {
+		return []interface{}{}
+	}
+
+	return []interface{}{map[string]interface{}{
+		"block_public_acls":       aws.BoolValue(config.BlockPublicAcls),
+		"block_public_policy":     aws.BoolValue(config.BlockPublicPolicy),
+		"ignore_public_acls":      aws.BoolValue(config.IgnorePublicAcls),
+		"restrict_public_buckets": aws.BoolValue(config.RestrictPublicBuckets),
+	}}
+}

--- a/aws/resource_aws_s3_access_point_test.go
+++ b/aws/resource_aws_s3_access_point_test.go
@@ -1,0 +1,577 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3control"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/jen20/awspolicyequivalence"
+)
+
+func TestAccAWSS3AccessPoint_basic(t *testing.T) {
+	var v s3control.GetAccessPointOutput
+	bucketName := acctest.RandomWithPrefix("tf-acc-test")
+	accessPointName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_s3_access_point.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3AccessPointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSS3AccessPointConfig_basic(bucketName, accessPointName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3AccessPointExists(resourceName, &v),
+					testAccCheckResourceAttrAccountID(resourceName, "account_id"),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "s3", fmt.Sprintf("accesspoint/%s", accessPointName)),
+					resource.TestCheckResourceAttr(resourceName, "bucket", bucketName),
+					testAccCheckAWSS3AccessPointDomainName(resourceName, "domain_name"),
+					resource.TestCheckResourceAttr(resourceName, "has_public_access_policy", "false"),
+					resource.TestCheckResourceAttr(resourceName, "name", accessPointName),
+					resource.TestCheckResourceAttr(resourceName, "network_origin", "Internet"),
+					resource.TestCheckResourceAttr(resourceName, "policy", ""),
+					resource.TestCheckResourceAttr(resourceName, "public_access_block_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "public_access_block_configuration.0.block_public_acls", "true"),
+					resource.TestCheckResourceAttr(resourceName, "public_access_block_configuration.0.block_public_policy", "true"),
+					resource.TestCheckResourceAttr(resourceName, "public_access_block_configuration.0.ignore_public_acls", "true"),
+					resource.TestCheckResourceAttr(resourceName, "public_access_block_configuration.0.restrict_public_buckets", "true"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_configuration.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSS3AccessPoint_disappears(t *testing.T) {
+	var v s3control.GetAccessPointOutput
+	bucketName := acctest.RandomWithPrefix("tf-acc-test")
+	accessPointName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_s3_access_point.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3AccessPointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSS3AccessPointConfig_basic(bucketName, accessPointName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3AccessPointExists(resourceName, &v),
+					testAccCheckAWSS3AccessPointDisappears(resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSS3AccessPoint_bucketDisappears(t *testing.T) {
+	var v s3control.GetAccessPointOutput
+	bucketName := acctest.RandomWithPrefix("tf-acc-test")
+	accessPointName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_s3_access_point.test"
+	bucketResourceName := "aws_s3_bucket.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3AccessPointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSS3AccessPointConfig_basic(bucketName, accessPointName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3AccessPointExists(resourceName, &v),
+					testAccCheckAWSS3DestroyBucket(bucketResourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSS3AccessPoint_Policy(t *testing.T) {
+	var v s3control.GetAccessPointOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_s3_access_point.test"
+
+	expectedPolicyText1 := func() string {
+		return fmt.Sprintf(`
+		{
+		  "Version": "2012-10-17",
+		  "Statement": [{
+			"Sid": "",
+			"Effect": "Allow",
+			"Principal": {"AWS":"*"},
+			"Action": "s3:GetObjectTagging",
+			"Resource": ["arn:%s:s3:%s:%s:accesspoint/%s/object/*"]
+		  }]
+		}
+		`, testAccGetPartition(), testAccGetRegion(), testAccGetAccountID(), rName)
+	}
+	expectedPolicyText2 := func() string {
+		return fmt.Sprintf(`
+		{
+		  "Version": "2012-10-17",
+		  "Statement": [{
+			"Sid": "",
+			"Effect": "Allow",
+			"Principal": {"AWS":"*"},
+			"Action": ["s3:GetObjectLegalHold","s3:GetObjectRetention"],
+			"Resource": ["arn:%s:s3:%s:%s:accesspoint/%s/object/*"]
+		  }]
+		}
+		`, testAccGetPartition(), testAccGetRegion(), testAccGetAccountID(), rName)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3AccessPointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSS3AccessPointConfig_policy(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3AccessPointExists(resourceName, &v),
+					testAccCheckAWSS3AccessPointHasPolicy(resourceName, expectedPolicyText1),
+					testAccCheckResourceAttrAccountID(resourceName, "account_id"),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "s3", fmt.Sprintf("accesspoint/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "bucket", rName),
+					resource.TestCheckResourceAttr(resourceName, "has_public_access_policy", "true"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "network_origin", "Internet"),
+					resource.TestCheckResourceAttr(resourceName, "public_access_block_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "public_access_block_configuration.0.block_public_acls", "true"),
+					resource.TestCheckResourceAttr(resourceName, "public_access_block_configuration.0.block_public_policy", "false"),
+					resource.TestCheckResourceAttr(resourceName, "public_access_block_configuration.0.ignore_public_acls", "true"),
+					resource.TestCheckResourceAttr(resourceName, "public_access_block_configuration.0.restrict_public_buckets", "false"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_configuration.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSS3AccessPointConfig_policyUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3AccessPointExists(resourceName, &v),
+					testAccCheckAWSS3AccessPointHasPolicy(resourceName, expectedPolicyText2),
+				),
+			},
+			{
+				Config: testAccAWSS3AccessPointConfig_noPolicy(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3AccessPointExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "has_public_access_policy", "false"),
+					resource.TestCheckResourceAttr(resourceName, "policy", ""),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSS3AccessPoint_PublicAccessBlockConfiguration(t *testing.T) {
+	var v s3control.GetAccessPointOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_s3_access_point.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3AccessPointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSS3AccessPointConfig_publicAccessBlock(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3AccessPointExists(resourceName, &v),
+					testAccCheckResourceAttrAccountID(resourceName, "account_id"),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "s3", fmt.Sprintf("accesspoint/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "bucket", rName),
+					resource.TestCheckResourceAttr(resourceName, "has_public_access_policy", "false"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "network_origin", "Internet"),
+					resource.TestCheckResourceAttr(resourceName, "policy", ""),
+					resource.TestCheckResourceAttr(resourceName, "public_access_block_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "public_access_block_configuration.0.block_public_acls", "false"),
+					resource.TestCheckResourceAttr(resourceName, "public_access_block_configuration.0.block_public_policy", "false"),
+					resource.TestCheckResourceAttr(resourceName, "public_access_block_configuration.0.ignore_public_acls", "false"),
+					resource.TestCheckResourceAttr(resourceName, "public_access_block_configuration.0.restrict_public_buckets", "false"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_configuration.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSS3AccessPoint_VpcConfiguration(t *testing.T) {
+	var v s3control.GetAccessPointOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_s3_access_point.test"
+	vpcResourceName := "aws_vpc.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3AccessPointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSS3AccessPointConfig_vpc(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3AccessPointExists(resourceName, &v),
+					testAccCheckResourceAttrAccountID(resourceName, "account_id"),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "s3", fmt.Sprintf("accesspoint/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "bucket", rName),
+					resource.TestCheckResourceAttr(resourceName, "has_public_access_policy", "false"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "network_origin", "VPC"),
+					resource.TestCheckResourceAttr(resourceName, "policy", ""),
+					resource.TestCheckResourceAttr(resourceName, "public_access_block_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "public_access_block_configuration.0.block_public_acls", "true"),
+					resource.TestCheckResourceAttr(resourceName, "public_access_block_configuration.0.block_public_policy", "true"),
+					resource.TestCheckResourceAttr(resourceName, "public_access_block_configuration.0.ignore_public_acls", "true"),
+					resource.TestCheckResourceAttr(resourceName, "public_access_block_configuration.0.restrict_public_buckets", "true"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_configuration.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_configuration.0.vpc_id", vpcResourceName, "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSS3AccessPointDisappears(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No S3 Access Point ID is set")
+		}
+
+		accountId, name, err := s3AccessPointParseId(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).s3controlconn
+
+		_, err = conn.DeleteAccessPoint(&s3control.DeleteAccessPointInput{
+			AccountId: aws.String(accountId),
+			Name:      aws.String(name),
+		})
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSS3AccessPointDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).s3controlconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_s3_access_point" {
+			continue
+		}
+
+		accountId, name, err := s3AccessPointParseId(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		_, err = conn.GetAccessPoint(&s3control.GetAccessPointInput{
+			AccountId: aws.String(accountId),
+			Name:      aws.String(name),
+		})
+		if err == nil {
+			return fmt.Errorf("S3 Access Point still exists")
+		}
+	}
+	return nil
+}
+
+func testAccCheckAWSS3AccessPointExists(n string, output *s3control.GetAccessPointOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No S3 Access Point ID is set")
+		}
+
+		accountId, name, err := s3AccessPointParseId(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).s3controlconn
+
+		resp, err := conn.GetAccessPoint(&s3control.GetAccessPointInput{
+			AccountId: aws.String(accountId),
+			Name:      aws.String(name),
+		})
+		if err != nil {
+			return err
+		}
+
+		*output = *resp
+
+		return nil
+	}
+}
+
+func testAccCheckAWSS3AccessPointDomainName(n string, key string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No S3 Access Point ID is set")
+		}
+
+		accountId, name, err := s3AccessPointParseId(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		value := fmt.Sprintf("%s-%s.s3-accesspoint.%s.amazonaws.com", name, accountId, testAccGetRegion())
+
+		return resource.TestCheckResourceAttr(n, key, value)(s)
+	}
+}
+
+func testAccCheckAWSS3AccessPointHasPolicy(n string, fn func() string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No S3 Access Point ID is set")
+		}
+
+		accountId, name, err := s3AccessPointParseId(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).s3controlconn
+
+		resp, err := conn.GetAccessPointPolicy(&s3control.GetAccessPointPolicyInput{
+			AccountId: aws.String(accountId),
+			Name:      aws.String(name),
+		})
+		if err != nil {
+			return err
+		}
+
+		actualPolicyText := *resp.Policy
+		expectedPolicyText := fn()
+
+		equivalent, err := awspolicy.PoliciesAreEquivalent(actualPolicyText, expectedPolicyText)
+		if err != nil {
+			return fmt.Errorf("Error testing policy equivalence: %s", err)
+		}
+		if !equivalent {
+			return fmt.Errorf("Non-equivalent policy error:\n\nexpected: %s\n\n     got: %s\n",
+				expectedPolicyText, actualPolicyText)
+		}
+
+		return nil
+	}
+}
+
+func testAccAWSS3AccessPointConfig_basic(bucketName, accessPointName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_access_point" "test" {
+  bucket = "${aws_s3_bucket.test.bucket}"
+  name   = %[2]q
+}
+`, bucketName, accessPointName)
+}
+
+func testAccAWSS3AccessPointConfig_policy(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_access_point" "test" {
+  bucket = "${aws_s3_bucket.test.bucket}"
+  name   = %[1]q
+  policy = "${data.aws_iam_policy_document.test.json}"
+
+  public_access_block_configuration {
+    block_public_acls       = true
+    block_public_policy     = false
+    ignore_public_acls      = true
+    restrict_public_buckets = false
+  }
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+data "aws_region" "current" {}
+
+data "aws_iam_policy_document" "test" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:GetObjectTagging",
+    ]
+
+    resources = [
+      "arn:${data.aws_partition.current.partition}:s3:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:accesspoint/%[1]s/object/*",
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+  }
+}
+`, rName)
+}
+
+func testAccAWSS3AccessPointConfig_policyUpdated(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_access_point" "test" {
+  bucket = "${aws_s3_bucket.test.bucket}"
+  name   = %[1]q
+  policy = "${data.aws_iam_policy_document.test.json}"
+
+  public_access_block_configuration {
+    block_public_acls       = true
+    block_public_policy     = false
+    ignore_public_acls      = true
+    restrict_public_buckets = false
+  }
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+data "aws_region" "current" {}
+
+data "aws_iam_policy_document" "test" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:GetObjectLegalHold",
+      "s3:GetObjectRetention"
+    ]
+
+    resources = [
+      "arn:${data.aws_partition.current.partition}:s3:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:accesspoint/%[1]s/object/*",
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+  }
+}
+`, rName)
+}
+
+func testAccAWSS3AccessPointConfig_noPolicy(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_access_point" "test" {
+  bucket = "${aws_s3_bucket.test.bucket}"
+  name   = %[1]q
+
+  public_access_block_configuration {
+    block_public_acls       = true
+    block_public_policy     = false
+    ignore_public_acls      = true
+    restrict_public_buckets = false
+  }
+}
+`, rName)
+}
+
+func testAccAWSS3AccessPointConfig_publicAccessBlock(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_access_point" "test" {
+  bucket = "${aws_s3_bucket.test.bucket}"
+  name   = %[1]q
+
+  public_access_block_configuration {
+    block_public_acls       = false
+    block_public_policy     = false
+    ignore_public_acls      = false
+    restrict_public_buckets = false
+  }
+}
+`, rName)
+}
+
+func testAccAWSS3AccessPointConfig_vpc(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_access_point" "test" {
+  bucket = "${aws_s3_bucket.test.bucket}"
+  name   = %[1]q
+
+  vpc_configuration {
+    vpc_id = "${aws_vpc.test.id}"
+  }
+}
+`, rName)
+}

--- a/aws/resource_aws_s3_bucket_object_test.go
+++ b/aws/resource_aws_s3_bucket_object_test.go
@@ -409,6 +409,44 @@ func TestAccAWSS3BucketObject_updatesWithVersioning(t *testing.T) {
 	})
 }
 
+func TestAccAWSS3BucketObject_updatesWithVersioningViaAccessPoint(t *testing.T) {
+	var originalObj, modifiedObj s3.GetObjectOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_s3_bucket_object.test"
+	accessPointResourceName := "aws_s3_access_point.test"
+
+	sourceInitial := testAccAWSS3BucketObjectCreateTempFile(t, "initial versioned object state")
+	defer os.Remove(sourceInitial)
+	sourceModified := testAccAWSS3BucketObjectCreateTempFile(t, "modified versioned object")
+	defer os.Remove(sourceInitial)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketObjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSS3BucketObjectConfig_updateableViaAccessPoint(rName, true, sourceInitial),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketObjectExists(resourceName, &originalObj),
+					testAccCheckAWSS3BucketObjectBody(&originalObj, "initial versioned object state"),
+					resource.TestCheckResourceAttrPair(resourceName, "bucket", accessPointResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "etag", "cee4407fa91906284e2a5e5e03e86b1b"),
+				),
+			},
+			{
+				Config: testAccAWSS3BucketObjectConfig_updateableViaAccessPoint(rName, true, sourceModified),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketObjectExists(resourceName, &modifiedObj),
+					testAccCheckAWSS3BucketObjectBody(&modifiedObj, "modified versioned object"),
+					resource.TestCheckResourceAttr(resourceName, "etag", "00b8c73b1b50e7cc932362c7225b8e29"),
+					testAccCheckAWSS3BucketObjectVersionIdDiffers(&modifiedObj, &originalObj),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSS3BucketObject_kms(t *testing.T) {
 	var obj s3.GetObjectOutput
 	resourceName := "aws_s3_bucket_object.object"
@@ -1232,6 +1270,30 @@ resource "aws_s3_bucket_object" "object" {
   etag   = "${filemd5("%s")}"
 }
 `, randInt, bucketVersioning, source, source)
+}
+
+func testAccAWSS3BucketObjectConfig_updateableViaAccessPoint(rName string, bucketVersioning bool, source string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+
+  versioning {
+    enabled = %[2]t
+  }
+}
+
+resource "aws_s3_access_point" "test" {
+  bucket = "${aws_s3_bucket.test.bucket}"
+  name   = %[1]q
+}
+
+resource "aws_s3_bucket_object" "test" {
+  bucket = "${aws_s3_access_point.test.arn}"
+  key    = "updateable-key"
+  source = %[3]q
+  etag   = "${filemd5(%[3]q)}"
+}
+`, rName, bucketVersioning, source)
 }
 
 func testAccAWSS3BucketObjectConfig_withKMSId(randInt int, source string) string {

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3control"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -85,6 +86,45 @@ func testSweepS3Buckets(region string) error {
 		if bucketRegion != region {
 			log.Printf("[INFO] Skipping S3 Bucket (%s) in different region: %s", name, bucketRegion)
 			continue
+		}
+
+		// "Before you can delete this bucket, you must first delete all access points associated with this bucket."
+		s3controlconn := client.(*AWSClient).s3controlconn
+
+		accountId := client.(*AWSClient).accountid
+		listAccessPointsInput := &s3control.ListAccessPointsInput{
+			AccountId: aws.String(accountId),
+			Bucket:    aws.String(name),
+		}
+		err = s3controlconn.ListAccessPointsPages(listAccessPointsInput, func(page *s3control.ListAccessPointsOutput, lastPage bool) bool {
+			if page == nil {
+				return !lastPage
+			}
+
+			for _, accessPoint := range page.AccessPointList {
+				accessPointName := aws.StringValue(accessPoint.Name)
+
+				log.Printf("[INFO] Deleting (%s) S3 Access Point: %s", name, accessPointName)
+				_, err := s3controlconn.DeleteAccessPoint(&s3control.DeleteAccessPointInput{
+					AccountId: aws.String(accountId),
+					Name:      aws.String(accessPointName),
+				})
+
+				if isAWSErr(err, "NoSuchAccessPoint", "") {
+					continue
+				}
+
+				if err != nil {
+					log.Printf("[ERROR] error deleting (%s) S3 Access Point (%s): %s", name, accessPointName, err)
+					continue
+				}
+			}
+
+			return !lastPage
+		})
+
+		if err != nil {
+			return fmt.Errorf("error listing S3 Access Points: %s", err)
 		}
 
 		input := &s3.DeleteBucketInput{

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -2561,6 +2561,9 @@
                             <a href="#">Resources</a>
                             <ul class="nav nav-auto-expand">
                                 <li>
+                                    <a href="/docs/providers/aws/r/s3_access_point.html">aws_s3_access_point</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/aws/r/s3_account_public_access_block.html">aws_s3_account_public_access_block</a>
                                 </li>
                                 <li>

--- a/website/docs/d/s3_bucket_object.html.markdown
+++ b/website/docs/d/s3_bucket_object.html.markdown
@@ -57,7 +57,7 @@ resource "aws_lambda_function" "test_lambda" {
 
 The following arguments are supported:
 
-* `bucket` - (Required) The name of the bucket to read the object from
+* `bucket` - (Required) The name of the bucket to read the object from. Alternatively, an [S3 access point](https://docs.aws.amazon.com/AmazonS3/latest/dev/using-access-points.html) ARN can be specified
 * `key` - (Required) The full path to the object inside the bucket
 * `version_id` - (Optional) Specific version ID of the object returned (defaults to latest version)
 

--- a/website/docs/d/s3_bucket_objects.html.markdown
+++ b/website/docs/d/s3_bucket_objects.html.markdown
@@ -32,7 +32,7 @@ data "aws_s3_bucket_object" "object_info" {
 
 The following arguments are supported:
 
-* `bucket` - (Required) Lists object keys in this S3 bucket
+* `bucket` - (Required) Lists object keys in this S3 bucket. Alternatively, an [S3 access point](https://docs.aws.amazon.com/AmazonS3/latest/dev/using-access-points.html) ARN can be specified
 * `prefix` - (Optional) Limits results to object keys with this prefix (Default: none)
 * `delimiter` - (Optional) A character used to group keys (Default: none)
 * `encoding_type` - (Optional) Encodes keys using this method (Default: none; besides none, only "url" can be used)

--- a/website/docs/r/s3_access_point.html.markdown
+++ b/website/docs/r/s3_access_point.html.markdown
@@ -1,0 +1,109 @@
+---
+subcategory: "S3"
+layout: "aws"
+page_title: "AWS: aws_s3_access_point"
+description: |-
+  Manages an S3 Access Point.
+---
+
+# Resource: aws_s3_access_point
+
+Provides a resource to manage an S3 Access Point.
+
+-> Advanced usage: To use a custom API endpoint for this Terraform resource, use the [`s3control` endpoint provider configuration](/docs/providers/aws/index.html#s3control), not the `s3` endpoint provider configuration.
+
+## Example Usage
+
+### Basic Usage
+
+```hcl
+data "aws_caller_identity" "current" {}
+
+resource "aws_s3_bucket" "example" {
+  bucket = "example"
+}
+
+resource "aws_s3_access_point" "example" {
+  account_id = data.aws_caller_identity.current.account_id
+  bucket     = aws_s3_bucket.example.id
+  name       = "example"
+}
+```
+
+### Access Point Restricted to a VPC
+
+```hcl
+data "aws_caller_identity" "current" {}
+
+resource "aws_s3_bucket" "example" {
+  bucket = "example"
+}
+
+resource "aws_s3_access_point" "example" {
+  account_id = data.aws_caller_identity.current.account_id
+  bucket     = aws_s3_bucket.example.id
+  name       = "example"
+
+  vpc_configuration {
+    vpc_id = aws_vpc.example.id
+  }
+}
+
+resource "aws_vpc" "example" {
+  cidr_block = "10.0.0.0/16"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `bucket` - (Required) The name of the bucket that you want to associate this access point with.
+* `name` - (Required) The name you want to assign to this access point.
+
+The following arguments are optional:
+
+* `account_id` - (Optional) The AWS account ID for the owner of the bucket for which you want to create an access point. Defaults to automatically determined account ID of the Terraform AWS provider.
+* `policy` - (Optional) A valid JSON document that specifies the policy that you want to apply to this access point.
+* `public_access_block_configuration` - (Optional) Configuration block to manage the `PublicAccessBlock` configuration that you want to apply to this Amazon S3 bucket. You can enable the configuration options in any combination. Detailed below.
+* `vpc_configuration` - (Optional) Configuration block to restrict access to this access point to requests from the specified Virtual Private Cloud (VPC). Detailed below.
+
+### public_access_block_configuration Configuration Block
+
+The following arguments are optional:
+
+* `block_public_acls` - (Optional) Whether Amazon S3 should block public ACLs for buckets in this account. Defaults to `true`. Enabling this setting does not affect existing policies or ACLs. When set to `true` causes the following behavior:
+  * PUT Bucket acl and PUT Object acl calls fail if the specified ACL is public.
+  * PUT Object calls fail if the request includes a public ACL.
+  * PUT Bucket calls fail if the request includes a public ACL.
+* `block_public_policy` - (Optional) Whether Amazon S3 should block public bucket policies for buckets in this account. Defaults to `true`. Enabling this setting does not affect existing bucket policies. When set to `true` causes Amazon S3 to:
+  * Reject calls to PUT Bucket policy if the specified bucket policy allows public access.
+* `ignore_public_acls` - (Optional) Whether Amazon S3 should ignore public ACLs for buckets in this account. Defaults to `true`. Enabling this setting does not affect the persistence of any existing ACLs and doesn't prevent new public ACLs from being set. When set to `true` causes Amazon S3 to:
+  * Ignore all public ACLs on buckets in this account and any objects that they contain.
+* `restrict_public_buckets` - (Optional) Whether Amazon S3 should restrict public bucket policies for buckets in this account. Defaults to `true`. Enabling this setting does not affect previously stored bucket policies, except that public and cross-account access within any public bucket policy, including non-public delegation to specific accounts, is blocked. When set to `true`:
+  * Only the bucket owner and AWS Services can access buckets with public policies.
+
+### vpc_configuration Configuration Block
+
+The following arguments are required:
+
+* `vpc_id` - (Required)  This access point will only allow connections from the specified VPC ID.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - Amazon Resource Name (ARN) of the S3 Access Point.
+* `domain_name` - The DNS domain name of the S3 Access Point in the format _`name`_-_`account_id`_.s3-accesspoint._region_.amazonaws.com.
+Note: S3 access points only support secure access by HTTPS. HTTP isn't supported.
+* `has_public_access_policy` - Indicates whether this access point currently has a policy that allows public access.
+* `id` - AWS account ID and access point name separated by a colon (`:`).
+* `network_origin` - Indicates whether this access point allows access from the public Internet. Values are `VPC` (the access point doesn't allow access from the public Internet) and `Internet` (the access point allows access from the public Internet, subject to the access point and bucket access policies).
+
+## Import
+
+S3 Access Points can be imported using the `account_id` and `name` separated by a colon (`:`), e.g.
+
+```
+$ terraform import aws_s3_access_point.example 123456789012:example
+```

--- a/website/docs/r/s3_bucket_object.html.markdown
+++ b/website/docs/r/s3_bucket_object.html.markdown
@@ -115,7 +115,7 @@ resource "aws_s3_bucket_object" "examplebucket_object" {
 
 The following arguments are supported:
 
-* `bucket` - (Required) The name of the bucket to put the file in.
+* `bucket` - (Required) The name of the bucket to put the file in. Alternatively, an [S3 access point](https://docs.aws.amazon.com/AmazonS3/latest/dev/using-access-points.html) ARN can be specified.
 * `key` - (Required) The name of the object once it is in the bucket.
 * `source` - (Optional, conflicts with `content` and `content_base64`) The path to a file that will be read and uploaded as raw bytes for the object content.
 * `content` - (Optional, conflicts with `source` and `content_base64`) Literal string value to use as the object content, which will be uploaded as UTF-8-encoded text.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/11123.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
**New Resource:** `aws_s3_access_point`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

#### aws_s3_access_point resource

```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSS3AccessPoint_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSS3AccessPoint_ -timeout 120m
=== RUN   TestAccAWSS3AccessPoint_basic
=== PAUSE TestAccAWSS3AccessPoint_basic
=== RUN   TestAccAWSS3AccessPoint_disappears
=== PAUSE TestAccAWSS3AccessPoint_disappears
=== RUN   TestAccAWSS3AccessPoint_bucketDisappears
=== PAUSE TestAccAWSS3AccessPoint_bucketDisappears
=== RUN   TestAccAWSS3AccessPoint_Policy
=== PAUSE TestAccAWSS3AccessPoint_Policy
=== RUN   TestAccAWSS3AccessPoint_PublicAccessBlockConfiguration
=== PAUSE TestAccAWSS3AccessPoint_PublicAccessBlockConfiguration
=== RUN   TestAccAWSS3AccessPoint_VpcConfiguration
=== PAUSE TestAccAWSS3AccessPoint_VpcConfiguration
=== CONT  TestAccAWSS3AccessPoint_basic
=== CONT  TestAccAWSS3AccessPoint_Policy
=== CONT  TestAccAWSS3AccessPoint_disappears
=== CONT  TestAccAWSS3AccessPoint_PublicAccessBlockConfiguration
=== CONT  TestAccAWSS3AccessPoint_VpcConfiguration
=== CONT  TestAccAWSS3AccessPoint_bucketDisappears
--- PASS: TestAccAWSS3AccessPoint_bucketDisappears (29.83s)
--- PASS: TestAccAWSS3AccessPoint_disappears (36.52s)
--- PASS: TestAccAWSS3AccessPoint_basic (42.12s)
--- PASS: TestAccAWSS3AccessPoint_VpcConfiguration (42.25s)
--- PASS: TestAccAWSS3AccessPoint_PublicAccessBlockConfiguration (42.33s)
--- PASS: TestAccAWSS3AccessPoint_Policy (100.66s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	100.688s
```

#### aws_s3_bucket_object resource

```console
$ $ make testacc TEST=./aws TESTARGS='-run=TestAccAWSS3BucketObject_updatesWithVersioningViaAccessPoint'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSS3BucketObject_updatesWithVersioningViaAccessPoint -timeout 120m
=== RUN   TestAccAWSS3BucketObject_updatesWithVersioningViaAccessPoint
=== PAUSE TestAccAWSS3BucketObject_updatesWithVersioningViaAccessPoint
=== CONT  TestAccAWSS3BucketObject_updatesWithVersioningViaAccessPoint
--- PASS: TestAccAWSS3BucketObject_updatesWithVersioningViaAccessPoint (72.39s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	72.440s
```

#### aws_s3_bucket_object data source

```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAWSS3BucketObject_basicViaAccessPoint'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAWSS3BucketObject_basicViaAccessPoint -timeout 120m
=== RUN   TestAccDataSourceAWSS3BucketObject_basicViaAccessPoint
=== PAUSE TestAccDataSourceAWSS3BucketObject_basicViaAccessPoint
=== CONT  TestAccDataSourceAWSS3BucketObject_basicViaAccessPoint
--- PASS: TestAccDataSourceAWSS3BucketObject_basicViaAccessPoint (44.76s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	44.792s
```

#### aws_s3_bucket_objects data source

```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAWSS3BucketObjects_basicViaAccessPoint'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAWSS3BucketObjects_basicViaAccessPoint -timeout 120m
=== RUN   TestAccDataSourceAWSS3BucketObjects_basicViaAccessPoint
=== PAUSE TestAccDataSourceAWSS3BucketObjects_basicViaAccessPoint
=== CONT  TestAccDataSourceAWSS3BucketObjects_basicViaAccessPoint
--- PASS: TestAccDataSourceAWSS3BucketObjects_basicViaAccessPoint (63.86s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	63.888s
```

#### aws_s3_bucket sweeper

```console
$ TEST=./aws SWEEP=us-west-2 SWEEPARGS=-sweep-run=aws_s3_bucket make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=us-west-2 -sweep-run=aws_s3_bucket
2019/12/14 18:15:59 [DEBUG] Running Sweepers for region (us-west-2):
2019/12/14 18:15:59 [DEBUG] Running Sweeper (aws_s3_bucket_object) in region (us-west-2)
2019/12/14 18:15:59 [INFO] Building AWS auth structure
2019/12/14 18:15:59 [INFO] Setting AWS metadata API timeout to 100ms
2019/12/14 18:16:00 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2019/12/14 18:16:00 [INFO] AWS Auth provider used: "EnvProvider"
2019/12/14 18:16:00 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/12/14 18:16:00 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/12/14 18:16:01 [INFO] Skipping S3 Bucket: 123456789012-awsmacietrail-dataevent
2019/12/14 18:16:03 [DEBUG] Sweeper (aws_s3_bucket) has dependency (aws_s3_bucket_object), running..
2019/12/14 18:16:03 [DEBUG] Sweeper (aws_s3_bucket_object) already ran in region (us-west-2)
2019/12/14 18:16:03 [DEBUG] Running Sweeper (aws_s3_bucket) in region (us-west-2)
2019/12/14 18:16:03 [INFO] Building AWS auth structure
2019/12/14 18:16:03 [INFO] Setting AWS metadata API timeout to 100ms
2019/12/14 18:16:04 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2019/12/14 18:16:04 [INFO] AWS Auth provider used: "EnvProvider"
2019/12/14 18:16:04 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/12/14 18:16:04 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/12/14 18:16:05 [INFO] Skipping S3 Bucket: 123456789012-awsmacietrail-dataevent
2019/12/14 18:16:06 [INFO] Deleting (tf-acc-ewbankkit-001) S3 Access Point: test1
2019/12/14 18:16:06 [INFO] Deleting (tf-acc-ewbankkit-001) S3 Access Point: test2
2019/12/14 18:16:07 [INFO] Deleting S3 Bucket: tf-acc-ewbankkit-001
2019/12/14 18:16:07 [DEBUG] Waiting for state to become: [success]
2019/12/14 18:16:07 Sweeper Tests ran successfully:
	- aws_s3_bucket_object
	- aws_s3_bucket
ok  	github.com/terraform-providers/terraform-provider-aws/aws	8.623s
```