### PR TITLE
internal/keyvaluetags: Automatically combine UpdateTags API call if TagFunction equals UntagFunction

### DIFF
--- a/aws/internal/keyvaluetags/update_tags_gen.go
+++ b/aws/internal/keyvaluetags/update_tags_gen.go
@@ -2693,33 +2693,31 @@ func ResourcegroupsUpdateTags(conn *resourcegroups.ResourceGroups, identifier st
 func Route53UpdateTags(conn *route53.Route53, identifier string, resourceType string, oldTagsMap interface{}, newTagsMap interface{}) error {
 	oldTags := New(oldTagsMap)
 	newTags := New(newTagsMap)
+	removedTags := oldTags.Removed(newTags)
+	updatedTags := oldTags.Updated(newTags)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
-		input := &route53.ChangeTagsForResourceInput{
-			ResourceId:    aws.String(identifier),
-			ResourceType:  aws.String(resourceType),
-			RemoveTagKeys: aws.StringSlice(removedTags.Keys()),
-		}
-
-		_, err := conn.ChangeTagsForResource(input)
-
-		if err != nil {
-			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
-		}
+	// Ensure we do not send empty requests
+	if len(removedTags) == 0 && len(updatedTags) == 0 {
+		return nil
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
-		input := &route53.ChangeTagsForResourceInput{
-			ResourceId:   aws.String(identifier),
-			ResourceType: aws.String(resourceType),
-			AddTags:      updatedTags.IgnoreAws().Route53Tags(),
-		}
+	input := &route53.ChangeTagsForResourceInput{
+		ResourceId:   aws.String(identifier),
+		ResourceType: aws.String(resourceType),
+	}
 
-		_, err := conn.ChangeTagsForResource(input)
+	if len(updatedTags) > 0 {
+		input.AddTags = updatedTags.IgnoreAws().Route53Tags()
+	}
 
-		if err != nil {
-			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
-		}
+	if len(removedTags) > 0 {
+		input.RemoveTagKeys = aws.StringSlice(removedTags.Keys())
+	}
+
+	_, err := conn.ChangeTagsForResource(input)
+
+	if err != nil {
+		return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
 	}
 
 	return nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/11292

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
--- PASS: TestAccAWSRoute53HealthCheck_withHealthCheckRegions (20.10s)
--- PASS: TestAccAWSRoute53HealthCheck_withChildHealthChecks (23.65s)
--- PASS: TestAccAWSRoute53HealthCheck_IpConfig (26.22s)
--- PASS: TestAccAWSRoute53HealthCheck_basic (28.45s)
--- PASS: TestAccAWSRoute53HealthCheck_CloudWatchAlarmCheck (31.48s)
--- PASS: TestAccAWSRoute53HealthCheck_withSearchString (31.57s)
--- PASS: TestAccAWSRoute53HealthCheck_withSNI (36.64s)
--- PASS: TestAccAWSRoute53HealthCheck_tags (49.80s)

--- PASS: TestAccAWSRoute53Zone_disappears (55.01s)
--- PASS: TestAccAWSRoute53Zone_basic (58.79s)
--- PASS: TestAccAWSRoute53Zone_DelegationSetID (61.95s)
--- PASS: TestAccAWSRoute53Zone_multiple (65.81s)
--- PASS: TestAccAWSRoute53Zone_Comment (67.14s)
--- PASS: TestAccAWSRoute53Zone_Tags (75.06s)
--- PASS: TestAccAWSRoute53Zone_VPC_Single (98.86s)
--- PASS: TestAccAWSRoute53Zone_VPC_Multiple (172.04s)
--- PASS: TestAccAWSRoute53Zone_ForceDestroy (190.90s)
--- PASS: TestAccAWSRoute53Zone_ForceDestroy_TrailingPeriod (190.90s)
--- PASS: TestAccAWSRoute53Zone_VPC_Updates (244.57s)
```
