### PR TITLE
data-source/aws_elb: Export arn attribute

### DIFF
--- a/aws/data_source_aws_elb_test.go
+++ b/aws/data_source_aws_elb_test.go
@@ -29,6 +29,7 @@ func TestAccDataSourceAWSELB_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.aws_elb.elb_test", "tags.TestName", t.Name()),
 					resource.TestCheckResourceAttrSet("data.aws_elb.elb_test", "dns_name"),
 					resource.TestCheckResourceAttrSet("data.aws_elb.elb_test", "zone_id"),
+					resource.TestCheckResourceAttrPair("data.aws_elb.elb_test", "arn", "aws_elb.elb_test", "arn"),
 				),
 			},
 		},


### PR DESCRIPTION
The documentation says that data source for aws_elb shall return the
same attributes as the resource type.

This commit exports arn on the data source to match the documented
behaviour.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data-source/aws_elb: Export arn attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccDataSourceAWSELB_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccDataSourceAWSELB_basic -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccDataSourceAWSELB_basic
=== PAUSE TestAccDataSourceAWSELB_basic
=== CONT  TestAccDataSourceAWSELB_basic
--- PASS: TestAccDataSourceAWSELB_basic (52.27s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       52.307s
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap      0.002s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags 0.008s [no tests to run]
```
