### PR TITLE
tests/resource/aws_eks_fargate_profile: Add PreCheck

### DIFF
--- a/aws/resource_aws_eks_fargate_profile_test.go
+++ b/aws/resource_aws_eks_fargate_profile_test.go
@@ -269,8 +269,8 @@ func testAccPreCheckAWSEksFargateProfile(t *testing.T) {
 
 The allowed regions are hardcoded in the acceptance testing since dynamically determining the
 functionality requires creating and destroying a real EKS Cluster, which is a lengthy process.
-If this check is out of date, please consider creating an issue in the Terraform AWS Provider
-repository (https://github.com/terraform-providers/terraform-provider-aws) or updating the
+If this check is out of date, please create an issue in the Terraform AWS Provider
+repository (https://github.com/terraform-providers/terraform-provider-aws) or submit a PR to update the
 check itself (testAccPreCheckAWSEksFargateProfile).
 
 For the most up to date supported region information, see the EKS User Guide:

--- a/aws/resource_aws_eks_fargate_profile_test.go
+++ b/aws/resource_aws_eks_fargate_profile_test.go
@@ -21,7 +21,7 @@ func TestAccAWSEksFargateProfile_basic(t *testing.T) {
 	resourceName := "aws_eks_fargate_profile.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t); testAccPreCheckAWSEksFargateProfile(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEksFargateProfileDestroy,
 		Steps: []resource.TestStep{
@@ -54,7 +54,7 @@ func TestAccAWSEksFargateProfile_disappears(t *testing.T) {
 	resourceName := "aws_eks_fargate_profile.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t); testAccPreCheckAWSEksFargateProfile(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEksFargateProfileDestroy,
 		Steps: []resource.TestStep{
@@ -76,7 +76,7 @@ func TestAccAWSEksFargateProfile_Selector_Labels(t *testing.T) {
 	resourceName := "aws_eks_fargate_profile.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t); testAccPreCheckAWSEksFargateProfile(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEksFargateProfileDestroy,
 		Steps: []resource.TestStep{
@@ -101,7 +101,7 @@ func TestAccAWSEksFargateProfile_Tags(t *testing.T) {
 	resourceName := "aws_eks_fargate_profile.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t); testAccPreCheckAWSEksFargateProfile(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEksFargateProfileDestroy,
 		Steps: []resource.TestStep{
@@ -239,6 +239,45 @@ func testAccCheckAWSEksFargateProfileDisappears(fargateProfile *eks.FargateProfi
 
 		return waitForEksFargateProfileDeletion(conn, aws.StringValue(fargateProfile.ClusterName), aws.StringValue(fargateProfile.FargateProfileName), 10*time.Minute)
 	}
+}
+
+func testAccPreCheckAWSEksFargateProfile(t *testing.T) {
+	// Most PreCheck functions try to use a list or describe API call to
+	// determine service or functionality availability, however
+	// ListFargateProfiles requires a valid ClusterName and does not indicate
+	// that the functionality is unavailable in a region. The create API call
+	// fails with same "ResourceNotFoundException: No cluster found" before
+	// returning the definitive "InvalidRequestException: CreateFargateProfile
+	// is not supported for region" error. We do not want to wait 20 minutes to
+	// create and destroy an EKS Cluster just to find the real error, instead
+	// we take the least desirable approach of hardcoding allowed regions.
+	allowedRegions := []string{
+		"ap-northeast-1",
+		"eu-west-1",
+		"us-east-1",
+		"us-east-2",
+	}
+	region := testAccProvider.Meta().(*AWSClient).region
+
+	for _, allowedRegion := range allowedRegions {
+		if region == allowedRegion {
+			return
+		}
+	}
+
+	message := fmt.Sprintf(`Test provider region (%s) not found in allowed EKS Fargate regions: %v
+
+The allowed regions are hardcoded in the acceptance testing since dynamically determining the
+functionality requires creating and destroying a real EKS Cluster, which is a lengthy process.
+If this check is out of date, please consider creating an issue in the Terraform AWS Provider
+repository (https://github.com/terraform-providers/terraform-provider-aws) or updating the
+check itself (testAccPreCheckAWSEksFargateProfile).
+
+For the most up to date supported region information, see the EKS User Guide:
+https://docs.aws.amazon.com/eks/latest/userguide/fargate.html
+`, region, allowedRegions)
+
+	t.Skipf("skipping acceptance testing:\n\n%s", message)
 }
 
 func testAccAWSEksFargateProfileConfigBase(rName string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Acceptance testing fails in our default region of us-west-2:

```
--- FAIL: TestAccAWSEksFargateProfile_basic (1244.08s)
    testing.go:635: Step 0 error: errors during apply:

        Error: error creating EKS Fargate Profile (tf-acc-test-6753867324954738062:tf-acc-test-6753867324954738062): InvalidRequestException: CreateFargateProfile is not supported for region: us-west-2
```

Determining if this functionality is available in a region requires trying to list or create an EKS Fargate Profile on an existing EKS Cluster, which takes upwards of 15-20 minutes to create and destroy on its own. Rather than introduce an extra 15-20 minutes to see the acceptance test skipping or even continue (then taking its normal 20 minutes), we implement a worst case hardcoded list of allowed regions with information about the list and a link to the most up to date documentation.

Output from acceptance testing in us-west-2:

```
--- SKIP: TestAccAWSEksFargateProfile_basic (2.62s)
    resource_aws_eks_fargate_profile_test.go:280: skipping acceptance testing:

        Test provider region (us-west-2) not found in allowed EKS Fargate regions: [ap-northeast-1 eu-west-1 us-east-1 us-east-2]

        The allowed regions are hardcoded in the acceptance testing since dynamically determining the
        functionality requires creating and destroying a real EKS Cluster, which is a lengthy process.
        If this check is out of date, please consider creating an issue in the Terraform AWS Provider
        repository (https://github.com/terraform-providers/terraform-provider-aws) or updating the
        check itself (testAccPreCheckAWSEksFargateProfile).

        For the most up to date supported region information, see the EKS User Guide:
        https://docs.aws.amazon.com/eks/latest/userguide/fargate.html
```

Output from acceptance testing in us-east-2:

```
--- PASS: TestAccAWSEksFargateProfile_basic (1432.20s)
```
