### PR TITLE
Support resetting of parameter group values

### DIFF
--- a/aws/resource_aws_db_parameter_group.go
+++ b/aws/resource_aws_db_parameter_group.go
@@ -288,27 +288,36 @@ func resourceAwsDbParameterGroupUpdate(d *schema.ResourceData, meta interface{})
 					return fmt.Errorf("Error modifying DB Parameter Group: %s", err)
 				}
 			}
-			d.SetPartial("parameter")
 		}
 
 		// Reset parameters that have been removed
-		parameters, err = expandParameters(os.Difference(ns).List())
+		resetParameters, err := expandParameters(os.Difference(ns).List())
 		if err != nil {
 			return err
 		}
-		if len(parameters) > 0 {
-			parameterGroupName := d.Get("name").(string)
-			resetOpts := rds.ResetDBParameterGroupInput{
-				DBParameterGroupName: aws.String(parameterGroupName),
-				Parameters:           parameters,
-			}
+		if len(resetParameters) > 0 {
+			maxParams := 20
+			for resetParameters != nil {
+				var paramsToReset []*rds.Parameter
+				if len(resetParameters) <= maxParams {
+					paramsToReset, resetParameters = resetParameters[:], nil
+				} else {
+					paramsToReset, resetParameters = resetParameters[:maxParams], resetParameters[maxParams:]
+				}
 
-			log.Printf("[DEBUG] Reset DB Parameter Group: %s", resetOpts)
-			_, err = rdsconn.ResetDBParameterGroup(&resetOpts)
-			if err != nil {
-				return fmt.Errorf("Error resetting DB Parameter Group: %s", err)
+				parameterGroupName := d.Get("name").(string)
+				resetOpts := rds.ResetDBParameterGroupInput{
+					DBParameterGroupName: aws.String(parameterGroupName),
+					Parameters:           paramsToReset,
+					ResetAllParameters:   aws.Bool(false),
+				}
+
+				log.Printf("[DEBUG] Reset DB Parameter Group: %s", resetOpts)
+				_, err = rdsconn.ResetDBParameterGroup(&resetOpts)
+				if err != nil {
+					return fmt.Errorf("Error resetting DB Parameter Group: %s", err)
+				}
 			}
-			d.SetPartial("parameter")
 		}
 	}
 

--- a/aws/resource_aws_db_parameter_group_test.go
+++ b/aws/resource_aws_db_parameter_group_test.go
@@ -359,6 +359,15 @@ func TestAccAWSDBParameterGroup_limit(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "parameter.748684209.value", "REPEATABLE-READ"),
 				),
 			},
+			{
+				Config: testAccAWSDBParameterGroupConfig(groupName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBParameterGroupExists("aws_db_parameter_group.bar", &v),
+					testAccCheckAWSDBParameterGroupAttributes(&v, groupName),
+					testAccCheckAWSDBParameterNotUserDefined("aws_db_parameter_group.bar", "collation_connection"),
+					testAccCheckAWSDBParameterNotUserDefined("aws_db_parameter_group.bar", "collation_server"),
+				),
+			},
 		},
 	})
 }
@@ -625,6 +634,55 @@ func testAccCheckAWSDBParameterGroupExists(n string, v *rds.DBParameterGroup) re
 
 		return nil
 	}
+}
+
+func testAccCheckAWSDBParameterNotUserDefined(n, paramName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No DB Parameter Group ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).rdsconn
+
+		opts := rds.DescribeDBParametersInput{
+			DBParameterGroupName: aws.String(rs.Primary.ID),
+			Source:               aws.String("user"),
+		}
+		fmt.Printf("test: %s\n", rs.Primary.ID)
+
+		userDefined := false
+		conn.DescribeDBParametersPages(&opts, func(page *rds.DescribeDBParametersOutput, lastPage bool) bool {
+			for _, param := range page.Parameters {
+				fmt.Printf("param: %s %s\n", *param.ParameterName, *param.Source)
+				if *param.ParameterName == paramName {
+					userDefined = true
+					return false
+				}
+			}
+			return true
+		})
+
+		if userDefined {
+			return fmt.Errorf("DB Parameter is user defined")
+		}
+
+		return nil
+	}
+}
+
+func randomString(strlen int) string {
+	rand.Seed(time.Now().UTC().UnixNano())
+	const chars = "abcdefghijklmnopqrstuvwxyz"
+	result := make([]byte, strlen)
+	for i := 0; i < strlen; i++ {
+		result[i] = chars[rand.Intn(len(chars))]
+	}
+	return string(result)
 }
 
 func testAccAWSDBParameterGroupConfig(n string) string {

--- a/aws/resource_aws_db_parameter_group_test.go
+++ b/aws/resource_aws_db_parameter_group_test.go
@@ -93,8 +93,6 @@ func TestAccAWSDBParameterGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						resourceName, "family", "mysql5.6"),
 					resource.TestCheckResourceAttr(
-						resourceName, "description", "Managed by Terraform"),
-					resource.TestCheckResourceAttr(
 						resourceName, "parameter.1708034931.name", "character_set_results"),
 					resource.TestCheckResourceAttr(
 						resourceName, "parameter.1708034931.value", "utf8"),
@@ -106,8 +104,6 @@ func TestAccAWSDBParameterGroup_basic(t *testing.T) {
 						resourceName, "parameter.2478663599.name", "character_set_client"),
 					resource.TestCheckResourceAttr(
 						resourceName, "parameter.2478663599.value", "utf8"),
-					resource.TestCheckResourceAttr(
-						resourceName, "tags.%", "1"),
 					resource.TestMatchResourceAttr(
 						resourceName, "arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:rds:[^:]+:\\d{12}:pg:%s", groupName))),
 				),
@@ -126,8 +122,6 @@ func TestAccAWSDBParameterGroup_basic(t *testing.T) {
 						resourceName, "name", groupName),
 					resource.TestCheckResourceAttr(
 						resourceName, "family", "mysql5.6"),
-					resource.TestCheckResourceAttr(
-						resourceName, "description", "Test parameter group for terraform"),
 					resource.TestCheckResourceAttr(
 						resourceName, "parameter.1706463059.name", "collation_connection"),
 					resource.TestCheckResourceAttr(
@@ -148,10 +142,19 @@ func TestAccAWSDBParameterGroup_basic(t *testing.T) {
 						resourceName, "parameter.2478663599.name", "character_set_client"),
 					resource.TestCheckResourceAttr(
 						resourceName, "parameter.2478663599.value", "utf8"),
-					resource.TestCheckResourceAttr(
-						resourceName, "tags.%", "2"),
 					resource.TestMatchResourceAttr(
 						resourceName, "arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:rds:[^:]+:\\d{12}:pg:%s", groupName))),
+				),
+			},
+			{
+				Config: testAccAWSDBParameterGroupConfig(groupName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBParameterGroupExists(resourceName, &v),
+					testAccCheckAWSDBParameterGroupAttributes(&v, groupName),
+					testAccCheckAWSDBParameterNotUserDefined(resourceName, "collation_connection"),
+					testAccCheckAWSDBParameterNotUserDefined(resourceName, "collation_server"),
+					resource.TestCheckNoResourceAttr(resourceName, "parameter.2475805061.value"),
+					resource.TestCheckNoResourceAttr(resourceName, "parameter.1706463059.value"),
 				),
 			},
 		},
@@ -176,7 +179,6 @@ func TestAccAWSDBParameterGroup_limit(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", groupName),
 					resource.TestCheckResourceAttr(resourceName, "family", "mysql5.6"),
 					resource.TestCheckResourceAttr(resourceName, "description", "RDS default parameter group: Exceed default AWS parameter group limit of twenty"),
-
 					resource.TestCheckResourceAttr(resourceName, "parameter.2421266705.name", "character_set_server"),
 					resource.TestCheckResourceAttr(resourceName, "parameter.2421266705.value", "utf8"),
 					resource.TestCheckResourceAttr(resourceName, "parameter.2478663599.name", "character_set_client"),
@@ -274,7 +276,6 @@ func TestAccAWSDBParameterGroup_limit(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", groupName),
 					resource.TestCheckResourceAttr(resourceName, "family", "mysql5.6"),
 					resource.TestCheckResourceAttr(resourceName, "description", "Updated RDS default parameter group: Exceed default AWS parameter group limit of twenty"),
-
 					resource.TestCheckResourceAttr(resourceName, "parameter.2421266705.name", "character_set_server"),
 					resource.TestCheckResourceAttr(resourceName, "parameter.2421266705.value", "utf8"),
 					resource.TestCheckResourceAttr(resourceName, "parameter.2478663599.name", "character_set_client"),
@@ -357,15 +358,6 @@ func TestAccAWSDBParameterGroup_limit(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "parameter.881816039.value", "0"),
 					resource.TestCheckResourceAttr(resourceName, "parameter.748684209.name", "tx_isolation"),
 					resource.TestCheckResourceAttr(resourceName, "parameter.748684209.value", "REPEATABLE-READ"),
-				),
-			},
-			{
-				Config: testAccAWSDBParameterGroupConfig(groupName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDBParameterGroupExists("aws_db_parameter_group.bar", &v),
-					testAccCheckAWSDBParameterGroupAttributes(&v, groupName),
-					testAccCheckAWSDBParameterNotUserDefined("aws_db_parameter_group.bar", "collation_connection"),
-					testAccCheckAWSDBParameterNotUserDefined("aws_db_parameter_group.bar", "collation_server"),
 				),
 			},
 		},
@@ -653,12 +645,10 @@ func testAccCheckAWSDBParameterNotUserDefined(n, paramName string) resource.Test
 			DBParameterGroupName: aws.String(rs.Primary.ID),
 			Source:               aws.String("user"),
 		}
-		fmt.Printf("test: %s\n", rs.Primary.ID)
 
 		userDefined := false
-		conn.DescribeDBParametersPages(&opts, func(page *rds.DescribeDBParametersOutput, lastPage bool) bool {
+		err := conn.DescribeDBParametersPages(&opts, func(page *rds.DescribeDBParametersOutput, lastPage bool) bool {
 			for _, param := range page.Parameters {
-				fmt.Printf("param: %s %s\n", *param.ParameterName, *param.Source)
 				if *param.ParameterName == paramName {
 					userDefined = true
 					return false
@@ -671,18 +661,8 @@ func testAccCheckAWSDBParameterNotUserDefined(n, paramName string) resource.Test
 			return fmt.Errorf("DB Parameter is user defined")
 		}
 
-		return nil
+		return err
 	}
-}
-
-func randomString(strlen int) string {
-	rand.Seed(time.Now().UTC().UnixNano())
-	const chars = "abcdefghijklmnopqrstuvwxyz"
-	result := make([]byte, strlen)
-	for i := 0; i < strlen; i++ {
-		result[i] = chars[rand.Intn(len(chars))]
-	}
-	return string(result)
 }
 
 func testAccAWSDBParameterGroupConfig(n string) string {
@@ -704,10 +684,6 @@ resource "aws_db_parameter_group" "test" {
   parameter {
     name  = "character_set_results"
     value = "utf8"
-  }
-
-  tags = {
-    foo = "test"
   }
 }
 `, n)
@@ -742,7 +718,6 @@ func testAccAWSDBParameterGroupAddParametersConfig(n string) string {
 resource "aws_db_parameter_group" "test" {
   name        = "%s"
   family      = "mysql5.6"
-  description = "Test parameter group for terraform"
 
   parameter {
     name  = "character_set_server"
@@ -767,11 +742,6 @@ resource "aws_db_parameter_group" "test" {
   parameter {
     name  = "collation_connection"
     value = "utf8_unicode_ci"
-  }
-
-  tags = {
-    foo = "test"
-    baz = "foo"
   }
 }
 `, n)

--- a/aws/resource_aws_rds_cluster_parameter_group.go
+++ b/aws/resource_aws_rds_cluster_parameter_group.go
@@ -161,7 +161,9 @@ func resourceAwsRDSClusterParameterGroupRead(d *schema.ResourceData, meta interf
 		return err
 	}
 
-	d.Set("parameter", flattenParameters(describeParametersResp.Parameters))
+	if err := d.Set("parameter", flattenParameters(describeParametersResp.Parameters)); err != nil {
+		return fmt.Errorf("error setting parameters: %s", err)
+	}
 
 	resp, err := rdsconn.ListTagsForResource(&rds.ListTagsForResourceInput{
 		ResourceName: aws.String(arn),
@@ -219,10 +221,9 @@ func resourceAwsRDSClusterParameterGroupUpdate(d *schema.ResourceData, meta inte
 				log.Printf("[DEBUG] Modify DB Cluster Parameter Group: %s", modifyOpts)
 				_, err = rdsconn.ModifyDBClusterParameterGroup(&modifyOpts)
 				if err != nil {
-					return fmt.Errorf("Error modifying DB Cluster Parameter Group: %s", err)
+					return fmt.Errorf("error modifying DB Cluster Parameter Group: %s", err)
 				}
 			}
-			d.SetPartial("parameter")
 		}
 
 		// Reset parameters that have been removed
@@ -231,18 +232,36 @@ func resourceAwsRDSClusterParameterGroupUpdate(d *schema.ResourceData, meta inte
 			return err
 		}
 		if len(parameters) > 0 {
-			parameterGroupName := d.Get("name").(string)
-			resetOpts := rds.ResetDBClusterParameterGroupInput{
-				DBClusterParameterGroupName: aws.String(parameterGroupName),
-				Parameters:                  parameters,
-			}
+			for parameters != nil {
+				parameterGroupName := d.Get("name").(string)
+				var paramsToReset []*rds.Parameter
+				if len(parameters) <= rdsClusterParameterGroupMaxParamsBulkEdit {
+					paramsToReset, parameters = parameters[:], nil
+				} else {
+					paramsToReset, parameters = parameters[:rdsClusterParameterGroupMaxParamsBulkEdit], parameters[rdsClusterParameterGroupMaxParamsBulkEdit:]
+				}
 
-			log.Printf("[DEBUG] Reset DB Cluster Parameter Group: %s", resetOpts)
-			_, err = rdsconn.ResetDBClusterParameterGroup(&resetOpts)
-			if err != nil {
-				return fmt.Errorf("Error resetting DB Cluster Parameter Group: %s", err)
+				resetOpts := rds.ResetDBClusterParameterGroupInput{
+					DBClusterParameterGroupName: aws.String(parameterGroupName),
+					Parameters:                  paramsToReset,
+					ResetAllParameters:          aws.Bool(false),
+				}
+
+				log.Printf("[DEBUG] Reset DB Cluster Parameter Group: %s", resetOpts)
+				err := resource.Retry(3*time.Minute, func() *resource.RetryError {
+					_, err := rdsconn.ResetDBClusterParameterGroup(&resetOpts)
+					if err != nil {
+						if isAWSErr(err, "InvalidDBParameterGroupState", "has pending changes") {
+							return resource.RetryableError(err)
+						}
+						return resource.NonRetryableError(err)
+					}
+					return nil
+				})
+				if err != nil {
+					return fmt.Errorf("error resetting DB Cluster Parameter Group: %s", err)
+				}
 			}
-			d.SetPartial("parameter")
 		}
 	}
 


### PR DESCRIPTION
This also fixes a bug in `TestAccAWSDBParameterGroup_basic` where the "update" didn't actually get applied because a new description in the second test config forced a new resource instead. 

(This pulls in commits from #5728)

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #661

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_db_parameter_group - Support resetting parameter group values
* resource/aws_rds_cluster_parameter_group - Support resetting parameter group values
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS="-run=TestAccAWSDBParameterGroup_"            
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSDBParameterGroup_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSDBParameterGroup_basic
=== PAUSE TestAccAWSDBParameterGroup_basic
=== RUN   TestAccAWSDBParameterGroup_limit
=== PAUSE TestAccAWSDBParameterGroup_limit
=== RUN   TestAccAWSDBParameterGroup_Disappears
=== PAUSE TestAccAWSDBParameterGroup_Disappears
=== RUN   TestAccAWSDBParameterGroup_namePrefix
=== PAUSE TestAccAWSDBParameterGroup_namePrefix
=== RUN   TestAccAWSDBParameterGroup_generatedName
=== PAUSE TestAccAWSDBParameterGroup_generatedName
=== RUN   TestAccAWSDBParameterGroup_withApplyMethod
=== PAUSE TestAccAWSDBParameterGroup_withApplyMethod
=== RUN   TestAccAWSDBParameterGroup_Only
=== PAUSE TestAccAWSDBParameterGroup_Only
=== RUN   TestAccAWSDBParameterGroup_MatchDefault
=== PAUSE TestAccAWSDBParameterGroup_MatchDefault
=== CONT  TestAccAWSDBParameterGroup_basic
=== CONT  TestAccAWSDBParameterGroup_withApplyMethod
=== CONT  TestAccAWSDBParameterGroup_generatedName
=== CONT  TestAccAWSDBParameterGroup_MatchDefault
=== CONT  TestAccAWSDBParameterGroup_namePrefix
=== CONT  TestAccAWSDBParameterGroup_Only
=== CONT  TestAccAWSDBParameterGroup_Disappears
=== CONT  TestAccAWSDBParameterGroup_limit
--- PASS: TestAccAWSDBParameterGroup_Disappears (28.98s)
--- PASS: TestAccAWSDBParameterGroup_Only (37.76s)
--- PASS: TestAccAWSDBParameterGroup_generatedName (41.40s)
--- PASS: TestAccAWSDBParameterGroup_namePrefix (41.46s)
--- PASS: TestAccAWSDBParameterGroup_MatchDefault (44.22s)
--- PASS: TestAccAWSDBParameterGroup_withApplyMethod (46.60s)
--- PASS: TestAccAWSDBParameterGroup_basic (111.70s)
--- PASS: TestAccAWSDBParameterGroup_limit (122.63s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       124.963s


make testacc TESTARGS="-run=TestAccAWSDBClusterParameterGroup_"         
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSDBClusterParameterGroup_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSDBClusterParameterGroup_basic
=== PAUSE TestAccAWSDBClusterParameterGroup_basic
=== RUN   TestAccAWSDBClusterParameterGroup_withApplyMethod
=== PAUSE TestAccAWSDBClusterParameterGroup_withApplyMethod
=== RUN   TestAccAWSDBClusterParameterGroup_namePrefix
=== PAUSE TestAccAWSDBClusterParameterGroup_namePrefix
=== RUN   TestAccAWSDBClusterParameterGroup_namePrefix_Parameter
=== PAUSE TestAccAWSDBClusterParameterGroup_namePrefix_Parameter
=== RUN   TestAccAWSDBClusterParameterGroup_generatedName
=== PAUSE TestAccAWSDBClusterParameterGroup_generatedName
=== RUN   TestAccAWSDBClusterParameterGroup_generatedName_Parameter
=== PAUSE TestAccAWSDBClusterParameterGroup_generatedName_Parameter
=== RUN   TestAccAWSDBClusterParameterGroup_disappears
=== PAUSE TestAccAWSDBClusterParameterGroup_disappears
=== RUN   TestAccAWSDBClusterParameterGroup_only
=== PAUSE TestAccAWSDBClusterParameterGroup_only
=== CONT  TestAccAWSDBClusterParameterGroup_basic
=== CONT  TestAccAWSDBClusterParameterGroup_generatedName_Parameter
=== CONT  TestAccAWSDBClusterParameterGroup_generatedName
=== CONT  TestAccAWSDBClusterParameterGroup_namePrefix
=== CONT  TestAccAWSDBClusterParameterGroup_namePrefix_Parameter
=== CONT  TestAccAWSDBClusterParameterGroup_only
=== CONT  TestAccAWSDBClusterParameterGroup_disappears
=== CONT  TestAccAWSDBClusterParameterGroup_withApplyMethod
--- PASS: TestAccAWSDBClusterParameterGroup_disappears (28.27s)
--- PASS: TestAccAWSDBClusterParameterGroup_namePrefix (37.64s)
--- PASS: TestAccAWSDBClusterParameterGroup_only (37.73s)
--- PASS: TestAccAWSDBClusterParameterGroup_generatedName (37.78s)
--- PASS: TestAccAWSDBClusterParameterGroup_namePrefix_Parameter (38.05s)
--- PASS: TestAccAWSDBClusterParameterGroup_generatedName_Parameter (39.10s)
--- PASS: TestAccAWSDBClusterParameterGroup_withApplyMethod (39.17s)
--- PASS: TestAccAWSDBClusterParameterGroup_basic (98.63s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       99.642s
```
