### PR TITLE
Deletes Global Accelerator listeners before accelerator

### DIFF
--- a/aws/resource_aws_globalaccelerator_accelerator.go
+++ b/aws/resource_aws_globalaccelerator_accelerator.go
@@ -113,7 +113,7 @@ func resourceAwsGlobalAcceleratorAcceleratorCreate(d *schema.ResourceData, meta 
 
 	d.SetId(*resp.Accelerator.AcceleratorArn)
 
-	err = resourceAwsGlobalAcceleratorAcceleratorWaitForState(conn, d.Id())
+	err = resourceAwsGlobalAcceleratorAcceleratorWaitForDeployedState(conn, d.Id())
 	if err != nil {
 		return err
 	}
@@ -258,7 +258,7 @@ func resourceAwsGlobalAcceleratorAcceleratorUpdate(d *schema.ResourceData, meta 
 		d.SetPartial("ip_address_type")
 		d.SetPartial("enabled")
 
-		err = resourceAwsGlobalAcceleratorAcceleratorWaitForState(conn, d.Id())
+		err = resourceAwsGlobalAcceleratorAcceleratorWaitForDeployedState(conn, d.Id())
 		if err != nil {
 			return err
 		}
@@ -281,7 +281,7 @@ func resourceAwsGlobalAcceleratorAcceleratorUpdate(d *schema.ResourceData, meta 
 	return resourceAwsGlobalAcceleratorAcceleratorRead(d, meta)
 }
 
-func resourceAwsGlobalAcceleratorAcceleratorWaitForState(conn *globalaccelerator.GlobalAccelerator, acceleratorArn string) error {
+func resourceAwsGlobalAcceleratorAcceleratorWaitForDeployedState(conn *globalaccelerator.GlobalAccelerator, acceleratorArn string) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{globalaccelerator.AcceleratorStatusInProgress},
 		Target:  []string{globalaccelerator.AcceleratorStatusDeployed},
@@ -338,7 +338,7 @@ func resourceAwsGlobalAcceleratorAcceleratorDelete(d *schema.ResourceData, meta 
 			return fmt.Errorf("Error disabling Global Accelerator accelerator: %s", err)
 		}
 
-		err = resourceAwsGlobalAcceleratorAcceleratorWaitForState(conn, d.Id())
+		err = resourceAwsGlobalAcceleratorAcceleratorWaitForDeployedState(conn, d.Id())
 		if err != nil {
 			return err
 		}

--- a/aws/resource_aws_globalaccelerator_endpoint_group.go
+++ b/aws/resource_aws_globalaccelerator_endpoint_group.go
@@ -151,7 +151,7 @@ func resourceAwsGlobalAcceleratorEndpointGroupCreate(d *schema.ResourceData, met
 		return err
 	}
 
-	err = resourceAwsGlobalAcceleratorAcceleratorWaitForState(conn, acceleratorArn)
+	err = resourceAwsGlobalAcceleratorAcceleratorWaitForDeployedState(conn, acceleratorArn)
 
 	if err != nil {
 		return err
@@ -302,7 +302,7 @@ func resourceAwsGlobalAcceleratorEndpointGroupUpdate(d *schema.ResourceData, met
 		return err
 	}
 
-	err = resourceAwsGlobalAcceleratorAcceleratorWaitForState(conn, acceleratorArn)
+	err = resourceAwsGlobalAcceleratorAcceleratorWaitForDeployedState(conn, acceleratorArn)
 
 	if err != nil {
 		return err
@@ -332,7 +332,7 @@ func resourceAwsGlobalAcceleratorEndpointGroupDelete(d *schema.ResourceData, met
 		return err
 	}
 
-	err = resourceAwsGlobalAcceleratorAcceleratorWaitForState(conn, acceleratorArn)
+	err = resourceAwsGlobalAcceleratorAcceleratorWaitForDeployedState(conn, acceleratorArn)
 
 	if err != nil {
 		return err

--- a/aws/resource_aws_globalaccelerator_listener.go
+++ b/aws/resource_aws_globalaccelerator_listener.go
@@ -212,17 +212,9 @@ func resourceAwsGlobalAcceleratorListenerUpdate(d *schema.ResourceData, meta int
 	}
 
 	// Creating a listener triggers the accelerator to change status to InPending
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{globalaccelerator.AcceleratorStatusInProgress},
-		Target:  []string{globalaccelerator.AcceleratorStatusDeployed},
-		Refresh: resourceAwsGlobalAcceleratorAcceleratorStateRefreshFunc(conn, d.Get("accelerator_arn").(string)),
-		Timeout: 5 * time.Minute,
-	}
-
-	log.Printf("[DEBUG] Waiting for Global Accelerator listener (%s) availability", d.Id())
-	_, err = stateConf.WaitForState()
+	err = resourceAwsGlobalAcceleratorAcceleratorWaitForDeployedState(conn, d.Get("accelerator_arn").(string))
 	if err != nil {
-		return fmt.Errorf("Error waiting for Global Accelerator listener (%s) availability: %s", d.Id(), err)
+		return nil
 	}
 
 	return resourceAwsGlobalAcceleratorListenerRead(d, meta)
@@ -244,17 +236,10 @@ func resourceAwsGlobalAcceleratorListenerDelete(d *schema.ResourceData, meta int
 	}
 
 	// Deleting a listener triggers the accelerator to change status to InPending
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{globalaccelerator.AcceleratorStatusInProgress},
-		Target:  []string{globalaccelerator.AcceleratorStatusDeployed},
-		Refresh: resourceAwsGlobalAcceleratorAcceleratorStateRefreshFunc(conn, d.Get("accelerator_arn").(string)),
-		Timeout: 5 * time.Minute,
-	}
-
-	log.Printf("[DEBUG] Waiting for Global Accelerator listener (%s) deletion", d.Id())
-	_, err = stateConf.WaitForState()
+	// }
+	err = resourceAwsGlobalAcceleratorAcceleratorWaitForDeployedState(conn, d.Get("accelerator_arn").(string))
 	if err != nil {
-		return fmt.Errorf("Error waiting for Global Accelerator listener (%s) deletion: %s", d.Id(), err)
+		return err
 	}
 
 	return nil

--- a/aws/resource_aws_globalaccelerator_listener.go
+++ b/aws/resource_aws_globalaccelerator_listener.go
@@ -214,7 +214,7 @@ func resourceAwsGlobalAcceleratorListenerUpdate(d *schema.ResourceData, meta int
 	// Creating a listener triggers the accelerator to change status to InPending
 	err = resourceAwsGlobalAcceleratorAcceleratorWaitForDeployedState(conn, d.Get("accelerator_arn").(string))
 	if err != nil {
-		return nil
+		return err
 	}
 
 	return resourceAwsGlobalAcceleratorListenerRead(d, meta)


### PR DESCRIPTION
The test sweeper for `aws_globalaccelerator_accelerator` returns the error

```
AssociatedListenerFoundException: Cannot delete accelerator <the ARN> because an associated listener was found.
```

when there is an associated listener.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11317 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ SWEEPARGS='-sweep-run=aws_globalaccelerator_accelerator' make sweep

2019/12/16 16:09:02 [DEBUG] Running Sweepers for region (us-east-1):
2019/12/16 16:09:02 [DEBUG] Running Sweeper (aws_globalaccelerator_accelerator) in region (us-east-1)
2019/12/16 16:09:02 [INFO] Building AWS auth structure
2019/12/16 16:09:02 [INFO] Setting AWS metadata API timeout to 100ms
2019/12/16 16:09:03 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2019/12/16 16:09:03 [INFO] AWS Auth provider used: "SharedCredentialsProvider"
2019/12/16 16:09:03 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/12/16 16:09:04 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/12/16 16:09:05 [INFO] deleting Listeners for Accelerator arn:aws:globalaccelerator::187416307283:accelerator/28d9762b-5082-430d-a507-45ba8dd38c36
2019/12/16 16:09:05 [INFO] deleting Endpoint Groups for Listener arn:aws:globalaccelerator::187416307283:accelerator/28d9762b-5082-430d-a507-45ba8dd38c36/listener/f5edba58
2019/12/16 16:09:06 [INFO] Disabling Global Accelerator Accelerator: arn:aws:globalaccelerator::187416307283:accelerator/28d9762b-5082-430d-a507-45ba8dd38c36
2019/12/16 16:09:06 [DEBUG] Waiting for Global Accelerator accelerator (arn:aws:globalaccelerator::187416307283:accelerator/28d9762b-5082-430d-a507-45ba8dd38c36) availability
2019/12/16 16:09:06 [DEBUG] Waiting for state to become: [DEPLOYED]
2019/12/16 16:09:06 [DEBUG] Global Accelerator accelerator (arn:aws:globalaccelerator::187416307283:accelerator/28d9762b-5082-430d-a507-45ba8dd38c36) status : IN_PROGRESS
2019/12/16 16:09:06 [TRACE] Waiting 200ms before next try
2019/12/16 16:09:06 [DEBUG] Global Accelerator accelerator (arn:aws:globalaccelerator::187416307283:accelerator/28d9762b-5082-430d-a507-45ba8dd38c36) status : IN_PROGRESS
2019/12/16 16:09:06 [TRACE] Waiting 400ms before next try
2019/12/16 16:09:07 [DEBUG] Global Accelerator accelerator (arn:aws:globalaccelerator::187416307283:accelerator/28d9762b-5082-430d-a507-45ba8dd38c36) status : IN_PROGRESS
2019/12/16 16:09:07 [TRACE] Waiting 800ms before next try
2019/12/16 16:09:08 [DEBUG] Global Accelerator accelerator (arn:aws:globalaccelerator::187416307283:accelerator/28d9762b-5082-430d-a507-45ba8dd38c36) status : IN_PROGRESS
2019/12/16 16:09:08 [TRACE] Waiting 1.6s before next try
2019/12/16 16:09:10 [DEBUG] Global Accelerator accelerator (arn:aws:globalaccelerator::187416307283:accelerator/28d9762b-5082-430d-a507-45ba8dd38c36) status : IN_PROGRESS
2019/12/16 16:09:10 [TRACE] Waiting 3.2s before next try
2019/12/16 16:09:13 [DEBUG] Global Accelerator accelerator (arn:aws:globalaccelerator::187416307283:accelerator/28d9762b-5082-430d-a507-45ba8dd38c36) status : IN_PROGRESS
2019/12/16 16:09:13 [TRACE] Waiting 6.4s before next try
2019/12/16 16:09:20 [DEBUG] Global Accelerator accelerator (arn:aws:globalaccelerator::187416307283:accelerator/28d9762b-5082-430d-a507-45ba8dd38c36) status : DEPLOYED
2019/12/16 16:09:20 [INFO] Deleting Global Accelerator Accelerator: arn:aws:globalaccelerator::187416307283:accelerator/28d9762b-5082-430d-a507-45ba8dd38c36
2019/12/16 16:09:21 Sweeper Tests ran successfully:
	- aws_globalaccelerator_accelerator
2019/12/16 16:09:21 [DEBUG] Running Sweepers for region (us-west-2):
2019/12/16 16:09:21 [DEBUG] Running Sweeper (aws_globalaccelerator_accelerator) in region (us-west-2)
2019/12/16 16:09:21 [INFO] Building AWS auth structure
2019/12/16 16:09:21 [INFO] Setting AWS metadata API timeout to 100ms
2019/12/16 16:09:21 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2019/12/16 16:09:21 [INFO] AWS Auth provider used: "SharedCredentialsProvider"
2019/12/16 16:09:21 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/12/16 16:09:21 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/12/16 16:09:22 Sweeper Tests ran successfully:
	- aws_globalaccelerator_accelerator
ok  	github.com/terraform-providers/terraform-provider-aws/aws	21.466s
```

```
$ make testacc TESTARGS='-run=TestAccAwsGlobalAccelerator'

--- PASS: TestAccAwsGlobalAcceleratorAccelerator_basic (61.91s)
--- PASS: TestAccAwsGlobalAcceleratorAccelerator_attributes (80.06s)
--- PASS: TestAccAwsGlobalAcceleratorAccelerator_update (85.06s)
--- PASS: TestAccAwsGlobalAcceleratorListener_basic (99.62s)
--- PASS: TestAccAwsGlobalAcceleratorListener_update (127.71s)
--- PASS: TestAccAwsGlobalAcceleratorEndpointGroup_basic (138.61s)
--- PASS: TestAccAwsGlobalAcceleratorEndpointGroup_update (177.94s)
```