### PR TITLE
iam_role a resource not data?

### DIFF
--- a/website/docs/d/iam_role.html.markdown
+++ b/website/docs/d/iam_role.html.markdown
@@ -15,7 +15,7 @@ properties without having to hard code ARNs as input.
 ## Example Usage
 
 ```hcl
-data "aws_iam_role" "example" {
+resource "aws_iam_role" "example" {
   name = "an_example_role_name"
 }
 ```


### PR DESCRIPTION
I was implementing an instance of `aws_iam_role` with an `assume_role_policy` field included as a string such as the following:
```
resource "aws_iam_role" "my_machine_role" {
  name               = "${var.env_name}-machine-role"
  assume_role_policy = <<EOF
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Action": "sts:AssumeRole",
      "Principal": {
        "Service": [
          "cloudtrail.amazonaws.com",
          "ec2.amazonaws.com"
        ]
      },
      "Effect": "Allow",
      "Sid": ""
    }
  ]
}
EOF
}
```
I received an error stating that `this field cannot be set` pointing specifically to `iam_role_policy`. Following many blogged examples online I changed this block type from `data` to `resource` and now this worked for me. Hence the PR.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
