### PR TITLE
Import support for ami launch permission resource

### DIFF
--- a/aws/resource_aws_ami_launch_permission_test.go
+++ b/aws/resource_aws_ami_launch_permission_test.go
@@ -26,6 +26,12 @@ func TestAccAWSAMILaunchPermission_Basic(t *testing.T) {
 					testAccCheckAWSAMILaunchPermissionExists(resourceName),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAMILaunchPermissionImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -183,10 +189,10 @@ func testAccCheckAWSAMILaunchPermissionAddPublic(resourceName string) resource.T
 
 		input := &ec2.ModifyImageAttributeInput{
 			ImageId:   aws.String(imageID),
-			Attribute: aws.String("launchPermission"),
+			Attribute: aws.String(ec2.ImageAttributeNameLaunchPermission),
 			LaunchPermission: &ec2.LaunchPermissionModifications{
 				Add: []*ec2.LaunchPermission{
-					{Group: aws.String("all")},
+					{Group: aws.String(ec2.PermissionGroupAll)},
 				},
 			},
 		}
@@ -214,7 +220,7 @@ func testAccCheckAWSAMILaunchPermissionDisappears(resourceName string) resource.
 
 		input := &ec2.ModifyImageAttributeInput{
 			ImageId:   aws.String(imageID),
-			Attribute: aws.String("launchPermission"),
+			Attribute: aws.String(ec2.ImageAttributeNameLaunchPermission),
 			LaunchPermission: &ec2.LaunchPermissionModifications{
 				Remove: []*ec2.LaunchPermission{
 					{UserId: aws.String(accountID)},
@@ -283,4 +289,15 @@ resource "aws_ami_launch_permission" "test" {
   image_id   = "${aws_ami_copy.test.id}"
 }
 `, rName, rName)
+}
+
+func testAccAWSAMILaunchPermissionImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["account_id"], rs.Primary.Attributes["image_id"]), nil
+	}
 }

--- a/website/docs/r/ami_launch_permission.html.markdown
+++ b/website/docs/r/ami_launch_permission.html.markdown
@@ -31,3 +31,12 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
   * `id` - A combination of "`image_id`-`account_id`".
+
+
+## Import
+
+AWS AMI Launch Permission can be imported using the `ACCOUNT-ID/IMAGE-ID`, e.g.
+
+```sh
+$ terraform import aws_ami_launch_permission.perm 12345abcde/example
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_ami_launch_permission: Support resource import
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSAMILaunchPermission_'
--- PASS: TestAccAWSAMILaunchPermission_Basic (367.74s)
--- PASS: TestAccAWSAMILaunchPermission_Disappears_LaunchPermission_Public (380.24s)
--- PASS: TestAccAWSAMILaunchPermission_Disappears_AMI (396.06s)
--- PASS: TestAccAWSAMILaunchPermission_Disappears_LaunchPermission (369.96s)
...
```
