### PR TITLE
add import support for waf regional xss match set

### DIFF
--- a/aws/resource_aws_wafregional_xss_match_set.go
+++ b/aws/resource_aws_wafregional_xss_match_set.go
@@ -16,6 +16,9 @@ func resourceAwsWafRegionalXssMatchSet() *schema.Resource {
 		Read:   resourceAwsWafRegionalXssMatchSetRead,
 		Update: resourceAwsWafRegionalXssMatchSetUpdate,
 		Delete: resourceAwsWafRegionalXssMatchSetDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/aws/resource_aws_wafregional_xss_match_set_test.go
+++ b/aws/resource_aws_wafregional_xss_match_set_test.go
@@ -15,6 +15,7 @@ import (
 func TestAccAWSWafRegionalXssMatchSet_basic(t *testing.T) {
 	var v waf.XssMatchSet
 	xssMatchSet := fmt.Sprintf("xssMatchSet-%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_xss_match_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -24,28 +25,23 @@ func TestAccAWSWafRegionalXssMatchSet_basic(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalXssMatchSetConfig(xssMatchSet),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalXssMatchSetExists("aws_wafregional_xss_match_set.xss_match_set", &v),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "name", xssMatchSet),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.#", "2"),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2018581549.field_to_match.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2018581549.field_to_match.2316364334.data", ""),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2018581549.field_to_match.2316364334.type", "QUERY_STRING"),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2018581549.text_transformation", "NONE"),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2786024938.field_to_match.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2786024938.field_to_match.3756326843.data", ""),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2786024938.field_to_match.3756326843.type", "URI"),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2786024938.text_transformation", "NONE"),
+					testAccCheckAWSWafRegionalXssMatchSetExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "name", xssMatchSet),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2018581549.field_to_match.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2018581549.field_to_match.2316364334.data", ""),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2018581549.field_to_match.2316364334.type", "QUERY_STRING"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2018581549.text_transformation", "NONE"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2786024938.field_to_match.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2786024938.field_to_match.3756326843.data", ""),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2786024938.field_to_match.3756326843.type", "URI"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2786024938.text_transformation", "NONE"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -55,6 +51,7 @@ func TestAccAWSWafRegionalXssMatchSet_changeNameForceNew(t *testing.T) {
 	var before, after waf.XssMatchSet
 	xssMatchSet := fmt.Sprintf("xssMatchSet-%s", acctest.RandString(5))
 	xssMatchSetNewName := fmt.Sprintf("xssMatchSetNewName-%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_xss_match_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -64,21 +61,22 @@ func TestAccAWSWafRegionalXssMatchSet_changeNameForceNew(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalXssMatchSetConfig(xssMatchSet),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalXssMatchSetExists("aws_wafregional_xss_match_set.xss_match_set", &before),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "name", xssMatchSet),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.#", "2"),
+					testAccCheckAWSWafRegionalXssMatchSetExists(resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "name", xssMatchSet),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.#", "2"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSWafRegionalXssMatchSetConfigChangeName(xssMatchSetNewName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalXssMatchSetExists("aws_wafregional_xss_match_set.xss_match_set", &after),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "name", xssMatchSetNewName),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.#", "2"),
+					testAccCheckAWSWafRegionalXssMatchSetExists(resourceName, &after),
+					resource.TestCheckResourceAttr(resourceName, "name", xssMatchSetNewName),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.#", "2"),
 				),
 			},
 		},
@@ -88,6 +86,7 @@ func TestAccAWSWafRegionalXssMatchSet_changeNameForceNew(t *testing.T) {
 func TestAccAWSWafRegionalXssMatchSet_disappears(t *testing.T) {
 	var v waf.XssMatchSet
 	xssMatchSet := fmt.Sprintf("xssMatchSet-%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_xss_match_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -97,7 +96,7 @@ func TestAccAWSWafRegionalXssMatchSet_disappears(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalXssMatchSetConfig(xssMatchSet),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalXssMatchSetExists("aws_wafregional_xss_match_set.xss_match_set", &v),
+					testAccCheckAWSWafRegionalXssMatchSetExists(resourceName, &v),
 					testAccCheckAWSWafRegionalXssMatchSetDisappears(&v),
 				),
 				ExpectNonEmptyPlan: true,
@@ -109,6 +108,7 @@ func TestAccAWSWafRegionalXssMatchSet_disappears(t *testing.T) {
 func TestAccAWSWafRegionalXssMatchSet_changeTuples(t *testing.T) {
 	var before, after waf.XssMatchSet
 	setName := fmt.Sprintf("xssMatchSet-%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_xss_match_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -118,53 +118,38 @@ func TestAccAWSWafRegionalXssMatchSet_changeTuples(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalXssMatchSetConfig(setName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafRegionalXssMatchSetExists("aws_wafregional_xss_match_set.xss_match_set", &before),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "name", setName),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.#", "2"),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2018581549.field_to_match.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2018581549.field_to_match.2316364334.data", ""),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2018581549.field_to_match.2316364334.type", "QUERY_STRING"),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2018581549.text_transformation", "NONE"),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2786024938.field_to_match.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2786024938.field_to_match.3756326843.data", ""),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2786024938.field_to_match.3756326843.type", "URI"),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2786024938.text_transformation", "NONE"),
+					testAccCheckAWSWafRegionalXssMatchSetExists(resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "name", setName),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2018581549.field_to_match.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2018581549.field_to_match.2316364334.data", ""),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2018581549.field_to_match.2316364334.type", "QUERY_STRING"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2018581549.text_transformation", "NONE"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2786024938.field_to_match.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2786024938.field_to_match.3756326843.data", ""),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2786024938.field_to_match.3756326843.type", "URI"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2786024938.text_transformation", "NONE"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSWafRegionalXssMatchSetConfig_changeTuples(setName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafRegionalXssMatchSetExists("aws_wafregional_xss_match_set.xss_match_set", &after),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "name", setName),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.#", "2"),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2893682529.field_to_match.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2893682529.field_to_match.4253810390.data", "GET"),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2893682529.field_to_match.4253810390.type", "METHOD"),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2893682529.text_transformation", "HTML_ENTITY_DECODE"),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.4270311415.field_to_match.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.4270311415.field_to_match.281401076.data", ""),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.4270311415.field_to_match.281401076.type", "BODY"),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.4270311415.text_transformation", "CMD_LINE"),
+					testAccCheckAWSWafRegionalXssMatchSetExists(resourceName, &after),
+					resource.TestCheckResourceAttr(resourceName, "name", setName),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2893682529.field_to_match.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2893682529.field_to_match.4253810390.data", "GET"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2893682529.field_to_match.4253810390.type", "METHOD"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2893682529.text_transformation", "HTML_ENTITY_DECODE"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.4270311415.field_to_match.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.4270311415.field_to_match.281401076.data", ""),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.4270311415.field_to_match.281401076.type", "BODY"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.4270311415.text_transformation", "CMD_LINE"),
 				),
 			},
 		},
@@ -174,6 +159,7 @@ func TestAccAWSWafRegionalXssMatchSet_changeTuples(t *testing.T) {
 func TestAccAWSWafRegionalXssMatchSet_noTuples(t *testing.T) {
 	var ipset waf.XssMatchSet
 	setName := fmt.Sprintf("xssMatchSet-%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_xss_match_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -183,12 +169,15 @@ func TestAccAWSWafRegionalXssMatchSet_noTuples(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalXssMatchSetConfig_noTuples(setName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafRegionalXssMatchSetExists("aws_wafregional_xss_match_set.xss_match_set", &ipset),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "name", setName),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.#", "0"),
+					testAccCheckAWSWafRegionalXssMatchSetExists(resourceName, &ipset),
+					resource.TestCheckResourceAttr(resourceName, "name", setName),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.#", "0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -208,7 +197,7 @@ func testAccCheckAWSWafRegionalXssMatchSetDisappears(v *waf.XssMatchSet) resourc
 
 			for _, xssMatchTuple := range v.XssMatchTuples {
 				xssMatchTupleUpdate := &waf.XssMatchSetUpdate{
-					Action: aws.String("DELETE"),
+					Action: aws.String(wafregional.ChangeActionDelete),
 					XssMatchTuple: &waf.XssMatchTuple{
 						FieldToMatch:       xssMatchTuple.FieldToMatch,
 						TextTransformation: xssMatchTuple.TextTransformation,
@@ -296,7 +285,7 @@ func testAccCheckAWSWafRegionalXssMatchSetDestroy(s *terraform.State) error {
 
 func testAccAWSWafRegionalXssMatchSetConfig(name string) string {
 	return fmt.Sprintf(`
-resource "aws_wafregional_xss_match_set" "xss_match_set" {
+resource "aws_wafregional_xss_match_set" "test" {
   name = "%s"
 
   xss_match_tuple {
@@ -320,7 +309,7 @@ resource "aws_wafregional_xss_match_set" "xss_match_set" {
 
 func testAccAWSWafRegionalXssMatchSetConfigChangeName(name string) string {
 	return fmt.Sprintf(`
-resource "aws_wafregional_xss_match_set" "xss_match_set" {
+resource "aws_wafregional_xss_match_set" "test" {
   name = "%s"
 
   xss_match_tuple {
@@ -344,7 +333,7 @@ resource "aws_wafregional_xss_match_set" "xss_match_set" {
 
 func testAccAWSWafRegionalXssMatchSetConfig_changeTuples(name string) string {
 	return fmt.Sprintf(`
-resource "aws_wafregional_xss_match_set" "xss_match_set" {
+resource "aws_wafregional_xss_match_set" "test" {
   name = "%s"
 
   xss_match_tuple {
@@ -369,7 +358,7 @@ resource "aws_wafregional_xss_match_set" "xss_match_set" {
 
 func testAccAWSWafRegionalXssMatchSetConfig_noTuples(name string) string {
 	return fmt.Sprintf(`
-resource "aws_wafregional_xss_match_set" "xss_match_set" {
+resource "aws_wafregional_xss_match_set" "test" {
   name = "%s"
 }
 `, name)

--- a/website/docs/r/wafregional_xss_match_set.html.markdown
+++ b/website/docs/r/wafregional_xss_match_set.html.markdown
@@ -58,3 +58,11 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the Regional WAF XSS Match Set.
+
+## Import
+
+AWS WAF Regional XSS Match can be imported using the `id`, e.g.
+
+```sh
+$ terraform import xss_match_set.set 12345abcde
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_wafregional_xss_match_set: Support resource import
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSWafRegionalXssMatchSet_'
--- PASS: TestAccAWSWafRegionalXssMatchSet_basic (66.24s)
--- PASS: TestAccAWSWafRegionalXssMatchSet_changeNameForceNew (85.67s)
--- PASS: TestAccAWSWafRegionalXssMatchSet_disappears (53.81s)
--- FAIL: TestAccAWSWafRegionalXssMatchSet_changeTuples (93.39s)
    testing.go:640: Step 2 error: After applying this step and refreshing, the plan was not empty:
        
        DIFF:
        
        UPDATE: aws_wafregional_xss_match_set.test
          id:                                      "455cfd97-a392-4996-bd96-629ab2e3c9c6" => "455cfd97-a392-4996-bd96-629ab2e3c9c6"
          name:                                    "xssMatchSet-8nn3z" => "xssMatchSet-8nn3z"
          xss_match_tuple.#:                       "2" => "2"
          xss_match_tuple.0.field_to_match.#:      "1" => "1"
          xss_match_tuple.0.field_to_match.0.data: "" => "GET"
          xss_match_tuple.0.field_to_match.0.type: "BODY" => "METHOD"
          xss_match_tuple.0.text_transformation:   "CMD_LINE" => "HTML_ENTITY_DECODE"
          xss_match_tuple.1.field_to_match.#:      "1" => "1"
          xss_match_tuple.1.field_to_match.0.data: "" => ""
          xss_match_tuple.1.field_to_match.0.type: "METHOD" => "BODY"
          xss_match_tuple.1.text_transformation:   "HTML_ENTITY_DECODE" => "CMD_LINE"
        
        
        
        STATE:
        
        aws_wafregional_xss_match_set.test:
          ID = 455cfd97-a392-4996-bd96-629ab2e3c9c6
          provider = provider.aws
          name = xssMatchSet-8nn3z
          xss_match_tuple.# = 2
          xss_match_tuple.0.field_to_match.# = 1
          xss_match_tuple.0.field_to_match.0.data = 
          xss_match_tuple.0.field_to_match.0.type = BODY
          xss_match_tuple.0.text_transformation = CMD_LINE
          xss_match_tuple.1.field_to_match.# = 1
          xss_match_tuple.1.field_to_match.0.data = 
          xss_match_tuple.1.field_to_match.0.type = METHOD
          xss_match_tuple.1.text_transformation = HTML_ENTITY_DECODE
--- PASS: TestAccAWSWafRegionalXssMatchSet_noTuples (52.66s)
...
```
