### PR TITLE
Update count example syntax to 0.12

### DIFF
--- a/examples/count/main.tf
+++ b/examples/count/main.tf
@@ -1,13 +1,13 @@
 # Specify the provider and access details
 provider "aws" {
-  region = "${var.aws_region}"
+  region = var.aws_region
 }
 
 resource "aws_elb" "web" {
   name = "terraform-example-elb"
 
   # The same availability zone as our instances
-  availability_zones = ["${aws_instance.web.*.availability_zone}"]
+  availability_zones = aws_instance.web.*.availability_zone
 
   listener {
     instance_port     = 80
@@ -17,13 +17,14 @@ resource "aws_elb" "web" {
   }
 
   # The instances are registered automatically
-  instances = ["${aws_instance.web.*.id}"]
+  instances = aws_instance.web.*.id
 }
 
 resource "aws_instance" "web" {
   instance_type = "m1.small"
-  ami           = "${lookup(var.aws_amis, var.aws_region)}"
+  ami           = var.aws_amis[var.aws_region]
 
   # This will create 4 instances
   count = 4
 }
+

--- a/examples/count/outputs.tf
+++ b/examples/count/outputs.tf
@@ -1,3 +1,4 @@
 output "address" {
   value = "Instances: ${element(aws_instance.web.*.id, 0)}"
 }
+

--- a/examples/count/variables.tf
+++ b/examples/count/variables.tf
@@ -12,3 +12,4 @@ variable "aws_amis" {
     "us-west-2" = "ami-21f78e11"
   }
 }
+

--- a/examples/count/versions.tf
+++ b/examples/count/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
@caseylang mentioned to me that the count examples were out of date with 0.12 syntax. This is the result of running the 0.12upgrade tool on the count examples

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
