### PR TITLE
route53 record allow zero ttl

### DIFF
--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -135,7 +135,7 @@ func resourceAwsRoute53Record() *schema.Resource {
 							Required: true,
 							ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
 								value := v.(string)
-								if value != "PRIMARY" && value != "SECONDARY" {
+								if value != route53.ResourceRecordSetFailoverPrimary && value != route53.ResourceRecordSetFailoverSecondary {
 									es = append(es, fmt.Errorf("Failover policy type must be PRIMARY or SECONDARY"))
 								}
 								return
@@ -769,7 +769,7 @@ func resourceAwsRoute53RecordBuildSet(d *schema.ResourceData, zoneName string) (
 		Type: aws.String(d.Get("type").(string)),
 	}
 
-	if v, ok := d.GetOk("ttl"); ok {
+	if v, ok := d.GetOkExists("ttl"); ok {
 		rec.TTL = aws.Int64(int64(v.(int)))
 	}
 
@@ -793,7 +793,7 @@ func resourceAwsRoute53RecordBuildSet(d *schema.ResourceData, zoneName string) (
 		}
 		log.Printf("[DEBUG] Creating alias: %#v", alias)
 	} else {
-		if _, ok := d.GetOk("ttl"); !ok {
+		if _, ok := d.GetOkExists("ttl"); !ok {
 			return nil, fmt.Errorf(`provider.aws: aws_route53_record: %s: "ttl": required field is not set`, d.Get("name").(string))
 		}
 

--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/route53"
 )
 
@@ -576,7 +575,7 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 
 	if record.Weight != nil {
 		v := []map[string]interface{}{{
-			"weight": aws.Int64Value((record.Weight)),
+			"weight": aws.Int64Value(record.Weight),
 		}}
 		if err := d.Set("weighted_routing_policy", v); err != nil {
 			return fmt.Errorf("Error setting weighted records for: %s, error: %#v", d.Id(), err)
@@ -618,7 +617,7 @@ func findRecord(d *schema.ResourceData, meta interface{}) (*route53.ResourceReco
 	// get expanded name
 	zoneRecord, err := conn.GetHostedZone(&route53.GetHostedZoneInput{Id: aws.String(zone)})
 	if err != nil {
-		if r53err, ok := err.(awserr.Error); ok && r53err.Code() == route53.ErrCodeNoSuchHostedZone {
+		if isAWSErr(err, route53.ErrCodeNoSuchHostedZone, "") {
 			return nil, r53NoHostedZoneFound
 		}
 		return nil, err

--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -880,7 +880,7 @@ func TestAccAWSRoute53Record_allowOverwrite(t *testing.T) {
 
 func TestAccAWSRoute53Record_zero_ttl(t *testing.T) {
 	var record1 route53.ResourceRecordSet
-	resourceName := "aws_route53_record.test"
+	resourceName := "aws_route53_record.default"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },

--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -12,7 +12,6 @@ import (
 	"regexp"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/route53"
 )
 
@@ -107,7 +106,7 @@ func TestParseRecordId(t *testing.T) {
 
 func TestAccAWSRoute53Record_basic(t *testing.T) {
 	var record1 route53.ResourceRecordSet
-	resourceName := "aws_route53_record.default"
+	resourceName := "aws_route53_record.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -159,7 +158,7 @@ func TestAccAWSRoute53Record_underscored(t *testing.T) {
 func TestAccAWSRoute53Record_disappears(t *testing.T) {
 	var record1 route53.ResourceRecordSet
 	var zone1 route53.GetHostedZoneOutput
-	resourceName := "aws_route53_record.default"
+	resourceName := "aws_route53_record.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -207,7 +206,7 @@ func TestAccAWSRoute53Record_disappears_MultipleRecords(t *testing.T) {
 
 func TestAccAWSRoute53Record_basic_fqdn(t *testing.T) {
 	var record1, record2 route53.ResourceRecordSet
-	resourceName := "aws_route53_record.default"
+	resourceName := "aws_route53_record.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -246,7 +245,7 @@ func TestAccAWSRoute53Record_basic_fqdn(t *testing.T) {
 
 func TestAccAWSRoute53Record_txtSupport(t *testing.T) {
 	var record1 route53.ResourceRecordSet
-	resourceName := "aws_route53_record.default"
+	resourceName := "aws_route53_record.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
@@ -273,7 +272,7 @@ func TestAccAWSRoute53Record_txtSupport(t *testing.T) {
 
 func TestAccAWSRoute53Record_spfSupport(t *testing.T) {
 	var record1 route53.ResourceRecordSet
-	resourceName := "aws_route53_record.default"
+	resourceName := "aws_route53_record.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -301,7 +300,7 @@ func TestAccAWSRoute53Record_spfSupport(t *testing.T) {
 
 func TestAccAWSRoute53Record_caaSupport(t *testing.T) {
 	var record1 route53.ResourceRecordSet
-	resourceName := "aws_route53_record.default"
+	resourceName := "aws_route53_record.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -329,7 +328,7 @@ func TestAccAWSRoute53Record_caaSupport(t *testing.T) {
 
 func TestAccAWSRoute53Record_generatesSuffix(t *testing.T) {
 	var record1 route53.ResourceRecordSet
-	resourceName := "aws_route53_record.default"
+	resourceName := "aws_route53_record.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -624,7 +623,7 @@ func TestAccAWSRoute53Record_weighted_alias(t *testing.T) {
 
 func TestAccAWSRoute53Record_geolocation_basic(t *testing.T) {
 	var record1, record2, record3, record4 route53.ResourceRecordSet
-	resourceName := "aws_route53_record.default"
+	resourceName := "aws_route53_record.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -634,7 +633,7 @@ func TestAccAWSRoute53Record_geolocation_basic(t *testing.T) {
 			{
 				Config: testAccRoute53GeolocationCNAMERecord,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.default", &record1),
+					testAccCheckRoute53RecordExists("aws_route53_record.test", &record1),
 					testAccCheckRoute53RecordExists("aws_route53_record.california", &record2),
 					testAccCheckRoute53RecordExists("aws_route53_record.oceania", &record3),
 					testAccCheckRoute53RecordExists("aws_route53_record.denmark", &record4),
@@ -881,7 +880,7 @@ func TestAccAWSRoute53Record_allowOverwrite(t *testing.T) {
 
 func TestAccAWSRoute53Record_zero_ttl(t *testing.T) {
 	var record1 route53.ResourceRecordSet
-	resourceName := "aws_route53_record.default"
+	resourceName := "aws_route53_record.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -928,11 +927,9 @@ func testAccCheckRoute53RecordDestroy(s *terraform.State) error {
 
 		resp, err := conn.ListResourceRecordSets(lopts)
 		if err != nil {
-			if awsErr, ok := err.(awserr.Error); ok {
-				// if NoSuchHostedZone, then all the things are destroyed
-				if awsErr.Code() == route53.ErrCodeNoSuchHostedZone {
-					return nil
-				}
+			// if NoSuchHostedZone, then all the things are destroyed
+			if isAWSErr(err, route53.ErrCodeNoSuchHostedZone, "") {
+				return nil
 			}
 			return err
 		}
@@ -1034,7 +1031,7 @@ resource "aws_route53_zone" "main" {
   name = "notexample.com."
 }
 
-resource "aws_route53_record" "default" {
+resource "aws_route53_record" "test" {
   zone_id = "${aws_route53_zone.main.zone_id}"
   name = "www.notexample.com"
   type = "A"
@@ -1043,7 +1040,7 @@ resource "aws_route53_record" "default" {
 }
 
 resource "aws_route53_record" "overwriting" {
-  depends_on = ["aws_route53_record.default"]
+  depends_on = ["aws_route53_record.test"]
 
   allow_overwrite = %v
   zone_id = "${aws_route53_zone.main.zone_id}"
@@ -1060,7 +1057,7 @@ resource "aws_route53_zone" "main" {
 	name = "notexample.com"
 }
 
-resource "aws_route53_record" "default" {
+resource "aws_route53_record" "test" {
 	zone_id = "${aws_route53_zone.main.zone_id}"
 	name = "www.NOTexamplE.com"
 	type = "A"
@@ -1074,7 +1071,7 @@ resource "aws_route53_zone" "main" {
 	name = "notexample.com"
 }
 
-resource "aws_route53_record" "default" {
+resource "aws_route53_record" "test" {
 	zone_id = "${aws_route53_zone.main.zone_id}"
 	name = "www.NOTexamplE.com"
 	type = "A"
@@ -1104,7 +1101,7 @@ resource "aws_route53_zone" "main" {
   name = "notexample.com"
 }
 
-resource "aws_route53_record" "default" {
+resource "aws_route53_record" "test" {
   zone_id = "${aws_route53_zone.main.zone_id}"
   name    = "www.NOTexamplE.com"
   type    = "A"
@@ -1122,7 +1119,7 @@ resource "aws_route53_zone" "main" {
   name = "notexample.com"
 }
 
-resource "aws_route53_record" "default" {
+resource "aws_route53_record" "test" {
   zone_id = "${aws_route53_zone.main.zone_id}"
   name    = "www.NOTexamplE.com."
   type    = "A"
@@ -1140,7 +1137,7 @@ resource "aws_route53_zone" "main" {
 	name = "notexample.com"
 }
 
-resource "aws_route53_record" "default" {
+resource "aws_route53_record" "test" {
 	zone_id = "${aws_route53_zone.main.zone_id}"
 	name = "subdomain"
 	type = "A"
@@ -1154,7 +1151,7 @@ resource "aws_route53_zone" "main" {
     name = "notexample.com"
 }
 
-resource "aws_route53_record" "default" {
+resource "aws_route53_record" "test" {
 	zone_id = "${aws_route53_zone.main.zone_id}"
 	name = "subdomain"
 	type = "A"
@@ -1176,7 +1173,7 @@ resource "aws_route53_zone" "main" {
     name = "notexample.com"
 }
 
-resource "aws_route53_record" "default" {
+resource "aws_route53_record" "test" {
 	zone_id = "${aws_route53_zone.main.zone_id}"
 	name = "subdomain"
 	type = "A"
@@ -1197,7 +1194,7 @@ resource "aws_route53_zone" "main" {
 	name = "notexample.com"
 }
 
-resource "aws_route53_record" "default" {
+resource "aws_route53_record" "test" {
 	zone_id = "/hostedzone/${aws_route53_zone.main.zone_id}"
 	name = "subdomain"
 	type = "TXT"
@@ -1210,7 +1207,7 @@ resource "aws_route53_zone" "main" {
 	name = "notexample.com"
 }
 
-resource "aws_route53_record" "default" {
+resource "aws_route53_record" "test" {
 	zone_id = "${aws_route53_zone.main.zone_id}"
 	name = "test"
 	type = "SPF"
@@ -1224,7 +1221,7 @@ resource "aws_route53_zone" "main" {
 	name = "notexample.com"
 }
 
-resource "aws_route53_record" "default" {
+resource "aws_route53_record" "test" {
 	zone_id = "${aws_route53_zone.main.zone_id}"
 	name = "test"
 	type = "CAA"
@@ -1324,7 +1321,7 @@ resource "aws_route53_zone" "main" {
   name = "notexample.com"
 }
 
-resource "aws_route53_record" "default" {
+resource "aws_route53_record" "test" {
   zone_id = "${aws_route53_zone.main.zone_id}"
   name = "www"
   type = "CNAME"
@@ -1332,7 +1329,7 @@ resource "aws_route53_record" "default" {
   geolocation_routing_policy {
     country = "*"
   }
-  set_identifier = "Default"
+  set_identifier = "test"
   records = ["dev.notexample.com"]
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11381

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_route53_record - allow 0 value ttl
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSRoute53Record_'
--- PASS: TestAccAWSRoute53Record_basic (193.09s)
--- PASS: TestAccAWSRoute53Record_underscored (136.86s)
--- PASS: TestAccAWSRoute53Record_disappears (140.23s)
--- PASS: TestAccAWSRoute53Record_disappears_MultipleRecords (232.90s)
--- PASS: TestAccAWSRoute53Record_basic_fqdn (221.45s)
--- PASS: TestAccAWSRoute53Record_txtSupport (178.64s)
--- PASS: TestAccAWSRoute53Record_spfSupport (187.23s)
--- PASS: TestAccAWSRoute53Record_caaSupport (206.77s)
--- PASS: TestAccAWSRoute53Record_generatesSuffix (168.98s)
--- PASS: TestAccAWSRoute53Record_wildcard (270.27s)
--- PASS: TestAccAWSRoute53Record_failover (192.64s)
--- PASS: TestAccAWSRoute53Record_weighted_basic (176.50s)
--- PASS: TestAccAWSRoute53Record_weighted_to_simple_basic (208.90s)
--- PASS: TestAccAWSRoute53Record_Alias_Elb (158.91s)
--- PASS: TestAccAWSRoute53Record_Alias_S3 (165.32s)
--- PASS: TestAccAWSRoute53Record_Alias_VpcEndpoint (571.85s)
--- PASS: TestAccAWSRoute53Record_Alias_Uppercase (204.08s)
--- PASS: TestAccAWSRoute53Record_weighted_alias (293.26s)
--- PASS: TestAccAWSRoute53Record_geolocation_basic (154.10s)
--- PASS: TestAccAWSRoute53Record_latency_basic (174.43s)
--- PASS: TestAccAWSRoute53Record_TypeChange (241.52s)
--- PASS: TestAccAWSRoute53Record_SetIdentifierChange (226.11s)
--- PASS: TestAccAWSRoute53Record_AliasChange (266.53s)
--- PASS: TestAccAWSRoute53Record_empty (190.96s)
--- PASS: TestAccAWSRoute53Record_longTXTrecord (173.65s)
--- PASS: TestAccAWSRoute53Record_multivalue_answer_basic (185.35s)
--- PASS: TestAccAWSRoute53Record_allowOverwrite (210.15s)
--- PASS: TestAccAWSRoute53Record_zero_ttl (174.61s)
...
```
