### PR TITLE
EC2 Placement Group tagging support

### DIFF
--- a/aws/resource_aws_placement_group.go
+++ b/aws/resource_aws_placement_group.go
@@ -10,12 +10,15 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsPlacementGroup() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsPlacementGroupCreate,
 		Read:   resourceAwsPlacementGroupRead,
+		Update: resourceAwsPlacementGroupUpdate,
 		Delete: resourceAwsPlacementGroupDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -31,7 +34,17 @@ func resourceAwsPlacementGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					ec2.PlacementStrategyCluster,
+					ec2.PlacementStrategyPartition,
+					ec2.PlacementStrategySpread,
+				}, false),
 			},
+			"placement_group_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -51,8 +64,8 @@ func resourceAwsPlacementGroupCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	wait := resource.StateChangeConf{
-		Pending:    []string{"pending"},
-		Target:     []string{"available"},
+		Pending:    []string{ec2.PlacementGroupStatePending},
+		Target:     []string{ec2.PlacementGroupStateAvailable},
 		Timeout:    5 * time.Minute,
 		MinTimeout: 1 * time.Second,
 		Refresh: func() (interface{}, string, error) {
@@ -82,6 +95,20 @@ func resourceAwsPlacementGroupCreate(d *schema.ResourceData, meta interface{}) e
 
 	d.SetId(name)
 
+	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
+		input := ec2.DescribePlacementGroupsInput{
+			GroupNames: []*string{aws.String(d.Id())},
+		}
+		out, err := conn.DescribePlacementGroups(&input)
+		if err != nil {
+			return err
+		}
+		pg := out.PlacementGroups[0]
+		if err := keyvaluetags.Ec2UpdateTags(conn, aws.StringValue(pg.GroupId), nil, v); err != nil {
+			return fmt.Errorf("error adding tags: %s", err)
+		}
+	}
+
 	return resourceAwsPlacementGroupRead(d, meta)
 }
 
@@ -100,8 +127,27 @@ func resourceAwsPlacementGroupRead(d *schema.ResourceData, meta interface{}) err
 
 	d.Set("name", pg.GroupName)
 	d.Set("strategy", pg.Strategy)
+	d.Set("placement_group_id", pg.GroupId)
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(pg.Tags).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
 
 	return nil
+}
+
+func resourceAwsPlacementGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		pgId := d.Get("placement_group_id").(string)
+		if err := keyvaluetags.Ec2UpdateTags(conn, pgId, o, n); err != nil {
+			return fmt.Errorf("error updating Placement Group (%s) tags: %s", pgId, err)
+		}
+	}
+
+	return resourceAwsPlacementGroupRead(d, meta)
 }
 
 func resourceAwsPlacementGroupDelete(d *schema.ResourceData, meta interface{}) error {
@@ -116,8 +162,8 @@ func resourceAwsPlacementGroupDelete(d *schema.ResourceData, meta interface{}) e
 	}
 
 	wait := resource.StateChangeConf{
-		Pending:    []string{"deleting"},
-		Target:     []string{"deleted"},
+		Pending:    []string{ec2.PlacementGroupStateDeleting},
+		Target:     []string{ec2.PlacementGroupStateDeleted},
 		Timeout:    5 * time.Minute,
 		MinTimeout: 1 * time.Second,
 		Refresh: func() (interface{}, string, error) {
@@ -134,7 +180,7 @@ func resourceAwsPlacementGroupDelete(d *schema.ResourceData, meta interface{}) e
 			}
 
 			if len(out.PlacementGroups) == 0 {
-				return out, "deleted", nil
+				return out, ec2.PlacementGroupStateDeleted, nil
 			}
 
 			pg := out.PlacementGroups[0]

--- a/aws/resource_aws_placement_group.go
+++ b/aws/resource_aws_placement_group.go
@@ -119,6 +119,12 @@ func resourceAwsPlacementGroupRead(d *schema.ResourceData, meta interface{}) err
 	}
 	out, err := conn.DescribePlacementGroups(&input)
 	if err != nil {
+		if isAWSErr(err, "InvalidPlacementGroup.Unknown", "") {
+			log.Printf("[WARN] Placement Group %s not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+
 		return err
 	}
 	pg := out.PlacementGroups[0]

--- a/aws/resource_aws_placement_group_test.go
+++ b/aws/resource_aws_placement_group_test.go
@@ -139,7 +139,12 @@ func testAccCheckAWSPlacementGroupDisappears(n string) resource.TestCheckFunc {
 
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
 		req := &ec2.DeletePlacementGroupInput{GroupName: aws.String(rs.Primary.ID)}
-		if _, err := conn.DeletePlacementGroup(req); err != nil {
+		_, err := conn.DeletePlacementGroup(req)
+
+		if err != nil {
+			if isAWSErr(err, "InvalidPlacementGroup.Unknown", "") {
+				return nil
+			}
 			return err
 		}
 		return nil

--- a/website/docs/r/placement_group.html.markdown
+++ b/website/docs/r/placement_group.html.markdown
@@ -26,12 +26,15 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the placement group.
 * `strategy` - (Required) The placement strategy.
+* `tags` - (Optional) Key-value mapping of resource tags.
+
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The name of the placement group.
+* `placement_group_id` - The ID of the placement group.
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11399 , Relates #10688

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_placement_group - add `tags` argument and `placement_group_id` attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSPlacementGroup_'
--- PASS: TestAccAWSPlacementGroup_basic (57.50s)
--- PASS: TestAccAWSPlacementGroup_tags (136.85s)
--- PASS: TestAccAWSPlacementGroup_disappears (40.69s)
...
```
