### PR TITLE
aws_acm_certificate: fix subject_alternative_names forces recreation

### DIFF
--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -60,11 +60,9 @@ func resourceAwsAcmCertificate() *schema.Resource {
 				},
 			},
 			"subject_alternative_names": {
-				Type:          schema.TypeList,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"private_key", "certificate_body", "certificate_chain"},
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 					StateFunc: func(v interface{}) string {
@@ -73,6 +71,8 @@ func resourceAwsAcmCertificate() *schema.Resource {
 						return strings.TrimSuffix(v.(string), ".")
 					},
 				},
+				Set:           schema.HashString,
+				ConflictsWith: []string{"private_key", "certificate_body", "certificate_chain"},
 			},
 			"validation_method": {
 				Type:          schema.TypeString,
@@ -197,8 +197,8 @@ func resourceAwsAcmCertificateCreateRequested(d *schema.ResourceData, meta inter
 	}
 
 	if sans, ok := d.GetOk("subject_alternative_names"); ok {
-		subjectAlternativeNames := make([]*string, len(sans.([]interface{})))
-		for i, sanRaw := range sans.([]interface{}) {
+		subjectAlternativeNames := make([]*string, len(sans.(*schema.Set).List()))
+		for i, sanRaw := range sans.(*schema.Set).List() {
 			subjectAlternativeNames[i] = aws.String(strings.TrimSuffix(sanRaw.(string), "."))
 		}
 		params.SubjectAlternativeNames = subjectAlternativeNames

--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -62,6 +62,7 @@ func resourceAwsAcmCertificate() *schema.Resource {
 			"subject_alternative_names": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Reference #8531
Closes #10959
Closes #13317

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
* resource/aws_acm_certificate: Prevent ordering differences with `subject_alternative_names` argument
```

## Acceptance testing:

```
$ export AWS_PROFILE=devops
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAcmCertificate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAcmCertificate -timeout 120m
=== RUN   TestAccAWSAcmCertificateDataSource_singleIssued
=== PAUSE TestAccAWSAcmCertificateDataSource_singleIssued
=== RUN   TestAccAWSAcmCertificateDataSource_multipleIssued
=== PAUSE TestAccAWSAcmCertificateDataSource_multipleIssued
=== RUN   TestAccAWSAcmCertificateDataSource_noMatchReturnsError
=== PAUSE TestAccAWSAcmCertificateDataSource_noMatchReturnsError
=== RUN   TestAccAWSAcmCertificateDataSource_KeyTypes
=== PAUSE TestAccAWSAcmCertificateDataSource_KeyTypes
=== RUN   TestAccAWSAcmCertificate_emailValidation
=== PAUSE TestAccAWSAcmCertificate_emailValidation
=== RUN   TestAccAWSAcmCertificate_dnsValidation
=== PAUSE TestAccAWSAcmCertificate_dnsValidation
=== RUN   TestAccAWSAcmCertificate_root
=== PAUSE TestAccAWSAcmCertificate_root
=== RUN   TestAccAWSAcmCertificate_privateCert
=== PAUSE TestAccAWSAcmCertificate_privateCert
=== RUN   TestAccAWSAcmCertificate_root_TrailingPeriod
=== PAUSE TestAccAWSAcmCertificate_root_TrailingPeriod
=== RUN   TestAccAWSAcmCertificate_rootAndWildcardSan
=== PAUSE TestAccAWSAcmCertificate_rootAndWildcardSan
=== RUN   TestAccAWSAcmCertificate_san_single
=== PAUSE TestAccAWSAcmCertificate_san_single
=== RUN   TestAccAWSAcmCertificate_san_multiple
=== PAUSE TestAccAWSAcmCertificate_san_multiple
=== RUN   TestAccAWSAcmCertificate_san_TrailingPeriod
=== PAUSE TestAccAWSAcmCertificate_san_TrailingPeriod
=== RUN   TestAccAWSAcmCertificate_wildcard
=== PAUSE TestAccAWSAcmCertificate_wildcard
=== RUN   TestAccAWSAcmCertificate_wildcardAndRootSan
=== PAUSE TestAccAWSAcmCertificate_wildcardAndRootSan
=== RUN   TestAccAWSAcmCertificate_disableCTLogging
=== PAUSE TestAccAWSAcmCertificate_disableCTLogging
=== RUN   TestAccAWSAcmCertificate_tags
=== PAUSE TestAccAWSAcmCertificate_tags
=== RUN   TestAccAWSAcmCertificate_imported_DomainName
=== PAUSE TestAccAWSAcmCertificate_imported_DomainName
=== RUN   TestAccAWSAcmCertificate_imported_IpAddress
=== PAUSE TestAccAWSAcmCertificate_imported_IpAddress
=== RUN   TestAccAWSAcmCertificateValidation_basic
=== PAUSE TestAccAWSAcmCertificateValidation_basic
=== RUN   TestAccAWSAcmCertificateValidation_timeout
=== PAUSE TestAccAWSAcmCertificateValidation_timeout
=== RUN   TestAccAWSAcmCertificateValidation_validationRecordFqdns
=== PAUSE TestAccAWSAcmCertificateValidation_validationRecordFqdns
=== RUN   TestAccAWSAcmCertificateValidation_validationRecordFqdnsEmail
=== PAUSE TestAccAWSAcmCertificateValidation_validationRecordFqdnsEmail
=== RUN   TestAccAWSAcmCertificateValidation_validationRecordFqdnsRoot
=== PAUSE TestAccAWSAcmCertificateValidation_validationRecordFqdnsRoot
=== RUN   TestAccAWSAcmCertificateValidation_validationRecordFqdnsRootAndWildcard
=== PAUSE TestAccAWSAcmCertificateValidation_validationRecordFqdnsRootAndWildcard
=== RUN   TestAccAWSAcmCertificateValidation_validationRecordFqdnsSan
=== PAUSE TestAccAWSAcmCertificateValidation_validationRecordFqdnsSan
=== RUN   TestAccAWSAcmCertificateValidation_validationRecordFqdnsWildcard
=== PAUSE TestAccAWSAcmCertificateValidation_validationRecordFqdnsWildcard
=== RUN   TestAccAWSAcmCertificateValidation_validationRecordFqdnsWildcardAndRoot
=== PAUSE TestAccAWSAcmCertificateValidation_validationRecordFqdnsWildcardAndRoot
=== CONT  TestAccAWSAcmCertificateDataSource_singleIssued
=== CONT  TestAccAWSAcmCertificateValidation_validationRecordFqdnsRootAndWildcard
=== CONT  TestAccAWSAcmCertificate_san_TrailingPeriod
=== CONT  TestAccAWSAcmCertificate_imported_DomainName
=== CONT  TestAccAWSAcmCertificate_tags
=== CONT  TestAccAWSAcmCertificateValidation_validationRecordFqdnsEmail
=== CONT  TestAccAWSAcmCertificateValidation_validationRecordFqdns
=== CONT  TestAccAWSAcmCertificate_imported_IpAddress
=== CONT  TestAccAWSAcmCertificate_disableCTLogging
=== CONT  TestAccAWSAcmCertificateValidation_basic
=== CONT  TestAccAWSAcmCertificateValidation_validationRecordFqdnsWildcardAndRoot
=== CONT  TestAccAWSAcmCertificateValidation_timeout
=== CONT  TestAccAWSAcmCertificateValidation_validationRecordFqdnsWildcard
=== CONT  TestAccAWSAcmCertificateValidation_validationRecordFqdnsRoot
=== CONT  TestAccAWSAcmCertificateValidation_validationRecordFqdnsSan
=== CONT  TestAccAWSAcmCertificate_wildcardAndRootSan
=== CONT  TestAccAWSAcmCertificate_root
=== CONT  TestAccAWSAcmCertificate_wildcard
=== CONT  TestAccAWSAcmCertificate_san_multiple
=== CONT  TestAccAWSAcmCertificate_san_single
--- FAIL: TestAccAWSAcmCertificateDataSource_singleIssued (27.89s)
    provider_test.go:67: No valid credential sources found for AWS Provider.
        	Please see https://terraform.io/docs/providers/aws/index.html for more information on
        	providing credentials for the AWS Provider
=== CONT  TestAccAWSAcmCertificateDataSource_KeyTypes
--- FAIL: TestAccAWSAcmCertificateValidation_timeout (27.89s)
    provider_test.go:67: No valid credential sources found for AWS Provider.
        	Please see https://terraform.io/docs/providers/aws/index.html for more information on
        	providing credentials for the AWS Provider
=== CONT  TestAccAWSAcmCertificate_dnsValidation
--- FAIL: TestAccAWSAcmCertificateValidation_validationRecordFqdnsWildcardAndRoot (27.89s)
    provider_test.go:67: No valid credential sources found for AWS Provider.
        	Please see https://terraform.io/docs/providers/aws/index.html for more information on
        	providing credentials for the AWS Provider
--- FAIL: TestAccAWSAcmCertificateValidation_validationRecordFqdnsEmail (27.89s)
    provider_test.go:67: No valid credential sources found for AWS Provider.
        	Please see https://terraform.io/docs/providers/aws/index.html for more information on
        	providing credentials for the AWS Provider
=== CONT  TestAccAWSAcmCertificate_rootAndWildcardSan
--- FAIL: TestAccAWSAcmCertificate_san_multiple (27.89s)
    provider_test.go:67: No valid credential sources found for AWS Provider.
        	Please see https://terraform.io/docs/providers/aws/index.html for more information on
        	providing credentials for the AWS Provider
--- FAIL: TestAccAWSAcmCertificateValidation_validationRecordFqdnsWildcard (27.89s)
    provider_test.go:67: No valid credential sources found for AWS Provider.
        	Please see https://terraform.io/docs/providers/aws/index.html for more information on
        	providing credentials for the AWS Provider
--- FAIL: TestAccAWSAcmCertificateValidation_validationRecordFqdnsRoot (27.89s)
    provider_test.go:67: No valid credential sources found for AWS Provider.
        	Please see https://terraform.io/docs/providers/aws/index.html for more information on
        	providing credentials for the AWS Provider
=== CONT  TestAccAWSAcmCertificate_root_TrailingPeriod
--- FAIL: TestAccAWSAcmCertificate_wildcardAndRootSan (27.89s)
    provider_test.go:67: No valid credential sources found for AWS Provider.
        	Please see https://terraform.io/docs/providers/aws/index.html for more information on
        	providing credentials for the AWS Provider
=== CONT  TestAccAWSAcmCertificate_privateCert
--- FAIL: TestAccAWSAcmCertificateValidation_basic (27.89s)
    provider_test.go:67: No valid credential sources found for AWS Provider.
        	Please see https://terraform.io/docs/providers/aws/index.html for more information on
        	providing credentials for the AWS Provider
--- FAIL: TestAccAWSAcmCertificateValidation_validationRecordFqdnsSan (27.89s)
    provider_test.go:67: No valid credential sources found for AWS Provider.
        	Please see https://terraform.io/docs/providers/aws/index.html for more information on
        	providing credentials for the AWS Provider
=== CONT  TestAccAWSAcmCertificate_emailValidation
--- FAIL: TestAccAWSAcmCertificate_wildcard (27.89s)
    provider_test.go:67: No valid credential sources found for AWS Provider.
        	Please see https://terraform.io/docs/providers/aws/index.html for more information on
        	providing credentials for the AWS Provider
--- FAIL: TestAccAWSAcmCertificateValidation_validationRecordFqdnsRootAndWildcard (27.89s)
    provider_test.go:67: No valid credential sources found for AWS Provider.
        	Please see https://terraform.io/docs/providers/aws/index.html for more information on
        	providing credentials for the AWS Provider
--- FAIL: TestAccAWSAcmCertificate_san_TrailingPeriod (27.89s)
    provider_test.go:67: No valid credential sources found for AWS Provider.
        	Please see https://terraform.io/docs/providers/aws/index.html for more information on
        	providing credentials for the AWS Provider
--- FAIL: TestAccAWSAcmCertificate_imported_IpAddress (28.20s)
    provider_test.go:67: No valid credential sources found for AWS Provider.
        	Please see https://terraform.io/docs/providers/aws/index.html for more information on
        	providing credentials for the AWS Provider
=== CONT  TestAccAWSAcmCertificateDataSource_noMatchReturnsError
--- FAIL: TestAccAWSAcmCertificate_root (27.89s)
    provider_test.go:67: No valid credential sources found for AWS Provider.
        	Please see https://terraform.io/docs/providers/aws/index.html for more information on
        	providing credentials for the AWS Provider
--- FAIL: TestAccAWSAcmCertificate_tags (27.89s)
    provider_test.go:67: No valid credential sources found for AWS Provider.
        	Please see https://terraform.io/docs/providers/aws/index.html for more information on
        	providing credentials for the AWS Provider
=== CONT  TestAccAWSAcmCertificateDataSource_multipleIssued
--- FAIL: TestAccAWSAcmCertificate_disableCTLogging (27.89s)
    provider_test.go:67: No valid credential sources found for AWS Provider.
        	Please see https://terraform.io/docs/providers/aws/index.html for more information on
        	providing credentials for the AWS Provider
--- FAIL: TestAccAWSAcmCertificate_san_single (27.89s)
    provider_test.go:67: No valid credential sources found for AWS Provider.
        	Please see https://terraform.io/docs/providers/aws/index.html for more information on
        	providing credentials for the AWS Provider
--- FAIL: TestAccAWSAcmCertificateValidation_validationRecordFqdns (27.89s)
    provider_test.go:67: No valid credential sources found for AWS Provider.
        	Please see https://terraform.io/docs/providers/aws/index.html for more information on
        	providing credentials for the AWS Provider
--- FAIL: TestAccAWSAcmCertificate_imported_DomainName (28.47s)
    provider_test.go:67: No valid credential sources found for AWS Provider.
        	Please see https://terraform.io/docs/providers/aws/index.html for more information on
        	providing credentials for the AWS Provider
--- FAIL: TestAccAWSAcmCertificate_root_TrailingPeriod (27.65s)
    provider_test.go:67: No valid credential sources found for AWS Provider.
        	Please see https://terraform.io/docs/providers/aws/index.html for more information on
        	providing credentials for the AWS Provider
--- FAIL: TestAccAWSAcmCertificateDataSource_KeyTypes (30.11s)
    provider_test.go:67: No valid credential sources found for AWS Provider.
        	Please see https://terraform.io/docs/providers/aws/index.html for more information on
        	providing credentials for the AWS Provider
--- FAIL: TestAccAWSAcmCertificateDataSource_multipleIssued (27.65s)
    provider_test.go:67: No valid credential sources found for AWS Provider.
        	Please see https://terraform.io/docs/providers/aws/index.html for more information on
        	providing credentials for the AWS Provider
--- FAIL: TestAccAWSAcmCertificate_rootAndWildcardSan (27.65s)
    provider_test.go:67: No valid credential sources found for AWS Provider.
        	Please see https://terraform.io/docs/providers/aws/index.html for more information on
        	providing credentials for the AWS Provider
--- FAIL: TestAccAWSAcmCertificateDataSource_noMatchReturnsError (27.65s)
    provider_test.go:67: No valid credential sources found for AWS Provider.
        	Please see https://terraform.io/docs/providers/aws/index.html for more information on
        	providing credentials for the AWS Provider
--- FAIL: TestAccAWSAcmCertificate_privateCert (27.65s)
    provider_test.go:67: No valid credential sources found for AWS Provider.
        	Please see https://terraform.io/docs/providers/aws/index.html for more information on
        	providing credentials for the AWS Provider
--- FAIL: TestAccAWSAcmCertificate_dnsValidation (27.65s)
    provider_test.go:67: No valid credential sources found for AWS Provider.
        	Please see https://terraform.io/docs/providers/aws/index.html for more information on
        	providing credentials for the AWS Provider
--- FAIL: TestAccAWSAcmCertificate_emailValidation (27.65s)
    provider_test.go:67: No valid credential sources found for AWS Provider.
        	Please see https://terraform.io/docs/providers/aws/index.html for more information on
        	providing credentials for the AWS Provider
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	58.917s
FAIL
make: *** [GNUmakefile:24: testacc] Error 1
```

Could someone please shed some light here? I do not see why `AWS_PROFILE` is not working for acceptance tests anymore...

## Example Code

```hcl
provider "aws" {
  max_retries = 1337
  region      = "eu-central-1"
  profile     = "devops"
}

resource "aws_acm_certificate" "test" {
  domain_name       = "test.dev.reservix.cloud"
  validation_method = "DNS"

  subject_alternative_names = [
    "one.test.dev.reservix.cloud",
    "two.test.dev.reservix.cloud",
    "three.test.dev.reservix.cloud",
    "four.test.dev.reservix.cloud",
    "five.test.dev.reservix.cloud",
    "six.test.dev.reservix.cloud",
    "seven.test.dev.reservix.cloud",
    "eight.test.dev.reservix.cloud",
    "nine.test.dev.reservix.cloud",
  ]
}
```

```console
tf apply

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_acm_certificate.test will be created
  + resource "aws_acm_certificate" "test" {
      + arn                       = (known after apply)
      + domain_name               = "test.dev.reservix.cloud"
      + domain_validation_options = (known after apply)
      + id                        = (known after apply)
      + subject_alternative_names = [
          + "eight.test.dev.reservix.cloud",
          + "five.test.dev.reservix.cloud",
          + "four.test.dev.reservix.cloud",
          + "nine.test.dev.reservix.cloud",
          + "one.test.dev.reservix.cloud",
          + "seven.test.dev.reservix.cloud",
          + "six.test.dev.reservix.cloud",
          + "three.test.dev.reservix.cloud",
          + "two.test.dev.reservix.cloud",
        ]
      + validation_emails         = (known after apply)
      + validation_method         = "DNS"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

aws_acm_certificate.test: Creating...
aws_acm_certificate.test: Still creating... [10s elapsed]
aws_acm_certificate.test: Still creating... [20s elapsed]
aws_acm_certificate.test: Still creating... [30s elapsed]
aws_acm_certificate.test: Still creating... [40s elapsed]
aws_acm_certificate.test: Still creating... [50s elapsed]
aws_acm_certificate.test: Creation complete after 52s [id=arn:aws:acm:eu-central-1:159388291991:certificate/7821b026-fe75-4391-977d-ea721ed02a56]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
$ tf apply
aws_acm_certificate.test: Refreshing state... [id=arn:aws:acm:eu-central-1:159388291991:certificate/7821b026-fe75-4391-977d-ea721ed02a56]

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
$ tf destroy
aws_acm_certificate.test: Refreshing state... [id=arn:aws:acm:eu-central-1:159388291991:certificate/7821b026-fe75-4391-977d-ea721ed02a56]

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # aws_acm_certificate.test will be destroyed
  - resource "aws_acm_certificate" "test" {
      - arn                       = "arn:aws:acm:eu-central-1:159388291991:certificate/7821b026-fe75-4391-977d-ea721ed02a56" -> null
      - domain_name               = "test.dev.reservix.cloud" -> null
      - domain_validation_options = [
          - {
              - domain_name           = "test.dev.reservix.cloud"
              - resource_record_name  = "_5f73fbc90b619a65895a4dffbacddfd7.test.dev.reservix.cloud."
              - resource_record_type  = "CNAME"
              - resource_record_value = "_eeccaa8d5151bfd6357930ad538b0b28.mzlfeqexyx.acm-validations.aws."
            },
          - {
              - domain_name           = "nine.test.dev.reservix.cloud"
              - resource_record_name  = "_d0b6b365ab587df1952c2df1e1087314.nine.test.dev.reservix.cloud."
              - resource_record_type  = "CNAME"
              - resource_record_value = "_29f21634897e69eb0d5fdcf8270f6a0c.mzlfeqexyx.acm-validations.aws."
            },
          - {
              - domain_name           = "three.test.dev.reservix.cloud"
              - resource_record_name  = "_3f1ed51a71c6868705bbfcfd312025ff.three.test.dev.reservix.cloud."
              - resource_record_type  = "CNAME"
              - resource_record_value = "_9e05a42d23907dd06acfc39c33474579.mzlfeqexyx.acm-validations.aws."
            },
          - {
              - domain_name           = "two.test.dev.reservix.cloud"
              - resource_record_name  = "_bcb7a37d8016410f717e3861d880b246.two.test.dev.reservix.cloud."
              - resource_record_type  = "CNAME"
              - resource_record_value = "_95e3ff8ba342f8d95916c0fbf5a7f426.mzlfeqexyx.acm-validations.aws."
            },
          - {
              - domain_name           = "one.test.dev.reservix.cloud"
              - resource_record_name  = "_ecb6ce42d1ef425e027d56f896892a42.one.test.dev.reservix.cloud."
              - resource_record_type  = "CNAME"
              - resource_record_value = "_6cdfde15f0ed0a234cb4f5691ce1d5a8.mzlfeqexyx.acm-validations.aws."
            },
          - {
              - domain_name           = "eight.test.dev.reservix.cloud"
              - resource_record_name  = "_38cf8495690716eece0b96323571cf65.eight.test.dev.reservix.cloud."
              - resource_record_type  = "CNAME"
              - resource_record_value = "_abbd0d5a6d7e4279c69401c09b65b50e.mzlfeqexyx.acm-validations.aws."
            },
          - {
              - domain_name           = "seven.test.dev.reservix.cloud"
              - resource_record_name  = "_a99a6433d8441811df0cf59bbfcb9331.seven.test.dev.reservix.cloud."
              - resource_record_type  = "CNAME"
              - resource_record_value = "_fdd1bb8eac7cca3db127c4ba313418df.mzlfeqexyx.acm-validations.aws."
            },
          - {
              - domain_name           = "six.test.dev.reservix.cloud"
              - resource_record_name  = "_189e80929f9fb54bb310bc70a00929b7.six.test.dev.reservix.cloud."
              - resource_record_type  = "CNAME"
              - resource_record_value = "_f1ad70f2f2d5723b89e3ef8c853a7ba4.mzlfeqexyx.acm-validations.aws."
            },
          - {
              - domain_name           = "five.test.dev.reservix.cloud"
              - resource_record_name  = "_ef19704d46946c309cec8d8ed148af7e.five.test.dev.reservix.cloud."
              - resource_record_type  = "CNAME"
              - resource_record_value = "_3fa16610ad17df0a595b1e651d82dba4.mzlfeqexyx.acm-validations.aws."
            },
          - {
              - domain_name           = "four.test.dev.reservix.cloud"
              - resource_record_name  = "_5c90a857aeb3c49005725446e3000e9b.four.test.dev.reservix.cloud."
              - resource_record_type  = "CNAME"
              - resource_record_value = "_c73a6232e9d56e0ab5df70eb480fbf12.mzlfeqexyx.acm-validations.aws."
            },
        ] -> null
      - id                        = "arn:aws:acm:eu-central-1:159388291991:certificate/7821b026-fe75-4391-977d-ea721ed02a56" -> null
      - subject_alternative_names = [
          - "eight.test.dev.reservix.cloud",
          - "five.test.dev.reservix.cloud",
          - "four.test.dev.reservix.cloud",
          - "nine.test.dev.reservix.cloud",
          - "one.test.dev.reservix.cloud",
          - "seven.test.dev.reservix.cloud",
          - "six.test.dev.reservix.cloud",
          - "three.test.dev.reservix.cloud",
          - "two.test.dev.reservix.cloud",
        ] -> null
      - tags                      = {} -> null
      - validation_emails         = [] -> null
      - validation_method         = "DNS" -> null

      - options {
          - certificate_transparency_logging_preference = "ENABLED" -> null
        }
    }

Plan: 0 to add, 0 to change, 1 to destroy.

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

aws_acm_certificate.test: Destroying... [id=arn:aws:acm:eu-central-1:159388291991:certificate/7821b026-fe75-4391-977d-ea721ed02a56]
aws_acm_certificate.test: Destruction complete after 0s

Destroy complete! Resources: 1 destroyed.
```



