### PR TITLE
set postgresql to postgres so postgresql is a valid input for field e…

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -863,6 +863,11 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			}
 		}
 
+		// allow postgresql as input as postgres
+		if strings.ToLower(d.Get("engine").(string)) == "postgresql" {
+			d.Set("engine", "postgres")
+		}
+
 		if attr, ok := d.GetOk("allocated_storage"); ok {
 			modifyDbInstanceInput.AllocatedStorage = aws.Int64(int64(attr.(int)))
 			requiresModifyDbInstance = true


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request


This is related to closed issue [4492](https://github.com/terraform-providers/terraform-provider-aws/issues/4492). And related to the open issue [11619](https://github.com/terraform-providers/terraform-provider-aws/issues/11619)

**Summary:** 
The end solution for issue [4492](https://github.com/terraform-providers/terraform-provider-aws/issues/4492) was to simply use `postgres`. If it plans, theoretically it should apply.  If `postgresql` is not a valid input then it should error out during `terraform plan`. This is not the current behavior. The changes set `postgresql` as `postgres`. 