### PR TITLE
Import support for API Gateway Authorizer resource

### DIFF
--- a/aws/resource_aws_api_gateway_authorizer.go
+++ b/aws/resource_aws_api_gateway_authorizer.go
@@ -21,6 +21,19 @@ func resourceAwsApiGatewayAuthorizer() *schema.Resource {
 		Update:        resourceAwsApiGatewayAuthorizerUpdate,
 		Delete:        resourceAwsApiGatewayAuthorizerDelete,
 		CustomizeDiff: resourceAwsApiGatewayAuthorizerCustomizeDiff,
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				idParts := strings.Split(d.Id(), "/")
+				if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
+					return nil, fmt.Errorf("Unexpected format of ID (%q), expected REST-API-ID/AUTHORIZER-ID", d.Id())
+				}
+				restAPIId := idParts[0]
+				authorizerId := idParts[1]
+				d.Set("rest_api_id", restAPIId)
+				d.SetId(authorizerId)
+				return []*schema.ResourceData{d}, nil
+			},
+		},
 
 		Schema: map[string]*schema.Schema{
 			"authorizer_uri": {
@@ -44,7 +57,7 @@ func resourceAwsApiGatewayAuthorizer() *schema.Resource {
 			"type": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "TOKEN",
+				Default:  apigateway.AuthorizerTypeToken,
 				ValidateFunc: validation.StringInSlice([]string{
 					apigateway.AuthorizerTypeCognitoUserPools,
 					apigateway.AuthorizerTypeRequest,
@@ -68,7 +81,10 @@ func resourceAwsApiGatewayAuthorizer() *schema.Resource {
 			"provider_arns": {
 				Type:     schema.TypeSet,
 				Optional: true, // provider_arns is required for authorizer COGNITO_USER_POOLS.
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validateArn,
+				},
 			},
 		},
 	}
@@ -125,7 +141,7 @@ func resourceAwsApiGatewayAuthorizerRead(d *schema.ResourceData, meta interface{
 
 	authorizer, err := conn.GetAuthorizer(&input)
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NotFoundException" {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == apigateway.ErrCodeNotFoundException {
 			log.Printf("[WARN] No API Gateway Authorizer found: %s", input)
 			d.SetId("")
 			return nil
@@ -164,14 +180,14 @@ func resourceAwsApiGatewayAuthorizerUpdate(d *schema.ResourceData, meta interfac
 
 	if d.HasChange("authorizer_uri") {
 		operations = append(operations, &apigateway.PatchOperation{
-			Op:    aws.String("replace"),
+			Op:    aws.String(apigateway.OpReplace),
 			Path:  aws.String("/authorizerUri"),
 			Value: aws.String(d.Get("authorizer_uri").(string)),
 		})
 	}
 	if d.HasChange("identity_source") {
 		operations = append(operations, &apigateway.PatchOperation{
-			Op:    aws.String("replace"),
+			Op:    aws.String(apigateway.OpReplace),
 			Path:  aws.String("/identitySource"),
 			Value: aws.String(d.Get("identity_source").(string)),
 		})
@@ -185,28 +201,28 @@ func resourceAwsApiGatewayAuthorizerUpdate(d *schema.ResourceData, meta interfac
 	}
 	if d.HasChange("type") {
 		operations = append(operations, &apigateway.PatchOperation{
-			Op:    aws.String("replace"),
+			Op:    aws.String(apigateway.OpReplace),
 			Path:  aws.String("/type"),
 			Value: aws.String(d.Get("type").(string)),
 		})
 	}
 	if d.HasChange("authorizer_credentials") {
 		operations = append(operations, &apigateway.PatchOperation{
-			Op:    aws.String("replace"),
+			Op:    aws.String(apigateway.OpReplace),
 			Path:  aws.String("/authorizerCredentials"),
 			Value: aws.String(d.Get("authorizer_credentials").(string)),
 		})
 	}
 	if d.HasChange("authorizer_result_ttl_in_seconds") {
 		operations = append(operations, &apigateway.PatchOperation{
-			Op:    aws.String("replace"),
+			Op:    aws.String(apigateway.OpReplace),
 			Path:  aws.String("/authorizerResultTtlInSeconds"),
 			Value: aws.String(fmt.Sprintf("%d", d.Get("authorizer_result_ttl_in_seconds").(int))),
 		})
 	}
 	if d.HasChange("identity_validation_expression") {
 		operations = append(operations, &apigateway.PatchOperation{
-			Op:    aws.String("replace"),
+			Op:    aws.String(apigateway.OpReplace),
 			Path:  aws.String("/identityValidationExpression"),
 			Value: aws.String(d.Get("identity_validation_expression").(string)),
 		})
@@ -219,7 +235,7 @@ func resourceAwsApiGatewayAuthorizerUpdate(d *schema.ResourceData, meta interfac
 		additionList := ns.Difference(os)
 		for _, v := range additionList.List() {
 			operations = append(operations, &apigateway.PatchOperation{
-				Op:    aws.String("add"),
+				Op:    aws.String(apigateway.OpAdd),
 				Path:  aws.String("/providerARNs"),
 				Value: aws.String(v.(string)),
 			})
@@ -227,7 +243,7 @@ func resourceAwsApiGatewayAuthorizerUpdate(d *schema.ResourceData, meta interfac
 		removalList := os.Difference(ns)
 		for _, v := range removalList.List() {
 			operations = append(operations, &apigateway.PatchOperation{
-				Op:    aws.String("remove"),
+				Op:    aws.String(apigateway.OpRemove),
 				Path:  aws.String("/providerARNs"),
 				Value: aws.String(v.(string)),
 			})
@@ -256,7 +272,7 @@ func resourceAwsApiGatewayAuthorizerDelete(d *schema.ResourceData, meta interfac
 	if err != nil {
 		// XXX: Figure out a way to delete the method that depends on the authorizer first
 		// otherwise the authorizer will be dangling until the API is deleted
-		if !strings.Contains(err.Error(), "ConflictException") {
+		if !strings.Contains(err.Error(), apigateway.ErrCodeConflictException) {
 			return fmt.Errorf("Deleting API Gateway Authorizer failed: %s", err)
 		}
 	}

--- a/aws/resource_aws_api_gateway_authorizer.go
+++ b/aws/resource_aws_api_gateway_authorizer.go
@@ -194,7 +194,7 @@ func resourceAwsApiGatewayAuthorizerUpdate(d *schema.ResourceData, meta interfac
 	}
 	if d.HasChange("name") {
 		operations = append(operations, &apigateway.PatchOperation{
-			Op:    aws.String("replace"),
+			Op:    aws.String(apigateway.OpReplace),
 			Path:  aws.String("/name"),
 			Value: aws.String(d.Get("name").(string)),
 		})

--- a/aws/resource_aws_api_gateway_authorizer_test.go
+++ b/aws/resource_aws_api_gateway_authorizer_test.go
@@ -15,10 +15,10 @@ import (
 
 func TestAccAWSAPIGatewayAuthorizer_basic(t *testing.T) {
 	var conf apigateway.Authorizer
-	rString := acctest.RandString(7)
-	apiGatewayName := "tf-acctest-apigw-" + rString
-	authorizerName := "tf-acctest-igw-authorizer-" + rString
-	lambdaName := "tf-acctest-igw-auth-lambda-" + rString
+	apiGatewayName := acctest.RandomWithPrefix("tf-acctest-apigw")
+	authorizerName := acctest.RandomWithPrefix("tf-acctest-igw-authorizer")
+	lambdaName := acctest.RandomWithPrefix("tf-acctest-igw-auth-lambda")
+	resourceName := "aws_api_gateway_authorizer.acctest"
 
 	expectedAuthUri := regexp.MustCompile("arn:aws:apigateway:[a-z0-9-]+:lambda:path/2015-03-31/functions/" +
 		"arn:aws:lambda:[a-z0-9-]+:[0-9]{12}:function:" + lambdaName + "/invocations")
@@ -32,41 +32,47 @@ func TestAccAWSAPIGatewayAuthorizer_basic(t *testing.T) {
 			{
 				Config: testAccAWSAPIGatewayAuthorizerConfig_lambda(apiGatewayName, authorizerName, lambdaName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayAuthorizerExists("aws_api_gateway_authorizer.acctest", &conf),
+					testAccCheckAWSAPIGatewayAuthorizerExists(resourceName, &conf),
 					testAccCheckAWSAPIGatewayAuthorizerAuthorizerUri(&conf, expectedAuthUri),
-					resource.TestMatchResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_uri", expectedAuthUri),
+					resource.TestMatchResourceAttr(resourceName, "authorizer_uri", expectedAuthUri),
 					testAccCheckAWSAPIGatewayAuthorizerIdentitySource(&conf, "method.request.header.Authorization"),
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "identity_source", "method.request.header.Authorization"),
+					resource.TestCheckResourceAttr(resourceName, "identity_source", "method.request.header.Authorization"),
 					testAccCheckAWSAPIGatewayAuthorizerName(&conf, authorizerName),
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "name", authorizerName),
+					resource.TestCheckResourceAttr(resourceName, "name", authorizerName),
 					testAccCheckAWSAPIGatewayAuthorizerType(&conf, "TOKEN"),
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "type", "TOKEN"),
+					resource.TestCheckResourceAttr(resourceName, "type", "TOKEN"),
 					testAccCheckAWSAPIGatewayAuthorizerAuthorizerCredentials(&conf, expectedCreds),
-					resource.TestMatchResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_credentials", expectedCreds),
+					resource.TestMatchResourceAttr(resourceName, "authorizer_credentials", expectedCreds),
 					testAccCheckAWSAPIGatewayAuthorizerAuthorizerResultTtlInSeconds(&conf, aws.Int64(defaultAuthorizerTTL)),
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_result_ttl_in_seconds", "300"),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", "300"),
 					testAccCheckAWSAPIGatewayAuthorizerIdentityValidationExpression(&conf, nil),
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "identity_validation_expression", ""),
+					resource.TestCheckResourceAttr(resourceName, "identity_validation_expression", ""),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAPIGatewayAuthorizerImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSAPIGatewayAuthorizerConfig_lambdaUpdate(apiGatewayName, authorizerName, lambdaName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayAuthorizerExists("aws_api_gateway_authorizer.acctest", &conf),
+					testAccCheckAWSAPIGatewayAuthorizerExists(resourceName, &conf),
 					testAccCheckAWSAPIGatewayAuthorizerAuthorizerUri(&conf, expectedAuthUri),
-					resource.TestMatchResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_uri", expectedAuthUri),
+					resource.TestMatchResourceAttr(resourceName, "authorizer_uri", expectedAuthUri),
 					testAccCheckAWSAPIGatewayAuthorizerIdentitySource(&conf, "method.request.header.Authorization"),
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "identity_source", "method.request.header.Authorization"),
+					resource.TestCheckResourceAttr(resourceName, "identity_source", "method.request.header.Authorization"),
 					testAccCheckAWSAPIGatewayAuthorizerName(&conf, authorizerName+"_modified"),
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "name", authorizerName+"_modified"),
+					resource.TestCheckResourceAttr(resourceName, "name", authorizerName+"_modified"),
 					testAccCheckAWSAPIGatewayAuthorizerType(&conf, "TOKEN"),
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "type", "TOKEN"),
+					resource.TestCheckResourceAttr(resourceName, "type", "TOKEN"),
 					testAccCheckAWSAPIGatewayAuthorizerAuthorizerCredentials(&conf, expectedCreds),
-					resource.TestMatchResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_credentials", expectedCreds),
+					resource.TestMatchResourceAttr(resourceName, "authorizer_credentials", expectedCreds),
 					testAccCheckAWSAPIGatewayAuthorizerAuthorizerResultTtlInSeconds(&conf, aws.Int64(360)),
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_result_ttl_in_seconds", "360"),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", "360"),
 					testAccCheckAWSAPIGatewayAuthorizerIdentityValidationExpression(&conf, aws.String(".*")),
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "identity_validation_expression", ".*"),
+					resource.TestCheckResourceAttr(resourceName, "identity_validation_expression", ".*"),
 				),
 			},
 		},
@@ -74,10 +80,10 @@ func TestAccAWSAPIGatewayAuthorizer_basic(t *testing.T) {
 }
 
 func TestAccAWSAPIGatewayAuthorizer_cognito(t *testing.T) {
-	rString := acctest.RandString(7)
-	apiGatewayName := "tf-acctest-apigw-" + rString
-	authorizerName := "tf-acctest-igw-authorizer-" + rString
-	cognitoName := "tf-acctest-cognito-user-pool-" + rString
+	apiGatewayName := acctest.RandomWithPrefix("tf-acctest-apigw")
+	authorizerName := acctest.RandomWithPrefix("tf-acctest-igw-authorizer")
+	cognitoName := acctest.RandomWithPrefix("tf-acctest-cognito-user-pool")
+	resourceName := "aws_api_gateway_authorizer.acctest"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -87,15 +93,21 @@ func TestAccAWSAPIGatewayAuthorizer_cognito(t *testing.T) {
 			{
 				Config: testAccAWSAPIGatewayAuthorizerConfig_cognito(apiGatewayName, authorizerName, cognitoName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "name", authorizerName+"-cognito"),
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "provider_arns.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "name", authorizerName+"-cognito"),
+					resource.TestCheckResourceAttr(resourceName, "provider_arns.#", "2"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAPIGatewayAuthorizerImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSAPIGatewayAuthorizerConfig_cognitoUpdate(apiGatewayName, authorizerName, cognitoName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "name", authorizerName+"-cognito-update"),
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "provider_arns.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "name", authorizerName+"-cognito-update"),
+					resource.TestCheckResourceAttr(resourceName, "provider_arns.#", "3"),
 				),
 			},
 		},
@@ -103,11 +115,11 @@ func TestAccAWSAPIGatewayAuthorizer_cognito(t *testing.T) {
 }
 
 func TestAccAWSAPIGatewayAuthorizer_switchAuthType(t *testing.T) {
-	rString := acctest.RandString(7)
-	apiGatewayName := "tf-acctest-apigw-" + rString
-	authorizerName := "tf-acctest-igw-authorizer-" + rString
-	cognitoName := "tf-acctest-cognito-user-pool-" + rString
-	lambdaName := "tf-acctest-igw-auth-lambda-" + rString
+	apiGatewayName := acctest.RandomWithPrefix("tf-acctest-apigw")
+	authorizerName := acctest.RandomWithPrefix("tf-acctest-igw-authorizer")
+	lambdaName := acctest.RandomWithPrefix("tf-acctest-igw-auth-lambda")
+	cognitoName := acctest.RandomWithPrefix("tf-acctest-cognito-user-pool")
+	resourceName := "aws_api_gateway_authorizer.acctest"
 
 	expectedAuthUri := regexp.MustCompile("arn:aws:apigateway:[a-z0-9-]+:lambda:path/2015-03-31/functions/" +
 		"arn:aws:lambda:[a-z0-9-]+:[0-9]{12}:function:" + lambdaName + "/invocations")
@@ -121,27 +133,33 @@ func TestAccAWSAPIGatewayAuthorizer_switchAuthType(t *testing.T) {
 			{
 				Config: testAccAWSAPIGatewayAuthorizerConfig_lambda(apiGatewayName, authorizerName, lambdaName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "name", authorizerName),
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "type", "TOKEN"),
-					resource.TestMatchResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_uri", expectedAuthUri),
-					resource.TestMatchResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_credentials", expectedCreds),
+					resource.TestCheckResourceAttr(resourceName, "name", authorizerName),
+					resource.TestCheckResourceAttr(resourceName, "type", "TOKEN"),
+					resource.TestMatchResourceAttr(resourceName, "authorizer_uri", expectedAuthUri),
+					resource.TestMatchResourceAttr(resourceName, "authorizer_credentials", expectedCreds),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAPIGatewayAuthorizerImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSAPIGatewayAuthorizerConfig_cognito(apiGatewayName, authorizerName, cognitoName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "name", authorizerName+"-cognito"),
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "type", "COGNITO_USER_POOLS"),
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "provider_arns.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "name", authorizerName+"-cognito"),
+					resource.TestCheckResourceAttr(resourceName, "type", "COGNITO_USER_POOLS"),
+					resource.TestCheckResourceAttr(resourceName, "provider_arns.#", "2"),
 				),
 			},
 			{
 				Config: testAccAWSAPIGatewayAuthorizerConfig_lambdaUpdate(apiGatewayName, authorizerName, lambdaName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "name", authorizerName+"_modified"),
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "type", "TOKEN"),
-					resource.TestMatchResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_uri", expectedAuthUri),
-					resource.TestMatchResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_credentials", expectedCreds),
+					resource.TestCheckResourceAttr(resourceName, "name", authorizerName+"_modified"),
+					resource.TestCheckResourceAttr(resourceName, "type", "TOKEN"),
+					resource.TestMatchResourceAttr(resourceName, "authorizer_uri", expectedAuthUri),
+					resource.TestMatchResourceAttr(resourceName, "authorizer_credentials", expectedCreds),
 				),
 			},
 		},
@@ -150,10 +168,10 @@ func TestAccAWSAPIGatewayAuthorizer_switchAuthType(t *testing.T) {
 
 func TestAccAWSAPIGatewayAuthorizer_switchAuthorizerTTL(t *testing.T) {
 	var conf apigateway.Authorizer
-	rString := acctest.RandString(7)
-	apiGatewayName := "tf-acctest-apigw-" + rString
-	authorizerName := "tf-acctest-igw-authorizer-" + rString
-	lambdaName := "tf-acctest-igw-auth-lambda-" + rString
+	apiGatewayName := acctest.RandomWithPrefix("tf-acctest-apigw")
+	authorizerName := acctest.RandomWithPrefix("tf-acctest-igw-authorizer")
+	lambdaName := acctest.RandomWithPrefix("tf-acctest-igw-auth-lambda")
+	resourceName := "aws_api_gateway_authorizer.acctest"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -163,33 +181,39 @@ func TestAccAWSAPIGatewayAuthorizer_switchAuthorizerTTL(t *testing.T) {
 			{
 				Config: testAccAWSAPIGatewayAuthorizerConfig_lambda(apiGatewayName, authorizerName, lambdaName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayAuthorizerExists("aws_api_gateway_authorizer.acctest", &conf),
+					testAccCheckAWSAPIGatewayAuthorizerExists(resourceName, &conf),
 					testAccCheckAWSAPIGatewayAuthorizerAuthorizerResultTtlInSeconds(&conf, aws.Int64(defaultAuthorizerTTL)),
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_result_ttl_in_seconds", "300"),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", "300"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAPIGatewayAuthorizerImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSAPIGatewayAuthorizerConfig_lambdaUpdate(apiGatewayName, authorizerName, lambdaName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayAuthorizerExists("aws_api_gateway_authorizer.acctest", &conf),
+					testAccCheckAWSAPIGatewayAuthorizerExists(resourceName, &conf),
 					testAccCheckAWSAPIGatewayAuthorizerAuthorizerResultTtlInSeconds(&conf, aws.Int64(360)),
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_result_ttl_in_seconds", "360"),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", "360"),
 				),
 			},
 			{
 				Config: testAccAWSAPIGatewayAuthorizerConfig_lambdaNoCache(apiGatewayName, authorizerName, lambdaName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayAuthorizerExists("aws_api_gateway_authorizer.acctest", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_result_ttl_in_seconds", "0"),
+					testAccCheckAWSAPIGatewayAuthorizerExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", "0"),
 					testAccCheckAWSAPIGatewayAuthorizerAuthorizerResultTtlInSeconds(&conf, aws.Int64(0)),
 				),
 			},
 			{
 				Config: testAccAWSAPIGatewayAuthorizerConfig_lambda(apiGatewayName, authorizerName, lambdaName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayAuthorizerExists("aws_api_gateway_authorizer.acctest", &conf),
+					testAccCheckAWSAPIGatewayAuthorizerExists(resourceName, &conf),
 					testAccCheckAWSAPIGatewayAuthorizerAuthorizerResultTtlInSeconds(&conf, aws.Int64(defaultAuthorizerTTL)),
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_result_ttl_in_seconds", "300"),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", "300"),
 				),
 			},
 		},
@@ -197,11 +221,10 @@ func TestAccAWSAPIGatewayAuthorizer_switchAuthorizerTTL(t *testing.T) {
 }
 
 func TestAccAWSAPIGatewayAuthorizer_authTypeValidation(t *testing.T) {
-	rString := acctest.RandString(7)
-	apiGatewayName := "tf-acctest-apigw-" + rString
-	authorizerName := "tf-acctest-igw-authorizer-" + rString
-	cognitoName := "tf-acctest-cognito-user-pool-" + rString
-	lambdaName := "tf-acctest-igw-auth-lambda-" + rString
+	apiGatewayName := acctest.RandomWithPrefix("tf-acctest-apigw")
+	authorizerName := acctest.RandomWithPrefix("tf-acctest-igw-authorizer")
+	lambdaName := acctest.RandomWithPrefix("tf-acctest-igw-auth-lambda")
+	cognitoName := acctest.RandomWithPrefix("tf-acctest-cognito-user-pool")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -374,7 +397,7 @@ func testAccCheckAWSAPIGatewayAuthorizerDestroy(s *terraform.State) error {
 		if !ok {
 			return err
 		}
-		if aws2err.Code() != "NotFoundException" {
+		if aws2err.Code() != apigateway.ErrCodeNotFoundException {
 			return err
 		}
 
@@ -382,6 +405,17 @@ func testAccCheckAWSAPIGatewayAuthorizerDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccAWSAPIGatewayAuthorizerImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["rest_api_id"], rs.Primary.ID), nil
+	}
 }
 
 func testAccAWSAPIGatewayAuthorizerConfig_baseLambda(apiGatewayName, lambdaName string) string {

--- a/website/docs/r/api_gateway_authorizer.html.markdown
+++ b/website/docs/r/api_gateway_authorizer.html.markdown
@@ -119,3 +119,11 @@ The following arguments are supported:
 	the client receives a 401 Unauthorized response.
 * `provider_arns` - (Optional, required for type `COGNITO_USER_POOLS`) A list of the Amazon Cognito user pool ARNs.
 	Each element is of this format: `arn:aws:cognito-idp:{region}:{account_id}:userpool/{user_pool_id}`.
+
+## Import
+
+AWS API Gateway Authorizer can be imported using the `REST-API-ID/AUTHORIZER-ID`, e.g.
+
+```sh
+$ terraform import aws_api_gateway_authorizer.authorizer 12345abcde/example
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9529, Relates #558

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_api_gateway_authorizer: Support resource import
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSAPIGatewayAuthorizer_'
--- PASS: TestAccAWSAPIGatewayAuthorizer_basic (109.12s)
--- PASS: TestAccAWSAPIGatewayAuthorizer_cognito (83.96s)
--- PASS: TestAccAWSAPIGatewayAuthorizer_switchAuthType (156.79s)
--- PASS: TestAccAWSAPIGatewayAuthorizer_switchAuthorizerTTL (172.34s)
--- PASS: TestAccAWSAPIGatewayAuthorizer_authTypeValidation (74.25s)
--- PASS: TestAccAWSAPIGatewayAuthorizer_disappears (66.43s)
...
```
