### PR TITLE
Wait for kubernetes API to be ready during EKS cluster creation

### DIFF
--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -45,7 +45,7 @@ output "kubeconfig-certificate-authority-data" {
 ```hcl
 resource "aws_iam_role" "example" {
   name = "eks-cluster-example"
-  
+
   assume_role_policy = <<POLICY
 {
   "Version": "2012-10-17",
@@ -155,6 +155,7 @@ The following arguments are supported:
 * `enabled_cluster_log_types` - (Optional) A list of the desired control plane logging to enable. For more information, see [Amazon EKS Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html)
 * `tags` - (Optional) Key-value mapping of resource tags.
 * `version` – (Optional) Desired Kubernetes master version. If you do not specify a value, the latest available version at resource creation is used and no upgrades will occur except those automatically triggered by EKS. The value must be configured and increased to upgrade the version when desired. Downgrades are not supported by EKS.
+* `wait_for_endpoint` - (Optional) Wait for the Kubernetes Endpoint to be healthy.
 
 ### vpc_config
 
@@ -176,7 +177,7 @@ In addition to all arguments above, the following attributes are exported:
   * `oidc` - Nested attribute containing [OpenID Connect](https://openid.net/connect/) identity provider information for the cluster.
     * `issuer` - Issuer URL for the OpenID Connect identity provider.
 * `platform_version` - The platform version for the cluster.
-* `status` - The status of the EKS cluster. One of `CREATING`, `ACTIVE`, `DELETING`, `FAILED`. 
+* `status` - The status of the EKS cluster. One of `CREATING`, `ACTIVE`, `DELETING`, `FAILED`.
 * `version` - The Kubernetes server version for the cluster.
 * `vpc_config` - Additional nested attributes:
   * `cluster_security_group_id` - The cluster security group that was created by Amazon EKS for the cluster.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
When creating an EKS cluster, the API return an `ACTIVE` status before the kubernetes endpoint become healthy and ready to process request.

This PR, will add the ability to wait for kubernetes to become ready by checking the `\healthz` endpoint.

This is a kind of proof of concept and I'm opening a PR to get feedback from the community. There is already and opened issue in the [AWS's containers-roadmap](https://github.com/aws/containers-roadmap/issues/654), but I don't know how they will handle this (if they do).

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates 
- https://github.com/aws/containers-roadmap/issues/654
- https://github.com/terraform-aws-modules/terraform-aws-eks/issues/621
- https://github.com/terraform-aws-modules/terraform-aws-eks/issues/621#issuecomment-565801697
- https://github.com/terraform-aws-modules/terraform-aws-eks/pull/639
