### PR TITLE
Delete old Route53 record when updating name

### DIFF
--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -630,7 +630,17 @@ func findRecord(d *schema.ResourceData, meta interface{}) (*route53.ResourceReco
 		return nil, err
 	}
 
-	en := expandRecordName(d.Get("name").(string), *zoneRecord.HostedZone.Name)
+	var name string
+	// If we're dealing with a change of record name, but we're operating on the old, rather than
+	// the new, resource, then we need to use the old name to find it (in order to delete it).
+	if !d.IsNewResource() && d.HasChange("name") {
+		oldName, _ := d.GetChange("name")
+		name = oldName.(string)
+	} else {
+		name = d.Get("name").(string)
+	}
+
+	en := expandRecordName(name, *zoneRecord.HostedZone.Name)
 	log.Printf("[DEBUG] Expanded record name: %s", en)
 	d.Set("fqdn", en)
 

--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -711,6 +711,41 @@ func TestAccAWSRoute53Record_TypeChange(t *testing.T) {
 	})
 }
 
+func TestAccAWSRoute53Record_NameChange(t *testing.T) {
+	var record1, record2 route53.ResourceRecordSet
+	resourceName := "aws_route53_record.sample"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckRoute53RecordDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53RecordNameChangePre,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53RecordExists(resourceName, &record1),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
+			},
+
+			// Cause a change, which will trigger a refresh
+			{
+				Config: testAccRoute53RecordNameChangePost,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53RecordExists(resourceName, &record2),
+					testAccCheckRoute53RecordDoesNotExist("aws_route53_zone.main", "sample", "CNAME"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSRoute53Record_SetIdentifierChange(t *testing.T) {
 	var record1, record2 route53.ResourceRecordSet
 	resourceName := "aws_route53_record.basic_to_weighted"
@@ -998,6 +1033,43 @@ func testAccCheckRoute53RecordExists(n string, resourceRecordSet *route53.Resour
 			}
 		}
 		return fmt.Errorf("Record does not exist: %#v", rs.Primary.ID)
+	}
+}
+
+func testAccCheckRoute53RecordDoesNotExist(zoneResourceName string, recordName string, recordType string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).r53conn
+		zoneResource, ok := s.RootModule().Resources[zoneResourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", zoneResourceName)
+		}
+
+		zoneId := zoneResource.Primary.ID
+		en := expandRecordName(recordName, zoneResource.Primary.Attributes["zone_id"])
+
+		lopts := &route53.ListResourceRecordSetsInput{
+			HostedZoneId: aws.String(cleanZoneID(zoneId)),
+		}
+
+		resp, err := conn.ListResourceRecordSets(lopts)
+		if err != nil {
+			return err
+		}
+
+		found := false
+		for _, rec := range resp.ResourceRecordSets {
+			recName := cleanRecordName(*rec.Name)
+			if FQDN(strings.ToLower(recName)) == FQDN(strings.ToLower(en)) && *rec.Type == recordType {
+				found = true
+				break
+			}
+		}
+
+		if found {
+			return fmt.Errorf("Record exists but should not: %s", en)
+		}
+
+		return nil
 	}
 }
 
@@ -1376,6 +1448,10 @@ resource "aws_route53_record" "ap-northeast-1" {
 `
 
 const testAccRoute53RecordConfigAliasElb = `
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_route53_zone" "main" {
   name = "notexample.com"
 }
@@ -1394,7 +1470,7 @@ resource "aws_route53_record" "alias" {
 
 resource "aws_elb" "main" {
   name = "foobar-terraform-elb-%s"
-  availability_zones = ["us-west-2a"]
+  availability_zones = slice(data.aws_availability_zones.available.names, 0, 1)
 
   listener {
     instance_port = 80
@@ -1406,6 +1482,10 @@ resource "aws_elb" "main" {
 `
 
 const testAccRoute53RecordConfigAliasElbUppercase = `
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_route53_zone" "main" {
   name = "notexample.com"
 }
@@ -1424,7 +1504,7 @@ resource "aws_route53_record" "alias" {
 
 resource "aws_elb" "main" {
   name = "FOOBAR-TERRAFORM-ELB-%s"
-  availability_zones = ["us-west-2a"]
+  availability_zones = slice(data.aws_availability_zones.available.names, 0, 1)
 
   listener {
     instance_port = 80
@@ -1551,13 +1631,17 @@ resource "aws_route53_record" "test" {
 }
 
 const testAccRoute53WeightedElbAliasRecord = `
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_route53_zone" "main" {
   name = "notexample.com"
 }
 
 resource "aws_elb" "live" {
   name = "foobar-terraform-elb-live"
-  availability_zones = ["us-west-2a"]
+  availability_zones = slice(data.aws_availability_zones.available.names, 0, 1)
 
   listener {
     instance_port = 80
@@ -1586,7 +1670,7 @@ resource "aws_route53_record" "elb_weighted_alias_live" {
 
 resource "aws_elb" "dev" {
   name = "foobar-terraform-elb-dev"
-  availability_zones = ["us-west-2a"]
+  availability_zones = slice(data.aws_availability_zones.available.names, 0, 1)
 
   listener {
     instance_port = 80
@@ -1698,6 +1782,34 @@ resource "aws_route53_record" "sample" {
 }
 `
 
+const testAccRoute53RecordNameChangePre = `
+resource "aws_route53_zone" "main" {
+	name = "notexample.com"
+}
+
+resource "aws_route53_record" "sample" {
+  zone_id = "${aws_route53_zone.main.zone_id}"
+  name = "sample"
+  type = "CNAME"
+  ttl = "30"
+  records = ["www.terraform.io"]
+}
+`
+
+const testAccRoute53RecordNameChangePost = `
+resource "aws_route53_zone" "main" {
+	name = "notexample.com"
+}
+
+resource "aws_route53_record" "sample" {
+  zone_id = "${aws_route53_zone.main.zone_id}"
+  name = "sample-new"
+  type = "CNAME"
+  ttl = "30"
+  records = ["www.terraform.io"]
+}
+`
+
 const testAccRoute53RecordSetIdentifierChangePre = `
 resource "aws_route53_zone" "main" {
 	name = "notexample.com"
@@ -1731,13 +1843,17 @@ resource "aws_route53_record" "basic_to_weighted" {
 `
 
 const testAccRoute53RecordAliasChangePre = `
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_route53_zone" "main" {
 	name = "notexample.com"
 }
 
 resource "aws_elb" "alias_change" {
   name = "foobar-tf-elb-alias-change"
-  availability_zones = ["us-west-2a"]
+  availability_zones = slice(data.aws_availability_zones.available.names, 0, 1)
 
   listener {
     instance_port = 80


### PR DESCRIPTION
If one updates the name of a Route53 record, it will show up in the plan as if the resource will be destroyed and then a new resource created in its place, but it actually leaves the old resource alone. This makes it difficult to refactor Route53 record resources if there will be any name collisions, because the old records can violate uniqueness constraints.

This PR adds a test which fails on the master branch, demonstrating the buggy behavior, and it updates the R53 `findRecord` function to handle this case correctly and make the test pass.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9024

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
aws_route53_record: properly delete old record when updating name
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ AWS_DEFAULT_REGION=us-east-1 AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... make testacc TEST=./aws TESTARGS='-run=TestAccAWSRoute53Record_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSRoute53Record_ -timeout 120m
=== RUN   TestAccAWSRoute53Record_basic
=== PAUSE TestAccAWSRoute53Record_basic
=== RUN   TestAccAWSRoute53Record_underscored
=== PAUSE TestAccAWSRoute53Record_underscored
=== RUN   TestAccAWSRoute53Record_disappears
=== PAUSE TestAccAWSRoute53Record_disappears
=== RUN   TestAccAWSRoute53Record_disappears_MultipleRecords
=== PAUSE TestAccAWSRoute53Record_disappears_MultipleRecords
=== RUN   TestAccAWSRoute53Record_basic_fqdn
=== PAUSE TestAccAWSRoute53Record_basic_fqdn
=== RUN   TestAccAWSRoute53Record_txtSupport
=== PAUSE TestAccAWSRoute53Record_txtSupport
=== RUN   TestAccAWSRoute53Record_spfSupport
=== PAUSE TestAccAWSRoute53Record_spfSupport
=== RUN   TestAccAWSRoute53Record_caaSupport
=== PAUSE TestAccAWSRoute53Record_caaSupport
=== RUN   TestAccAWSRoute53Record_generatesSuffix
=== PAUSE TestAccAWSRoute53Record_generatesSuffix
=== RUN   TestAccAWSRoute53Record_wildcard
=== PAUSE TestAccAWSRoute53Record_wildcard
=== RUN   TestAccAWSRoute53Record_failover
=== PAUSE TestAccAWSRoute53Record_failover
=== RUN   TestAccAWSRoute53Record_weighted_basic
=== PAUSE TestAccAWSRoute53Record_weighted_basic
=== RUN   TestAccAWSRoute53Record_weighted_to_simple_basic
=== PAUSE TestAccAWSRoute53Record_weighted_to_simple_basic
=== RUN   TestAccAWSRoute53Record_Alias_Elb
=== PAUSE TestAccAWSRoute53Record_Alias_Elb
=== RUN   TestAccAWSRoute53Record_Alias_S3
=== PAUSE TestAccAWSRoute53Record_Alias_S3
=== RUN   TestAccAWSRoute53Record_Alias_VpcEndpoint
=== PAUSE TestAccAWSRoute53Record_Alias_VpcEndpoint
=== RUN   TestAccAWSRoute53Record_Alias_Uppercase
=== PAUSE TestAccAWSRoute53Record_Alias_Uppercase
=== RUN   TestAccAWSRoute53Record_weighted_alias
=== PAUSE TestAccAWSRoute53Record_weighted_alias
=== RUN   TestAccAWSRoute53Record_geolocation_basic
=== PAUSE TestAccAWSRoute53Record_geolocation_basic
=== RUN   TestAccAWSRoute53Record_latency_basic
=== PAUSE TestAccAWSRoute53Record_latency_basic
=== RUN   TestAccAWSRoute53Record_TypeChange
=== PAUSE TestAccAWSRoute53Record_TypeChange
=== RUN   TestAccAWSRoute53Record_NameChange
=== PAUSE TestAccAWSRoute53Record_NameChange
=== RUN   TestAccAWSRoute53Record_SetIdentifierChange
=== PAUSE TestAccAWSRoute53Record_SetIdentifierChange
=== RUN   TestAccAWSRoute53Record_AliasChange
=== PAUSE TestAccAWSRoute53Record_AliasChange
=== RUN   TestAccAWSRoute53Record_empty
=== PAUSE TestAccAWSRoute53Record_empty
=== RUN   TestAccAWSRoute53Record_longTXTrecord
=== PAUSE TestAccAWSRoute53Record_longTXTrecord
=== RUN   TestAccAWSRoute53Record_multivalue_answer_basic
=== PAUSE TestAccAWSRoute53Record_multivalue_answer_basic
=== RUN   TestAccAWSRoute53Record_allowOverwrite
=== PAUSE TestAccAWSRoute53Record_allowOverwrite
=== CONT  TestAccAWSRoute53Record_basic
=== CONT  TestAccAWSRoute53Record_longTXTrecord
=== CONT  TestAccAWSRoute53Record_multivalue_answer_basic
=== CONT  TestAccAWSRoute53Record_NameChange
=== CONT  TestAccAWSRoute53Record_geolocation_basic
=== CONT  TestAccAWSRoute53Record_empty
=== CONT  TestAccAWSRoute53Record_AliasChange
=== CONT  TestAccAWSRoute53Record_allowOverwrite
=== CONT  TestAccAWSRoute53Record_SetIdentifierChange
=== CONT  TestAccAWSRoute53Record_weighted_basic
=== CONT  TestAccAWSRoute53Record_TypeChange
=== CONT  TestAccAWSRoute53Record_latency_basic
=== CONT  TestAccAWSRoute53Record_weighted_alias
=== CONT  TestAccAWSRoute53Record_Alias_Uppercase
=== CONT  TestAccAWSRoute53Record_Alias_VpcEndpoint
=== CONT  TestAccAWSRoute53Record_Alias_S3
=== CONT  TestAccAWSRoute53Record_Alias_Elb
=== CONT  TestAccAWSRoute53Record_weighted_to_simple_basic
=== CONT  TestAccAWSRoute53Record_spfSupport
=== CONT  TestAccAWSRoute53Record_failover
--- PASS: TestAccAWSRoute53Record_longTXTrecord (138.32s)
=== CONT  TestAccAWSRoute53Record_wildcard
--- PASS: TestAccAWSRoute53Record_failover (147.67s)
=== CONT  TestAccAWSRoute53Record_generatesSuffix
--- PASS: TestAccAWSRoute53Record_Alias_Elb (151.26s)
=== CONT  TestAccAWSRoute53Record_caaSupport
--- PASS: TestAccAWSRoute53Record_empty (169.00s)
=== CONT  TestAccAWSRoute53Record_disappears_MultipleRecords
--- PASS: TestAccAWSRoute53Record_multivalue_answer_basic (177.89s)
=== CONT  TestAccAWSRoute53Record_txtSupport
--- PASS: TestAccAWSRoute53Record_Alias_Uppercase (180.78s)
=== CONT  TestAccAWSRoute53Record_basic_fqdn
--- PASS: TestAccAWSRoute53Record_spfSupport (184.73s)
=== CONT  TestAccAWSRoute53Record_disappears
--- PASS: TestAccAWSRoute53Record_latency_basic (192.39s)
=== CONT  TestAccAWSRoute53Record_underscored
--- PASS: TestAccAWSRoute53Record_Alias_S3 (197.97s)
--- PASS: TestAccAWSRoute53Record_geolocation_basic (204.19s)
--- PASS: TestAccAWSRoute53Record_basic (211.41s)
--- PASS: TestAccAWSRoute53Record_TypeChange (221.02s)
--- PASS: TestAccAWSRoute53Record_SetIdentifierChange (229.11s)
--- PASS: TestAccAWSRoute53Record_weighted_to_simple_basic (239.16s)
--- PASS: TestAccAWSRoute53Record_AliasChange (253.06s)
--- PASS: TestAccAWSRoute53Record_allowOverwrite (260.47s)
--- PASS: TestAccAWSRoute53Record_weighted_basic (281.95s)
--- PASS: TestAccAWSRoute53Record_generatesSuffix (136.26s)
--- PASS: TestAccAWSRoute53Record_NameChange (288.70s)
--- PASS: TestAccAWSRoute53Record_caaSupport (137.73s)
--- PASS: TestAccAWSRoute53Record_weighted_alias (312.53s)
--- PASS: TestAccAWSRoute53Record_txtSupport (139.52s)
--- PASS: TestAccAWSRoute53Record_disappears (136.58s)
--- PASS: TestAccAWSRoute53Record_underscored (138.32s)
--- PASS: TestAccAWSRoute53Record_wildcard (194.25s)
--- PASS: TestAccAWSRoute53Record_basic_fqdn (154.01s)
--- PASS: TestAccAWSRoute53Record_disappears_MultipleRecords (176.53s)
--- PASS: TestAccAWSRoute53Record_Alias_VpcEndpoint (537.54s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws   537.599s
```
