### PR TITLE
resource/aws_rds_cluster_instance: Prevent is already being deleted error on deletion

### DIFF
--- a/aws/resource_aws_rds_cluster_instance.go
+++ b/aws/resource_aws_rds_cluster_instance.go
@@ -614,7 +614,6 @@ func resourceAwsRDSClusterInstanceDelete(d *schema.ResourceData, meta interface{
 	log.Printf("[DEBUG] RDS Cluster Instance destroy configuration: %s", opts)
 	_, err := conn.DeleteDBInstance(&opts)
 
-	// InvalidDBInstanceState: Instance XXX is already being deleted.
 	if err != nil && !isAWSErr(err, rds.ErrCodeInvalidDBInstanceStateFault, "is already being deleted") {
 		return fmt.Errorf("error deleting Database Instance %q: %s", d.Id(), err)
 	}

--- a/aws/resource_aws_rds_cluster_instance.go
+++ b/aws/resource_aws_rds_cluster_instance.go
@@ -612,8 +612,11 @@ func resourceAwsRDSClusterInstanceDelete(d *schema.ResourceData, meta interface{
 	opts := rds.DeleteDBInstanceInput{DBInstanceIdentifier: aws.String(d.Id())}
 
 	log.Printf("[DEBUG] RDS Cluster Instance destroy configuration: %s", opts)
-	if _, err := conn.DeleteDBInstance(&opts); err != nil {
-		return err
+	_, err := conn.DeleteDBInstance(&opts)
+
+	// InvalidDBInstanceState: Instance XXX is already being deleted.
+	if err != nil && !isAWSErr(err, rds.ErrCodeInvalidDBInstanceStateFault, "is already being deleted") {
+		return fmt.Errorf("error deleting Database Instance %q: %s", d.Id(), err)
 	}
 
 	// re-uses db_instance refresh func
@@ -627,7 +630,7 @@ func resourceAwsRDSClusterInstanceDelete(d *schema.ResourceData, meta interface{
 		Delay:      30 * time.Second, // Wait 30 secs before starting
 	}
 
-	_, err := stateConf.WaitForState()
+	_, err = stateConf.WaitForState()
 	return err
 
 }

--- a/aws/resource_aws_rds_cluster_instance_test.go
+++ b/aws/resource_aws_rds_cluster_instance_test.go
@@ -18,6 +18,7 @@ import (
 
 func TestAccAWSRDSClusterInstance_basic(t *testing.T) {
 	var v rds.DBInstance
+	resourceName := "aws_rds_cluster_instance.cluster_instances"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -27,21 +28,21 @@ func TestAccAWSRDSClusterInstance_basic(t *testing.T) {
 			{
 				Config: testAccAWSClusterInstanceConfig(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSClusterInstanceExists("aws_rds_cluster_instance.cluster_instances", &v),
+					testAccCheckAWSClusterInstanceExists(resourceName, &v),
 					testAccCheckAWSDBClusterInstanceAttributes(&v),
-					resource.TestMatchResourceAttr("aws_rds_cluster_instance.cluster_instances", "arn", regexp.MustCompile(`^arn:[^:]+:rds:[^:]+:[^:]+:db:.+`)),
-					resource.TestCheckResourceAttr("aws_rds_cluster_instance.cluster_instances", "auto_minor_version_upgrade", "true"),
-					resource.TestCheckResourceAttr("aws_rds_cluster_instance.cluster_instances", "copy_tags_to_snapshot", "false"),
-					resource.TestCheckResourceAttrSet("aws_rds_cluster_instance.cluster_instances", "preferred_maintenance_window"),
-					resource.TestCheckResourceAttrSet("aws_rds_cluster_instance.cluster_instances", "preferred_backup_window"),
-					resource.TestCheckResourceAttrSet("aws_rds_cluster_instance.cluster_instances", "dbi_resource_id"),
-					resource.TestCheckResourceAttrSet("aws_rds_cluster_instance.cluster_instances", "availability_zone"),
-					resource.TestCheckResourceAttrSet("aws_rds_cluster_instance.cluster_instances", "engine_version"),
-					resource.TestCheckResourceAttr("aws_rds_cluster_instance.cluster_instances", "engine", "aurora"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "rds", regexp.MustCompile(`db:.+`)),
+					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "true"),
+					resource.TestCheckResourceAttr(resourceName, "copy_tags_to_snapshot", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "preferred_maintenance_window"),
+					resource.TestCheckResourceAttrSet(resourceName, "preferred_backup_window"),
+					resource.TestCheckResourceAttrSet(resourceName, "dbi_resource_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "availability_zone"),
+					resource.TestCheckResourceAttrSet(resourceName, "engine_version"),
+					resource.TestCheckResourceAttr(resourceName, "engine", "aurora"),
 				),
 			},
 			{
-				ResourceName:      "aws_rds_cluster_instance.cluster_instances",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -52,10 +53,46 @@ func TestAccAWSRDSClusterInstance_basic(t *testing.T) {
 			{
 				Config: testAccAWSClusterInstanceConfigModified(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSClusterInstanceExists("aws_rds_cluster_instance.cluster_instances", &v),
+					testAccCheckAWSClusterInstanceExists(resourceName, &v),
 					testAccCheckAWSDBClusterInstanceAttributes(&v),
-					resource.TestCheckResourceAttr("aws_rds_cluster_instance.cluster_instances", "auto_minor_version_upgrade", "false"),
+					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRDSClusterInstance_isAlreadyBeingDeleted(t *testing.T) {
+	var v rds.DBInstance
+	resourceName := "aws_rds_cluster_instance.cluster_instances"
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSClusterInstanceConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSClusterInstanceExists(resourceName, &v),
+				),
+			},
+			{
+				PreConfig: func() {
+					// Get Database Instance into deleting state
+					conn := testAccProvider.Meta().(*AWSClient).rdsconn
+					input := &rds.DeleteDBInstanceInput{
+						DBInstanceIdentifier: aws.String(fmt.Sprintf("tf-cluster-instance-%d", rInt)),
+						SkipFinalSnapshot:    aws.Bool(true),
+					}
+					_, err := conn.DeleteDBInstance(input)
+					if err != nil {
+						t.Fatalf("error deleting Database Instance: %s", err)
+					}
+				},
+				Config:  testAccAWSClusterInstanceConfig(rInt),
+				Destroy: true,
 			},
 		},
 	})
@@ -63,6 +100,7 @@ func TestAccAWSRDSClusterInstance_basic(t *testing.T) {
 
 func TestAccAWSRDSClusterInstance_az(t *testing.T) {
 	var v rds.DBInstance
+	resourceName := "aws_rds_cluster_instance.cluster_instances"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -72,13 +110,13 @@ func TestAccAWSRDSClusterInstance_az(t *testing.T) {
 			{
 				Config: testAccAWSClusterInstanceConfig_az(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSClusterInstanceExists("aws_rds_cluster_instance.cluster_instances", &v),
+					testAccCheckAWSClusterInstanceExists(resourceName, &v),
 					testAccCheckAWSDBClusterInstanceAttributes(&v),
-					resource.TestMatchResourceAttr("aws_rds_cluster_instance.cluster_instances", "availability_zone", regexp.MustCompile("^us-west-2[a-z]{1}$")),
+					resource.TestMatchResourceAttr(resourceName, "availability_zone", regexp.MustCompile("^us-west-2[a-z]{1}$")),
 				),
 			},
 			{
-				ResourceName:      "aws_rds_cluster_instance.cluster_instances",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -93,6 +131,7 @@ func TestAccAWSRDSClusterInstance_az(t *testing.T) {
 func TestAccAWSRDSClusterInstance_namePrefix(t *testing.T) {
 	var v rds.DBInstance
 	rInt := acctest.RandInt()
+	resourceName := "aws_rds_cluster_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -102,16 +141,14 @@ func TestAccAWSRDSClusterInstance_namePrefix(t *testing.T) {
 			{
 				Config: testAccAWSClusterInstanceConfig_namePrefix(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSClusterInstanceExists("aws_rds_cluster_instance.test", &v),
+					testAccCheckAWSClusterInstanceExists(resourceName, &v),
 					testAccCheckAWSDBClusterInstanceAttributes(&v),
-					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_instance.test", "db_subnet_group_name", fmt.Sprintf("tf-test-%d", rInt)),
-					resource.TestMatchResourceAttr(
-						"aws_rds_cluster_instance.test", "identifier", regexp.MustCompile("^tf-cluster-instance-")),
+					resource.TestCheckResourceAttr(resourceName, "db_subnet_group_name", fmt.Sprintf("tf-test-%d", rInt)),
+					resource.TestMatchResourceAttr(resourceName, "identifier", regexp.MustCompile("^tf-cluster-instance-")),
 				),
 			},
 			{
-				ResourceName:      "aws_rds_cluster_instance.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -125,6 +162,7 @@ func TestAccAWSRDSClusterInstance_namePrefix(t *testing.T) {
 
 func TestAccAWSRDSClusterInstance_generatedName(t *testing.T) {
 	var v rds.DBInstance
+	resourceName := "aws_rds_cluster_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -134,14 +172,13 @@ func TestAccAWSRDSClusterInstance_generatedName(t *testing.T) {
 			{
 				Config: testAccAWSClusterInstanceConfig_generatedName(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSClusterInstanceExists("aws_rds_cluster_instance.test", &v),
+					testAccCheckAWSClusterInstanceExists(resourceName, &v),
 					testAccCheckAWSDBClusterInstanceAttributes(&v),
-					resource.TestMatchResourceAttr(
-						"aws_rds_cluster_instance.test", "identifier", regexp.MustCompile("^tf-")),
+					resource.TestMatchResourceAttr(resourceName, "identifier", regexp.MustCompile("^tf-")),
 				),
 			},
 			{
-				ResourceName:      "aws_rds_cluster_instance.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -156,6 +193,7 @@ func TestAccAWSRDSClusterInstance_generatedName(t *testing.T) {
 func TestAccAWSRDSClusterInstance_kmsKey(t *testing.T) {
 	var v rds.DBInstance
 	keyRegex := regexp.MustCompile("^arn:aws:kms:")
+	resourceName := "aws_rds_cluster_instance.cluster_instances"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -165,13 +203,12 @@ func TestAccAWSRDSClusterInstance_kmsKey(t *testing.T) {
 			{
 				Config: testAccAWSClusterInstanceConfigKmsKey(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSClusterInstanceExists("aws_rds_cluster_instance.cluster_instances", &v),
-					resource.TestMatchResourceAttr(
-						"aws_rds_cluster_instance.cluster_instances", "kms_key_id", keyRegex),
+					testAccCheckAWSClusterInstanceExists(resourceName, &v),
+					resource.TestMatchResourceAttr(resourceName, "kms_key_id", keyRegex),
 				),
 			},
 			{
-				ResourceName:      "aws_rds_cluster_instance.cluster_instances",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -186,6 +223,7 @@ func TestAccAWSRDSClusterInstance_kmsKey(t *testing.T) {
 // https://github.com/hashicorp/terraform/issues/5350
 func TestAccAWSRDSClusterInstance_disappears(t *testing.T) {
 	var v rds.DBInstance
+	resourceName := "aws_rds_cluster_instance.cluster_instances"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -195,7 +233,7 @@ func TestAccAWSRDSClusterInstance_disappears(t *testing.T) {
 			{
 				Config: testAccAWSClusterInstanceConfig(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSClusterInstanceExists("aws_rds_cluster_instance.cluster_instances", &v),
+					testAccCheckAWSClusterInstanceExists(resourceName, &v),
 					testAccAWSClusterInstanceDisappears(&v),
 				),
 				// A non-empty plan is what we want. A crash is what we don't want. :)
@@ -245,6 +283,7 @@ func TestAccAWSRDSClusterInstance_PubliclyAccessible(t *testing.T) {
 func TestAccAWSRDSClusterInstance_CopyTagsToSnapshot(t *testing.T) {
 	var dbInstance rds.DBInstance
 	rNameSuffix := acctest.RandInt()
+	resourceName := "aws_rds_cluster_instance.cluster_instances"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -254,13 +293,12 @@ func TestAccAWSRDSClusterInstance_CopyTagsToSnapshot(t *testing.T) {
 			{
 				Config: testAccAWSClusterInstanceConfig_CopyTagsToSnapshot(rNameSuffix, true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSClusterInstanceExists("aws_rds_cluster_instance.cluster_instances", &dbInstance),
-					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_instance.cluster_instances", "copy_tags_to_snapshot", "true"),
+					testAccCheckAWSClusterInstanceExists(resourceName, &dbInstance),
+					resource.TestCheckResourceAttr(resourceName, "copy_tags_to_snapshot", "true"),
 				),
 			},
 			{
-				ResourceName:      "aws_rds_cluster_instance.cluster_instances",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -271,9 +309,8 @@ func TestAccAWSRDSClusterInstance_CopyTagsToSnapshot(t *testing.T) {
 			{
 				Config: testAccAWSClusterInstanceConfig_CopyTagsToSnapshot(rNameSuffix, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSClusterInstanceExists("aws_rds_cluster_instance.cluster_instances", &dbInstance),
-					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_instance.cluster_instances", "copy_tags_to_snapshot", "false"),
+					testAccCheckAWSClusterInstanceExists(resourceName, &dbInstance),
+					resource.TestCheckResourceAttr(resourceName, "copy_tags_to_snapshot", "false"),
 				),
 			},
 		},
@@ -311,7 +348,7 @@ func testAccAWSClusterInstanceDisappears(v *rds.DBInstance) resource.TestCheckFu
 			_, err := conn.DescribeDBInstances(opts)
 			if err != nil {
 				dbinstanceerr, ok := err.(awserr.Error)
-				if ok && dbinstanceerr.Code() == "DBInstanceNotFound" {
+				if ok && dbinstanceerr.Code() == rds.ErrCodeDBInstanceNotFoundFault {
 					return nil
 				}
 				return resource.NonRetryableError(


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11434

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_rds_cluster_instance: Prevent is already being deleted error on deletion and wait for deletion completion
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSRDSClusterInstance_isAlreadyBeingDeleted (795.50s)
--- PASS: TestAccAWSRDSClusterInstance_basic (1290.20s)
```
