### PR TITLE
d/aws_ecs_cluster: add attributes

### DIFF
--- a/aws/data_source_aws_ecs_cluster_test.go
+++ b/aws/data_source_aws_ecs_cluster_test.go
@@ -9,6 +9,9 @@ import (
 )
 
 func TestAccAWSEcsDataSource_ecsCluster(t *testing.T) {
+	dataSourceName := "data.aws_ecs_cluster.test"
+	resourceName := "aws_ecs_cluster.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -16,11 +19,15 @@ func TestAccAWSEcsDataSource_ecsCluster(t *testing.T) {
 			{
 				Config: testAccCheckAwsEcsClusterDataSourceConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_ecs_cluster.default", "status", "ACTIVE"),
-					resource.TestCheckResourceAttr("data.aws_ecs_cluster.default", "pending_tasks_count", "0"),
-					resource.TestCheckResourceAttr("data.aws_ecs_cluster.default", "running_tasks_count", "0"),
-					resource.TestCheckResourceAttr("data.aws_ecs_cluster.default", "registered_container_instances_count", "0"),
-					resource.TestCheckResourceAttrSet("data.aws_ecs_cluster.default", "arn"),
+					resource.TestCheckResourceAttr(dataSourceName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttr(dataSourceName, "pending_tasks_count", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "running_tasks_count", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "registered_container_instances_count", "0"),
+					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags", dataSourceName, "tags"),
+					resource.TestCheckResourceAttrPair(resourceName, "default_capacity_provider_strategy", dataSourceName, "default_capacity_provider_strategy"),
+					resource.TestCheckResourceAttrPair(resourceName, "capacity_providers", dataSourceName, "capacity_providers"),
+					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "cluster_name"),
 				),
 			},
 		},
@@ -28,6 +35,9 @@ func TestAccAWSEcsDataSource_ecsCluster(t *testing.T) {
 }
 
 func TestAccAWSEcsDataSource_ecsClusterContainerInsights(t *testing.T) {
+	dataSourceName := "data.aws_ecs_cluster.test"
+	resourceName := "aws_ecs_cluster.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -35,12 +45,13 @@ func TestAccAWSEcsDataSource_ecsClusterContainerInsights(t *testing.T) {
 			{
 				Config: testAccCheckAwsEcsClusterDataSourceConfigContainerInsights,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_ecs_cluster.default", "status", "ACTIVE"),
-					resource.TestCheckResourceAttr("data.aws_ecs_cluster.default", "pending_tasks_count", "0"),
-					resource.TestCheckResourceAttr("data.aws_ecs_cluster.default", "running_tasks_count", "0"),
-					resource.TestCheckResourceAttr("data.aws_ecs_cluster.default", "registered_container_instances_count", "0"),
-					resource.TestCheckResourceAttrSet("data.aws_ecs_cluster.default", "arn"),
-					resource.TestCheckResourceAttrPair("data.aws_ecs_cluster.default", "setting.#", "aws_ecs_cluster.default", "setting.#"),
+					resource.TestCheckResourceAttr(dataSourceName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttr(dataSourceName, "pending_tasks_count", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "running_tasks_count", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "registered_container_instances_count", "0"),
+					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "setting", resourceName, "setting"),
+					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "cluster_name"),
 				),
 			},
 		},
@@ -48,25 +59,25 @@ func TestAccAWSEcsDataSource_ecsClusterContainerInsights(t *testing.T) {
 }
 
 var testAccCheckAwsEcsClusterDataSourceConfig = fmt.Sprintf(`
-resource "aws_ecs_cluster" "default" {
-  name = "default-%d"
+resource "aws_ecs_cluster" "test" {
+  name = %q
 }
 
-data "aws_ecs_cluster" "default" {
-  cluster_name = "${aws_ecs_cluster.default.name}"
+data "aws_ecs_cluster" "test" {
+  cluster_name = "${aws_ecs_cluster.test.name}"
 }
-`, acctest.RandInt())
+`, acctest.RandomWithPrefix("tf-acc"))
 
 var testAccCheckAwsEcsClusterDataSourceConfigContainerInsights = fmt.Sprintf(`
-resource "aws_ecs_cluster" "default" {
-  name = "default-%d"
+resource "aws_ecs_cluster" "test" {
+  name = %q
   setting {
     name = "containerInsights"
     value = "enabled"
   }
 }
 
-data "aws_ecs_cluster" "default" {
-  cluster_name = "${aws_ecs_cluster.default.name}"
+data "aws_ecs_cluster" "test" {
+  cluster_name = "${aws_ecs_cluster.test.name}"
 }
-`, acctest.RandInt())
+`, acctest.RandomWithPrefix("tf-acc-insight"))

--- a/website/docs/d/ecs_cluster.html.markdown
+++ b/website/docs/d/ecs_cluster.html.markdown
@@ -35,3 +35,6 @@ In addition to all arguments above, the following attributes are exported:
 * `running_tasks_count` - The number of running tasks for the ECS Cluster
 * `registered_container_instances_count` - The number of registered container instances for the ECS Cluster
 * `setting` - The settings associated with the ECS Cluster.
+* `capacity_providers` - List of short names of one or more capacity providers to associate with the cluster.
+* `default_capacity_provider_strategy` - The capacity provider strategy to use by default for the cluster.
+* `tags` - Key-value mapping of resource tags


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data_source_aws_ecs_cluster: add `default_capacity_provider_strategy`, `capacity_providers` and `tags` attributes
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEcsDataSource_ecsCluster'
--- PASS: TestAccAWSEcsDataSource_ecsCluster (84.56s)
--- PASS: TestAccAWSEcsDataSource_ecsClusterContainerInsights (84.56s)
...
```
