### PR TITLE
r/d-launch_configuration-arn addition

### DIFF
--- a/aws/data_source_aws_launch_configuration.go
+++ b/aws/data_source_aws_launch_configuration.go
@@ -14,6 +14,10 @@ func dataSourceAwsLaunchConfiguration() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceAwsLaunchConfigurationRead,
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -214,6 +218,7 @@ func dataSourceAwsLaunchConfigurationRead(d *schema.ResourceData, meta interface
 	d.Set("key_name", lc.KeyName)
 	d.Set("image_id", lc.ImageId)
 	d.Set("instance_type", lc.InstanceType)
+	d.Set("arn", lc.LaunchConfigurationARN)
 	d.Set("name", lc.LaunchConfigurationName)
 	d.Set("user_data", lc.UserData)
 	d.Set("iam_instance_profile", lc.IamInstanceProfile)

--- a/aws/data_source_aws_launch_configuration_test.go
+++ b/aws/data_source_aws_launch_configuration_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -26,6 +27,7 @@ func TestAccAWSLaunchConfigurationDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "root_block_device.#", "1"),
 					resource.TestCheckResourceAttr(rName, "ebs_block_device.#", "1"),
 					resource.TestCheckResourceAttr(rName, "ephemeral_block_device.#", "1"),
+					testAccMatchResourceAttrRegionalARN(rName, "arn", "autoscaling", regexp.MustCompile(`launchConfiguration:.+`)),
 				),
 			},
 		},

--- a/aws/resource_aws_launch_configuration.go
+++ b/aws/resource_aws_launch_configuration.go
@@ -25,6 +25,10 @@ func resourceAwsLaunchConfiguration() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"name": {
 				Type:          schema.TypeString,
 				Optional:      true,
@@ -552,6 +556,7 @@ func resourceAwsLaunchConfigurationRead(d *schema.ResourceData, meta interface{}
 	d.Set("image_id", lc.ImageId)
 	d.Set("instance_type", lc.InstanceType)
 	d.Set("name", lc.LaunchConfigurationName)
+	d.Set("arn", lc.LaunchConfigurationARN)
 
 	d.Set("iam_instance_profile", lc.IamInstanceProfile)
 	d.Set("ebs_optimized", lc.EbsOptimized)

--- a/aws/resource_aws_launch_configuration_test.go
+++ b/aws/resource_aws_launch_configuration_test.go
@@ -77,6 +77,7 @@ func TestAccAWSLaunchConfiguration_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLaunchConfigurationExists(resourceName, &conf),
 					testAccCheckAWSLaunchConfigurationGeneratedNamePrefix(resourceName, "terraform-"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "autoscaling", regexp.MustCompile(`launchConfiguration:.+`)),
 				),
 			},
 			{

--- a/website/docs/d/launch_configuration.html.markdown
+++ b/website/docs/d/launch_configuration.html.markdown
@@ -29,6 +29,7 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the launch configuration.
+* `arn` - The Amazon Resource Name of the launch configuration.
 * `name` - The Name of the launch configuration.
 * `image_id` - The EC2 Image ID of the instance.
 * `instance_type` - The Instance Type of the instance to launch.

--- a/website/docs/r/launch_configuration.html.markdown
+++ b/website/docs/r/launch_configuration.html.markdown
@@ -224,6 +224,7 @@ configuration, resource recreation can be manually triggered by using the
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the launch configuration.
+* `arn` - The Amazon Resource Name of the launch configuration.
 * `name` - The name of the launch configuration.
 
 [1]: /docs/providers/aws/r/autoscaling_group.html


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10858

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_launch_configuration: Makes `arn` of cluster available as resource attribute. [GH-10858]
* data/aws_launch_configuration: Makes `arn` of cluster available as resource attribute. [GH-10858]
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
root@916d62d75b44:/go/src/github.com/terraform-providers/terraform-provider-aws# AWS_PROFILE=default make testacc test=./aws TESTARGS='-run=TestAccAWSLaunchConfiguration_'     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSLaunchConfiguration_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSLaunchConfiguration_basic
=== PAUSE TestAccAWSLaunchConfiguration_basic
=== RUN   TestAccAWSLaunchConfiguration_withBlockDevices
=== PAUSE TestAccAWSLaunchConfiguration_withBlockDevices
=== RUN   TestAccAWSLaunchConfiguration_updateRootBlockDevice
=== PAUSE TestAccAWSLaunchConfiguration_updateRootBlockDevice
=== RUN   TestAccAWSLaunchConfiguration_encryptedRootBlockDevice
=== PAUSE TestAccAWSLaunchConfiguration_encryptedRootBlockDevice
=== RUN   TestAccAWSLaunchConfiguration_withSpotPrice
=== PAUSE TestAccAWSLaunchConfiguration_withSpotPrice
=== RUN   TestAccAWSLaunchConfiguration_withVpcClassicLink
=== PAUSE TestAccAWSLaunchConfiguration_withVpcClassicLink
=== RUN   TestAccAWSLaunchConfiguration_withIAMProfile
=== PAUSE TestAccAWSLaunchConfiguration_withIAMProfile
=== RUN   TestAccAWSLaunchConfiguration_withEncryption
=== PAUSE TestAccAWSLaunchConfiguration_withEncryption
=== RUN   TestAccAWSLaunchConfiguration_updateEbsBlockDevices
=== PAUSE TestAccAWSLaunchConfiguration_updateEbsBlockDevices
=== RUN   TestAccAWSLaunchConfiguration_ebs_noDevice
=== PAUSE TestAccAWSLaunchConfiguration_ebs_noDevice
=== RUN   TestAccAWSLaunchConfiguration_userData
=== PAUSE TestAccAWSLaunchConfiguration_userData
=== CONT  TestAccAWSLaunchConfiguration_basic
=== CONT  TestAccAWSLaunchConfiguration_withEncryption
=== CONT  TestAccAWSLaunchConfiguration_userData
=== CONT  TestAccAWSLaunchConfiguration_withSpotPrice
=== CONT  TestAccAWSLaunchConfiguration_withIAMProfile
=== CONT  TestAccAWSLaunchConfiguration_ebs_noDevice
=== CONT  TestAccAWSLaunchConfiguration_updateRootBlockDevice
=== CONT  TestAccAWSLaunchConfiguration_withVpcClassicLink
=== CONT  TestAccAWSLaunchConfiguration_encryptedRootBlockDevice
=== CONT  TestAccAWSLaunchConfiguration_withBlockDevices
=== CONT  TestAccAWSLaunchConfiguration_updateEbsBlockDevices
--- PASS: TestAccAWSLaunchConfiguration_withSpotPrice (31.93s)
--- PASS: TestAccAWSLaunchConfiguration_ebs_noDevice (33.64s)
--- PASS: TestAccAWSLaunchConfiguration_withBlockDevices (33.84s)
--- PASS: TestAccAWSLaunchConfiguration_withEncryption (35.05s)
--- PASS: TestAccAWSLaunchConfiguration_encryptedRootBlockDevice (55.17s)
--- PASS: TestAccAWSLaunchConfiguration_withIAMProfile (59.38s)
--- PASS: TestAccAWSLaunchConfiguration_withVpcClassicLink (61.38s)
--- PASS: TestAccAWSLaunchConfiguration_userData (63.37s)
--- PASS: TestAccAWSLaunchConfiguration_basic (63.38s)
--- PASS: TestAccAWSLaunchConfiguration_updateEbsBlockDevices (67.51s)
--- PASS: TestAccAWSLaunchConfiguration_updateRootBlockDevice (68.08s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	68.139s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.010s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.050s [no tests to run]
root@916d62d75b44:/go/src/github.com/terraform-providers/terraform-provider-aws# AWS_PROFILE=default make testacc test=./aws TESTARGS='-run=TestAccAWSLaunchConfigurationDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSLaunchConfigurationDataSource_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSLaunchConfigurationDataSource_basic
=== PAUSE TestAccAWSLaunchConfigurationDataSource_basic
=== RUN   TestAccAWSLaunchConfigurationDataSource_securityGroups
=== PAUSE TestAccAWSLaunchConfigurationDataSource_securityGroups
=== CONT  TestAccAWSLaunchConfigurationDataSource_basic
=== CONT  TestAccAWSLaunchConfigurationDataSource_securityGroups
--- PASS: TestAccAWSLaunchConfigurationDataSource_basic (31.58s)
--- PASS: TestAccAWSLaunchConfigurationDataSource_securityGroups (46.65s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	46.687s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.034s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.004s [no tests to run]
root@916d62d75b44:/go/src/github.com/terraform-providers/terraform-provider-aws# 
```
