### PR TITLE
resource_aws_ssm_maintenance_window - add support for description argument

### DIFF
--- a/aws/resource_aws_ssm_maintenance_window.go
+++ b/aws/resource_aws_ssm_maintenance_window.go
@@ -69,6 +69,10 @@ func resourceAwsSsmMaintenanceWindow() *schema.Resource {
 			},
 
 			"tags": tagsSchema(),
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -98,6 +102,10 @@ func resourceAwsSsmMaintenanceWindowCreate(d *schema.ResourceData, meta interfac
 
 	if v, ok := d.GetOk("start_date"); ok {
 		params.StartDate = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		params.Description = aws.String(v.(string))
 	}
 
 	resp, err := ssmconn.CreateMaintenanceWindow(params)
@@ -150,6 +158,10 @@ func resourceAwsSsmMaintenanceWindowUpdate(d *schema.ResourceData, meta interfac
 		params.StartDate = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("description"); ok {
+		params.Description = aws.String(v.(string))
+	}
+
 	_, err := ssmconn.UpdateMaintenanceWindow(params)
 	if err != nil {
 		if isAWSErr(err, ssm.ErrCodeDoesNotExistException, "") {
@@ -197,6 +209,7 @@ func resourceAwsSsmMaintenanceWindowRead(d *schema.ResourceData, meta interface{
 	d.Set("schedule_timezone", resp.ScheduleTimezone)
 	d.Set("schedule", resp.Schedule)
 	d.Set("start_date", resp.StartDate)
+	d.Set("description", resp.Description)
 
 	tags, err := keyvaluetags.SsmListTags(ssmconn, d.Id(), ssm.ResourceTypeForTaggingMaintenanceWindow)
 

--- a/aws/resource_aws_ssm_maintenance_window_test.go
+++ b/aws/resource_aws_ssm_maintenance_window_test.go
@@ -46,6 +46,41 @@ func TestAccAWSSSMMaintenanceWindow_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSSSMMaintenanceWindow_description(t *testing.T) {
+	var winId ssm.MaintenanceWindowIdentity
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ssm_maintenance_window.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMMaintenanceWindowDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMMaintenanceWindowConfigDescription(rName, "foo"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowExists(resourceName, &winId),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "foo"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSSSMMaintenanceWindowConfigDescription(rName, "bar"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowExists(resourceName, &winId),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "bar"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSSSMMaintenanceWindow_tags(t *testing.T) {
 	var winId ssm.MaintenanceWindowIdentity
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -494,6 +529,18 @@ resource "aws_ssm_maintenance_window" "test" {
   schedule = "cron(0 16 ? * TUE *)"
 }
 `, rName)
+}
+
+func testAccAWSSSMMaintenanceWindowConfigDescription(rName, desc string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_maintenance_window" "test" {
+  cutoff      = 1
+  duration    = 3
+  name        = %[1]q
+  description = %[2]q
+  schedule    = "cron(0 16 ? * TUE *)"
+}
+`, rName, desc)
 }
 
 func testAccAWSSSMMaintenanceWindowConfigTags1(rName, tagKey1, tagValue1 string) string {

--- a/website/docs/r/ssm_maintenance_window.html.markdown
+++ b/website/docs/r/ssm_maintenance_window.html.markdown
@@ -29,6 +29,7 @@ The following arguments are supported:
 * `schedule` - (Required) The schedule of the Maintenance Window in the form of a [cron](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-maintenance-cron.html) or rate expression.
 * `cutoff` - (Required) The number of hours before the end of the Maintenance Window that Systems Manager stops scheduling new tasks for execution.
 * `duration` - (Required) The duration of the Maintenance Window in hours.
+* `description` - (Optional) A description for the maintenance window.
 * `allow_unassociated_targets` - (Optional) Whether targets must be registered with the Maintenance Window before tasks can be defined for those targets.
 * `enabled` - (Optional) Whether the maintenance window is enabled. Default: `true`.
 * `end_date` - (Optional) Timestamp in [ISO-8601 extended format](https://www.iso.org/iso-8601-date-and-time-format.html) when to no longer run the maintenance window.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9035

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_ssm_maintenance_window - add support for `description` argument
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSSMMaintenanceWindow_'
--- PASS: TestAccAWSSSMMaintenanceWindow_basic (44.37s)
--- PASS: TestAccAWSSSMMaintenanceWindow_description (70.28s)
--- PASS: TestAccAWSSSMMaintenanceWindow_tags (122.08s)
--- PASS: TestAccAWSSSMMaintenanceWindow_disappears (31.40s)
--- PASS: TestAccAWSSSMMaintenanceWindow_multipleUpdates (65.73s)
--- PASS: TestAccAWSSSMMaintenanceWindow_Cutoff (70.31s)
--- PASS: TestAccAWSSSMMaintenanceWindow_Duration (71.23s)
--- PASS: TestAccAWSSSMMaintenanceWindow_Enabled (83.06s)
--- PASS: TestAccAWSSSMMaintenanceWindow_EndDate (100.18s)
--- PASS: TestAccAWSSSMMaintenanceWindow_Schedule (71.42s)
--- PASS: TestAccAWSSSMMaintenanceWindow_ScheduleTimezone (119.36s)
--- PASS: TestAccAWSSSMMaintenanceWindow_StartDate (99.58s)
```
