### PR TITLE
Fix test to create expected NamespaceAlreadyExists error

### DIFF
--- a/aws/resource_aws_service_discovery_private_dns_namespace_test.go
+++ b/aws/resource_aws_service_discovery_private_dns_namespace_test.go
@@ -57,7 +57,6 @@ func TestAccAWSServiceDiscoveryPrivateDnsNamespace_longname(t *testing.T) {
 //  * https://github.com/terraform-providers/terraform-provider-aws/issues/5532
 func TestAccAWSServiceDiscoveryPrivateDnsNamespace_error_Overlap(t *testing.T) {
 	rName := acctest.RandString(5) + ".example.com"
-	subDomain := acctest.RandString(5) + "." + rName
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceDiscovery(t) },
@@ -65,7 +64,7 @@ func TestAccAWSServiceDiscoveryPrivateDnsNamespace_error_Overlap(t *testing.T) {
 		CheckDestroy: testAccCheckAwsServiceDiscoveryPrivateDnsNamespaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccServiceDiscoveryPrivateDnsNamespaceConfigOverlapping(rName, subDomain),
+				Config:      testAccServiceDiscoveryPrivateDnsNamespaceConfigOverlapping(rName),
 				ExpectError: regexp.MustCompile(`overlapping name space`),
 			},
 		},
@@ -140,7 +139,7 @@ resource "aws_service_discovery_private_dns_namespace" "test" {
 `, rName)
 }
 
-func testAccServiceDiscoveryPrivateDnsNamespaceConfigOverlapping(topDomain, subDomain string) string {
+func testAccServiceDiscoveryPrivateDnsNamespaceConfigOverlapping(topDomain string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -157,8 +156,8 @@ resource "aws_service_discovery_private_dns_namespace" "top" {
 
 # Ensure ordering after first namespace
 resource "aws_service_discovery_private_dns_namespace" "subdomain" {
-  name = %q
+  name = "${aws_service_discovery_private_dns_namespace.top.name}"
   vpc  = "${aws_service_discovery_private_dns_namespace.top.vpc}"
 }
-`, topDomain, subDomain)
+`, topDomain)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

AWS doesn't seem to be returning an error from the overlapping subdomain, only exact name matches, as of 11/23/19. Since the purpose of the test is to check our error handling and not the specific subdomain case, I've updated it.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSServiceDiscoveryPrivateDnsNamespace_error_Overlap'

--- PASS: TestAccAWSServiceDiscoveryPrivateDnsNamespace_error_Overlap (174.46s)

```
