### PR TITLE
Update available Autoscaling metrics

### DIFF
--- a/aws/resource_aws_autoscaling_group_test.go
+++ b/aws/resource_aws_autoscaling_group_test.go
@@ -682,7 +682,7 @@ func TestAccAWSAutoScalingGroup_withMetrics(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAutoScalingGroupExists("aws_autoscaling_group.bar", &group),
 					resource.TestCheckResourceAttr(
-						"aws_autoscaling_group.bar", "enabled_metrics.#", "7"),
+						"aws_autoscaling_group.bar", "enabled_metrics.#", "13"),
 				),
 			},
 			{
@@ -704,7 +704,7 @@ func TestAccAWSAutoScalingGroup_withMetrics(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAutoScalingGroupExists("aws_autoscaling_group.bar", &group),
 					resource.TestCheckResourceAttr(
-						"aws_autoscaling_group.bar", "enabled_metrics.#", "5"),
+						"aws_autoscaling_group.bar", "enabled_metrics.#", "13"),
 				),
 			},
 		},

--- a/aws/resource_aws_autoscaling_group_test.go
+++ b/aws/resource_aws_autoscaling_group_test.go
@@ -2739,7 +2739,13 @@ resource "aws_autoscaling_group" "bar" {
   	     "GroupDesiredCapacity",
   	     "GroupInServiceInstances",
   	     "GroupMinSize",
-  	     "GroupMaxSize"
+  	     "GroupMaxSize",
+  	     "GroupPendingCapacity",
+  	     "GroupInServiceCapacity",
+  	     "GroupStandbyCapacity",
+  	     "GroupTotalCapacity",
+  	     "GroupTerminatingCapacity",
+  	     "GroupStandbyInstances"
   ]
   metrics_granularity = "1Minute"
 }
@@ -2775,7 +2781,15 @@ resource "aws_autoscaling_group" "bar" {
   	     "GroupPendingInstances",
   	     "GroupTerminatingInstances",
   	     "GroupDesiredCapacity",
-  	     "GroupMaxSize"
+  	     "GroupInServiceInstances",
+  	     "GroupMinSize",
+  	     "GroupMaxSize",
+  	     "GroupPendingCapacity",
+  	     "GroupInServiceCapacity",
+  	     "GroupStandbyCapacity",
+  	     "GroupTotalCapacity",
+  	     "GroupTerminatingCapacity",
+  	     "GroupStandbyInstances"
   ]
   metrics_granularity = "1Minute"
 }

--- a/aws/resource_aws_autoscaling_group_test.go
+++ b/aws/resource_aws_autoscaling_group_test.go
@@ -704,7 +704,7 @@ func TestAccAWSAutoScalingGroup_withMetrics(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAutoScalingGroupExists("aws_autoscaling_group.bar", &group),
 					resource.TestCheckResourceAttr(
-						"aws_autoscaling_group.bar", "enabled_metrics.#", "13"),
+						"aws_autoscaling_group.bar", "enabled_metrics.#", "5"),
 				),
 			},
 		},
@@ -2781,15 +2781,7 @@ resource "aws_autoscaling_group" "bar" {
   	     "GroupPendingInstances",
   	     "GroupTerminatingInstances",
   	     "GroupDesiredCapacity",
-  	     "GroupInServiceInstances",
-  	     "GroupMinSize",
-  	     "GroupMaxSize",
-  	     "GroupPendingCapacity",
-  	     "GroupInServiceCapacity",
-  	     "GroupStandbyCapacity",
-  	     "GroupTotalCapacity",
-  	     "GroupTerminatingCapacity",
-  	     "GroupStandbyInstances"
+  	     "GroupMaxSize"
   ]
   metrics_granularity = "1Minute"
 }

--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -214,7 +214,8 @@ Note that if you suspend either the `Launch` or `Terminate` process types, it ca
 * `tags` (Optional) A list of tag blocks (maps). Tags documented below.
 * `placement_group` (Optional) The name of the placement group into which you'll launch your instances, if any.
 * `metrics_granularity` - (Optional) The granularity to associate with the metrics to collect. The only valid value is `1Minute`. Default is `1Minute`.
-* `enabled_metrics` - (Optional) A list of metrics to collect. The allowed values are `GroupMinSize`, `GroupMaxSize`, `GroupDesiredCapacity`, `GroupInServiceInstances`, `GroupPendingInstances`, `GroupStandbyInstances`, `GroupTerminatingInstances`, `GroupTotalInstances`.
+* `enabled_metrics` - (Optional) A list of metrics to collect. The allowed values are `GroupDesiredCapacity`, `GroupInServiceCapacity`, `GroupPendingCapacity`, `GroupMinSize`, `GroupMaxSize`, `GroupInServiceInstances`, `GroupPendingInstances`, `GroupStandbyInstances`, `GroupStandbyCapacity`,
+, `GroupTerminatingCapacity`, `GroupTerminatingInstances`, `GroupTotalCapacity`, `GroupTotalInstances`.
 * `wait_for_capacity_timeout` (Default: "10m") A maximum
   [duration](https://golang.org/pkg/time/#ParseDuration) that Terraform should
   wait for ASG instances to be healthy before timing out.  (See also [Waiting


### PR DESCRIPTION
Autoscaling groups can now provide additional metrics, this PR allows for these new metrics to be enabled.

Documentation is also updated.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
```
resource/aws_autoscaling_group: Allow enabling of all autoscaling group metrics
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSAutoScalingGroup_withMetrics'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAutoScalingGroup_withMetrics -timeout 120m
=== RUN   TestAccAWSAutoScalingGroup_withMetrics
=== PAUSE TestAccAWSAutoScalingGroup_withMetrics
=== CONT  TestAccAWSAutoScalingGroup_withMetrics
--- PASS: TestAccAWSAutoScalingGroup_withMetrics (89.38s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	89.441s

...
```
