### PR TITLE
Intermittent error when updating Capacity Providers on ECS Cluster

### DIFF
--- a/aws/resource_aws_ecs_cluster.go
+++ b/aws/resource_aws_ecs_cluster.go
@@ -14,6 +14,12 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
+const (
+	timeoutCreate = 10 * time.Minute
+	timeoutDelete = 10 * time.Minute
+	timeoutUpdate = 10 * time.Minute
+)
+
 func resourceAwsEcsCluster() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsEcsClusterCreate,
@@ -131,6 +137,10 @@ func resourceAwsEcsClusterCreate(d *schema.ResourceData, meta interface{}) error
 
 	d.SetId(aws.StringValue(out.Cluster.ClusterArn))
 
+	if err = waitForEcsClusterActive(conn, clusterName, timeoutCreate); err != nil {
+		return err
+	}
+
 	return resourceAwsEcsClusterRead(d, meta)
 }
 
@@ -220,6 +230,8 @@ func resourceAwsEcsClusterRead(d *schema.ResourceData, meta interface{}) error {
 func resourceAwsEcsClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ecsconn
 
+	clusterName := d.Get("name").(string)
+
 	if d.HasChange("setting") {
 		input := ecs.UpdateClusterSettingsInput{
 			Cluster:  aws.String(d.Id()),
@@ -229,6 +241,10 @@ func resourceAwsEcsClusterUpdate(d *schema.ResourceData, meta interface{}) error
 		_, err := conn.UpdateClusterSettings(&input)
 		if err != nil {
 			return fmt.Errorf("error changing ECS cluster settings (%s): %s", d.Id(), err)
+		}
+
+		if err = waitForEcsClusterActive(conn, clusterName, timeoutUpdate); err != nil {
+			return err
 		}
 	}
 
@@ -255,6 +271,10 @@ func resourceAwsEcsClusterUpdate(d *schema.ResourceData, meta interface{}) error
 		if err != nil {
 			return fmt.Errorf("error changing ECS cluster capacity provider settings (%s): %s", d.Id(), err)
 		}
+
+		if err = waitForEcsClusterActive(conn, clusterName, timeoutUpdate); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -267,7 +287,7 @@ func resourceAwsEcsClusterDelete(d *schema.ResourceData, meta interface{}) error
 	input := &ecs.DeleteClusterInput{
 		Cluster: aws.String(d.Id()),
 	}
-	err := resource.Retry(10*time.Minute, func() *resource.RetryError {
+	err := resource.Retry(timeoutDelete, func() *resource.RetryError {
 		_, err := conn.DeleteCluster(input)
 
 		if err == nil {
@@ -297,32 +317,13 @@ func resourceAwsEcsClusterDelete(d *schema.ResourceData, meta interface{}) error
 	}
 
 	clusterName := d.Get("name").(string)
-	dcInput := &ecs.DescribeClustersInput{
-		Clusters: []*string{aws.String(clusterName)},
+	stateConf := resource.StateChangeConf{
+		Pending: []string{"ACTIVE", "DEPROVISIONING"},
+		Target:  []string{"INACTIVE"},
+		Timeout: timeoutDelete,
+		Refresh: refreshEcsClusterStatus(conn, clusterName),
 	}
-	var out *ecs.DescribeClustersOutput
-	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
-		log.Printf("[DEBUG] Checking if ECS Cluster %q is INACTIVE", d.Id())
-		out, err = conn.DescribeClusters(dcInput)
-
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
-		if !ecsClusterInactive(out, clusterName) {
-			return resource.RetryableError(fmt.Errorf("ECS Cluster %q is not inactive", clusterName))
-		}
-
-		return nil
-	})
-	if isResourceTimeoutError(err) {
-		out, err = conn.DescribeClusters(dcInput)
-		if err != nil {
-			return fmt.Errorf("Error waiting for ECS cluster to become inactive: %s", err)
-		}
-		if !ecsClusterInactive(out, clusterName) {
-			return fmt.Errorf("ECS Cluster %q is still not inactive", clusterName)
-		}
-	}
+	_, err = stateConf.WaitForState()
 	if err != nil {
 		return fmt.Errorf("Error waiting for ECS cluster to become inactive: %s", err)
 	}
@@ -331,15 +332,32 @@ func resourceAwsEcsClusterDelete(d *schema.ResourceData, meta interface{}) error
 	return nil
 }
 
-func ecsClusterInactive(out *ecs.DescribeClustersOutput, clusterName string) bool {
-	for _, c := range out.Clusters {
-		if aws.StringValue(c.ClusterName) == clusterName {
-			if *c.Status == "INACTIVE" {
-				return true
+func waitForEcsClusterActive(conn *ecs.ECS, clusterName string, timeout time.Duration) error {
+	stateConf := resource.StateChangeConf{
+		Pending: []string{"PROVISIONING"},
+		Target:  []string{"ACTIVE"},
+		Timeout: timeout,
+		Refresh: refreshEcsClusterStatus(conn, clusterName),
+	}
+	_, err := stateConf.WaitForState()
+	return err
+}
+
+func refreshEcsClusterStatus(conn *ecs.ECS, clusterName string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := conn.DescribeClusters(&ecs.DescribeClustersInput{
+			Clusters: []*string{aws.String(clusterName)},
+		})
+		if err != nil {
+			return nil, "", err
+		}
+		for _, c := range output.Clusters {
+			if aws.StringValue(c.ClusterName) == clusterName {
+				return c, aws.StringValue(c.Status), nil
 			}
 		}
+		return nil, "", fmt.Errorf("ECS cluster %q missing", clusterName)
 	}
-	return false
 }
 
 func expandEcsSettings(configured *schema.Set) []*ecs.ClusterSetting {


### PR DESCRIPTION
Fixes an intermittent failure when updating the capacity providers on an ECS cluster when the cluster status is not `ACTIVE`.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11285 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_ecs_cluster: fixes intermittent failures on update when cluster dependencies are updating.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEcsCluster_'

--- PASS: TestAccAWSEcsCluster_disappears (14.50s)
--- PASS: TestAccAWSEcsCluster_basic (18.39s)
--- PASS: TestAccAWSEcsCluster_containerInsights (39.06s)
--- PASS: TestAccAWSEcsCluster_Tags (40.84s)
--- PASS: TestAccAWSEcsCluster_CapacityProviders (47.33s)
--- PASS: TestAccAWSEcsCluster_CapacityProvidersUpdate (51.29s)
--- PASS: TestAccAWSEcsCluster_SingleCapacityProvider (86.14s)
```
