### PR TITLE
docs/r: Change minimum_healthy_hosts to required

### DIFF
--- a/website/docs/r/codedeploy_deployment_config.html.markdown
+++ b/website/docs/r/codedeploy_deployment_config.html.markdown
@@ -95,7 +95,7 @@ The following arguments are supported:
 
 * `deployment_config_name` - (Required) The name of the deployment config.
 * `compute_platform` - (Optional) The compute platform can be `Server`, `Lambda`, or `ECS`. Default is `Server`.
-* `minimum_healthy_hosts` - (Optional) A minimum_healthy_hosts block. Minimum Healthy Hosts are documented below.
+* `minimum_healthy_hosts` - (Required) A minimum_healthy_hosts block. Minimum Healthy Hosts are documented below.
 * `traffic_routing_config` - (Optional) A traffic_routing_config block. Traffic Routing Config is documented below.
 
 The `minimum_healthy_hosts` block supports the following:


### PR DESCRIPTION
Declare a resource with only deployment_config_name would cause `Error: InvalidMinimumHealthyHostValueException: minimum healthy hosts argument is missing` in terraform v0.12.17. This field should be required or maybe terraform should set a proper default value to 0 if it is not configured.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
