### PR TITLE
bugfix - aws storage aws_storage_gateway_upload_buffer disk id changes

### DIFF
--- a/aws/resource_aws_storagegateway_upload_buffer.go
+++ b/aws/resource_aws_storagegateway_upload_buffer.go
@@ -55,6 +55,34 @@ func resourceAwsStorageGatewayUploadBufferCreate(d *schema.ResourceData, meta in
 
 	d.SetId(fmt.Sprintf("%s:%s", gatewayARN, diskID))
 
+	// Depending on the Storage Gateway software, it will sometimes relabel a local DiskId
+	// with a UUID if previously unlabeled, e.g.
+	// Before conn.AddUploadBuffer(): "DiskId": "/dev/xvdb",
+	// After conn.AddUploadBuffer(): "DiskId": "112764d7-7e83-42ce-9af3-d482985a31cc",
+	// This prevents us from successfully reading the disk after creation.
+	// Here we try to refresh the local disks to see if we can find a new DiskId.
+
+	listLocalDisksInput := &storagegateway.ListLocalDisksInput{
+		GatewayARN: aws.String(gatewayARN),
+	}
+
+	log.Printf("[DEBUG] Reading Storage Gateway Local Disk: %s", listLocalDisksInput)
+	output, err := conn.ListLocalDisks(listLocalDisksInput)
+	if err != nil {
+		return fmt.Errorf("error reading Storage Gateway Local Disk: %s", err)
+	}
+
+	if output != nil {
+		for _, disk := range output.Disks {
+			if aws.StringValue(disk.DiskId) == diskID || aws.StringValue(disk.DiskNode) == diskID || aws.StringValue(disk.DiskPath) == diskID {
+				diskID = aws.StringValue(disk.DiskId)
+				break
+			}
+		}
+	}
+
+	d.SetId(fmt.Sprintf("%s:%s", gatewayARN, diskID))
+
 	return resourceAwsStorageGatewayUploadBufferRead(d, meta)
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_storagegateway_upload_buffer:  bugfix for occasions where aws_storage_gateway_upload_buffer disk_id param value changes after creation
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=testAccCheckAWSStorageGatewayUploadBufferExists'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=testAccCheckAWSStorageGatewayUploadBufferExists -timeout 120m
go: downloading github.com/pquerna/otp v1.2.0
go: downloading github.com/hashicorp/vault v0.10.4
go: extracting github.com/pquerna/otp v1.2.0
go: downloading github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc
go: extracting github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc
go: extracting github.com/hashicorp/vault v0.10.4
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       0.063s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap      0.011s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags 0.030s [no tests to run]

make testacc TESTARGS='-run=testAccAWSStorageGatewayUploadBufferConfig_Basic' 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=testAccAWSStorageGatewayUploadBufferConfig_Basic -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       0.061s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap      0.008s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags 0.020s [no tests to run]
(main3)
...
```
