### PR TITLE
Updates defaults and configuration of RDS Cluster scaling configuration

### DIFF
--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -16,6 +16,11 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
+const (
+	rdsClusterScalingConfiguration_DefaultMinCapacity = 2
+	rdsClusterScalingConfiguration_DefaultMaxCapacity = 16
+)
+
 func resourceAwsRDSCluster() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsRDSClusterCreate,
@@ -158,15 +163,10 @@ func resourceAwsRDSCluster() *schema.Resource {
 			},
 
 			"scaling_configuration": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					if old == "1" && new == "0" {
-						return true
-					}
-					return false
-				},
+				Type:             schema.TypeList,
+				Optional:         true,
+				MaxItems:         1,
+				DiffSuppressFunc: suppressMissingOptionalConfigurationBlock,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"auto_pause": {
@@ -177,12 +177,12 @@ func resourceAwsRDSCluster() *schema.Resource {
 						"max_capacity": {
 							Type:     schema.TypeInt,
 							Optional: true,
-							Default:  16,
+							Default:  rdsClusterScalingConfiguration_DefaultMaxCapacity,
 						},
 						"min_capacity": {
 							Type:     schema.TypeInt,
 							Optional: true,
-							Default:  1,
+							Default:  rdsClusterScalingConfiguration_DefaultMinCapacity,
 						},
 						"seconds_until_auto_pause": {
 							Type:         schema.TypeInt,
@@ -448,7 +448,7 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 			DeletionProtection:   aws.Bool(d.Get("deletion_protection").(bool)),
 			Engine:               aws.String(d.Get("engine").(string)),
 			EngineMode:           aws.String(d.Get("engine_mode").(string)),
-			ScalingConfiguration: expandRdsScalingConfiguration(d.Get("scaling_configuration").([]interface{})),
+			ScalingConfiguration: expandRdsClusterScalingConfiguration(d.Get("scaling_configuration").([]interface{}), d.Get("engine_mode").(string)),
 			SnapshotIdentifier:   aws.String(d.Get("snapshot_identifier").(string)),
 			Tags:                 tags,
 		}
@@ -544,7 +544,7 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 			Engine:                      aws.String(d.Get("engine").(string)),
 			EngineMode:                  aws.String(d.Get("engine_mode").(string)),
 			ReplicationSourceIdentifier: aws.String(d.Get("replication_source_identifier").(string)),
-			ScalingConfiguration:        expandRdsScalingConfiguration(d.Get("scaling_configuration").([]interface{})),
+			ScalingConfiguration:        expandRdsClusterScalingConfiguration(d.Get("scaling_configuration").([]interface{}), d.Get("engine_mode").(string)),
 			Tags:                        tags,
 		}
 
@@ -758,12 +758,13 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 		}
 
 		createOpts := &rds.CreateDBClusterInput{
-			CopyTagsToSnapshot:  aws.Bool(d.Get("copy_tags_to_snapshot").(bool)),
-			DBClusterIdentifier: aws.String(identifier),
-			DeletionProtection:  aws.Bool(d.Get("deletion_protection").(bool)),
-			Engine:              aws.String(d.Get("engine").(string)),
-			EngineMode:          aws.String(d.Get("engine_mode").(string)),
-			Tags:                tags,
+			CopyTagsToSnapshot:   aws.Bool(d.Get("copy_tags_to_snapshot").(bool)),
+			DBClusterIdentifier:  aws.String(identifier),
+			DeletionProtection:   aws.Bool(d.Get("deletion_protection").(bool)),
+			Engine:               aws.String(d.Get("engine").(string)),
+			EngineMode:           aws.String(d.Get("engine_mode").(string)),
+			ScalingConfiguration: expandRdsClusterScalingConfiguration(d.Get("scaling_configuration").([]interface{}), d.Get("engine_mode").(string)),
+			Tags:                 tags,
 		}
 
 		if v, ok := d.GetOk("master_password"); ok && v.(string) != "" {
@@ -838,10 +839,6 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 
 		if attr, ok := d.GetOk("enabled_cloudwatch_logs_exports"); ok && len(attr.([]interface{})) > 0 {
 			createOpts.EnableCloudwatchLogsExports = expandStringList(attr.([]interface{}))
-		}
-
-		if attr, ok := d.GetOk("scaling_configuration"); ok && len(attr.([]interface{})) > 0 {
-			createOpts.ScalingConfiguration = expandRdsScalingConfiguration(attr.([]interface{}))
 		}
 
 		if attr, ok := d.GetOkExists("storage_encrypted"); ok {
@@ -1135,7 +1132,7 @@ func resourceAwsRDSClusterUpdate(d *schema.ResourceData, meta interface{}) error
 
 	if d.HasChange("scaling_configuration") {
 		d.SetPartial("scaling_configuration")
-		req.ScalingConfiguration = expandRdsScalingConfiguration(d.Get("scaling_configuration").([]interface{}))
+		req.ScalingConfiguration = expandRdsClusterScalingConfiguration(d.Get("scaling_configuration").([]interface{}), d.Get("engine_mode").(string))
 		requestUpdate = true
 	}
 

--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -182,7 +182,7 @@ func resourceAwsRDSCluster() *schema.Resource {
 						"min_capacity": {
 							Type:     schema.TypeInt,
 							Optional: true,
-							Default:  2,
+							Default:  1,
 						},
 						"seconds_until_auto_pause": {
 							Type:         schema.TypeInt,
@@ -758,13 +758,12 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 		}
 
 		createOpts := &rds.CreateDBClusterInput{
-			CopyTagsToSnapshot:   aws.Bool(d.Get("copy_tags_to_snapshot").(bool)),
-			DBClusterIdentifier:  aws.String(identifier),
-			DeletionProtection:   aws.Bool(d.Get("deletion_protection").(bool)),
-			Engine:               aws.String(d.Get("engine").(string)),
-			EngineMode:           aws.String(d.Get("engine_mode").(string)),
-			ScalingConfiguration: expandRdsScalingConfiguration(d.Get("scaling_configuration").([]interface{})),
-			Tags:                 tags,
+			CopyTagsToSnapshot:  aws.Bool(d.Get("copy_tags_to_snapshot").(bool)),
+			DBClusterIdentifier: aws.String(identifier),
+			DeletionProtection:  aws.Bool(d.Get("deletion_protection").(bool)),
+			Engine:              aws.String(d.Get("engine").(string)),
+			EngineMode:          aws.String(d.Get("engine_mode").(string)),
+			Tags:                tags,
 		}
 
 		if v, ok := d.GetOk("master_password"); ok && v.(string) != "" {

--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -849,6 +849,7 @@ func TestAccAWSRDSCluster_EngineMode(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterExists(resourceName, &dbCluster1),
 					resource.TestCheckResourceAttr(resourceName, "engine_mode", "serverless"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_configuration.#", "1"),
 				),
 			},
 			{
@@ -869,6 +870,7 @@ func TestAccAWSRDSCluster_EngineMode(t *testing.T) {
 					testAccCheckAWSClusterExists(resourceName, &dbCluster2),
 					testAccCheckAWSClusterRecreated(&dbCluster1, &dbCluster2),
 					resource.TestCheckResourceAttr(resourceName, "engine_mode", "provisioned"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_configuration.#", "0"),
 				),
 			},
 			{

--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -2890,6 +2890,10 @@ resource "aws_rds_cluster" "test" {
   master_password     = "barbarbarbar"
   master_username     = "foo"
   skip_final_snapshot = true
+
+//   scaling_configuration {
+// 	min_capacity = 2
+//   }
 }
 `, rName, engineMode)
 }

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -4775,9 +4775,17 @@ func flattenDaxEncryptAtRestOptions(options *dax.SSEDescription) []map[string]in
 	return []map[string]interface{}{m}
 }
 
-func expandRdsScalingConfiguration(l []interface{}) *rds.ScalingConfiguration {
+func expandRdsClusterScalingConfiguration(l []interface{}, engineMode string) *rds.ScalingConfiguration {
 	if len(l) == 0 || l[0] == nil {
-		return nil
+		// Our default value for MinCapacity is different from AWS's.
+		// We need to override it here to avoid a non-empty plan with an empty ScalingConfiguration.
+		if engineMode == "serverless" {
+			return &rds.ScalingConfiguration{
+				MinCapacity: aws.Int64(int64(rdsClusterScalingConfiguration_DefaultMinCapacity)),
+			}
+		} else {
+			return nil
+		}
 	}
 
 	m := l[0].(map[string]interface{})

--- a/aws/structure_test.go
+++ b/aws/structure_test.go
@@ -1545,3 +1545,102 @@ const testExampleXML_from_msdn_flawed = `
     </items>
 </purchaseOrder>
 `
+
+func TestExpandRdsClusterScalingConfiguration_serverless(t *testing.T) {
+	type testCase struct {
+		EngineMode string
+		Input      []interface{}
+		Expected   *rds.ScalingConfiguration
+	}
+	cases := []testCase{
+		{
+			EngineMode: "serverless",
+			Input: []interface{}{
+				map[string]interface{}{
+					"auto_pause":               false,
+					"max_capacity":             32,
+					"min_capacity":             4,
+					"seconds_until_auto_pause": 600,
+					"timeout_action":           "ForceApplyCapacityChange",
+				},
+			},
+			Expected: &rds.ScalingConfiguration{
+				AutoPause:             aws.Bool(false),
+				MaxCapacity:           aws.Int64(32),
+				MinCapacity:           aws.Int64(4),
+				SecondsUntilAutoPause: aws.Int64(600),
+				TimeoutAction:         aws.String("ForceApplyCapacityChange"),
+			},
+		},
+		{
+			EngineMode: "serverless",
+			Input:      []interface{}{},
+			Expected: &rds.ScalingConfiguration{
+				MinCapacity: aws.Int64(2),
+			},
+		},
+		{
+			EngineMode: "serverless",
+			Input: []interface{}{
+				nil,
+			},
+			Expected: &rds.ScalingConfiguration{
+				MinCapacity: aws.Int64(2),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		output := expandRdsClusterScalingConfiguration(tc.Input, tc.EngineMode)
+		if !reflect.DeepEqual(output, tc.Expected) {
+			t.Errorf("EngineMode: %s\nExpected: %v,\nGot: %v", tc.EngineMode, tc.Expected, output)
+		}
+	}
+}
+
+func TestExpandRdsClusterScalingConfiguration_basic(t *testing.T) {
+	type testCase struct {
+		EngineMode string
+		Input      []interface{}
+		ExpectNil  bool
+	}
+	cases := []testCase{}
+
+	// RDS Cluster Scaling Configuration is only valid for serverless, but we're relying on AWS errors.
+	// If Terraform adds whole-resource validation, we can do our own validation at plan time.
+	for _, engineMode := range []string{"global", "multimaster", "parallelquery", "provisioned"} {
+		cases = append(cases, []testCase{
+			{
+				EngineMode: engineMode,
+				Input: []interface{}{
+					map[string]interface{}{
+						"auto_pause":               false,
+						"max_capacity":             32,
+						"min_capacity":             4,
+						"seconds_until_auto_pause": 600,
+						"timeout_action":           "ForceApplyCapacityChange",
+					},
+				},
+				ExpectNil: false,
+			},
+			{
+				EngineMode: engineMode,
+				Input:      []interface{}{},
+				ExpectNil:  true,
+			}, {
+				EngineMode: engineMode,
+				Input: []interface{}{
+					nil,
+				},
+				ExpectNil: true,
+			},
+		}...)
+	}
+
+	for _, tc := range cases {
+		output := expandRdsClusterScalingConfiguration(tc.Input, tc.EngineMode)
+		if tc.ExpectNil != (output == nil) {
+			t.Errorf("EngineMode %q: Expected nil: %t, Got: %v", tc.EngineMode, tc.ExpectNil, output)
+		}
+	}
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Acceptance tests fails with:
```
--- FAIL: TestAccAWSRDSCluster_EngineMode (269.60s)
    testing.go:640: Step 0 error: After applying this step, the plan was not empty:
    ...
    scaling_configuration.0.min_capacity:             "1" => "2"
```

The default value returned by the AWS API is `1`, while the resource schema defined a minimum value of `2`. This PR creates a default configuration with `min_capacity` set to `2` if the resource does not specify a `scaling_configuration` block.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSRDSCluster_'

--- SKIP: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Serverless (0.00s)
--- PASS: TestAccAWSRDSCluster_basic (113.60s)
--- PASS: TestAccAWSRDSCluster_EngineMode_Global (115.97s)
--- PASS: TestAccAWSRDSCluster_generatedName (133.67s)
--- PASS: TestAccAWSRDSCluster_EngineMode_Multimaster (135.63s)
--- PASS: TestAccAWSRDSCluster_EngineMode_ParallelQuery (141.87s)
--- PASS: TestAccAWSRDSCluster_EngineVersion (157.09s)
--- PASS: TestAccAWSRDSCluster_DeletionProtection (157.44s)
--- PASS: TestAccAWSRDSCluster_backupsUpdate (175.18s)
--- PASS: TestAccAWSRDSCluster_iamAuth (175.76s)
--- PASS: TestAccAWSRDSCluster_kmsKey (197.65s)
--- FAIL: TestAccAWSRDSCluster_SnapshotIdentifier_PreferredBackupWindow (306.38s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_Update (133.33s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_PreferredMaintenanceWindow (323.76s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EncryptedRestore (324.02s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_Remove (148.38s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_MasterPassword (346.79s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_Add (156.80s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_Tags (375.79s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds_Tags (388.84s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Equal (406.43s)
--- PASS: TestAccAWSRDSCluster_EngineMode (433.81s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier (127.55s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Provisioned (333.05s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds (449.04s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_MasterUsername (449.54s)
--- PASS: TestAccAWSRDSCluster_Port (297.39s)
--- PASS: TestAccAWSRDSCluster_missingUserNameCausesError (6.32s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Different (362.64s)
--- PASS: TestAccAWSRDSCluster_AvailabilityZones (152.77s)
--- PASS: TestAccAWSRDSCluster_BacktrackWindow (163.83s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier (351.57s)
--- PASS: TestAccAWSRDSCluster_ScalingConfiguration (350.99s)
--- PASS: TestAccAWSRDSCluster_Tags (136.27s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_DeletionProtection (379.55s)
--- PASS: TestAccAWSRDSCluster_updateIamRoles (161.16s)
--- PASS: TestAccAWSRDSCluster_ClusterIdentifierPrefix (117.47s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_ParallelQuery (417.74s)
--- PASS: TestAccAWSRDSCluster_DbSubnetGroupName (120.75s)
--- PASS: TestAccAWSRDSCluster_copyTagsToSnapshot (209.04s)
--- PASS: TestAccAWSRDSCluster_encrypted (131.50s)
--- PASS: TestAccAWSRDSCluster_takeFinalSnapshot (152.07s)
--- PASS: TestAccAWSRDSCluster_EnabledCloudwatchLogsExports (352.80s)
--- PASS: TestAccAWSRDSCluster_EngineVersionWithPrimaryInstance (1091.14s)
--- FAIL: TestAccAWSRDSCluster_s3Restore (754.88s)
--- PASS: TestAccAWSRDSCluster_EncryptedCrossRegionReplication (1049.91s)
```
**Note:** `TestAccAWSRDSCluster_SnapshotIdentifier_PreferredBackupWindow` and `TestAccAWSRDSCluster_s3Restore` are pre-existing failures