### PR TITLE
Documentation update for ECS Capacity Providers

### DIFF
--- a/website/docs/r/ecs_capacity_provider.html.markdown
+++ b/website/docs/r/ecs_capacity_provider.html.markdown
@@ -61,7 +61,7 @@ The `managed_scaling` block supports the following:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The Amazon Resource Name (ARN) that identifies the capacity provider.
+* `id` - The ID that identifies the capacity provider.
 * `arn` - The Amazon Resource Name (ARN) that identifies the capacity provider.
 
 ## Import


### PR DESCRIPTION
The 'id' attribute in the documentation should not reference the ARN - it should mention the ID instead - a minor change.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Documentation update for ECS Capacity Provider - now references capacity provider ID instead of ARN.
```
