### PR TITLE
Add client_ip_preservation_enabled to global accelerator

### DIFF
--- a/aws/resource_aws_globalaccelerator_endpoint_group.go
+++ b/aws/resource_aws_globalaccelerator_endpoint_group.go
@@ -87,6 +87,10 @@ func resourceAwsGlobalAcceleratorEndpointGroup() *schema.Resource {
 							Type:     schema.TypeInt,
 							Optional: true,
 						},
+						"client_ip_preservation_enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -213,6 +217,7 @@ func resourceAwsGlobalAcceleratorEndpointGroupExpandEndpointConfigurations(confi
 
 		m.EndpointId = aws.String(configuration["endpoint_id"].(string))
 		m.Weight = aws.Int64(int64(configuration["weight"].(int)))
+		m.ClientIPPreservationEnabled = aws.Bool(configuration["client_ip_preservation_enabled"].(bool))
 
 		out[i] = &m
 	}
@@ -229,6 +234,7 @@ func resourceAwsGlobalAcceleratorEndpointGroupFlattenEndpointDescriptions(config
 
 		m["endpoint_id"] = aws.StringValue(configuration.EndpointId)
 		m["weight"] = aws.Int64Value(configuration.Weight)
+		m["client_ip_preservation_enabled"] = aws.BoolValue(configuration.ClientIPPreservationEnabled)
 
 		out[i] = m
 	}

--- a/aws/resource_aws_globalaccelerator_endpoint_group_test.go
+++ b/aws/resource_aws_globalaccelerator_endpoint_group_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -29,6 +30,39 @@ func TestAccAwsGlobalAcceleratorEndpointGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "threshold_count", "3"),
 					resource.TestCheckResourceAttr(resourceName, "traffic_dial_percentage", "100"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsGlobalAcceleratorEndpointGroup_alb_clientip(t *testing.T) {
+	resourceName := "aws_globalaccelerator_endpoint_group.example"
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGlobalAcceleratorEndpointGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlobalAcceleratorEndpointGroup_alb_clientip(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlobalAcceleratorEndpointGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "health_check_interval_seconds", "30"),
+					resource.TestCheckResourceAttr(resourceName, "health_check_path", "/"),
+					resource.TestCheckResourceAttr(resourceName, "health_check_port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "health_check_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "threshold_count", "3"),
+					resource.TestCheckResourceAttr(resourceName, "traffic_dial_percentage", "100"),
+					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.#", "1"),
+					testAccCheckGlobalAcceleratorEndpointGroupConfig(resourceName, "client_ip_preservation_enabled",
+						"false"),
 				),
 			},
 			{
@@ -161,6 +195,112 @@ resource "aws_globalaccelerator_endpoint_group" "example" {
 `, rInt)
 }
 
+func testAccGlobalAcceleratorEndpointGroup_alb_clientip(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_lb" "lb_test" {
+  name            = "%d"
+  internal        = false
+  security_groups = ["${aws_security_group.alb_test.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
+
+  idle_timeout               = 30
+  enable_deletion_protection = false
+
+  tags = {
+    Name = "TestAccAWSALB_basic"
+  }
+}
+
+variable "subnets" {
+  default = ["10.0.1.0/24", "10.0.2.0/24"]
+  type    = "list"
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "alb_test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "terraform-testacc-lb-basic"
+  }
+}
+
+resource "aws_subnet" "alb_test" {
+  count                   = 2
+  vpc_id                  = "${aws_vpc.alb_test.id}"
+  cidr_block              = "${element(var.subnets, count.index)}"
+  map_public_ip_on_launch = true
+  availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
+
+  tags = {
+    Name = "tf-acc-lb-basic"
+  }
+}
+
+resource "aws_security_group" "alb_test" {
+  name        = "allow_all_alb_test"
+  description = "Used for ALB Testing"
+  vpc_id      = "${aws_vpc.alb_test.id}"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_internet_gateway" "example" {
+  vpc_id = "${aws_vpc.alb_test.id}"
+}
+
+resource "aws_globalaccelerator_accelerator" "example" {
+  name            = "tf-%d"
+  ip_address_type = "IPV4"
+  enabled         = false
+}
+
+resource "aws_globalaccelerator_listener" "example" {
+  accelerator_arn = "${aws_globalaccelerator_accelerator.example.id}"
+  protocol        = "TCP"
+
+  port_range {
+    from_port = 80
+    to_port   = 80
+  }
+}
+
+resource "aws_globalaccelerator_endpoint_group" "example" {
+  listener_arn = "${aws_globalaccelerator_listener.example.id}"
+
+  endpoint_configuration {
+    endpoint_id = "${aws_lb.lb_test.id}"
+    weight      = 20
+	client_ip_preservation_enabled = false
+  }
+
+  health_check_interval_seconds = 30
+  health_check_path             = "/"
+  health_check_port             = 80
+  health_check_protocol         = "HTTP"
+  threshold_count               = 3
+  traffic_dial_percentage       = 100
+}
+`, rInt, rInt)
+}
+
 func testAccGlobalAcceleratorEndpointGroup_update(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_globalaccelerator_accelerator" "example" {
@@ -200,4 +340,32 @@ resource "aws_globalaccelerator_endpoint_group" "example" {
   traffic_dial_percentage       = 50
 }
 `, rInt)
+}
+
+func testAccCheckGlobalAcceleratorEndpointGroupConfig(n, k, v string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		r := fmt.Sprintf(`endpoint_configuration.\d+.%s`, k)
+		reg, err := regexp.Compile(r)
+		if err != nil {
+			return fmt.Errorf("Regular Express not correct err: %+v", err)
+		}
+		for configKey, configValue := range rs.Primary.Attributes {
+			if reg.MatchString(configKey) {
+				if configValue == v {
+					return nil
+				} else {
+					return fmt.Errorf("endpoint_configuration key: %s value does not match.  Expected: %s,"+
+						" Got: %s", configKey, v, configValue)
+				}
+			}
+		}
+
+		// Failed to find value
+		return fmt.Errorf("endpoint_configuration is missing key: %s", k)
+	}
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9940

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* Add client_ip_preservation_enabled to Global Accelerator Endpoint Group.  Note it must be used with EC2 or ALB.
```

Output from acceptance testing:
Ok, a little bit about acceptance testing.  The current acceptance testing for the global accelerator endpoint only checks if the endpoint configuration exists but not the values.  I expanded the test to be more detailed but hit a major roadblock.  It seems to check client ip I needed to setup a VPC, ALBs and etc.  No problem, but, if its set to true it seems tearing down the VPC causes AWS to throw error ```Error: errors during apply: Error deleting VPC: DependencyViolation: The vpc 'vpc-XXXX' has dependencies and cannot be deleted```.  I cant for the life of me figure out why or how does it tie back to my changes.  Some googling seems to show in general VPC deletion can be flaky and its possible AWS has a race of some kind as deleting the VPC from AWSs UI works fine. Open to ideas on how to fix this, or is it fine testing that setting the value (in this case false) is fine.

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$make testacc TEST=./aws TESTARGS='-run=TestAccAwsGlobalAcceleratorEndpointGroup_alb_clientip'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsGlobalAcceleratorEndpointGroup_alb_clientip -timeout 120m
=== RUN   TestAccAwsGlobalAcceleratorEndpointGroup_alb_clientip
=== PAUSE TestAccAwsGlobalAcceleratorEndpointGroup_alb_clientip
=== CONT  TestAccAwsGlobalAcceleratorEndpointGroup_alb_clientip
--- PASS: TestAccAwsGlobalAcceleratorEndpointGroup_alb_clientip (289.94s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	289.994s
...
```
