### PR TITLE
Configure "FROM email address" for Cognito user pool (aws_cognito_user_pool)

### DIFF
--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -154,9 +154,6 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 						"from_email_address": {
 							Type:     schema.TypeString,
 							Optional: true,
-							ValidateFunc: validation.Any(
-								validation.StringInSlice([]string{""}, false),
-							),
 						},
 						"email_sending_account": {
 							Type:     schema.TypeString,

--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -1007,9 +1007,9 @@ func resourceAwsCognitoUserPoolUpdate(d *schema.ResourceData, meta interface{}) 
 					emailConfigurationType.EmailSendingAccount = aws.String(v.(string))
 				}
 
-                if v, ok := config["from_email_address"]; ok && v.(string) != "" {
-                    emailConfigurationType.From = aws.String(v.(string))
-                }
+				if v, ok := config["from_email_address"]; ok && v.(string) != "" {
+					emailConfigurationType.From = aws.String(v.(string))
+				}
 
 				params.EmailConfiguration = emailConfigurationType
 			}

--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -151,6 +151,13 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 							Optional:     true,
 							ValidateFunc: validateArn,
 						},
+						"from_email_address": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.Any(
+								validation.StringInSlice([]string{""}, false),
+							),
+						},
 						"email_sending_account": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -567,6 +574,10 @@ func resourceAwsCognitoUserPoolCreate(d *schema.ResourceData, meta interface{}) 
 
 			if v, ok := config["source_arn"]; ok && v.(string) != "" {
 				emailConfigurationType.SourceArn = aws.String(v.(string))
+			}
+
+			if v, ok := config["from_email_address"]; ok && v.(string) != "" {
+				emailConfigurationType.From = aws.String(v.(string))
 			}
 
 			if v, ok := config["email_sending_account"]; ok && v.(string) != "" {
@@ -998,6 +1009,10 @@ func resourceAwsCognitoUserPoolUpdate(d *schema.ResourceData, meta interface{}) 
 				if v, ok := config["email_sending_account"]; ok && v.(string) != "" {
 					emailConfigurationType.EmailSendingAccount = aws.String(v.(string))
 				}
+
+                if v, ok := config["from_email_address"]; ok && v.(string) != "" {
+                    emailConfigurationType.From = aws.String(v.(string))
+                }
 
 				params.EmailConfiguration = emailConfigurationType
 			}

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -704,11 +704,12 @@ func TestAccAWSCognitoUserPool_withEmailConfiguration(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withEmailConfiguration(name, "", "", "COGNITO_DEFAULT"),
+				Config: testAccAWSCognitoUserPoolConfig_withEmailConfiguration(name, "", "", "", "COGNITO_DEFAULT"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "email_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "email_configuration.0.reply_to_email_address", ""),
 					resource.TestCheckResourceAttr(resourceName, "email_configuration.0.email_sending_account", "COGNITO_DEFAULT"),
+					resource.TestCheckResourceAttr(resourceName, "email_configuration.0.from_email_address", ""),
 				),
 			},
 			{
@@ -717,12 +718,13 @@ func TestAccAWSCognitoUserPool_withEmailConfiguration(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withEmailConfiguration(name, replyTo, sourceARN, "DEVELOPER"),
+				Config: testAccAWSCognitoUserPoolConfig_withEmailConfiguration(name, replyTo, sourceARN, "John Smith <john@smith.com>", "DEVELOPER"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "email_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "email_configuration.0.reply_to_email_address", replyTo),
 					resource.TestCheckResourceAttr(resourceName, "email_configuration.0.email_sending_account", "DEVELOPER"),
 					resource.TestCheckResourceAttr(resourceName, "email_configuration.0.source_arn", sourceARN),
+					resource.TestCheckResourceAttr(resourceName, "email_configuration.0.from_email_address", "John Smith <john@smith.com>"),
 				),
 			},
 		},
@@ -1473,7 +1475,7 @@ resource "aws_cognito_user_pool" "test" {
 `, name, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccAWSCognitoUserPoolConfig_withEmailConfiguration(name, email, arn, account string) string {
+func testAccAWSCognitoUserPoolConfig_withEmailConfiguration(name, email, arn, from, account string) string {
 	return fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
     name = "terraform-test-pool-%[1]s"
@@ -1482,9 +1484,10 @@ resource "aws_cognito_user_pool" "test" {
     email_configuration {
       reply_to_email_address = %[2]q
       source_arn = %[3]q
-      email_sending_account = %[4]q
+      from_email_address = %[4]q
+      email_sending_account = %[5]q
     }
-  }`, name, email, arn, account)
+  }`, name, email, arn, from, account)
 }
 
 func testAccAWSCognitoUserPoolConfig_withAliasAttributes(name string) string {

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -2530,6 +2530,10 @@ func flattenCognitoUserPoolEmailConfiguration(s *cognitoidentityprovider.EmailCo
 		m["reply_to_email_address"] = *s.ReplyToEmailAddress
 	}
 
+	if s.From != nil {
+		m["from_email_address"] = *s.From
+	}
+
 	if s.SourceArn != nil {
 		m["source_arn"] = *s.SourceArn
 	}

--- a/website/docs/r/cognito_user_pool.markdown
+++ b/website/docs/r/cognito_user_pool.markdown
@@ -89,6 +89,7 @@ The following arguments are supported:
 
   * `reply_to_email_address` (Optional) - The REPLY-TO email address.
   * `source_arn` (Optional) - The ARN of the email source.
+  * `from_email_address` (Optional) - Sender’s email address or sender’s name with their email address (e.g. "john@smith.com" or "John Smith <john@smith.com>")
   * `email_sending_account` (Optional) - Instruct Cognito to either use its built-in functional or Amazon SES to send out emails.
 
 #### Lambda Configuration


### PR DESCRIPTION
An AWS Cognito User Pool can be configured to use a custom "FROM email address" (see General Settings > Message customizations > FROM email address).
In the [CreateUserPool](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateUserPool.html) and [UpdateUserPool](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UpdateUserPool.html) API reference the path to this field is "EmailConfiguration.From".
The value may contain email sender strings such as `John Smith` or `John Smith <john@smith.com>`.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11507

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
* resource/aws_cognito_user_pool: Add `from_email_address` to `email_configuration`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
TODO
...
```
