### PR TITLE
Updates ECS capacity providers

### DIFF
--- a/aws/resource_aws_ecs_service.go
+++ b/aws/resource_aws_ecs_service.go
@@ -63,7 +63,6 @@ func resourceAwsEcsService() *schema.Resource {
 					},
 				},
 			},
-
 			"cluster": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -429,7 +428,7 @@ func resourceAwsEcsServiceCreate(d *schema.ResourceData, meta interface{}) error
 		input.PlatformVersion = aws.String(v.(string))
 	}
 
-	input.CapacityProviderStrategy = expandEcsCapacityProviderStrategy(d.Get("capacity_provider_strategy").(*schema.Set).List())
+	input.CapacityProviderStrategy = expandEcsCapacityProviderStrategy(d.Get("capacity_provider_strategy").(*schema.Set))
 
 	loadBalancers := expandEcsLoadBalancers(d.Get("load_balancer").(*schema.Set).List())
 	if len(loadBalancers) > 0 {
@@ -738,12 +737,13 @@ func expandEcsNetworkConfiguration(nc []interface{}) *ecs.NetworkConfiguration {
 	return &ecs.NetworkConfiguration{AwsvpcConfiguration: awsVpcConfig}
 }
 
-func expandEcsCapacityProviderStrategy(cps []interface{}) []*ecs.CapacityProviderStrategyItem {
-	if len(cps) == 0 {
+func expandEcsCapacityProviderStrategy(cps *schema.Set) []*ecs.CapacityProviderStrategyItem {
+	list := cps.List()
+	if len(list) == 0 {
 		return nil
 	}
 	results := make([]*ecs.CapacityProviderStrategyItem, 0)
-	for _, raw := range cps {
+	for _, raw := range list {
 		cp := raw.(map[string]interface{})
 		ps := &ecs.CapacityProviderStrategyItem{}
 		if val, ok := cp["base"]; ok {
@@ -922,7 +922,7 @@ func resourceAwsEcsServiceUpdate(d *schema.ResourceData, meta interface{}) error
 
 	if d.HasChange("capacity_provider_strategy") {
 		updateService = true
-		input.CapacityProviderStrategy = expandEcsCapacityProviderStrategy(d.Get("capacity_provider_strategy").(*schema.Set).List())
+		input.CapacityProviderStrategy = expandEcsCapacityProviderStrategy(d.Get("capacity_provider_strategy").(*schema.Set))
 	}
 
 	if updateService {

--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -257,6 +257,31 @@ func TestAccAWSEcsService_withCapacityProviderStrategy(t *testing.T) {
 	})
 }
 
+func TestAccAWSEcsService_withMultipleCapacityProviderStrategies(t *testing.T) {
+	var service ecs.Service
+	rString := acctest.RandString(8)
+
+	clusterName := fmt.Sprintf("tf-acc-cluster-svc-w-mcps-%s", rString)
+	tdName := fmt.Sprintf("tf-acc-td-svc-w-mcps-%s", rString)
+	svcName := fmt.Sprintf("tf-acc-svc-w-mcps-%s", rString)
+	sgName := fmt.Sprintf("tf-acc-sg-svc-w-mcps-%s", rString)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEcsServiceWithMultipleCapacityProviderStrategies(clusterName, tdName, svcName, sgName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcsServiceExists("aws_ecs_service.mongo", &service),
+					resource.TestCheckResourceAttr("aws_ecs_service.mongo", "capacity_provider_strategy.#", "2"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSEcsService_withFamilyAndRevision(t *testing.T) {
 	var service ecs.Service
 	rString := acctest.RandString(8)
@@ -1303,12 +1328,88 @@ resource "aws_ecs_service" "mongo" {
 
   capacity_provider_strategy {
     capacity_provider = aws_ecs_capacity_provider.test.name
-    weight =  %d
-    base =  %d
+    weight = %d
+    base   = %d
+  }
+}
+`, providerName, clusterName, tdName, svcName, weight, base)
+}
+
+func testAccAWSEcsServiceWithMultipleCapacityProviderStrategies(clusterName, tdName, svcName, sgName string) string {
+	return testAccAWSEcsClusterCapacityProviders(clusterName) + fmt.Sprintf(`
+resource "aws_ecs_service" "mongo" {
+  name            = "%s"
+  cluster         = aws_ecs_cluster.test.id
+  task_definition = aws_ecs_task_definition.mongo.arn
+  desired_count   = 1
+  
+  network_configuration {
+    security_groups  = [aws_security_group.allow_all.id]
+    subnets          = [aws_subnet.main.id]
+    assign_public_ip = false
+  }
+
+  capacity_provider_strategy {
+    capacity_provider = "FARGATE"
+    weight            = 1
+  }
+  capacity_provider_strategy {
+    capacity_provider = "FARGATE_SPOT"
+    weight            = 1
   }
 }
 
-`, providerName, clusterName, tdName, svcName, weight, base)
+resource "aws_ecs_task_definition" "mongo" {
+  family                   = "%s"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "256"
+  memory                   = "512"
+
+  container_definitions = <<DEFINITION
+[
+  {
+    "cpu": 256,
+    "essential": true,
+    "image": "mongo:latest",
+    "memory": 512,
+    "name": "mongodb",
+    "networkMode": "awsvpc"
+  }
+]
+DEFINITION
+}
+
+resource "aws_security_group" "allow_all" {
+  name        = "%s"
+  description = "Allow all inbound traffic"
+  vpc_id      = "${aws_vpc.main.id}"
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = 80
+    to_port     = 8000
+    cidr_blocks = ["${aws_vpc.main.cidr_block}"]
+  }
+}
+
+resource "aws_subnet" "main" {
+  cidr_block        = "${cidrsubnet(aws_vpc.main.cidr_block, 8, 1)}"
+  vpc_id            = "${aws_vpc.main.id}"
+
+  tags = {
+    Name = "tf-acc-ecs-service-with-multiple-capacity-providers"
+  }
+}
+
+resource "aws_vpc" "main" {
+  cidr_block = "10.10.0.0/16"
+
+  tags = {
+    Name = "tf-acc-ecs-service-with-multiple-capacity-providers"
+  }
+}
+`, tdName, svcName, sgName)
 }
 
 func testAccAWSEcsServiceWithPlacementStrategy(clusterName, tdName, svcName string) string {

--- a/website/docs/r/ecs_cluster.html.markdown
+++ b/website/docs/r/ecs_cluster.html.markdown
@@ -24,10 +24,10 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the cluster (up to 255 letters, numbers, hyphens, and underscores)
 * `capacity_providers` - (Optional) List of short names or full Amazon Resource Names (ARNs) of one or more capacity providers to associate with the cluster. Valid values also include `FARGATE` and `FARGATE_SPOT`.
-* `default_capacity_provider_strategy` - (Optional) The capacity provider strategy to use by default for the cluster.  Defined below.
+* `default_capacity_provider_strategy` - (Optional) The capacity provider strategy to use by default for the cluster. Can be one or more.  Defined below.
 * `tags` - (Optional) Key-value mapping of resource tags
 * `setting` - (Optional) Configuration block(s) with cluster settings. For example, this can be used to enable CloudWatch Container Insights for a cluster. Defined below.
- 
+
 ## setting
 
 The `setting` configuration block supports the following:

--- a/website/docs/r/ecs_service.html.markdown
+++ b/website/docs/r/ecs_service.html.markdown
@@ -77,7 +77,7 @@ resource "aws_ecs_service" "bar" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the service (up to 255 letters, numbers, hyphens, and underscores)
-* `capacity_provider_strategy` - (Optional) The capacity provider strategy to use for the service.  Defined below.
+* `capacity_provider_strategy` - (Optional) The capacity provider strategy to use for the service. Can be one or more.  Defined below.
 * `cluster` - (Optional) ARN of an ECS cluster
 * `deployment_controller` - (Optional) Configuration block containing deployment controller configuration. Defined below.
 * `deployment_maximum_percent` - (Optional) The upper limit (as a percentage of the service's desiredCount) of the number of running tasks that can be running in a service during a deployment. Not valid when using the `DAEMON` scheduling strategy.


### PR DESCRIPTION
A handful of updates to the ECS cluster capacity provider feature.

* Removes ordering from `capacity_providers` on cluster.
* Allows more than one `default_capacity_provider_strategy` entry on cluster.
* Allows retry on cluster deletion when update is in progress.
* Adds tests for multiple capacity providers and capacity provider strategies

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates #11151

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWS\(EcsCluster\|EcsService\)_'

--- PASS: TestAccAWSEcsCapacityProvider_ManagedScalingPartial (42.92s)
--- PASS: TestAccAWSEcsCapacityProvider_basic (52.06s)
--- PASS: TestAccAWSEcsCapacityProvider_ManagedScaling (53.15s)
--- PASS: TestAccAWSEcsCapacityProvider_Tags (87.74s)
--- PASS: TestAccAWSEcsCluster_disappears (13.17s)
--- PASS: TestAccAWSEcsCluster_basic (16.83s)
--- PASS: TestAccAWSEcsCluster_containerInsights (37.46s)
--- PASS: TestAccAWSEcsCluster_Tags (40.02s)
--- PASS: TestAccAWSEcsCluster_CapacityProviders (41.82s)
--- PASS: TestAccAWSEcsCluster_CapacityProvidersUpdate (45.30s)
--- PASS: TestAccAWSEcsCluster_SingleCapacityProvider (81.06s)
--- PASS: TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration (90.58s)
--- PASS: TestAccAWSEcsService_withFamilyAndRevision (74.65s)
--- PASS: TestAccAWSEcsService_withDeploymentValues (52.48s)
--- PASS: TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion (127.47s)
--- PASS: TestAccAWSEcsService_withLaunchTypeFargate (136.79s)
--- PASS: TestAccAWSEcsService_disappears (62.31s)
--- PASS: TestAccAWSEcsService_withMultipleCapacityProviderStrategies (97.07s)
--- PASS: TestAccAWSEcsService_withRenamedCluster (142.38s)
--- PASS: TestAccAWSEcsService_basicImport (66.47s)
--- PASS: TestAccAWSEcsService_withUnnormalizedPlacementStrategy (72.07s)
--- PASS: TestAccAWSEcsService_withServiceRegistries_container (172.25s)
--- PASS: TestAccAWSEcsService_withServiceRegistries (172.26s)
--- PASS: TestAccAWSEcsService_withCapacityProviderStrategy (174.16s)
--- PASS: TestAccAWSEcsService_withIamRole (135.06s)
--- PASS: TestAccAWSEcsService_withLbChanges (229.95s)
--- PASS: TestAccAWSEcsService_withPlacementStrategy (240.13s)
--- PASS: TestAccAWSEcsService_withAlb (260.14s)
--- PASS: TestAccAWSEcsService_withDeploymentController_Type_CodeDeploy (196.20s)
--- PASS: TestAccAWSEcsService_withMultipleTargetGroups (261.46s)
--- PASS: TestAccAWSEcsService_healthCheckGracePeriodSeconds (262.02s)
--- PASS: TestAccAWSEcsService_Tags (59.62s)
--- PASS: TestAccAWSEcsService_ManagedTags (64.34s)
--- PASS: TestAccAWSEcsService_PropagateTags (194.36s)
```