### PR TITLE
tests/provider: Add dependency checks (go mod tidy and go mod vendor) to TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ matrix:
       name: "Code UnitTest"
       script: make test
     - go: "1.13.x"
+      name: "Dependencies"
+      script: make depscheck
+    - go: "1.13.x"
       name: "Website"
       script:
         - make docscheck

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -34,6 +34,16 @@ fmtcheck:
 websitefmtcheck:
 	@sh -c "'$(CURDIR)/scripts/websitefmtcheck.sh'"
 
+depscheck:
+	@echo "==> Checking source code with go mod tidy..."
+	@go mod tidy
+	@git diff --exit-code -- go.mod go.sum || \
+		(echo; echo "Unexpected difference in go.mod/go.sum files. Run 'go mod tidy' command or revert any go.mod/go.sum changes and commit."; exit 1)
+	@echo "==> Checking source code with go mod vendor..."
+	@go mod vendor
+	@git diff --compact-summary --exit-code -- vendor || \
+		(echo; echo "Unexpected difference in vendor/ directory. Run 'go mod vendor' command or revert any go.mod/go.sum/vendor changes and commit."; exit 1)
+
 docscheck:
 	@tfproviderdocs check \
 		-require-resource-subcategory
@@ -96,5 +106,5 @@ ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
 endif
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
-.PHONY: build gen sweep test testacc fmt fmtcheck lint tools test-compile website website-lint website-test docscheck
+.PHONY: build gen sweep test testacc fmt fmtcheck lint tools test-compile website website-lint website-test depscheck docscheck
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

This quick checking ensures that Go dependencies are handled as expected with `go mod tidy` and `go mod vendor` ran against the version of Go in CI, as well as to try and protect against inadvertent dependencies updates. This is similar to checking we had with `govendor` prior to the change to Go modules.

For example, when run against the changes in #10892, produces the following and exits 1:

```console
$ git pull https://github.com/afrazkhan/terraform-provider-aws.git master
From ssh://github.com/afrazkhan/terraform-provider-aws
 * branch                master     -> FETCH_HEAD
Auto-merging go.sum
Auto-merging go.mod
Merge made by the 'recursive' strategy.
 aws/data_source_aws_autoscaling_group.go       | 10 ++++++++++
 go.mod                                         |  2 ++
 go.sum                                         |  8 ++++++++
 website/docs/d/autoscaling_group.html.markdown |  2 ++
 4 files changed, 22 insertions(+)
$ make depscheck
==> Checking source code with go mod tidy...
==> Checking source code with go mod vendor...
 vendor/google.golang.org/api/gensupport/buffer.go (gone)                     |  79 ---------------------------
 vendor/google.golang.org/api/gensupport/doc.go (gone)                        |  10 ----
 vendor/google.golang.org/api/gensupport/json.go (gone)                       | 211 ----------------------------------------------------------------------
 vendor/google.golang.org/api/gensupport/jsonfloat.go (gone)                  |  57 -------------------
 vendor/google.golang.org/api/gensupport/media.go (gone)                      | 363 ------------------------------------------------------------------------------------------------------------------------
 vendor/google.golang.org/api/gensupport/params.go (gone)                     |  51 -----------------
 vendor/google.golang.org/api/gensupport/resumable.go (gone)                  | 241 --------------------------------------------------------------------------------
 vendor/google.golang.org/api/gensupport/send.go (gone)                       |  87 -----------------------------
 vendor/google.golang.org/api/googleapi/googleapi.go                          |  14 ++++-
 vendor/google.golang.org/api/googleapi/internal/uritemplates/uritemplates.go |   2 +-
 vendor/google.golang.org/api/googleapi/transport/apikey.go                   |   2 +-
 vendor/google.golang.org/api/googleapi/types.go                              |   2 +-
 vendor/google.golang.org/api/internal/creds.go                               |  16 +-----
 vendor/google.golang.org/api/internal/pool.go                                |  16 +-----
 vendor/google.golang.org/api/internal/settings.go                            |  16 +-----
 vendor/google.golang.org/api/iterator/iterator.go                            |  36 ++++++------
 vendor/google.golang.org/api/option/credentials_go19.go                      |  16 +-----
 vendor/google.golang.org/api/option/credentials_notgo19.go                   |  16 +-----
 vendor/google.golang.org/api/option/option.go                                |  16 +-----
 vendor/google.golang.org/api/storage/v1/storage-api.json                     |  17 +++++-
 vendor/google.golang.org/api/storage/v1/storage-gen.go                       | 129 +++++++++++++++++++++++++------------------
 vendor/google.golang.org/api/transport/http/dial.go                          |  16 +-----
 vendor/google.golang.org/api/transport/http/dial_appengine.go                |  16 +-----
 vendor/google.golang.org/api/transport/http/internal/propagation/http.go     |  16 +-----
 vendor/google.golang.org/grpc/.travis.yml                                    |  27 +++++----
 vendor/google.golang.org/grpc/CONTRIBUTING.md                                |   4 +-
 vendor/google.golang.org/grpc/backoff.go                                     |  20 +++++++
 vendor/google.golang.org/grpc/balancer/balancer.go                           |  13 ++++-
 vendor/google.golang.org/grpc/balancer/base/balancer.go                      |   9 ++-
 vendor/google.golang.org/grpc/balancer_conn_wrappers.go                      | 140 +++++++++++++----------------------------------
 vendor/google.golang.org/grpc/clientconn.go                                  | 200 +++++++++++++++++++++++++++++++++++++++++++++++++------------------
 vendor/google.golang.org/grpc/credentials/credentials.go                     |  40 ++++++++++++--
 vendor/google.golang.org/grpc/dialoptions.go                                 |  51 ++++++++++++++---
 vendor/google.golang.org/grpc/encoding/encoding.go                           |   4 ++
 vendor/google.golang.org/grpc/go.mod                                         |  15 ++---
 vendor/google.golang.org/grpc/go.sum                                         |  36 ++++++++----
 vendor/google.golang.org/grpc/grpclog/grpclog.go                             |   2 +-
 vendor/google.golang.org/grpc/health/client.go                               |  28 +++++-----
 vendor/google.golang.org/grpc/health/grpc_health_v1/health.pb.go             |  96 ++++++++++++++++++--------------
 vendor/google.golang.org/grpc/health/server.go                               |  10 ++--
 vendor/google.golang.org/grpc/internal/backoff/backoff.go                    |  27 ++++-----
 vendor/google.golang.org/grpc/internal/binarylog/binarylog.go                |   2 +-
 vendor/google.golang.org/grpc/internal/binarylog/env_config.go               |   4 +-
 vendor/google.golang.org/grpc/internal/binarylog/sink.go                     |   2 +-
 vendor/google.golang.org/grpc/internal/internal.go                           |  13 +++--
 vendor/google.golang.org/grpc/internal/transport/controlbuf.go               |  12 ++--
 vendor/google.golang.org/grpc/internal/transport/http2_client.go             | 189 ++++++++++++++++++++++++++++++++++++---------------------------
 vendor/google.golang.org/grpc/internal/transport/http2_server.go             |  43 +++++++++------
 vendor/google.golang.org/grpc/internal/transport/http_util.go                |   1 +
 vendor/google.golang.org/grpc/internal/transport/transport.go                |  61 +++++++++------------
 vendor/google.golang.org/grpc/resolver/dns/dns_resolver.go (gone)            | 457 --------------------------------------------------------------------------------------------------------------------------------------------------------
 vendor/google.golang.org/grpc/resolver/passthrough/passthrough.go (gone)     |  57 -------------------
 vendor/google.golang.org/grpc/resolver/resolver.go                           |  52 +++++++++++++++---
 vendor/google.golang.org/grpc/resolver_conn_wrapper.go                       | 163 +++++++++++++++++++++++++++++++++++++++++++-----------
 vendor/google.golang.org/grpc/rpc_util.go                                    |  53 +++++++++++++-----
 vendor/google.golang.org/grpc/server.go                                      |  12 ++++
 vendor/google.golang.org/grpc/service_config.go                              |  35 +++++++-----
 vendor/google.golang.org/grpc/serviceconfig/serviceconfig.go                 |  21 +++----
 vendor/google.golang.org/grpc/stream.go                                      |   2 +-
 vendor/google.golang.org/grpc/test/bufconn/bufconn.go                        |  74 +++++++++++++++++++++++--
 vendor/google.golang.org/grpc/version.go                                     |   2 +-
 vendor/google.golang.org/grpc/vet.sh                                         |  18 ++++--
 vendor/modules.txt                                                           |  12 ++--
 63 files changed, 1110 insertions(+), 2342 deletions(-)

Unexpected difference in vendor/ directory. Run 'go mod vendor' command or revert any go.mod/go.sum/vendor changes and commit.
make: *** [depscheck] Error 1
```

Output from acceptance testing: N/A
