### PR TITLE
Remove wrong code type hint in aws_ecs_capacity_provider docs

### DIFF
--- a/website/docs/r/ecs_capacity_provider.html.markdown
+++ b/website/docs/r/ecs_capacity_provider.html.markdown
@@ -68,6 +68,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ECS Capacity Providers can be imported using the `name`, e.g.
 
-```hcl
+```
 $ terraform import aws_ecs_capacity_provider.example example
 ```


### PR DESCRIPTION
The import command was marked as HCL, which caused the docs to be coloured weirdly on the website.
Removed this to be consistent with how the rest of the import commands are displayed.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11279 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
NONE
```
This tiny change fixes the red highlighting in [aws_ecs_capacity_provider docs](https://www.terraform.io/docs/providers/aws/r/ecs_capacity_provider.html):
![image](https://user-images.githubusercontent.com/1011549/70900169-e9092180-2000-11ea-8ec3-9b5d8f5c3783.png)

