### PR TITLE
Enable organization tag policies with attachment

### DIFF
--- a/aws/resource_aws_organizations_policy.go
+++ b/aws/resource_aws_organizations_policy.go
@@ -48,6 +48,7 @@ func resourceAwsOrganizationsPolicy() *schema.Resource {
 				Default:  organizations.PolicyTypeServiceControlPolicy,
 				ValidateFunc: validation.StringInSlice([]string{
 					organizations.PolicyTypeServiceControlPolicy,
+					organizations.PolicyTypeTagPolicy,
 				}, false),
 			},
 		},

--- a/aws/resource_aws_organizations_policy_attachment.go
+++ b/aws/resource_aws_organizations_policy_attachment.go
@@ -84,16 +84,16 @@ func resourceAwsOrganizationsPolicyAttachmentRead(d *schema.ResourceData, meta i
 		return err
 	}
 
-	input := &organizations.ListPoliciesForTargetInput{
-		Filter:   aws.String(organizations.PolicyTypeServiceControlPolicy),
-		TargetId: aws.String(targetID),
+	input := &organizations.ListTargetsForPolicyInput{
+		PolicyId: aws.String(policyID),
 	}
 
 	log.Printf("[DEBUG] Listing Organizations Policies for Target: %s", input)
-	var output *organizations.PolicySummary
-	err = conn.ListPoliciesForTargetPages(input, func(page *organizations.ListPoliciesForTargetOutput, lastPage bool) bool {
-		for _, policySummary := range page.Policies {
-			if aws.StringValue(policySummary.Id) == policyID {
+	var output *organizations.PolicyTargetSummary
+
+	err = conn.ListTargetsForPolicyPages(input, func(page *organizations.ListTargetsForPolicyOutput, lastPage bool) bool {
+		for _, policySummary := range page.Targets {
+			if aws.StringValue(policySummary.TargetId) == targetID {
 				output = policySummary
 				return true
 			}

--- a/aws/resource_aws_organizations_policy_attachment_test.go
+++ b/aws/resource_aws_organizations_policy_attachment_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strconv"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -18,13 +19,24 @@ func testAccAwsOrganizationsPolicyAttachment_Account(t *testing.T) {
 	policyIdResourceName := "aws_organizations_policy.test"
 	targetIdResourceName := "aws_organizations_organization.test"
 
+	serviceControlPolicyContent := `{"Version": "2012-10-17", "Statement": { "Effect": "Allow", "Action": "*", "Resource": "*"}}`
+	tagPolicyContent := `{ "tags": { "Product": { "tag_key": { "@@assign": "Product" }, "enforced_for": { "@@assign": [ "ec2:instance" ] } } } }`
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOrganizationsPolicyAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsOrganizationsPolicyAttachmentConfig_Account(rName),
+				Config: testAccAwsOrganizationsPolicyAttachmentConfig_Account(rName, organizations.PolicyTypeServiceControlPolicy, serviceControlPolicyContent),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsOrganizationsPolicyAttachmentExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "policy_id", policyIdResourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "target_id", targetIdResourceName, "master_account_id"),
+				),
+			},
+			{
+				Config: testAccAwsOrganizationsPolicyAttachmentConfig_Account(rName, organizations.PolicyTypeTagPolicy, tagPolicyContent),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsOrganizationsPolicyAttachmentExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "policy_id", policyIdResourceName, "id"),
@@ -163,16 +175,15 @@ func testAccCheckAwsOrganizationsPolicyAttachmentExists(resourceName string) res
 			return err
 		}
 
-		input := &organizations.ListPoliciesForTargetInput{
-			Filter:   aws.String(organizations.PolicyTypeServiceControlPolicy),
-			TargetId: aws.String(targetID),
+		input := &organizations.ListTargetsForPolicyInput{
+			PolicyId: aws.String(policyID),
 		}
 
 		log.Printf("[DEBUG] Listing Organizations Policies for Target: %s", input)
-		var output *organizations.PolicySummary
-		err = conn.ListPoliciesForTargetPages(input, func(page *organizations.ListPoliciesForTargetOutput, lastPage bool) bool {
-			for _, policySummary := range page.Policies {
-				if aws.StringValue(policySummary.Id) == policyID {
+		var output *organizations.PolicyTargetSummary
+		err = conn.ListTargetsForPolicyPages(input, func(page *organizations.ListTargetsForPolicyOutput, lastPage bool) bool {
+			for _, policySummary := range page.Targets {
+				if aws.StringValue(policySummary.TargetId) == targetID {
 					output = policySummary
 					return true
 				}
@@ -192,24 +203,25 @@ func testAccCheckAwsOrganizationsPolicyAttachmentExists(resourceName string) res
 	}
 }
 
-func testAccAwsOrganizationsPolicyAttachmentConfig_Account(rName string) string {
+func testAccAwsOrganizationsPolicyAttachmentConfig_Account(rName, policyType, policyContent string) string {
 	return fmt.Sprintf(`
 resource "aws_organizations_organization" "test" {
-  enabled_policy_types = ["SERVICE_CONTROL_POLICY"]
+  enabled_policy_types = ["SERVICE_CONTROL_POLICY", "TAG_POLICY"]
 }
 
 resource "aws_organizations_policy" "test" {
   depends_on = ["aws_organizations_organization.test"]
 
-  content = "{\"Version\": \"2012-10-17\", \"Statement\": { \"Effect\": \"Allow\", \"Action\": \"*\", \"Resource\": \"*\"}}"
   name    = "%s"
+  type = "%s"
+  content = %s
 }
 
 resource "aws_organizations_policy_attachment" "test" {
   policy_id = "${aws_organizations_policy.test.id}"
   target_id = "${aws_organizations_organization.test.master_account_id}"
 }
-`, rName)
+`, rName, policyType, strconv.Quote(policyContent))
 }
 
 func testAccAwsOrganizationsPolicyAttachmentConfig_OrganizationalUnit(rName string) string {

--- a/aws/resource_aws_organizations_test.go
+++ b/aws/resource_aws_organizations_test.go
@@ -29,6 +29,7 @@ func TestAccAWSOrganizations(t *testing.T) {
 			"basic":       testAccAwsOrganizationsPolicy_basic,
 			"concurrent":  testAccAwsOrganizationsPolicy_concurrent,
 			"Description": testAccAwsOrganizationsPolicy_description,
+			"Type":        testAccAwsOrganizationsPolicy_type,
 		},
 		"PolicyAttachment": {
 			"Account":            testAccAwsOrganizationsPolicyAttachment_Account,

--- a/website/docs/r/organizations_policy.html.markdown
+++ b/website/docs/r/organizations_policy.html.markdown
@@ -33,10 +33,10 @@ CONTENT
 
 The following arguments are supported:
 
-* `content` - (Required) The policy content to add to the new policy. For example, if you create a [service control policy (SCP)](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scp.html), this string must be JSON text that specifies the permissions that admins in attached accounts can delegate to their users, groups, and roles. For more information about the SCP syntax, see the [Service Control Policy Syntax documentation](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_reference_scp-syntax.html).
+* `content` - (Required) The policy content to add to the new policy. For example, if you create a [service control policy (SCP)](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scp.html), this string must be JSON text that specifies the permissions that admins in attached accounts can delegate to their users, groups, and roles. For more information about the SCP syntax, see the [Service Control Policy Syntax documentation](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_reference_scp-syntax.html) and for more information on the Tag Policy syntax, see the [Tag Policy Syntax documentation](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_example-tag-policies.html).
 * `name` - (Required) The friendly name to assign to the policy.
 * `description` - (Optional) A description to assign to the policy.
-* `type` - (Optional) The type of policy to create. Currently, the only valid value is `SERVICE_CONTROL_POLICY` (SCP).
+* `type` - (Optional) The type of policy to create. Currently, the only valid values are `SERVICE_CONTROL_POLICY` (SCP) and `TAG_POLICY`. Defaults to `SERVICE_CONTROL_POLICY`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Overview
This PR enables the `TAG_POLICY` as a permitted `aws_organizations_policy` type and refactors the `aws_organizations_policy_attachment` to permit attaching policies of type `TAG_POLICY`
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11032
Relates #11202

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_organizations_policy: Support `TAG_POLICY` type [GH-11032]
resource/aws_organizations_policy_attachment: Support `TAG_POLICY` type [GH-11032]
```

Output from acceptance testing:
```bash
make testacc TEST=./aws TESTARGS='-run=TestAccAWSOrganizations'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSOrganizations -timeout 120m
go: downloading github.com/aws/aws-sdk-go v1.28.8
go: downloading github.com/hashicorp/terraform-plugin-sdk v1.5.0
go: extracting github.com/hashicorp/terraform-plugin-sdk v1.5.0
go: extracting github.com/aws/aws-sdk-go v1.28.8
go: finding github.com/aws/aws-sdk-go v1.28.8
go: finding github.com/hashicorp/terraform-plugin-sdk v1.5.0
=== RUN   TestAccAWSOrganizations
=== RUN   TestAccAWSOrganizations/Organization
=== RUN   TestAccAWSOrganizations/Organization/EnabledPolicyTypes
=== RUN   TestAccAWSOrganizations/Organization/FeatureSet
=== RUN   TestAccAWSOrganizations/Organization/DataSource
=== RUN   TestAccAWSOrganizations/Organization/basic
=== RUN   TestAccAWSOrganizations/Organization/AwsServiceAccessPrincipals
=== RUN   TestAccAWSOrganizations/Account
=== RUN   TestAccAWSOrganizations/Account/basic
=== RUN   TestAccAWSOrganizations/Account/ParentId
=== RUN   TestAccAWSOrganizations/Account/Tags
=== RUN   TestAccAWSOrganizations/OrganizationalUnit
=== RUN   TestAccAWSOrganizations/OrganizationalUnit/basic
=== RUN   TestAccAWSOrganizations/OrganizationalUnit/Name
=== RUN   TestAccAWSOrganizations/OrganizationalUnits
=== RUN   TestAccAWSOrganizations/OrganizationalUnits/DataSource
=== PAUSE TestAccAWSOrganizations/OrganizationalUnits/DataSource
=== CONT  TestAccAWSOrganizations/OrganizationalUnits/DataSource
=== RUN   TestAccAWSOrganizations/Policy
=== RUN   TestAccAWSOrganizations/Policy/basic
=== RUN   TestAccAWSOrganizations/Policy/concurrent
=== RUN   TestAccAWSOrganizations/Policy/Description
=== RUN   TestAccAWSOrganizations/Policy/Type
=== RUN   TestAccAWSOrganizations/PolicyAttachment
=== RUN   TestAccAWSOrganizations/PolicyAttachment/Account
=== RUN   TestAccAWSOrganizations/PolicyAttachment/OrganizationalUnit
=== RUN   TestAccAWSOrganizations/PolicyAttachment/Root
--- PASS: TestAccAWSOrganizations (676.62s)
    --- PASS: TestAccAWSOrganizations/Organization (280.69s)
        --- PASS: TestAccAWSOrganizations/Organization/EnabledPolicyTypes (115.62s)
        --- PASS: TestAccAWSOrganizations/Organization/FeatureSet (24.66s)
        --- PASS: TestAccAWSOrganizations/Organization/DataSource (52.64s)
        --- PASS: TestAccAWSOrganizations/Organization/basic (26.63s)
        --- PASS: TestAccAWSOrganizations/Organization/AwsServiceAccessPrincipals (61.14s)
    --- PASS: TestAccAWSOrganizations/Account (0.00s)
        --- SKIP: TestAccAWSOrganizations/Account/basic (0.00s)
            resource_aws_organizations_account_test.go:15: AWS Organizations Account testing is not currently automated due to manual account deletion steps.
        --- SKIP: TestAccAWSOrganizations/Account/ParentId (0.00s)
            resource_aws_organizations_account_test.go:58: AWS Organizations Account testing is not currently automated due to manual account deletion steps.
        --- SKIP: TestAccAWSOrganizations/Account/Tags (0.00s)
            resource_aws_organizations_account_test.go:104: AWS Organizations Account testing is not currently automated due to manual account deletion steps.
    --- PASS: TestAccAWSOrganizations/OrganizationalUnit (73.84s)
        --- PASS: TestAccAWSOrganizations/OrganizationalUnit/basic (28.90s)
        --- PASS: TestAccAWSOrganizations/OrganizationalUnit/Name (44.94s)
    --- PASS: TestAccAWSOrganizations/OrganizationalUnits (0.00s)
        --- PASS: TestAccAWSOrganizations/OrganizationalUnits/DataSource (30.47s)
    --- PASS: TestAccAWSOrganizations/Policy (174.62s)
        --- PASS: TestAccAWSOrganizations/Policy/basic (43.08s)
        --- PASS: TestAccAWSOrganizations/Policy/concurrent (29.37s)
        --- PASS: TestAccAWSOrganizations/Policy/Description (43.36s)
        --- PASS: TestAccAWSOrganizations/Policy/Type (58.80s)
    --- PASS: TestAccAWSOrganizations/PolicyAttachment (116.99s)
        --- PASS: TestAccAWSOrganizations/PolicyAttachment/Account (51.02s)
        --- PASS: TestAccAWSOrganizations/PolicyAttachment/OrganizationalUnit (33.44s)
        --- PASS: TestAccAWSOrganizations/PolicyAttachment/Root (32.53s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       677.120s
```
