### PR TITLE
Create sweepers for EFS resources

### DIFF
--- a/aws/resource_aws_efs_file_system.go
+++ b/aws/resource_aws_efs_file_system.go
@@ -382,7 +382,6 @@ func waitForDeleteEfsFileSystem(conn *efs.EFS, id string, timeout time.Duration)
 		Delay:      2 * time.Second,
 		MinTimeout: 3 * time.Second,
 	}
-
 	_, err := stateConf.WaitForState()
 	return err
 }

--- a/aws/resource_aws_efs_file_system.go
+++ b/aws/resource_aws_efs_file_system.go
@@ -343,12 +343,24 @@ func resourceAwsEfsFileSystemDelete(d *schema.ResourceData, meta interface{}) er
 	if err != nil {
 		return fmt.Errorf("Error delete file system: %s with err %s", d.Id(), err.Error())
 	}
+
+	err = waitForDeleteEfsFileSystem(conn, d.Id(), 10*time.Minute)
+	if err != nil {
+		return fmt.Errorf("Error waiting for EFS file system (%q) to delete: %w", d.Id(), err)
+	}
+
+	log.Printf("[DEBUG] EFS file system %q deleted.", d.Id())
+
+	return nil
+}
+
+func waitForDeleteEfsFileSystem(conn *efs.EFS, id string, timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"available", "deleting"},
 		Target:  []string{},
 		Refresh: func() (interface{}, string, error) {
 			resp, err := conn.DescribeFileSystems(&efs.DescribeFileSystemsInput{
-				FileSystemId: aws.String(d.Id()),
+				FileSystemId: aws.String(id),
 			})
 			if err != nil {
 				efsErr, ok := err.(awserr.Error)
@@ -366,20 +378,13 @@ func resourceAwsEfsFileSystemDelete(d *schema.ResourceData, meta interface{}) er
 			log.Printf("[DEBUG] current status of %q: %q", *fs.FileSystemId, *fs.LifeCycleState)
 			return fs, *fs.LifeCycleState, nil
 		},
-		Timeout:    10 * time.Minute,
+		Timeout:    timeout,
 		Delay:      2 * time.Second,
 		MinTimeout: 3 * time.Second,
 	}
 
-	_, err = stateConf.WaitForState()
-	if err != nil {
-		return fmt.Errorf("Error waiting for EFS file system (%q) to delete: %s",
-			d.Id(), err.Error())
-	}
-
-	log.Printf("[DEBUG] EFS file system %q deleted.", d.Id())
-
-	return nil
+	_, err := stateConf.WaitForState()
+	return err
 }
 
 func hasEmptyFileSystems(fs *efs.DescribeFileSystemsOutput) bool {

--- a/aws/resource_aws_efs_file_system_test.go
+++ b/aws/resource_aws_efs_file_system_test.go
@@ -21,6 +21,9 @@ func init() {
 	resource.AddTestSweepers("aws_efs_file_system", &resource.Sweeper{
 		Name: "aws_efs_file_system",
 		F:    testSweepEfsFileSystems,
+		Dependencies: []string{
+			"aws_efs_mount_target",
+		},
 	})
 }
 

--- a/aws/resource_aws_efs_mount_target_test.go
+++ b/aws/resource_aws_efs_mount_target_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 	"testing"
 	"time"
@@ -10,10 +11,101 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/efs"
 
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_efs_mount_target", &resource.Sweeper{
+		Name: "aws_efs_mount_target",
+		F:    testSweepEfsMountTargets,
+	})
+}
+
+func testSweepEfsMountTargets(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).efsconn
+
+	var errors error
+	input := &efs.DescribeFileSystemsInput{}
+	for {
+		out, err := conn.DescribeFileSystems(input)
+		if err != nil {
+			if testSweepSkipSweepError(err) {
+				log.Printf("[WARN] Skipping EFS Mount Targets sweep for %s: %s", region, err)
+				return errors
+			}
+			errors = multierror.Append(errors, fmt.Errorf("error retrieving EFS Mount Targets: %w", err))
+			return errors
+		}
+
+		if out == nil || len(out.FileSystems) == 0 {
+			log.Printf("[INFO] No EFS File Systems to sweep")
+			return errors
+		}
+
+		for _, filesystem := range out.FileSystems {
+			id := aws.StringValue(filesystem.FileSystemId)
+
+			log.Printf("[INFO] Deleting Mount Targets for EFS File System: %s", id)
+			input := &efs.DescribeMountTargetsInput{
+				FileSystemId: filesystem.FileSystemId,
+			}
+			for {
+				out, err := conn.DescribeMountTargets(input)
+				if err != nil {
+					if testSweepSkipSweepError(err) {
+						log.Printf("[WARN] Skipping EFS Mount Targets sweep for %s: %s", region, err)
+						return errors
+					}
+					errors = multierror.Append(errors, fmt.Errorf("error retrieving EFS Mount Targets on File System %q: %w", id, err))
+					break
+				}
+
+				if out == nil || len(out.MountTargets) == 0 {
+					log.Printf("[INFO] No EFS Mount Targets to sweep on File System %q", id)
+					break
+				}
+
+				for _, mounttarget := range out.MountTargets {
+					id := aws.StringValue(mounttarget.MountTargetId)
+
+					log.Printf("[INFO] Deleting EFS Mount Target: %s", id)
+					_, err := conn.DeleteMountTarget(&efs.DeleteMountTargetInput{
+						MountTargetId: mounttarget.MountTargetId,
+					})
+					if err != nil {
+						errors = multierror.Append(errors, fmt.Errorf("error deleting EFS Mount Target %q: %w", id, err))
+						continue
+					}
+
+					err = waitForDeleteEfsMountTarget(conn, id, 10*time.Minute)
+					if err != nil {
+						errors = multierror.Append(errors, fmt.Errorf("error waiting for EFS Mount Target %q to delete: %w", id, err))
+						continue
+					}
+				}
+
+				if out.NextMarker == nil {
+					break
+				}
+				input.Marker = out.NextMarker
+			}
+		}
+
+		if out.NextMarker == nil {
+			break
+		}
+		input.Marker = out.NextMarker
+	}
+
+	return errors
+}
 
 func TestAccAWSEFSMountTarget_basic(t *testing.T) {
 	var mount efs.MountTargetDescription

--- a/aws/resource_aws_efs_mount_target_test.go
+++ b/aws/resource_aws_efs_mount_target_test.go
@@ -85,7 +85,7 @@ func testSweepEfsMountTargets(region string) error {
 		errors = multierror.Append(errors, fmt.Errorf("error retrieving EFS File Systems: %w", err))
 	}
 
-	return err
+	return errors
 }
 
 func TestAccAWSEFSMountTarget_basic(t *testing.T) {

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -31,6 +31,7 @@ func init() {
 			"aws_directory_service_directory",
 			"aws_ec2_client_vpn_endpoint",
 			"aws_ec2_transit_gateway_vpc_attachment",
+			"aws_efs_file_system",
 			"aws_eks_cluster",
 			"aws_elasticache_cluster",
 			"aws_elasticache_replication_group",


### PR DESCRIPTION
Prevent sweeper failures for Subnets by adding sweepers for `aws_efs_file_system` and `aws_efs_mount_target`.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11495

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make sweep SWEEPARGS="-sweep-run=aws_efs_file_system"

2020/01/15 17:08:58 Sweeper Tests ran successfully:
	- aws_efs_mount_target
	- aws_efs_file_system
```
