### PR TITLE
tests/provider: Enable allowed documentation subcategories check

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -504,6 +504,7 @@ into Terraform.
   - In `aws/config.go`: Create the new service client in the `{SERVICE}conn`
     field in the `AWSClient` instantiation within `Client()`. e.g.
     `quicksightconn: quicksight.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["quicksight"])})),`
+  - In `website/allowed-subcategories.txt`: Add a name acceptable for the documentation navigation.
   - In `website/docs/guides/custom-service-endpoints.html.md`: Add the service
     name in the list of customizable endpoints.
   - In `.hashibot.hcl`: Add the new service to automated issue and pull request labeling. e.g. with the `quicksight` service

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -36,6 +36,7 @@ websitefmtcheck:
 
 docscheck:
 	@tfproviderdocs check \
+		-allowed-resource-subcategories-file website/allowed-subcategories.txt \
 		-require-resource-subcategory
 
 lint:

--- a/website/allowed-subcategories.txt
+++ b/website/allowed-subcategories.txt
@@ -1,0 +1,106 @@
+
+ACM PCA
+ACM
+API Gateway
+Access Analyzer
+AppMesh
+AppSync
+Application Autoscaling
+Athena
+Autoscaling
+Backup
+Batch
+Budgets
+Cloud9
+CloudFormation
+CloudFront
+CloudHSM v2
+CloudTrail
+CloudWatch
+CodeBuild
+CodeCommit
+CodeDeploy
+CodePipeline
+Cognito
+Config
+Cost and Usage Report
+Data Lifecycle Manager (DLM)
+DataPipeline
+DataSync
+Database Migration Service (DMS)
+Device Farm
+Direct Connect
+Directory Service
+DocumentDB
+DynamoDB Accelerator (DAX)
+DynamoDB
+EC2
+ECR
+ECS
+EFS
+EKS
+ElastiCache
+Elastic Beanstalk
+Elastic Load Balancing (ELB Classic)
+Elastic Load Balancing v2 (ALB/NLB)
+Elastic Map Reduce (EMR)
+Elastic Transcoder
+ElasticSearch
+File System (FSx)
+Firewall Manager (FMS)
+Gamelift
+Glacier
+Global Accelerator
+Glue
+GuardDuty
+IAM
+Inspector
+IoT
+KMS
+Kinesis Firehose
+Kinesis
+Lambda
+License Manager
+Lightsail
+MQ
+Macie
+Managed Streaming for Kafka (MSK)
+MediaConvert
+MediaPackage
+MediaStore
+Neptune
+OpsWorks
+Organizations
+Pinpoint
+Pricing
+Quantum Ledger Database (QLDB)
+QuickSight
+RAM
+RDS
+Redshift
+Resource Groups
+Route53 Resolver
+Route53
+S3
+SES
+SNS
+SQS
+SSM
+SWF
+Sagemaker
+Secrets Manager
+Security Hub
+Service Catalog
+Service Discovery
+Service Quotas
+Shield
+SimpleDB
+Step Function (SFN)
+Storage Gateway
+Transfer
+VPC
+WAF Regional
+WAF
+WorkLink
+WorkSpaces
+XRay

--- a/website/docs/d/workspaces_bundle.html.markdown
+++ b/website/docs/d/workspaces_bundle.html.markdown
@@ -3,12 +3,12 @@ subcategory: "WorkSpaces"
 layout: "aws"
 page_title: "AWS: aws_workspaces_bundle"
 description: |-
-  Get information on a Workspaces Bundle.
+  Get information on a WorkSpaces Bundle.
 ---
 
 # Data Source: aws_workspaces_bundle
 
-Use this data source to get information about a Workspaces Bundle.
+Use this data source to get information about a WorkSpaces Bundle.
 
 ## Example Usage
 

--- a/website/docs/r/workspaces_ip_group.html.markdown
+++ b/website/docs/r/workspaces_ip_group.html.markdown
@@ -1,14 +1,14 @@
 ---
-subcategory: "Workspaces"
+subcategory: "WorkSpaces"
 layout: "aws"
 page_title: "AWS: aws_workspaces_ip_group"
 description: |-
-  Provides an IP access control group in AWS Workspaces Service.
+  Provides an IP access control group in AWS WorkSpaces Service.
 ---
 
 # Resource: aws_workspaces_ip_group
 
-Provides an IP access control group in AWS Workspaces Service
+Provides an IP access control group in AWS WorkSpaces Service
 
 ## Example Usage
 
@@ -44,7 +44,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Workspaces IP groups can be imported using their GroupID, e.g.
+WorkSpaces IP groups can be imported using their GroupID, e.g.
 
 ```
 $ terraform import aws_workspaces_ip_group.example wsipg-488lrtl3k


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

To prevent issues with the subcategory frontmatter such as differing capitalization or naming, which adversely affects the display of the provider documentation navigation in the Terraform Registry.

In the future, this list can be likely be generated by the codebase.

This should fail currently with:

```
Error checking Terraform Provider documentation: 1 error occurred:
	* website/docs/r/workspaces_ip_group.html.markdown: error checking file frontmatter: YAML frontmatter subcategory (Workspaces) does not match allowed subcategories ([]string{"", "ACM PCA", "ACM", "API Gateway", "Access Analyzer", "AppMesh", "AppSync", "Application Autoscaling", "Athena", "Autoscaling", "Backup", "Batch", "Budgets", "Cloud9", "CloudFormation", "CloudFront", "CloudHSM v2", "CloudTrail", "CloudWatch", "CodeBuild", "CodeCommit", "CodeDeploy", "CodePipeline", "Cognito", "Config", "Cost and Usage Report", "Data Lifecycle Manager (DLM)", "DataPipeline", "DataSync", "Database Migration Service (DMS)", "Device Farm", "Direct Connect", "Directory Service", "DocumentDB", "DynamoDB Accelerator (DAX)", "DynamoDB", "EC2", "ECR", "ECS", "EFS", "EKS", "ElastiCache", "Elastic Beanstalk", "Elastic Load Balancing (ELB Classic)", "Elastic Load Balancing v2 (ALB/NLB)", "Elastic Map Reduce (EMR)", "Elastic Transcoder", "ElasticSearch", "File System (FSx)", "Firewall Manager (FMS)", "Gamelift", "Glacier", "Global Accelerator", "Glue", "GuardDuty", "IAM", "Inspector", "IoT", "KMS", "Kinesis Firehose", "Kinesis", "Lambda", "License Manager", "Lightsail", "MQ", "Macie", "Managed Streaming for Kafka (MSK)", "MediaConvert", "MediaPackage", "MediaStore", "Neptune", "OpsWorks", "Organizations", "Pinpoint", "Pricing", "Quantum Ledger Database (QLDB)", "QuickSight", "RAM", "RDS", "Redshift", "Resource Groups", "Route53 Resolver", "Route53", "S3", "SES", "SNS", "SQS", "SSM", "SWF", "Sagemaker", "Secrets Manager", "Security Hub", "Service Catalog", "Service Discovery", "Service Quotas", "Shield", "SimpleDB", "Step Function (SFN)", "Storage Gateway", "Transfer", "VPC", "WAF Regional", "WAF", "WorkLink", "WorkSpaces", "XRay"})
```

Which will be fixed in a subsequent commit to this PR, once its shown failing.