### PR TITLE
.github: Enable GitHub Actions pull request workflow to comment and fail on CHANGELOG.md changes

### DIFF
--- a/.github/workflows/changelog_checks.yml
+++ b/.github/workflows/changelog_checks.yml
@@ -1,0 +1,24 @@
+name: CHANGELOG Checks
+on:
+  pull_request:
+    paths:
+      - CHANGELOG.md
+
+jobs:
+  PRCheck:
+    name: PR Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR Comment
+        uses: unsplash/comment-on-pr@v1.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          msg: |-
+            Thank you for your contribution! :rocket:
+            
+            Please note that the `CHANGELOG.md` file contents are handled by the maintainers during merge. This is to prevent pull request merge conflicts, especially for contributions which may not be merged immediately. Please see the [Contributing Guide](https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md) for additional pull request review items.
+
+            Remove any changes to the `CHANGELOG.md` file and commit them in this pull request to prevent delays with reviewing and potentially merging this pull request.
+      - name: Fail the check
+        run: exit 1


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

This was verified in a separate testing repository:

- Adjust non-`CHANGELOG.md` file: https://github.com/bflad/github-action-testing/pull/2
  - Check not ran (which is what we want)
- Adjust `CHANGELOG.md` file: https://github.com/bflad/github-action-testing/pull/4
  - Check ran
  - Comment left in PR
  - Check failure displayed
- Adjust `CHANGELOG.md` content then remove those changes: https://github.com/bflad/github-action-testing/pull/5
  - On changes (same as before), check ran, commented, and displayed failure
  - On update to remove changes, check failure removed

Output from acceptance testing: N/A