### PR TITLE
Update workspaces_bundle_test to check whether `description` is set

### DIFF
--- a/aws/data_source_aws_workspaces_bundle_test.go
+++ b/aws/data_source_aws_workspaces_bundle_test.go
@@ -20,7 +20,7 @@ func TestAccDataSourceAwsWorkspaceBundle_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "bundle_id", "wsb-b0s22j3d7"),
 					resource.TestCheckResourceAttr(dataSourceName, "compute_type.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "compute_type.0.name", "PERFORMANCE"),
-					resource.TestCheckResourceAttr(dataSourceName, "description", "Windows 7 Experience provided by Windows Server 2008 R2, 2 vCPU, 7.5GiB Memory, 100GB Storage"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "description"),
 					resource.TestCheckResourceAttr(dataSourceName, "name", "Performance with Windows 7"),
 					resource.TestCheckResourceAttr(dataSourceName, "owner", "Amazon"),
 					resource.TestCheckResourceAttr(dataSourceName, "root_storage.#", "1"),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

I think this is the best option to prevent the test failure we're having, since the actual description text isn't very important to checking this data source's functionality.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccDataSourceAwsWorkspaceBundle_basic'
--- PASS: TestAccDataSourceAwsWorkspaceBundle_basic (17.19s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	19.243s
```
