### PR TITLE
Direct Connect connection and LAG: Refactor tagging logic to keyvaluetags package

### DIFF
--- a/aws/internal/keyvaluetags/generators/listtags/main.go
+++ b/aws/internal/keyvaluetags/generators/listtags/main.go
@@ -42,6 +42,7 @@ var serviceNames = []string{
 	"datasync",
 	"dax",
 	"devicefarm",
+	"directconnect",
 	"directoryservice",
 	"dlm",
 	"docdb",
@@ -209,6 +210,8 @@ func ServiceListTagsFunction(serviceName string) string {
 		return "ListTagsLogGroup"
 	case "dax":
 		return "ListTags"
+	case "directconnect":
+		return "DescribeTags"
 	case "dynamodb":
 		return "ListTagsOfResource"
 	case "efs":
@@ -267,6 +270,8 @@ func ServiceListTagsInputIdentifierField(serviceName string) string {
 		return "ResourceName"
 	case "devicefarm":
 		return "ResourceARN"
+	case "directconnect":
+		return "ResourceArns"
 	case "directoryservice":
 		return "ResourceId"
 	case "docdb":
@@ -329,6 +334,8 @@ func ServiceListTagsInputIdentifierRequiresSlice(serviceName string) string {
 	switch serviceName {
 	case "cloudtrail":
 		return "yes"
+	case "directconnect":
+		return "yes"
 	case "elbv2":
 		return "yes"
 	default:
@@ -355,6 +362,8 @@ func ServiceListTagsOutputTagsField(serviceName string) string {
 		return "ResourceTagList[0].TagsList"
 	case "databasemigrationservice":
 		return "TagList"
+	case "directconnect":
+		return "ResourceTags[0].Tags"
 	case "docdb":
 		return "TagList"
 	case "elasticache":

--- a/aws/internal/keyvaluetags/list_tags_gen.go
+++ b/aws/internal/keyvaluetags/list_tags_gen.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/datasync"
 	"github.com/aws/aws-sdk-go/service/dax"
 	"github.com/aws/aws-sdk-go/service/devicefarm"
+	"github.com/aws/aws-sdk-go/service/directconnect"
 	"github.com/aws/aws-sdk-go/service/directoryservice"
 	"github.com/aws/aws-sdk-go/service/dlm"
 	"github.com/aws/aws-sdk-go/service/docdb"
@@ -507,6 +508,23 @@ func DevicefarmListTags(conn *devicefarm.DeviceFarm, identifier string) (KeyValu
 	}
 
 	return DevicefarmKeyValueTags(output.Tags), nil
+}
+
+// DirectconnectListTags lists directconnect service tags.
+// The identifier is typically the Amazon Resource Name (ARN), although
+// it may also be a different identifier depending on the service.
+func DirectconnectListTags(conn *directconnect.DirectConnect, identifier string) (KeyValueTags, error) {
+	input := &directconnect.DescribeTagsInput{
+		ResourceArns: aws.StringSlice([]string{identifier}),
+	}
+
+	output, err := conn.DescribeTags(input)
+
+	if err != nil {
+		return New(nil), err
+	}
+
+	return DirectconnectKeyValueTags(output.ResourceTags[0].Tags), nil
 }
 
 // DirectoryserviceListTags lists directoryservice service tags.

--- a/aws/resource_aws_dx_connection.go
+++ b/aws/resource_aws_dx_connection.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/directconnect"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsDxConnection() *schema.Resource {
@@ -69,6 +70,10 @@ func resourceAwsDxConnectionCreate(d *schema.ResourceData, meta interface{}) err
 		Location:       aws.String(d.Get("location").(string)),
 	}
 
+	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
+		req.Tags = keyvaluetags.New(v).IgnoreAws().DirectconnectTags()
+	}
+
 	log.Printf("[DEBUG] Creating Direct Connect connection: %#v", req)
 	resp, err := conn.CreateConnection(req)
 	if err != nil {
@@ -76,7 +81,8 @@ func resourceAwsDxConnectionCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	d.SetId(aws.StringValue(resp.ConnectionId))
-	return resourceAwsDxConnectionUpdate(d, meta)
+
+	return resourceAwsDxConnectionRead(d, meta)
 }
 
 func resourceAwsDxConnectionRead(d *schema.ResourceData, meta interface{}) error {
@@ -127,22 +133,29 @@ func resourceAwsDxConnectionRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("has_logical_redundancy", connection.HasLogicalRedundancy)
 	d.Set("aws_device", connection.AwsDeviceV2)
 
-	err1 := getTagsDX(conn, d, arn)
-	return err1
+	tags, err := keyvaluetags.DirectconnectListTags(conn, arn)
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for Direct Connect connection (%s): %s", arn, err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
 }
 
 func resourceAwsDxConnectionUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).dxconn
 
-	arn := arn.ARN{
-		Partition: meta.(*AWSClient).partition,
-		Region:    meta.(*AWSClient).region,
-		Service:   "directconnect",
-		AccountID: meta.(*AWSClient).accountid,
-		Resource:  fmt.Sprintf("dxcon/%s", d.Id()),
-	}.String()
-	if err := setTagsDX(conn, d, arn); err != nil {
-		return err
+	arn := d.Get("arn").(string)
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.DirectconnectUpdateTags(conn, arn, o, n); err != nil {
+			return fmt.Errorf("error updating Direct Connect connection (%s) tags: %s", arn, err)
+		}
 	}
 
 	return resourceAwsDxConnectionRead(d, meta)

--- a/aws/resource_aws_dx_lag.go
+++ b/aws/resource_aws_dx_lag.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/directconnect"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsDxLag() *schema.Resource {
@@ -77,6 +78,10 @@ func resourceAwsDxLagCreate(d *schema.ResourceData, meta interface{}) error {
 		NumberOfConnections:  aws.Int64(int64(1)),
 	}
 
+	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
+		req.Tags = keyvaluetags.New(v).IgnoreAws().DirectconnectTags()
+	}
+
 	log.Printf("[DEBUG] Creating Direct Connect LAG: %#v", req)
 	resp, err := conn.CreateLag(req)
 	if err != nil {
@@ -96,7 +101,7 @@ func resourceAwsDxLagCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error deleting newly created and unmanaged Direct Connect LAG (%s) Connection (%s): %s", d.Id(), connectionID, err)
 	}
 
-	return resourceAwsDxLagUpdate(d, meta)
+	return resourceAwsDxLagRead(d, meta)
 }
 
 func resourceAwsDxLagRead(d *schema.ResourceData, meta interface{}) error {
@@ -147,14 +152,21 @@ func resourceAwsDxLagRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("jumbo_frame_capable", lag.JumboFrameCapable)
 	d.Set("has_logical_redundancy", lag.HasLogicalRedundancy)
 
-	err1 := getTagsDX(conn, d, arn)
-	return err1
+	tags, err := keyvaluetags.DirectconnectListTags(conn, arn)
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for Direct Connect LAG (%s): %s", arn, err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
 }
 
 func resourceAwsDxLagUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).dxconn
-
-	d.Partial(true)
 
 	if d.HasChange("name") {
 		req := &directconnect.UpdateLagInput{
@@ -165,26 +177,18 @@ func resourceAwsDxLagUpdate(d *schema.ResourceData, meta interface{}) error {
 		log.Printf("[DEBUG] Updating Direct Connect LAG: %#v", req)
 		_, err := conn.UpdateLag(req)
 		if err != nil {
-			return err
-		} else {
-			d.SetPartial("name")
+			return fmt.Errorf("error updating Direct Connect LAG (%s): %s", d.Id(), err)
 		}
 	}
 
-	arn := arn.ARN{
-		Partition: meta.(*AWSClient).partition,
-		Region:    meta.(*AWSClient).region,
-		Service:   "directconnect",
-		AccountID: meta.(*AWSClient).accountid,
-		Resource:  fmt.Sprintf("dxlag/%s", d.Id()),
-	}.String()
-	if err := setTagsDX(conn, d, arn); err != nil {
-		return err
-	} else {
-		d.SetPartial("tags")
-	}
+	arn := d.Get("arn").(string)
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
 
-	d.Partial(false)
+		if err := keyvaluetags.DirectconnectUpdateTags(conn, arn, o, n); err != nil {
+			return fmt.Errorf("error updating Direct Connect LAG (%s) tags: %s", arn, err)
+		}
+	}
 
 	return resourceAwsDxLagRead(d, meta)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10688.
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/9172.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_dx_connection: Add support for tag-on-create
resource/aws_dx_lag: Add support for tag-on-create
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSDxConnection_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 1 -run=TestAccAWSDxConnection_ -timeout 120m
=== RUN   TestAccAWSDxConnection_basic
=== PAUSE TestAccAWSDxConnection_basic
=== RUN   TestAccAWSDxConnection_tags
=== PAUSE TestAccAWSDxConnection_tags
=== CONT  TestAccAWSDxConnection_basic
--- PASS: TestAccAWSDxConnection_basic (35.12s)
=== CONT  TestAccAWSDxConnection_tags
--- PASS: TestAccAWSDxConnection_tags (50.59s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	85.926s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSDxLag_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 1 -run=TestAccAWSDxLag_ -timeout 120m
=== RUN   TestAccAWSDxLag_basic
=== PAUSE TestAccAWSDxLag_basic
=== RUN   TestAccAWSDxLag_tags
=== PAUSE TestAccAWSDxLag_tags
=== CONT  TestAccAWSDxLag_basic
=== CONT  TestAccAWSDxLag_tags
--- PASS: TestAccAWSDxLag_basic (54.65s)
--- PASS: TestAccAWSDxLag_tags (70.67s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	125.414s
```

These 2 Direct Connection resources do not require any special setup or pre-configuration for acceptance testing.