### PR TITLE
aws_codebuild_project: allow empty value of environment variables

### DIFF
--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -836,7 +836,7 @@ func expandProjectEnvironment(d *schema.ResourceData) *codebuild.ProjectEnvironm
 					projectEnvironmentVar.Name = &v
 				}
 
-				if v := config["value"].(string); v != "" {
+				if v, ok := config["value"].(string); ok {
 					projectEnvironmentVar.Value = &v
 				}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

Previously, although an empty string ("") is a valid input for the value of an environment variable, it was treated as if the value is not passed at all (and resulted in validation error). This change fixes it by checking nil in a relevant type assertion.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11192

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_codebuild_project: allow empty string ("") for value of environment variable
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCodeBuildProject_Source_Auth'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSCodeBuildProject_Source_Auth -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCodeBuildProject_Source_Auth
=== PAUSE TestAccAWSCodeBuildProject_Source_Auth
=== CONT  TestAccAWSCodeBuildProject_Source_Auth
--- PASS: TestAccAWSCodeBuildProject_Source_Auth (52.05s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       52.101s
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap      0.007s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags 0.034s [no tests to run]
notsu-mac:terraform-provider-aws arata$ make testacc TESTARGS='-run=TestAccAWSCodeBuildProject'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSCodeBuildProject -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCodeBuildProject_basic
=== PAUSE TestAccAWSCodeBuildProject_basic
=== RUN   TestAccAWSCodeBuildProject_BadgeEnabled
=== PAUSE TestAccAWSCodeBuildProject_BadgeEnabled
=== RUN   TestAccAWSCodeBuildProject_BuildTimeout
=== PAUSE TestAccAWSCodeBuildProject_BuildTimeout
=== RUN   TestAccAWSCodeBuildProject_QueuedTimeout
=== PAUSE TestAccAWSCodeBuildProject_QueuedTimeout
=== RUN   TestAccAWSCodeBuildProject_Cache
=== PAUSE TestAccAWSCodeBuildProject_Cache
=== RUN   TestAccAWSCodeBuildProject_Description
=== PAUSE TestAccAWSCodeBuildProject_Description
=== RUN   TestAccAWSCodeBuildProject_EncryptionKey
=== PAUSE TestAccAWSCodeBuildProject_EncryptionKey
=== RUN   TestAccAWSCodeBuildProject_Environment_EnvironmentVariable
=== PAUSE TestAccAWSCodeBuildProject_Environment_EnvironmentVariable
=== RUN   TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type
=== PAUSE TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type
=== RUN   TestAccAWSCodeBuildProject_Environment_Certificate
=== PAUSE TestAccAWSCodeBuildProject_Environment_Certificate
=== RUN   TestAccAWSCodeBuildProject_LogsConfig_CloudWatchLogs
=== PAUSE TestAccAWSCodeBuildProject_LogsConfig_CloudWatchLogs
=== RUN   TestAccAWSCodeBuildProject_LogsConfig_S3Logs
=== PAUSE TestAccAWSCodeBuildProject_LogsConfig_S3Logs
=== RUN   TestAccAWSCodeBuildProject_Source_Auth
=== PAUSE TestAccAWSCodeBuildProject_Source_Auth
=== RUN   TestAccAWSCodeBuildProject_Source_GitCloneDepth
=== PAUSE TestAccAWSCodeBuildProject_Source_GitCloneDepth
=== RUN   TestAccAWSCodeBuildProject_Source_InsecureSSL
=== PAUSE TestAccAWSCodeBuildProject_Source_InsecureSSL
=== RUN   TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket
=== PAUSE TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket
=== RUN   TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub
=== PAUSE TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub
=== RUN   TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise
=== PAUSE TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise
=== RUN   TestAccAWSCodeBuildProject_Source_Type_Bitbucket
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_Bitbucket
=== RUN   TestAccAWSCodeBuildProject_Source_Type_CodeCommit
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_CodeCommit
=== RUN   TestAccAWSCodeBuildProject_Source_Type_CodePipeline
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_CodePipeline
=== RUN   TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise
=== RUN   TestAccAWSCodeBuildProject_Source_Type_S3
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_S3
=== RUN   TestAccAWSCodeBuildProject_Source_Type_NoSource
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_NoSource
=== RUN   TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid
=== PAUSE TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid
=== RUN   TestAccAWSCodeBuildProject_Tags
=== PAUSE TestAccAWSCodeBuildProject_Tags
=== RUN   TestAccAWSCodeBuildProject_VpcConfig
=== PAUSE TestAccAWSCodeBuildProject_VpcConfig
=== RUN   TestAccAWSCodeBuildProject_WindowsContainer
=== PAUSE TestAccAWSCodeBuildProject_WindowsContainer
=== RUN   TestAccAWSCodeBuildProject_ARMContainer
=== PAUSE TestAccAWSCodeBuildProject_ARMContainer
=== RUN   TestAccAWSCodeBuildProject_Artifacts_ArtifactIdentifier
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_ArtifactIdentifier
=== RUN   TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled
=== RUN   TestAccAWSCodeBuildProject_Artifacts_Location
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_Location
=== RUN   TestAccAWSCodeBuildProject_Artifacts_Name
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_Name
=== RUN   TestAccAWSCodeBuildProject_Artifacts_NamespaceType
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_NamespaceType
=== RUN   TestAccAWSCodeBuildProject_Artifacts_OverrideArtifactName
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_OverrideArtifactName
=== RUN   TestAccAWSCodeBuildProject_Artifacts_Packaging
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_Packaging
=== RUN   TestAccAWSCodeBuildProject_Artifacts_Path
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_Path
=== RUN   TestAccAWSCodeBuildProject_Artifacts_Type
=== PAUSE TestAccAWSCodeBuildProject_Artifacts_Type
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_ArtifactIdentifier
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_ArtifactIdentifier
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_OverrideArtifactName
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_OverrideArtifactName
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_EncryptionDisabled
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_EncryptionDisabled
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_Location
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_Location
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_Name
--- SKIP: TestAccAWSCodeBuildProject_SecondaryArtifacts_Name (0.00s)
    resource_aws_codebuild_project_test.go:1566: Currently no solution to allow updates on name attribute
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_NamespaceType
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_NamespaceType
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_Packaging
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_Packaging
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_Path
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_Path
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts_Type
=== PAUSE TestAccAWSCodeBuildProject_SecondaryArtifacts_Type
=== RUN   TestAccAWSCodeBuildProject_SecondarySources_CodeCommit
=== PAUSE TestAccAWSCodeBuildProject_SecondarySources_CodeCommit
=== RUN   TestAccAWSCodeBuildProject_Environment_RegistryCredential
=== PAUSE TestAccAWSCodeBuildProject_Environment_RegistryCredential
=== CONT  TestAccAWSCodeBuildProject_basic
=== CONT  TestAccAWSCodeBuildProject_Artifacts_ArtifactIdentifier
=== CONT  TestAccAWSCodeBuildProject_Source_Type_S3
=== CONT  TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket
=== CONT  TestAccAWSCodeBuildProject_ARMContainer
=== CONT  TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise
=== CONT  TestAccAWSCodeBuildProject_Source_Type_CodePipeline
=== CONT  TestAccAWSCodeBuildProject_Source_Type_CodeCommit
=== CONT  TestAccAWSCodeBuildProject_Source_Type_Bitbucket
=== CONT  TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise
=== CONT  TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub
=== CONT  TestAccAWSCodeBuildProject_Tags
=== CONT  TestAccAWSCodeBuildProject_WindowsContainer
=== CONT  TestAccAWSCodeBuildProject_VpcConfig
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_OverrideArtifactName
=== CONT  TestAccAWSCodeBuildProject_Environment_RegistryCredential
=== CONT  TestAccAWSCodeBuildProject_SecondarySources_CodeCommit
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_Type
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_Path
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_Packaging
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodeCommit (57.95s)
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_NamespaceType
--- PASS: TestAccAWSCodeBuildProject_WindowsContainer (58.51s)
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_Location
--- PASS: TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise (59.69s)
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_EncryptionDisabled
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodePipeline (64.23s)
=== CONT  TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_CodeCommit (65.81s)
=== CONT  TestAccAWSCodeBuildProject_Source_InsecureSSL
--- PASS: TestAccAWSCodeBuildProject_Source_Type_S3 (72.55s)
=== CONT  TestAccAWSCodeBuildProject_Source_GitCloneDepth
--- PASS: TestAccAWSCodeBuildProject_Source_Type_Bitbucket (75.70s)
=== CONT  TestAccAWSCodeBuildProject_Source_Auth
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Type (81.11s)
=== CONT  TestAccAWSCodeBuildProject_LogsConfig_S3Logs
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise (83.48s)
=== CONT  TestAccAWSCodeBuildProject_LogsConfig_CloudWatchLogs
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub (93.67s)
=== CONT  TestAccAWSCodeBuildProject_Environment_Certificate
--- PASS: TestAccAWSCodeBuildProject_basic (94.36s)
=== CONT  TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid
--- PASS: TestAccAWSCodeBuildProject_Environment_RegistryCredential (98.34s)
=== CONT  TestAccAWSCodeBuildProject_Cache
--- PASS: TestAccAWSCodeBuildProject_Tags (100.65s)
=== CONT  TestAccAWSCodeBuildProject_Environment_EnvironmentVariable
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket (103.84s)
=== CONT  TestAccAWSCodeBuildProject_EncryptionKey
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Path (107.38s)
=== CONT  TestAccAWSCodeBuildProject_Description
--- PASS: TestAccAWSCodeBuildProject_Artifacts_ArtifactIdentifier (110.63s)
=== CONT  TestAccAWSCodeBuildProject_Artifacts_Packaging
--- PASS: TestAccAWSCodeBuildProject_ARMContainer (112.33s)
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts_ArtifactIdentifier
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_OverrideArtifactName (114.67s)
=== CONT  TestAccAWSCodeBuildProject_SecondaryArtifacts
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Packaging (120.60s)
=== CONT  TestAccAWSCodeBuildProject_Artifacts_Type
--- PASS: TestAccAWSCodeBuildProject_Source_Auth (50.77s)
=== CONT  TestAccAWSCodeBuildProject_Artifacts_Path
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid (33.12s)
=== CONT  TestAccAWSCodeBuildProject_BuildTimeout
--- PASS: TestAccAWSCodeBuildProject_VpcConfig (133.62s)
=== CONT  TestAccAWSCodeBuildProject_QueuedTimeout
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type (72.94s)
=== CONT  TestAccAWSCodeBuildProject_BadgeEnabled
--- PASS: TestAccAWSCodeBuildProject_Source_InsecureSSL (72.10s)
=== CONT  TestAccAWSCodeBuildProject_Source_Type_NoSource
--- PASS: TestAccAWSCodeBuildProject_Source_GitCloneDepth (75.31s)
=== CONT  TestAccAWSCodeBuildProject_Artifacts_Name
--- PASS: TestAccAWSCodeBuildProject_Environment_Certificate (64.58s)
=== CONT  TestAccAWSCodeBuildProject_Artifacts_OverrideArtifactName
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_NamespaceType (101.46s)
=== CONT  TestAccAWSCodeBuildProject_Artifacts_NamespaceType
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Location (111.16s)
=== CONT  TestAccAWSCodeBuildProject_Artifacts_Location
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts (60.14s)
=== CONT  TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled
--- PASS: TestAccAWSCodeBuildProject_Description (70.95s)
--- PASS: TestAccAWSCodeBuildProject_LogsConfig_CloudWatchLogs (95.38s)
--- PASS: TestAccAWSCodeBuildProject_EncryptionKey (79.20s)
--- PASS: TestAccAWSCodeBuildProject_BadgeEnabled (48.61s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSource (49.54s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_EncryptionDisabled (129.11s)
--- PASS: TestAccAWSCodeBuildProject_BuildTimeout (74.32s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable (104.63s)
--- PASS: TestAccAWSCodeBuildProject_QueuedTimeout (73.45s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Packaging (100.55s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_ArtifactIdentifier (99.80s)
--- PASS: TestAccAWSCodeBuildProject_LogsConfig_S3Logs (133.27s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Type (97.92s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Path (99.62s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Name (108.57s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_OverrideArtifactName (108.19s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_NamespaceType (107.11s)
--- PASS: TestAccAWSCodeBuildProject_Cache (177.96s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled (107.45s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Location (121.04s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       290.792s
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap      0.007s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags 0.030s [no tests to run]
```
