### PR TITLE
resource/aws_opsworks_permission: Prevent `Unable to change own permission level` error during self updates

### DIFF
--- a/aws/resource_aws_opsworks_permission.go
+++ b/aws/resource_aws_opsworks_permission.go
@@ -116,8 +116,8 @@ func resourceAwsOpsworksSetPermission(d *schema.ResourceData, meta interface{}) 
 		StackId:    aws.String(d.Get("stack_id").(string)),
 	}
 
-	if v, ok := d.GetOk("level"); ok {
-		req.Level = aws.String(v.(string))
+	if d.HasChange("level") {
+		req.Level = aws.String(d.Get("level").(string))
 	}
 
 	err := resource.Retry(2*time.Minute, func() *resource.RetryError {

--- a/aws/resource_aws_opsworks_permission_test.go
+++ b/aws/resource_aws_opsworks_permission_test.go
@@ -92,6 +92,37 @@ func TestAccAWSOpsworksPermission_basic(t *testing.T) {
 	})
 }
 
+// Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/4804
+func TestAccAWSOpsworksPermission_Self(t *testing.T) {
+	var opsperm opsworks.Permission
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_opsworks_permission.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil, // Cannot delete own OpsWorks Permission
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsOpsworksPermissionSelf(rName, true, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksPermissionExists(resourceName, &opsperm),
+					resource.TestCheckResourceAttr(resourceName, "allow_ssh", "true"),
+					resource.TestCheckResourceAttr(resourceName, "allow_sudo", "true"),
+				),
+			},
+			{
+				Config: testAccAwsOpsworksPermissionSelf(rName, true, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksPermissionExists(resourceName, &opsperm),
+					resource.TestCheckResourceAttr(resourceName, "allow_ssh", "true"),
+					resource.TestCheckResourceAttr(resourceName, "allow_sudo", "false"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSOpsworksPermissionExists(
 	n string, opsperm *opsworks.Permission) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -173,6 +204,111 @@ func testAccCheckAwsOpsworksPermissionDestroy(s *terraform.State) error {
 	return nil
 }
 
+func testAccAwsOpsworksPermissionBase(rName string) string {
+	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/24"
+
+  tags = {
+    Name = "tf-acc-test-opsworks-permission"
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block = aws_vpc.test.cidr_block
+  vpc_id     = aws_vpc.test.id
+
+  tags = {
+    Name = "tf-acc-test-opsworks-permissions"
+  }
+}
+
+resource "aws_opsworks_stack" "test" {
+  name                          = %[1]q
+  region                        = data.aws_region.current.name
+  vpc_id                        = aws_vpc.test.id
+  default_subnet_id             = aws_subnet.test.id
+  service_role_arn              = aws_iam_role.service.arn
+  default_instance_profile_arn  = aws_iam_instance_profile.test.arn
+  default_os                    = "Amazon Linux 2016.09"
+  default_root_device_type      = "ebs"
+  custom_json                   = "{\"key\": \"value\"}"
+  configuration_manager_version = "11.10"
+  use_opsworks_security_groups  = false
+}
+
+resource "aws_iam_role" "service" {
+  name = "%[1]s-service"
+
+  assume_role_policy = <<EOT
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "opsworks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOT
+}
+
+resource "aws_iam_role_policy" "service" {
+  name = %[1]q
+  role = aws_iam_role.service.id
+
+  policy = <<EOT
+{
+  "Statement": [
+    {
+      "Action": [
+        "ec2:*",
+        "iam:PassRole",
+        "cloudwatch:GetMetricStatistics",
+        "elasticloadbalancing:*",
+        "rds:*"
+      ],
+      "Effect": "Allow",
+      "Resource": ["*"]
+    }
+  ]
+}
+EOT
+}
+
+resource "aws_iam_role" "instance" {
+  name = "%[1]s-instance"
+
+  assume_role_policy = <<EOT
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOT
+}
+
+resource "aws_iam_instance_profile" "test" {
+  name = %[1]q
+  role = aws_iam_role.instance.name
+}
+`, rName)
+}
+
 func testAccAwsOpsworksPermissionCreate(name, ssh, sudo, level string) string {
 	return fmt.Sprintf(`
 resource "aws_opsworks_permission" "tf-acc-perm" {
@@ -197,4 +333,17 @@ resource "aws_iam_user" "user" {
 %s
 
 `, ssh, sudo, level, name, testAccAwsOpsworksStackConfigVpcCreate(name))
+}
+
+func testAccAwsOpsworksPermissionSelf(rName string, allowSsh bool, allowSudo bool) string {
+	return testAccAwsOpsworksPermissionBase(rName) + fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+resource "aws_opsworks_permission" "test" {
+  allow_ssh  = %[1]t
+  allow_sudo = %[2]t
+  stack_id   = aws_opsworks_stack.test.id
+  user_arn   = data.aws_caller_identity.current.arn
+}
+`, allowSsh, allowSudo)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #4804

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_opsworks_permission: Prevent `Unable to change own permission level` error during self updates
```

Output from acceptance testing before code change:

```
--- FAIL: TestAccAWSOpsworksPermission_Self (51.18s)
    testing.go:640: Step 1 error: errors during apply:

        Error: ValidationException: Unable to change own permission level. Only AllowSsh and AllowSudo allowed.
```

Output from acceptance testing after code change:

```
--- PASS: TestAccAWSOpsworksPermission_Self (64.52s)
--- PASS: TestAccAWSOpsworksPermission_basic (104.39s)
```
