### PR TITLE
r/aws_network_interface: Add an update check

### DIFF
--- a/aws/resource_aws_network_interface.go
+++ b/aws/resource_aws_network_interface.go
@@ -323,17 +323,21 @@ func resourceAwsNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{})
 		d.SetPartial("private_ips")
 	}
 
-	request := &ec2.ModifyNetworkInterfaceAttributeInput{
-		NetworkInterfaceId: aws.String(d.Id()),
-		SourceDestCheck:    &ec2.AttributeBooleanValue{Value: aws.Bool(d.Get("source_dest_check").(bool))},
-	}
+	// ModifyNetworkInterfaceAttribute needs to be called after creating an ENI
+	// since CreateNetworkInterface doesn't take SourceDeskCheck paramter.
+	if d.HasChange("source_dest_check") || d.IsNewResource() {
+		request := &ec2.ModifyNetworkInterfaceAttributeInput{
+			NetworkInterfaceId: aws.String(d.Id()),
+			SourceDestCheck:    &ec2.AttributeBooleanValue{Value: aws.Bool(d.Get("source_dest_check").(bool))},
+		}
 
-	_, err := conn.ModifyNetworkInterfaceAttribute(request)
-	if err != nil {
-		return fmt.Errorf("Failure updating ENI: %s", err)
-	}
+		_, err := conn.ModifyNetworkInterfaceAttribute(request)
+		if err != nil {
+			return fmt.Errorf("Failure updating ENI: %s", err)
+		}
 
-	d.SetPartial("source_dest_check")
+		d.SetPartial("source_dest_check")
+	}
 
 	if d.HasChange("private_ips_count") && !d.IsNewResource() {
 		o, n := d.GetChange("private_ips_count")

--- a/aws/resource_aws_network_interface.go
+++ b/aws/resource_aws_network_interface.go
@@ -324,7 +324,7 @@ func resourceAwsNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{})
 	}
 
 	// ModifyNetworkInterfaceAttribute needs to be called after creating an ENI
-	// since CreateNetworkInterface doesn't take SourceDeskCheck paramter.
+	// since CreateNetworkInterface doesn't take SourceDeskCheck parameter.
 	if d.HasChange("source_dest_check") || d.IsNewResource() {
 		request := &ec2.ModifyNetworkInterfaceAttributeInput{
 			NetworkInterfaceId: aws.String(d.Id()),


### PR DESCRIPTION
Do not call ec2:ModifyNetworkInterfaceAttribute when arguments are not
changed.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11273 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_network_interface: Do not call ec2:ModifyNetworkInterfaceAttribute when arguments are not changed.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSENI_sourceDestCheck'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSENI_sourceDestCheck -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSENI_sourceDestCheck
=== PAUSE TestAccAWSENI_sourceDestCheck
=== CONT  TestAccAWSENI_sourceDestCheck
--- PASS: TestAccAWSENI_sourceDestCheck (65.85s)
PASS                                                             
ok      github.com/terraform-providers/terraform-provider-aws/aws       65.882s
testing: warning: no tests to run                                
PASS                                                             
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap      0.032s [no tests to run]
testing: warning: no tests to run                                                                                                 
PASS                                                             
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags 0.005s [no tests to run]
```
