### PR TITLE
Add Importer for aws_iam_policy_attachment

### DIFF
--- a/aws/resource_aws_iam_policy_attachment.go
+++ b/aws/resource_aws_iam_policy_attachment.go
@@ -20,6 +20,9 @@ func resourceAwsIamPolicyAttachment() *schema.Resource {
 		Read:   resourceAwsIamPolicyAttachmentRead,
 		Update: resourceAwsIamPolicyAttachmentUpdate,
 		Delete: resourceAwsIamPolicyAttachmentDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsIamPolicyAttachmentImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -375,4 +378,10 @@ func detachPolicyFromGroups(conn *iam.IAM, groups []*string, arn string) error {
 		}
 	}
 	return nil
+}
+
+func resourceAwsIamPolicyAttachmentImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	d.SetId(d.Id())
+	d.Set("policy_arn", d.Id())
+	return []*schema.ResourceData{d}, nil
 }

--- a/aws/resource_aws_iam_policy_attachment_test.go
+++ b/aws/resource_aws_iam_policy_attachment_test.go
@@ -50,6 +50,11 @@ func TestAccAWSIAMPolicyAttachment_basic(t *testing.T) {
 						[]string{roleName2, roleName3}, []string{groupName2, groupName3}, &out),
 				),
 			},
+			{
+				ResourceName:      policyName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes:  #11400

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_iam_policy_attachment: Allow import of resource
```

Output from acceptance testing:

Currently unable to run acceptance test (will be able to do so on my own in the new year).
