### PR TITLE
aws_msk_cluster: support Cluster expansion and Open Monitoring

### DIFF
--- a/aws/resource_aws_msk_cluster.go
+++ b/aws/resource_aws_msk_cluster.go
@@ -213,10 +213,9 @@ func resourceAwsMskCluster() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"prometheus": {
-							Type:             schema.TypeList,
-							Optional:         true,
-							DiffSuppressFunc: suppressMissingOptionalConfigurationBlock,
-							MaxItems:         1,
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"jmx_exporter": {

--- a/aws/resource_aws_msk_cluster.go
+++ b/aws/resource_aws_msk_cluster.go
@@ -189,7 +189,6 @@ func resourceAwsMskCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  kafka.EnhancedMonitoringDefault,
-				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					kafka.EnhancedMonitoringDefault,
 					kafka.EnhancedMonitoringPerBroker,
@@ -205,6 +204,54 @@ func resourceAwsMskCluster() *schema.Resource {
 			"number_of_broker_nodes": {
 				Type:     schema.TypeInt,
 				Required: true,
+			},
+			"open_monitoring": {
+				Type:             schema.TypeList,
+				Optional:         true,
+				DiffSuppressFunc: suppressMissingOptionalConfigurationBlock,
+				MaxItems:         1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"prometheus": {
+							Type:             schema.TypeList,
+							Optional:         true,
+							DiffSuppressFunc: suppressMissingOptionalConfigurationBlock,
+							MaxItems:         1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"jmx_exporter": {
+										Type:             schema.TypeList,
+										Optional:         true,
+										DiffSuppressFunc: suppressMissingOptionalConfigurationBlock,
+										MaxItems:         1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"enabled_in_broker": {
+													Type:     schema.TypeBool,
+													Required: true,
+												},
+											},
+										},
+									},
+									"node_exporter": {
+										Type:             schema.TypeList,
+										Optional:         true,
+										DiffSuppressFunc: suppressMissingOptionalConfigurationBlock,
+										MaxItems:         1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"enabled_in_broker": {
+													Type:     schema.TypeBool,
+													Required: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 			"tags": tagsSchema(),
 			"zookeeper_connect_string": {
@@ -227,6 +274,7 @@ func resourceAwsMskClusterCreate(d *schema.ResourceData, meta interface{}) error
 		EnhancedMonitoring:   aws.String(d.Get("enhanced_monitoring").(string)),
 		KafkaVersion:         aws.String(d.Get("kafka_version").(string)),
 		NumberOfBrokerNodes:  aws.Int64(int64(d.Get("number_of_broker_nodes").(int))),
+		OpenMonitoring:       expandMskOpenMonitoring(d.Get("open_monitoring").([]interface{})),
 		Tags:                 keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().KafkaTags(),
 	}
 
@@ -342,6 +390,10 @@ func resourceAwsMskClusterRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 
+	if err := d.Set("open_monitoring", flattenMskOpenMonitoring(cluster.OpenMonitoring)); err != nil {
+		return fmt.Errorf("error setting open_monitoring: %s", err)
+	}
+
 	d.Set("zookeeper_connect_string", aws.StringValue(cluster.ZookeeperConnectString))
 
 	return nil
@@ -394,6 +446,31 @@ func resourceAwsMskClusterUpdate(d *schema.ResourceData, meta interface{}) error
 
 		if output == nil {
 			return fmt.Errorf("error updating MSK Cluster (%s) broker count: empty response", d.Id())
+		}
+
+		clusterOperationARN := aws.StringValue(output.ClusterOperationArn)
+
+		if err := waitForMskClusterOperation(conn, clusterOperationARN); err != nil {
+			return fmt.Errorf("error waiting for MSK Cluster (%s) operation (%s): %s", d.Id(), clusterOperationARN, err)
+		}
+	}
+
+	if d.HasChange("enhanced_monitoring") || d.HasChange("open_monitoring") {
+		input := &kafka.UpdateMonitoringInput{
+			ClusterArn:         aws.String(d.Id()),
+			CurrentVersion:     aws.String(d.Get("current_version").(string)),
+			EnhancedMonitoring: aws.String(d.Get("enhanced_monitoring").(string)),
+			OpenMonitoring:     expandMskOpenMonitoring(d.Get("open_monitoring").([]interface{})),
+		}
+
+		output, err := conn.UpdateMonitoring(input)
+
+		if err != nil {
+			return fmt.Errorf("error updating MSK Cluster (%s) monitoring: %s", d.Id(), err)
+		}
+
+		if output == nil {
+			return fmt.Errorf("error updating MSK Cluster (%s) monitoring: empty response", d.Id())
 		}
 
 		clusterOperationARN := aws.StringValue(output.ClusterOperationArn)
@@ -539,6 +616,63 @@ func expandMskClusterTls(l []interface{}) *kafka.Tls {
 	return tls
 }
 
+func expandMskOpenMonitoring(l []interface{}) *kafka.OpenMonitoringInfo {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	openMonitoring := &kafka.OpenMonitoringInfo{
+		Prometheus: expandMskOpenMonitoringPrometheus(m["prometheus"].([]interface{})),
+	}
+
+	return openMonitoring
+}
+
+func expandMskOpenMonitoringPrometheus(l []interface{}) *kafka.PrometheusInfo {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	prometheus := &kafka.PrometheusInfo{
+		JmxExporter:  expandMskOpenMonitoringPrometheusJmxExporter(m["jmx_exporter"].([]interface{})),
+		NodeExporter: expandMskOpenMonitoringPrometheusNodeExporter(m["node_exporter"].([]interface{})),
+	}
+
+	return prometheus
+}
+
+func expandMskOpenMonitoringPrometheusJmxExporter(l []interface{}) *kafka.JmxExporterInfo {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	jmxExporter := &kafka.JmxExporterInfo{
+		EnabledInBroker: aws.Bool(m["enabled_in_broker"].(bool)),
+	}
+
+	return jmxExporter
+}
+
+func expandMskOpenMonitoringPrometheusNodeExporter(l []interface{}) *kafka.NodeExporterInfo {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	nodeExporter := &kafka.NodeExporterInfo{
+		EnabledInBroker: aws.Bool(m["enabled_in_broker"].(bool)),
+	}
+
+	return nodeExporter
+}
+
 func flattenMskBrokerNodeGroupInfo(b *kafka.BrokerNodeGroupInfo) []map[string]interface{} {
 
 	if b == nil {
@@ -617,6 +751,55 @@ func flattenMskTls(tls *kafka.Tls) []map[string]interface{} {
 
 	m := map[string]interface{}{
 		"certificate_authority_arns": aws.StringValueSlice(tls.CertificateAuthorityArnList),
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func flattenMskOpenMonitoring(e *kafka.OpenMonitoring) []map[string]interface{} {
+	if e == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"prometheus": flattenMskOpenMonitoringPrometheus(e.Prometheus),
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func flattenMskOpenMonitoringPrometheus(e *kafka.Prometheus) []map[string]interface{} {
+	if e == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"jmx_exporter":  flattenMskOpenMonitoringPrometheusJmxExporter(e.JmxExporter),
+		"node_exporter": flattenMskOpenMonitoringPrometheusNodeExporter(e.NodeExporter),
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func flattenMskOpenMonitoringPrometheusJmxExporter(e *kafka.JmxExporter) []map[string]interface{} {
+	if e == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"enabled_in_broker": aws.BoolValue(e.EnabledInBroker),
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func flattenMskOpenMonitoringPrometheusNodeExporter(e *kafka.NodeExporter) []map[string]interface{} {
+	if e == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"enabled_in_broker": aws.BoolValue(e.EnabledInBroker),
 	}
 
 	return []map[string]interface{}{m}

--- a/aws/resource_aws_msk_cluster_test.go
+++ b/aws/resource_aws_msk_cluster_test.go
@@ -95,7 +95,7 @@ func TestAccAWSMskCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "kafka_version", "2.2.1"),
 					resource.TestCheckResourceAttr(resourceName, "number_of_broker_nodes", "3"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-					resource.TestMatchResourceAttr(resourceName, "zookeeper_connect_string", regexp.MustCompile(`^\d+\.\d+\.\d+\.\d+:\d+,\d+\.\d+\.\d+\.\d+:\d+,\d+\.\d+\.\d+\.\d+:\d+$`)),
+					resource.TestMatchResourceAttr(resourceName, "zookeeper_connect_string", regexp.MustCompile(`^(([-\w]+\.){1,}[\w]+:\d+,){2,}([-\w]+\.){1,}[\w]+:\d+$`)),
 				),
 			},
 			{
@@ -670,6 +670,12 @@ resource "aws_msk_cluster" "test" {
   kafka_version          = "2.2.1"
   number_of_broker_nodes = 3
 
+  encryption_info {
+    encryption_in_transit {
+      client_broker = "TLS_PLAINTEXT"
+    }
+  }
+
   broker_node_group_info {
     client_subnets  = ["${aws_subnet.example_subnet_az1.id}", "${aws_subnet.example_subnet_az2.id}", "${aws_subnet.example_subnet_az3.id}"]
     ebs_volume_size = 10
@@ -686,6 +692,12 @@ resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
   kafka_version          = "2.2.1"
   number_of_broker_nodes = 3
+
+  encryption_info {
+    encryption_in_transit {
+      client_broker = "TLS_PLAINTEXT"
+    }
+  }
 
   broker_node_group_info {
     client_subnets  = ["${aws_subnet.example_subnet_az1.id}", "${aws_subnet.example_subnet_az2.id}", "${aws_subnet.example_subnet_az3.id}"]
@@ -753,6 +765,12 @@ resource "aws_msk_cluster" "test" {
   kafka_version          = "2.2.1"
   number_of_broker_nodes = 3
 
+  encryption_info {
+    encryption_in_transit {
+      client_broker = "TLS_PLAINTEXT"
+    }
+  }
+
   broker_node_group_info {
     client_subnets  = ["${aws_subnet.example_subnet_az1.id}", "${aws_subnet.example_subnet_az2.id}", "${aws_subnet.example_subnet_az3.id}"]
     ebs_volume_size = 10
@@ -783,6 +801,12 @@ resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
   kafka_version          = "2.2.1"
   number_of_broker_nodes = 3
+
+  encryption_info {
+    encryption_in_transit {
+      client_broker = "TLS_PLAINTEXT"
+    }
+  }
 
   broker_node_group_info {
     client_subnets  = ["${aws_subnet.example_subnet_az1.id}", "${aws_subnet.example_subnet_az2.id}", "${aws_subnet.example_subnet_az3.id}"]
@@ -823,6 +847,9 @@ resource "aws_msk_cluster" "test" {
 
   encryption_info {
     encryption_at_rest_kms_key_arn = "${aws_kms_key.example_key.arn}"
+    encryption_in_transit {
+      client_broker = "TLS_PLAINTEXT"
+    }
   }
 }
 `, rName)
@@ -868,6 +895,7 @@ resource "aws_msk_cluster" "test" {
 
   encryption_info {
     encryption_in_transit {
+      client_broker = "TLS_PLAINTEXT"
       in_cluster = %[2]t
     }
   }
@@ -965,6 +993,12 @@ resource "aws_msk_cluster" "test" {
   kafka_version          = "2.2.1"
   number_of_broker_nodes = 3
 
+  encryption_info {
+    encryption_in_transit {
+      client_broker = "TLS_PLAINTEXT"
+    }
+  }
+
   broker_node_group_info {
     client_subnets  = ["${aws_subnet.example_subnet_az1.id}", "${aws_subnet.example_subnet_az2.id}", "${aws_subnet.example_subnet_az3.id}"]
     ebs_volume_size = 10
@@ -985,6 +1019,12 @@ resource "aws_msk_cluster" "test" {
   cluster_name           = %[1]q
   kafka_version          = "2.2.1"
   number_of_broker_nodes = 3
+
+  encryption_info {
+    encryption_in_transit {
+      client_broker = "TLS_PLAINTEXT"
+    }
+  }
 
   broker_node_group_info {
     client_subnets  = ["${aws_subnet.example_subnet_az1.id}", "${aws_subnet.example_subnet_az2.id}", "${aws_subnet.example_subnet_az3.id}"]

--- a/website/docs/d/msk_cluster.html.markdown
+++ b/website/docs/d/msk_cluster.html.markdown
@@ -34,4 +34,4 @@ In addition to all arguments above, the following attributes are exported:
 * `kafka_version` - Apache Kafka version.
 * `number_of_broker_nodes` - Number of broker nodes in the cluster.
 * `tags` - Map of key-value pairs assigned to the cluster.
-* `zookeeper_connect_string` - A comma separated list of one or more IP:port pairs to use to connect to the Apache Zookeeper cluster.
+* `zookeeper_connect_string` - A comma separated list of one or more hostname:port pairs to use to connect to the Apache Zookeeper cluster.

--- a/website/docs/r/msk_cluster.html.markdown
+++ b/website/docs/r/msk_cluster.html.markdown
@@ -147,7 +147,7 @@ The following arguments are supported:
 
 #### open_monitoring Argument Reference
 
-* `prometheus` - (Optional) Configuration block for Prometheus settings for open monitoring. See below.
+* `prometheus` - (Required) Configuration block for Prometheus settings for open monitoring. See below.
 
 #### open_monitoring prometheus Argument Reference
 

--- a/website/docs/r/msk_cluster.html.markdown
+++ b/website/docs/r/msk_cluster.html.markdown
@@ -68,6 +68,17 @@ resource "aws_msk_cluster" "example" {
     encryption_at_rest_kms_key_arn = "${aws_kms_key.kms.arn}"
   }
 
+  open_monitoring {
+    prometheus {
+      jmx_exporter {
+        enabled_in_broker = true
+      }
+      node_exporter {
+        enabled_in_broker = true
+      }
+    }
+  }
+
   tags = {
     foo = "bar"
   }
@@ -100,6 +111,7 @@ The following arguments are supported:
 * `configuration_info` - (Optional) Configuration block for specifying a MSK Configuration to attach to Kafka brokers. See below.
 * `encryption_info` - (Optional) Configuration block for specifying encryption. See below.
 * `enhanced_monitoring` - (Optional) Specify the desired enhanced MSK CloudWatch monitoring level.  See [Monitoring Amazon MSK with Amazon CloudWatch](https://docs.aws.amazon.com/msk/latest/developerguide/monitoring.html)
+* `open_monitoring` - (Optional) Configuration block for JMX and Node monitoring for the MSK cluster. See below.
 * `tags` - (Optional) A mapping of tags to assign to the resource
 
 ### broker_node_group_info Argument Reference
@@ -132,6 +144,23 @@ The following arguments are supported:
 
 * `client_broker` - (Optional) Encryption setting for data in transit between clients and brokers. Valid values: `TLS`, `TLS_PLAINTEXT`, and `PLAINTEXT`. Default value: `TLS_PLAINTEXT`.
 * `in_cluster` - (Optional) Whether data communication among broker nodes is encrypted. Default value: `true`.
+
+#### open_monitoring Argument Reference
+
+* `prometheus` - (Optional) Configuration block for Prometheus settings for open monitoring. See below.
+
+#### open_monitoring prometheus Argument Reference
+
+* `jmx_exporter` - (Optional) Configuration block for JMX Exporter. See below.
+* `node_exporter` - (Optional) Configuration block for Node Exporter. See below.
+
+#### open_monitoring prometheus jmx_exporter Argument Reference
+
+* `enabled_in_broker` - (Required) Indicates whether you want to enable or disable the JMX Exporter. 
+
+#### open_monitoring prometheus node_exporter Argument Reference
+
+* `enabled_in_broker` - (Required) Indicates whether you want to enable or disable the Node Exporter.
 
 ## Attributes Reference
 

--- a/website/docs/r/msk_cluster.html.markdown
+++ b/website/docs/r/msk_cluster.html.markdown
@@ -171,7 +171,7 @@ In addition to all arguments above, the following attributes are exported:
 * `bootstrap_brokers_tls` - A comma separated list of one or more DNS names (or IPs) and TLS port pairs kafka brokers suitable to boostrap connectivity to the kafka cluster. Only contains value if `client_broker` encryption in transit is set to `TLS_PLAINTEXT` or `TLS`.
 * `current_version` - Current version of the MSK Cluster used for updates, e.g. `K13V1IB3VIYZZH`
 * `encryption_info.0.encryption_at_rest_kms_key_arn` - The ARN of the KMS key used for encryption at rest of the broker data volumes.
-* `zookeeper_connect_string` - A comma separated list of one or more IP:port pairs to use to connect to the Apache Zookeeper cluster.
+* `zookeeper_connect_string` - A comma separated list of one or more hostname:port pairs to use to connect to the Apache Zookeeper cluster.
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes: #11215 
Closes: #10553 
Relates: #10673 (fix acceptance tests)

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_msk_cluster: support cluster expansion without cluster recreation [GH-10553]
resource/aws_msk_cluster: support changes to `enhanced_monitoring` without cluster recreation
resource/aws_msk_cluster: support `open_monitoring` configuration [GH-11215]
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSMskCluster_'
...
--- PASS: TestAccAWSMskCluster_basic (911.50s)
--- PASS: TestAccAWSMskCluster_BrokerNodeGroupInfo_EbsVolumeSize (1229.32s)
--- PASS: TestAccAWSMskCluster_EncryptionInfo_EncryptionInTransit_ClientBroker (875.43s)
--- PASS: TestAccAWSMskCluster_EncryptionInfo_EncryptionInTransit_InCluster (942.38s)
--- PASS: TestAccAWSMskCluster_EncryptionInfo_EncryptionAtRestKmsKeyArn (1005.02s)
--- PASS: TestAccAWSMskCluster_EnhancedMonitoring (1151.67s)
--- PASS: TestAccAWSMskCluster_OpenMonitoring (1300.95s)
--- PASS: TestAccAWSMskCluster_NumberOfBrokerNodes (1575.17s)
--- PASS: TestAccAWSMskCluster_Tags (876.30s)
...
```
Since enhanced monitoring is update via the same API call of open monitoring, this came free.

In order to make the acceptance tests pass I explicitly declared encryption_info configuration for all test templates. I don't know if it may be useful to write some notes inside the tests to specify this behavior.

I also fixed some tests & docs that were probably outdated (`zookeeper_connect_string` is now a list of hostnames and ports). 
