### PR TITLE
SFN State Machine Express support

### DIFF
--- a/aws/resource_aws_sfn_state_machine.go
+++ b/aws/resource_aws_sfn_state_machine.go
@@ -70,7 +70,7 @@ func resourceAwsSfnStateMachine() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"destinations": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Required: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
@@ -270,7 +270,7 @@ func expandSfnLoggingConfig(config []interface{}) *sfn.LoggingConfiguration {
 	}
 
 	m := config[0].(map[string]interface{})
-	destinations := expandSfnDestinations(m["destinations"].(*schema.Set).List())
+	destinations := expandSfnDestinations(m["destinations"].([]interface{}))
 
 	loggingConfiguration := &sfn.LoggingConfiguration{
 		Destinations:         destinations,

--- a/aws/resource_aws_sfn_state_machine.go
+++ b/aws/resource_aws_sfn_state_machine.go
@@ -57,6 +57,7 @@ func resourceAwsSfnStateMachine() *schema.Resource {
 			"type": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 				Default:  sfn.StateMachineTypeStandard,
 				ValidateFunc: validation.StringInSlice([]string{
 					sfn.StateMachineTypeStandard,
@@ -66,6 +67,7 @@ func resourceAwsSfnStateMachine() *schema.Resource {
 			"logging_configuration": {
 				Type:     schema.TypeList,
 				Optional: true,
+				ForceNew: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -85,11 +87,11 @@ func resourceAwsSfnStateMachine() *schema.Resource {
 						},
 						"include_execution_data": {
 							Type:     schema.TypeBool,
-							Optional: true,
+							Required: true,
 						},
 						"level": {
 							Type:     schema.TypeString,
-							Optional: true,
+							Required: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								sfn.LogLevelAll,
 								sfn.LogLevelError,
@@ -270,10 +272,8 @@ func expandSfnLoggingConfig(config []interface{}) *sfn.LoggingConfiguration {
 	}
 
 	m := config[0].(map[string]interface{})
-	destinations := expandSfnDestinations(m["destinations"].([]interface{}))
-
 	loggingConfiguration := &sfn.LoggingConfiguration{
-		Destinations:         destinations,
+		Destinations:         expandSfnDestinations(m["destinations"].([]interface{})),
 		IncludeExecutionData: aws.Bool(m["include_execution_data"].(bool)),
 		Level:                aws.String(m["level"].(string)),
 	}

--- a/aws/resource_aws_sfn_state_machine_test.go
+++ b/aws/resource_aws_sfn_state_machine_test.go
@@ -92,13 +92,13 @@ func TestAccAWSSfnStateMachine_logging_configuration(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSfnStateMachineDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSfnStateMachineConfigLogging(rName, "ALL", true),
+				Config: testAccAWSSfnStateMachineConfigLogging(rName, "OFF", true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSfnExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.level", "OFF"),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.include_execution_data", "true"),
-					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.level", "ALL"),
 					testAccMatchResourceAttrRegionalARN(resourceName, "logging_configuration.0.destinations.0.cloudwatch_log_group_arn", "logs", regexp.MustCompile(`log-group.+`)),
 				),
 			},
@@ -106,28 +106,6 @@ func TestAccAWSSfnStateMachine_logging_configuration(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-			},
-			{
-				Config: testAccAWSSfnStateMachineConfigLogging(rName, "FATAL", false),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSfnExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.include_execution_data", "false"),
-					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.level", "FATAL"),
-					testAccMatchResourceAttrRegionalARN(resourceName, "logging_configuration.0.destinations.0.cloudwatch_log_group_arn", "logs", regexp.MustCompile(`log-group.+`)),
-				),
-			},
-			{
-				Config: testAccAWSSfnStateMachineConfigLogging(rName, "OFF", false),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSfnExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.include_execution_data", "false"),
-					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.level", "OFF"),
-					testAccMatchResourceAttrRegionalARN(resourceName, "logging_configuration.0.destinations.0.cloudwatch_log_group_arn", "logs", regexp.MustCompile(`log-group.+`)),
-				),
 			},
 		},
 	})

--- a/aws/resource_aws_sfn_state_machine_test.go
+++ b/aws/resource_aws_sfn_state_machine_test.go
@@ -99,7 +99,7 @@ func TestAccAWSSfnStateMachine_logging_configuration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.include_execution_data", "true"),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.level", "ALL"),
-					testAccMatchResourceAttrRegionalARN(resourceName, "logging_configuration.0.destinations.0.cloudwatch_log_group_arn", "cloudwatch", regexp.MustCompile(`role/.+`)),
+					testAccMatchResourceAttrRegionalARN(resourceName, "logging_configuration.0.destinations.0.cloudwatch_log_group_arn", "logs", regexp.MustCompile(`log-group/.+`)),
 				),
 			},
 			{
@@ -115,7 +115,7 @@ func TestAccAWSSfnStateMachine_logging_configuration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.include_execution_data", "false"),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.level", "FATAL"),
-					//testAccMatchResourceAttrRegionalARN(resourceName, "logging_configuration.0.destinations.0.cloudwatch_log_group_arn", "cloudwatch", regexp.MustCompile(`role/.+`)),
+					testAccMatchResourceAttrRegionalARN(resourceName, "logging_configuration.0.destinations.0.cloudwatch_log_group_arn", "logs", regexp.MustCompile(`log-group/.+`)),
 				),
 			},
 			{
@@ -126,8 +126,7 @@ func TestAccAWSSfnStateMachine_logging_configuration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.include_execution_data", "false"),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.level", "OFF"),
-					//resource.TestCheckResourceAttrSet(resourceName,"logging_configuration.0.destinations.0.cloudwatch_log_group_arn"),
-					//testAccMatchResourceAttrRegionalARN(resourceName, "logging_configuration.0.destinations.0.cloudwatch_log_group_arn", "cloudwatch", regexp.MustCompile(`role/.+`)),
+					testAccMatchResourceAttrRegionalARN(resourceName, "logging_configuration.0.destinations.0.cloudwatch_log_group_arn", "logs", regexp.MustCompile(`log-group/.+`)),
 				),
 			},
 		},

--- a/aws/resource_aws_sfn_state_machine_test.go
+++ b/aws/resource_aws_sfn_state_machine_test.go
@@ -99,7 +99,7 @@ func TestAccAWSSfnStateMachine_logging_configuration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.include_execution_data", "true"),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.level", "ALL"),
-					//testAccMatchResourceAttrRegionalARN(resourceName, "logging_configuration.0.destinations.0.cloudwatch_log_group_arn", "cloudwatch", regexp.MustCompile(`role/.+`)),
+					testAccMatchResourceAttrRegionalARN(resourceName, "logging_configuration.0.destinations.0.cloudwatch_log_group_arn", "cloudwatch", regexp.MustCompile(`role/.+`)),
 				),
 			},
 			{
@@ -108,13 +108,25 @@ func TestAccAWSSfnStateMachine_logging_configuration(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSSfnStateMachineConfigLogging(rName, "ERROR", false),
+				Config: testAccAWSSfnStateMachineConfigLogging(rName, "FATAL", false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSfnExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.include_execution_data", "false"),
-					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.level", "ERROR"),
+					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.level", "FATAL"),
+					//testAccMatchResourceAttrRegionalARN(resourceName, "logging_configuration.0.destinations.0.cloudwatch_log_group_arn", "cloudwatch", regexp.MustCompile(`role/.+`)),
+				),
+			},
+			{
+				Config: testAccAWSSfnStateMachineConfigLogging(rName, "OFF", false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSfnExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.include_execution_data", "false"),
+					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.level", "OFF"),
+					//resource.TestCheckResourceAttrSet(resourceName,"logging_configuration.0.destinations.0.cloudwatch_log_group_arn"),
 					//testAccMatchResourceAttrRegionalARN(resourceName, "logging_configuration.0.destinations.0.cloudwatch_log_group_arn", "cloudwatch", regexp.MustCompile(`role/.+`)),
 				),
 			},

--- a/aws/resource_aws_sfn_state_machine_test.go
+++ b/aws/resource_aws_sfn_state_machine_test.go
@@ -92,7 +92,7 @@ func TestAccAWSSfnStateMachine_logging_configuration(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSfnStateMachineDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSfnStateMachineConfigLogging(rName, "OFF", true),
+				Config: testAccAWSSfnStateMachineConfigLogging(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSfnExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -323,7 +323,7 @@ EOF
 `, rName, rMaxAttempts)
 }
 
-func testAccAWSSfnStateMachineConfigLogging(rName, logLevel string, includeData bool) string {
+func testAccAWSSfnStateMachineConfigLogging(rName string) string {
 	return testAccAWSSfnStateMachineConfigBase(rName) + fmt.Sprintf(`
 resource "aws_cloudwatch_log_group" "test" {
   name = %[1]q
@@ -338,8 +338,8 @@ resource "aws_sfn_state_machine" "test" {
 	destinations {
 		cloudwatch_log_group_arn = "${aws_cloudwatch_log_group.test.arn}"
     }
-	include_execution_data = %[3]t
-	level                  = %[2]q
+	include_execution_data = true
+	level                  = ALL
   }
 
   definition = <<EOF
@@ -364,7 +364,7 @@ resource "aws_sfn_state_machine" "test" {
 }
 EOF
 }
-`, rName, logLevel, includeData)
+`, rName)
 }
 
 func testAccAWSSfnStateMachineConfigType(rName, typ string) string {

--- a/aws/resource_aws_sfn_state_machine_test.go
+++ b/aws/resource_aws_sfn_state_machine_test.go
@@ -70,8 +70,7 @@ func TestAccAWSSfnStateMachine_type_express(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSfnExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "type", "EXPRESS"),
-				),
+					resource.TestCheckResourceAttr(resourceName, "type", "EXPRESS")),
 			},
 			{
 				ResourceName:      resourceName,

--- a/aws/resource_aws_sfn_state_machine_test.go
+++ b/aws/resource_aws_sfn_state_machine_test.go
@@ -338,7 +338,7 @@ resource "aws_sfn_state_machine" "test" {
 		cloudwatch_log_group_arn = "${aws_cloudwatch_log_group.test.arn}"
     }
 	include_execution_data = true
-	level                  = ALL
+	level                  = "ALL"
   }
 
   definition = <<EOF

--- a/aws/resource_aws_sfn_state_machine_test.go
+++ b/aws/resource_aws_sfn_state_machine_test.go
@@ -99,7 +99,7 @@ func TestAccAWSSfnStateMachine_logging_configuration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.include_execution_data", "true"),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.level", "ALL"),
-					testAccMatchResourceAttrRegionalARN(resourceName, "logging_configuration.0.destinations.0.cloudwatch_log_group_arn", "logs", regexp.MustCompile(`log-group/.+`)),
+					testAccMatchResourceAttrRegionalARN(resourceName, "logging_configuration.0.destinations.0.cloudwatch_log_group_arn", "logs", regexp.MustCompile(`log-group.+`)),
 				),
 			},
 			{
@@ -115,7 +115,7 @@ func TestAccAWSSfnStateMachine_logging_configuration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.include_execution_data", "false"),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.level", "FATAL"),
-					testAccMatchResourceAttrRegionalARN(resourceName, "logging_configuration.0.destinations.0.cloudwatch_log_group_arn", "logs", regexp.MustCompile(`log-group/.+`)),
+					testAccMatchResourceAttrRegionalARN(resourceName, "logging_configuration.0.destinations.0.cloudwatch_log_group_arn", "logs", regexp.MustCompile(`log-group.+`)),
 				),
 			},
 			{
@@ -126,7 +126,7 @@ func TestAccAWSSfnStateMachine_logging_configuration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.include_execution_data", "false"),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.level", "OFF"),
-					testAccMatchResourceAttrRegionalARN(resourceName, "logging_configuration.0.destinations.0.cloudwatch_log_group_arn", "logs", regexp.MustCompile(`log-group/.+`)),
+					testAccMatchResourceAttrRegionalARN(resourceName, "logging_configuration.0.destinations.0.cloudwatch_log_group_arn", "logs", regexp.MustCompile(`log-group.+`)),
 				),
 			},
 		},

--- a/aws/resource_aws_sfn_state_machine_test.go
+++ b/aws/resource_aws_sfn_state_machine_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/sfn"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -76,6 +75,13 @@ func TestAccAWSSfnStateMachine_type_express(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSSfnStateMachineConfigType(rName, "STANDARD"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSfnExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", sfn.StateMachineTypeStandard)),
 			},
 		},
 	})
@@ -158,7 +164,7 @@ func testAccCheckAWSSfnStateMachineDestroy(s *terraform.State) error {
 		})
 
 		if err != nil {
-			if wserr, ok := err.(awserr.Error); ok && wserr.Code() == sfn.ErrCodeStateMachineDoesNotExist {
+			if isAWSErr(err, sfn.ErrCodeStateMachineDoesNotExist, "") {
 				return nil
 			}
 			return err
@@ -220,21 +226,7 @@ resource "aws_iam_role_policy" "iam_policy_for_sfn" {
         "lambda:InvokeFunction"
       ],
         "Resource": "${aws_lambda_function.test.arn}"
-	},
-	{
-    "Effect": "Allow",
-    "Action": [
-		"logs:CreateLogDelivery",
-		"logs:GetLogDelivery",
-		"logs:UpdateLogDelivery",
-		"logs:DeleteLogDelivery",
-		"logs:ListLogDeliveries",
-		"logs:PutResourcePolicy",
-		"logs:DescribeResourcePolicies",
-		"logs:DescribeLogGroups"
-    ],
-    "Resource": "*"
-  }
+	}
   ]
 }
 EOF

--- a/website/docs/r/sfn_state_machine.html.markdown
+++ b/website/docs/r/sfn_state_machine.html.markdown
@@ -35,6 +35,40 @@ EOF
 }
 ```
 
+## Express State Machine Example
+
+```hcl
+# ...
+
+resource "aws_sfn_state_machine" "sfn_state_machine" {
+  name     = "my-state-machine"
+  role_arn = "${aws_iam_role.iam_for_sfn.arn}"
+  type     = "EXPRESS"
+
+  logging_configuration {
+	destinations {
+		cloudwatch_log_group_arn = "${aws_cloudwatch_log_group.test.arn}"
+    }
+	include_execution_data = true
+	level                  = "ALL"
+  }
+
+  definition = <<EOF
+{
+  "Comment": "A Hello World example of the Amazon States Language using an AWS Lambda Function",
+  "StartAt": "HelloWorld",
+  "States": {
+    "HelloWorld": {
+      "Type": "Task",
+      "Resource": "${aws_lambda_function.lambda.arn}",
+      "End": true
+    }
+  }
+}
+EOF
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -42,7 +76,19 @@ The following arguments are supported:
 * `name` - (Required) The name of the state machine.
 * `definition` - (Required) The Amazon States Language definition of the state machine.
 * `role_arn` - (Required) The Amazon Resource Name (ARN) of the IAM role to use for this state machine.
+* `type` - (Optional) Determines whether a `Standard` or `Express` state machine is created. If not set, Standard is created.
+* `logging_configuration` - (Optional) Configuration block to enable State Machine logging. Detailed below. Defines what execution history events are logged and where they are logged. Can only be used with an `EXPRESS` State Machine.
 * `tags` - (Optional) Key-value mapping of resource tags
+
+### `logging_configuration` Configuration Block
+
+* `destinations` - (Required) Configuration block to define logging destinations. Detailed below.
+* `include_execution_data` - (Required) Determines whether execution history data is included in your log. When set to false, data is excluded.
+* `level` - (Required) Defines which category of execution history events are logged. Possible values are `INFO`, `ERROR`, `FATAL` and `OFF`.
+
+### `destinations` Configuration Block
+
+* `cloudwatch_log_group_arn` - (Optional) Amazon Resource Name (ARN) of Cloudwatch Log Group.
 
 ## Attributes Reference
 

--- a/website/docs/r/sfn_state_machine.html.markdown
+++ b/website/docs/r/sfn_state_machine.html.markdown
@@ -45,14 +45,6 @@ resource "aws_sfn_state_machine" "sfn_state_machine" {
   role_arn = "${aws_iam_role.iam_for_sfn.arn}"
   type     = "EXPRESS"
 
-  logging_configuration {
-	destinations {
-		cloudwatch_log_group_arn = "${aws_cloudwatch_log_group.test.arn}"
-    }
-	include_execution_data = true
-	level                  = "ALL"
-  }
-
   definition = <<EOF
 {
   "Comment": "A Hello World example of the Amazon States Language using an AWS Lambda Function",
@@ -77,18 +69,7 @@ The following arguments are supported:
 * `definition` - (Required) The Amazon States Language definition of the state machine.
 * `role_arn` - (Required) The Amazon Resource Name (ARN) of the IAM role to use for this state machine.
 * `type` - (Optional) Determines whether a `Standard` or `Express` state machine is created. If not set, Standard is created.
-* `logging_configuration` - (Optional) Configuration block to enable State Machine logging. Detailed below. Defines what execution history events are logged and where they are logged. Can only be used with an `EXPRESS` State Machine.
 * `tags` - (Optional) Key-value mapping of resource tags
-
-### `logging_configuration` Configuration Block
-
-* `destinations` - (Required) Configuration block to define logging destinations. Detailed below.
-* `include_execution_data` - (Required) Determines whether execution history data is included in your log. When set to false, data is excluded.
-* `level` - (Required) Defines which category of execution history events are logged. Possible values are `INFO`, `ERROR`, `FATAL` and `OFF`.
-
-### `destinations` Configuration Block
-
-* `cloudwatch_log_group_arn` - (Optional) Amazon Resource Name (ARN) of Cloudwatch Log Group.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11348, #7893

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
- resource/resource_aws_sfn_state_machine: add `type` argument
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSfnStateMachine_'

--- PASS: TestAccAWSSfnStateMachine_Tags (137.24s)
--- PASS: TestAccAWSSfnStateMachine_type_express (69.36s)
--- PASS: TestAccAWSLambdaFunction_disappears (78.15s)
--- FAIL: TestAccAWSSfnStateMachine_createUpdate (94.95s)
    testing.go:635: Step 2 error: Check failed: Check 6/7 error: aws_sfn_state_machine.test: Attribute 'definition' didn't match..


...
```

Tried to add logging config for the `EXPRESS` type but had issue with perceptual diffs so will open a seperate PR
