### PR TITLE
resource/aws_network_acl_rule: Fix provider error when missing rule

### DIFF
--- a/aws/resource_aws_network_acl_rule.go
+++ b/aws/resource_aws_network_acl_rule.go
@@ -300,6 +300,7 @@ func findNetworkAclRule(d *schema.ResourceData, meta interface{}) (*ec2.NetworkA
 				return i, nil
 			}
 		}
+		return nil, nil
 	}
 	return nil, fmt.Errorf(
 		"Expected the Network ACL to have Entries, got: %#v",

--- a/aws/resource_aws_network_acl_rule_test.go
+++ b/aws/resource_aws_network_acl_rule_test.go
@@ -54,6 +54,26 @@ func TestAccAWSNetworkAclRule_disappears(t *testing.T) {
 	})
 }
 
+func TestAccAWSNetworkAclRule_ingressEgressSameNumberDisappears(t *testing.T) {
+	var networkAcl ec2.NetworkAcl
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNetworkAclRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSNetworkAclRuleIngressEgressSameNumberMissing,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSNetworkAclRuleExists("aws_network_acl_rule.baz", &networkAcl),
+					testAccCheckAWSNetworkAclRuleDelete("aws_network_acl_rule.baz"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSNetworkAclRule_disappears_NetworkAcl(t *testing.T) {
 	var networkAcl ec2.NetworkAcl
 	resourceName := "aws_network_acl.bar"
@@ -550,6 +570,44 @@ resource "aws_network_acl_rule" "baz" {
 	protocol = "tcp"
 	rule_action = "allow"
 	ipv6_cidr_block = "::/0"
+	from_port = 22
+	to_port = 22
+}
+`
+
+const testAccAWSNetworkAclRuleIngressEgressSameNumberMissing = `
+resource "aws_vpc" "foo" {
+	cidr_block = "10.3.0.0/16"
+	tags = {
+		Name = "terraform-testacc-network-acl-rule-ingress-egress-same-number-missing"
+	}
+}
+
+resource "aws_network_acl" "bar" {
+	vpc_id = "${aws_vpc.foo.id}"
+	tags = {
+		Name = "tf-acc-acl-rule-basic"
+	}
+}
+
+resource "aws_network_acl_rule" "baz" {
+	network_acl_id = "${aws_network_acl.bar.id}"
+	rule_number = 100
+	egress = false
+	protocol = "tcp"
+	rule_action = "allow"
+	cidr_block = "0.0.0.0/0"
+	from_port = 22
+	to_port = 22
+}
+
+resource "aws_network_acl_rule" "qux" {
+	network_acl_id = "${aws_network_acl.bar.id}"
+	rule_number = 100
+	egress = true
+	protocol = "tcp"
+	rule_action = "allow"
+	cidr_block = "0.0.0.0/0"
 	from_port = 22
 	to_port = 22
 }


### PR DESCRIPTION
Ref: https://github.com/terraform-providers/terraform-provider-aws/issues/2291

Even though
https://github.com/terraform-providers/terraform-provider-aws/pull/9710
fixed one case of the problem, there is another case which is harder to
reproduce.

When a network acl has ingress and egress with same rule number, which
is valid per aws doc, if one of them missing (maybe manually deleted),
then terraform plan will stop working.

The main problem is there is a change in aws api and the egress filter
is not supported anymore.

Current doc: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeNetworkAcls.html
2017 doc: https://web.archive.org/web/20171216154650/http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeNetworkAcls.html

Noted `entry.egress` is gone. So the query return the nacl with same
number rule but not which correct type. Which make this for loop
https://github.com/terraform-providers/terraform-provider-aws/blob/5348ed3f1c47900f18c7f457a920de5f33cf7142/aws/resource_aws_network_acl_rule.go#L298
couldn't find the correct rule and fall down to the wrong return https://github.com/terraform-providers/terraform-provider-aws/blob/5348ed3f1c47900f18c7f457a920de5f33cf7142/aws/resource_aws_network_acl_rule.go#L304

The fix simple `return nil, nil` so the rule will be deleted

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSNetworkAclRule_ingressEgressSameNumberDisappears'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSNetworkAclRule_ingressEgressSameNumberDisappears -timeout 120m
=== RUN   TestAccAWSNetworkAclRule_ingressEgressSameNumberDisappears
=== PAUSE TestAccAWSNetworkAclRule_ingressEgressSameNumberDisappears
=== CONT  TestAccAWSNetworkAclRule_ingressEgressSameNumberDisappears
--- PASS: TestAccAWSNetworkAclRule_ingressEgressSameNumberDisappears (60.61s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       60.659s
```
