### PR TITLE
resource/aws_waf_sql_injection_match_set: Properly set sql_injection_match_tuples into Terraform state

### DIFF
--- a/aws/resource_aws_waf_sql_injection_match_set.go
+++ b/aws/resource_aws_waf_sql_injection_match_set.go
@@ -98,7 +98,10 @@ func resourceAwsWafSqlInjectionMatchSetRead(d *schema.ResourceData, meta interfa
 	}
 
 	d.Set("name", resp.SqlInjectionMatchSet.Name)
-	d.Set("sql_injection_match_tuples", resp.SqlInjectionMatchSet.SqlInjectionMatchTuples)
+
+	if err := d.Set("sql_injection_match_tuples", flattenWafSqlInjectionMatchTuples(resp.SqlInjectionMatchSet.SqlInjectionMatchTuples)); err != nil {
+		return fmt.Errorf("error setting sql_injection_match_tuples: %s", err)
+	}
 
 	return nil
 }

--- a/aws/resource_aws_waf_sql_injection_match_set_test.go
+++ b/aws/resource_aws_waf_sql_injection_match_set_test.go
@@ -134,14 +134,6 @@ func TestAccAWSWafSqlInjectionMatchSet_changeTuples(t *testing.T) {
 						"aws_waf_sql_injection_match_set.sql_injection_match_set", "name", setName),
 					resource.TestCheckResourceAttr(
 						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.3333510133.field_to_match.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.3333510133.field_to_match.4253810390.data", "GET"),
-					resource.TestCheckResourceAttr(
-						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.3333510133.field_to_match.4253810390.type", "METHOD"),
-					resource.TestCheckResourceAttr(
-						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.3333510133.text_transformation", "NONE"),
 				),
 			},
 		},
@@ -314,7 +306,6 @@ resource "aws_waf_sql_injection_match_set" "sql_injection_match_set" {
 
     field_to_match {
       type = "METHOD"
-      data = "GET"
     }
   }
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #462
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/9954

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_waf_sql_injection_match_set: Properly set `sql_injection_match_tuples` value into Terraform state
```

Previously:

```
/Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_waf_sql_injection_match_set.go:101:38: R004: ResourceData.Set() incompatible value type: []*github.com/aws/aws-sdk-go/service/waf.SqlInjectionMatchTuple
```

Fixes `d.Set()` handling for this attribute with existing flatten function (used by `aws_wafregional_sql_injection_match_set` resource) and one associated test configuration so that it matches API canonicalization, which is now enforced by the testing since the value is being properly read into the Terraform state.

Output from acceptance testing:

```
--- PASS: TestAccAWSWafSqlInjectionMatchSet_noTuples (13.29s)
--- PASS: TestAccAWSWafSqlInjectionMatchSet_disappears (17.63s)
--- PASS: TestAccAWSWafSqlInjectionMatchSet_basic (17.65s)
--- PASS: TestAccAWSWafSqlInjectionMatchSet_changeTuples (23.46s)
--- PASS: TestAccAWSWafSqlInjectionMatchSet_changeNameForceNew (31.73s)
```