### PR TITLE
Support tagging for Gamelift resources - Alias, Build & Session Queue

### DIFF
--- a/aws/internal/keyvaluetags/generators/listtags/main.go
+++ b/aws/internal/keyvaluetags/generators/listtags/main.go
@@ -294,6 +294,8 @@ func ServiceListTagsInputIdentifierField(serviceName string) string {
 		return "DeliveryStreamName"
 	case "fsx":
 		return "ResourceARN"
+	case "gamelift":
+		return "ResourceARN"
 	case "kinesis":
 		return "StreamName"
 	case "kinesisanalytics":

--- a/aws/internal/keyvaluetags/generators/listtags/main.go
+++ b/aws/internal/keyvaluetags/generators/listtags/main.go
@@ -57,6 +57,7 @@ var serviceNames = []string{
 	"elbv2",
 	"firehose",
 	"fsx",
+	"gamelift",
 	"glue",
 	"guardduty",
 	"greengrass",

--- a/aws/internal/keyvaluetags/generators/servicetags/main.go
+++ b/aws/internal/keyvaluetags/generators/servicetags/main.go
@@ -55,6 +55,7 @@ var sliceServiceNames = []string{
 	"firehose",
 	"fms",
 	"fsx",
+	"gamelift",
 	"iam",
 	"inspector",
 	"iot",

--- a/aws/internal/keyvaluetags/generators/updatetags/main.go
+++ b/aws/internal/keyvaluetags/generators/updatetags/main.go
@@ -420,6 +420,8 @@ func ServiceTagInputIdentifierField(serviceName string) string {
 		return "DeliveryStreamName"
 	case "fsx":
 		return "ResourceARN"
+	case "gamelift":
+		return "ResourceARN"
 	case "kinesis":
 		return "StreamName"
 	case "kinesisanalytics":

--- a/aws/internal/keyvaluetags/generators/updatetags/main.go
+++ b/aws/internal/keyvaluetags/generators/updatetags/main.go
@@ -61,6 +61,7 @@ var serviceNames = []string{
 	"emr",
 	"firehose",
 	"fsx",
+	"gamelift",
 	"glue",
 	"guardduty",
 	"greengrass",

--- a/aws/internal/keyvaluetags/list_tags_gen.go
+++ b/aws/internal/keyvaluetags/list_tags_gen.go
@@ -44,6 +44,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/firehose"
 	"github.com/aws/aws-sdk-go/service/fsx"
+	"github.com/aws/aws-sdk-go/service/gamelift"
 	"github.com/aws/aws-sdk-go/service/glue"
 	"github.com/aws/aws-sdk-go/service/greengrass"
 	"github.com/aws/aws-sdk-go/service/guardduty"
@@ -766,6 +767,23 @@ func FsxListTags(conn *fsx.FSx, identifier string) (KeyValueTags, error) {
 	}
 
 	return FsxKeyValueTags(output.Tags), nil
+}
+
+// GameliftListTags lists gamelift service tags.
+// The identifier is typically the Amazon Resource Name (ARN), although
+// it may also be a different identifier depending on the service.
+func GameliftListTags(conn *gamelift.GameLift, identifier string) (KeyValueTags, error) {
+	input := &gamelift.ListTagsForResourceInput{
+		ResourceARN: aws.String(identifier),
+	}
+
+	output, err := conn.ListTagsForResource(input)
+
+	if err != nil {
+		return New(nil), err
+	}
+
+	return GameliftKeyValueTags(output.Tags), nil
 }
 
 // GlueListTags lists glue service tags.

--- a/aws/internal/keyvaluetags/service_generation_customizations.go
+++ b/aws/internal/keyvaluetags/service_generation_customizations.go
@@ -52,6 +52,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/emr"
 	"github.com/aws/aws-sdk-go/service/firehose"
 	"github.com/aws/aws-sdk-go/service/fsx"
+	"github.com/aws/aws-sdk-go/service/gamelift"
 	"github.com/aws/aws-sdk-go/service/glue"
 	"github.com/aws/aws-sdk-go/service/greengrass"
 	"github.com/aws/aws-sdk-go/service/guardduty"
@@ -200,6 +201,8 @@ func ServiceClientType(serviceName string) string {
 		funcType = reflect.TypeOf(firehose.New)
 	case "fsx":
 		funcType = reflect.TypeOf(fsx.New)
+	case "gamelift":
+		funcType = reflect.TypeOf(gamelift.New)
 	case "glue":
 		funcType = reflect.TypeOf(glue.New)
 	case "guardduty":

--- a/aws/internal/keyvaluetags/service_tags_gen.go
+++ b/aws/internal/keyvaluetags/service_tags_gen.go
@@ -40,6 +40,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/firehose"
 	"github.com/aws/aws-sdk-go/service/fms"
 	"github.com/aws/aws-sdk-go/service/fsx"
+	"github.com/aws/aws-sdk-go/service/gamelift"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/inspector"
 	"github.com/aws/aws-sdk-go/service/iot"
@@ -1372,6 +1373,33 @@ func (tags KeyValueTags) FsxTags() []*fsx.Tag {
 
 // FsxKeyValueTags creates KeyValueTags from fsx service tags.
 func FsxKeyValueTags(tags []*fsx.Tag) KeyValueTags {
+	m := make(map[string]*string, len(tags))
+
+	for _, tag := range tags {
+		m[aws.StringValue(tag.Key)] = tag.Value
+	}
+
+	return New(m)
+}
+
+// GameliftTags returns gamelift service tags.
+func (tags KeyValueTags) GameliftTags() []*gamelift.Tag {
+	result := make([]*gamelift.Tag, 0, len(tags))
+
+	for k, v := range tags.Map() {
+		tag := &gamelift.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		}
+
+		result = append(result, tag)
+	}
+
+	return result
+}
+
+// GameliftKeyValueTags creates KeyValueTags from gamelift service tags.
+func GameliftKeyValueTags(tags []*gamelift.Tag) KeyValueTags {
 	m := make(map[string]*string, len(tags))
 
 	for _, tag := range tags {

--- a/aws/internal/keyvaluetags/update_tags_gen.go
+++ b/aws/internal/keyvaluetags/update_tags_gen.go
@@ -50,6 +50,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/emr"
 	"github.com/aws/aws-sdk-go/service/firehose"
 	"github.com/aws/aws-sdk-go/service/fsx"
+	"github.com/aws/aws-sdk-go/service/gamelift"
 	"github.com/aws/aws-sdk-go/service/glue"
 	"github.com/aws/aws-sdk-go/service/greengrass"
 	"github.com/aws/aws-sdk-go/service/guardduty"
@@ -1669,6 +1670,42 @@ func FsxUpdateTags(conn *fsx.FSx, identifier string, oldTagsMap interface{}, new
 		input := &fsx.TagResourceInput{
 			ResourceARN: aws.String(identifier),
 			Tags:        updatedTags.IgnoreAws().FsxTags(),
+		}
+
+		_, err := conn.TagResource(input)
+
+		if err != nil {
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
+		}
+	}
+
+	return nil
+}
+
+// GameliftUpdateTags updates gamelift service tags.
+// The identifier is typically the Amazon Resource Name (ARN), although
+// it may also be a different identifier depending on the service.
+func GameliftUpdateTags(conn *gamelift.GameLift, identifier string, oldTagsMap interface{}, newTagsMap interface{}) error {
+	oldTags := New(oldTagsMap)
+	newTags := New(newTagsMap)
+
+	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+		input := &gamelift.UntagResourceInput{
+			ResourceARN: aws.String(identifier),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
+		}
+
+		_, err := conn.UntagResource(input)
+
+		if err != nil {
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
+		}
+	}
+
+	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+		input := &gamelift.TagResourceInput{
+			ResourceARN: aws.String(identifier),
+			Tags:        updatedTags.IgnoreAws().GameliftTags(),
 		}
 
 		_, err := conn.TagResource(input)

--- a/aws/resource_aws_gamelift_alias.go
+++ b/aws/resource_aws_gamelift_alias.go
@@ -1,12 +1,14 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/gamelift"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsGameliftAlias() *schema.Resource {
@@ -60,6 +62,7 @@ func resourceAwsGameliftAlias() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -71,6 +74,7 @@ func resourceAwsGameliftAliasCreate(d *schema.ResourceData, meta interface{}) er
 	input := gamelift.CreateAliasInput{
 		Name:            aws.String(d.Get("name").(string)),
 		RoutingStrategy: rs,
+		Tags:            keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().GameliftTags(),
 	}
 	if v, ok := d.GetOk("description"); ok {
 		input.Description = aws.String(v.(string))
@@ -103,10 +107,20 @@ func resourceAwsGameliftAliasRead(d *schema.ResourceData, meta interface{}) erro
 	}
 	a := out.Alias
 
-	d.Set("arn", a.AliasArn)
+	arn := aws.StringValue(a.AliasArn)
+	d.Set("arn", arn)
 	d.Set("description", a.Description)
 	d.Set("name", a.Name)
 	d.Set("routing_strategy", flattenGameliftRoutingStrategy(a.RoutingStrategy))
+	tags, err := keyvaluetags.GameliftListTags(conn, arn)
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for Game Lift Alias (%s): %s", arn, err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
 
 	return nil
 }
@@ -123,6 +137,15 @@ func resourceAwsGameliftAliasUpdate(d *schema.ResourceData, meta interface{}) er
 	})
 	if err != nil {
 		return err
+	}
+
+	arn := d.Get("arn").(string)
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.GameliftUpdateTags(conn, arn, o, n); err != nil {
+			return fmt.Errorf("error updating Game Lift Alias (%s) tags: %s", arn, err)
+		}
 	}
 
 	return resourceAwsGameliftAliasRead(d, meta)

--- a/aws/resource_aws_gamelift_alias_test.go
+++ b/aws/resource_aws_gamelift_alias_test.go
@@ -106,6 +106,7 @@ func TestAccAWSGameliftAlias_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "routing_strategy.0.type", "TERMINAL"),
 					resource.TestCheckResourceAttr(resourceName, "name", aliasName),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
@@ -123,6 +124,7 @@ func TestAccAWSGameliftAlias_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "routing_strategy.0.type", "TERMINAL"),
 					resource.TestCheckResourceAttr(resourceName, "name", uAliasName),
 					resource.TestCheckResourceAttr(resourceName, "description", uDescription),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 		},

--- a/aws/resource_aws_gamelift_alias_test.go
+++ b/aws/resource_aws_gamelift_alias_test.go
@@ -214,7 +214,7 @@ func TestAccAWSGameliftAlias_fleetRouting(t *testing.T) {
 					fleetName, launchPath, params, buildName, bucketName, key, roleArn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGameliftAliasExists(resourceName, &conf),
-					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "gamelift", regexp.MustCompile(`alias/alias-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "routing_strategy.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "routing_strategy.0.fleet_id"),
 					resource.TestCheckResourceAttr(resourceName, "routing_strategy.0.type", "SIMPLE"),

--- a/aws/resource_aws_gamelift_alias_test.go
+++ b/aws/resource_aws_gamelift_alias_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -99,7 +100,7 @@ func TestAccAWSGameliftAlias_basic(t *testing.T) {
 				Config: testAccAWSGameliftAliasBasicConfig(aliasName, description, message),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGameliftAliasExists(resourceName, &conf),
-					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "gamelift", regexp.MustCompile(`alias/alias-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "routing_strategy.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "routing_strategy.0.message", message),
 					resource.TestCheckResourceAttr(resourceName, "routing_strategy.0.type", "TERMINAL"),
@@ -116,7 +117,7 @@ func TestAccAWSGameliftAlias_basic(t *testing.T) {
 				Config: testAccAWSGameliftAliasBasicConfig(uAliasName, uDescription, uMessage),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGameliftAliasExists(resourceName, &conf),
-					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "gamelift", regexp.MustCompile(`alias/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "routing_strategy.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "routing_strategy.0.message", uMessage),
 					resource.TestCheckResourceAttr(resourceName, "routing_strategy.0.type", "TERMINAL"),

--- a/aws/resource_aws_gamelift_build.go
+++ b/aws/resource_aws_gamelift_build.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsGameliftBuild() *schema.Resource {
@@ -65,6 +66,11 @@ func resourceAwsGameliftBuild() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.StringLenBetween(1, 1024),
 			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -77,6 +83,7 @@ func resourceAwsGameliftBuildCreate(d *schema.ResourceData, meta interface{}) er
 		Name:            aws.String(d.Get("name").(string)),
 		OperatingSystem: aws.String(d.Get("operating_system").(string)),
 		StorageLocation: sl,
+		Tags:            keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().GameliftTags(),
 	}
 	if v, ok := d.GetOk("version"); ok {
 		input.Version = aws.String(v.(string))
@@ -147,6 +154,18 @@ func resourceAwsGameliftBuildRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("operating_system", b.OperatingSystem)
 	d.Set("version", b.Version)
 
+	arn := aws.StringValue(b.BuildArn)
+	d.Set("arn", arn)
+	tags, err := keyvaluetags.GameliftListTags(conn, arn)
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for Game Lift Build (%s): %s", arn, err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
 	return nil
 }
 
@@ -165,6 +184,15 @@ func resourceAwsGameliftBuildUpdate(d *schema.ResourceData, meta interface{}) er
 	_, err := conn.UpdateBuild(&input)
 	if err != nil {
 		return err
+	}
+
+	arn := d.Get("arn").(string)
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.GameliftUpdateTags(conn, arn, o, n); err != nil {
+			return fmt.Errorf("error updating Game Lift Build (%s) tags: %s", arn, err)
+		}
 	}
 
 	return resourceAwsGameliftBuildRead(d, meta)

--- a/aws/resource_aws_gamelift_build_test.go
+++ b/aws/resource_aws_gamelift_build_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -93,11 +94,13 @@ func TestAccAWSGameliftBuild_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGameliftBuildExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "name", buildName),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "gamelift", regexp.MustCompile(`build/build-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "operating_system", "WINDOWS_2012"),
 					resource.TestCheckResourceAttr(resourceName, "storage_location.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "storage_location.0.bucket", bucketName),
 					resource.TestCheckResourceAttr(resourceName, "storage_location.0.key", key),
 					resource.TestCheckResourceAttr(resourceName, "storage_location.0.role_arn", roleArn),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
@@ -105,11 +108,13 @@ func TestAccAWSGameliftBuild_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGameliftBuildExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "name", uBuildName),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "gamelift", regexp.MustCompile(`build/build-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "operating_system", "WINDOWS_2012"),
 					resource.TestCheckResourceAttr(resourceName, "storage_location.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "storage_location.0.bucket", bucketName),
 					resource.TestCheckResourceAttr(resourceName, "storage_location.0.key", key),
 					resource.TestCheckResourceAttr(resourceName, "storage_location.0.role_arn", roleArn),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 		},

--- a/aws/resource_aws_gamelift_build_test.go
+++ b/aws/resource_aws_gamelift_build_test.go
@@ -62,6 +62,7 @@ func TestAccAWSGameliftBuild_basic(t *testing.T) {
 	var conf gamelift.Build
 
 	rString := acctest.RandString(8)
+	resourceName := "aws_gamelift_build.test"
 
 	buildName := fmt.Sprintf("%s_%s", testAccGameliftBuildPrefix, rString)
 	uBuildName := fmt.Sprintf("%s_updated_%s", testAccGameliftBuildPrefix, rString)
@@ -90,26 +91,124 @@ func TestAccAWSGameliftBuild_basic(t *testing.T) {
 			{
 				Config: testAccAWSGameliftBuildBasicConfig(buildName, bucketName, key, roleArn),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSGameliftBuildExists("aws_gamelift_build.test", &conf),
-					resource.TestCheckResourceAttr("aws_gamelift_build.test", "name", buildName),
-					resource.TestCheckResourceAttr("aws_gamelift_build.test", "operating_system", "WINDOWS_2012"),
-					resource.TestCheckResourceAttr("aws_gamelift_build.test", "storage_location.#", "1"),
-					resource.TestCheckResourceAttr("aws_gamelift_build.test", "storage_location.0.bucket", bucketName),
-					resource.TestCheckResourceAttr("aws_gamelift_build.test", "storage_location.0.key", key),
-					resource.TestCheckResourceAttr("aws_gamelift_build.test", "storage_location.0.role_arn", roleArn),
+					testAccCheckAWSGameliftBuildExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "name", buildName),
+					resource.TestCheckResourceAttr(resourceName, "operating_system", "WINDOWS_2012"),
+					resource.TestCheckResourceAttr(resourceName, "storage_location.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_location.0.bucket", bucketName),
+					resource.TestCheckResourceAttr(resourceName, "storage_location.0.key", key),
+					resource.TestCheckResourceAttr(resourceName, "storage_location.0.role_arn", roleArn),
 				),
 			},
 			{
 				Config: testAccAWSGameliftBuildBasicConfig(uBuildName, bucketName, key, roleArn),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSGameliftBuildExists("aws_gamelift_build.test", &conf),
-					resource.TestCheckResourceAttr("aws_gamelift_build.test", "name", uBuildName),
-					resource.TestCheckResourceAttr("aws_gamelift_build.test", "operating_system", "WINDOWS_2012"),
-					resource.TestCheckResourceAttr("aws_gamelift_build.test", "storage_location.#", "1"),
-					resource.TestCheckResourceAttr("aws_gamelift_build.test", "storage_location.0.bucket", bucketName),
-					resource.TestCheckResourceAttr("aws_gamelift_build.test", "storage_location.0.key", key),
-					resource.TestCheckResourceAttr("aws_gamelift_build.test", "storage_location.0.role_arn", roleArn),
+					testAccCheckAWSGameliftBuildExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "name", uBuildName),
+					resource.TestCheckResourceAttr(resourceName, "operating_system", "WINDOWS_2012"),
+					resource.TestCheckResourceAttr(resourceName, "storage_location.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_location.0.bucket", bucketName),
+					resource.TestCheckResourceAttr(resourceName, "storage_location.0.key", key),
+					resource.TestCheckResourceAttr(resourceName, "storage_location.0.role_arn", roleArn),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAWSGameliftBuild_tags(t *testing.T) {
+	var conf gamelift.Build
+
+	rString := acctest.RandString(8)
+	resourceName := "aws_gamelift_build.test"
+
+	buildName := fmt.Sprintf("%s_%s", testAccGameliftBuildPrefix, rString)
+	region := testAccGetRegion()
+	g, err := testAccAWSGameliftSampleGame(region)
+
+	if isResourceNotFoundError(err) {
+		t.Skip(err)
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loc := g.Location
+	bucketName := *loc.Bucket
+	roleArn := *loc.RoleArn
+	key := *loc.Key
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGameliftBuildDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGameliftBuildBasicConfigTags1(buildName, bucketName, key, roleArn, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGameliftBuildExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				Config: testAccAWSGameliftBuildBasicConfigTags2(buildName, bucketName, key, roleArn, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGameliftBuildExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSGameliftBuildBasicConfigTags1(buildName, bucketName, key, roleArn, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGameliftBuildExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSGameliftBuild_disappears(t *testing.T) {
+	var conf gamelift.Build
+
+	rString := acctest.RandString(8)
+	resourceName := "aws_gamelift_build.test"
+
+	buildName := fmt.Sprintf("%s_%s", testAccGameliftBuildPrefix, rString)
+
+	region := testAccGetRegion()
+	g, err := testAccAWSGameliftSampleGame(region)
+
+	if isResourceNotFoundError(err) {
+		t.Skip(err)
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loc := g.Location
+	bucketName := *loc.Bucket
+	roleArn := *loc.RoleArn
+	key := *loc.Key
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGameliftBuildDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGameliftBuildBasicConfig(buildName, bucketName, key, roleArn),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGameliftBuildExists(resourceName, &conf),
+					testAccCheckAWSGameliftBuildDisappears(&conf),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -145,6 +244,17 @@ func testAccCheckAWSGameliftBuildExists(n string, res *gamelift.Build) resource.
 		*res = *b
 
 		return nil
+	}
+}
+
+func testAccCheckAWSGameliftBuildDisappears(res *gamelift.Build) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).gameliftconn
+
+		input := &gamelift.DeleteBuildInput{BuildId: res.BuildId}
+
+		_, err := conn.DeleteBuild(input)
+		return err
 	}
 }
 
@@ -204,4 +314,43 @@ resource "aws_gamelift_build" "test" {
   }
 }
 `, buildName, bucketName, key, roleArn)
+}
+
+func testAccAWSGameliftBuildBasicConfigTags1(buildName, bucketName, key, roleArn, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_gamelift_build" "test" {
+  name             = %[1]q
+  operating_system = "WINDOWS_2012"
+
+  storage_location {
+    bucket   = %[2]q
+    key      = %[3]q
+    role_arn = %[4]q
+  }
+
+  tags = {
+    %[5]q = %[6]q
+  }
+}
+`, buildName, bucketName, key, roleArn, tagKey1, tagValue1)
+}
+
+func testAccAWSGameliftBuildBasicConfigTags2(buildName, bucketName, key, roleArn, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_gamelift_build" "test" {
+  name             = %[1]q
+  operating_system = "WINDOWS_2012"
+
+  storage_location {
+    bucket   = %[2]q
+    key      = %[3]q
+    role_arn = %[4]q
+  }
+
+  tags = {
+    %[5]q = %[6]q
+    %[7]q = %[8]q
+  }
+}
+`, buildName, bucketName, key, roleArn, tagKey1, tagValue1, tagKey2, tagValue2)
 }

--- a/aws/resource_aws_gamelift_game_session_queue.go
+++ b/aws/resource_aws_gamelift_game_session_queue.go
@@ -2,11 +2,13 @@ package aws
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/gamelift"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	"log"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsGameliftGameSessionQueue() *schema.Resource {
@@ -58,6 +60,7 @@ func resourceAwsGameliftGameSessionQueue() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -70,6 +73,7 @@ func resourceAwsGameliftGameSessionQueueCreate(d *schema.ResourceData, meta inte
 		Destinations:          expandGameliftGameSessionQueueDestinations(d.Get("destinations").([]interface{})),
 		PlayerLatencyPolicies: expandGameliftGameSessionPlayerLatencyPolicies(d.Get("player_latency_policy").([]interface{})),
 		TimeoutInSeconds:      aws.Int64(int64(d.Get("timeout_in_seconds").(int))),
+		Tags:                  keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().GameliftTags(),
 	}
 	log.Printf("[INFO] Creating Gamelift Session Queue: %s", input)
 	out, err := conn.CreateGameSessionQueue(&input)
@@ -111,7 +115,8 @@ func resourceAwsGameliftGameSessionQueueRead(d *schema.ResourceData, meta interf
 	}
 	sessionQueue := sessionQueues[0]
 
-	d.Set("arn", sessionQueue.GameSessionQueueArn)
+	arn := aws.StringValue(sessionQueue.GameSessionQueueArn)
+	d.Set("arn", arn)
 	d.Set("name", sessionQueue.Name)
 	d.Set("timeout_in_seconds", sessionQueue.TimeoutInSeconds)
 	if err := d.Set("destinations", flattenGameliftGameSessionQueueDestinations(sessionQueue.Destinations)); err != nil {
@@ -119,6 +124,16 @@ func resourceAwsGameliftGameSessionQueueRead(d *schema.ResourceData, meta interf
 	}
 	if err := d.Set("player_latency_policy", flattenGameliftPlayerLatencyPolicies(sessionQueue.PlayerLatencyPolicies)); err != nil {
 		return fmt.Errorf("error setting player_latency_policy: %s", err)
+	}
+
+	tags, err := keyvaluetags.GameliftListTags(conn, arn)
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for Game Lift Session Queue (%s): %s", arn, err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
 	}
 
 	return nil
@@ -164,6 +179,15 @@ func resourceAwsGameliftGameSessionQueueUpdate(d *schema.ResourceData, meta inte
 	_, err := conn.UpdateGameSessionQueue(&input)
 	if err != nil {
 		return fmt.Errorf("error updating Gamelift Game Session Queue (%s): %s", d.Id(), err)
+	}
+
+	arn := d.Get("arn").(string)
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.GameliftUpdateTags(conn, arn, o, n); err != nil {
+			return fmt.Errorf("error updating Game Lift Session Queue (%s) tags: %s", arn, err)
+		}
 	}
 
 	return resourceAwsGameliftGameSessionQueueRead(d, meta)

--- a/aws/resource_aws_gamelift_game_session_queue_test.go
+++ b/aws/resource_aws_gamelift_game_session_queue_test.go
@@ -64,6 +64,7 @@ func testSweepGameliftGameSessionQueue(region string) error {
 func TestAccAWSGameliftGameSessionQueue_basic(t *testing.T) {
 	var conf gamelift.GameSessionQueue
 
+	resourceName := "aws_gamelift_game_session_queue.test"
 	queueName := testAccGameliftGameSessionQueuePrefix + acctest.RandString(8)
 	playerLatencyPolicies := []gamelift.PlayerLatencyPolicy{
 		{
@@ -99,70 +100,123 @@ func TestAccAWSGameliftGameSessionQueue_basic(t *testing.T) {
 				Config: testAccAWSGameliftGameSessionQueueBasicConfig(queueName,
 					playerLatencyPolicies, timeoutInSeconds),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSGameliftGameSessionQueueExists("aws_gamelift_game_session_queue.test", &conf),
-					resource.TestCheckResourceAttr("aws_gamelift_game_session_queue.test", "name", queueName),
-
-					resource.TestCheckResourceAttr("aws_gamelift_game_session_queue.test",
-						"destinations.#", "0"),
-
-					resource.TestCheckResourceAttr("aws_gamelift_game_session_queue.test",
-						"player_latency_policy.#", "2"),
-
-					resource.TestCheckResourceAttr("aws_gamelift_game_session_queue.test",
-						"player_latency_policy.0.maximum_individual_player_latency_milliseconds",
+					testAccCheckAWSGameliftGameSessionQueueExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "name", queueName),
+					resource.TestCheckResourceAttr(resourceName, "destinations.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "player_latency_policy.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "player_latency_policy.0.maximum_individual_player_latency_milliseconds",
 						fmt.Sprintf("%d", *playerLatencyPolicies[0].MaximumIndividualPlayerLatencyMilliseconds)),
-
-					resource.TestCheckResourceAttr("aws_gamelift_game_session_queue.test",
-						"player_latency_policy.0.policy_duration_seconds",
+					resource.TestCheckResourceAttr(resourceName, "player_latency_policy.0.policy_duration_seconds",
 						fmt.Sprintf("%d", *playerLatencyPolicies[0].PolicyDurationSeconds)),
-
-					resource.TestCheckResourceAttr("aws_gamelift_game_session_queue.test",
-						"player_latency_policy.1.maximum_individual_player_latency_milliseconds",
+					resource.TestCheckResourceAttr(resourceName, "player_latency_policy.1.maximum_individual_player_latency_milliseconds",
 						fmt.Sprintf("%d", *playerLatencyPolicies[1].MaximumIndividualPlayerLatencyMilliseconds)),
-
-					resource.TestCheckResourceAttr("aws_gamelift_game_session_queue.test",
-						"player_latency_policy.1.policy_duration_seconds", "0"),
-
-					resource.TestCheckResourceAttr("aws_gamelift_game_session_queue.test",
-						"timeout_in_seconds", fmt.Sprintf("%d", timeoutInSeconds)),
+					resource.TestCheckResourceAttr(resourceName, "player_latency_policy.1.policy_duration_seconds", "0"),
+					resource.TestCheckResourceAttr(resourceName, "timeout_in_seconds", fmt.Sprintf("%d", timeoutInSeconds)),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
-				Config: testAccAWSGameliftGameSessionQueueBasicConfig(uQueueName,
-					uPlayerLatencyPolicies, uTimeoutInSeconds),
+				Config: testAccAWSGameliftGameSessionQueueBasicConfig(uQueueName, uPlayerLatencyPolicies, uTimeoutInSeconds),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSGameliftGameSessionQueueExists("aws_gamelift_game_session_queue.test", &conf),
-					resource.TestCheckResourceAttr("aws_gamelift_game_session_queue.test", "name", uQueueName),
-
-					resource.TestCheckResourceAttr("aws_gamelift_game_session_queue.test",
-						"destinations.#", "0"),
-
-					resource.TestCheckResourceAttr("aws_gamelift_game_session_queue.test",
-						"player_latency_policy.#", "2"),
-
-					resource.TestCheckResourceAttr("aws_gamelift_game_session_queue.test",
-						"player_latency_policy.0.maximum_individual_player_latency_milliseconds",
+					testAccCheckAWSGameliftGameSessionQueueExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "name", uQueueName),
+					resource.TestCheckResourceAttr(resourceName, "destinations.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "player_latency_policy.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "player_latency_policy.0.maximum_individual_player_latency_milliseconds",
 						fmt.Sprintf("%d", *uPlayerLatencyPolicies[0].MaximumIndividualPlayerLatencyMilliseconds)),
-
-					resource.TestCheckResourceAttr("aws_gamelift_game_session_queue.test",
-						"player_latency_policy.0.policy_duration_seconds",
+					resource.TestCheckResourceAttr(resourceName, "player_latency_policy.0.policy_duration_seconds",
 						fmt.Sprintf("%d", *uPlayerLatencyPolicies[0].PolicyDurationSeconds)),
-
-					resource.TestCheckResourceAttr("aws_gamelift_game_session_queue.test",
-						"player_latency_policy.1.maximum_individual_player_latency_milliseconds",
+					resource.TestCheckResourceAttr(resourceName, "player_latency_policy.1.maximum_individual_player_latency_milliseconds",
 						fmt.Sprintf("%d", *uPlayerLatencyPolicies[1].MaximumIndividualPlayerLatencyMilliseconds)),
-
-					resource.TestCheckResourceAttr("aws_gamelift_game_session_queue.test",
-						"player_latency_policy.1.policy_duration_seconds", "0"),
-
-					resource.TestCheckResourceAttr("aws_gamelift_game_session_queue.test",
-						"timeout_in_seconds", fmt.Sprintf("%d", uTimeoutInSeconds)),
+					resource.TestCheckResourceAttr(resourceName, "player_latency_policy.1.policy_duration_seconds", "0"),
+					resource.TestCheckResourceAttr(resourceName, "timeout_in_seconds", fmt.Sprintf("%d", uTimeoutInSeconds)),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
-				ResourceName:      "aws_gamelift_game_session_queue.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSGameliftGameSessionQueue_tags(t *testing.T) {
+	var conf gamelift.GameSessionQueue
+
+	resourceName := "aws_gamelift_game_session_queue.test"
+	queueName := testAccGameliftGameSessionQueuePrefix + acctest.RandString(8)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGameliftGameSessionQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGameliftGameSessionQueueBasicConfigTags1(queueName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGameliftGameSessionQueueExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSGameliftGameSessionQueueBasicConfigTags2(queueName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGameliftGameSessionQueueExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSGameliftGameSessionQueueBasicConfigTags1(queueName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGameliftGameSessionQueueExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSGameliftGameSessionQueue_disappears(t *testing.T) {
+	var conf gamelift.GameSessionQueue
+
+	resourceName := "aws_gamelift_game_session_queue.test"
+	queueName := testAccGameliftGameSessionQueuePrefix + acctest.RandString(8)
+	playerLatencyPolicies := []gamelift.PlayerLatencyPolicy{
+		{
+			MaximumIndividualPlayerLatencyMilliseconds: aws.Int64(100),
+			PolicyDurationSeconds:                      aws.Int64(5),
+		},
+		{
+			MaximumIndividualPlayerLatencyMilliseconds: aws.Int64(200),
+			PolicyDurationSeconds:                      nil,
+		},
+	}
+	timeoutInSeconds := int64(124)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGameliftGameSessionQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGameliftGameSessionQueueBasicConfig(queueName,
+					playerLatencyPolicies, timeoutInSeconds),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGameliftGameSessionQueueExists(resourceName, &conf),
+					testAccCheckAWSGameliftGameSessionQueueDisappears(&conf),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -207,6 +261,18 @@ func testAccCheckAWSGameliftGameSessionQueueExists(n string, res *gamelift.GameS
 		*res = *queue
 
 		return nil
+	}
+}
+
+func testAccCheckAWSGameliftGameSessionQueueDisappears(res *gamelift.GameSessionQueue) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).gameliftconn
+
+		input := &gamelift.DeleteGameSessionQueueInput{Name: res.Name}
+
+		_, err := conn.DeleteGameSessionQueue(input)
+
+		return err
 	}
 }
 
@@ -276,4 +342,53 @@ resource "aws_gamelift_game_session_queue" "test" {
 		*playerLatencyPolicies[0].PolicyDurationSeconds,
 		*playerLatencyPolicies[1].MaximumIndividualPlayerLatencyMilliseconds,
 		timeoutInSeconds)
+}
+
+func testAccAWSGameliftGameSessionQueueBasicConfigTags1(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_gamelift_game_session_queue" "test" {
+  name         = %[1]q 
+  destinations = []
+
+  player_latency_policy {
+    maximum_individual_player_latency_milliseconds = 100000
+    policy_duration_seconds                        = 10
+  }
+
+  player_latency_policy {
+    maximum_individual_player_latency_milliseconds = 100000
+  }
+
+  timeout_in_seconds = 10
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccAWSGameliftGameSessionQueueBasicConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_gamelift_game_session_queue" "test" {
+  name         = %[1]q 
+  destinations = []
+
+  player_latency_policy {
+    maximum_individual_player_latency_milliseconds = 100000
+    policy_duration_seconds                        = 10
+  }
+
+  player_latency_policy {
+    maximum_individual_player_latency_milliseconds = 100000
+  }
+
+  timeout_in_seconds = 10
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }

--- a/aws/resource_aws_gamelift_game_session_queue_test.go
+++ b/aws/resource_aws_gamelift_game_session_queue_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"testing"
 	"time"
 
@@ -101,6 +102,7 @@ func TestAccAWSGameliftGameSessionQueue_basic(t *testing.T) {
 					playerLatencyPolicies, timeoutInSeconds),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGameliftGameSessionQueueExists(resourceName, &conf),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "gamelift", regexp.MustCompile(`gamesessionqueue/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "name", queueName),
 					resource.TestCheckResourceAttr(resourceName, "destinations.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "player_latency_policy.#", "2"),
@@ -119,6 +121,7 @@ func TestAccAWSGameliftGameSessionQueue_basic(t *testing.T) {
 				Config: testAccAWSGameliftGameSessionQueueBasicConfig(uQueueName, uPlayerLatencyPolicies, uTimeoutInSeconds),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGameliftGameSessionQueueExists(resourceName, &conf),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "gamelift", regexp.MustCompile(`gamesessionqueue/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "name", uQueueName),
 					resource.TestCheckResourceAttr(resourceName, "destinations.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "player_latency_policy.#", "2"),

--- a/website/docs/r/gamelift_alias.html.markdown
+++ b/website/docs/r/gamelift_alias.html.markdown
@@ -39,6 +39,7 @@ The following arguments are supported:
 * `fleet_id` - (Optional) ID of the Gamelift Fleet to point the alias to.
 * `message` - (Optional) Message text to be used with the `TERMINAL` routing strategy.
 * `type` - (Required) Type of routing strategy. e.g. `SIMPLE` or `TERMINAL`
+* `tags` - (Optional) Key-value mapping of resource tags
 
 ## Attributes Reference
 

--- a/website/docs/r/gamelift_build.html.markdown
+++ b/website/docs/r/gamelift_build.html.markdown
@@ -35,6 +35,7 @@ The following arguments are supported:
 * `operating_system` - (Required) Operating system that the game server binaries are built to run on. e.g. `WINDOWS_2012` or `AMAZON_LINUX`.
 * `storage_location` - (Required) Information indicating where your game build files are stored. See below.
 * `version` - (Optional) Version that is associated with this build.
+* `tags` - (Optional) Key-value mapping of resource tags
 
 ### Nested Fields
 
@@ -48,7 +49,9 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Build ID.
+* `id` - Gamelift Build ID.
+* `arn` - Gamelift Build ARN.
+
 
 ## Import
 

--- a/website/docs/r/gamelift_game_session_queue.html.markdown
+++ b/website/docs/r/gamelift_game_session_queue.html.markdown
@@ -42,6 +42,7 @@ The following arguments are supported:
 * `timeout_in_seconds` - (Required) Maximum time a game session request can remain in the queue.
 * `destinations` - (Optional) List of fleet/alias ARNs used by session queue for placing game sessions.
 * `player_latency_policy` - (Optional) One or more policies used to choose fleet based on player latency. See below.
+* `tags` - (Optional) Key-value mapping of resource tags
 
 ### Nested Fields
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11384

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_gamelift_alias - add `tags` argument
resource_aws_gamelift_build - add `tags` argument and `arn` attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSGameliftAlias_'
--- PASS: TestAccAWSGameliftAlias_basic (88.10s)
--- PASS: TestAccAWSGameliftAlias_tags (110.00s) 
--- PASS: TestAccAWSGameliftAlias_disappears (42.51s)
--- PASS: TestAccAWSGameliftAlias_fleetRouting (1464.86s)
...
```

```
$ make testacc TESTARGS='-run=TestAccAWSGameliftBuild_'
--- PASS: TestAccAWSGameliftBuild_basic (69.16s)
--- PASS: TestAccAWSGameliftBuild_tags (94.39s)
--- PASS: TestAccAWSGameliftBuild_disappears (30.10s)
```

```
$ make testacc TESTARGS='-run=TestAccAWSGameliftGameSessionQueue_'
--- PASS: TestAccAWSGameliftGameSessionQueue_basic (72.84s)
--- PASS: TestAccAWSGameliftGameSessionQueue_tags (96.20s)
--- PASS: TestAccAWSGameliftGameSessionQueue_disappears (30.12s)
```
