### PR TITLE
Serializes WorkSpaces Directory tests

### DIFF
--- a/aws/resource_aws_workspaces_directory_test.go
+++ b/aws/resource_aws_workspaces_directory_test.go
@@ -12,7 +12,21 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAwsWorkspacesDirectory_basic(t *testing.T) {
+// These tests need to be serialized, because they all rely on the IAM Role `workspaces_DefaultRole`.
+func TestAccAwsWorkspacesDirectory(t *testing.T) {
+	testCases := map[string]func(t *testing.T){
+		"basic":     testAccAwsWorkspacesDirectory_basic,
+		"subnetIds": testAccAwsWorkspacesDirectory_subnetIds,
+	}
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			tc(t)
+		})
+	}
+}
+
+func testAccAwsWorkspacesDirectory_basic(t *testing.T) {
 	booster := acctest.RandString(8)
 	resourceName := "aws_workspaces_directory.main"
 
@@ -75,7 +89,7 @@ func TestAccAwsWorkspacesDirectory_basic(t *testing.T) {
 	})
 }
 
-func TestAccAwsWorkspacesDirectory_subnetIds(t *testing.T) {
+func testAccAwsWorkspacesDirectory_subnetIds(t *testing.T) {
 	booster := acctest.RandString(8)
 	resourceName := "aws_workspaces_directory.main"
 

--- a/website/docs/r/workspaces_directory.html.markdown
+++ b/website/docs/r/workspaces_directory.html.markdown
@@ -1,14 +1,14 @@
 ---
-subcategory: "Workspaces"
+subcategory: "WorkSpaces"
 layout: "aws"
 page_title: "AWS: aws_workspaces_directory"
 description: |-
-  Provides a directory registration in AWS Workspaces Service.
+  Provides a directory registration in AWS WorkSpaces Service.
 ---
 
 # Resource: aws_workspaces_directory
 
-Provides a directory registration in AWS Workspaces Service
+Provides a directory registration in AWS WorkSpaces Service
 
 ## Example Usage
 
@@ -53,24 +53,24 @@ resource "aws_workspaces_directory" "main" {
 
 The following arguments are supported:
 
-* `directory_id` - (Required) The directory identifier for registration in Workspaces service.
-* `subnet_ids` - (Optional) The identifiers of the subnets where the directory resides new workspaces.
-* `tags` – (Optional) A mapping of tags assigned to the workspaces directory.
+* `directory_id` - (Required) The directory identifier for registration in WorkSpaces service.
+* `subnet_ids` - (Optional) The identifiers of the subnets where the directory resides.
+* `tags` – (Optional) A mapping of tags assigned to the WorkSpaces directory.
 * `self_service_permissions` – (Optional) The permissions to enable or disable self-service capabilities.
 
 `self_service_permissions` supports the following:
 
-* `change_compute_type` – (Optional) Whether workspaces directory users can change the compute type (bundle) for their workspace. Default `false`.
-* `increase_volume_size` – (Optional) Whether workspaces directory users can increase the volume size of the drives on their workspace. Default `false`.
-* `rebuild_workspace` – (Optional) Whether workspaces directory users can rebuild the operating system of a workspace to its original state. Default `false`.
-* `restart_workspace` – (Optional) Whether workspaces directory users can restart their workspace. Default `true`.
-* `switch_running_mode` – (Optional) Whether workspaces directory users can switch the running mode of their workspace. Default `false`.
+* `change_compute_type` – (Optional) Whether WorkSpaces directory users can change the compute type (bundle) for their workspace. Default `false`.
+* `increase_volume_size` – (Optional) Whether WorkSpaces directory users can increase the volume size of the drives on their workspace. Default `false`.
+* `rebuild_workspace` – (Optional) Whether WorkSpaces directory users can rebuild the operating system of a workspace to its original state. Default `false`.
+* `restart_workspace` – (Optional) Whether WorkSpaces directory users can restart their workspace. Default `true`.
+* `switch_running_mode` – (Optional) Whether WorkSpaces directory users can switch the running mode of their workspace. Default `false`.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The workspaces directory identifier.
+* `id` - The WorkSpaces directory identifier.
 
 ## Import
 


### PR DESCRIPTION
Serializes the acceptance tests added in #11023, since they use a shared IAM Role.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates  #11023 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsWorkspacesDirectory'

--- PASS: TestAccAwsWorkspacesDirectory (1217.71s)
    --- PASS: TestAccAwsWorkspacesDirectory/basic (630.88s)
    --- PASS: TestAccAwsWorkspacesDirectory/subnetIds (586.83s)
```
