### PR TITLE
resource/aws_cloudwatch_log_stream: Prevent early state removal

### DIFF
--- a/aws/resource_aws_cloudwatch_log_stream.go
+++ b/aws/resource_aws_cloudwatch_log_stream.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -60,7 +62,24 @@ func resourceAwsCloudWatchLogStreamRead(d *schema.ResourceData, meta interface{}
 
 	group := d.Get("log_group_name").(string)
 
-	ls, exists, err := lookupCloudWatchLogStream(conn, d.Id(), group, nil)
+	var ls *cloudwatchlogs.LogStream
+	var exists bool
+
+	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+		var err error
+		ls, exists, err = lookupCloudWatchLogStream(conn, d.Id(), group, nil)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		if d.IsNewResource() && !exists {
+			return resource.RetryableError(&resource.NotFoundError{})
+		}
+		return nil
+	})
+	if isResourceTimeoutError(err) {
+		ls, exists, err = lookupCloudWatchLogStream(conn, d.Id(), group, nil)
+	}
+
 	if err != nil {
 		if !isAWSErr(err, cloudwatchlogs.ErrCodeResourceNotFoundException, "") {
 			return err


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Closes #11611

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
* resource/aws_cloudwatch_log_stream: Prevent state removal of resource immediately after creation due to eventual consistency ([#11611](https://github.com/terraform-providers/terraform-provider-aws/issues/11611))
```

The AWS logs service has eventual consistency considerations. The `aws_cloudwatch_log_stream` resource immediately tries to read a stream after creation. If the stream is not found, the logs service returns a 200 OK with an empty list of streams. Since no streams are present, the
`aws_cloudwatch_log_stream` resource removes the created resource from state, leading to a "produced an unexpected new value for was present, but now absent" error.

With the changes in this commit, the empty list of streams in the response for the newly created resource will result in a NotFoundError being returned and a retry of the read request. A subsequent retry should hopefully be successful, leading to the state being preserved.

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudWatchLogStream_'
...
--- PASS: TestAccAWSCloudWatchLogStream_disappears_LogGroup (16.77s)
--- PASS: TestAccAWSCloudWatchLogStream_disappears (19.55s)
--- PASS: TestAccAWSCloudWatchLogStream_basic (19.91s)
```