### PR TITLE
resource/aws_appautoscaling_policy: Remove unimplemented alarms attribute

### DIFF
--- a/aws/resource_aws_appautoscaling_policy.go
+++ b/aws/resource_aws_appautoscaling_policy.go
@@ -102,13 +102,6 @@ func resourceAwsAppautoscalingPolicy() *schema.Resource {
 					},
 				},
 			},
-			"alarms": {
-				Type:     schema.TypeList,
-				Optional: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-
 			"adjustment_type": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -330,7 +323,7 @@ func resourceAwsAppautoscalingPolicyRead(d *schema.ResourceData, meta interface{
 	d.Set("resource_id", p.ResourceId)
 	d.Set("scalable_dimension", p.ScalableDimension)
 	d.Set("service_namespace", p.ServiceNamespace)
-	d.Set("alarms", p.Alarms)
+
 	if err := d.Set("step_scaling_policy_configuration", flattenStepScalingPolicyConfiguration(p.StepScalingPolicyConfiguration)); err != nil {
 		return fmt.Errorf("error setting step_scaling_policy_configuration: %s", err)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/9954

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
/Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_appautoscaling_policy.go:333:18: R004: ResourceData.Set() incompatible value type: []*github.com/aws/aws-sdk-go/service/applicationautoscaling.Alarm
```

The `alarms` attribute was never actually implemented:

- `d.Set()` never would have set anything in the Terraform state due to silently ignoring the error above, so Terraform configuration references to the attribute would always have been invalid trying to reference a non-existent resource attribute
- Configuring `alarms` in a configuration was never valid as it would not have done anything (CloudWatch Alarms are a read-only property of Application Auto Scaling Policies)
- Not acceptance tested
- Not documented

Due to these conditions and since there are no associated bug reports or feature requests for this attribute, it feels safe to bypass our normal attribute deprecation/removal process and just remove the errant attribute definition from the schema. If desired in the future, this could be implemented as a `Computed: true` only attribute.

Output from acceptance testing:

```
--- PASS: TestAccAWSAppautoScalingPolicy_dynamoDb (34.67s)
--- PASS: TestAccAWSAppautoScalingPolicy_multiplePoliciesSameName (40.33s)
--- PASS: TestAccAWSAppautoScalingPolicy_multiplePoliciesSameResource (41.44s)
--- PASS: TestAccAWSAppautoScalingPolicy_disappears (72.83s)
--- PASS: TestAccAWSAppautoScalingPolicy_basic (78.93s)
--- PASS: TestAccAWSAppautoScalingPolicy_spotFleetRequest (81.81s)
--- PASS: TestAccAWSAppautoScalingPolicy_ResourceId_ForceNew (87.53s)
--- PASS: TestAccAWSAppautoScalingPolicy_scaleOutAndIn (88.80s)
```
