### PR TITLE
Remove deprecated `nodejs8.10` Lambda function runtime from tests

### DIFF
--- a/aws/data_source_aws_lambda_function_test.go
+++ b/aws/data_source_aws_lambda_function_test.go
@@ -221,7 +221,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = "${aws_iam_role.lambda.arn}"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 data "aws_lambda_function" "test" {
@@ -238,7 +238,7 @@ resource "aws_lambda_function" "test" {
   handler       = "exports.example"
   publish       = true
   role          = "${aws_iam_role.lambda.arn}"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 data "aws_lambda_function" "test" {
@@ -256,7 +256,7 @@ resource "aws_lambda_function" "test" {
   handler       = "exports.example"
   publish       = true
   role          = "${aws_iam_role.lambda.arn}"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_lambda_alias" "test" {
@@ -277,7 +277,7 @@ func testAccDataSourceAWSLambdaFunctionConfigLayers(rName string) string {
 resource "aws_lambda_layer_version" "test" {
   filename            = "test-fixtures/lambdatest.zip"
   layer_name          = %[1]q
-  compatible_runtimes = ["nodejs8.10"]
+  compatible_runtimes = ["nodejs12.x"]
 }
 
 resource "aws_lambda_function" "test" {
@@ -286,7 +286,7 @@ resource "aws_lambda_function" "test" {
   handler       = "exports.example"
   layers        = ["${aws_lambda_layer_version.test.arn}"]
   role          = "${aws_iam_role.lambda.arn}"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 data "aws_lambda_function" "test" {
@@ -339,7 +339,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = "${aws_iam_role.lambda.arn}"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 
   vpc_config {
     security_group_ids = ["${aws_security_group.test.id}"]
@@ -360,7 +360,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = "${aws_iam_role.lambda.arn}"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 
   environment {
     variables = {

--- a/aws/data_source_aws_lambda_invocation_test.go
+++ b/aws/data_source_aws_lambda_invocation_test.go
@@ -131,7 +131,7 @@ resource "aws_lambda_function" "lambda" {
   function_name = "%s"
   role          = "${aws_iam_role.lambda_role.arn}"
   handler       = "lambda_invocation.handler"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 
   environment {
     variables = {
@@ -162,7 +162,7 @@ resource "aws_lambda_function" "lambda" {
   function_name = "%s"
   role          = "${aws_iam_role.lambda_role.arn}"
   handler       = "lambda_invocation.handler"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
   publish       = true
 
   environment {
@@ -195,7 +195,7 @@ resource "aws_lambda_function" "lambda" {
   function_name = "%s"
   role          = "${aws_iam_role.lambda_role.arn}"
   handler       = "lambda_invocation.handler"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
   publish       = true
 
   environment {

--- a/aws/data_source_aws_lambda_layer_version_test.go
+++ b/aws/data_source_aws_lambda_layer_version_test.go
@@ -81,7 +81,7 @@ func testAccDataSourceAWSLambdaLayerVersionConfigBasic(rName string) string {
 resource "aws_lambda_layer_version" "test" {
   filename            = "test-fixtures/lambdatest.zip"
   layer_name          = %[1]q
-  compatible_runtimes = ["nodejs8.10"]
+  compatible_runtimes = ["nodejs12.x"]
 }
 
 data "aws_lambda_layer_version" "test" {
@@ -95,13 +95,13 @@ func testAccDataSourceAWSLambdaLayerVersionConfigVersion(rName string) string {
 resource "aws_lambda_layer_version" "test" {
   filename            = "test-fixtures/lambdatest.zip"
   layer_name          = %[1]q
-  compatible_runtimes = ["nodejs8.10"]
+  compatible_runtimes = ["nodejs12.x"]
 }
 
 resource "aws_lambda_layer_version" "test_two" {
   filename            = "test-fixtures/lambdatest_modified.zip"
   layer_name          = %[1]q
-  compatible_runtimes = ["nodejs8.10"]
+  compatible_runtimes = ["nodejs12.x"]
 }
 
 data "aws_lambda_layer_version" "test" {
@@ -122,7 +122,7 @@ resource "aws_lambda_layer_version" "test" {
 resource "aws_lambda_layer_version" "test_two" {
   filename            = "test-fixtures/lambdatest_modified.zip"
   layer_name          = "${aws_lambda_layer_version.test.layer_name}"
-  compatible_runtimes = ["nodejs8.10"]
+  compatible_runtimes = ["nodejs12.x"]
 }
 
 data "aws_lambda_layer_version" "test" {

--- a/aws/resource_aws_api_gateway_authorizer_test.go
+++ b/aws/resource_aws_api_gateway_authorizer_test.go
@@ -537,7 +537,7 @@ resource "aws_lambda_function" "authorizer" {
   function_name    = "%s"
   role             = "${aws_iam_role.iam_for_lambda.arn}"
   handler          = "exports.example"
-  runtime          = "nodejs8.10"
+  runtime          = "nodejs12.x"
 }
 `, apiGatewayName, apiGatewayName, apiGatewayName, lambdaName)
 }

--- a/aws/resource_aws_api_gateway_method_test.go
+++ b/aws/resource_aws_api_gateway_method_test.go
@@ -387,7 +387,7 @@ resource "aws_lambda_function" "authorizer" {
   function_name    = "tf_acc_api_gateway_authorizer_%d"
   role             = "${aws_iam_role.iam_for_lambda.arn}"
   handler          = "exports.example"
-  runtime          = "nodejs8.10"
+  runtime          = "nodejs12.x"
 }
 
 resource "aws_api_gateway_authorizer" "test" {

--- a/aws/resource_aws_appsync_datasource_test.go
+++ b/aws/resource_aws_appsync_datasource_test.go
@@ -577,7 +577,7 @@ resource "aws_lambda_function" "test" {
   function_name = %q
   handler       = "exports.test"
   role          = "${aws_iam_role.lambda.arn}"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_iam_role" "test" {

--- a/aws/resource_aws_cloudtrail_test.go
+++ b/aws/resource_aws_cloudtrail_test.go
@@ -1399,7 +1399,7 @@ resource "aws_lambda_function" "lambda_function_test" {
   function_name = "tf-test-trail-event-select-%d"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
   handler       = "exports.example"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 `, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
 }

--- a/aws/resource_aws_cloudwatch_event_target_test.go
+++ b/aws/resource_aws_cloudwatch_event_target_test.go
@@ -1087,7 +1087,7 @@ resource "aws_lambda_function" "lambda" {
   source_code_hash = "${filebase64sha256("test-fixtures/lambdatest.zip")}"
   role             = "${aws_iam_role.iam_for_lambda.arn}"
   handler          = "exports.example"
-  runtime          = "nodejs8.10"
+  runtime          = "nodejs12.x"
 }
 
 resource "aws_cloudwatch_event_rule" "schedule" {

--- a/aws/resource_aws_cloudwatch_log_subscription_filter_test.go
+++ b/aws/resource_aws_cloudwatch_log_subscription_filter_test.go
@@ -544,7 +544,7 @@ resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = %[1]q
   role          = "${aws_iam_role.test.arn}"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
   handler       = "exports.handler"
 }
 

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -1139,7 +1139,7 @@ resource "aws_lambda_function" "test" {
   function_name = "%[1]s"
   role          = "${aws_iam_role.test.arn}"
   handler       = "exports.example"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_cognito_user_pool" "test" {
@@ -1188,7 +1188,7 @@ resource "aws_lambda_function" "test" {
   function_name = "%[1]s"
   role          = "${aws_iam_role.test.arn}"
   handler       = "exports.example"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_lambda_function" "second" {
@@ -1196,7 +1196,7 @@ resource "aws_lambda_function" "second" {
   function_name = "%[1]s_second"
   role          = "${aws_iam_role.test.arn}"
   handler       = "exports.example"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_cognito_user_pool" "test" {

--- a/aws/resource_aws_config_config_rule_test.go
+++ b/aws/resource_aws_config_config_rule_test.go
@@ -461,7 +461,7 @@ resource "aws_lambda_function" "f" {
   function_name = "tf_acc_lambda_awsconfig_%d"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
   handler       = "exports.example"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_lambda_permission" "p" {

--- a/aws/resource_aws_config_organization_custom_rule_test.go
+++ b/aws/resource_aws_config_organization_custom_rule_test.go
@@ -559,7 +559,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = "${aws_iam_role.lambda.arn}"
   handler       = "exports.example"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_lambda_permission" "test" {
@@ -623,7 +623,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = "${aws_iam_role.lambda.arn}"
   handler       = "exports.example"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_organizations_organization" "test" {
@@ -702,7 +702,7 @@ resource "aws_lambda_function" "test2" {
   function_name = "%[1]s2"
   role          = "${aws_iam_role.lambda.arn}"
   handler       = "exports.example"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_lambda_permission" "test2" {

--- a/aws/resource_aws_kinesis_analytics_application_test.go
+++ b/aws/resource_aws_kinesis_analytics_application_test.go
@@ -785,7 +785,7 @@ resource "aws_lambda_function" "test" {
   function_name = "testAcc-%d"
   handler       = "exports.example"
   role          = "${aws_iam_role.lambda.arn}"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "test" {
@@ -1053,7 +1053,7 @@ resource "aws_lambda_function" "test" {
   function_name = "tf-acc-test-%d"
   handler       = "exports.example"
   role          = "${aws_iam_role.lambda_function.arn}"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_kinesis_analytics_application" "test" {

--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -1314,7 +1314,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs8.10"
+    runtime = "nodejs12.x"
 }
 `, funcName)
 }

--- a/aws/resource_aws_lambda_alias_test.go
+++ b/aws/resource_aws_lambda_alias_test.go
@@ -274,7 +274,7 @@ resource "aws_lambda_function" "lambda_function_test_create" {
   function_name    = "%s"
   role             = "${aws_iam_role.iam_for_lambda.arn}"
   handler          = "exports.example"
-  runtime          = "nodejs8.10"
+  runtime          = "nodejs12.x"
   source_code_hash = "${filebase64sha256("test-fixtures/lambdatest.zip")}"
   publish          = "true"
 }
@@ -342,7 +342,7 @@ resource "aws_lambda_function" "lambda_function_test_create" {
   function_name    = "%s"
   role             = "${aws_iam_role.iam_for_lambda.arn}"
   handler          = "exports.example"
-  runtime          = "nodejs8.10"
+  runtime          = "nodejs12.x"
   source_code_hash = "${filebase64sha256("test-fixtures/lambdatest_modified.zip")}"
   publish          = "true"
 }

--- a/aws/resource_aws_lambda_event_source_mapping_test.go
+++ b/aws/resource_aws_lambda_event_source_mapping_test.go
@@ -575,7 +575,7 @@ resource "aws_lambda_function" "test" {
   function_name = %q
   handler       = "exports.example"
   role          = "${aws_iam_role.test.arn}"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 `, rName, rName, rName)
 }
@@ -675,7 +675,7 @@ resource "aws_lambda_function" "lambda_function_test_create" {
   function_name = "%s"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
   handler       = "exports.example"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_lambda_function" "lambda_function_test_update" {
@@ -683,7 +683,7 @@ resource "aws_lambda_function" "lambda_function_test_update" {
   function_name = "%s"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
   handler       = "exports.example"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_lambda_event_source_mapping" "lambda_event_source_mapping_test" {
@@ -766,7 +766,7 @@ resource "aws_lambda_function" "lambda_function_test_create" {
   function_name = "%s"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
   handler       = "exports.example"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_lambda_function" "lambda_function_test_update" {
@@ -774,7 +774,7 @@ resource "aws_lambda_function" "lambda_function_test_update" {
   function_name = "%s"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
   handler       = "exports.example"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_lambda_event_source_mapping" "lambda_event_source_mapping_test" {
@@ -857,7 +857,7 @@ resource "aws_lambda_function" "lambda_function_test_create" {
   function_name = "%s"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
   handler       = "exports.example"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_lambda_function" "lambda_function_test_update" {
@@ -865,7 +865,7 @@ resource "aws_lambda_function" "lambda_function_test_update" {
   function_name = "%s"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
   handler       = "exports.example"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_lambda_event_source_mapping" "lambda_event_source_mapping_test" {
@@ -938,7 +938,7 @@ resource "aws_lambda_function" "lambda_function_test_create" {
   function_name = "%s"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
   handler       = "exports.example"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_lambda_function" "lambda_function_test_update" {
@@ -946,7 +946,7 @@ resource "aws_lambda_function" "lambda_function_test_update" {
   function_name = "%s"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
   handler       = "exports.example"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_lambda_event_source_mapping" "lambda_event_source_mapping_test" {
@@ -1019,7 +1019,7 @@ resource "aws_lambda_function" "lambda_function_test_create" {
   function_name = "%s"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
   handler       = "exports.example"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_lambda_function" "lambda_function_test_update" {
@@ -1027,7 +1027,7 @@ resource "aws_lambda_function" "lambda_function_test_update" {
   function_name = "%s"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
   handler       = "exports.example"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_lambda_event_source_mapping" "lambda_event_source_mapping_test" {
@@ -1098,7 +1098,7 @@ resource "aws_lambda_function" "lambda_function_test_create" {
   function_name = "%[5]s"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
   handler       = "exports.example"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_lambda_event_source_mapping" "lambda_event_source_mapping_test" {

--- a/aws/resource_aws_lambda_function_event_invoke_config_test.go
+++ b/aws/resource_aws_lambda_function_event_invoke_config_test.go
@@ -556,7 +556,7 @@ resource "aws_lambda_function" "test" {
   role          = aws_iam_role.test.arn
   handler       = "lambdapinpoint.handler"
   publish       = true
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 
   depends_on = [
     aws_iam_role_policy_attachment.test,

--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -234,7 +234,7 @@ func TestAccAWSLambdaFunction_updateRuntime(t *testing.T) {
 				Config: testAccAWSLambdaConfigBasic(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
-					resource.TestCheckResourceAttr(resourceName, "runtime", "nodejs8.10"),
+					resource.TestCheckResourceAttr(resourceName, "runtime", "nodejs12.x"),
 				),
 			},
 			{
@@ -1274,38 +1274,6 @@ func TestAccAWSLambdaFunction_runtimeValidation_noRuntime(t *testing.T) {
 	})
 }
 
-func TestAccAWSLambdaFunction_runtimeValidation_NodeJs810(t *testing.T) {
-	var conf lambda.GetFunctionOutput
-
-	rString := acctest.RandString(8)
-	resourceName := "aws_lambda_function.test"
-	funcName := fmt.Sprintf("tf_acc_lambda_func_runtime_valid_nodejs810_%s", rString)
-	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_runtime_valid_nodejs810_%s", rString)
-	roleName := fmt.Sprintf("tf_acc_role_lambda_func_runtime_valid_nodejs810_%s", rString)
-	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_runtime_valid_nodejs810_%s", rString)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLambdaFunctionDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSLambdaConfigNodeJs810Runtime(funcName, policyName, roleName, sgName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
-					resource.TestCheckResourceAttr(resourceName, "runtime", lambda.RuntimeNodejs810),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"filename", "publish"},
-			},
-		},
-	})
-}
-
 func TestAccAWSLambdaFunction_runtimeValidation_NodeJs10x(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
@@ -1997,7 +1965,7 @@ resource "aws_lambda_function" "test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs8.10"
+    runtime = "nodejs12.x"
 }
 `, funcName)
 }
@@ -2009,7 +1977,7 @@ resource "aws_lambda_function" "test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs8.10"
+    runtime = "nodejs12.x"
     reserved_concurrent_executions = 111
 }
 `, funcName)
@@ -2022,7 +1990,7 @@ resource "aws_lambda_function" "test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs8.10"
+    runtime = "nodejs12.x"
     reserved_concurrent_executions = 222
 }
 `, funcName)
@@ -2046,7 +2014,7 @@ resource "aws_lambda_function" "test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-		runtime = "nodejs8.10"
+		runtime = "nodejs12.x"
 }
 `, funcName)
 }
@@ -2058,7 +2026,7 @@ resource "aws_lambda_function" "test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs8.10"
+    runtime = "nodejs12.x"
     environment {
         variables = {
             foo = "bar"
@@ -2075,7 +2043,7 @@ resource "aws_lambda_function" "test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs8.10"
+    runtime = "nodejs12.x"
     environment {
         variables = {
             foo = "baz"
@@ -2093,7 +2061,7 @@ resource "aws_lambda_function" "test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs8.10"
+    runtime = "nodejs12.x"
 }
 `, funcName)
 }
@@ -2127,7 +2095,7 @@ resource "aws_lambda_function" "test" {
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
     kms_key_arn = "${aws_kms_key.foo.arn}"
-    runtime = "nodejs8.10"
+    runtime = "nodejs12.x"
     environment {
         variables = {
             foo = "bar"
@@ -2165,7 +2133,7 @@ resource "aws_lambda_function" "test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs8.10"
+    runtime = "nodejs12.x"
     environment {
         variables = {
             foo = "bar"
@@ -2183,7 +2151,7 @@ resource "aws_lambda_function" "test" {
     publish = true
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs8.10"
+    runtime = "nodejs12.x"
 }
 `, fileName, funcName)
 }
@@ -2255,7 +2223,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = "${aws_iam_role.test.arn}"
   handler       = "exports.example"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 
   vpc_config {
     subnet_ids         = ["${aws_subnet.test.id}"]
@@ -2272,7 +2240,7 @@ resource "aws_lambda_function" "test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs8.10"
+    runtime = "nodejs12.x"
 
     tracing_config {
         mode = "Active"
@@ -2288,7 +2256,7 @@ resource "aws_lambda_function" "test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs8.10"
+    runtime = "nodejs12.x"
 
     tracing_config {
         mode = "PassThrough"
@@ -2304,7 +2272,7 @@ resource "aws_lambda_function" "test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs8.10"
+    runtime = "nodejs12.x"
 
     dead_letter_config {
         target_arn = "${aws_sns_topic.test.arn}"
@@ -2325,7 +2293,7 @@ resource "aws_lambda_function" "test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs8.10"
+    runtime = "nodejs12.x"
 
     dead_letter_config {
         target_arn = "${aws_sns_topic.test_2.arn}"
@@ -2349,7 +2317,7 @@ resource "aws_lambda_function" "test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs8.10"
+    runtime = "nodejs12.x"
 
     dead_letter_config {
         target_arn = ""
@@ -2389,7 +2357,7 @@ resource "aws_lambda_function" "test" {
   handler       = "exports.example"
   kms_key_arn   = "${aws_kms_key.test.arn}"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 `, rName)
 }
@@ -2399,7 +2367,7 @@ func testAccAWSLambdaConfigWithLayers(funcName, layerName, policyName, roleName,
 resource "aws_lambda_layer_version" "test" {
     filename = "test-fixtures/lambdatest.zip"
     layer_name = "%s"
-    compatible_runtimes = ["nodejs8.10"]
+    compatible_runtimes = ["nodejs12.x"]
 }
 
 resource "aws_lambda_function" "test" {
@@ -2407,7 +2375,7 @@ resource "aws_lambda_function" "test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs8.10"
+    runtime = "nodejs12.x"
     layers = ["${aws_lambda_layer_version.test.arn}"]
 }
 `, layerName, funcName)
@@ -2418,13 +2386,13 @@ func testAccAWSLambdaConfigWithLayersUpdated(funcName, layerName, layer2Name, po
 resource "aws_lambda_layer_version" "test" {
     filename = "test-fixtures/lambdatest.zip"
     layer_name = "%s"
-    compatible_runtimes = ["nodejs8.10"]
+    compatible_runtimes = ["nodejs12.x"]
 }
 
 resource "aws_lambda_layer_version" "test_2" {
     filename = "test-fixtures/lambdatest_modified.zip"
     layer_name = "%s"
-    compatible_runtimes = ["nodejs8.10"]
+    compatible_runtimes = ["nodejs12.x"]
 }
 
 resource "aws_lambda_function" "test" {
@@ -2432,7 +2400,7 @@ resource "aws_lambda_function" "test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs8.10"
+    runtime = "nodejs12.x"
     layers = [
         "${aws_lambda_layer_version.test.arn}",
         "${aws_lambda_layer_version.test_2.arn}",
@@ -2448,7 +2416,7 @@ resource "aws_lambda_function" "test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs8.10"
+    runtime = "nodejs12.x"
 
     vpc_config {
         subnet_ids = ["${aws_subnet.subnet_for_lambda.id}"]
@@ -2465,7 +2433,7 @@ resource "aws_lambda_function" "test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs8.10"
+    runtime = "nodejs12.x"
 
     vpc_config {
         subnet_ids = ["${aws_subnet.subnet_for_lambda.id}", "${aws_subnet.subnet_for_lambda_2.id}"]
@@ -2511,7 +2479,7 @@ resource "aws_lambda_function" "test" {
     function_name = "%s"
     role          = "${aws_iam_role.iam_for_lambda.arn}"
     handler       = "exports.example"
-    runtime       = "nodejs8.10"
+    runtime       = "nodejs12.x"
 
     vpc_config {
         subnet_ids         = []
@@ -2559,7 +2527,7 @@ resource "aws_lambda_function" "test" {
   function_name = "%s"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
   handler       = "exports.example"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 `, bucketName, roleName, funcName)
 }
@@ -2582,7 +2550,7 @@ resource "aws_lambda_function" "test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs8.10"
+    runtime = "nodejs12.x"
 }
 `, funcName)
 }
@@ -2654,7 +2622,7 @@ resource "aws_lambda_function" "test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs8.10"
+    runtime = "nodejs12.x"
   tags = {
 		Key1 = "Value One"
 		Description = "Very interesting"
@@ -2670,7 +2638,7 @@ resource "aws_lambda_function" "test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs8.10"
+    runtime = "nodejs12.x"
   tags = {
 		Key1 = "Value One Changed"
 		Key2 = "Value Two"
@@ -2768,7 +2736,7 @@ resource "aws_lambda_function" "test" {
   function_name    = "%s"
   role             = "${aws_iam_role.iam_for_lambda.arn}"
   handler          = "exports.example"
-  runtime          = "nodejs8.10"
+  runtime          = "nodejs12.x"
 }
 `, roleName, filePath, filePath, funcName)
 }
@@ -2804,7 +2772,7 @@ resource "aws_lambda_function" "test" {
   function_name = "%s"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
   handler       = "exports.example"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 `, roleName, filePath, funcName)
 }
@@ -2855,7 +2823,7 @@ resource "aws_lambda_function" "test" {
   function_name     = "%s"
   role              = "${aws_iam_role.iam_for_lambda.arn}"
   handler           = "exports.example"
-  runtime           = "nodejs8.10"
+  runtime           = "nodejs12.x"
 }
 `, bucketName, key, path, path, roleName, funcName)
 }
@@ -2901,7 +2869,7 @@ resource "aws_lambda_function" "test" {
   function_name = "%s"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
   handler       = "exports.example"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 `, bucketName, key, path, path, roleName, funcName)
 }

--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -2543,18 +2543,6 @@ resource "aws_lambda_function" "test" {
 `, funcName)
 }
 
-func testAccAWSLambdaConfigNodeJs810Runtime(funcName, policyName, roleName, sgName string) string {
-	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
-resource "aws_lambda_function" "test" {
-    filename = "test-fixtures/lambdatest.zip"
-    function_name = "%s"
-    role = "${aws_iam_role.iam_for_lambda.arn}"
-    handler = "exports.example"
-    runtime = "nodejs12.x"
-}
-`, funcName)
-}
-
 func testAccAWSLambdaConfigNodeJs10xRuntime(funcName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "test" {

--- a/aws/resource_aws_lambda_layer_version_test.go
+++ b/aws/resource_aws_lambda_layer_version_test.go
@@ -345,7 +345,7 @@ resource "aws_lambda_layer_version" "lambda_layer_test" {
   filename   = "test-fixtures/lambdatest.zip"
   layer_name = "%s"
 
-  compatible_runtimes = ["nodejs8.10", "nodejs10.x"]
+  compatible_runtimes = ["nodejs12.x", "nodejs10.x"]
 }
 `, layerName)
 }

--- a/aws/resource_aws_lambda_permission_test.go
+++ b/aws/resource_aws_lambda_permission_test.go
@@ -653,7 +653,7 @@ resource "aws_lambda_function" "test_lambda" {
   function_name = "%s"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
   handler       = "exports.handler"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
@@ -701,7 +701,7 @@ resource "aws_lambda_function" "test" {
   function_name = %q
   handler       = "exports.handler"
   role          = "${aws_iam_role.test.arn}"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_iam_role" "test" {
@@ -740,7 +740,7 @@ resource "aws_lambda_function" "test_lambda" {
   function_name = "%s"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
   handler       = "exports.handler"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
@@ -779,7 +779,7 @@ resource "aws_lambda_function" "test_lambda" {
   function_name = "lambda_function_name_perm"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
   handler       = "exports.handler"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
@@ -828,7 +828,7 @@ resource "aws_lambda_function" "test_lambda" {
   function_name = "%s"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
   handler       = "exports.handler"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
@@ -874,7 +874,7 @@ resource "aws_lambda_function" "test_lambda" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.handler"
-    runtime = "nodejs8.10"
+    runtime = "nodejs12.x"
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
@@ -934,7 +934,7 @@ resource "aws_lambda_function" "my-func" {
   function_name = "%s"
   role          = "${aws_iam_role.police.arn}"
   handler       = "exports.handler"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_iam_role" "police" {
@@ -984,7 +984,7 @@ resource "aws_lambda_function" "my-func" {
   function_name = "%s"
   role          = "${aws_iam_role.police.arn}"
   handler       = "exports.handler"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_iam_role" "police" {
@@ -1023,7 +1023,7 @@ resource "aws_lambda_function" "my-func" {
   function_name = "%s"
   role          = "${aws_iam_role.police.arn}"
   handler       = "exports.handler"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_iam_role" "police" {

--- a/aws/resource_aws_lambda_provisioned_concurrency_config_test.go
+++ b/aws/resource_aws_lambda_provisioned_concurrency_config_test.go
@@ -287,7 +287,7 @@ resource "aws_lambda_function" "test" {
   role          = aws_iam_role.test.arn
   handler       = "lambdapinpoint.handler"
   publish       = true
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 
   depends_on = [aws_iam_role_policy_attachment.test]
 }

--- a/aws/resource_aws_pinpoint_app_test.go
+++ b/aws/resource_aws_pinpoint_app_test.go
@@ -242,7 +242,7 @@ resource "aws_lambda_function" "test" {
   function_name = "%s"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
   handler       = "lambdapinpoint.handler"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
   publish       = true
 }
 

--- a/aws/resource_aws_s3_bucket_notification_test.go
+++ b/aws/resource_aws_s3_bucket_notification_test.go
@@ -612,7 +612,7 @@ resource "aws_lambda_function" "func" {
   function_name = %[1]q
   role          = "${aws_iam_role.iam_for_lambda.arn}"
   handler       = "exports.example"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_s3_bucket" "bucket" {
@@ -651,7 +651,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = "${aws_iam_role.test.arn}"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_lambda_alias" "test" {

--- a/aws/resource_aws_secretsmanager_secret_test.go
+++ b/aws/resource_aws_secretsmanager_secret_test.go
@@ -594,7 +594,7 @@ resource "aws_lambda_function" "test1" {
   function_name = "%[1]s-1"
   handler       = "exports.example"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_lambda_permission" "test1" {
@@ -610,7 +610,7 @@ resource "aws_lambda_function" "test2" {
   function_name = "%[1]s-2"
   handler       = "exports.example"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_lambda_permission" "test2" {
@@ -637,7 +637,7 @@ resource "aws_lambda_function" "test" {
   function_name = "%[1]s"
   handler       = "exports.example"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_lambda_permission" "test" {

--- a/aws/resource_aws_sfn_state_machine_test.go
+++ b/aws/resource_aws_sfn_state_machine_test.go
@@ -225,7 +225,7 @@ resource "aws_lambda_function" "lambda_function_test" {
   function_name = "sfn-%s"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
   handler       = "exports.example"
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs12.x"
 }
 
 resource "aws_sfn_state_machine" "foo" {
@@ -343,7 +343,7 @@ resource "aws_lambda_function" "lambda_function_test" {
   function_name = "sfn-%s"
   role = "${aws_iam_role.iam_for_lambda.arn}"
   handler = "exports.example"
-  runtime = "nodejs8.10"
+  runtime = "nodejs12.x"
 }
 
 resource "aws_sfn_state_machine" "foo" {
@@ -464,7 +464,7 @@ resource "aws_lambda_function" "lambda_function_test" {
   function_name = "sfn-%s"
   role = "${aws_iam_role.iam_for_lambda.arn}"
   handler = "exports.example"
-  runtime = "nodejs8.10"
+  runtime = "nodejs12.x"
 }
 
 resource "aws_sfn_state_machine" "foo" {

--- a/aws/resource_aws_sns_topic_subscription_test.go
+++ b/aws/resource_aws_sns_topic_subscription_test.go
@@ -759,7 +759,7 @@ resource "aws_lambda_function" "authorizer" {
   function_name    = "tf-acc-test-authorizer-%d"
   role             = "${aws_iam_role.iam_for_lambda.arn}"
   handler          = "main.authenticate"
-  runtime          = "nodejs8.10"
+  runtime          = "nodejs12.x"
 
   environment {
     variables = {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Details: https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
None
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSLambdaFunction'
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_noRuntime (3.10s)
--- PASS: TestAccAWSLambdaFunction_s3 (46.77s)
--- PASS: TestAccAWSLambdaFunction_EmptyVpcConfig (49.72s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_NodeJs10x (57.02s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_NodeJs12x (64.60s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python27 (71.44s)
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (72.24s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python38 (75.67s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_provided (82.91s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_java8 (90.23s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python36 (101.71s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_ruby25 (108.60s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python37 (127.48s)
--- PASS: TestAccAWSLambdaFunction_expectFilenameAndS3Attributes (25.31s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_java11 (134.50s)
--- PASS: TestAccAWSLambdaFunction_tags (137.61s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_basic (138.77s)
--- PASS: TestAccAWSLambdaFunction_updateRuntime (141.91s)
--- PASS: TestAccAWSLambdaFunction_localUpdate (302.09s)
--- PASS: TestAccAWSLambdaFunction_Layers (540.54s)
--- PASS: TestAccAWSLambdaFunction_KmsKeyArn_NoEnvironmentVariables (543.29s)
--- PASS: TestAccAWSLambdaFunction_versioned (535.59s)
--- PASS: TestAccAWSLambdaFunction_LayersUpdate (555.40s)
--- PASS: TestAccAWSLambdaFunction_tracingConfig (566.73s)
--- PASS: TestAccAWSLambdaFunction_nilDeadLetterConfig (510.79s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_MaximumEventAgeInSeconds (536.13s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_MaximumRetryAttempts (561.40s)
--- PASS: TestAccAWSLambdaFunction_encryptedEnvVariables (584.60s)
--- PASS: TestAccAWSLambdaFunction_concurrency (545.73s)
--- PASS: TestAccAWSLambdaFunction_concurrencyCycle (560.73s)
--- PASS: TestAccAWSLambdaFunction_basic (74.07s)
--- PASS: TestAccAWSLambdaFunction_versionedUpdate (555.71s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_Qualifier_Latest (48.27s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfigUpdated (397.26s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfig (97.63s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_FunctionName_Arn (42.99s)
--- PASS: TestAccAWSLambdaFunction_s3Update_basic (73.03s)
--- PASS: TestAccAWSLambdaFunction_envVariables (613.83s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_disappears_LambdaFunctionEventInvokeConfig (39.76s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_DestinationConfig_Remove (597.08s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_disappears_LambdaFunction (48.85s)
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (74.44s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_DestinationConfig_OnFailure_Destination (76.16s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_Qualifier_AliasName (59.28s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_DestinationConfig_OnSuccess_Destination (75.75s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_DestinationConfig_Swap (73.28s)
--- PASS: TestAccAWSLambdaFunction_disappears (320.48s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_Qualifier_FunctionVersion (330.09s)
--- PASS: TestAccAWSLambdaFunction_VpcConfig_ProperIamDependencies (1269.51s)
--- PASS: TestAccAWSLambdaFunction_VPC_withInvocation (1430.01s)
--- PASS: TestAccAWSLambdaFunction_VPC (1554.30s)
--- PASS: TestAccAWSLambdaFunction_VPCUpdate (1616.71s)
--- PASS: TestAccAWSLambdaFunction_VPCRemoval (1782.75s)
```
