### PR TITLE
ECS Service enums + eventual consistency for service-role

### DIFF
--- a/aws/resource_aws_ecs_service.go
+++ b/aws/resource_aws_ecs_service.go
@@ -100,6 +100,10 @@ func resourceAwsEcsService() *schema.Resource {
 				ForceNew: true,
 				Optional: true,
 				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					ecs.LaunchTypeEc2,
+					ecs.LaunchTypeFargate,
+				}, false),
 			},
 
 			"platform_version": {
@@ -120,10 +124,11 @@ func resourceAwsEcsService() *schema.Resource {
 			},
 
 			"iam_role": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Optional: true,
-				Computed: true,
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validateArn,
 			},
 
 			"deployment_controller": {
@@ -190,9 +195,10 @@ func resourceAwsEcsService() *schema.Resource {
 						},
 
 						"target_group_arn": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validateArn,
 						},
 
 						"container_name": {
@@ -202,9 +208,10 @@ func resourceAwsEcsService() *schema.Resource {
 						},
 
 						"container_port": {
-							Type:     schema.TypeInt,
-							Required: true,
-							ForceNew: true,
+							Type:         schema.TypeInt,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.IntBetween(0, 65536),
 						},
 					},
 				},
@@ -247,6 +254,11 @@ func resourceAwsEcsService() *schema.Resource {
 						"type": {
 							Type:     schema.TypeString,
 							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								ecs.PlacementStrategyTypeBinpack,
+								ecs.PlacementStrategyTypeRandom,
+								ecs.PlacementStrategyTypeSpread,
+							}, false),
 						},
 						"field": {
 							Type:     schema.TypeString,
@@ -299,6 +311,10 @@ func resourceAwsEcsService() *schema.Resource {
 							Type:     schema.TypeString,
 							ForceNew: true,
 							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								ecs.PlacementConstraintTypeDistinctInstance,
+								ecs.PlacementConstraintTypeMemberOf,
+							}, false),
 						},
 						"expression": {
 							Type:     schema.TypeString,
@@ -510,6 +526,10 @@ func resourceAwsEcsServiceCreate(d *schema.ResourceData, meta interface{}) error
 				return resource.RetryableError(err)
 			}
 			if isAWSErr(err, ecs.ErrCodeInvalidParameterException, "does not have an associated load balancer") {
+				return resource.RetryableError(err)
+			}
+			if isAWSErr(err, ecs.ErrCodeInvalidParameterException, "Unable to assume the service linked role."+
+				" Please verify that the ECS service linked role exists") {
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)

--- a/aws/resource_aws_ecs_service.go
+++ b/aws/resource_aws_ecs_service.go
@@ -124,11 +124,10 @@ func resourceAwsEcsService() *schema.Resource {
 			},
 
 			"iam_role": {
-				Type:         schema.TypeString,
-				ForceNew:     true,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validateArn,
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+				Computed: true,
 			},
 
 			"deployment_controller": {

--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -322,11 +322,6 @@ func TestAccAWSEcsService_withRenamedCluster(t *testing.T) {
 	tdName := fmt.Sprintf("tf-acc-td-svc-w-rc-%s", rString)
 	svcName := fmt.Sprintf("tf-acc-svc-w-rc-%s", rString)
 
-	//originalRegexp := regexp.MustCompile(
-	//	"^arn:aws:ecs:[^:]+:[0-9]+:cluster/" + clusterName + "$")
-	//modifiedRegexp := regexp.MustCompile(
-	//	"^arn:aws:ecs:[^:]+:[0-9]+:cluster/" + uClusterName + "$")
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -339,7 +339,7 @@ func TestAccAWSEcsService_withRenamedCluster(t *testing.T) {
 				Config: testAccAWSEcsServiceWithRenamedCluster(uClusterName, tdName, svcName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsServiceExists("aws_ecs_service.ghost", &service),
-					testAccCheckResourceAttrRegionalARN("aws_ecs_service.ghost", "cluster", "ecs", "cluster/"+uClusterName+"$"),
+					resource.TestCheckResourceAttrPair("aws_ecs_service.ghost", "cluster", "aws_ecs_cluster.default", "arn"),
 				),
 			},
 		},

--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -2680,6 +2680,10 @@ data "aws_availability_zones" "test" {}
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "tf-acc-with-svc-reg"
+  }
 }
 
 resource "aws_subnet" "test" {
@@ -2687,6 +2691,10 @@ resource "aws_subnet" "test" {
   cidr_block        = "${cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)}"
   availability_zone = "${data.aws_availability_zones.test.names[count.index]}"
   vpc_id            = "${aws_vpc.test.id}"
+
+  tags = {
+    Name = "tf-acc-with-svc-reg"
+  }
 }
 
 resource "aws_security_group" "test" {
@@ -2766,6 +2774,10 @@ data "aws_availability_zones" "test" {}
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "tf-acc-with-svc-reg-cont"
+  }
 }
 
 resource "aws_subnet" "test" {
@@ -2773,6 +2785,10 @@ resource "aws_subnet" "test" {
   cidr_block        = "${cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)}"
   availability_zone = "${data.aws_availability_zones.test.names[count.index]}"
   vpc_id            = "${aws_vpc.test.id}"
+
+  tags = {
+    Name = "tf-acc-with-svc-reg"
+  }
 }
 
 resource "aws_security_group" "test" {

--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -322,10 +322,10 @@ func TestAccAWSEcsService_withRenamedCluster(t *testing.T) {
 	tdName := fmt.Sprintf("tf-acc-td-svc-w-rc-%s", rString)
 	svcName := fmt.Sprintf("tf-acc-svc-w-rc-%s", rString)
 
-	originalRegexp := regexp.MustCompile(
-		"^arn:aws:ecs:[^:]+:[0-9]+:cluster/" + clusterName + "$")
-	modifiedRegexp := regexp.MustCompile(
-		"^arn:aws:ecs:[^:]+:[0-9]+:cluster/" + uClusterName + "$")
+	//originalRegexp := regexp.MustCompile(
+	//	"^arn:aws:ecs:[^:]+:[0-9]+:cluster/" + clusterName + "$")
+	//modifiedRegexp := regexp.MustCompile(
+	//	"^arn:aws:ecs:[^:]+:[0-9]+:cluster/" + uClusterName + "$")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -336,8 +336,7 @@ func TestAccAWSEcsService_withRenamedCluster(t *testing.T) {
 				Config: testAccAWSEcsServiceWithRenamedCluster(clusterName, tdName, svcName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsServiceExists("aws_ecs_service.ghost", &service),
-					resource.TestMatchResourceAttr(
-						"aws_ecs_service.ghost", "cluster", originalRegexp),
+					testAccCheckResourceAttrRegionalARN("aws_ecs_service.ghost", "cluster", "ecs", "cluster/"+clusterName+"$"),
 				),
 			},
 
@@ -345,8 +344,7 @@ func TestAccAWSEcsService_withRenamedCluster(t *testing.T) {
 				Config: testAccAWSEcsServiceWithRenamedCluster(uClusterName, tdName, svcName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsServiceExists("aws_ecs_service.ghost", &service),
-					resource.TestMatchResourceAttr(
-						"aws_ecs_service.ghost", "cluster", modifiedRegexp),
+					testAccCheckResourceAttrRegionalARN("aws_ecs_service.ghost", "cluster", "ecs", "cluster/"+uClusterName+"$"),
 				),
 			},
 		},

--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -331,7 +331,7 @@ func TestAccAWSEcsService_withRenamedCluster(t *testing.T) {
 				Config: testAccAWSEcsServiceWithRenamedCluster(clusterName, tdName, svcName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsServiceExists("aws_ecs_service.ghost", &service),
-					testAccCheckResourceAttrRegionalARN("aws_ecs_service.ghost", "cluster", "ecs", "cluster/"+clusterName+"$"),
+					resource.TestCheckResourceAttrPair("aws_ecs_service.ghost", "cluster", "aws_ecs_cluster.default", "arn"),
 				),
 			},
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11417

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEcsService_'
--- PASS: TestAccAWSEcsService_withARN (119.91s)
--- PASS: TestAccAWSEcsService_basicImport (108.86s)
--- PASS: TestAccAWSEcsService_disappears (85.71s)
--- PASS: TestAccAWSEcsService_withUnnormalizedPlacementStrategy (86.39s)
--- PASS: TestAccAWSEcsService_withCapacityProviderStrategy (217.09s)
--- PASS: TestAccAWSEcsService_withMultipleCapacityProviderStrategies (181.20s)
--- PASS: TestAccAWSEcsService_withFamilyAndRevision (113.15s)
--- PASS: TestAccAWSEcsService_withRenamedCluster (144.32s)
--- PASS: TestAccAWSEcsService_healthCheckGracePeriodSeconds (491.93s)
--- PASS: TestAccAWSEcsService_withIamRole (204.28s)
--- PASS: TestAccAWSEcsService_withDeploymentController_Type_CodeDeploy (425.01s)
--- PASS: TestAccAWSEcsService_withDeploymentValues (88.47s)
--- PASS: TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred (88.05s)
--- PASS: TestAccAWSEcsService_withLbChanges (311.33s)
--- PASS: TestAccAWSEcsService_withEcsClusterName (86.52s)
--- PASS: TestAccAWSEcsService_withAlb (318.14s)
--- PASS: TestAccAWSEcsService_withMultipleTargetGroups (343.37s)
--- PASS: TestAccAWSEcsService_withPlacementStrategy (309.91s)
--- PASS: TestAccAWSEcsService_withPlacementConstraints (97.22s)
--- PASS: TestAccAWSEcsService_withPlacementConstraints_emptyExpression (88.17s)
--- PASS: TestAccAWSEcsService_withLaunchTypeFargate (272.64s)
--- PASS: TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion (274.08s)
--- PASS: TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration (198.85s)
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategy (57.49s)
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum (49.63s)
--- PASS: TestAccAWSEcsService_withReplicaSchedulingStrategy (98.25s)
--- PASS: TestAccAWSEcsService_withServiceRegistries (241.48s)
--- PASS: TestAccAWSEcsService_withServiceRegistries_container (228.24s)
--- FAIL: TestAccAWSEcsService_Tags (24.47s)
    testing.go:640: Step 0 error: errors during apply:
        
        Error: InvalidParameterException: The new ARN and resource ID format must be enabled to add tags to the service. Opt in to the new format and try again.
        	status code: 400, request id: a95f242d-f39d-4a0c-b3d3-77aa58290108 "tf-acc-test-842556518505141709"

--- FAIL: TestAccAWSEcsService_ManagedTags (25.97s)
    testing.go:640: Step 0 error: errors during apply:
        
        Error: InvalidParameterException: The new ARN and resource ID format must be enabled to work with ECS managed tags. Opt in to the new format and try again.
        	status code: 400, request id: 4b45ee96-fb50-49fb-a7fd-362c638e709b "tf-acc-test-842556518505141709"
        
--- FAIL: TestAccAWSEcsService_PropagateTags (26.38s)
    testing.go:640: Step 0 error: errors during apply:
        
        Error: InvalidParameterException: The new ARN and resource ID format must be enabled to work with ECS managed tags. Opt in to the new format and try again.
        	status code: 400, request id: 1d0d6c37-1f1a-43d9-b002-2979eb79009f "tf-acc-test-842556518505141709"
...
```
