### PR TITLE
resource/aws_dms_certificate: Properly set certificate_wallet into Terraform state

### DIFF
--- a/aws/resource_aws_dms_certificate.go
+++ b/aws/resource_aws_dms_certificate.go
@@ -126,8 +126,8 @@ func resourceAwsDmsCertificateSetState(d *schema.ResourceData, cert *dms.Certifi
 	if cert.CertificatePem != nil && *cert.CertificatePem != "" {
 		d.Set("certificate_pem", cert.CertificatePem)
 	}
-	if cert.CertificateWallet != nil && len(cert.CertificateWallet) == 0 {
-		d.Set("certificate_wallet", cert.CertificateWallet)
+	if cert.CertificateWallet != nil && len(cert.CertificateWallet) != 0 {
+		d.Set("certificate_wallet", string(cert.CertificateWallet))
 	}
 
 	return nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/9954
Reference: https://github.com/terraform-providers/terraform-provider-aws/blob/768341474a743c3db30610c6b434fed598d98cd8/aws/resource_aws_dms_certificate.go#L71

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_dms_certificate: Properly set `certificate_wallet` value into Terraform state
```

Previously:

```
/Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_dms_certificate.go:130:31: R004: ResourceData.Set() incompatible value type: []byte
```

Here we perform the opposite `[]byte` to `string` conversion as compared to the creation function to prevent silently ignoring a type error in the `d.Set()` call and fix drift detection for the attribute.

Output from acceptance testing:

```
--- PASS: TestAccAWSDmsCertificateBasic (17.45s)
```

Aside: Its worth noting that this attribute is not acceptance tested and potentially may not work as given in Terraform 0.12+ if there are non UTF-8 characters in the value (e.g. the `file()` function will error). Generally `[]byte` attributes must have base64 encoding/decoding added above and beyond the AWS Go SDK's handling, however I do not have intimate knowledge about this particular DMS functionality, so it may be okay. There are no bug reports and it would take a non-trivial amount of effort to create a valid Oracle Wallet acceptance test, so this fix is best effort with other similar fixes to allow us to continue working towards enabling the `tfproviderlint` `R004` check in the near future.