### PR TITLE
Amazon Resource Names are not a valid option

### DIFF
--- a/website/docs/r/ecs_cluster.html.markdown
+++ b/website/docs/r/ecs_cluster.html.markdown
@@ -23,7 +23,7 @@ resource "aws_ecs_cluster" "foo" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the cluster (up to 255 letters, numbers, hyphens, and underscores)
-* `capacity_providers` - (Optional) List of short names or full Amazon Resource Names (ARNs) of one or more capacity providers to associate with the cluster. Valid values also include `FARGATE` and `FARGATE_SPOT`.
+* `capacity_providers` - (Optional) List of short names of one or more capacity providers to associate with the cluster. Valid values also include `FARGATE` and `FARGATE_SPOT`.
 * `default_capacity_provider_strategy` - (Optional) The capacity provider strategy to use by default for the cluster. Can be one or more.  Defined below.
 * `tags` - (Optional) Key-value mapping of resource tags
 * `setting` - (Optional) Configuration block(s) with cluster settings. For example, this can be used to enable CloudWatch Container Insights for a cluster. Defined below.
@@ -39,7 +39,7 @@ The `setting` configuration block supports the following:
 
 The `default_capacity_provider_strategy` configuration block supports the following:
 
-* `capacity_provider` - (Required) The short name or full Amazon Resource Name (ARN) of the capacity provider.
+* `capacity_provider` - (Required) The short name of the capacity provider.
 * `weight` - (Required) The relative percentage of the total number of launched tasks that should use the specified capacity provider.
 * `base` - (Optional) The number of tasks, at a minimum, to run on the specified capacity provider. Only one capacity provider in a capacity provider strategy can have a base defined.
 


### PR DESCRIPTION
Amazon Resource Names (ARNs) are not a valid option, only the short name of the resource is valid. See the [aws cli documentation](https://docs.aws.amazon.com/cli/latest/reference/ecs/put-cluster-capacity-providers.html) example.

> --capacity-providers (list)
> The name of one or more capacity providers to associate with the cluster.

Here is also a link to the direct [API Reference](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_PutClusterCapacityProviders.html#API_PutClusterCapacityProviders_RequestSyntax)

> capacityProviders
>    The name of one or more capacity providers to associate with the cluster.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11338 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
NONE - Documentation update.
```
