### PR TITLE
Fix example of IP ranges usage

### DIFF
--- a/website/docs/d/ip_ranges.html.markdown
+++ b/website/docs/d/ip_ranges.html.markdown
@@ -25,8 +25,8 @@ resource "aws_security_group" "from_europe" {
     from_port        = "443"
     to_port          = "443"
     protocol         = "tcp"
-    cidr_blocks      = "${data.aws_ip_ranges.european_ec2.cidr_blocks}"
-    ipv6_cidr_blocks = "${data.aws_ip_ranges.european_ec2.ipv6_cidr_blocks}"
+    cidr_blocks      = data.aws_ip_ranges.european_ec2.cidr_blocks
+    ipv6_cidr_blocks = data.aws_ip_ranges.european_ec2.ipv6_cidr_blocks
   }
 
   tags = {

--- a/website/docs/d/ip_ranges.html.markdown
+++ b/website/docs/d/ip_ranges.html.markdown
@@ -25,8 +25,8 @@ resource "aws_security_group" "from_europe" {
     from_port        = "443"
     to_port          = "443"
     protocol         = "tcp"
-    cidr_blocks      = ["${data.aws_ip_ranges.european_ec2.cidr_blocks}"]
-    ipv6_cidr_blocks = ["${data.aws_ip_ranges.european_ec2.ipv6_cidr_blocks}"]
+    cidr_blocks      = "${data.aws_ip_ranges.european_ec2.cidr_blocks}"
+    ipv6_cidr_blocks = "${data.aws_ip_ranges.european_ec2.ipv6_cidr_blocks}"
   }
 
   tags = {


### PR DESCRIPTION
# brief

cidr_blocks and ipv6_cidr_blocks are list of strings.

https://github.com/terraform-providers/terraform-provider-aws/blob/69f3f606/aws/data_source_aws_ip_ranges.go#L40-L53

In ingress, also list of strings is needed. Therefore no need [ and ].

Tested in my environment.

```
 % terraform --version
Terraform v0.12.13
+ provider.aws v2.36.0
```

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
None
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

n/a. This PR is document fix.
