### PR TITLE
Add support for instance_role_arn in GameLift Fleet

### DIFF
--- a/aws/resource_aws_gamelift_fleet.go
+++ b/aws/resource_aws_gamelift_fleet.go
@@ -45,6 +45,12 @@ func resourceAwsGameliftFleet() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validation.StringLenBetween(1, 1024),
 			},
+			"instance_role_arn": {
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
+				Optional:     true,
+			},
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -182,6 +188,7 @@ func resourceAwsGameliftFleetCreate(d *schema.ResourceData, meta interface{}) er
 		BuildId:         aws.String(d.Get("build_id").(string)),
 		EC2InstanceType: aws.String(d.Get("ec2_instance_type").(string)),
 		Name:            aws.String(d.Get("name").(string)),
+		InstanceRoleArn: aws.String(d.Get("instance_role_arn").(string)),
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -286,6 +293,7 @@ func resourceAwsGameliftFleetRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("log_paths", aws.StringValueSlice(fleet.LogPaths))
 	d.Set("metric_groups", flattenStringList(fleet.MetricGroups))
 	d.Set("name", fleet.Name)
+	d.Set("instance_role_arn", fleet.InstanceRoleArn)
 	d.Set("new_game_session_protection_policy", fleet.NewGameSessionProtectionPolicy)
 	d.Set("operating_system", fleet.OperatingSystem)
 	d.Set("resource_creation_limit_policy", flattenGameliftResourceCreationLimitPolicy(fleet.ResourceCreationLimitPolicy))
@@ -299,7 +307,8 @@ func resourceAwsGameliftFleetUpdate(d *schema.ResourceData, meta interface{}) er
 	log.Printf("[INFO] Updating Gamelift Fleet: %s", d.Id())
 
 	if d.HasChange("description") || d.HasChange("metric_groups") || d.HasChange("name") ||
-		d.HasChange("new_game_session_protection_policy") || d.HasChange("resource_creation_limit_policy") {
+		d.HasChange("new_game_session_protection_policy") || d.HasChange("resource_creation_limit_policy") ||
+		d.HasChange("instance_role_arn") {
 		_, err := conn.UpdateFleetAttributes(&gamelift.UpdateFleetAttributesInput{
 			Description:                    aws.String(d.Get("description").(string)),
 			FleetId:                        aws.String(d.Id()),

--- a/aws/resource_aws_gamelift_fleet_test.go
+++ b/aws/resource_aws_gamelift_fleet_test.go
@@ -277,6 +277,7 @@ func TestAccAWSGameliftFleet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_gamelift_fleet.test", "ec2_instance_type", "c4.large"),
 					resource.TestCheckResourceAttr("aws_gamelift_fleet.test", "log_paths.#", "0"),
 					resource.TestCheckResourceAttr("aws_gamelift_fleet.test", "name", fleetName),
+					resource.TestCheckResourceAttr("aws_gamelift_fleet.test", "instance_role_arn", roleArn),
 					resource.TestCheckResourceAttr("aws_gamelift_fleet.test", "metric_groups.#", "1"),
 					resource.TestCheckResourceAttr("aws_gamelift_fleet.test", "metric_groups.0", "default"),
 					resource.TestCheckResourceAttr("aws_gamelift_fleet.test", "new_game_session_protection_policy", "NoProtection"),
@@ -296,6 +297,7 @@ func TestAccAWSGameliftFleet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_gamelift_fleet.test", "ec2_instance_type", "c4.large"),
 					resource.TestCheckResourceAttr("aws_gamelift_fleet.test", "log_paths.#", "0"),
 					resource.TestCheckResourceAttr("aws_gamelift_fleet.test", "name", uFleetName),
+					resource.TestCheckResourceAttr("aws_gamelift_fleet.test", "instance_role_arn", roleArn),
 					resource.TestCheckResourceAttr("aws_gamelift_fleet.test", "description", desc),
 					resource.TestCheckResourceAttr("aws_gamelift_fleet.test", "metric_groups.#", "1"),
 					resource.TestCheckResourceAttr("aws_gamelift_fleet.test", "metric_groups.0", "UpdatedGroup"),
@@ -503,6 +505,7 @@ func testAccAWSGameliftFleetBasicConfig(fleetName, launchPath, params, buildName
 resource "aws_gamelift_fleet" "test" {
   build_id          = "${aws_gamelift_build.test.id}"
   ec2_instance_type = "c4.large"
+  instance_role_arn = "%s"
   name              = "%s"
 
   runtime_configuration {
@@ -516,7 +519,7 @@ resource "aws_gamelift_fleet" "test" {
 
 %s
 
-`, fleetName, launchPath, params, testAccAWSGameliftFleetBasicTemplate(buildName, bucketName, key, roleArn))
+`, roleArn, fleetName, launchPath, params, testAccAWSGameliftFleetBasicTemplate(buildName, bucketName, key, roleArn))
 }
 
 func testAccAWSGameliftFleetBasicUpdatedConfig(desc, fleetName, launchPath, params, buildName, bucketName, key, roleArn string) string {
@@ -528,6 +531,7 @@ resource "aws_gamelift_fleet" "test" {
   name                               = "%s"
   metric_groups                      = ["UpdatedGroup"]
   new_game_session_protection_policy = "FullProtection"
+  instance_role_arn                  = "%s"
 
   resource_creation_limit_policy {
     new_game_sessions_per_creator = 2
@@ -545,7 +549,7 @@ resource "aws_gamelift_fleet" "test" {
 
 %s
 
-`, desc, fleetName, launchPath, params, testAccAWSGameliftFleetBasicTemplate(buildName, bucketName, key, roleArn))
+`, desc, fleetName, roleArn, launchPath, params, testAccAWSGameliftFleetBasicTemplate(buildName, bucketName, key, roleArn))
 }
 
 func testAccAWSGameliftFleetAllFieldsConfig(fleetName, desc, launchPath string, params string, buildName, bucketName, key, roleArn string) string {
@@ -555,6 +559,7 @@ resource "aws_gamelift_fleet" "test" {
   ec2_instance_type = "c4.large"
   name              = "%s"
   description       = "%s"
+  instance_role_arn = "%s"
 
   ec2_inbound_permission {
     from_port = 8080
@@ -599,7 +604,7 @@ resource "aws_gamelift_fleet" "test" {
 
 %s
 
-`, fleetName, desc, launchPath, params,
+`, fleetName, desc, roleArn, launchPath, params,
 		testAccAWSGameliftFleetBasicTemplate(buildName, bucketName, key, roleArn))
 }
 
@@ -610,6 +615,7 @@ resource "aws_gamelift_fleet" "test" {
   ec2_instance_type = "c4.large"
   name              = "%s"
   description       = "%s"
+  instance_role_arn = "%s"
 
   ec2_inbound_permission {
     from_port = 8888
@@ -654,7 +660,7 @@ resource "aws_gamelift_fleet" "test" {
 
 %s
 
-`, fleetName, desc, launchPath, params,
+`, fleetName, desc, roleArn, launchPath, params,
 		testAccAWSGameliftFleetBasicTemplate(buildName, bucketName, key, roleArn))
 }
 

--- a/aws/resource_aws_gamelift_test.go
+++ b/aws/resource_aws_gamelift_test.go
@@ -28,7 +28,6 @@ func testAccAWSGameliftSampleGame(region string) (*testAccGameliftGame, error) {
 	bucket := fmt.Sprintf("gamelift-sample-builds-prod-%s", region)
 	key := fmt.Sprintf("%s/server/sample_build_%s", version, version)
 	roleArn := fmt.Sprintf("arn:aws:iam::%s:role/sample-build-upload-role-%s", accId, region)
-
 	launchPath := `C:\game\Bin64.Release.Dedicated\MultiplayerProjectLauncher_Server.exe`
 
 	gg := &testAccGameliftGame{

--- a/website/docs/r/gamelift_fleet.html.markdown
+++ b/website/docs/r/gamelift_fleet.html.markdown
@@ -32,11 +32,12 @@ resource "aws_gamelift_fleet" "example" {
 The following arguments are supported:
 
 * `build_id` - (Required) ID of the Gamelift Build to be deployed on the fleet.
-* `ec2_instance_type` - (Required) Name of an EC2 instance type. e.g. `t2.micro`
-* `name` - (Required) The name of the fleet.
 * `description` - (Optional) Human-readable description of the fleet.
 * `ec2_inbound_permission` - (Optional) Range of IP addresses and port settings that permit inbound traffic to access server processes running on the fleet. See below.
+* `ec2_instance_type` - (Required) Name of an EC2 instance type. e.g. `t2.micro`
+* `instance_role_arn` - (Optional) ARN of an IAM role that instances in the fleet can assume.
 * `metric_groups` - (Optional) List of names of metric groups to add this fleet to. A metric group tracks metrics across all fleets in the group. Defaults to `default`.
+* `name` - (Required) The name of the fleet.
 * `new_game_session_protection_policy` - (Optional) Game session protection policy to apply to all instances in this fleet. e.g. `FullProtection`. Defaults to `NoProtection`.
 * `resource_creation_limit_policy` - (Optional) Policy that limits the number of game sessions an individual player can create over a span of time for this fleet. See below.
 * `runtime_configuration` - (Optional) Instructions for launching server processes on each instance in the fleet. See below.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10800

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES
* resource/aws_gamelift_fleet - Add support for instance_role_arn
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSGameliftFleet_basic (1447.61s)
--- PASS: TestAccAWSGameliftFleet_allFields (1555.11s)
```

Screenshot:
![image](https://user-images.githubusercontent.com/397565/72172040-78bda800-33d4-11ea-8a2d-12e18a9c3a5f.png)
