### PR TITLE
Gamelift fleet tagging support

### DIFF
--- a/aws/resource_aws_gamelift_fleet.go
+++ b/aws/resource_aws_gamelift_fleet.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsGameliftFleet() *schema.Resource {
@@ -39,6 +40,10 @@ func resourceAwsGameliftFleet() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					gamelift.ProtectionPolicyNoProtection,
+					gamelift.ProtectionPolicyFullProtection,
+				}, false),
 			},
 			"fleet_type": {
 				Type:     schema.TypeString,
@@ -187,6 +192,7 @@ func resourceAwsGameliftFleet() *schema.Resource {
 					},
 				},
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -198,6 +204,7 @@ func resourceAwsGameliftFleetCreate(d *schema.ResourceData, meta interface{}) er
 		BuildId:         aws.String(d.Get("build_id").(string)),
 		EC2InstanceType: aws.String(d.Get("ec2_instance_type").(string)),
 		Name:            aws.String(d.Get("name").(string)),
+		Tags:            keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().GameliftTags(),
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -315,9 +322,10 @@ func resourceAwsGameliftFleetRead(d *schema.ResourceData, meta interface{}) erro
 	}
 	fleet := attributes[0]
 
+	arn := aws.StringValue(fleet.FleetArn)
 	d.Set("build_id", fleet.BuildId)
 	d.Set("description", fleet.Description)
-	d.Set("arn", fleet.FleetArn)
+	d.Set("arn", arn)
 	d.Set("log_paths", aws.StringValueSlice(fleet.LogPaths))
 	d.Set("metric_groups", flattenStringList(fleet.MetricGroups))
 	d.Set("name", fleet.Name)
@@ -326,6 +334,15 @@ func resourceAwsGameliftFleetRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("new_game_session_protection_policy", fleet.NewGameSessionProtectionPolicy)
 	d.Set("operating_system", fleet.OperatingSystem)
 	d.Set("resource_creation_limit_policy", flattenGameliftResourceCreationLimitPolicy(fleet.ResourceCreationLimitPolicy))
+	tags, err := keyvaluetags.GameliftListTags(conn, arn)
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for Game Lift Fleet (%s): %s", arn, err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
 
 	return nil
 }
@@ -371,6 +388,15 @@ func resourceAwsGameliftFleetUpdate(d *schema.ResourceData, meta interface{}) er
 		})
 		if err != nil {
 			return err
+		}
+	}
+
+	arn := d.Get("arn").(string)
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.GameliftUpdateTags(conn, arn, o, n); err != nil {
+			return fmt.Errorf("error updating Game Lift Fleet (%s) tags: %s", arn, err)
 		}
 	}
 

--- a/aws/resource_aws_gamelift_fleet.go
+++ b/aws/resource_aws_gamelift_fleet.go
@@ -40,10 +40,6 @@ func resourceAwsGameliftFleet() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					gamelift.ProtectionPolicyNoProtection,
-					gamelift.ProtectionPolicyFullProtection,
-				}, false),
 			},
 			"fleet_type": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_gamelift_fleet.go
+++ b/aws/resource_aws_gamelift_fleet.go
@@ -332,6 +332,10 @@ func resourceAwsGameliftFleetRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("resource_creation_limit_policy", flattenGameliftResourceCreationLimitPolicy(fleet.ResourceCreationLimitPolicy))
 	tags, err := keyvaluetags.GameliftListTags(conn, arn)
 
+	if isAWSErr(err, gamelift.ErrCodeInvalidRequestException, fmt.Sprintf("Resource %s is not in a taggable state", d.Id())) {
+		return nil
+	}
+
 	if err != nil {
 		return fmt.Errorf("error listing tags for Game Lift Fleet (%s): %s", arn, err)
 	}

--- a/aws/resource_aws_gamelift_fleet_test.go
+++ b/aws/resource_aws_gamelift_fleet_test.go
@@ -556,13 +556,13 @@ func testAccAWSGameliftFleetBasicConfig(fleetName, launchPath, params, buildName
 resource "aws_gamelift_fleet" "test" {
   build_id          = "${aws_gamelift_build.test.id}"
   ec2_instance_type = "c4.large"
-  name              = "%s"
+  name              = %[1]q
 
   runtime_configuration {
     server_process {
       concurrent_executions = 1
-      launch_path           = %q
-      parameters            = "%s"
+      launch_path           = %[2]q
+      parameters            = %[3]q
     }
   }
 }
@@ -734,13 +734,13 @@ resource "aws_gamelift_fleet" "test" {
 func testAccAWSGameliftFleetBasicTemplate(buildName, bucketName, key, roleArn string) string {
 	return fmt.Sprintf(`
 resource "aws_gamelift_build" "test" {
-  name             = "%s"
+  name             = %[1]q
   operating_system = "WINDOWS_2012"
 
   storage_location {
-    bucket   = "%s"
-    key      = "%s"
-    role_arn = "%s"
+    bucket   = %[2]q
+    key      = %[3]q
+    role_arn = %[4]q
   }
 }
 `, buildName, bucketName, key, roleArn)

--- a/aws/resource_aws_gamelift_fleet_test.go
+++ b/aws/resource_aws_gamelift_fleet_test.go
@@ -715,7 +715,8 @@ resource "aws_gamelift_fleet" "test" {
 }
 
 func testAccAWSGameliftFleetAllFieldsConfig(fleetName, desc, launchPath string, params string, buildName, bucketName, key, roleArn string) string {
-	return testAccAWSGameliftFleetBasicTemplate(buildName, bucketName, key, roleArn) + fmt.Sprintf(`
+	return testAccAWSGameliftFleetBasicTemplate(buildName, bucketName, key, roleArn) +
+		testAccAWSGameLiftFleetIAMRole(buildName) + fmt.Sprintf(`
 resource "aws_gamelift_fleet" "test" {
   build_id          = "${aws_gamelift_build.test.id}"
   ec2_instance_type = "c4.large"
@@ -768,7 +769,8 @@ resource "aws_gamelift_fleet" "test" {
 }
 
 func testAccAWSGameliftFleetAllFieldsUpdatedConfig(fleetName, desc, launchPath string, params string, buildName, bucketName, key, roleArn string) string {
-	return testAccAWSGameliftFleetBasicTemplate(buildName, bucketName, key, roleArn) + fmt.Sprintf(`
+	return testAccAWSGameliftFleetBasicTemplate(buildName, bucketName, key, roleArn) +
+		testAccAWSGameLiftFleetIAMRole(buildName) + fmt.Sprintf(`
 resource "aws_gamelift_fleet" "test" {
   build_id          = "${aws_gamelift_build.test.id}"
   ec2_instance_type = "c4.large"

--- a/aws/resource_aws_gamelift_fleet_test.go
+++ b/aws/resource_aws_gamelift_fleet_test.go
@@ -594,7 +594,7 @@ func testAccCheckAWSGameliftFleetDisappears(res *gamelift.FleetAttributes) resou
 			return fmt.Errorf("Error deleting Gamelift fleet: %s", err)
 		}
 
-		return waitForGameliftFleetToBeDeleted(conn, *res.FleetId, 5*time.Minute)
+		return waitForGameliftFleetToBeDeleted(conn, *res.FleetId, 15*time.Minute)
 	}
 }
 

--- a/website/docs/r/gamelift_fleet.html.markdown
+++ b/website/docs/r/gamelift_fleet.html.markdown
@@ -43,6 +43,7 @@ The following arguments are supported:
 * `new_game_session_protection_policy` - (Optional) Game session protection policy to apply to all instances in this fleet. e.g. `FullProtection`. Defaults to `NoProtection`.
 * `resource_creation_limit_policy` - (Optional) Policy that limits the number of game sessions an individual player can create over a span of time for this fleet. See below.
 * `runtime_configuration` - (Optional) Instructions for launching server processes on each instance in the fleet. See below.
+* `tags` - (Optional) Key-value mapping of resource tags
 
 ### Nested Fields
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11384

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_gamelift_fleet: add support for `tags` argument
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSGameliftFleet_'
--- PASS: TestAccAWSGameliftFleet_basic (1764.12s)
--- PASS: TestAccAWSGameliftFleet_allFields (1641.65s)
--- PASS: TestAccAWSGameliftFleet_tags (1691.93s)
--- PASS: TestAccAWSGameliftFleet_disappears (1478.92s)
...
```
