### PR TITLE
resource/aws_batch_compute_environment - refactor to use keyvaluetags

### DIFF
--- a/aws/resource_aws_batch_compute_environment.go
+++ b/aws/resource_aws_batch_compute_environment.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsBatchComputeEnvironment() *schema.Resource {
@@ -246,7 +247,7 @@ func resourceAwsBatchComputeEnvironmentCreate(d *schema.ResourceData, meta inter
 			input.ComputeResources.SpotIamFleetRole = aws.String(v.(string))
 		}
 		if v, ok := computeResource["tags"]; ok {
-			input.ComputeResources.Tags = tagsFromMapGeneric(v.(map[string]interface{}))
+			input.ComputeResources.Tags = keyvaluetags.New(v.(map[string]interface{})).IgnoreAws().BatchTags()
 		}
 
 		if raw, ok := computeResource["launch_template"]; ok && len(raw.([]interface{})) > 0 {
@@ -342,7 +343,7 @@ func flattenBatchComputeResources(computeResource *batch.ComputeResource) []map[
 	m["security_group_ids"] = schema.NewSet(schema.HashString, flattenStringList(computeResource.SecurityGroupIds))
 	m["spot_iam_fleet_role"] = aws.StringValue(computeResource.SpotIamFleetRole)
 	m["subnets"] = schema.NewSet(schema.HashString, flattenStringList(computeResource.Subnets))
-	m["tags"] = tagsToMapGeneric(computeResource.Tags)
+	m["tags"] = keyvaluetags.BatchKeyValueTags(computeResource.Tags).IgnoreAws().Map()
 	m["type"] = aws.StringValue(computeResource.Type)
 
 	if launchTemplate := computeResource.LaunchTemplate; launchTemplate != nil {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10688

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSBatchComputeEnvironment_'
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2 (86.71s)
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2WithTags (85.12s)
--- PASS: TestAccAWSBatchComputeEnvironment_createSpot (87.50s)
--- PASS: TestAccAWSBatchComputeEnvironment_createUnmanaged (82.82s)
--- PASS: TestAccAWSBatchComputeEnvironment_updateMaxvCpus (125.01s)
--- PASS: TestAccAWSBatchComputeEnvironment_updateInstanceType (145.20s)
--- PASS: TestAccAWSBatchComputeEnvironment_updateComputeEnvironmentName (148.12s)
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources (47.69s)
--- PASS: TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources (78.13s)
--- PASS: TestAccAWSBatchComputeEnvironment_launchTemplate (86.84s)
--- PASS: TestAccAWSBatchComputeEnvironment_UpdateLaunchTemplate (146.28s)
--- PASS: TestAccAWSBatchComputeEnvironment_createSpotWithoutBidPercentage (49.22s)
--- PASS: TestAccAWSBatchComputeEnvironment_updateState (130.87s)
```
