### PR TITLE
Always pass both fields from ECS cluster capacity updates

### DIFF
--- a/aws/resource_aws_ecs_cluster.go
+++ b/aws/resource_aws_ecs_cluster.go
@@ -242,13 +242,9 @@ func resourceAwsEcsClusterUpdate(d *schema.ResourceData, meta interface{}) error
 
 	if d.HasChange("capacity_providers") || d.HasChange("default_capacity_provider_strategy") {
 		input := ecs.PutClusterCapacityProvidersInput{
-			Cluster: aws.String(d.Id()),
-		}
-		if d.HasChange("capacity_providers") {
-			input.CapacityProviders = expandStringSet(d.Get("capacity_providers").(*schema.Set))
-		}
-		if d.HasChange("default_capacity_provider_strategy") {
-			input.DefaultCapacityProviderStrategy = expandEcsCapacityProviderStrategy(d.Get("default_capacity_provider_strategy").(*schema.Set))
+			Cluster:                         aws.String(d.Id()),
+			CapacityProviders:               expandStringSet(d.Get("capacity_providers").(*schema.Set)),
+			DefaultCapacityProviderStrategy: expandEcsCapacityProviderStrategy(d.Get("default_capacity_provider_strategy").(*schema.Set)),
 		}
 
 		_, err := conn.PutClusterCapacityProviders(&input)

--- a/aws/resource_aws_ecs_cluster_test.go
+++ b/aws/resource_aws_ecs_cluster_test.go
@@ -243,6 +243,45 @@ func TestAccAWSEcsCluster_CapacityProvidersUpdate(t *testing.T) {
 					testAccCheckAWSEcsClusterExists(resourceName, &cluster1),
 				),
 			},
+			{
+				Config: testAccAWSEcsClusterCapacityProvidersFargateBoth(rName, providerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcsClusterExists(resourceName, &cluster1),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEcsCluster_CapacityProvidersNoStrategy(t *testing.T) {
+	var cluster1 ecs.Cluster
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	providerName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ecs_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcsClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEcsClusterCapacityProvidersFargateNoStrategy(rName, providerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcsClusterExists(resourceName, &cluster1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateId:     rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSEcsClusterCapacityProvidersFargateSpotNoStrategy(rName, providerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcsClusterExists(resourceName, &cluster1),
+				),
+			},
 		},
 	})
 }
@@ -479,6 +518,42 @@ resource "aws_ecs_cluster" "test" {
 		capacity_provider = "FARGATE_SPOT"
 		weight = 1
 	}
+}
+`, rName)
+}
+
+func testAccAWSEcsClusterCapacityProvidersFargateBoth(rName, providerName string) string {
+	return fmt.Sprintf(`
+resource "aws_ecs_cluster" "test" {
+	name = %[1]q
+
+	capacity_providers = ["FARGATE", "FARGATE_SPOT"]
+
+	default_capacity_provider_strategy {
+		base = 1
+		capacity_provider = "FARGATE_SPOT"
+		weight = 1
+	}
+}
+`, rName)
+}
+
+func testAccAWSEcsClusterCapacityProvidersFargateNoStrategy(rName, providerName string) string {
+	return fmt.Sprintf(`
+resource "aws_ecs_cluster" "test" {
+	name = %[1]q
+
+	capacity_providers = ["FARGATE"]
+}
+`, rName)
+}
+
+func testAccAWSEcsClusterCapacityProvidersFargateSpotNoStrategy(rName, providerName string) string {
+	return fmt.Sprintf(`
+resource "aws_ecs_cluster" "test" {
+	name = %[1]q
+
+	capacity_providers = ["FARGATE_SPOT"]
 }
 `, rName)
 }

--- a/aws/resource_aws_ecs_service.go
+++ b/aws/resource_aws_ecs_service.go
@@ -739,9 +739,6 @@ func expandEcsNetworkConfiguration(nc []interface{}) *ecs.NetworkConfiguration {
 
 func expandEcsCapacityProviderStrategy(cps *schema.Set) []*ecs.CapacityProviderStrategyItem {
 	list := cps.List()
-	if len(list) == 0 {
-		return nil
-	}
 	results := make([]*ecs.CapacityProviderStrategyItem, 0)
 	for _, raw := range list {
 		cp := raw.(map[string]interface{})


### PR DESCRIPTION
The API documentation for `PutClusterCapacityProviders` states that

> You must specify both the available capacity providers and a default capacity provider strategy for the cluster.

Changing the list of cluster capacity providers without changing the default strategy fails with

```
InvalidParameter: 1 validation error(s) found.
        - missing required field, PutClusterCapacityProvidersInput.DefaultCapacityProviderStrategy.
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11311 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_ecs_cluster: fixes bug where ECS cluster capacity providers are updated but default provider strategy is not changed
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWS\(EcsCluster\|EcsService\)_'

--- PASS: TestAccAWSEcsCluster_basic (18.19s)
--- PASS: TestAccAWSEcsCluster_CapacityProvidersUpdate (42.08s)
--- PASS: TestAccAWSEcsService_disappears (53.73s)
--- PASS: TestAccAWSEcsService_withPlacementConstraints_emptyExpression (63.34s)
--- PASS: TestAccAWSEcsService_withUnnormalizedPlacementStrategy (73.87s)
--- PASS: TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred (73.91s)
--- PASS: TestAccAWSEcsService_withFamilyAndRevision (76.27s)
--- PASS: TestAccAWSEcsService_basicImport (77.60s)
--- PASS: TestAccAWSEcsService_withDeploymentValues (84.12s)
--- PASS: TestAccAWSEcsService_ManagedTags (84.42s)
--- PASS: TestAccAWSEcsService_withARN (87.70s)
--- PASS: TestAccAWSEcsService_Tags (89.35s)
--- PASS: TestAccAWSEcsService_withPlacementConstraints (77.58s)
--- PASS: TestAccAWSEcsCluster_CapacityProviders (40.99s)
--- PASS: TestAccAWSEcsCluster_Tags (39.72s)
--- PASS: TestAccAWSEcsService_withMultipleCapacityProviderStrategies (130.50s)
--- PASS: TestAccAWSEcsService_withRenamedCluster (133.47s)
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum (43.05s)
--- PASS: TestAccAWSEcsService_withIamRole (146.49s)
--- PASS: TestAccAWSEcsService_withEcsClusterName (73.72s)
--- PASS: TestAccAWSEcsService_withReplicaSchedulingStrategy (62.62s)
--- PASS: TestAccAWSEcsCluster_disappears (13.22s)
--- PASS: TestAccAWSEcsCluster_SingleCapacityProvider (78.99s)
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategy (42.96s)
--- PASS: TestAccAWSEcsCluster_containerInsights (36.83s)
--- PASS: TestAccAWSEcsService_withServiceRegistries_container (170.94s)
--- PASS: TestAccAWSEcsService_withCapacityProviderStrategy (173.91s)
--- PASS: TestAccAWSEcsService_PropagateTags (179.02s)
--- PASS: TestAccAWSEcsCluster_CapacityProvidersNoStrategy (44.54s)
--- PASS: TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration (89.26s)
--- PASS: TestAccAWSEcsService_withLaunchTypeFargate (146.40s)
--- PASS: TestAccAWSEcsService_withServiceRegistries (160.89s)
--- PASS: TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion (124.80s)
--- PASS: TestAccAWSEcsService_withDeploymentController_Type_CodeDeploy (288.14s)
--- PASS: TestAccAWSEcsService_healthCheckGracePeriodSeconds (314.58s)
--- PASS: TestAccAWSEcsService_withMultipleTargetGroups (278.11s)
--- PASS: TestAccAWSEcsService_withPlacementStrategy (290.52s)
--- PASS: TestAccAWSEcsService_withAlb (276.32s)
--- PASS: TestAccAWSEcsService_withLbChanges (269.41s)
```
