### PR TITLE
Remove deprecated 'sidebar_current's that have crept in to documentation

### DIFF
--- a/scripts/docscheck.sh
+++ b/scripts/docscheck.sh
@@ -25,6 +25,13 @@ for doc in $docs; do
         echo "Doc is missing a subcategory: $doc"
         error=true
       fi
+
+      # sidebar_current is deprecated
+      # https://github.com/hashicorp/terraform-website#yaml-frontmatter
+      grep "^sidebar_current: " "$doc" > /dev/null
+      if [[ "$?" == "0" ]]; then
+        echo "Doc contains a deprecated sidebar_current: $doc"
+      fi
       ;;
 
     *)

--- a/website/docs/d/waf_rate_based_rule.html.markdown
+++ b/website/docs/d/waf_rate_based_rule.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "WAF"
 layout: "aws"
 page_title: "AWS: aws_waf_rate_based_rule"
-sidebar_current: "docs-aws-datasource-waf-rate-based-rule"
 description: |-
   Retrieves an AWS WAF rate based rule id.
 ---

--- a/website/docs/d/wafregional_rate_based_rule.html.markdown
+++ b/website/docs/d/wafregional_rate_based_rule.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "WAF Regional"
 layout: "aws"
 page_title: "AWS: aws_wafregional_rate_based_rule"
-sidebar_current: "docs-aws-datasource-wafregional-rate-based-rule"
 description: |-
   Retrieves an AWS WAF Regional rate based rule id.
 ---

--- a/website/docs/r/dx_hosted_transit_virtual_interface.html.markdown
+++ b/website/docs/r/dx_hosted_transit_virtual_interface.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Direct Connect"
 layout: "aws"
 page_title: "AWS: aws_dx_hosted_transit_virtual_interface"
-sidebar_current: "docs-aws-resource-dx-hosted-transit-virtual-interface"
 description: |-
   Provides a Direct Connect hosted transit virtual interface resource.
 ---

--- a/website/docs/r/dx_hosted_transit_virtual_interface_accepter.html.markdown
+++ b/website/docs/r/dx_hosted_transit_virtual_interface_accepter.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Direct Connect"
 layout: "aws"
 page_title: "AWS: aws_dx_hosted_transit_virtual_interface_accepter"
-sidebar_current: "docs-aws-resource-dx-hosted-transit-virtual-interface-accepter"
 description: |-
   Provides a resource to manage the accepter's side of a Direct Connect hosted transit virtual interface.
 ---

--- a/website/docs/r/media_convert_queue.html.markdown
+++ b/website/docs/r/media_convert_queue.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "MediaConvert"
 layout: "aws"
 page_title: "AWS: aws_media_convert_queue"
-sidebar_current: "docs-aws-resource-media-convert-queue"
 description: |-
   Provides an AWS Elemental MediaConvert Queue.
 ---

--- a/website/docs/r/workspaces_ip_group.html.markdown
+++ b/website/docs/r/workspaces_ip_group.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Workspaces"
 layout: "aws"
 page_title: "AWS: aws_workspaces_ip_group"
-sidebar_current: "docs-aws-resource-workspaces-ip-group"
 description: |-
   Provides an IP access control group in AWS Workspaces Service.
 ---


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/terraform-providers/terraform-provider-aws/pull/10288.

Some `sidebar_current` directives have crept into the documentation since https://github.com/terraform-providers/terraform-provider-aws/pull/10288 was merged.
This directive is [deprecated](https://github.com/hashicorp/terraform-website#yaml-frontmatter) in YAML frontmatter.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
Was (with modified `docscheck.sh`):

```console
$ make docscheck
Doc has a deprecated sidebar_current: website/docs/d/waf_rate_based_rule.html.markdown
Doc has a deprecated sidebar_current: website/docs/d/wafregional_rate_based_rule.html.markdown
Doc has a deprecated sidebar_current: website/docs/r/dx_hosted_transit_virtual_interface.html.markdown
Doc has a deprecated sidebar_current: website/docs/r/dx_hosted_transit_virtual_interface_accepter.html.markdown
Doc has a deprecated sidebar_current: website/docs/r/media_convert_queue.html.markdown
Doc has a deprecated sidebar_current: website/docs/r/workspaces_ip_group.html.markdown
```

Now:

```console
$ make docscheck
```