### PR TITLE
Add  attributes for aws_transfer_user resource

### DIFF
--- a/aws/resource_aws_transfer_user.go
+++ b/aws/resource_aws_transfer_user.go
@@ -43,12 +43,14 @@ func resourceAwsTransferUser() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"entry": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringLenBetween(0, 1024),
 						},
 						"target": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringLenBetween(0, 1024),
 						},
 					},
 				},

--- a/aws/resource_aws_transfer_user.go
+++ b/aws/resource_aws_transfer_user.go
@@ -37,6 +37,30 @@ func resourceAwsTransferUser() *schema.Resource {
 				ValidateFunc: validation.StringLenBetween(0, 1024),
 			},
 
+			"home_directory_mappings": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"entry": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"target": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+
+			"home_directory_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      transfer.HomeDirectoryTypePath,
+				ValidateFunc: validation.StringInSlice([]string{transfer.HomeDirectoryTypePath, transfer.HomeDirectoryTypeLogical}, false),
+			},
+
 			"policy": {
 				Type:             schema.TypeString,
 				Optional:         true,
@@ -82,6 +106,14 @@ func resourceAwsTransferUserCreate(d *schema.ResourceData, meta interface{}) err
 
 	if attr, ok := d.GetOk("home_directory"); ok {
 		createOpts.HomeDirectory = aws.String(attr.(string))
+	}
+
+	if attr, ok := d.GetOk("home_directory_type"); ok {
+		createOpts.HomeDirectoryType = aws.String(attr.(string))
+	}
+
+	if attr, ok := d.GetOk("home_directory_mappings"); ok {
+		createOpts.HomeDirectoryMappings = expandAwsTransferHomeDirectoryMappings(attr.([]interface{}))
 	}
 
 	if attr, ok := d.GetOk("policy"); ok {
@@ -132,8 +164,13 @@ func resourceAwsTransferUserRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("user_name", resp.User.UserName)
 	d.Set("arn", resp.User.Arn)
 	d.Set("home_directory", resp.User.HomeDirectory)
+	d.Set("home_directory_type", resp.User.HomeDirectoryType)
 	d.Set("policy", resp.User.Policy)
 	d.Set("role", resp.User.Role)
+
+	if err := d.Set("home_directory_mappings", flattenAwsTransferHomeDirectoryMappings(resp.User.HomeDirectoryMappings)); err != nil {
+		return fmt.Errorf("Error setting home_directory_mappings: %s", err)
+	}
 
 	if err := d.Set("tags", keyvaluetags.TransferKeyValueTags(resp.User.Tags).IgnoreAws().Map()); err != nil {
 		return fmt.Errorf("Error setting tags: %s", err)
@@ -156,6 +193,16 @@ func resourceAwsTransferUserUpdate(d *schema.ResourceData, meta interface{}) err
 
 	if d.HasChange("home_directory") {
 		updateOpts.HomeDirectory = aws.String(d.Get("home_directory").(string))
+		updateFlag = true
+	}
+
+	if d.HasChange("home_directory_mappings") {
+		updateOpts.HomeDirectoryMappings = expandAwsTransferHomeDirectoryMappings(d.Get("home_directory_mappings").([]interface{}))
+		updateFlag = true
+	}
+
+	if d.HasChange("home_directory_type") {
+		updateOpts.HomeDirectoryType = aws.String(d.Get("home_directory_type").(string))
 		updateFlag = true
 	}
 
@@ -258,4 +305,32 @@ func waitForTransferUserDeletion(conn *transfer.Transfer, serverID, userName str
 		return fmt.Errorf("Error decoding transfer user ID: %s", err)
 	}
 	return nil
+}
+
+func expandAwsTransferHomeDirectoryMappings(in []interface{}) []*transfer.HomeDirectoryMapEntry {
+	mappings := make([]*transfer.HomeDirectoryMapEntry, 0)
+
+	for _, tConfig := range in {
+		config := tConfig.(map[string]interface{})
+
+		m := &transfer.HomeDirectoryMapEntry{
+			Entry:  aws.String(config["entry"].(string)),
+			Target: aws.String(config["target"].(string)),
+		}
+
+		mappings = append(mappings, m)
+	}
+
+	return mappings
+}
+
+func flattenAwsTransferHomeDirectoryMappings(mappings []*transfer.HomeDirectoryMapEntry) []interface{} {
+	l := make([]interface{}, len(mappings))
+	for i, m := range mappings {
+		l[i] = map[string]interface{}{
+			"entry":  aws.StringValue(m.Entry),
+			"target": aws.StringValue(m.Target),
+		}
+	}
+	return l
 }

--- a/aws/resource_aws_transfer_user_test.go
+++ b/aws/resource_aws_transfer_user_test.go
@@ -156,6 +156,40 @@ func TestAccAWSTransferUser_UserName_Validation(t *testing.T) {
 	})
 }
 
+func TestAccAWSTransferUser_homeDirectoryMappings(t *testing.T) {
+	var conf transfer.DescribedUser
+	rName := acctest.RandString(10)
+	resourceName := "aws_transfer_user.foo"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSTransferUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSTransferUserConfig_homeDirectoryMappings(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSTransferUserExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "home_directory_mappings.#", "1"),
+				),
+			},
+			{
+				Config: testAccAWSTransferUserConfig_homeDirectoryMappingsUpdate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSTransferUserExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "home_directory_mappings.#", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAWSTransferUserExists(n string, res *transfer.DescribedUser) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -233,8 +267,7 @@ func testAccCheckAWSTransferUserDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAWSTransferUserConfig_basic(rName string) string {
-	return fmt.Sprintf(`
+const testAccAWSTransferUserConfig_base = `
 resource "aws_transfer_server" "foo" {
   identity_provider_type = "SERVICE_MANAGED"
 
@@ -242,6 +275,10 @@ resource "aws_transfer_server" "foo" {
     NAME = "tf-acc-test-transfer-server"
   }
 }
+`
+
+func testAccAWSTransferUserConfig_basic(rName string) string {
+	return testAccAWSTransferUserConfig_base + fmt.Sprintf(`
 
 resource "aws_iam_role" "foo" {
   name = "tf-test-transfer-user-iam-role-%s"
@@ -292,14 +329,7 @@ resource "aws_transfer_user" "foo" {
 }
 
 func testAccAWSTransferUserName_validation(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_transfer_server" "foo" {
-  identity_provider_type = "SERVICE_MANAGED"
-
-  tags = {
-    NAME = "tf-acc-test-transfer-server"
-  }
-}
+	return testAccAWSTransferUserConfig_base + fmt.Sprintf(`
 
 resource "aws_transfer_user" "foo" {
   server_id = "${aws_transfer_server.foo.id}"
@@ -329,14 +359,7 @@ EOF
 }
 
 func testAccAWSTransferUserConfig_options(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_transfer_server" "foo" {
-  identity_provider_type = "SERVICE_MANAGED"
-
-  tags = {
-    NAME = "tf-acc-test-transfer-server"
-  }
-}
+	return testAccAWSTransferUserConfig_base + fmt.Sprintf(`
 
 resource "aws_iam_role" "foo" {
   name = "tf-test-transfer-user-iam-role-%s"
@@ -438,14 +461,7 @@ resource "aws_transfer_user" "foo" {
 }
 
 func testAccAWSTransferUserConfig_modify(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_transfer_server" "foo" {
-  identity_provider_type = "SERVICE_MANAGED"
-
-  tags = {
-    NAME = "tf-acc-test-transfer-server"
-  }
-}
+	return testAccAWSTransferUserConfig_base + fmt.Sprintf(`
 
 resource "aws_iam_role" "foo" {
   name = "tf-test-transfer-user-iam-role-%s"
@@ -544,14 +560,7 @@ resource "aws_transfer_user" "foo" {
 }
 
 func testAccAWSTransferUserConfig_forceNew(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_transfer_server" "foo" {
-  identity_provider_type = "SERVICE_MANAGED"
-
-  tags = {
-    NAME = "tf-acc-test-transfer-server"
-  }
-}
+	return testAccAWSTransferUserConfig_base + fmt.Sprintf(`
 
 resource "aws_iam_role" "foo" {
   name = "tf-test-transfer-user-iam-role-%s"
@@ -646,6 +655,125 @@ resource "aws_transfer_user" "foo" {
   tags = {
     NAME = "tf-test-user"
     TEST = "test2"
+  }
+}
+`, rName, rName)
+}
+
+func testAccAWSTransferUserConfig_homeDirectoryMappings(rName string) string {
+	return testAccAWSTransferUserConfig_base + fmt.Sprintf(`
+
+resource "aws_iam_role" "foo" {
+  name = "tf-test-transfer-user-iam-role-%s"
+
+  assume_role_policy = <<EOF
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Principal": {
+				"Service": "transfer.amazonaws.com"
+			},
+			"Action": "sts:AssumeRole"
+		}
+	]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "foo" {
+  name = "tf-test-transfer-user-iam-policy-%s"
+  role = "${aws_iam_role.foo.id}"
+
+  policy = <<POLICY
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "AllowFullAccesstoS3",
+			"Effect": "Allow",
+			"Action": [
+				"s3:*"
+			],
+			"Resource": "*"
+		}
+	]
+}
+POLICY
+}
+
+resource "aws_transfer_user" "foo" {
+  server_id = "${aws_transfer_server.foo.id}"
+  user_name = "tftestuser"
+  role      = "${aws_iam_role.foo.arn}"
+  home_directory_type = "LOGICAL"
+
+  home_directory_mappings {
+    entry = "/your-personal-report.pdf"
+    target = "/bucket3/customized-reports/tftestuser.pdf" 
+  }
+}
+`, rName, rName)
+}
+
+func testAccAWSTransferUserConfig_homeDirectoryMappingsUpdate(rName string) string {
+	return testAccAWSTransferUserConfig_base + fmt.Sprintf(`
+
+resource "aws_iam_role" "foo" {
+  name = "tf-test-transfer-user-iam-role-%s"
+
+  assume_role_policy = <<EOF
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Principal": {
+				"Service": "transfer.amazonaws.com"
+			},
+			"Action": "sts:AssumeRole"
+		}
+	]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "foo" {
+  name = "tf-test-transfer-user-iam-policy-%s"
+  role = "${aws_iam_role.foo.id}"
+
+  policy = <<POLICY
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "AllowFullAccesstoS3",
+			"Effect": "Allow",
+			"Action": [
+				"s3:*"
+			],
+			"Resource": "*"
+		}
+	]
+}
+POLICY
+}
+
+resource "aws_transfer_user" "foo" {
+  server_id = "${aws_transfer_server.foo.id}"
+  user_name = "tftestuser"
+  role      = "${aws_iam_role.foo.arn}"
+  home_directory_type = "LOGICAL"
+
+  home_directory_mappings {
+    entry = "/your-personal-report.pdf"
+    target = "/bucket3/customized-reports/tftestuser.pdf" 
+  }
+
+  home_directory_mappings {
+    entry = "/your-personal-report2.pdf"
+    target = "/bucket3/customized-reports2/tftestuser.pdf" 
   }
 }
 `, rName, rName)

--- a/website/docs/r/transfer_user.html.markdown
+++ b/website/docs/r/transfer_user.html.markdown
@@ -74,9 +74,16 @@ The following arguments are supported:
 * `server_id` - (Requirement) The Server ID of the Transfer Server (e.g. `s-12345678`)
 * `user_name` - (Requirement) The name used for log in to your SFTP server.
 * `home_directory` - (Optional) The landing directory (folder) for a user when they log in to the server using their SFTP client.  It should begin with a `/`.  The first item in the path is the name of the home bucket (accessible as `${Transfer:HomeBucket}` in the policy) and the rest is the home directory (accessible as `${Transfer:HomeDirectory}` in the policy). For example, `/example-bucket-1234/username` would set the home bucket to `example-bucket-1234` and the home directory to `username`.
+* `home_directory_mappings` - (Optional) Logical directory mappings that specify what S3 paths and keys should be visible to your user and how you want to make them visible. documented below.
+* `home_directory_type` - (Optional) The type of landing directory (folder) you mapped for your users' home directory. Valid values are `PATH` and `LOGICAL`.
 * `policy` - (Optional) An IAM JSON policy document that scopes down user access to portions of their Amazon S3 bucket. IAM variables you can use inside this policy include `${Transfer:UserName}`, `${Transfer:HomeDirectory}`, and `${Transfer:HomeBucket}`. Since the IAM variable syntax matches Terraform's interpolation syntax, they must be escaped inside Terraform configuration strings (`$${Transfer:UserName}`).  These are evaluated on-the-fly when navigating the bucket.
 * `role` - (Requirement) Amazon Resource Name (ARN) of an IAM role that allows the service to controls your user’s access to your Amazon S3 bucket.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+
+Home Directory Mappings (`home_directory_mappings`) support the following:
+
+* `entry` - (Requirement) Represents an entry and a target.
+* `target` - (Requirement) Represents the map target.
 
 ## Attributes Reference
 In addition to all arguments above, the following attributes are exported:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11281

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add home_directory_type and home_directory_mappings attributes for aws_transfer_user resource
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSTransferUser_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSTransferUser_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSTransferUser_basic
=== PAUSE TestAccAWSTransferUser_basic
=== RUN   TestAccAWSTransferUser_modifyWithOptions
=== PAUSE TestAccAWSTransferUser_modifyWithOptions
=== RUN   TestAccAWSTransferUser_disappears
=== PAUSE TestAccAWSTransferUser_disappears
=== RUN   TestAccAWSTransferUser_UserName_Validation
=== PAUSE TestAccAWSTransferUser_UserName_Validation
=== RUN   TestAccAWSTransferUser_homeDirectoryMappings
=== PAUSE TestAccAWSTransferUser_homeDirectoryMappings
=== CONT  TestAccAWSTransferUser_basic
=== CONT  TestAccAWSTransferUser_UserName_Validation
=== CONT  TestAccAWSTransferUser_homeDirectoryMappings
=== CONT  TestAccAWSTransferUser_modifyWithOptions
=== CONT  TestAccAWSTransferUser_disappears
--- PASS: TestAccAWSTransferUser_UserName_Validation (16.74s)
--- PASS: TestAccAWSTransferUser_disappears (40.76s)
--- PASS: TestAccAWSTransferUser_basic (43.77s)
--- PASS: TestAccAWSTransferUser_homeDirectoryMappings (69.97s)
--- PASS: TestAccAWSTransferUser_modifyWithOptions (105.03s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	105.116s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.013s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.118s [no tests to run]
```
