### PR TITLE
resource/aws_ecs_task_definition: prevent spurious environment variable diffs

### DIFF
--- a/aws/ecs_task_definition_equivalency.go
+++ b/aws/ecs_task_definition_equivalency.go
@@ -56,6 +56,9 @@ func EcsContainerDefinitionsAreEquivalent(def1, def2 string, isAWSVPC bool) (boo
 type containerDefinitions []*ecs.ContainerDefinition
 
 func (cd containerDefinitions) Reduce(isAWSVPC bool) error {
+	// Deal with fields which may be re-ordered in the API
+	cd.OrderEnvironmentVariables()
+
 	for i, def := range cd {
 		// Deal with special fields which have defaults
 		if def.Cpu != nil && *def.Cpu == 0 {
@@ -75,11 +78,6 @@ func (cd containerDefinitions) Reduce(isAWSVPC bool) error {
 				cd[i].PortMappings[j].HostPort = cd[i].PortMappings[j].ContainerPort
 			}
 		}
-
-		// Deal with fields which may be re-ordered in the API
-		sort.Slice(def.Environment, func(i, j int) bool {
-			return aws.StringValue(def.Environment[i].Name) < aws.StringValue(def.Environment[j].Name)
-		})
 
 		// Create a mutable copy
 		defCopy, err := copystructure.Copy(def)
@@ -102,4 +100,12 @@ func (cd containerDefinitions) Reduce(isAWSVPC bool) error {
 		cd[i] = &iface
 	}
 	return nil
+}
+
+func (cd containerDefinitions) OrderEnvironmentVariables() {
+	for _, def := range cd {
+		sort.Slice(def.Environment, func(i, j int) bool {
+			return aws.StringValue(def.Environment[i].Name) < aws.StringValue(def.Environment[j].Name)
+		})
+	}
 }

--- a/aws/resource_aws_ecs_task_definition.go
+++ b/aws/resource_aws_ecs_task_definition.go
@@ -73,7 +73,13 @@ func resourceAwsEcsTaskDefinition() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 				StateFunc: func(v interface{}) string {
-					json, _ := structure.NormalizeJsonString(v)
+					// Sort the lists of environment variables as they are serialized to state, so we won't get
+					// spurious reorderings in plans (diff is suppressed if the environment variables haven't changed,
+					// but they still show in the plan if some other property changes).
+					orderedCDs, _ := expandEcsContainerDefinitions(v.(string))
+					containerDefinitions(orderedCDs).OrderEnvironmentVariables()
+					unnormalizedJson, _ := flattenEcsContainerDefinitions(orderedCDs)
+					json, _ := structure.NormalizeJsonString(unnormalizedJson)
 					return json
 				},
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
@@ -476,6 +482,11 @@ func resourceAwsEcsTaskDefinitionRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("arn", taskDefinition.TaskDefinitionArn)
 	d.Set("family", taskDefinition.Family)
 	d.Set("revision", taskDefinition.Revision)
+
+	// Sort the lists of environment variables as they come in, so we won't get spurious reorderings in plans
+	// (diff is suppressed if the environment variables haven't changed, but they still show in the plan if
+	// some other property changes).
+	containerDefinitions(taskDefinition.ContainerDefinitions).OrderEnvironmentVariables()
 
 	defs, err := flattenEcsContainerDefinitions(taskDefinition.ContainerDefinitions)
 	if err != nil {


### PR DESCRIPTION
An ECS container definition's environment variables are stored by ECS as a list (rather than a map), and the ECS service reorders them arbitrarily because there is no meaningful order to them. There's already code in place to sort the list of environment variable when computing the plan, so that, if that reordering is the *only* change, then the container definition is considered clean.

However, if anything *else* in the container definition changes, then we rightfully get a plan. The environment variables still show up in the plan, and, because of the reordering, there appears to be a big change. It's extremely difficult to inspect manually.

Here's an example:

```
provider "aws" {}

resource "aws_ecs_task_definition" "default" {
  family                = "reordering-demonstration"
  container_definitions = jsonencode(
    [
      {
        "name": "main",
        "image": "hello-world",
        "cpu": 10,
        "memory": 512,
        "essential": true,
        "environment": [
          {"name": "abc", "value": "123"},
          {"name": "def", "value": "456"},
          {"name": "ghi", "value": "789"},
          {"name": "jkl", "value": "321"},
          {"name": "mno", "value": "654"},
          {"name": "pqr", "value": "987"},
        ]
      }
    ]
  )
}
```

Apply, and then change the memory from 512 to 1024. The next plan is:

```
Terraform will perform the following actions:

  # aws_ecs_task_definition.default must be replaced
-/+ resource "aws_ecs_task_definition" "default" {
      ~ arn                      = "..." -> (known after apply)
      ~ container_definitions    = jsonencode(
          ~ [ # forces replacement
              ~ {
                    cpu          = 10
                  ~ environment  = [
                      - {
                          - name  = "pqr"
                          - value = "987"
                        },
                      - {
                          - name  = "ghi"
                          - value = "789"
                        },
                      - {
                          - name  = "jkl"
                          - value = "321"
                        },
                        {
                            name  = "abc"
                            value = "123"
                        },
                        {
                            name  = "def"
                            value = "456"
                        },
                      + {
                          + name  = "ghi"
                          + value = "789"
                        },
                      + {
                          + name  = "jkl"
                          + value = "321"
                        },
                        {
                            name  = "mno"
                            value = "654"
                        },
                      + {
                          + name  = "pqr"
                          + value = "987"
                        },
                    ]
                    essential    = true
                    image        = "hello-world"
                  ~ memory       = 512 -> 1024
                  - mountPoints  = [] -> null
                    name         = "main"
                  - portMappings = [] -> null
                  - volumesFrom  = [] -> null
                } # forces replacement,
            ]
        )
        family                   = "reordering-demonstration"
      ~ id                       = "reordering-demonstration" -> (known after apply)
      + network_mode             = (known after apply)
      - requires_compatibilities = [] -> null
      ~ revision                 = 5 -> (known after apply)
      - tags                     = {} -> null
    }

Plan: 1 to add, 0 to change, 1 to destroy.
```

The correct plan would show `memory = 512 -> 1024` but `environment` would be left alone.

This PR attempts to correct the problem by ordering the list of environment variables (by name) when we read the task definition from ECS, and when we serialize to state. In my testing (with the toy example above), it fixes the issue.

This approach also gives a clean plan if environment variables in the container definition are reordered in the Terraform source. That seems like reasonable behavior to me, because there is no meaningful order to the list.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_ecs_task_definition: don't show a spurious environment variable diff when another property on the task definition is changing.
```

Output from acceptance testing:

The useful thing to test here is that, while a change to some other attribute is legitimately resulting in a plan, the unchanged environment variables don't show up as changed in the diff. Unfortunately, I didn't see a way to inspect the contents of a plan using the testing framework. If somebody can advise on where/how to write a test for this, I'll add one. It probably should be a unit test, though, rather than an acceptance test.