### PR TITLE
r/aws_egress_only_internet_gateway: Add tags argument

### DIFF
--- a/aws/resource_aws_egress_only_internet_gateway_test.go
+++ b/aws/resource_aws_egress_only_internet_gateway_test.go
@@ -85,7 +85,7 @@ func TestAccAWSEgressOnlyInternetGateway_basic(t *testing.T) {
 	})
 }
 
-func TestAccCheckAWSEgressOnlyInternetGateway_tags(t *testing.T) {
+func TestAccAWSEgressOnlyInternetGateway_tags(t *testing.T) {
 	var v ec2.EgressOnlyInternetGateway
 	resourceName := "aws_egress_only_internet_gateway.test"
 

--- a/website/docs/r/egress_only_internet_gateway.html.markdown
+++ b/website/docs/r/egress_only_internet_gateway.html.markdown
@@ -23,6 +23,10 @@ resource "aws_vpc" "example" {
 
 resource "aws_egress_only_internet_gateway" "example" {
   vpc_id = "${aws_vpc.example.id}"
+
+  tags = {
+    Name = "main"
+  }
 }
 ```
 
@@ -31,6 +35,7 @@ resource "aws_egress_only_internet_gateway" "example" {
 The following arguments are supported:
 
 * `vpc_id` - (Required) The VPC ID to create in.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11563. I will rebase this branch when #11501 is merged.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_egress_only_internet_gateway: Add `tags` argument
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEgressOnlyInternetGateway_tags'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccCheckAWSEgressOnlyInternetGateway_tags -timeout 120m
=== RUN   TestAccAWSEgressOnlyInternetGateway_tags
=== PAUSE TestAccAWSEgressOnlyInternetGateway_tags
=== CONT  TestAccAWSEgressOnlyInternetGateway_tags
--- PASS: TestAccAWSEgressOnlyInternetGateway_tags (64.51s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	64.539s
```
