### PR TITLE
d/aws_ecs_task_definition: add attributes

### DIFF
--- a/aws/data_source_aws_ecs_task_definition.go
+++ b/aws/data_source_aws_ecs_task_definition.go
@@ -97,6 +97,22 @@ func dataSourceAwsEcsTaskDefinition() *schema.Resource {
 								},
 							},
 						},
+						"efs_volume_configuration": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"file_system_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"root_directory": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
 					},
 				},
 				Set: resourceAwsEcsTaskDefinitionVolumeHash,

--- a/aws/data_source_aws_ecs_task_definition.go
+++ b/aws/data_source_aws_ecs_task_definition.go
@@ -69,7 +69,6 @@ func dataSourceAwsEcsTaskDefinition() *schema.Resource {
 						"docker_volume_configuration": {
 							Type:     schema.TypeList,
 							Computed: true,
-							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"scope": {
@@ -120,7 +119,6 @@ func dataSourceAwsEcsTaskDefinition() *schema.Resource {
 			"placement_constraints": {
 				Type:     schema.TypeSet,
 				Computed: true,
-				MaxItems: 10,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": {
@@ -141,7 +139,6 @@ func dataSourceAwsEcsTaskDefinition() *schema.Resource {
 			},
 			"proxy_configuration": {
 				Type:     schema.TypeList,
-				MaxItems: 1,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/aws/data_source_aws_ecs_task_definition.go
+++ b/aws/data_source_aws_ecs_task_definition.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func dataSourceAwsEcsTaskDefinition() *schema.Resource {
@@ -40,6 +41,111 @@ func dataSourceAwsEcsTaskDefinition() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"execution_role_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cpu": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"memory": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"volume": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"host_path": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"docker_volume_configuration": {
+							Type:     schema.TypeList,
+							Computed: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"scope": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"autoprovision": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"driver": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"driver_opts": {
+										Type:     schema.TypeMap,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+										Computed: true,
+									},
+									"labels": {
+										Type:     schema.TypeMap,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+				Set: resourceAwsEcsTaskDefinitionVolumeHash,
+			},
+			"placement_constraints": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				MaxItems: 10,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"expression": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"requires_compatibilities": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"proxy_configuration": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"container_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"properties": {
+							Type:     schema.TypeMap,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"tags": tagsSchemaComputed(),
 		},
 	}
 }
@@ -49,6 +155,7 @@ func dataSourceAwsEcsTaskDefinitionRead(d *schema.ResourceData, meta interface{}
 
 	params := &ecs.DescribeTaskDefinitionInput{
 		TaskDefinition: aws.String(d.Get("task_definition").(string)),
+		Include:        []*string{aws.String(ecs.TaskDefinitionFieldTags)},
 	}
 	log.Printf("[DEBUG] Reading ECS Task Definition: %s", params)
 	desc, err := conn.DescribeTaskDefinition(params)
@@ -65,6 +172,28 @@ func dataSourceAwsEcsTaskDefinitionRead(d *schema.ResourceData, meta interface{}
 	d.Set("revision", aws.Int64Value(taskDefinition.Revision))
 	d.Set("status", aws.StringValue(taskDefinition.Status))
 	d.Set("task_role_arn", aws.StringValue(taskDefinition.TaskRoleArn))
+	d.Set("execution_role_arn", taskDefinition.ExecutionRoleArn)
+	d.Set("cpu", taskDefinition.Cpu)
+	d.Set("memory", taskDefinition.Memory)
+	if err := d.Set("tags", keyvaluetags.EcsKeyValueTags(desc.Tags).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	if err := d.Set("volume", flattenEcsVolumes(taskDefinition.Volumes)); err != nil {
+		return fmt.Errorf("error setting volume: %s", err)
+	}
+
+	if err := d.Set("placement_constraints", flattenPlacementConstraints(taskDefinition.PlacementConstraints)); err != nil {
+		log.Printf("[ERR] Error setting placement_constraints for (%s): %s", d.Id(), err)
+	}
+
+	if err := d.Set("requires_compatibilities", flattenStringList(taskDefinition.RequiresCompatibilities)); err != nil {
+		return fmt.Errorf("error setting requires_compatibilities: %s", err)
+	}
+
+	if err := d.Set("proxy_configuration", flattenProxyConfiguration(taskDefinition.ProxyConfiguration)); err != nil {
+		return fmt.Errorf("error setting proxy_configuration: %s", err)
+	}
 
 	if d.Id() == "" {
 		return fmt.Errorf("task definition %q not found", d.Get("task_definition").(string))

--- a/aws/data_source_aws_ecs_task_definition_test.go
+++ b/aws/data_source_aws_ecs_task_definition_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -23,7 +22,7 @@ func TestAccAWSEcsDataSource_ecsTaskDefinition(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "family", resourceName, "family"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "network_mode", resourceName, "network_mode"),
-					resource.TestMatchResourceAttr(dataSourceName, "revision", regexp.MustCompile("^[1-9][0-9]*$")),
+					resource.TestCheckResourceAttrPair(dataSourceName, "revision", resourceName, "revision"),
 					resource.TestCheckResourceAttr(dataSourceName, "status", "ACTIVE"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "task_role_arn", resourceName, "task_role_arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "execution_role_arn", resourceName, "execution_role_arn"),

--- a/aws/data_source_aws_ecs_task_definition_test.go
+++ b/aws/data_source_aws_ecs_task_definition_test.go
@@ -33,7 +33,6 @@ func TestAccAWSEcsDataSource_ecsTaskDefinition(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "placement_constraints", resourceName, "placement_constraints"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "requires_compatibilities", resourceName, "requires_compatibilities"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "proxy_configuration", resourceName, "proxy_configuration"),
-					resource.TestCheckResourceAttrPair(resourceName, "task_role_arn", "aws_iam_role.test", "arn"),
 				),
 			},
 		},

--- a/website/docs/d/ecs_task_definition.html.markdown
+++ b/website/docs/d/ecs_task_definition.html.markdown
@@ -17,15 +17,15 @@ a specific AWS ECS task definition.
 ```hcl
 # Simply specify the family to find the latest ACTIVE revision in that family.
 data "aws_ecs_task_definition" "mongo" {
-  task_definition = "${aws_ecs_task_definition.mongo.family}"
+  task_definition = "${aws_ecs_task_definition.test.family}"
 }
 
-resource "aws_ecs_cluster" "foo" {
-  name = "foo"
+resource "aws_ecs_cluster" "test" {
+  name = "test"
 }
 
-resource "aws_ecs_task_definition" "mongo" {
-  family = "mongodb"
+resource "aws_ecs_task_definition" "test" {
+  family = "test"
 
   container_definitions = <<DEFINITION
 [
@@ -45,13 +45,13 @@ resource "aws_ecs_task_definition" "mongo" {
 DEFINITION
 }
 
-resource "aws_ecs_service" "mongo" {
-  name          = "mongo"
-  cluster       = "${aws_ecs_cluster.foo.id}"
+resource "aws_ecs_service" "test" {
+  name          = "test"
+  cluster       = "${aws_ecs_cluster.test.id}"
   desired_count = 2
 
   # Track the latest ACTIVE revision
-  task_definition = "${aws_ecs_task_definition.mongo.family}:${max("${aws_ecs_task_definition.mongo.revision}", "${data.aws_ecs_task_definition.mongo.revision}")}"
+  task_definition = "${aws_ecs_task_definition.test.family}:${max("${aws_ecs_task_definition.test.revision}", "${data.aws_ecs_task_definition.test.revision}")}"
 }
 ```
 

--- a/website/docs/d/ecs_task_definition.html.markdown
+++ b/website/docs/d/ecs_task_definition.html.markdown
@@ -70,3 +70,11 @@ In addition to all arguments above, the following attributes are exported:
 * `revision` - The revision of this task definition
 * `status` - The status of this task definition
 * `task_role_arn` - The ARN of the IAM role that containers in this task can assume
+* `execution_role_arn` - The Amazon Resource Name (ARN) of the task execution role that the Amazon ECS container agent and the Docker daemon can assume.
+* `volume` - A set of volume blocks that containers in your task may use.
+* `placement_constraints` - A set of placement constraints rules that are taken into consideration during task placement.
+* `cpu` - The number of cpu units used by the task.
+* `memory` - The amount (in MiB) of memory used by the task.
+* `requires_compatibilities` - A set of launch types required by the task. The valid values are `EC2` and `FARGATE`.
+* `proxy_configuration` - The proxy configuration details for the App Mesh proxy.
+* `tags` - Key-value mapping of resource tags


### PR DESCRIPTION

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data_source_aws_ecs_task_definition: add `execution_role_arn`, `cpu`, `memory`, `volume`, `placement_constraints`, `requires_compatibilities`, `proxy_configuration` and `tags` attributes
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEcsDataSource_ecsTaskDefinition'
--- PASS: TestAccAWSEcsDataSource_ecsTaskDefinition (93.49s)
...
```
