### PR TITLE
resource_aws_ssm_document - add support for target type argument 

### DIFF
--- a/aws/resource_aws_ssm_document.go
+++ b/aws/resource_aws_ssm_document.go
@@ -164,6 +164,9 @@ func resourceAwsSsmDocument() *schema.Resource {
 						"type": {
 							Type:     schema.TypeString,
 							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								ssm.DocumentPermissionTypeShare,
+							}, false),
 						},
 						"account_ids": {
 							Type:     schema.TypeString,

--- a/aws/resource_aws_ssm_document.go
+++ b/aws/resource_aws_ssm_document.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 	"time"
 
@@ -172,6 +173,10 @@ func resourceAwsSsmDocument() *schema.Resource {
 				},
 			},
 			"tags": tagsSchema(),
+			"target_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -194,6 +199,10 @@ func resourceAwsSsmDocumentCreate(d *schema.ResourceData, meta interface{}) erro
 
 	if v, ok := d.GetOk("attachments_source"); ok {
 		docInput.Attachments = expandSsmAttachmentsSources(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("target_type"); ok {
+		docInput.TargetType = aws.String(v.(string))
 	}
 
 	log.Printf("[DEBUG] Waiting for SSM Document %q to be created", d.Get("name").(string))
@@ -335,6 +344,10 @@ func resourceAwsSsmDocumentRead(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 
+	if err := d.Set("target_type", doc.TargetType); err != nil {
+		return fmt.Errorf("error setting target type: %s", err)
+	}
+
 	return nil
 }
 
@@ -357,7 +370,10 @@ func resourceAwsSsmDocumentUpdate(d *schema.ResourceData, meta interface{}) erro
 		log.Printf("[DEBUG] Not setting document permissions on %q", d.Id())
 	}
 
-	if !d.HasChange("content") {
+	// update for schema version 1.x is not allowed
+	isSchemaVersion1, _ := regexp.MatchString("^1[.][0-9]$", d.Get("schema_version").(string))
+
+	if !d.HasChange("content") && isSchemaVersion1 {
 		return nil
 	}
 
@@ -629,6 +645,10 @@ func updateAwsSSMDocument(d *schema.ResourceData, meta interface{}) error {
 		DocumentVersion: aws.String(d.Get("default_version").(string)),
 	}
 
+	if v, ok := d.GetOk("target_type"); ok {
+		updateDocInput.TargetType = aws.String(v.(string))
+	}
+
 	if d.HasChange("attachments_source") {
 		updateDocInput.Attachments = expandSsmAttachmentsSources(d.Get("attachments_source").([]interface{}))
 	}
@@ -638,7 +658,7 @@ func updateAwsSSMDocument(d *schema.ResourceData, meta interface{}) error {
 	ssmconn := meta.(*AWSClient).ssmconn
 	updated, err := ssmconn.UpdateDocument(updateDocInput)
 
-	if isAWSErr(err, "DuplicateDocumentContent", "") {
+	if isAWSErr(err, ssm.ErrCodeDuplicateDocumentContent, "") {
 		log.Printf("[DEBUG] Content is a duplicate of the latest version so update is not necessary: %s", d.Id())
 		log.Printf("[INFO] Updating the default version to the latest version %s: %s", newDefaultVersion, d.Id())
 

--- a/aws/resource_aws_ssm_document_test.go
+++ b/aws/resource_aws_ssm_document_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestAccAWSSSMDocument_basic(t *testing.T) {
 	name := acctest.RandString(10)
-	resourceName := "aws_ssm_document.foo"
+	resourceName := "aws_ssm_document.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -42,7 +42,7 @@ func TestAccAWSSSMDocument_basic(t *testing.T) {
 
 func TestAccAWSSSMDocument_target_type(t *testing.T) {
 	name := acctest.RandString(10)
-	resourceName := "aws_ssm_document.foo"
+	resourceName := "aws_ssm_document.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -73,7 +73,7 @@ func TestAccAWSSSMDocument_target_type(t *testing.T) {
 
 func TestAccAWSSSMDocument_update(t *testing.T) {
 	name := acctest.RandString(10)
-	resourceName := "aws_ssm_document.foo"
+	resourceName := "aws_ssm_document.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -107,7 +107,7 @@ func TestAccAWSSSMDocument_update(t *testing.T) {
 
 func TestAccAWSSSMDocument_permission_public(t *testing.T) {
 	name := acctest.RandString(10)
-	resourceName := "aws_ssm_document.foo"
+	resourceName := "aws_ssm_document.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -132,7 +132,7 @@ func TestAccAWSSSMDocument_permission_public(t *testing.T) {
 
 func TestAccAWSSSMDocument_permission_private(t *testing.T) {
 	name := acctest.RandString(10)
-	resourceName := "aws_ssm_document.foo"
+	resourceName := "aws_ssm_document.test"
 	ids := "123456789012"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -157,7 +157,7 @@ func TestAccAWSSSMDocument_permission_private(t *testing.T) {
 
 func TestAccAWSSSMDocument_permission_batching(t *testing.T) {
 	name := acctest.RandString(10)
-	resourceName := "aws_ssm_document.foo"
+	resourceName := "aws_ssm_document.test"
 	ids := "123456789012,123456789013,123456789014,123456789015,123456789016,123456789017,123456789018,123456789019,123456789020,123456789021,123456789022,123456789023,123456789024,123456789025,123456789026,123456789027,123456789028,123456789029,123456789030,123456789031,123456789032"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -182,7 +182,7 @@ func TestAccAWSSSMDocument_permission_batching(t *testing.T) {
 
 func TestAccAWSSSMDocument_permission_change(t *testing.T) {
 	name := acctest.RandString(10)
-	resourceName := "aws_ssm_document.foo"
+	resourceName := "aws_ssm_document.test"
 	idsInitial := "123456789012,123456789013"
 	idsRemove := "123456789012"
 	idsAdd := "123456789012,123456789014"
@@ -226,7 +226,7 @@ func TestAccAWSSSMDocument_permission_change(t *testing.T) {
 
 func TestAccAWSSSMDocument_params(t *testing.T) {
 	name := acctest.RandString(10)
-	resourceName := "aws_ssm_document.foo"
+	resourceName := "aws_ssm_document.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -255,7 +255,7 @@ func TestAccAWSSSMDocument_params(t *testing.T) {
 
 func TestAccAWSSSMDocument_automation(t *testing.T) {
 	name := acctest.RandString(10)
-	resourceName := "aws_ssm_document.foo"
+	resourceName := "aws_ssm_document.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -281,6 +281,7 @@ func TestAccAWSSSMDocument_package(t *testing.T) {
 	name := acctest.RandString(10)
 	rInt := acctest.RandInt()
 	rInt2 := acctest.RandInt()
+	resourceName := "aws_ssm_document.test"
 
 	source := testAccAWSS3BucketObjectCreateTempFile(t, "{anything will do }")
 	defer os.Remove(source)
@@ -293,13 +294,12 @@ func TestAccAWSSSMDocument_package(t *testing.T) {
 			{
 				Config: testAccAWSSSMDocumentTypePackageConfig(name, source, rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMDocumentExists("aws_ssm_document.test"),
-					resource.TestCheckResourceAttr(
-						"aws_ssm_document.test", "document_type", "Package"),
+					testAccCheckAWSSSMDocumentExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "document_type", "Package"),
 				),
 			},
 			{
-				ResourceName:            "aws_ssm_document.test",
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"attachments_source"}, // This doesn't work because the API doesn't provide attachments info directly
@@ -307,9 +307,8 @@ func TestAccAWSSSMDocument_package(t *testing.T) {
 			{
 				Config: testAccAWSSSMDocumentTypePackageConfig(name, source, rInt2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMDocumentExists("aws_ssm_document.test"),
-					resource.TestCheckResourceAttr(
-						"aws_ssm_document.test", "document_type", "Package"),
+					testAccCheckAWSSSMDocumentExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "document_type", "Package"),
 				),
 			},
 		},
@@ -350,7 +349,7 @@ func TestAccAWSSSMDocument_SchemaVersion_1(t *testing.T) {
 
 func TestAccAWSSSMDocument_session(t *testing.T) {
 	name := acctest.RandString(10)
-	resourceName := "aws_ssm_document.foo"
+	resourceName := "aws_ssm_document.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -374,7 +373,7 @@ func TestAccAWSSSMDocument_session(t *testing.T) {
 
 func TestAccAWSSSMDocument_DocumentFormat_YAML(t *testing.T) {
 	name := acctest.RandString(10)
-	resourceName := "aws_ssm_document.foo"
+	resourceName := "aws_ssm_document.test"
 	content1 := `
 ---
 schemaVersion: '2.2'
@@ -429,7 +428,7 @@ mainSteps:
 
 func TestAccAWSSSMDocument_Tags(t *testing.T) {
 	rName := acctest.RandString(10)
-	resourceName := "aws_ssm_document.foo"
+	resourceName := "aws_ssm_document.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -527,7 +526,7 @@ Based on examples from here: https://docs.aws.amazon.com/AWSEC2/latest/WindowsGu
 
 func testAccAWSSSMDocumentBasicConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_ssm_document" "foo" {
+resource "aws_ssm_document" "test" {
   name          = "%s"
   document_type = "Command"
 
@@ -555,7 +554,7 @@ DOC
 
 func testAccAWSSSMDocumentBasicConfigTargetType(rName, typ string) string {
 	return fmt.Sprintf(`
-resource "aws_ssm_document" "foo" {
+resource "aws_ssm_document" "test" {
   name          = "%s"
   document_type = "Command"
   target_type   = "%s"
@@ -586,7 +585,7 @@ DOC
 
 func testAccAWSSSMDocument20Config(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_ssm_document" "foo" {
+resource "aws_ssm_document" "test" {
   name          = "test_document-%s"
   document_type = "Command"
 
@@ -616,7 +615,7 @@ DOC
 
 func testAccAWSSSMDocument20UpdatedConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_ssm_document" "foo" {
+resource "aws_ssm_document" "test" {
   name          = "test_document-%s"
   document_type = "Command"
 
@@ -646,7 +645,7 @@ DOC
 
 func testAccAWSSSMDocumentPublicPermissionConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_ssm_document" "foo" {
+resource "aws_ssm_document" "test" {
   name          = "test_document-%s"
   document_type = "Command"
 
@@ -680,7 +679,7 @@ DOC
 
 func testAccAWSSSMDocumentPrivatePermissionConfig(rName string, rIds string) string {
 	return fmt.Sprintf(`
-resource "aws_ssm_document" "foo" {
+resource "aws_ssm_document" "test" {
   name          = "test_document-%s"
   document_type = "Command"
 
@@ -714,7 +713,7 @@ DOC
 
 func testAccAWSSSMDocumentParamConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_ssm_document" "foo" {
+resource "aws_ssm_document" "test" {
   name          = "test_document-%s"
   document_type = "Command"
 
@@ -798,7 +797,7 @@ resource "aws_iam_role" "ssm_role" {
 EOF
 }
 
-resource "aws_ssm_document" "foo" {
+resource "aws_ssm_document" "test" {
   name          = "test_document-%s"
   document_type = "Automation"
 
@@ -940,7 +939,7 @@ DOC
 
 func testAccAWSSSMDocumentTypeSessionConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_ssm_document" "foo" {
+resource "aws_ssm_document" "test" {
   name          = "test_document-%s"
   document_type = "Session"
 
@@ -964,7 +963,7 @@ DOC
 
 func testAccAWSSSMDocumentConfig_DocumentFormat_YAML(rName, content string) string {
 	return fmt.Sprintf(`
-resource "aws_ssm_document" "foo" {
+resource "aws_ssm_document" "test" {
   document_format = "YAML"
   document_type   = "Command"
   name            = "test_document-%s"
@@ -1026,7 +1025,7 @@ DOC
 
 func testAccAWSSSMDocumentConfig_Tags_Single(rName, key1, value1 string) string {
 	return fmt.Sprintf(`
-resource "aws_ssm_document" "foo" {
+resource "aws_ssm_document" "test" {
   document_type = "Command"
   name          = "test_document-%s"
 
@@ -1059,7 +1058,7 @@ DOC
 
 func testAccAWSSSMDocumentConfig_Tags_Multiple(rName, key1, value1, key2, value2 string) string {
 	return fmt.Sprintf(`
-resource "aws_ssm_document" "foo" {
+resource "aws_ssm_document" "test" {
   document_type = "Command"
   name          = "test_document-%s"
 

--- a/aws/resource_aws_ssm_document_test.go
+++ b/aws/resource_aws_ssm_document_test.go
@@ -854,7 +854,7 @@ DOC
 
 func testAccAWSSSMDocumentTypePackageConfig(rName, source string, rInt int) string {
 	return fmt.Sprintf(`
-data "aws_ami" "ssm_ami" {
+data "aws_ami" "test" {
   most_recent = true
   owners      = ["099720109477"] # Canonical
 
@@ -864,12 +864,12 @@ data "aws_ami" "ssm_ami" {
   }
 }
 
-resource "aws_iam_instance_profile" "ssm_profile" {
+resource "aws_iam_instance_profile" "test" {
   name = "ssm_profile-%s"
-  role = "${aws_iam_role.ssm_role.name}"
+  role = "${aws_iam_role.test.name}"
 }
 
-resource "aws_iam_role" "ssm_role" {
+resource "aws_iam_role" "test" {
   name = "ssm_role-%s"
   path = "/"
 
@@ -890,23 +890,23 @@ resource "aws_iam_role" "ssm_role" {
 EOF
 }
 
-resource "aws_s3_bucket" "object_bucket" {
-	bucket = "tf-object-test-bucket-%d"
-  }
+resource "aws_s3_bucket" "test" {
+  bucket = "tf-object-test-bucket-%d"
+}
 
-  resource "aws_s3_bucket_object" "object" {
-	bucket = "${aws_s3_bucket.object_bucket.bucket}"
-	key = "test.zip"
-	source       = "%s"
-	content_type = "binary/octet-stream"
-  }
+resource "aws_s3_bucket_object" "test" {
+  bucket       = "${aws_s3_bucket.test.bucket}"
+  key          = "test.zip"
+  source       = %q
+  content_type = "binary/octet-stream"
+}
 
 resource "aws_ssm_document" "test" {
   name          = "test_document-%s"
   document_type = "Package"
   attachments_source {
 	key = "SourceUrl"
-	values = ["s3://${aws_s3_bucket.object_bucket.bucket}/test.zip"]
+	values = ["s3://${aws_s3_bucket.test.bucket}/test.zip"]
   }
 
   content = <<DOC
@@ -914,7 +914,7 @@ resource "aws_ssm_document" "test" {
 	   "description": "Systems Manager Package Document Test",
 	   "schemaVersion": "2.0",
 	   "version": "0.1",
-	   "assumeRole": "${aws_iam_role.ssm_role.arn}",
+	   "assumeRole": "${aws_iam_role.test.arn}",
 	   "files": {
 		   "test.zip": {
 			   "checksums": {

--- a/website/docs/r/ssm_document.html.markdown
+++ b/website/docs/r/ssm_document.html.markdown
@@ -53,6 +53,7 @@ The following arguments are supported:
 * `document_format` - (Optional, defaults to JSON) The format of the document. Valid document types include: `JSON` and `YAML`
 * `document_type` - (Required) The type of the document. Valid document types include: `Automation`, `Command`, `Package`, `Policy`, and `Session`
 * `permissions` - (Optional) Additional Permissions to attach to the document. See [Permissions](#permissions) below for details.
+* `target_type` - (Optional) The target type which defines the kinds of resources the document can run on. For example, /AWS::EC2::Instance. For a list of valid resource types, see AWS Resource Types Reference (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html)
 * `tags` - (Optional) A mapping of tags to assign to the object.
 
 ## attachments_source


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10540

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_ssm_document - add support for `target type` argument 
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSSMDocument_'
--- PASS: TestAccAWSSSMDocument_basic (52.73s)
--- PASS: TestAccAWSSSMDocument_target_type (81.52s)
--- PASS: TestAccAWSSSMDocument_update (81.51s)
--- PASS: TestAccAWSSSMDocument_permission_public (55.50s)
--- PASS: TestAccAWSSSMDocument_permission_private (59.87s)
--- PASS: TestAccAWSSSMDocument_permission_batching (61.90s)
--- PASS: TestAccAWSSSMDocument_permission_change (125.19s)
--- PASS: TestAccAWSSSMDocument_params (56.32s)
--- PASS: TestAccAWSSSMDocument_automation (74.82s)
--- PASS: TestAccAWSSSMDocument_SchemaVersion_1 (81.13s)
--- PASS: TestAccAWSSSMDocument_session (56.72s)
--- PASS: TestAccAWSSSMDocument_DocumentFormat_YAML (82.62s)
--- PASS: TestAccAWSSSMDocument_Tags (114.85s)
...
```
