### PR TITLE
d/aws_efs_file_system - add attributes

### DIFF
--- a/aws/data_source_aws_efs_file_system.go
+++ b/aws/data_source_aws_efs_file_system.go
@@ -51,6 +51,27 @@ func dataSourceAwsEfsFileSystem() *schema.Resource {
 				Computed: true,
 			},
 			"tags": tagsSchemaComputed(),
+			"throughput_mode": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"provisioned_throughput_in_mibps": {
+				Type:     schema.TypeFloat,
+				Computed: true,
+			},
+			"lifecycle_policy": {
+				Type:     schema.TypeList,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"transition_to_ia": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -78,16 +99,6 @@ func dataSourceAwsEfsFileSystemRead(d *schema.ResourceData, meta interface{}) er
 	}
 
 	d.SetId(*describeResp.FileSystems[0].FileSystemId)
-
-	tags, err := keyvaluetags.EfsListTags(efsconn, d.Id())
-
-	if err != nil {
-		return fmt.Errorf("error listing tags for EFS file system (%s): %s", d.Id(), err)
-	}
-
-	if err := d.Set("tags", tags.IgnoreAws().Map()); err != nil {
-		return fmt.Errorf("error settings tags: %s", err)
-	}
 
 	var fs *efs.FileSystemDescription
 	for _, f := range describeResp.FileSystems {
@@ -117,6 +128,23 @@ func dataSourceAwsEfsFileSystemRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("file_system_id", fs.FileSystemId)
 	d.Set("encrypted", fs.Encrypted)
 	d.Set("kms_key_id", fs.KmsKeyId)
+	d.Set("provisioned_throughput_in_mibps", fs.ProvisionedThroughputInMibps)
+	d.Set("throughput_mode", fs.ThroughputMode)
+
+	if err := d.Set("tags", keyvaluetags.EfsKeyValueTags(fs.Tags).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	res, err := efsconn.DescribeLifecycleConfiguration(&efs.DescribeLifecycleConfigurationInput{
+		FileSystemId: fs.FileSystemId,
+	})
+	if err != nil {
+		return fmt.Errorf("Error describing lifecycle configuration for EFS file system (%s): %s",
+			aws.StringValue(fs.FileSystemId), err)
+	}
+	if err := resourceAwsEfsFileSystemSetLifecyclePolicy(d, res.LifecyclePolicies); err != nil {
+		return err
+	}
 
 	region := meta.(*AWSClient).region
 	err = d.Set("dns_name", resourceAwsEfsDnsName(*fs.FileSystemId, region))

--- a/aws/data_source_aws_efs_file_system_test.go
+++ b/aws/data_source_aws_efs_file_system_test.go
@@ -2,40 +2,76 @@ package aws
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccDataSourceAwsEfsFileSystem(t *testing.T) {
+func TestAccDataSourceAwsEfsFileSystem_id(t *testing.T) {
+	dataSourceName := "data.aws_efs_file_system.test"
+	resourceName := "aws_efs_file_system.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsEfsFileSystemConfig,
+				Config: testAccDataSourceAwsEfsFileSystemIDConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair("data.aws_efs_file_system.by_id", "arn", "aws_efs_file_system.test", "arn"),
-					testAccDataSourceAwsEfsFileSystemCheck("data.aws_efs_file_system.by_creation_token"),
-					testAccDataSourceAwsEfsFileSystemCheck("data.aws_efs_file_system.by_id"),
-					resource.TestMatchResourceAttr("data.aws_efs_file_system.by_creation_token", "dns_name", regexp.MustCompile(`^[^.]+.efs.([a-z]{2}-(gov-)?[a-z]+-\d{1})?.amazonaws.com$`)),
-					resource.TestMatchResourceAttr("data.aws_efs_file_system.by_id", "dns_name", regexp.MustCompile(`^[^.]+.efs.([a-z]{2}-(gov-)?[a-z]+-\d{1})?.amazonaws.com$`)),
+					testAccDataSourceAwsEfsFileSystemCheck(dataSourceName, resourceName),
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "performance_mode", resourceName, "performance_mode"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "creation_token", resourceName, "creation_token"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "encrypted", resourceName, "encrypted"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "kms_key_id", resourceName, "kms_key_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags", resourceName, "tags"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "dns_name", resourceName, "dns_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "provisioned_throughput_in_mibps", resourceName, "provisioned_throughput_in_mibps"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "throughput_mode", resourceName, "throughput_mode"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "lifecycle_policy", resourceName, "lifecycle_policy"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceAwsEfsFileSystemCheck(name string) resource.TestCheckFunc {
+func TestAccDataSourceAwsEfsFileSystem_name(t *testing.T) {
+	dataSourceName := "data.aws_efs_file_system.test"
+	resourceName := "aws_efs_file_system.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsEfsFileSystemNameConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsEfsFileSystemCheck(dataSourceName, resourceName),
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "performance_mode", resourceName, "performance_mode"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "creation_token", resourceName, "creation_token"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "encrypted", resourceName, "encrypted"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "kms_key_id", resourceName, "kms_key_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags", resourceName, "tags"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "dns_name", resourceName, "dns_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "provisioned_throughput_in_mibps", resourceName, "provisioned_throughput_in_mibps"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "throughput_mode", resourceName, "throughput_mode"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "lifecycle_policy", resourceName, "lifecycle_policy"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsEfsFileSystemCheck(dName, rName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[dName]
 		if !ok {
-			return fmt.Errorf("root module has no resource called %s", name)
+			return fmt.Errorf("root module has no resource called %s", dName)
 		}
 
-		efsRs, ok := s.RootModule().Resources["aws_efs_file_system.test"]
+		efsRs, ok := s.RootModule().Resources[rName]
 		if !ok {
 			return fmt.Errorf("can't find aws_efs_file_system.test in state")
 		}
@@ -62,14 +98,18 @@ func testAccDataSourceAwsEfsFileSystemCheck(name string) resource.TestCheckFunc 
 	}
 }
 
-const testAccDataSourceAwsEfsFileSystemConfig = `
+const testAccDataSourceAwsEfsFileSystemNameConfig = `
 resource "aws_efs_file_system" "test" {}
 
-data "aws_efs_file_system" "by_creation_token" {
-  creation_token = "${aws_efs_file_system.test.creation_token}"
+data "aws_efs_file_system" "test" {
+creation_token = "${aws_efs_file_system.test.creation_token}"
 }
+`
 
-data "aws_efs_file_system" "by_id" {
+const testAccDataSourceAwsEfsFileSystemIDConfig = `
+resource "aws_efs_file_system" "test" {}
+
+data "aws_efs_file_system" "test" {
   file_system_id = "${aws_efs_file_system.test.id}"
 }
 `

--- a/website/docs/d/efs_file_system.html.markdown
+++ b/website/docs/d/efs_file_system.html.markdown
@@ -30,6 +30,7 @@ The following arguments are supported:
 * `file_system_id` - (Optional) The ID that identifies the file system (e.g. fs-ccfc0d65).
 * `creation_token` - (Optional) Restricts the list to the file system with this creation token.
 
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -40,3 +41,9 @@ In addition to all arguments above, the following attributes are exported:
 * `encrypted` - Whether EFS is encrypted.
 * `kms_key_id` - The ARN for the KMS encryption key.
 * `dns_name` - The DNS name for the filesystem per [documented convention](http://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-dns-name.html).
+* `lifecycle_policy` - A file system [lifecycle policy](https://docs.aws.amazon.com/efs/latest/ug/API_LifecyclePolicy.html) object.
+* `performance_mode` - The file system performance mode.
+* `provisioned_throughput_in_mibps` - The throughput, measured in MiB/s, that you want to provision for the file system.
+* `tags` -A mapping of tags to assign to the file system.
+* `throughput_mode` - Throughput mode for the file system.
+


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data_source_aws_efs_file_system: add `throughput_mode`, `provisioned_throughput_in_mibps`, and  `lifecycle_policy` attributes.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccDataSourceAwsEfsFileSystem_'
--- PASS: TestAccDataSourceAwsEfsFileSystem_id (82.64s)
--- PASS: TestAccDataSourceAwsEfsFileSystem_name (81.08s)
...
```
