### PR TITLE
New Resource: aws_workspaces_workspace

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -884,6 +884,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_worklink_fleet":                                      resourceAwsWorkLinkFleet(),
 			"aws_worklink_website_certificate_authority_association":  resourceAwsWorkLinkWebsiteCertificateAuthorityAssociation(),
 			"aws_workspaces_directory":                                resourceAwsWorkspacesDirectory(),
+			"aws_workspaces_workspace":                                resourceAwsWorkspacesWorkspace(),
 			"aws_batch_compute_environment":                           resourceAwsBatchComputeEnvironment(),
 			"aws_batch_job_definition":                                resourceAwsBatchJobDefinition(),
 			"aws_batch_job_queue":                                     resourceAwsBatchJobQueue(),

--- a/aws/resource_aws_workspaces_directory.go
+++ b/aws/resource_aws_workspaces_directory.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/workspaces"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
@@ -252,18 +253,15 @@ func resourceAwsWorkspacesDirectoryDelete(d *schema.ResourceData, meta interface
 	if err != nil {
 		return fmt.Errorf("error deleting workspaces directory (%s): %s", d.Id(), err)
 	}
-	log.Printf("[DEBUG] Workspaces directory %q is deregistered", d.Id())
 
 	return nil
 }
 
 func workspacesDirectoryDelete(id string, conn *workspaces.WorkSpaces) error {
-	input := &workspaces.DeregisterWorkspaceDirectoryInput{
-		DirectoryId: aws.String(id),
-	}
-
 	log.Printf("[DEBUG] Deregistering Workspace Directory %q", id)
-	_, err := conn.DeregisterWorkspaceDirectory(input)
+	_, err := conn.DeregisterWorkspaceDirectory(&workspaces.DeregisterWorkspaceDirectoryInput{
+		DirectoryId: aws.String(id),
+	})
 	if err != nil {
 		return fmt.Errorf("error deregistering Workspace Directory %q: %w", id, err)
 	}
@@ -286,6 +284,8 @@ func workspacesDirectoryDelete(id string, conn *workspaces.WorkSpaces) error {
 	if err != nil {
 		return fmt.Errorf("error waiting for Workspace Directory %q to be deregistered: %w", id, err)
 	}
+	log.Printf("[DEBUG] Workspaces Directory %q is deregistered", id)
+
 	return nil
 }
 

--- a/aws/resource_aws_workspaces_directory_test.go
+++ b/aws/resource_aws_workspaces_directory_test.go
@@ -16,8 +16,9 @@ import (
 
 func init() {
 	resource.AddTestSweepers("aws_workspaces_directory", &resource.Sweeper{
-		Name: "aws_workspaces_directory",
-		F:    testSweepWorkspacesDirectories,
+		Name:         "aws_workspaces_directory",
+		F:            testSweepWorkspacesDirectories,
+		Dependencies: []string{"aws_workspaces_workspace"},
 	})
 }
 

--- a/aws/resource_aws_workspaces_workspace.go
+++ b/aws/resource_aws_workspaces_workspace.go
@@ -1,0 +1,469 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/workspaces"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+func resourceAwsWorkspacesWorkspace() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsWorkspacesWorkspaceCreate,
+		Read:   resourceAwsWorkspacesWorkspaceRead,
+		Update: resourceAwsWorkspacesWorkspaceUpdate,
+		Delete: resourceAwsWorkspacesWorkspaceDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"bundle_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"directory_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"ip_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"computer_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"root_volume_encryption_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  false,
+			},
+			"user_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"user_volume_encryption_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  false,
+			},
+			"volume_encryption_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"workspace_properties": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"compute_type_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  workspaces.ComputeValue,
+							ValidateFunc: validation.StringInSlice([]string{
+								workspaces.ComputeValue,
+								workspaces.ComputeStandard,
+								workspaces.ComputePerformance,
+								workspaces.ComputePower,
+								workspaces.ComputePowerpro,
+								workspaces.ComputeGraphics,
+								workspaces.ComputeGraphicspro,
+							}, false),
+						},
+						"root_volume_size_gib": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  80,
+							ValidateFunc: validation.Any(
+								validation.IntInSlice([]int{80}),
+								validation.IntBetween(175, 2000),
+							),
+						},
+						"running_mode": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  workspaces.RunningModeAlwaysOn,
+							ValidateFunc: validation.StringInSlice([]string{
+								workspaces.RunningModeAlwaysOn,
+								workspaces.RunningModeAutoStop,
+							}, false),
+						},
+						"running_mode_auto_stop_timeout_in_minutes": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+								val := v.(int)
+								if val%60 != 0 {
+									errors = append(errors, fmt.Errorf(
+										"%q should be configured in 60-minute intervals, got: %d", k, val))
+								}
+								return
+							},
+						},
+						"user_volume_size_gib": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  10,
+							ValidateFunc: validation.Any(
+								validation.IntInSlice([]int{10, 50}),
+								validation.IntBetween(100, 2000),
+							),
+						},
+					},
+				},
+			},
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsWorkspacesWorkspaceCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).workspacesconn
+
+	tags := keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().WorkspacesTags()
+
+	input := &workspaces.WorkspaceRequest{
+		BundleId:                    aws.String(d.Get("bundle_id").(string)),
+		DirectoryId:                 aws.String(d.Get("directory_id").(string)),
+		UserName:                    aws.String(d.Get("user_name").(string)),
+		RootVolumeEncryptionEnabled: aws.Bool(d.Get("root_volume_encryption_enabled").(bool)),
+		UserVolumeEncryptionEnabled: aws.Bool(d.Get("user_volume_encryption_enabled").(bool)),
+		Tags:                        tags,
+	}
+
+	if v, ok := d.GetOk("volume_encryption_key"); ok {
+		input.VolumeEncryptionKey = aws.String(v.(string))
+	}
+
+	input.WorkspaceProperties = expandWorkspaceProperties(d.Get("workspace_properties").([]interface{}))
+
+	log.Printf("[DEBUG] Creating workspace...\n%#v\n", *input)
+	resp, err := conn.CreateWorkspaces(&workspaces.CreateWorkspacesInput{
+		Workspaces: []*workspaces.WorkspaceRequest{input},
+	})
+	if err != nil {
+		return err
+	}
+
+	wsFail := resp.FailedRequests
+
+	if len(wsFail) > 0 {
+		return fmt.Errorf("workspace creation failed: %s", *wsFail[0].ErrorMessage)
+	}
+
+	wsPendingID := aws.StringValue(resp.PendingRequests[0].WorkspaceId)
+
+	log.Printf("[DEBUG] Waiting for workspace to be available...")
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			workspaces.WorkspaceStatePending,
+			workspaces.WorkspaceStateStarting,
+		},
+		Target:       []string{workspaces.WorkspaceStateAvailable},
+		Refresh:      workspaceRefreshStateFunc(conn, wsPendingID),
+		PollInterval: 30 * time.Second,
+		Timeout:      25 * time.Minute,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("workspace %q is not available: %s", wsPendingID, err)
+	}
+
+	wsAvailableID := wsPendingID
+
+	d.SetId(wsAvailableID)
+	log.Printf("[DEBUG] Workspace %q is available", d.Id())
+
+	return resourceAwsWorkspacesWorkspaceRead(d, meta)
+}
+
+func resourceAwsWorkspacesWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).workspacesconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
+	workspace, state, err := workspaceRefreshStateFunc(conn, d.Id())()
+	if err != nil {
+		return fmt.Errorf("error reading workspace (%s): %s", d.Id(), err)
+	}
+	if state == workspaces.WorkspaceStateTerminated {
+		log.Printf("[WARN] workspace (%s) is not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	ws := workspace.(*workspaces.Workspace)
+	d.Set("bundle_id", ws.BundleId)
+	d.Set("directory_id", ws.DirectoryId)
+	d.Set("ip_address", ws.IpAddress)
+	d.Set("computer_name", ws.ComputerName)
+	d.Set("state", ws.State)
+	d.Set("root_volume_encryption_enabled", ws.RootVolumeEncryptionEnabled)
+	d.Set("user_name", ws.UserName)
+	d.Set("user_volume_encryption_enabled", ws.UserVolumeEncryptionEnabled)
+	d.Set("volume_encryption_key", ws.VolumeEncryptionKey)
+	if err := d.Set("workspace_properties", flattenWorkspaceProperties(ws.WorkspaceProperties)); err != nil {
+		return fmt.Errorf("error setting workspace properties: %s", err)
+	}
+
+	tags, err := keyvaluetags.WorkspacesListTags(conn, d.Id())
+	if err != nil {
+		return fmt.Errorf("error listing tags: %s", err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsWorkspacesWorkspaceUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).workspacesconn
+
+	// IMPORTANT: Only one workspace property could be changed in a time.
+	// I've create AWS Support feature request to allow multiple properties modification in a time.
+	// https://docs.aws.amazon.com/workspaces/latest/adminguide/modify-workspaces.html
+
+	if d.HasChange("workspace_properties.0.compute_type_name") {
+		if err := workspacePropertyUpdate("compute_type_name", conn, d); err != nil {
+			return err
+		}
+	}
+
+	if d.HasChange("workspace_properties.0.root_volume_size_gib") {
+		if err := workspacePropertyUpdate("root_volume_size_gib", conn, d); err != nil {
+			return err
+		}
+	}
+
+	if d.HasChange("workspace_properties.0.running_mode") {
+		if err := workspacePropertyUpdate("running_mode", conn, d); err != nil {
+			return err
+		}
+	}
+
+	if d.HasChange("workspace_properties.0.running_mode_auto_stop_timeout_in_minutes") {
+		if err := workspacePropertyUpdate("running_mode_auto_stop_timeout_in_minutes", conn, d); err != nil {
+			return err
+		}
+	}
+
+	if d.HasChange("workspace_properties.0.user_volume_size_gib") {
+		if err := workspacePropertyUpdate("user_volume_size_gib", conn, d); err != nil {
+			return err
+		}
+	}
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+		if err := keyvaluetags.WorkspacesUpdateTags(conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("error updating tags: %s", err)
+		}
+	}
+
+	return resourceAwsWorkspacesWorkspaceRead(d, meta)
+}
+
+func resourceAwsWorkspacesWorkspaceDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).workspacesconn
+
+	err := workspaceDelete(d.Id(), conn)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func workspaceDelete(id string, conn *workspaces.WorkSpaces) error {
+	log.Printf("[DEBUG] Terminating workspace %q", id)
+	_, err := conn.TerminateWorkspaces(&workspaces.TerminateWorkspacesInput{
+		TerminateWorkspaceRequests: []*workspaces.TerminateRequest{
+			{
+				WorkspaceId: aws.String(id),
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Waiting for workspace %q to be terminated", id)
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			workspaces.WorkspaceStatePending,
+			workspaces.WorkspaceStateAvailable,
+			workspaces.WorkspaceStateImpaired,
+			workspaces.WorkspaceStateUnhealthy,
+			workspaces.WorkspaceStateRebooting,
+			workspaces.WorkspaceStateStarting,
+			workspaces.WorkspaceStateRebuilding,
+			workspaces.WorkspaceStateRestoring,
+			workspaces.WorkspaceStateMaintenance,
+			workspaces.WorkspaceStateAdminMaintenance,
+			workspaces.WorkspaceStateSuspended,
+			workspaces.WorkspaceStateUpdating,
+			workspaces.WorkspaceStateStopping,
+			workspaces.WorkspaceStateStopped,
+			workspaces.WorkspaceStateError,
+		},
+		Target: []string{
+			workspaces.WorkspaceStateTerminating,
+			workspaces.WorkspaceStateTerminated,
+		},
+		Refresh:      workspaceRefreshStateFunc(conn, id),
+		PollInterval: 15 * time.Second,
+		Timeout:      10 * time.Minute,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("workspace %q was not terminated: %s", id, err)
+	}
+	log.Printf("[DEBUG] Workspace %q is terminated", id)
+
+	return nil
+}
+
+func workspacePropertyUpdate(p string, conn *workspaces.WorkSpaces, d *schema.ResourceData) error {
+	id := d.Id()
+
+	log.Printf("[DEBUG] Modifying workspace %q %s property...", id, p)
+
+	var wsp *workspaces.WorkspaceProperties
+
+	switch p {
+	case "compute_type_name":
+		wsp = &workspaces.WorkspaceProperties{
+			ComputeTypeName: aws.String(d.Get("workspace_properties.0.compute_type_name").(string)),
+		}
+	case "root_volume_size_gib":
+		wsp = &workspaces.WorkspaceProperties{
+			RootVolumeSizeGib: aws.Int64(int64(d.Get("workspace_properties.0.root_volume_size_gib").(int))),
+		}
+	case "running_mode":
+		wsp = &workspaces.WorkspaceProperties{
+			RunningMode: aws.String(d.Get("workspace_properties.0.running_mode").(string)),
+		}
+	case "running_mode_auto_stop_timeout_in_minutes":
+		if d.Get("workspace_properties.0.running_mode") != workspaces.RunningModeAutoStop {
+			log.Printf("[DEBUG] Property running_mode_auto_stop_timeout_in_minutes makes sense only for AUTO_STOP running mode")
+			return nil
+		}
+
+		wsp = &workspaces.WorkspaceProperties{
+			RunningModeAutoStopTimeoutInMinutes: aws.Int64(int64(d.Get("workspace_properties.0.running_mode_auto_stop_timeout_in_minutes").(int))),
+		}
+	case "user_volume_size_gib":
+		wsp = &workspaces.WorkspaceProperties{
+			UserVolumeSizeGib: aws.Int64(int64(d.Get("workspace_properties.0.user_volume_size_gib").(int))),
+		}
+	}
+
+	_, err := conn.ModifyWorkspaceProperties(&workspaces.ModifyWorkspacePropertiesInput{
+		WorkspaceId:         aws.String(id),
+		WorkspaceProperties: wsp,
+	})
+	if err != nil {
+		return fmt.Errorf("workspace %q %s property was not modified: %s", d.Id(), p, err)
+	}
+
+	log.Printf("[DEBUG] Waiting for workspace %q %s property to be modified...", d.Id(), p)
+	// OperationInProgressException: The properties of this WorkSpace are currently under modification. Please try again in a moment.
+	// AWS Workspaces service doesn't change instance status to "Updating" during property modification. Respective AWS Support feature request has been created. Meanwhile, artificial delay is placed here as a workaround.
+	time.Sleep(1 * time.Minute)
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			workspaces.WorkspaceStateUpdating,
+		},
+		Target: []string{
+			workspaces.WorkspaceStateAvailable,
+			workspaces.WorkspaceStateStopped,
+		},
+		Refresh:      workspaceRefreshStateFunc(conn, d.Id()),
+		PollInterval: 30 * time.Second,
+		Timeout:      10 * time.Minute,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("workspace %q %s property was not modified: %s", d.Id(), p, err)
+	}
+	log.Printf("[DEBUG] Workspace %q %s property is modified", d.Id(), p)
+
+	return nil
+}
+
+func workspaceRefreshStateFunc(conn *workspaces.WorkSpaces, workspaceID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := conn.DescribeWorkspaces(&workspaces.DescribeWorkspacesInput{
+			WorkspaceIds: []*string{aws.String(workspaceID)},
+		})
+		if err != nil {
+			return nil, workspaces.WorkspaceStateError, err
+		}
+		if len(resp.Workspaces) == 0 {
+			return resp, workspaces.WorkspaceStateTerminated, nil
+		}
+		workspace := resp.Workspaces[0]
+		return workspace, aws.StringValue(workspace.State), nil
+	}
+}
+
+func expandWorkspaceProperties(properties []interface{}) *workspaces.WorkspaceProperties {
+	log.Printf("[DEBUG] Expand Workspace properties: %+v ", properties)
+
+	if len(properties) == 0 || properties[0] == nil {
+		return nil
+	}
+
+	p := properties[0].(map[string]interface{})
+
+	return &workspaces.WorkspaceProperties{
+		ComputeTypeName:                     aws.String(p["compute_type_name"].(string)),
+		RootVolumeSizeGib:                   aws.Int64(int64(p["root_volume_size_gib"].(int))),
+		RunningMode:                         aws.String(p["running_mode"].(string)),
+		RunningModeAutoStopTimeoutInMinutes: aws.Int64(int64(p["running_mode_auto_stop_timeout_in_minutes"].(int))),
+		UserVolumeSizeGib:                   aws.Int64(int64(p["user_volume_size_gib"].(int))),
+	}
+}
+
+func flattenWorkspaceProperties(properties *workspaces.WorkspaceProperties) []map[string]interface{} {
+	log.Printf("[DEBUG] Flatten workspace properties: %+v ", properties)
+
+	if properties == nil {
+		return []map[string]interface{}{}
+	}
+
+	return []map[string]interface{}{
+		{
+			"compute_type_name":                         aws.StringValue(properties.ComputeTypeName),
+			"root_volume_size_gib":                      int(aws.Int64Value(properties.RootVolumeSizeGib)),
+			"running_mode":                              aws.StringValue(properties.RunningMode),
+			"running_mode_auto_stop_timeout_in_minutes": int(aws.Int64Value(properties.RunningModeAutoStopTimeoutInMinutes)),
+			"user_volume_size_gib":                      int(aws.Int64Value(properties.UserVolumeSizeGib)),
+		},
+	}
+}

--- a/aws/resource_aws_workspaces_workspace_test.go
+++ b/aws/resource_aws_workspaces_workspace_test.go
@@ -1,0 +1,578 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"reflect"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/workspaces"
+	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_workspace", &resource.Sweeper{
+		Name: "aws_workspace",
+		F:    testSweepWorkspaces,
+	})
+}
+
+func testSweepWorkspaces(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+	conn := client.(*AWSClient).workspacesconn
+
+	var errors error
+	input := &workspaces.DescribeWorkspacesInput{}
+	err = conn.DescribeWorkspacesPages(input, func(resp *workspaces.DescribeWorkspacesOutput, _ bool) bool {
+		for _, workspace := range resp.Workspaces {
+			err := workspaceDelete(aws.StringValue(workspace.WorkspaceId), conn)
+			if err != nil {
+				errors = multierror.Append(errors, err)
+			}
+
+		}
+		return true
+	})
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping workspaces sweep for %s: %s", region, err)
+		return errors // In case we have completed some pages, but had errors
+	}
+	if err != nil {
+		errors = multierror.Append(errors, fmt.Errorf("error listing workspaces: %s", err))
+	}
+
+	return errors
+}
+
+func TestAccAwsWorkspacesWorkspace_basic(t *testing.T) {
+	directoryResourceName := "aws_workspaces_directory.test"
+	bundleDataSourceName := "data.aws_workspaces_bundle.test"
+	resourceName := "aws_workspaces_workspace.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsWorkspacesWorkspaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Destroy: false,
+				Config:  testAccWorkspacesWorkspaceConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAwsWorkspacesWorkspaceExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "directory_id", directoryResourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "bundle_id", bundleDataSourceName, "id"),
+					resource.TestMatchResourceAttr(resourceName, "ip_address", regexp.MustCompile(`\d+\.\d+\.\d+\.\d+`)),
+					resource.TestCheckResourceAttr(resourceName, "state", workspaces.WorkspaceStateAvailable),
+					resource.TestCheckResourceAttr(resourceName, "root_volume_encryption_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "user_name", "Administrator"),
+					resource.TestCheckResourceAttr(resourceName, "volume_encryption_key", ""),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.compute_type_name", workspaces.ComputeValue),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.root_volume_size_gib", "80"),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.running_mode", workspaces.RunningModeAlwaysOn),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.running_mode_auto_stop_timeout_in_minutes", "0"),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.user_volume_size_gib", "10"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsWorkspacesWorkspace_Tags(t *testing.T) {
+	resourceName := "aws_workspaces_workspace.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsWorkspacesWorkspaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkspacesWorkspaceConfig_TagsA(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAwsWorkspacesWorkspaceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.TerraformProviderAwsTest", "true"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Alpha", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccWorkspacesWorkspaceConfig_TagsB(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAwsWorkspacesWorkspaceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.TerraformProviderAwsTest", "true"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Beta", "2"),
+				),
+			},
+			{
+				Config: testAccWorkspacesWorkspaceConfig_TagsC(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAwsWorkspacesWorkspaceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.TerraformProviderAwsTest", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAwsWorkspacesWorkspace_WorkspaceProperties(t *testing.T) {
+	resourceName := "aws_workspaces_workspace.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsWorkspacesWorkspaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Destroy: false,
+				Config:  testAccWorkspacesWorkspaceConfig_WorkspacePropertiesA(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAwsWorkspacesWorkspaceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.compute_type_name", workspaces.ComputeValue),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.root_volume_size_gib", "80"),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.running_mode", workspaces.RunningModeAutoStop),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.running_mode_auto_stop_timeout_in_minutes", "120"),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.user_volume_size_gib", "10"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccWorkspacesWorkspaceConfig_WorkspacePropertiesB(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAwsWorkspacesWorkspaceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.compute_type_name", workspaces.ComputeValue),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.root_volume_size_gib", "80"),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.running_mode", workspaces.RunningModeAlwaysOn),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.running_mode_auto_stop_timeout_in_minutes", "0"),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.user_volume_size_gib", "10"),
+				),
+			},
+			{
+				Config: testAccWorkspacesWorkspaceConfig_WorkspacePropertiesC(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAwsWorkspacesWorkspaceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.compute_type_name", workspaces.ComputeValue),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.root_volume_size_gib", "80"),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.running_mode", workspaces.RunningModeAlwaysOn),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.running_mode_auto_stop_timeout_in_minutes", "0"),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.user_volume_size_gib", "10"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAwsWorkspacesWorkspace_validateRootVolumeSize(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsWorkspacesWorkspaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccWorkspacesWorkspaceConfig_validateRootVolumeSize(),
+				ExpectError: regexp.MustCompile(regexp.QuoteMeta("expected workspace_properties.0.root_volume_size_gib to be one of [80], got 90")),
+			},
+		},
+	})
+}
+
+func TestAccAwsWorkspacesWorkspace_validateUserVolumeSize(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsWorkspacesWorkspaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccWorkspacesWorkspaceConfig_validateUserVolumeSize(),
+				ExpectError: regexp.MustCompile(regexp.QuoteMeta("workspace_properties.0.user_volume_size_gib to be one of [10 50], got 60")),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsWorkspacesWorkspaceDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).workspacesconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_workspace" {
+			continue
+		}
+
+		resp, err := conn.DescribeWorkspaces(&workspaces.DescribeWorkspacesInput{
+			WorkspaceIds: []*string{aws.String(rs.Primary.ID)},
+		})
+		if err != nil {
+			return err
+		}
+
+		if len(resp.Workspaces) == 0 {
+			return fmt.Errorf("workspace %q was not terminated", rs.Primary.ID)
+		}
+		ws := resp.Workspaces[0]
+
+		if *ws.State != workspaces.WorkspaceStateTerminating && *ws.State != workspaces.WorkspaceStateTerminated {
+			return fmt.Errorf("workspace %q was not terminated", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAwsWorkspacesWorkspaceExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).workspacesconn
+
+		_, err := conn.DescribeWorkspaces(&workspaces.DescribeWorkspacesInput{
+			WorkspaceIds: []*string{aws.String(rs.Primary.ID)},
+		})
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func testAccAwsWorkspacesWorkspaceConfig_Prerequisites() string {
+	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+  region_workspaces_az_ids = {
+    "us-east-1" = formatlist("use1-az%%d", [2, 4, 6])
+  }
+
+  workspaces_az_ids = lookup(local.region_workspaces_az_ids, data.aws_region.current.name, data.aws_availability_zones.available.zone_ids)
+}
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnet" "default" {
+  count = length(local.workspaces_az_ids)
+  availability_zone_id = "${local.workspaces_az_ids[count.index]}"
+  default_for_az = true
+}
+
+resource "aws_directory_service_directory" "test" {
+  size = "Small"
+  name = "tf-acctest.neverland.com"
+  password = "#S1ncerely"
+
+  vpc_settings {
+    vpc_id = "${data.aws_vpc.default.id}"
+	subnet_ids = ["${data.aws_subnet.default.*.id[0]}", "${data.aws_subnet.default.*.id[1]}"]
+  }
+}
+
+data "aws_iam_policy_document" "workspaces" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["workspaces.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "workspaces-default" {
+  name               = "workspaces_DefaultRole"
+  assume_role_policy = data.aws_iam_policy_document.workspaces.json
+}
+
+resource "aws_iam_role_policy_attachment" "workspaces-default-skylight-service-access" {
+  role       = aws_iam_role.workspaces-default.name
+  policy_arn = "arn:aws:iam::aws:policy/SkyLightServiceAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "workspaces-default-skylight-self-service-access" {
+  role       = aws_iam_role.workspaces-default.name
+  policy_arn = "arn:aws:iam::aws:policy/SkyLightSelfServiceAccess"
+}
+
+data "aws_workspaces_bundle" "test" {
+  bundle_id = "wsb-bh8rsxt14" # Value with Windows 10 (English)
+}
+
+resource "aws_workspaces_directory" "test" {
+ directory_id = "${aws_directory_service_directory.test.id}"
+}
+`)
+}
+
+func testAccWorkspacesWorkspaceConfig() string {
+	return testAccAwsWorkspacesWorkspaceConfig_Prerequisites() + fmt.Sprintf(`
+resource "aws_workspaces_workspace" "test" {
+  bundle_id = "${data.aws_workspaces_bundle.test.id}"
+  directory_id = "${aws_workspaces_directory.test.id}"
+  # NOTE: WorkSpaces API doesn't allow creating users in the directory.
+  # However, "Administrator"" user is always present in a bare directory.
+  user_name = "Administrator"
+}
+`)
+}
+
+func testAccWorkspacesWorkspaceConfig_TagsA() string {
+	return testAccAwsWorkspacesWorkspaceConfig_Prerequisites() + fmt.Sprintf(`
+resource "aws_workspaces_workspace" "test" {
+  bundle_id = "${data.aws_workspaces_bundle.test.id}"
+  directory_id = "${aws_workspaces_directory.test.id}"
+  # NOTE: WorkSpaces API doesn't allow creating users in the directory.
+  # However, "Administrator"" user is always present in a bare directory.
+  user_name = "Administrator"
+
+  tags = {
+    TerraformProviderAwsTest = true
+    Alpha                    = 1
+  }
+}
+`)
+}
+
+func testAccWorkspacesWorkspaceConfig_TagsB() string {
+	return testAccAwsWorkspacesWorkspaceConfig_Prerequisites() + fmt.Sprintf(`
+resource "aws_workspaces_workspace" "test" {
+  bundle_id = "${data.aws_workspaces_bundle.test.id}"
+  directory_id = "${aws_workspaces_directory.test.id}"
+  # NOTE: WorkSpaces API doesn't allow creating users in the directory.
+  # However, "Administrator"" user is always present in a bare directory.
+  user_name = "Administrator"
+
+  tags = {
+    TerraformProviderAwsTest = true
+    Beta                     = 2
+  }
+}
+`)
+}
+
+func testAccWorkspacesWorkspaceConfig_TagsC() string {
+	return testAccAwsWorkspacesWorkspaceConfig_Prerequisites() + fmt.Sprintf(`
+resource "aws_workspaces_workspace" "test" {
+  bundle_id = "${data.aws_workspaces_bundle.test.id}"
+  directory_id = "${aws_workspaces_directory.test.id}"
+  # NOTE: WorkSpaces API doesn't allow creating users in the directory.
+  # However, "Administrator"" user is always present in a bare directory.
+  user_name = "Administrator"
+
+  tags = {
+    TerraformProviderAwsTest = true
+  }
+}
+`)
+}
+
+func testAccWorkspacesWorkspaceConfig_WorkspacePropertiesA() string {
+	return testAccAwsWorkspacesWorkspaceConfig_Prerequisites() + fmt.Sprintf(`
+resource "aws_workspaces_workspace" "test" {
+  bundle_id = "${data.aws_workspaces_bundle.test.id}"
+  directory_id = "${aws_workspaces_directory.test.id}"
+  # NOTE: WorkSpaces API doesn't allow creating users in the directory.
+  # However, "Administrator"" user is always present in a bare directory.
+  user_name = "Administrator"
+  
+  workspace_properties {
+    # NOTE: Compute type and volume size update not allowed within 6 hours after creation.
+    running_mode = "AUTO_STOP"
+    running_mode_auto_stop_timeout_in_minutes = 120
+  }
+
+  tags = {
+    TerraformProviderAwsTest = true
+  }
+}
+`)
+}
+
+func testAccWorkspacesWorkspaceConfig_WorkspacePropertiesB() string {
+	return testAccAwsWorkspacesWorkspaceConfig_Prerequisites() + fmt.Sprintf(`
+resource "aws_workspaces_workspace" "test" {
+  bundle_id = "${data.aws_workspaces_bundle.test.id}"
+  directory_id = "${aws_workspaces_directory.test.id}"
+  # NOTE: WorkSpaces API doesn't allow creating users in the directory.
+  # However, "Administrator"" user is always present in a bare directory.
+  user_name = "Administrator" 
+
+  workspace_properties {
+    # NOTE: Compute type and volume size update not allowed within 6 hours after creation.
+    running_mode = "ALWAYS_ON"
+  }
+  
+  tags = {
+    TerraformProviderAwsTest = true
+  }
+}
+`)
+}
+
+func testAccWorkspacesWorkspaceConfig_WorkspacePropertiesC() string {
+	return testAccAwsWorkspacesWorkspaceConfig_Prerequisites() + fmt.Sprintf(`
+resource "aws_workspaces_workspace" "test" {
+  bundle_id = "${data.aws_workspaces_bundle.test.id}"
+  directory_id = "${aws_workspaces_directory.test.id}"
+  # NOTE: WorkSpaces API doesn't allow creating users in the directory.
+  # However, "Administrator"" user is always present in a bare directory.
+  user_name = "Administrator"
+
+  workspace_properties {
+  }
+}
+`)
+}
+
+func testAccWorkspacesWorkspaceConfig_validateRootVolumeSize() string {
+	return testAccAwsWorkspacesWorkspaceConfig_Prerequisites() + fmt.Sprintf(`
+resource "aws_workspaces_workspace" "test" {
+  bundle_id = "${data.aws_workspaces_bundle.test.id}"
+  directory_id = "${aws_workspaces_directory.test.id}"
+  # NOTE: WorkSpaces API doesn't allow creating users in the directory.
+  # However, "Administrator"" user is always present in a bare directory.
+  user_name = "Administrator" 
+ 
+  workspace_properties {
+    root_volume_size_gib = 90
+    user_volume_size_gib = 50
+  }
+
+  tags = {
+    TerraformProviderAwsTest = true
+  }
+}
+`)
+}
+
+func testAccWorkspacesWorkspaceConfig_validateUserVolumeSize() string {
+	return testAccAwsWorkspacesWorkspaceConfig_Prerequisites() + fmt.Sprintf(`
+resource "aws_workspaces_workspace" "test" {
+  bundle_id = "${data.aws_workspaces_bundle.test.id}"
+  directory_id = "${aws_workspaces_directory.test.id}"
+  # NOTE: WorkSpaces API doesn't allow creating users in the directory.
+  # However, "Administrator"" user is always present in a bare directory.
+  user_name = "Administrator" 
+ 
+  workspace_properties {
+    root_volume_size_gib = 80
+    user_volume_size_gib = 60
+  }
+
+  tags = {
+    TerraformProviderAwsTest = true
+  }
+}
+`)
+}
+
+func TestExpandWorkspaceProperties(t *testing.T) {
+	cases := []struct {
+		input    []interface{}
+		expected *workspaces.WorkspaceProperties
+	}{
+		// Empty
+		{
+			input:    []interface{}{},
+			expected: nil,
+		},
+		// Full
+		{
+			input: []interface{}{
+				map[string]interface{}{
+					"compute_type_name":                         workspaces.ComputeValue,
+					"root_volume_size_gib":                      80,
+					"running_mode":                              workspaces.RunningModeAutoStop,
+					"running_mode_auto_stop_timeout_in_minutes": 60,
+					"user_volume_size_gib":                      10,
+				},
+			},
+			expected: &workspaces.WorkspaceProperties{
+				ComputeTypeName:                     aws.String(workspaces.ComputeValue),
+				RootVolumeSizeGib:                   aws.Int64(80),
+				RunningMode:                         aws.String(workspaces.RunningModeAutoStop),
+				RunningModeAutoStopTimeoutInMinutes: aws.Int64(60),
+				UserVolumeSizeGib:                   aws.Int64(10),
+			},
+		},
+	}
+
+	for _, c := range cases {
+		actual := expandWorkspaceProperties(c.input)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Fatalf("expected\n\n%#+v\n\ngot\n\n%#+v", c.expected, actual)
+		}
+	}
+}
+
+func TestFlattenWorkspaceProperties(t *testing.T) {
+	cases := []struct {
+		input    *workspaces.WorkspaceProperties
+		expected []map[string]interface{}
+	}{
+		// Empty
+		{
+			input:    nil,
+			expected: []map[string]interface{}{},
+		},
+		// Full
+		{
+			input: &workspaces.WorkspaceProperties{
+				ComputeTypeName:                     aws.String(workspaces.ComputeValue),
+				RootVolumeSizeGib:                   aws.Int64(80),
+				RunningMode:                         aws.String(workspaces.RunningModeAutoStop),
+				RunningModeAutoStopTimeoutInMinutes: aws.Int64(60),
+				UserVolumeSizeGib:                   aws.Int64(10),
+			},
+			expected: []map[string]interface{}{
+				{
+					"compute_type_name":                         workspaces.ComputeValue,
+					"root_volume_size_gib":                      80,
+					"running_mode":                              workspaces.RunningModeAutoStop,
+					"running_mode_auto_stop_timeout_in_minutes": 60,
+					"user_volume_size_gib":                      10,
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		actual := flattenWorkspaceProperties(c.input)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Fatalf("expected\n\n%#+v\n\ngot\n\n%#+v", c.expected, actual)
+		}
+	}
+}

--- a/aws/resource_aws_workspaces_workspace_test.go
+++ b/aws/resource_aws_workspaces_workspace_test.go
@@ -317,14 +317,14 @@ resource "aws_iam_role" "workspaces-default" {
   assume_role_policy = data.aws_iam_policy_document.workspaces.json
 }
 
-resource "aws_iam_role_policy_attachment" "workspaces-default-skylight-service-access" {
+resource "aws_iam_role_policy_attachment" "workspaces-default-service-access" {
   role       = aws_iam_role.workspaces-default.name
-  policy_arn = "arn:aws:iam::aws:policy/SkyLightServiceAccess"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonWorkSpacesServiceAccess"
 }
 
-resource "aws_iam_role_policy_attachment" "workspaces-default-skylight-self-service-access" {
+resource "aws_iam_role_policy_attachment" "workspaces-default-self-service-access" {
   role       = aws_iam_role.workspaces-default.name
-  policy_arn = "arn:aws:iam::aws:policy/SkyLightSelfServiceAccess"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonWorkSpacesSelfServiceAccess"
 }
 
 data "aws_workspaces_bundle" "test" {

--- a/examples/workspaces/main.tf
+++ b/examples/workspaces/main.tf
@@ -33,6 +33,32 @@ resource "aws_workspaces_directory" "main" {
   subnet_ids   = ["${aws_subnet.private-a.id}", "${aws_subnet.private-b.id}"]
 }
 
+data "aws_workspaces_bundle" "value_windows" {
+  bundle_id = "wsb-bh8rsxt14" # Value with Windows 10 (English)
+}
+
+resource "aws_workspaces_workspace" "jhon.doe" {
+  directory_id = "${aws_workspaces_directory.main.id}"
+  bundle_id    = "${data.aws_workspaces_bundle.value_windows.id}"
+  user_name    = "jhon.doe"
+
+  root_volume_encryption_enabled = true
+  user_volume_encryption_enabled = true
+  volume_encryption_key          = "aws/workspaces"
+
+  workspace_properties {
+    compute_type_name                         = "VALUE"
+    user_volume_size_gib                      = 10
+    root_volume_size_gib                      = 80
+    running_mode                              = "AUTO_STOP"
+    running_mode_auto_stop_timeout_in_minutes = 60
+  }
+
+  tags = {
+    Department = "IT"
+  }
+}
+
 resource "aws_workspaces_ip_group" "main" {
   name        = "main"
   description = "Main IP access control group"

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -3543,14 +3543,6 @@
                                 </li>
                             </ul>
                         </li>
-                        <li>
-                            <a href="#">Resources</a>
-                            <ul class="nav nav-auto-expand">
-                                <li>
-                                    <a href="/docs/providers/aws/r/workspaces_directory.html">aws_workspaces_directory</a>
-                                </li>
-                            </ul>
-                        </li>
                     </ul>
                 </li>
                 <li>
@@ -3588,6 +3580,9 @@
                                 </li>
                                 <li>
                                     <a href="/docs/providers/aws/r/workspaces_ip_group.html">aws_workspaces_ip_group</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/workspaces_workspace.html">aws_workspaces_workspace</a>
                                 </li>
                             </ul>
                         </li>

--- a/website/docs/r/workspaces_workspace.html.markdown
+++ b/website/docs/r/workspaces_workspace.html.markdown
@@ -1,0 +1,84 @@
+---
+subcategory: "WorkSpaces"
+layout: "aws"
+page_title: "AWS: aws_workspaces_workspace"
+description: |-
+  Provides a workspaces in AWS Workspaces Service.
+---
+
+# Resource: aws_workspace
+
+Provides a workspace in [AWS Workspaces](https://docs.aws.amazon.com/workspaces/latest/adminguide/amazon-workspaces.html) Service
+
+## Example Usage
+
+```hcl
+data "aws_workspaces_directory" "main" {
+  directory_id = "d-ten5h0y19"
+}
+
+data "aws_workspaces_bundle" "value_windows_10" {
+  bundle_id = "wsb-bh8rsxt14" # Value with Windows 10 (English)
+}
+
+resource "aws_workspaces_workspace" "jhon.doe" {
+  directory_id = "${data.aws_workspaces_directory.main.id}"
+  bundle_id    = "${data.aws_workspaces_bundle.value_windows_10.id}"
+  user_name    = "jhon.doe"
+
+  root_volume_encryption_enabled = true
+  user_volume_encryption_enabled = true
+  volume_encryption_key          = "aws/workspaces"
+
+  workspace_properties {
+    compute_type_name                         = "VALUE"
+    user_volume_size_gib                      = 10
+    root_volume_size_gib                      = 80
+    running_mode                              = "AUTO_STOP"
+    running_mode_auto_stop_timeout_in_minutes = 60
+  }
+
+  tags = {
+    Department = "IT"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `directory_id` - (Required) The ID of the directory for the WorkSpace.
+* `bundle_id` - (Required) The ID of the bundle for the WorkSpace.
+* `user_name` – (Required) The user name of the user for the WorkSpace. This user name must exist in the directory for the WorkSpace.
+* `root_volume_encryption_enabled` - (Optional) Indicates whether the data stored on the root volume is encrypted.
+* `user_volume_encryption_enabled` – (Optional) Indicates whether the data stored on the user volume is encrypted.
+* `volume_encryption_key` – (Optional) The symmetric AWS KMS customer master key (CMK) used to encrypt data stored on your WorkSpace. Amazon WorkSpaces does not support asymmetric CMKs.
+* `tags` - (Optional) The tags for the WorkSpace.
+* `workspace_properties` – (Optional) The WorkSpace properties.
+
+`workspace_properties` supports the following:
+
+* `compute_type_name` – (Optional) The compute type. For more information, see [Amazon WorkSpaces Bundles](http://aws.amazon.com/workspaces/details/#Amazon_WorkSpaces_Bundles). Valid values are `VALUE`, `STANDARD`, `PERFORMANCE`, `POWER`, `GRAPHICS`, `POWERPRO` and `GRAPHICSPRO`.
+* `root_volume_size_gib` – (Optional) The size of the root volume.
+* `running_mode` – (Optional) The size of the root volume. The running mode. For more information, see [Manage the WorkSpace Running Mode](https://docs.aws.amazon.com/workspaces/latest/adminguide/running-mode.html). Valid values are `AUTO_STOP` and `ALWAYS_ON`.
+* `running_mode_auto_stop_timeout_in_minutes` – (Optional) The time after a user logs off when WorkSpaces are automatically stopped. Configured in 60-minute intervals.
+* `user_volume_size_gib` – (Optional) The size of the user storage.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The workspaces ID.
+* `ip_address` - The IP address of the WorkSpace.
+* `computer_name` - The name of the WorkSpace, as seen by the operating system.
+* `state` - The operational state of the WorkSpace.
+
+## Import
+
+Workspaces can be imported using their ID, e.g.
+
+```
+$ terraform import aws_workspaces_workspace.example ws-9z9zmbkhv
+```
+


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

**New Data Source:** `aws_workspaces_workspace` (#11608)

### Example

```hcl
data "aws_workspaces_directory" "main" {
  directory_id = "d-ten5h0y19"
}

data "aws_workspaces_bundle" "value_windows" {
  bundle_id = "b-ten5h0y19"
}

resource "aws_workspaces_workspace" "jhon.doe" {
  directory_id = "${data.aws_workspaces_directory.main.id}"
  bundle_id = "${data.aws_workspaces_bundle.value_windows.id}"
  user_name = "jhon.doe"

  root_volume_encryption_enabled = true
  user_volume_encryption_enabled = true
  volume_encryption_key = "aws/workspaces"

  workspace_properties {
    compute_type_name = "VALUE" 
    root_volume_size_gib = 80
    running_mode = "AUTO_STOP"
    running_mode_auto_stop_timeout_in_minutes = 120
    user_volume_size_gib = 10
  }
  
  tags = {
    Department = "IT"
  }
}
```

### Acceptance Tests

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAwsWorkspacesWorkspace'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsWorkspacesWorkspace -timeout 120m
=== RUN   TestAccAwsWorkspacesWorkspace_basic
--- PASS: TestAccAwsWorkspacesWorkspace_basic (1483.87s)
=== RUN   TestAccAwsWorkspacesWorkspace_Tags
--- PASS: TestAccAwsWorkspacesWorkspace_Tags (1546.16s)
=== RUN   TestAccAwsWorkspacesWorkspace_WorkspaceProperties
--- PASS: TestAccAwsWorkspacesWorkspace_WorkspaceProperties (1667.00s)
=== RUN   TestAccAwsWorkspacesWorkspace_validateRootVolumeSize
--- PASS: TestAccAwsWorkspacesWorkspace_validateRootVolumeSize (2.48s)
=== RUN   TestAccAwsWorkspacesWorkspace_validateUserVolumeSize
--- PASS: TestAccAwsWorkspacesWorkspace_validateUserVolumeSize (3.28s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	4704.253s
```

### Considerations

There is a warning which I'm not sure how I should address:
```
    The following problems may be the cause of any confusing errors from downstream operations:
      - .volume_encryption_key: was null, but now cty.StringVal("")
```
What is the general strategy for absent attributes?

### References

- [Support for AWS Workspaces](https://github.com/terraform-providers/terraform-provider-aws/issues/434)