### PR TITLE
provider: Ensure hashibot appropriately labels aws_vpn* as service/ec2 and aws_kinesis_analytics_* as service/kinesisanalytics

### DIFF
--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -240,6 +240,7 @@ behavior "regexp_issue_labeler_v2" "service_labels" {
       "aws_placement_group",
       "aws_spot",
       "aws_route(\"|`|$)",
+      "aws_vpn_",
     ],
     "service/ecr" = [
       "aws_ecr_",
@@ -337,7 +338,7 @@ behavior "regexp_issue_labeler_v2" "service_labels" {
       "aws_kinesis_([^f]|f[^i]|fi[^r]|fir[^e]|fire[^h]|fireh[^o]|fireho[^s]|firehos[^e]|firehose[^_])",
     ],
     "service/kinesisanalytics" = [
-      "aws_kinesisanalytics_",
+      "aws_kinesis_analytics_",
     ],
     "service/kms" = [
       "aws_kms_",
@@ -935,8 +936,8 @@ behavior "pull_request_path_labeler" "service_labels" {
       "website/kinesis_stream*"
     ]
     "service/kinesisanalytics" = [
-      "**/*_kinesisanalytics_*",
-      "**/kinesisanalytics_*"
+      "**/*_kinesis_analytics_*",
+      "**/kinesis_analytics_*"
     ]
     "service/kms" = [
       "**/*_kms_*",


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/11293
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/11347
Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/11349

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing: N/A
