### PR TITLE
resource/aws_ram_resource_share_accepter: Fix Read operation since invitations are purged after 7 days

### DIFF
--- a/aws/resource_aws_ram_resource_share_accepter.go
+++ b/aws/resource_aws_ram_resource_share_accepter.go
@@ -36,6 +36,12 @@ func resourceAwsRamResourceShareAccepter() *schema.Resource {
 				ValidateFunc: validateArn,
 			},
 
+			"account_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"invitation_arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -128,33 +134,52 @@ func resourceAwsRamResourceShareAccepterCreate(d *schema.ResourceData, meta inte
 }
 
 func resourceAwsRamResourceShareAccepterRead(d *schema.ResourceData, meta interface{}) error {
+
 	conn := meta.(*AWSClient).ramconn
 
 	invitation, err := resourceAwsRamResourceShareGetInvitation(conn, d.Id(), ram.ResourceShareInvitationStatusAccepted)
 
-	if err == nil && invitation == nil {
-		log.Printf("[WARN] No RAM resource share invitation by ARN (%s) found, removing from state", d.Id())
+	if err != nil {
+		return fmt.Errorf("Error retrieving invitation for resource share %s: %s", d.Id(), err)
+	}
+
+	if invitation != nil {
+		d.Set("invitation_arn", invitation.ResourceShareInvitationArn)
+		d.Set("receiver_account_id", invitation.ReceiverAccountId)
+	} else {
+		if d.Get("receiver_account_id") == nil && d.Get("account_id") != nil {
+			d.Set("receiver_account_id", d.Get("account_id")) // Kind of a hack to allow deletion of resource imported after invitation disappeared
+		}
+	}
+
+	listResourceSharesInput := &ram.GetResourceSharesInput{
+		ResourceOwner:     aws.String(ram.ResourceOwnerOtherAccounts),
+		ResourceShareArns: aws.StringSlice([]string{d.Id()}),
+	}
+
+	shares, err := conn.GetResourceShares(listResourceSharesInput)
+	if err != nil {
+		return fmt.Errorf("Error retrieving resource shares: %s", err)
+	}
+
+	if len(shares.ResourceShares) != 1 {
+		log.Printf("[WARN] No RAM resource share with ARN (%s) found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
-	if err != nil {
-		return err
-	}
+	resourceShare := shares.ResourceShares[0]
 
-	d.Set("status", invitation.Status)
-	d.Set("receiver_account_id", invitation.ReceiverAccountId)
-	d.Set("sender_account_id", invitation.SenderAccountId)
-	d.Set("share_arn", invitation.ResourceShareArn)
-	d.Set("invitation_arn", invitation.ResourceShareInvitationArn)
+	d.Set("status", resourceShare.Status)
+	d.Set("sender_account_id", resourceShare.OwningAccountId)
+	d.Set("share_arn", resourceShare.ResourceShareArn)
 	d.Set("share_id", resourceAwsRamResourceShareGetIDFromARN(d.Id()))
-	d.Set("share_name", invitation.ResourceShareName)
+	d.Set("share_name", resourceShare.Name)
 
 	listInput := &ram.ListResourcesInput{
 		MaxResults:        aws.Int64(int64(500)),
 		ResourceOwner:     aws.String(ram.ResourceOwnerOtherAccounts),
 		ResourceShareArns: aws.StringSlice([]string{d.Id()}),
-		Principal:         invitation.SenderAccountId,
 	}
 
 	var resourceARNs []*string

--- a/aws/resource_aws_ram_resource_share_accepter_test.go
+++ b/aws/resource_aws_ram_resource_share_accepter_test.go
@@ -32,9 +32,8 @@ func TestAccAwsRamResourceShareAccepter_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsRamResourceShareAccepterExists(resourceName),
 					resource.TestMatchResourceAttr(resourceName, "share_arn", regexp.MustCompile(`^arn\:aws\:ram\:.*resource-share/.+$`)),
-					resource.TestMatchResourceAttr(resourceName, "invitation_arn", regexp.MustCompile(`^arn\:aws\:ram\:.*resource-share-invitation/.+$`)),
 					resource.TestMatchResourceAttr(resourceName, "share_id", regexp.MustCompile(`^rs-.+$`)),
-					resource.TestCheckResourceAttr(resourceName, "status", ram.ResourceShareInvitationStatusAccepted),
+					resource.TestCheckResourceAttr(resourceName, "status", ram.ResourceShareStatusActive),
 					resource.TestMatchResourceAttr(resourceName, "receiver_account_id", regexp.MustCompile(`\d{12}`)),
 					resource.TestMatchResourceAttr(resourceName, "sender_account_id", regexp.MustCompile(`\d{12}`)),
 					resource.TestCheckResourceAttr(resourceName, "share_name", shareName),

--- a/aws/resource_aws_ram_resource_share_accepter_test.go
+++ b/aws/resource_aws_ram_resource_share_accepter_test.go
@@ -32,6 +32,7 @@ func TestAccAwsRamResourceShareAccepter_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsRamResourceShareAccepterExists(resourceName),
 					resource.TestMatchResourceAttr(resourceName, "share_arn", regexp.MustCompile(`^arn\:aws\:ram\:.*resource-share/.+$`)),
+					resource.TestMatchResourceAttr(resourceName, "invitation_arn", regexp.MustCompile(`^arn\:aws\:ram\:.*resource-share-invitation/.+$`)),
 					resource.TestMatchResourceAttr(resourceName, "share_id", regexp.MustCompile(`^rs-.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "status", ram.ResourceShareStatusActive),
 					resource.TestMatchResourceAttr(resourceName, "receiver_account_id", regexp.MustCompile(`\d{12}`)),

--- a/website/docs/r/ram_resource_share_accepter.markdown
+++ b/website/docs/r/ram_resource_share_accepter.markdown
@@ -56,7 +56,6 @@ resource "aws_ram_resource_share_accepter" "receiver_accept" {
 The following arguments are supported:
 
 * `share_arn` - (Required) The ARN of the resource share.
-* `account_id` - (Optional) The account ID of the receiver account.
 
 ## Attributes Reference
 
@@ -77,5 +76,3 @@ Resource share accepters can be imported using the resource share ARN, e.g.
 ```
 $ terraform import aws_ram_resource_share_accepter.example arn:aws:ram:us-east-1:123456789012:resource-share/c4b56393-e8d9-89d9-6dc9-883752de4767
 ```
-
-~> **Note:** This resource can be imported only if the corresponding invitation has already been accepted. In such a case, the argument `account_id` must be specified to ensure the resource can be deleted, since this information is required by AWS to dissassociate from a Resource Share. Under normal operation this argument is sourced from the invitation and stored in the `receiver_account_id`, but the invitation has usually disappeared when an import is made.

--- a/website/docs/r/ram_resource_share_accepter.markdown
+++ b/website/docs/r/ram_resource_share_accepter.markdown
@@ -56,6 +56,7 @@ resource "aws_ram_resource_share_accepter" "receiver_accept" {
 The following arguments are supported:
 
 * `share_arn` - (Required) The ARN of the resource share.
+* `account_id` - (Optional) The account ID of the receiver account.
 
 ## Attributes Reference
 
@@ -63,9 +64,9 @@ In addition to all arguments above, the following attributes are exported:
 
 * `invitation_arn` - The ARN of the resource share invitation.
 * `share_id` - The ID of the resource share as displayed in the console.
-* `status` - The status of the invitation (e.g., ACCEPTED, REJECTED).
+* `status` - The status of the resource share (ACTIVE, PENDING, FAILED, DELETING, DELETED).
 * `receiver_account_id` - The account ID of the receiver account which accepts the invitation.
-* `sender_account_id` - The account ID of the sender account which extends the invitation.
+* `sender_account_id` - The account ID of the sender account which submits the invitation.
 * `share_name` - The name of the resource share.
 * `resources` - A list of the resource ARNs shared via the resource share.
 
@@ -76,3 +77,5 @@ Resource share accepters can be imported using the resource share ARN, e.g.
 ```
 $ terraform import aws_ram_resource_share_accepter.example arn:aws:ram:us-east-1:123456789012:resource-share/c4b56393-e8d9-89d9-6dc9-883752de4767
 ```
+
+~> **Note:** This resource can be imported only if the corresponding invitation has already been accepted. In such a case, the argument `account_id` must be specified to ensure the resource can be deleted, since this information is required by AWS to dissassociate from a Resource Share. Under normal operation this argument is sourced from the invitation and stored in the `receiver_account_id`, but the invitation has usually disappeared when an import is made.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #10064
Closes #10186
Closes #11785

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
```release-note
resource/aws_ram_resource_share_accepter: Fix resource wanting to create again and import not working after invitation has been purged
```

Output from acceptance testing:
```
$ make testacc TEST='./aws' TESTARGS='-run=TestAccAwsRamResourceShareAccepter_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsRamResourceShareAccepter_basic -timeout 120m
=== RUN   TestAccAwsRamResourceShareAccepter_basic
=== PAUSE TestAccAwsRamResourceShareAccepter_basic
=== CONT  TestAccAwsRamResourceShareAccepter_basic
--- PASS: TestAccAwsRamResourceShareAccepter_basic (58.54s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	58.606s
```
