### PR TITLE
Allows enabling support of tag policies

### DIFF
--- a/aws/resource_aws_organizations_organization.go
+++ b/aws/resource_aws_organizations_organization.go
@@ -137,6 +137,7 @@ func resourceAwsOrganizationsOrganization() *schema.Resource {
 					Type: schema.TypeString,
 					ValidateFunc: validation.StringInSlice([]string{
 						organizations.PolicyTypeServiceControlPolicy,
+						organizations.PolicyTypeTagPolicy,
 					}, false),
 				},
 			},

--- a/aws/resource_aws_organizations_organization_test.go
+++ b/aws/resource_aws_organizations_organization_test.go
@@ -132,15 +132,15 @@ func addTestStepsAwsOrganizationsOrganization_EnabledPolicyTypes(policyTypes *[]
 	return &testSteps
 }
 
-func testAccAwsOrganizationsOrganization_EnabledPolicyTypes(t *testing.T) {	
+func testAccAwsOrganizationsOrganization_EnabledPolicyTypes(t *testing.T) {
 	policyTypes := []string{organizations.PolicyTypeServiceControlPolicy, organizations.PolicyTypeTagPolicy}
 	testSteps := *addTestStepsAwsOrganizationsOrganization_EnabledPolicyTypes(&policyTypes)
-	
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOrganizationsOrganizationDestroy,
-		Steps: testSteps,
+		Steps:        testSteps,
 	})
 }
 

--- a/aws/resource_aws_organizations_organization_test.go
+++ b/aws/resource_aws_organizations_organization_test.go
@@ -94,42 +94,52 @@ func testAccAwsOrganizationsOrganization_AwsServiceAccessPrincipals(t *testing.T
 	})
 }
 
-func testAccAwsOrganizationsOrganization_EnabledPolicyTypes(t *testing.T) {
-	var organization organizations.Organization
+func addTestStepsAwsOrganizationsOrganization_EnabledPolicyTypes(policyType string, testSteps *[]resource.TestStep) {
 	resourceName := "aws_organizations_organization.test"
+	var organization organizations.Organization
+	newSteps := *testSteps
+	
+	*testSteps = append(newSteps, []resource.TestStep{
+		{
+			Config: testAccAwsOrganizationsOrganizationConfigEnabledPolicyTypes1(policyType),
+			Check: resource.ComposeTestCheckFunc(
+				testAccCheckAwsOrganizationsOrganizationExists(resourceName, &organization),
+				resource.TestCheckResourceAttr(resourceName, "enabled_policy_types.#", "1"),
+			),
+		},
+		{
+			ResourceName:      resourceName,
+			ImportState:       true,
+			ImportStateVerify: true,
+		},
+		{
+			Config: testAccAwsOrganizationsOrganizationConfig,
+			Check: resource.ComposeTestCheckFunc(
+				testAccCheckAwsOrganizationsOrganizationExists(resourceName, &organization),
+				resource.TestCheckResourceAttr(resourceName, "enabled_policy_types.#", "0"),
+			),
+		},
+		{
+			Config: testAccAwsOrganizationsOrganizationConfigEnabledPolicyTypes1(policyType),
+			Check: resource.ComposeTestCheckFunc(
+				testAccCheckAwsOrganizationsOrganizationExists(resourceName, &organization),
+				resource.TestCheckResourceAttr(resourceName, "enabled_policy_types.#", "1"),
+			),
+		},
+	})
+}
 
+func testAccAwsOrganizationsOrganization_EnabledPolicyTypes(t *testing.T) {	
+	var testSteps []resource.TestStep
+
+	addTestStepsAwsOrganizationsOrganization_EnabledPolicyTypes(organizations.PolicyTypeServiceControlPolicy, &testSteps)
+	addTestStepsAwsOrganizationsOrganization_EnabledPolicyTypes(organizations.PolicyTypeTagPolicy, &testSteps)
+	
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOrganizationsOrganizationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAwsOrganizationsOrganizationConfigEnabledPolicyTypes1(organizations.PolicyTypeServiceControlPolicy),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsOrganizationsOrganizationExists(resourceName, &organization),
-					resource.TestCheckResourceAttr(resourceName, "enabled_policy_types.#", "1"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccAwsOrganizationsOrganizationConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsOrganizationsOrganizationExists(resourceName, &organization),
-					resource.TestCheckResourceAttr(resourceName, "enabled_policy_types.#", "0"),
-				),
-			},
-			{
-				Config: testAccAwsOrganizationsOrganizationConfigEnabledPolicyTypes1(organizations.PolicyTypeServiceControlPolicy),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsOrganizationsOrganizationExists(resourceName, &organization),
-					resource.TestCheckResourceAttr(resourceName, "enabled_policy_types.#", "1"),
-				),
-			},
-		},
+		Steps: testSteps,
 	})
 }
 

--- a/aws/resource_aws_organizations_organization_test.go
+++ b/aws/resource_aws_organizations_organization_test.go
@@ -94,46 +94,47 @@ func testAccAwsOrganizationsOrganization_AwsServiceAccessPrincipals(t *testing.T
 	})
 }
 
-func addTestStepsAwsOrganizationsOrganization_EnabledPolicyTypes(policyType string, testSteps *[]resource.TestStep) {
+func addTestStepsAwsOrganizationsOrganization_EnabledPolicyTypes(policyTypes *[]string) *[]resource.TestStep {
 	resourceName := "aws_organizations_organization.test"
 	var organization organizations.Organization
-	newSteps := *testSteps
-	
-	*testSteps = append(newSteps, []resource.TestStep{
-		{
-			Config: testAccAwsOrganizationsOrganizationConfigEnabledPolicyTypes1(policyType),
-			Check: resource.ComposeTestCheckFunc(
-				testAccCheckAwsOrganizationsOrganizationExists(resourceName, &organization),
-				resource.TestCheckResourceAttr(resourceName, "enabled_policy_types.#", "1"),
-			),
-		},
-		{
-			ResourceName:      resourceName,
-			ImportState:       true,
-			ImportStateVerify: true,
-		},
-		{
-			Config: testAccAwsOrganizationsOrganizationConfig,
-			Check: resource.ComposeTestCheckFunc(
-				testAccCheckAwsOrganizationsOrganizationExists(resourceName, &organization),
-				resource.TestCheckResourceAttr(resourceName, "enabled_policy_types.#", "0"),
-			),
-		},
-		{
-			Config: testAccAwsOrganizationsOrganizationConfigEnabledPolicyTypes1(policyType),
-			Check: resource.ComposeTestCheckFunc(
-				testAccCheckAwsOrganizationsOrganizationExists(resourceName, &organization),
-				resource.TestCheckResourceAttr(resourceName, "enabled_policy_types.#", "1"),
-			),
-		},
-	})
+	var testSteps []resource.TestStep
+
+	for _, policyType := range *policyTypes {
+		testSteps = append(testSteps, []resource.TestStep{
+			{
+				Config: testAccAwsOrganizationsOrganizationConfigEnabledPolicyTypes1(policyType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsOrganizationsOrganizationExists(resourceName, &organization),
+					resource.TestCheckResourceAttr(resourceName, "enabled_policy_types.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAwsOrganizationsOrganizationConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsOrganizationsOrganizationExists(resourceName, &organization),
+					resource.TestCheckResourceAttr(resourceName, "enabled_policy_types.#", "0"),
+				),
+			},
+			{
+				Config: testAccAwsOrganizationsOrganizationConfigEnabledPolicyTypes1(policyType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsOrganizationsOrganizationExists(resourceName, &organization),
+					resource.TestCheckResourceAttr(resourceName, "enabled_policy_types.#", "1"),
+				),
+			},
+		}...)
+	}
+	return &testSteps
 }
 
 func testAccAwsOrganizationsOrganization_EnabledPolicyTypes(t *testing.T) {	
-	var testSteps []resource.TestStep
-
-	addTestStepsAwsOrganizationsOrganization_EnabledPolicyTypes(organizations.PolicyTypeServiceControlPolicy, &testSteps)
-	addTestStepsAwsOrganizationsOrganization_EnabledPolicyTypes(organizations.PolicyTypeTagPolicy, &testSteps)
+	policyTypes := []string{organizations.PolicyTypeServiceControlPolicy, organizations.PolicyTypeTagPolicy}
+	testSteps := *addTestStepsAwsOrganizationsOrganization_EnabledPolicyTypes(&policyTypes)
 	
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },

--- a/website/docs/r/ami_launch_permission.html.markdown
+++ b/website/docs/r/ami_launch_permission.html.markdown
@@ -32,11 +32,10 @@ In addition to all arguments above, the following attributes are exported:
 
   * `id` - A combination of "`image_id`-`account_id`".
 
-
 ## Import
 
 AWS AMI Launch Permission can be imported using the `ACCOUNT-ID/IMAGE-ID`, e.g.
 
 ```sh
-$ terraform import aws_ami_launch_permission.perm 12345abcde/example
+$ terraform import aws_ami_launch_permission.example 123456789012/ami-12345678
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

This will allow support of tag policies (https://aws.amazon.com/about-aws/whats-new/2019/11/aws-launches-tag-policies/) to be enabled. 

The change allows the keyword "TAG_POLICY" to be used in enabled_policy_types list for the aws_organizations_organization resource. Tests for policy types are slightly changed to allow for more flexible use and tests for the new value is added. 

Related feature requests #11202 and #11032

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
