### PR TITLE
Addresses a number of issues with blocks in `aws_codedeploy_deployment_group`

### DIFF
--- a/aws/resource_aws_codedeploy_deployment_group.go
+++ b/aws/resource_aws_codedeploy_deployment_group.go
@@ -76,15 +76,16 @@ func resourceAwsCodeDeployDeploymentGroup() *schema.Resource {
 			},
 
 			"deployment_style": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
+				Type:             schema.TypeList,
+				Optional:         true,
+				DiffSuppressFunc: suppressMissingOptionalConfigurationBlock,
+				MaxItems:         1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"deployment_option": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Default:  codedeploy.DeploymentOptionWithoutTrafficControl,
 							ValidateFunc: validation.StringInSlice([]string{
 								codedeploy.DeploymentOptionWithTrafficControl,
 								codedeploy.DeploymentOptionWithoutTrafficControl,
@@ -93,6 +94,7 @@ func resourceAwsCodeDeployDeploymentGroup() *schema.Resource {
 						"deployment_type": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Default:  codedeploy.DeploymentTypeInPlace,
 							ValidateFunc: validation.StringInSlice([]string{
 								codedeploy.DeploymentTypeInPlace,
 								codedeploy.DeploymentTypeBlueGreen,

--- a/aws/resource_aws_codedeploy_deployment_group.go
+++ b/aws/resource_aws_codedeploy_deployment_group.go
@@ -211,7 +211,6 @@ func resourceAwsCodeDeployDeploymentGroup() *schema.Resource {
 			"load_balancer_info": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -1030,14 +1029,14 @@ func expandDeploymentStyle(list []interface{}) *codedeploy.DeploymentStyle {
 }
 
 // expandLoadBalancerInfo converts a raw schema list containing a map[string]interface{}
-// into a single codedeploy.LoadBalancerInfo object
+// into a single codedeploy.LoadBalancerInfo object. Returns an empty object if list is nil.
 func expandLoadBalancerInfo(list []interface{}) *codedeploy.LoadBalancerInfo {
+	loadBalancerInfo := &codedeploy.LoadBalancerInfo{}
 	if len(list) == 0 || list[0] == nil {
-		return nil
+		return loadBalancerInfo
 	}
 
 	lbInfo := list[0].(map[string]interface{})
-	loadBalancerInfo := &codedeploy.LoadBalancerInfo{}
 
 	if attr, ok := lbInfo["elb_info"]; ok && attr.(*schema.Set).Len() > 0 {
 		loadBalancerInfo.ElbInfoList = expandCodeDeployElbInfo(attr.(*schema.Set).List())

--- a/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -2324,10 +2324,9 @@ func testAccAWSCodeDeployDeploymentGroup(rName string, tagGroup bool) string {
 
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
-  
+  service_role_arn      = aws_iam_role.test.arn
   %[2]s
 }
 
@@ -2336,8 +2335,8 @@ resource "aws_codedeploy_app" "test" {
 }
 
 resource "aws_iam_role_policy" "test" {
-  name = "tf-acc-test-%[1]s"
-  role = "${aws_iam_role.test.id}"
+  name   = "tf-acc-test-%[1]s"
+  role   = aws_iam_role.test.id
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -2361,10 +2360,11 @@ resource "aws_iam_role_policy" "test" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_role" "test" {
-  name = "tf-acc-test-%[1]s"
+  name               = "tf-acc-test-%[1]s"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -2382,6 +2382,7 @@ resource "aws_iam_role" "test" {
   ]
 }
 EOF
+
 }
 `, rName, tagGroupOrFilter)
 }
@@ -2408,20 +2409,19 @@ func testAccAWSCodeDeployDeploymentGroupModified(rName string, tagGroup bool) st
 
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-updated-%[1]s"
-  service_role_arn = "${aws_iam_role.test_new.arn}"
-
+  service_role_arn      = aws_iam_role.test_new.arn
   %[2]s
 }
 
 resource "aws_codedeploy_app" "test" {
-	name = "tf-acc-test-%[1]s"
+  name = "tf-acc-test-%[1]s"
 }
 
 resource "aws_iam_role_policy" "test" {
-  name = "tf-acc-test-%[1]s"
-  role = "${aws_iam_role.test_new.id}"
+  name   = "tf-acc-test-%[1]s"
+  role   = aws_iam_role.test_new.id
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -2445,10 +2445,11 @@ resource "aws_iam_role_policy" "test" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_role" "test_new" {
-  name = "tf-acc-test-updated-%[1]s"
+  name               = "tf-acc-test-updated-%[1]s"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -2466,6 +2467,7 @@ resource "aws_iam_role" "test_new" {
   ]
 }
 EOF
+
 }
 `, rName, tagGroupOrFilter)
 }
@@ -2477,8 +2479,8 @@ resource "aws_codedeploy_app" "test" {
 }
 
 resource "aws_iam_role_policy" "test" {
-  name = "tf-acc-test-%[1]s"
-  role = "${aws_iam_role.test.id}"
+  name   = "tf-acc-test-%[1]s"
+  role   = aws_iam_role.test.id
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -2502,10 +2504,11 @@ resource "aws_iam_role_policy" "test" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_role" "test" {
-  name = "tf-acc-test-%[1]s"
+  name               = "tf-acc-test-%[1]s"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -2523,16 +2526,17 @@ resource "aws_iam_role" "test" {
   ]
 }
 EOF
+
 }
 
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn      = aws_iam_role.test.arn
 
   on_premises_instance_tag_filter {
-    key = "filterkey"
-    type = "KEY_AND_VALUE"
+    key   = "filterkey"
+    type  = "KEY_AND_VALUE"
     value = "filtervalue"
   }
 }
@@ -2542,12 +2546,12 @@ resource "aws_codedeploy_deployment_group" "test" {
 func baseCodeDeployConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_app" "test" {
-	name = "tf-acc-test-%[1]s"
+  name = "tf-acc-test-%[1]s"
 }
 
 resource "aws_iam_role_policy" "test" {
-	name = "tf-acc-test-%[1]s"
-	role = "${aws_iam_role.test.id}"
+  name   = "tf-acc-test-%[1]s"
+  role   = aws_iam_role.test.id
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -2573,10 +2577,11 @@ resource "aws_iam_role_policy" "test" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_role" "test" {
-  name = "tf-acc-test-%[1]s"
+  name               = "tf-acc-test-%[1]s"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -2592,6 +2597,7 @@ resource "aws_iam_role" "test" {
   ]
 }
 EOF
+
 }
 
 resource "aws_sns_topic" "test" {
@@ -2603,14 +2609,14 @@ resource "aws_sns_topic" "test" {
 func testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_create(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn      = aws_iam_role.test.arn
 
   trigger_configuration {
-    trigger_events = ["DeploymentFailure"]
-    trigger_name = "test-trigger"
-    trigger_target_arn = "${aws_sns_topic.test.arn}"
+    trigger_events     = ["DeploymentFailure"]
+    trigger_name       = "test-trigger"
+    trigger_target_arn = aws_sns_topic.test.arn
   }
 }
 `, rName) + baseCodeDeployConfig(rName)
@@ -2619,14 +2625,14 @@ resource "aws_codedeploy_deployment_group" "test" {
 func testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_update(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn      = aws_iam_role.test.arn
 
   trigger_configuration {
-    trigger_events = ["DeploymentSuccess", "DeploymentFailure"]
-    trigger_name = "test-trigger"
-    trigger_target_arn = "${aws_sns_topic.test.arn}"
+    trigger_events     = ["DeploymentSuccess", "DeploymentFailure"]
+    trigger_name       = "test-trigger"
+    trigger_target_arn = aws_sns_topic.test.arn
   }
 }
 `, rName) + baseCodeDeployConfig(rName)
@@ -2635,70 +2641,69 @@ resource "aws_codedeploy_deployment_group" "test" {
 func testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_createMultiple(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn      = aws_iam_role.test.arn
 
   trigger_configuration {
-    trigger_events = ["DeploymentFailure"]
-    trigger_name = "test-trigger-1"
-    trigger_target_arn = "${aws_sns_topic.test.arn}"
+    trigger_events     = ["DeploymentFailure"]
+    trigger_name       = "test-trigger-1"
+    trigger_target_arn = aws_sns_topic.test.arn
   }
 
   trigger_configuration {
-    trigger_events = ["InstanceFailure"]
-    trigger_name = "test-trigger-2"
-    trigger_target_arn = "${aws_sns_topic.test_2.arn}"
+    trigger_events     = ["InstanceFailure"]
+    trigger_name       = "test-trigger-2"
+    trigger_target_arn = aws_sns_topic.test_2.arn
   }
 }
 
 resource "aws_sns_topic" "test_2" {
   name = "tf-acc-test-2-%[1]s"
-}  
+}
 `, rName) + baseCodeDeployConfig(rName)
 }
 
 func testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_updateMultiple(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn      = aws_iam_role.test.arn
 
   trigger_configuration {
-    trigger_events = ["DeploymentStart", "DeploymentSuccess", "DeploymentFailure", "DeploymentStop"]
-    trigger_name = "test-trigger-1"
-    trigger_target_arn = "${aws_sns_topic.test.arn}"
+    trigger_events     = ["DeploymentStart", "DeploymentSuccess", "DeploymentFailure", "DeploymentStop"]
+    trigger_name       = "test-trigger-1"
+    trigger_target_arn = aws_sns_topic.test.arn
   }
 
   trigger_configuration {
-    trigger_events = ["InstanceFailure"]
-    trigger_name = "test-trigger-2"
-    trigger_target_arn = "${aws_sns_topic.test_3.arn}"
+    trigger_events     = ["InstanceFailure"]
+    trigger_name       = "test-trigger-2"
+    trigger_target_arn = aws_sns_topic.test_3.arn
   }
 }
 
 resource "aws_sns_topic" "test_2" {
   name = "tf-acc-test-2-%[1]s"
-}  
+}
 
 resource "aws_sns_topic" "test_3" {
   name = "tf-acc-test-3-%[1]s"
 }
-
 `, rName) + baseCodeDeployConfig(rName)
 }
 
 func test_config_auto_rollback_configuration_create(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn      = aws_iam_role.test.arn
 
   auto_rollback_configuration {
     enabled = true
-    events = ["DEPLOYMENT_FAILURE"]
+    events  = ["DEPLOYMENT_FAILURE"]
   }
 }
 `, rName) + baseCodeDeployConfig(rName)
@@ -2707,13 +2712,13 @@ resource "aws_codedeploy_deployment_group" "test" {
 func test_config_auto_rollback_configuration_update(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn      = aws_iam_role.test.arn
 
   auto_rollback_configuration {
     enabled = true
-    events = ["DEPLOYMENT_FAILURE", "DEPLOYMENT_STOP_ON_ALARM"]
+    events  = ["DEPLOYMENT_FAILURE", "DEPLOYMENT_STOP_ON_ALARM"]
   }
 }
 `, rName) + baseCodeDeployConfig(rName)
@@ -2722,9 +2727,9 @@ resource "aws_codedeploy_deployment_group" "test" {
 func test_config_auto_rollback_configuration_none(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn      = aws_iam_role.test.arn
 }
 `, rName) + baseCodeDeployConfig(rName)
 }
@@ -2732,13 +2737,13 @@ resource "aws_codedeploy_deployment_group" "test" {
 func test_config_auto_rollback_configuration_disable(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn      = aws_iam_role.test.arn
 
   auto_rollback_configuration {
     enabled = false
-    events = ["DEPLOYMENT_FAILURE"]
+    events  = ["DEPLOYMENT_FAILURE"]
   }
 }
 `, rName) + baseCodeDeployConfig(rName)
@@ -2747,12 +2752,12 @@ resource "aws_codedeploy_deployment_group" "test" {
 func test_config_alarm_configuration_create(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn      = aws_iam_role.test.arn
 
   alarm_configuration {
-    alarms = ["test-alarm"]
+    alarms  = ["test-alarm"]
     enabled = true
   }
 }
@@ -2762,13 +2767,13 @@ resource "aws_codedeploy_deployment_group" "test" {
 func test_config_alarm_configuration_update(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn      = aws_iam_role.test.arn
 
   alarm_configuration {
-    alarms = ["test-alarm", "test-alarm-2"]
-    enabled = true
+    alarms                    = ["test-alarm", "test-alarm-2"]
+    enabled                   = true
     ignore_poll_alarm_failure = true
   }
 }
@@ -2778,9 +2783,9 @@ resource "aws_codedeploy_deployment_group" "test" {
 func test_config_alarm_configuration_none(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn      = aws_iam_role.test.arn
 }
 `, rName) + baseCodeDeployConfig(rName)
 }
@@ -2788,12 +2793,12 @@ resource "aws_codedeploy_deployment_group" "test" {
 func test_config_alarm_configuration_disable(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn      = aws_iam_role.test.arn
 
   alarm_configuration {
-    alarms = ["test-alarm"]
+    alarms  = ["test-alarm"]
     enabled = false
   }
 }
@@ -2803,9 +2808,9 @@ resource "aws_codedeploy_deployment_group" "test" {
 func test_config_deployment_style_default(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn      = aws_iam_role.test.arn
 }
 `, rName) + baseCodeDeployConfig(rName)
 }
@@ -2813,13 +2818,13 @@ resource "aws_codedeploy_deployment_group" "test" {
 func test_config_deployment_style_create(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn      = aws_iam_role.test.arn
 
   deployment_style {
     deployment_option = "WITH_TRAFFIC_CONTROL"
-    deployment_type = "BLUE_GREEN"
+    deployment_type   = "BLUE_GREEN"
   }
 
   load_balancer_info {
@@ -2834,13 +2839,13 @@ resource "aws_codedeploy_deployment_group" "test" {
 func test_config_deployment_style_update(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn      = aws_iam_role.test.arn
 
   deployment_style {
     deployment_option = "WITHOUT_TRAFFIC_CONTROL"
-    deployment_type = "IN_PLACE"
+    deployment_type   = "IN_PLACE"
   }
 }
 `, rName) + baseCodeDeployConfig(rName)
@@ -2849,9 +2854,9 @@ resource "aws_codedeploy_deployment_group" "test" {
 func test_config_load_balancer_info_none(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn      = aws_iam_role.test.arn
 }
 `, rName) + baseCodeDeployConfig(rName)
 }
@@ -2859,9 +2864,9 @@ resource "aws_codedeploy_deployment_group" "test" {
 func test_config_load_balancer_info_create(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn      = aws_iam_role.test.arn
 
   load_balancer_info {
     elb_info {
@@ -2875,9 +2880,9 @@ resource "aws_codedeploy_deployment_group" "test" {
 func test_config_load_balancer_info_update(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn      = aws_iam_role.test.arn
 
   load_balancer_info {
     elb_info {
@@ -2891,9 +2896,9 @@ resource "aws_codedeploy_deployment_group" "test" {
 func test_config_load_balancer_info_target_group_info_create(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn      = aws_iam_role.test.arn
 
   load_balancer_info {
     target_group_info {
@@ -2907,9 +2912,9 @@ resource "aws_codedeploy_deployment_group" "test" {
 func test_config_load_balancer_info_target_group_info_update(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn      = aws_iam_role.test.arn
 
   load_balancer_info {
     target_group_info {
@@ -2923,9 +2928,9 @@ resource "aws_codedeploy_deployment_group" "test" {
 func test_config_load_balancer_info_target_group_info_delete(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn      = aws_iam_role.test.arn
 }
 `, rName) + baseCodeDeployConfig(rName)
 }
@@ -2933,13 +2938,13 @@ resource "aws_codedeploy_deployment_group" "test" {
 func test_config_in_place_deployment_with_traffic_control_create(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn      = aws_iam_role.test.arn
 
   deployment_style {
     deployment_option = "WITH_TRAFFIC_CONTROL"
-    deployment_type = "IN_PLACE"
+    deployment_type   = "IN_PLACE"
   }
 
   load_balancer_info {
@@ -2954,13 +2959,13 @@ resource "aws_codedeploy_deployment_group" "test" {
 func test_config_in_place_deployment_with_traffic_control_update(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn      = aws_iam_role.test.arn
 
   deployment_style {
     deployment_option = "WITH_TRAFFIC_CONTROL"
-    deployment_type = "BLUE_GREEN"
+    deployment_type   = "BLUE_GREEN"
   }
 
   load_balancer_info {
@@ -2989,9 +2994,9 @@ resource "aws_codedeploy_deployment_group" "test" {
 func test_config_blue_green_deployment_config_delete(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn      = aws_iam_role.test.arn
 }
 `, rName) + baseCodeDeployConfig(rName)
 }
@@ -2999,35 +3004,35 @@ resource "aws_codedeploy_deployment_group" "test" {
 func test_config_blue_green_deployment_config_create_with_asg(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn      = aws_iam_role.test.arn
 
   deployment_style {
-	deployment_option = "WITH_TRAFFIC_CONTROL"
-	deployment_type   = "BLUE_GREEN"
+    deployment_option = "WITH_TRAFFIC_CONTROL"
+    deployment_type   = "BLUE_GREEN"
   }
-  
-  autoscaling_groups = ["${aws_autoscaling_group.test.name}"]
+
+  autoscaling_groups = [aws_autoscaling_group.test.name]
 
   load_balancer_info {
     elb_info {
       name = "acc-test-codedeploy-dep-group"
     }
   }
-  
+
   blue_green_deployment_config {
     deployment_ready_option {
-      action_on_timeout = "STOP_DEPLOYMENT"
+      action_on_timeout    = "STOP_DEPLOYMENT"
       wait_time_in_minutes = 60
     }
-    
+
     green_fleet_provisioning_option {
       action = "COPY_AUTO_SCALING_GROUP"
     }
-    
+
     terminate_blue_instances_on_deployment_success {
-      action = "TERMINATE"
+      action                           = "TERMINATE"
       termination_wait_time_in_minutes = 120
     }
   }
@@ -3038,26 +3043,27 @@ data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
   owners      = ["amazon"]
 
   filter {
-    name = "name"
+    name   = "name"
     values = ["amzn-ami-minimal-hvm-*"]
   }
   filter {
-    name = "root-device-type"
+    name   = "root-device-type"
     values = ["ebs"]
   }
 }
 
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+}
 
 data "aws_subnet" "test" {
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  availability_zone = data.aws_availability_zones.available.names[0]
   default_for_az    = "true"
 }
 
 resource "aws_launch_configuration" "test" {
-  image_id = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = "t2.micro"
-  name_prefix = "tf-acc-test-codedeploy-deployment-group-"
+  name_prefix   = "tf-acc-test-codedeploy-deployment-group-"
 
   lifecycle {
     create_before_destroy = true
@@ -3065,14 +3071,14 @@ resource "aws_launch_configuration" "test" {
 }
 
 resource "aws_autoscaling_group" "test" {
-  name = "tf-acc-test-codedeploy-deployment-group-%[1]s"
-  max_size = 2
-  min_size = 0
+  name             = "tf-acc-test-codedeploy-deployment-group-%[1]s"
+  max_size         = 2
+  min_size         = 0
   desired_capacity = 1
 
-  vpc_zone_identifier = ["${data.aws_subnet.test.id}"]
+  vpc_zone_identifier = [data.aws_subnet.test.id]
 
-  launch_configuration = "${aws_launch_configuration.test.name}"
+  launch_configuration = aws_launch_configuration.test.name
 
   lifecycle {
     create_before_destroy = true
@@ -3084,16 +3090,16 @@ resource "aws_autoscaling_group" "test" {
 func test_config_blue_green_deployment_config_update_with_asg(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn      = aws_iam_role.test.arn
 
   deployment_style {
-	deployment_option = "WITH_TRAFFIC_CONTROL"
-	deployment_type   = "BLUE_GREEN"
+    deployment_option = "WITH_TRAFFIC_CONTROL"
+    deployment_type   = "BLUE_GREEN"
   }
 
-  autoscaling_groups = ["${aws_autoscaling_group.test.name}"]
+  autoscaling_groups = [aws_autoscaling_group.test.name]
 
   load_balancer_info {
     elb_info {
@@ -3103,7 +3109,7 @@ resource "aws_codedeploy_deployment_group" "test" {
 
   blue_green_deployment_config {
     deployment_ready_option {
-      action_on_timeout = "STOP_DEPLOYMENT"
+      action_on_timeout    = "STOP_DEPLOYMENT"
       wait_time_in_minutes = 60
     }
 
@@ -3122,26 +3128,27 @@ data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
   owners      = ["amazon"]
 
   filter {
-    name = "name"
+    name   = "name"
     values = ["amzn-ami-minimal-hvm-*"]
   }
   filter {
-    name = "root-device-type"
+    name   = "root-device-type"
     values = ["ebs"]
   }
 }
 
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+}
 
 data "aws_subnet" "test" {
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  availability_zone = data.aws_availability_zones.available.names[0]
   default_for_az    = "true"
 }
 
 resource "aws_launch_configuration" "test" {
-  image_id = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = "t2.micro"
-  name_prefix = "tf-acc-test-codedeploy-deployment-group-"
+  name_prefix   = "tf-acc-test-codedeploy-deployment-group-"
 
   lifecycle {
     create_before_destroy = true
@@ -3149,14 +3156,14 @@ resource "aws_launch_configuration" "test" {
 }
 
 resource "aws_autoscaling_group" "test" {
-  name = "tf-acc-test-codedeploy-deployment-group-%[1]s"
-  max_size = 2
-  min_size = 0
+  name             = "tf-acc-test-codedeploy-deployment-group-%[1]s"
+  max_size         = 2
+  min_size         = 0
   desired_capacity = 1
 
-  vpc_zone_identifier = ["${data.aws_subnet.test.id}"]
+  vpc_zone_identifier = [data.aws_subnet.test.id]
 
-  launch_configuration = "${aws_launch_configuration.test.name}"
+  launch_configuration = aws_launch_configuration.test.name
 
   lifecycle {
     create_before_destroy = true
@@ -3168,13 +3175,13 @@ resource "aws_autoscaling_group" "test" {
 func test_config_blue_green_deployment_config_create_no_asg(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn      = aws_iam_role.test.arn
 
   deployment_style {
-	deployment_option = "WITH_TRAFFIC_CONTROL"
-	deployment_type   = "BLUE_GREEN"
+    deployment_option = "WITH_TRAFFIC_CONTROL"
+    deployment_type   = "BLUE_GREEN"
   }
 
   load_balancer_info {
@@ -3185,7 +3192,7 @@ resource "aws_codedeploy_deployment_group" "test" {
 
   blue_green_deployment_config {
     deployment_ready_option {
-      action_on_timeout = "STOP_DEPLOYMENT"
+      action_on_timeout    = "STOP_DEPLOYMENT"
       wait_time_in_minutes = 60
     }
 
@@ -3194,7 +3201,7 @@ resource "aws_codedeploy_deployment_group" "test" {
     }
 
     terminate_blue_instances_on_deployment_success {
-      action = "TERMINATE"
+      action                           = "TERMINATE"
       termination_wait_time_in_minutes = 120
     }
   }
@@ -3205,13 +3212,13 @@ resource "aws_codedeploy_deployment_group" "test" {
 func test_config_blue_green_deployment_config_update_no_asg(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn      = aws_iam_role.test.arn
 
   deployment_style {
-	deployment_option = "WITH_TRAFFIC_CONTROL"
-	deployment_type   = "BLUE_GREEN"
+    deployment_option = "WITH_TRAFFIC_CONTROL"
+    deployment_type   = "BLUE_GREEN"
   }
 
   load_balancer_info {
@@ -3240,13 +3247,13 @@ resource "aws_codedeploy_deployment_group" "test" {
 func test_config_blue_green_deployment_complete(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn      = aws_iam_role.test.arn
 
   deployment_style {
     deployment_option = "WITH_TRAFFIC_CONTROL"
-    deployment_type = "BLUE_GREEN"
+    deployment_type   = "BLUE_GREEN"
   }
 
   load_balancer_info {
@@ -3257,7 +3264,7 @@ resource "aws_codedeploy_deployment_group" "test" {
 
   blue_green_deployment_config {
     deployment_ready_option {
-      action_on_timeout = "STOP_DEPLOYMENT"
+      action_on_timeout    = "STOP_DEPLOYMENT"
       wait_time_in_minutes = 60
     }
 
@@ -3276,13 +3283,13 @@ resource "aws_codedeploy_deployment_group" "test" {
 func test_config_blue_green_deployment_complete_updated(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_group" "test" {
-  app_name = "${aws_codedeploy_app.test.name}"
+  app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-%[1]s"
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn      = aws_iam_role.test.arn
 
   deployment_style {
     deployment_option = "WITH_TRAFFIC_CONTROL"
-    deployment_type = "BLUE_GREEN"
+    deployment_type   = "BLUE_GREEN"
   }
 
   load_balancer_info {
@@ -3310,7 +3317,8 @@ resource "aws_codedeploy_deployment_group" "test" {
 
 func testAccAWSCodeDeployDeploymentGroupConfigEcsBase(rName string) string {
 	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+}
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -3323,9 +3331,9 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "test" {
   count = 2
 
-  availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
-  cidr_block        = "${cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)}"
-  vpc_id            = "${aws_vpc.test.id}"
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
+  vpc_id            = aws_vpc.test.id
 
   tags = {
     Name = "tf-acc-test-codedeploy-deployment-group-ecs"
@@ -3334,10 +3342,10 @@ resource "aws_subnet" "test" {
 
 resource "aws_security_group" "test" {
   name   = %[1]q
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 
   ingress {
-    cidr_blocks = ["${aws_vpc.test.cidr_block}"]
+    cidr_blocks = [aws_vpc.test.cidr_block]
     from_port   = 80
     protocol    = "6"
     to_port     = 8000
@@ -3349,7 +3357,7 @@ resource "aws_lb_target_group" "blue" {
   port        = 80
   protocol    = "HTTP"
   target_type = "ip"
-  vpc_id      = "${aws_vpc.test.id}"
+  vpc_id      = aws_vpc.test.id
 }
 
 resource "aws_lb_target_group" "green" {
@@ -3357,22 +3365,22 @@ resource "aws_lb_target_group" "green" {
   port        = 80
   protocol    = "HTTP"
   target_type = "ip"
-  vpc_id      = "${aws_vpc.test.id}"
+  vpc_id      = aws_vpc.test.id
 }
 
 resource "aws_lb" "test" {
   internal = true
   name     = %[1]q
-  subnets  = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
+  subnets  = [aws_subnet.test[0].id, aws_subnet.test[1].id]
 }
 
 resource "aws_lb_listener" "test" {
-  load_balancer_arn = "${aws_lb.test.arn}"
+  load_balancer_arn = aws_lb.test.arn
   port              = "80"
   protocol          = "HTTP"
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.blue.arn}"
+    target_group_arn = aws_lb_target_group.blue.arn
     type             = "forward"
   }
 }
@@ -3406,14 +3414,15 @@ resource "aws_ecs_task_definition" "test" {
   }
 ]
 DEFINITION
+
 }
 
 resource "aws_ecs_service" "test" {
-  cluster         = "${aws_ecs_cluster.test.id}"
+  cluster         = aws_ecs_cluster.test.id
   desired_count   = 1
   launch_type     = "FARGATE"
   name            = %[1]q
-  task_definition = "${aws_ecs_task_definition.test.arn}"
+  task_definition = aws_ecs_task_definition.test.arn
 
   deployment_controller {
     type = "CODE_DEPLOY"
@@ -3422,13 +3431,13 @@ resource "aws_ecs_service" "test" {
   load_balancer {
     container_name   = "test"
     container_port   = "80"
-    target_group_arn = "${aws_lb_target_group.blue.id}"
+    target_group_arn = aws_lb_target_group.blue.id
   }
 
   network_configuration {
     assign_public_ip = true
-    security_groups  = ["${aws_security_group.test.id}"]
-    subnets          = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
+    security_groups  = [aws_security_group.test.id]
+    subnets          = [aws_subnet.test[0].id, aws_subnet.test[1].id]
   }
 }
 
@@ -3455,10 +3464,11 @@ resource "aws_iam_role" "test" {
   ]
 }
 POLICY
+
 }
 
 resource "aws_iam_role_policy" "test" {
-  role = "${aws_iam_role.test.name}"
+  role = aws_iam_role.test.name
 
   policy = <<POLICY
 {
@@ -3488,6 +3498,7 @@ resource "aws_iam_role_policy" "test" {
   ]
 }
 POLICY
+
 }
 `, rName)
 }

--- a/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -31,76 +31,76 @@ func TestAccAWSCodeDeployDeploymentGroup_basic(t *testing.T) {
 			{
 				Config: testAccAWSCodeDeployDeploymentGroup(rName, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "app_name", "foo_app_"+rName),
+						"aws_codedeploy_deployment_group.test", "app_name", "tf-acc-test-"+rName),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "deployment_group_name", "foo_"+rName),
+						"aws_codedeploy_deployment_group.test", "deployment_group_name", "tf-acc-test-"+rName),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "deployment_config_name", "CodeDeployDefault.OneAtATime"),
+						"aws_codedeploy_deployment_group.test", "deployment_config_name", "CodeDeployDefault.OneAtATime"),
 					resource.TestMatchResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "service_role_arn",
-						regexp.MustCompile("arn:aws:iam::[0-9]{12}:role/foo_role_.*")),
+						"aws_codedeploy_deployment_group.test", "service_role_arn",
+						regexp.MustCompile("arn:aws:iam::[0-9]{12}:role/tf-acc-test-.*")),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "blue_green_deployment_config.#", "0"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.#", "0"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "ec2_tag_set.#", "0"),
+						"aws_codedeploy_deployment_group.test", "ec2_tag_set.#", "0"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.#", "1"),
+						"aws_codedeploy_deployment_group.test", "ec2_tag_filter.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.2916377465.key", "filterkey"),
+						"aws_codedeploy_deployment_group.test", "ec2_tag_filter.2916377465.key", "filterkey"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.2916377465.type", "KEY_AND_VALUE"),
+						"aws_codedeploy_deployment_group.test", "ec2_tag_filter.2916377465.type", "KEY_AND_VALUE"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.2916377465.value", "filtervalue"),
+						"aws_codedeploy_deployment_group.test", "ec2_tag_filter.2916377465.value", "filtervalue"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "alarm_configuration.#", "0"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.#", "0"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "auto_rollback_configuration.#", "0"),
+						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.#", "0"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "trigger_configuration.#", "0"),
+						"aws_codedeploy_deployment_group.test", "trigger_configuration.#", "0"),
 				),
 			},
 			{
 				Config: testAccAWSCodeDeployDeploymentGroupModified(rName, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "app_name", "foo_app_"+rName),
+						"aws_codedeploy_deployment_group.test", "app_name", "tf-acc-test-"+rName),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "deployment_group_name", "bar_"+rName),
+						"aws_codedeploy_deployment_group.test", "deployment_group_name", "tf-acc-test-updated-"+rName),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "deployment_config_name", "CodeDeployDefault.OneAtATime"),
+						"aws_codedeploy_deployment_group.test", "deployment_config_name", "CodeDeployDefault.OneAtATime"),
 					resource.TestMatchResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "service_role_arn",
-						regexp.MustCompile("arn:aws:iam::[0-9]{12}:role/bar_role_.*")),
+						"aws_codedeploy_deployment_group.test", "service_role_arn",
+						regexp.MustCompile("arn:aws:iam::[0-9]{12}:role/tf-acc-test-updated-.*")),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "ec2_tag_set.#", "0"),
+						"aws_codedeploy_deployment_group.test", "ec2_tag_set.#", "0"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.#", "1"),
+						"aws_codedeploy_deployment_group.test", "ec2_tag_filter.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.2369538975.key", "filterkey"),
+						"aws_codedeploy_deployment_group.test", "ec2_tag_filter.2369538975.key", "filterkey"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.2369538975.type", "KEY_AND_VALUE"),
+						"aws_codedeploy_deployment_group.test", "ec2_tag_filter.2369538975.type", "KEY_AND_VALUE"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.2369538975.value", "anotherfiltervalue"),
+						"aws_codedeploy_deployment_group.test", "ec2_tag_filter.2369538975.value", "anotherfiltervalue"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "alarm_configuration.#", "0"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.#", "0"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "auto_rollback_configuration.#", "0"),
+						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.#", "0"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "trigger_configuration.#", "0"),
+						"aws_codedeploy_deployment_group.test", "trigger_configuration.#", "0"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.foo",
+				ResourceName:      "aws_codedeploy_deployment_group.test",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
 				ImportStateVerify: true,
 			},
 		},
@@ -120,77 +120,77 @@ func TestAccAWSCodeDeployDeploymentGroup_basic_tagSet(t *testing.T) {
 			{
 				Config: testAccAWSCodeDeployDeploymentGroup(rName, true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "app_name", "foo_app_"+rName),
+						"aws_codedeploy_deployment_group.test", "app_name", "tf-acc-test-"+rName),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "deployment_group_name", "foo_"+rName),
+						"aws_codedeploy_deployment_group.test", "deployment_group_name", "tf-acc-test-"+rName),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "deployment_config_name", "CodeDeployDefault.OneAtATime"),
+						"aws_codedeploy_deployment_group.test", "deployment_config_name", "CodeDeployDefault.OneAtATime"),
 					resource.TestMatchResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "service_role_arn",
-						regexp.MustCompile("arn:aws:iam::[0-9]{12}:role/foo_role_.*")),
+						"aws_codedeploy_deployment_group.test", "service_role_arn",
+						regexp.MustCompile("arn:aws:iam::[0-9]{12}:role/tf-acc-test-.*")),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "ec2_tag_set.#", "1"),
+						"aws_codedeploy_deployment_group.test", "ec2_tag_set.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "ec2_tag_set.2916377593.ec2_tag_filter.#", "1"),
+						"aws_codedeploy_deployment_group.test", "ec2_tag_set.2916377593.ec2_tag_filter.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "ec2_tag_set.2916377593.ec2_tag_filter.2916377465.key", "filterkey"),
+						"aws_codedeploy_deployment_group.test", "ec2_tag_set.2916377593.ec2_tag_filter.2916377465.key", "filterkey"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "ec2_tag_set.2916377593.ec2_tag_filter.2916377465.type", "KEY_AND_VALUE"),
+						"aws_codedeploy_deployment_group.test", "ec2_tag_set.2916377593.ec2_tag_filter.2916377465.type", "KEY_AND_VALUE"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "ec2_tag_set.2916377593.ec2_tag_filter.2916377465.value", "filtervalue"),
+						"aws_codedeploy_deployment_group.test", "ec2_tag_set.2916377593.ec2_tag_filter.2916377465.value", "filtervalue"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.#", "0"),
+						"aws_codedeploy_deployment_group.test", "ec2_tag_filter.#", "0"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "alarm_configuration.#", "0"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.#", "0"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "auto_rollback_configuration.#", "0"),
+						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.#", "0"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "trigger_configuration.#", "0"),
+						"aws_codedeploy_deployment_group.test", "trigger_configuration.#", "0"),
 				),
 			},
 			{
 				Config: testAccAWSCodeDeployDeploymentGroupModified(rName, true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "app_name", "foo_app_"+rName),
+						"aws_codedeploy_deployment_group.test", "app_name", "tf-acc-test-"+rName),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "deployment_group_name", "bar_"+rName),
+						"aws_codedeploy_deployment_group.test", "deployment_group_name", "tf-acc-test-updated-"+rName),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "deployment_config_name", "CodeDeployDefault.OneAtATime"),
+						"aws_codedeploy_deployment_group.test", "deployment_config_name", "CodeDeployDefault.OneAtATime"),
 					resource.TestMatchResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "service_role_arn",
-						regexp.MustCompile("arn:aws:iam::[0-9]{12}:role/bar_role_.*")),
+						"aws_codedeploy_deployment_group.test", "service_role_arn",
+						regexp.MustCompile("arn:aws:iam::[0-9]{12}:role/tf-acc-test-updated-.*")),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "ec2_tag_set.#", "1"),
+						"aws_codedeploy_deployment_group.test", "ec2_tag_set.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "ec2_tag_set.2369538847.ec2_tag_filter.#", "1"),
+						"aws_codedeploy_deployment_group.test", "ec2_tag_set.2369538847.ec2_tag_filter.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "ec2_tag_set.2369538847.ec2_tag_filter.2369538975.key", "filterkey"),
+						"aws_codedeploy_deployment_group.test", "ec2_tag_set.2369538847.ec2_tag_filter.2369538975.key", "filterkey"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "ec2_tag_set.2369538847.ec2_tag_filter.2369538975.type", "KEY_AND_VALUE"),
+						"aws_codedeploy_deployment_group.test", "ec2_tag_set.2369538847.ec2_tag_filter.2369538975.type", "KEY_AND_VALUE"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "ec2_tag_set.2369538847.ec2_tag_filter.2369538975.value", "anotherfiltervalue"),
+						"aws_codedeploy_deployment_group.test", "ec2_tag_set.2369538847.ec2_tag_filter.2369538975.value", "anotherfiltervalue"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.#", "0"),
+						"aws_codedeploy_deployment_group.test", "ec2_tag_filter.#", "0"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "alarm_configuration.#", "0"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.#", "0"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "auto_rollback_configuration.#", "0"),
+						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.#", "0"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "trigger_configuration.#", "0"),
+						"aws_codedeploy_deployment_group.test", "trigger_configuration.#", "0"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.foo",
+				ResourceName:      "aws_codedeploy_deployment_group.test",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
 				ImportStateVerify: true,
 			},
 		},
@@ -210,28 +210,28 @@ func TestAccAWSCodeDeployDeploymentGroup_onPremiseTag(t *testing.T) {
 			{
 				Config: testAccAWSCodeDeployDeploymentGroupOnPremiseTags(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "app_name", "foo_app_"+rName),
+						"aws_codedeploy_deployment_group.test", "app_name", "tf-acc-test-"+rName),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "deployment_group_name", "foo_"+rName),
+						"aws_codedeploy_deployment_group.test", "deployment_group_name", "tf-acc-test-"+rName),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "deployment_config_name", "CodeDeployDefault.OneAtATime"),
+						"aws_codedeploy_deployment_group.test", "deployment_config_name", "CodeDeployDefault.OneAtATime"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "on_premises_instance_tag_filter.#", "1"),
+						"aws_codedeploy_deployment_group.test", "on_premises_instance_tag_filter.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "on_premises_instance_tag_filter.2916377465.key", "filterkey"),
+						"aws_codedeploy_deployment_group.test", "on_premises_instance_tag_filter.2916377465.key", "filterkey"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "on_premises_instance_tag_filter.2916377465.type", "KEY_AND_VALUE"),
+						"aws_codedeploy_deployment_group.test", "on_premises_instance_tag_filter.2916377465.type", "KEY_AND_VALUE"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo", "on_premises_instance_tag_filter.2916377465.value", "filtervalue"),
+						"aws_codedeploy_deployment_group.test", "on_premises_instance_tag_filter.2916377465.value", "filtervalue"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.foo",
+				ResourceName:      "aws_codedeploy_deployment_group.test",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
 				ImportStateVerify: true,
 			},
 		},
@@ -250,7 +250,7 @@ func TestAccAWSCodeDeployDeploymentGroup_disappears(t *testing.T) {
 			{
 				Config: testAccAWSCodeDeployDeploymentGroup(rName, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					testAccAWSCodeDeployDeploymentGroupDisappears(&group),
 				),
 				ExpectNonEmptyPlan: true,
@@ -272,12 +272,12 @@ func TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic(t *testing.T
 			{
 				Config: testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "app_name", "foo-app-"+rName),
+						"aws_codedeploy_deployment_group.test", "app_name", "tf-acc-test-"+rName),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_group_name", "foo-group-"+rName),
-					testAccCheckTriggerEvents(&group, "foo-trigger", []string{
+						"aws_codedeploy_deployment_group.test", "deployment_group_name", "tf-acc-test-"+rName),
+					testAccCheckCodeDeployDeploymentGroupTriggerEvents(&group, "test-trigger", []string{
 						"DeploymentFailure",
 					}),
 				),
@@ -285,21 +285,21 @@ func TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic(t *testing.T
 			{
 				Config: testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_update(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "app_name", "foo-app-"+rName),
+						"aws_codedeploy_deployment_group.test", "app_name", "tf-acc-test-"+rName),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_group_name", "foo-group-"+rName),
-					testAccCheckTriggerEvents(&group, "foo-trigger", []string{
+						"aws_codedeploy_deployment_group.test", "deployment_group_name", "tf-acc-test-"+rName),
+					testAccCheckCodeDeployDeploymentGroupTriggerEvents(&group, "test-trigger", []string{
 						"DeploymentFailure",
 						"DeploymentSuccess",
 					}),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ResourceName:      "aws_codedeploy_deployment_group.test",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
 				ImportStateVerify: true,
 			},
 		},
@@ -319,46 +319,46 @@ func TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple(t *testin
 			{
 				Config: testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_createMultiple(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "app_name", "foo-app-"+rName),
+						"aws_codedeploy_deployment_group.test", "app_name", "tf-acc-test-"+rName),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_group_name", "foo-group-"+rName),
-					testAccCheckTriggerEvents(&group, "foo-trigger", []string{
+						"aws_codedeploy_deployment_group.test", "deployment_group_name", "tf-acc-test-"+rName),
+					testAccCheckCodeDeployDeploymentGroupTriggerEvents(&group, "test-trigger-1", []string{
 						"DeploymentFailure",
 					}),
-					testAccCheckTriggerEvents(&group, "bar-trigger", []string{
+					testAccCheckCodeDeployDeploymentGroupTriggerEvents(&group, "test-trigger-2", []string{
 						"InstanceFailure",
 					}),
-					testAccCheckTriggerTargetArn(&group, "bar-trigger",
-						regexp.MustCompile("^arn:aws:sns:[^:]+:[0-9]{12}:bar-topic-"+rName+"$")),
+					testAccCheckCodeDeployDeploymentGroupTriggerTargetArn(&group, "test-trigger-2",
+						regexp.MustCompile("^arn:aws:sns:[^:]+:[0-9]{12}:tf-acc-test-2-"+rName+"$")),
 				),
 			},
 			{
 				Config: testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_updateMultiple(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "app_name", "foo-app-"+rName),
+						"aws_codedeploy_deployment_group.test", "app_name", "tf-acc-test-"+rName),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_group_name", "foo-group-"+rName),
-					testAccCheckTriggerEvents(&group, "foo-trigger", []string{
+						"aws_codedeploy_deployment_group.test", "deployment_group_name", "tf-acc-test-"+rName),
+					testAccCheckCodeDeployDeploymentGroupTriggerEvents(&group, "test-trigger-1", []string{
 						"DeploymentFailure",
 						"DeploymentStart",
 						"DeploymentStop",
 						"DeploymentSuccess",
 					}),
-					testAccCheckTriggerEvents(&group, "bar-trigger", []string{
+					testAccCheckCodeDeployDeploymentGroupTriggerEvents(&group, "test-trigger-2", []string{
 						"InstanceFailure",
 					}),
-					testAccCheckTriggerTargetArn(&group, "bar-trigger",
-						regexp.MustCompile("^arn:aws:sns:[^:]+:[0-9]{12}:baz-topic-"+rName+"$")),
+					testAccCheckCodeDeployDeploymentGroupTriggerTargetArn(&group, "test-trigger-2",
+						regexp.MustCompile("^arn:aws:sns:[^:]+:[0-9]{12}:tf-acc-test-3-"+rName+"$")),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ResourceName:      "aws_codedeploy_deployment_group.test",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
 				ImportStateVerify: true,
 			},
 		},
@@ -376,31 +376,23 @@ func TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create(t *tes
 		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: test_config_auto_rollback_configuration_delete(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.#", "0"),
-				),
-			},
-			{
 				Config: test_config_auto_rollback_configuration_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.#", "1"),
+						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.enabled", "true"),
+						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.events.#", "1"),
+						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.events.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.events.135881253", "DEPLOYMENT_FAILURE"),
+						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.events.135881253", "DEPLOYMENT_FAILURE"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ResourceName:      "aws_codedeploy_deployment_group.test",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
 				ImportStateVerify: true,
 			},
 		},
@@ -420,37 +412,37 @@ func TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_update(t *tes
 			{
 				Config: test_config_auto_rollback_configuration_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.#", "1"),
+						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.enabled", "true"),
+						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.events.#", "1"),
+						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.events.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.events.135881253", "DEPLOYMENT_FAILURE"),
+						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.events.135881253", "DEPLOYMENT_FAILURE"),
 				),
 			},
 			{
 				Config: test_config_auto_rollback_configuration_update(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.#", "1"),
+						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.enabled", "true"),
+						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.events.#", "2"),
+						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.events.#", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.events.104943466", "DEPLOYMENT_STOP_ON_ALARM"),
+						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.events.104943466", "DEPLOYMENT_STOP_ON_ALARM"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.events.135881253", "DEPLOYMENT_FAILURE"),
+						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.events.135881253", "DEPLOYMENT_FAILURE"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ResourceName:      "aws_codedeploy_deployment_group.test",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
 				ImportStateVerify: true,
 			},
 		},
@@ -470,29 +462,29 @@ func TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete(t *tes
 			{
 				Config: test_config_auto_rollback_configuration_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.#", "1"),
+						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.enabled", "true"),
+						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.events.#", "1"),
+						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.events.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.events.135881253", "DEPLOYMENT_FAILURE"),
+						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.events.135881253", "DEPLOYMENT_FAILURE"),
 				),
 			},
 			{
-				Config: test_config_auto_rollback_configuration_delete(rName),
+				Config: test_config_auto_rollback_configuration_none(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.#", "0"),
+						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.#", "0"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ResourceName:      "aws_codedeploy_deployment_group.test",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
 				ImportStateVerify: true,
 			},
 		},
@@ -512,35 +504,35 @@ func TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable(t *te
 			{
 				Config: test_config_auto_rollback_configuration_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.#", "1"),
+						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.enabled", "true"),
+						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.events.#", "1"),
+						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.events.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.events.135881253", "DEPLOYMENT_FAILURE"),
+						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.events.135881253", "DEPLOYMENT_FAILURE"),
 				),
 			},
 			{
 				Config: test_config_auto_rollback_configuration_disable(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.#", "1"),
+						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.enabled", "false"),
+						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.enabled", "false"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.events.#", "1"),
+						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.events.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.events.135881253", "DEPLOYMENT_FAILURE"),
+						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.0.events.135881253", "DEPLOYMENT_FAILURE"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ResourceName:      "aws_codedeploy_deployment_group.test",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
 				ImportStateVerify: true,
 			},
 		},
@@ -558,33 +550,25 @@ func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create(t *testing.T)
 		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: test_config_alarm_configuration_delete(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.#", "0"),
-				),
-			},
-			{
 				Config: test_config_alarm_configuration_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.#", "1"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.enabled", "true"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.alarms.#", "1"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.alarms.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.alarms.2356372769", "foo"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.alarms.967527452", "test-alarm"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.ignore_poll_alarm_failure", "false"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.ignore_poll_alarm_failure", "false"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ResourceName:      "aws_codedeploy_deployment_group.test",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
 				ImportStateVerify: true,
 			},
 		},
@@ -604,41 +588,41 @@ func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_update(t *testing.T)
 			{
 				Config: test_config_alarm_configuration_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.#", "1"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.enabled", "true"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.alarms.#", "1"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.alarms.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.alarms.2356372769", "foo"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.alarms.967527452", "test-alarm"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.ignore_poll_alarm_failure", "false"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.ignore_poll_alarm_failure", "false"),
 				),
 			},
 			{
 				Config: test_config_alarm_configuration_update(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.#", "1"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.enabled", "true"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.alarms.#", "2"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.alarms.#", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.alarms.1996459178", "bar"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.alarms.967527452", "test-alarm"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.alarms.2356372769", "foo"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.alarms.809070813", "test-alarm-2"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.ignore_poll_alarm_failure", "true"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.ignore_poll_alarm_failure", "true"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ResourceName:      "aws_codedeploy_deployment_group.test",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
 				ImportStateVerify: true,
 			},
 		},
@@ -658,31 +642,31 @@ func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete(t *testing.T)
 			{
 				Config: test_config_alarm_configuration_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.#", "1"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.enabled", "true"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.alarms.#", "1"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.alarms.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.alarms.2356372769", "foo"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.alarms.967527452", "test-alarm"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.ignore_poll_alarm_failure", "false"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.ignore_poll_alarm_failure", "false"),
 				),
 			},
 			{
-				Config: test_config_alarm_configuration_delete(rName),
+				Config: test_config_alarm_configuration_none(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.#", "0"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.#", "0"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ResourceName:      "aws_codedeploy_deployment_group.test",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
 				ImportStateVerify: true,
 			},
 		},
@@ -702,39 +686,39 @@ func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable(t *testing.T
 			{
 				Config: test_config_alarm_configuration_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.#", "1"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.enabled", "true"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.alarms.#", "1"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.alarms.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.alarms.2356372769", "foo"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.alarms.967527452", "test-alarm"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.ignore_poll_alarm_failure", "false"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.ignore_poll_alarm_failure", "false"),
 				),
 			},
 			{
 				Config: test_config_alarm_configuration_disable(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.#", "1"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.enabled", "false"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.enabled", "false"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.alarms.#", "1"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.alarms.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.alarms.2356372769", "foo"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.alarms.967527452", "test-alarm"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.ignore_poll_alarm_failure", "false"),
+						"aws_codedeploy_deployment_group.test", "alarm_configuration.0.ignore_poll_alarm_failure", "false"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ResourceName:      "aws_codedeploy_deployment_group.test",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
 				ImportStateVerify: true,
 			},
 		},
@@ -755,19 +739,19 @@ func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_default(t *testing.T) {
 			{
 				Config: test_config_deployment_style_default(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.#", "1"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
 					resource.TestCheckResourceAttrSet(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_option"),
 					resource.TestCheckResourceAttrSet(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ResourceName:      "aws_codedeploy_deployment_group.test",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
 				ImportStateVerify: true,
 			},
 		},
@@ -785,40 +769,28 @@ func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_create(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: test_config_deployment_style_default(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.#", "1"),
-					resource.TestCheckResourceAttrSet(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option"),
-					resource.TestCheckResourceAttrSet(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type"),
-				),
-			},
-			{
 				Config: test_config_deployment_style_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.#", "1"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type", "BLUE_GREEN"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type", "BLUE_GREEN"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "1"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.#", "1"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.2441772102.name", "foo-elb"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.6632477.name", "acc-test-codedeploy-dep-group"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ResourceName:      "aws_codedeploy_deployment_group.test",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
 				ImportStateVerify: true,
 			},
 		},
@@ -838,37 +810,38 @@ func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_update(t *testing.T) {
 			{
 				Config: test_config_deployment_style_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.#", "1"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type", "BLUE_GREEN"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type", "BLUE_GREEN"),
 				),
 			},
 			{
 				Config: test_config_deployment_style_update(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.#", "1"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option", "WITHOUT_TRAFFIC_CONTROL"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_option", "WITHOUT_TRAFFIC_CONTROL"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type", "IN_PLACE"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type", "IN_PLACE"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ResourceName:      "aws_codedeploy_deployment_group.test",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
 				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
+// Delete reverts to default configuration. It does not remove the deployment_style block
 func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_delete(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
 
@@ -882,31 +855,31 @@ func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_delete(t *testing.T) {
 			{
 				Config: test_config_deployment_style_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.#", "1"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type", "BLUE_GREEN"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type", "BLUE_GREEN"),
 				),
 			},
 			{
 				Config: test_config_deployment_style_default(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.#", "1"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option", "WITHOUT_TRAFFIC_CONTROL"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_option", "WITHOUT_TRAFFIC_CONTROL"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type", "IN_PLACE"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type", "IN_PLACE"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ResourceName:      "aws_codedeploy_deployment_group.test",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
 				ImportStateVerify: true,
 			},
 		},
@@ -924,29 +897,21 @@ func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_create(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: test_config_load_balancer_info_default(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "0"),
-				),
-			},
-			{
 				Config: test_config_load_balancer_info_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "1"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.#", "1"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.2441772102.name", "foo-elb"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.6632477.name", "acc-test-codedeploy-dep-group"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ResourceName:      "aws_codedeploy_deployment_group.test",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
 				ImportStateVerify: true,
 			},
 		},
@@ -966,31 +931,31 @@ func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_update(t *testing.T) {
 			{
 				Config: test_config_load_balancer_info_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "1"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.#", "1"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.2441772102.name", "foo-elb"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.6632477.name", "acc-test-codedeploy-dep-group"),
 				),
 			},
 			{
 				Config: test_config_load_balancer_info_update(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "1"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.#", "1"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.4206303396.name", "bar-elb"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.934183479.name", "acc-test-codedeploy-dep-group-2"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ResourceName:      "aws_codedeploy_deployment_group.test",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
 				ImportStateVerify: true,
 			},
 		},
@@ -1010,27 +975,27 @@ func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete(t *testing.T) {
 			{
 				Config: test_config_load_balancer_info_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "1"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.#", "1"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.2441772102.name", "foo-elb"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.6632477.name", "acc-test-codedeploy-dep-group"),
 				),
 			},
 			{
-				Config: test_config_load_balancer_info_delete(rName),
+				Config: test_config_load_balancer_info_none(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "0"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "0"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ResourceName:      "aws_codedeploy_deployment_group.test",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
 				ImportStateVerify: true,
 			},
 		},
@@ -1048,30 +1013,22 @@ func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_create
 		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: test_config_load_balancer_info_default(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "0"),
-				),
-			},
-			{
 				Config: test_config_load_balancer_info_target_group_info_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "1"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "1"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.target_group_info.#", "1"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.target_group_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.target_group_info.4178177480.name", "foo-tg"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.target_group_info.6632477.name", "acc-test-codedeploy-dep-group"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ResourceName:      "aws_codedeploy_deployment_group.test",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
 				ImportStateVerify: true,
 			},
 		},
@@ -1091,31 +1048,31 @@ func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_update
 			{
 				Config: test_config_load_balancer_info_target_group_info_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "1"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.target_group_info.#", "1"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.target_group_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.target_group_info.4178177480.name", "foo-tg"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.target_group_info.6632477.name", "acc-test-codedeploy-dep-group"),
 				),
 			},
 			{
 				Config: test_config_load_balancer_info_target_group_info_update(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "1"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.target_group_info.#", "1"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.target_group_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.target_group_info.2940009368.name", "bar-tg"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.target_group_info.934183479.name", "acc-test-codedeploy-dep-group-2"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ResourceName:      "aws_codedeploy_deployment_group.test",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
 				ImportStateVerify: true,
 			},
 		},
@@ -1135,87 +1092,34 @@ func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_delete
 			{
 				Config: test_config_load_balancer_info_target_group_info_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "1"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.target_group_info.#", "1"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.target_group_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.target_group_info.4178177480.name", "foo-tg"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.target_group_info.6632477.name", "acc-test-codedeploy-dep-group"),
 				),
 			},
 			{
 				Config: test_config_load_balancer_info_target_group_info_delete(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "0"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "0"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ResourceName:      "aws_codedeploy_deployment_group.test",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
 				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
-func TestAccAWSCodeDeployDeploymentGroup_in_place_deployment_with_traffic_control_create(t *testing.T) {
-	var group codedeploy.DeploymentGroupInfo
-
-	rName := acctest.RandString(5)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: test_config_deployment_style_default(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.#", "1"),
-					resource.TestCheckResourceAttrSet(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option"),
-					resource.TestCheckResourceAttrSet(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "0"),
-				),
-			},
-			{
-				Config: test_config_in_place_deployment_with_traffic_control_create(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type", "IN_PLACE"),
-
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.2441772102.name", "foo-elb"),
-				),
-			},
-			{
-				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
-				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSCodeDeployDeploymentGroup_in_place_deployment_with_traffic_control_update(t *testing.T) {
+func TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_create(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
 
 	rName := acctest.RandString(5)
@@ -1228,60 +1132,99 @@ func TestAccAWSCodeDeployDeploymentGroup_in_place_deployment_with_traffic_contro
 			{
 				Config: test_config_in_place_deployment_with_traffic_control_create(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.#", "1"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type", "IN_PLACE"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type", "IN_PLACE"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "1"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.#", "1"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.2441772102.name", "foo-elb"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.6632477.name", "acc-test-codedeploy-dep-group"),
+				),
+			},
+			{
+				ResourceName:      "aws_codedeploy_deployment_group.test",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_update(t *testing.T) {
+	var group codedeploy.DeploymentGroupInfo
+
+	rName := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: test_config_in_place_deployment_with_traffic_control_create(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type", "IN_PLACE"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.6632477.name", "acc-test-codedeploy-dep-group"),
 				),
 			},
 			{
 				Config: test_config_in_place_deployment_with_traffic_control_update(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.#", "1"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type", "BLUE_GREEN"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type", "BLUE_GREEN"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "1"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.#", "1"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.2441772102.name", "foo-elb"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.6632477.name", "acc-test-codedeploy-dep-group"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "CONTINUE_DEPLOYMENT"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "CONTINUE_DEPLOYMENT"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "DISCOVER_EXISTING"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "DISCOVER_EXISTING"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "KEEP_ALIVE"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "KEEP_ALIVE"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ResourceName:      "aws_codedeploy_deployment_group.test",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
 				ImportStateVerify: true,
 			},
 		},
@@ -1301,41 +1244,41 @@ func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_create
 			{
 				Config: test_config_blue_green_deployment_config_create_with_asg(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.#", "1"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type", "BLUE_GREEN"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type", "BLUE_GREEN"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.#", "1"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "60"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "60"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "COPY_AUTO_SCALING_GROUP"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "COPY_AUTO_SCALING_GROUP"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "TERMINATE"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "TERMINATE"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "120"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "120"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ResourceName:      "aws_codedeploy_deployment_group.test",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
 				ImportStateVerify: true,
 			},
 		},
@@ -1355,53 +1298,53 @@ func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update
 			{
 				Config: test_config_blue_green_deployment_config_create_with_asg(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.#", "1"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "60"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "60"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "COPY_AUTO_SCALING_GROUP"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "COPY_AUTO_SCALING_GROUP"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "TERMINATE"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "TERMINATE"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "120"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "120"),
 				),
 			},
 			{
 				Config: test_config_blue_green_deployment_config_update_with_asg(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.#", "1"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "60"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "60"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "COPY_AUTO_SCALING_GROUP"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "COPY_AUTO_SCALING_GROUP"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "KEEP_ALIVE"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "KEEP_ALIVE"),
 				),
 			},
 		},
@@ -1421,65 +1364,65 @@ func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update
 			{
 				Config: test_config_blue_green_deployment_config_create_no_asg(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.#", "1"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type", "BLUE_GREEN"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type", "BLUE_GREEN"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.#", "1"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "60"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "60"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "DISCOVER_EXISTING"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "DISCOVER_EXISTING"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "TERMINATE"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "TERMINATE"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "120"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "120"),
 				),
 			},
 			{
 				Config: test_config_blue_green_deployment_config_update_no_asg(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.#", "1"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type", "BLUE_GREEN"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type", "BLUE_GREEN"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.#", "1"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "CONTINUE_DEPLOYMENT"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "CONTINUE_DEPLOYMENT"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "DISCOVER_EXISTING"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "DISCOVER_EXISTING"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "KEEP_ALIVE"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "KEEP_ALIVE"),
 				),
 			},
 		},
@@ -1501,53 +1444,53 @@ func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete
 			{
 				Config: test_config_blue_green_deployment_config_create_no_asg(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.#", "1"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type", "BLUE_GREEN"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type", "BLUE_GREEN"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.#", "1"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "60"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "60"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "DISCOVER_EXISTING"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "DISCOVER_EXISTING"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "TERMINATE"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "TERMINATE"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "120"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "120"),
 				),
 			},
 			{
 				Config: test_config_blue_green_deployment_config_delete(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.#", "1"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type", "IN_PLACE"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type", "IN_PLACE"),
 
 					// The state is preserved, but AWS ignores it
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.#", "1"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ResourceName:      "aws_codedeploy_deployment_group.test",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
 				ImportStateVerify: true,
 			},
 		},
@@ -1567,89 +1510,89 @@ func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeployment_complete(t *testing
 			{
 				Config: test_config_blue_green_deployment_complete(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.#", "1"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type", "BLUE_GREEN"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type", "BLUE_GREEN"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "1"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.#", "1"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.2441772102.name", "foo-elb"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.6632477.name", "acc-test-codedeploy-dep-group"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.#", "1"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "60"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "60"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "DISCOVER_EXISTING"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "DISCOVER_EXISTING"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "KEEP_ALIVE"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "KEEP_ALIVE"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "0"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "0"),
 				),
 			},
 			{
 				Config: test_config_blue_green_deployment_complete_updated(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.#", "1"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type", "BLUE_GREEN"),
+						"aws_codedeploy_deployment_group.test", "deployment_style.0.deployment_type", "BLUE_GREEN"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "1"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.#", "1"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.2441772102.name", "foo-elb"),
+						"aws_codedeploy_deployment_group.test", "load_balancer_info.0.elb_info.6632477.name", "acc-test-codedeploy-dep-group"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.#", "1"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "CONTINUE_DEPLOYMENT"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "CONTINUE_DEPLOYMENT"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "DISCOVER_EXISTING"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "DISCOVER_EXISTING"),
 
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "KEEP_ALIVE"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "KEEP_ALIVE"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "0"),
+						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "0"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ResourceName:      "aws_codedeploy_deployment_group.test",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
 				ImportStateVerify: true,
 			},
 		},
@@ -1703,8 +1646,8 @@ func TestAWSCodeDeployDeploymentGroup_buildTriggerConfigs(t *testing.T) {
 			"trigger_events": schema.NewSet(schema.HashString, []interface{}{
 				"DeploymentFailure",
 			}),
-			"trigger_name":       "foo-trigger",
-			"trigger_target_arn": "arn:aws:sns:us-west-2:123456789012:foo-topic",
+			"trigger_name":       "test-trigger",
+			"trigger_target_arn": "arn:aws:sns:us-west-2:123456789012:test-topic",
 		},
 	}
 
@@ -1713,8 +1656,8 @@ func TestAWSCodeDeployDeploymentGroup_buildTriggerConfigs(t *testing.T) {
 			TriggerEvents: []*string{
 				aws.String("DeploymentFailure"),
 			},
-			TriggerName:      aws.String("foo-trigger"),
-			TriggerTargetArn: aws.String("arn:aws:sns:us-west-2:123456789012:foo-topic"),
+			TriggerName:      aws.String("test-trigger"),
+			TriggerTargetArn: aws.String("arn:aws:sns:us-west-2:123456789012:test-topic"),
 		},
 	}
 
@@ -1733,8 +1676,8 @@ func TestAWSCodeDeployDeploymentGroup_triggerConfigsToMap(t *testing.T) {
 				aws.String("DeploymentFailure"),
 				aws.String("InstanceFailure"),
 			},
-			TriggerName:      aws.String("bar-trigger"),
-			TriggerTargetArn: aws.String("arn:aws:sns:us-west-2:123456789012:bar-topic"),
+			TriggerName:      aws.String("test-trigger-2"),
+			TriggerTargetArn: aws.String("arn:aws:sns:us-west-2:123456789012:test-topic-2"),
 		},
 	}
 
@@ -1743,8 +1686,8 @@ func TestAWSCodeDeployDeploymentGroup_triggerConfigsToMap(t *testing.T) {
 			"DeploymentFailure",
 			"InstanceFailure",
 		}),
-		"trigger_name":       "bar-trigger",
-		"trigger_target_arn": "arn:aws:sns:us-west-2:123456789012:bar-topic",
+		"trigger_name":       "test-trigger-2",
+		"trigger_target_arn": "arn:aws:sns:us-west-2:123456789012:test-topic-2",
 	}
 
 	actual := triggerConfigsToMap(input)[0]
@@ -1897,10 +1840,10 @@ func TestAWSCodeDeployDeploymentGroup_expandLoadBalancerInfo(t *testing.T) {
 				map[string]interface{}{
 					"elb_info": schema.NewSet(loadBalancerInfoHash, []interface{}{
 						map[string]interface{}{
-							"name": "foo-elb",
+							"name": "acc-test-codedeploy-dep-group",
 						},
 						map[string]interface{}{
-							"name": "bar-elb",
+							"name": "acc-test-codedeploy-dep-group-2",
 						},
 					}),
 				},
@@ -1908,10 +1851,10 @@ func TestAWSCodeDeployDeploymentGroup_expandLoadBalancerInfo(t *testing.T) {
 			Expected: &codedeploy.LoadBalancerInfo{
 				ElbInfoList: []*codedeploy.ELBInfo{
 					{
-						Name: aws.String("foo-elb"),
+						Name: aws.String("acc-test-codedeploy-dep-group"),
 					},
 					{
-						Name: aws.String("bar-elb"),
+						Name: aws.String("acc-test-codedeploy-dep-group-2"),
 					},
 				},
 			},
@@ -2091,7 +2034,7 @@ func TestAWSCodeDeployDeploymentGroup_buildAlarmConfig(t *testing.T) {
 	input := []interface{}{
 		map[string]interface{}{
 			"alarms": schema.NewSet(schema.HashString, []interface{}{
-				"foo-alarm",
+				"test-alarm",
 			}),
 			"enabled":                   true,
 			"ignore_poll_alarm_failure": false,
@@ -2101,7 +2044,7 @@ func TestAWSCodeDeployDeploymentGroup_buildAlarmConfig(t *testing.T) {
 	expected := &codedeploy.AlarmConfiguration{
 		Alarms: []*codedeploy.Alarm{
 			{
-				Name: aws.String("foo-alarm"),
+				Name: aws.String("test-alarm"),
 			},
 		},
 		Enabled:                aws.Bool(true),
@@ -2120,10 +2063,10 @@ func TestAWSCodeDeployDeploymentGroup_alarmConfigToMap(t *testing.T) {
 	input := &codedeploy.AlarmConfiguration{
 		Alarms: []*codedeploy.Alarm{
 			{
-				Name: aws.String("bar-alarm"),
+				Name: aws.String("test-alarm-2"),
 			},
 			{
-				Name: aws.String("foo-alarm"),
+				Name: aws.String("test-alarm"),
 			},
 		},
 		Enabled:                aws.Bool(false),
@@ -2132,8 +2075,8 @@ func TestAWSCodeDeployDeploymentGroup_alarmConfigToMap(t *testing.T) {
 
 	expected := map[string]interface{}{
 		"alarms": schema.NewSet(schema.HashString, []interface{}{
-			"bar-alarm",
-			"foo-alarm",
+			"test-alarm-2",
+			"test-alarm",
 		}),
 		"enabled":                   false,
 		"ignore_poll_alarm_failure": true,
@@ -2163,11 +2106,13 @@ func TestAWSCodeDeployDeploymentGroup_alarmConfigToMap(t *testing.T) {
 	}
 }
 
-func testAccCheckTriggerEvents(group *codedeploy.DeploymentGroupInfo, triggerName string, expectedEvents []string) resource.TestCheckFunc {
+func testAccCheckCodeDeployDeploymentGroupTriggerEvents(group *codedeploy.DeploymentGroupInfo, triggerName string, expectedEvents []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
+		found := false
 		for _, actual := range group.TriggerConfigurations {
 			if *actual.TriggerName == triggerName {
+				found = true
 
 				numberOfEvents := len(actual.TriggerEvents)
 				if numberOfEvents != len(expectedEvents) {
@@ -2188,14 +2133,20 @@ func testAccCheckTriggerEvents(group *codedeploy.DeploymentGroupInfo, triggerNam
 				break
 			}
 		}
-		return nil
+		if found {
+			return nil
+		} else {
+			return fmt.Errorf("trigger configuration %q not found", triggerName)
+		}
 	}
 }
 
-func testAccCheckTriggerTargetArn(group *codedeploy.DeploymentGroupInfo, triggerName string, r *regexp.Regexp) resource.TestCheckFunc {
+func testAccCheckCodeDeployDeploymentGroupTriggerTargetArn(group *codedeploy.DeploymentGroupInfo, triggerName string, r *regexp.Regexp) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
+		found := false
 		for _, actual := range group.TriggerConfigurations {
 			if *actual.TriggerName == triggerName {
+				found = true
 				if !r.MatchString(*actual.TriggerTargetArn) {
 					return fmt.Errorf("Trigger target arn does not match regular expression.\nRegex: %v\nTriggerTargetArn: %v\n",
 						r, *actual.TriggerTargetArn)
@@ -2203,7 +2154,11 @@ func testAccCheckTriggerTargetArn(group *codedeploy.DeploymentGroupInfo, trigger
 				break
 			}
 		}
-		return nil
+		if found {
+			return nil
+		} else {
+			return fmt.Errorf("trigger configuration %q not found", triggerName)
+		}
 	}
 }
 
@@ -2294,7 +2249,7 @@ func TestAWSCodeDeployDeploymentGroup_handleCodeDeployApiError(t *testing.T) {
 	notAnAwsError := errors.New("Not an awserr")
 	invalidRoleException := awserr.New("InvalidRoleException", "Invalid role exception", nil)
 	invalidTriggerConfigExceptionNoMatch := awserr.New("InvalidTriggerConfigException", "Some other error message", nil)
-	invalidTriggerConfigExceptionMatch := awserr.New("InvalidTriggerConfigException", "Topic ARN foo is not valid", nil)
+	invalidTriggerConfigExceptionMatch := awserr.New("InvalidTriggerConfigException", "Topic ARN INVALID_ARN is not valid", nil)
 	fakeAwsError := awserr.New("FakeAwsException", "Not a real AWS error", nil)
 
 	testCases := []struct {
@@ -2352,29 +2307,37 @@ func testAccAWSCodeDeployDeploymentGroup(rName string, tagGroup bool) string {
 	if tagGroup {
 		tagGroupOrFilter = `ec2_tag_set {
     ec2_tag_filter {
-      key = "filterkey"
-      type = "KEY_AND_VALUE"
+      key   = "filterkey"
+      type  = "KEY_AND_VALUE"
       value = "filtervalue"
     }
   }
 `
 	} else {
 		tagGroupOrFilter = `ec2_tag_filter {
-    key = "filterkey"
-    type = "KEY_AND_VALUE"
+    key   = "filterkey"
+    type  = "KEY_AND_VALUE"
     value = "filtervalue"
   }
 `
 	}
 
 	return fmt.Sprintf(`
-resource "aws_codedeploy_app" "foo_app" {
-  name = "foo_app_%s"
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
+  
+  %[2]s
 }
 
-resource "aws_iam_role_policy" "foo_policy" {
-  name = "foo_policy_%s"
-  role = "${aws_iam_role.foo_role.id}"
+resource "aws_codedeploy_app" "test" {
+  name = "tf-acc-test-%[1]s"
+}
+
+resource "aws_iam_role_policy" "test" {
+  name = "tf-acc-test-%[1]s"
+  role = "${aws_iam_role.test.id}"
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -2400,8 +2363,8 @@ resource "aws_iam_role_policy" "foo_policy" {
 EOF
 }
 
-resource "aws_iam_role" "foo_role" {
-  name = "foo_role_%s"
+resource "aws_iam_role" "test" {
+  name = "tf-acc-test-%[1]s"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -2420,14 +2383,7 @@ resource "aws_iam_role" "foo_role" {
 }
 EOF
 }
-
-resource "aws_codedeploy_deployment_group" "foo" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo_%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
-  %s
-}
-`, rName, rName, rName, rName, tagGroupOrFilter)
+`, rName, tagGroupOrFilter)
 }
 
 func testAccAWSCodeDeployDeploymentGroupModified(rName string, tagGroup bool) string {
@@ -2435,29 +2391,37 @@ func testAccAWSCodeDeployDeploymentGroupModified(rName string, tagGroup bool) st
 	if tagGroup {
 		tagGroupOrFilter = `ec2_tag_set {
     ec2_tag_filter {
-      key = "filterkey"
-      type = "KEY_AND_VALUE"
+      key   = "filterkey"
+      type  = "KEY_AND_VALUE"
       value = "anotherfiltervalue"
     }
   }
 `
 	} else {
 		tagGroupOrFilter = `ec2_tag_filter {
-    key = "filterkey"
-    type = "KEY_AND_VALUE"
+    key   = "filterkey"
+    type  = "KEY_AND_VALUE"
     value = "anotherfiltervalue"
   }
 `
 	}
 
 	return fmt.Sprintf(`
-resource "aws_codedeploy_app" "foo_app" {
-  name = "foo_app_%s"
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-updated-%[1]s"
+  service_role_arn = "${aws_iam_role.test_new.arn}"
+
+  %[2]s
 }
 
-resource "aws_iam_role_policy" "foo_policy" {
-  name = "foo_policy_%s"
-  role = "${aws_iam_role.bar_role.id}"
+resource "aws_codedeploy_app" "test" {
+	name = "tf-acc-test-%[1]s"
+}
+
+resource "aws_iam_role_policy" "test" {
+  name = "tf-acc-test-%[1]s"
+  role = "${aws_iam_role.test_new.id}"
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -2483,8 +2447,8 @@ resource "aws_iam_role_policy" "foo_policy" {
 EOF
 }
 
-resource "aws_iam_role" "bar_role" {
-  name = "bar_role_%s"
+resource "aws_iam_role" "test_new" {
+  name = "tf-acc-test-updated-%[1]s"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -2503,25 +2467,18 @@ resource "aws_iam_role" "bar_role" {
 }
 EOF
 }
-
-resource "aws_codedeploy_deployment_group" "foo" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "bar_%s"
-  service_role_arn = "${aws_iam_role.bar_role.arn}"
-  %s
-}
-`, rName, rName, rName, rName, tagGroupOrFilter)
+`, rName, tagGroupOrFilter)
 }
 
 func testAccAWSCodeDeployDeploymentGroupOnPremiseTags(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_codedeploy_app" "foo_app" {
-  name = "foo_app_%s"
+resource "aws_codedeploy_app" "test" {
+  name = "tf-acc-test-%[1]s"
 }
 
-resource "aws_iam_role_policy" "foo_policy" {
-  name = "foo_policy_%s"
-  role = "${aws_iam_role.foo_role.id}"
+resource "aws_iam_role_policy" "test" {
+  name = "tf-acc-test-%[1]s"
+  role = "${aws_iam_role.test.id}"
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -2547,8 +2504,8 @@ resource "aws_iam_role_policy" "foo_policy" {
 EOF
 }
 
-resource "aws_iam_role" "foo_role" {
-  name = "foo_role_%s"
+resource "aws_iam_role" "test" {
+  name = "tf-acc-test-%[1]s"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -2568,28 +2525,29 @@ resource "aws_iam_role" "foo_role" {
 EOF
 }
 
-resource "aws_codedeploy_deployment_group" "foo" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo_%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
+
   on_premises_instance_tag_filter {
     key = "filterkey"
     type = "KEY_AND_VALUE"
     value = "filtervalue"
   }
 }
-`, rName, rName, rName, rName)
+`, rName)
 }
 
 func baseCodeDeployConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_codedeploy_app" "foo_app" {
-  name = "foo-app-%s"
+resource "aws_codedeploy_app" "test" {
+	name = "tf-acc-test-%[1]s"
 }
 
-resource "aws_iam_role_policy" "foo_policy" {
-  name = "foo-policy-%s"
-  role = "${aws_iam_role.foo_role.id}"
+resource "aws_iam_role_policy" "test" {
+	name = "tf-acc-test-%[1]s"
+	role = "${aws_iam_role.test.id}"
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -2617,8 +2575,8 @@ resource "aws_iam_role_policy" "foo_policy" {
 EOF
 }
 
-resource "aws_iam_role" "foo_role" {
-  name = "foo-role-%s"
+resource "aws_iam_role" "test" {
+  name = "tf-acc-test-%[1]s"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -2636,269 +2594,228 @@ resource "aws_iam_role" "foo_role" {
 EOF
 }
 
-resource "aws_sns_topic" "foo_topic" {
-  name = "foo-topic-%s"
+resource "aws_sns_topic" "test" {
+  name = "tf-acc-test-%[1]s"
 }
-`, rName, rName, rName, rName)
+`, rName)
 }
 
 func testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_create(rName string) string {
 	return fmt.Sprintf(`
-
-  %s
-
-resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo-group-%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
 
   trigger_configuration {
     trigger_events = ["DeploymentFailure"]
-    trigger_name = "foo-trigger"
-    trigger_target_arn = "${aws_sns_topic.foo_topic.arn}"
+    trigger_name = "test-trigger"
+    trigger_target_arn = "${aws_sns_topic.test.arn}"
   }
 }
-`, baseCodeDeployConfig(rName), rName)
+`, rName) + baseCodeDeployConfig(rName)
 }
 
 func testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_update(rName string) string {
 	return fmt.Sprintf(`
-
-  %s
-
-resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo-group-%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
 
   trigger_configuration {
     trigger_events = ["DeploymentSuccess", "DeploymentFailure"]
-    trigger_name = "foo-trigger"
-    trigger_target_arn = "${aws_sns_topic.foo_topic.arn}"
+    trigger_name = "test-trigger"
+    trigger_target_arn = "${aws_sns_topic.test.arn}"
   }
 }
-`, baseCodeDeployConfig(rName), rName)
+`, rName) + baseCodeDeployConfig(rName)
 }
 
 func testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_createMultiple(rName string) string {
 	return fmt.Sprintf(`
-
-  %s
-
-resource "aws_sns_topic" "bar_topic" {
-  name = "bar-topic-%s"
-}
-
-resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo-group-%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
 
   trigger_configuration {
     trigger_events = ["DeploymentFailure"]
-    trigger_name = "foo-trigger"
-    trigger_target_arn = "${aws_sns_topic.foo_topic.arn}"
+    trigger_name = "test-trigger-1"
+    trigger_target_arn = "${aws_sns_topic.test.arn}"
   }
 
   trigger_configuration {
     trigger_events = ["InstanceFailure"]
-    trigger_name = "bar-trigger"
-    trigger_target_arn = "${aws_sns_topic.bar_topic.arn}"
+    trigger_name = "test-trigger-2"
+    trigger_target_arn = "${aws_sns_topic.test_2.arn}"
   }
 }
-`, baseCodeDeployConfig(rName), rName, rName)
+
+resource "aws_sns_topic" "test_2" {
+  name = "tf-acc-test-2-%[1]s"
+}  
+`, rName) + baseCodeDeployConfig(rName)
 }
 
 func testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_updateMultiple(rName string) string {
 	return fmt.Sprintf(`
-
-  %s
-
-resource "aws_sns_topic" "bar_topic" {
-  name = "bar-topic-%s"
-}
-
-resource "aws_sns_topic" "baz_topic" {
-  name = "baz-topic-%s"
-}
-
-resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo-group-%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
 
   trigger_configuration {
     trigger_events = ["DeploymentStart", "DeploymentSuccess", "DeploymentFailure", "DeploymentStop"]
-    trigger_name = "foo-trigger"
-    trigger_target_arn = "${aws_sns_topic.foo_topic.arn}"
+    trigger_name = "test-trigger-1"
+    trigger_target_arn = "${aws_sns_topic.test.arn}"
   }
 
   trigger_configuration {
     trigger_events = ["InstanceFailure"]
-    trigger_name = "bar-trigger"
-    trigger_target_arn = "${aws_sns_topic.baz_topic.arn}"
+    trigger_name = "test-trigger-2"
+    trigger_target_arn = "${aws_sns_topic.test_3.arn}"
   }
 }
-`, baseCodeDeployConfig(rName), rName, rName, rName)
+
+resource "aws_sns_topic" "test_2" {
+  name = "tf-acc-test-2-%[1]s"
+}  
+
+resource "aws_sns_topic" "test_3" {
+  name = "tf-acc-test-3-%[1]s"
+}
+
+`, rName) + baseCodeDeployConfig(rName)
 }
 
 func test_config_auto_rollback_configuration_create(rName string) string {
 	return fmt.Sprintf(`
-
-  %s
-
-resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo-group-%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
 
   auto_rollback_configuration {
     enabled = true
     events = ["DEPLOYMENT_FAILURE"]
   }
 }
-`, baseCodeDeployConfig(rName), rName)
+`, rName) + baseCodeDeployConfig(rName)
 }
 
 func test_config_auto_rollback_configuration_update(rName string) string {
 	return fmt.Sprintf(`
-
-  %s
-
-resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo-group-%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
 
   auto_rollback_configuration {
     enabled = true
     events = ["DEPLOYMENT_FAILURE", "DEPLOYMENT_STOP_ON_ALARM"]
   }
 }
-`, baseCodeDeployConfig(rName), rName)
+`, rName) + baseCodeDeployConfig(rName)
 }
 
-func test_config_auto_rollback_configuration_delete(rName string) string {
+func test_config_auto_rollback_configuration_none(rName string) string {
 	return fmt.Sprintf(`
-
-  %s
-
-resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo-group-%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
 }
-`, baseCodeDeployConfig(rName), rName)
+`, rName) + baseCodeDeployConfig(rName)
 }
 
 func test_config_auto_rollback_configuration_disable(rName string) string {
 	return fmt.Sprintf(`
-
-  %s
-
-resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo-group-%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
 
   auto_rollback_configuration {
     enabled = false
     events = ["DEPLOYMENT_FAILURE"]
   }
 }
-`, baseCodeDeployConfig(rName), rName)
+`, rName) + baseCodeDeployConfig(rName)
 }
 
 func test_config_alarm_configuration_create(rName string) string {
 	return fmt.Sprintf(`
-
-  %s
-
-resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo-group-%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
 
   alarm_configuration {
-    alarms = ["foo"]
+    alarms = ["test-alarm"]
     enabled = true
   }
 }
-`, baseCodeDeployConfig(rName), rName)
+`, rName) + baseCodeDeployConfig(rName)
 }
 
 func test_config_alarm_configuration_update(rName string) string {
 	return fmt.Sprintf(`
-
-  %s
-
-resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo-group-%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
 
   alarm_configuration {
-    alarms = ["foo", "bar"]
+    alarms = ["test-alarm", "test-alarm-2"]
     enabled = true
     ignore_poll_alarm_failure = true
   }
 }
-`, baseCodeDeployConfig(rName), rName)
+`, rName) + baseCodeDeployConfig(rName)
 }
 
-func test_config_alarm_configuration_delete(rName string) string {
+func test_config_alarm_configuration_none(rName string) string {
 	return fmt.Sprintf(`
-
-  %s
-
-resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo-group-%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
 }
-`, baseCodeDeployConfig(rName), rName)
+`, rName) + baseCodeDeployConfig(rName)
 }
 
 func test_config_alarm_configuration_disable(rName string) string {
 	return fmt.Sprintf(`
-
-  %s
-
-resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo-group-%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
 
   alarm_configuration {
-    alarms = ["foo"]
+    alarms = ["test-alarm"]
     enabled = false
   }
 }
-`, baseCodeDeployConfig(rName), rName)
+`, rName) + baseCodeDeployConfig(rName)
 }
 
 func test_config_deployment_style_default(rName string) string {
 	return fmt.Sprintf(`
-
-  %s
-
-resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo-group-%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
 }
-`, baseCodeDeployConfig(rName), rName)
+`, rName) + baseCodeDeployConfig(rName)
 }
 
 func test_config_deployment_style_create(rName string) string {
 	return fmt.Sprintf(`
-
-  %s
-
-resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo-group-%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
 
   deployment_style {
     deployment_option = "WITH_TRAFFIC_CONTROL"
@@ -2907,155 +2824,118 @@ resource "aws_codedeploy_deployment_group" "foo_group" {
 
   load_balancer_info {
     elb_info {
-      name = "foo-elb"
+      name = "acc-test-codedeploy-dep-group"
     }
   }
 }
-`, baseCodeDeployConfig(rName), rName)
+`, rName) + baseCodeDeployConfig(rName)
 }
 
 func test_config_deployment_style_update(rName string) string {
 	return fmt.Sprintf(`
-
-  %s
-
-resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo-group-%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
 
   deployment_style {
     deployment_option = "WITHOUT_TRAFFIC_CONTROL"
     deployment_type = "IN_PLACE"
   }
 }
-`, baseCodeDeployConfig(rName), rName)
+`, rName) + baseCodeDeployConfig(rName)
 }
 
-func test_config_load_balancer_info_default(rName string) string {
+func test_config_load_balancer_info_none(rName string) string {
 	return fmt.Sprintf(`
-
-  %s
-
-resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo-group-%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
 }
-`, baseCodeDeployConfig(rName), rName)
+`, rName) + baseCodeDeployConfig(rName)
 }
 
 func test_config_load_balancer_info_create(rName string) string {
 	return fmt.Sprintf(`
-
-  %s
-
-resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo-group-%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
 
   load_balancer_info {
     elb_info {
-      name = "foo-elb"
+      name = "acc-test-codedeploy-dep-group"
     }
   }
 }
-`, baseCodeDeployConfig(rName), rName)
+`, rName) + baseCodeDeployConfig(rName)
 }
 
 func test_config_load_balancer_info_update(rName string) string {
 	return fmt.Sprintf(`
-
-  %s
-
-resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo-group-%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
 
   load_balancer_info {
     elb_info {
-      name = "bar-elb"
+      name = "acc-test-codedeploy-dep-group-2"
     }
   }
 }
-`, baseCodeDeployConfig(rName), rName)
-}
-
-func test_config_load_balancer_info_delete(rName string) string {
-	return fmt.Sprintf(`
-
-  %s
-
-resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo-group-%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
-}
-`, baseCodeDeployConfig(rName), rName)
+`, rName) + baseCodeDeployConfig(rName)
 }
 
 func test_config_load_balancer_info_target_group_info_create(rName string) string {
 	return fmt.Sprintf(`
-
-  %s
-
-resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo-group-%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
 
   load_balancer_info {
     target_group_info {
-      name = "foo-tg"
+      name = "acc-test-codedeploy-dep-group"
     }
   }
 }
-`, baseCodeDeployConfig(rName), rName)
+`, rName) + baseCodeDeployConfig(rName)
 }
 
 func test_config_load_balancer_info_target_group_info_update(rName string) string {
 	return fmt.Sprintf(`
-
-  %s
-
-resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo-group-%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
 
   load_balancer_info {
     target_group_info {
-      name = "bar-tg"
+      name = "acc-test-codedeploy-dep-group-2"
     }
   }
 }
-`, baseCodeDeployConfig(rName), rName)
+`, rName) + baseCodeDeployConfig(rName)
 }
 
 func test_config_load_balancer_info_target_group_info_delete(rName string) string {
 	return fmt.Sprintf(`
-
-  %s
-
-resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo-group-%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
 }
-`, baseCodeDeployConfig(rName), rName)
+`, rName) + baseCodeDeployConfig(rName)
 }
 
 func test_config_in_place_deployment_with_traffic_control_create(rName string) string {
 	return fmt.Sprintf(`
-
-  %s
-
-resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo-group-%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
 
   deployment_style {
     deployment_option = "WITH_TRAFFIC_CONTROL"
@@ -3064,22 +2944,19 @@ resource "aws_codedeploy_deployment_group" "foo_group" {
 
   load_balancer_info {
     elb_info {
-      name = "foo-elb"
+      name = "acc-test-codedeploy-dep-group"
     }
   }
 }
-`, baseCodeDeployConfig(rName), rName)
+`, rName) + baseCodeDeployConfig(rName)
 }
 
 func test_config_in_place_deployment_with_traffic_control_update(rName string) string {
 	return fmt.Sprintf(`
-
-  %s
-
-resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo-group-%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
 
   deployment_style {
     deployment_option = "WITH_TRAFFIC_CONTROL"
@@ -3088,7 +2965,7 @@ resource "aws_codedeploy_deployment_group" "foo_group" {
 
   load_balancer_info {
     elb_info {
-      name = "foo-elb"
+      name = "acc-test-codedeploy-dep-group"
     }
   }
 
@@ -3106,21 +2983,56 @@ resource "aws_codedeploy_deployment_group" "foo_group" {
     }
   }
 }
-`, baseCodeDeployConfig(rName), rName)
+`, rName) + baseCodeDeployConfig(rName)
 }
 
 func test_config_blue_green_deployment_config_delete(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo-group-%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
 }
 `, rName) + baseCodeDeployConfig(rName)
 }
 
 func test_config_blue_green_deployment_config_create_with_asg(rName string) string {
 	return fmt.Sprintf(`
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
+
+  deployment_style {
+	deployment_option = "WITH_TRAFFIC_CONTROL"
+	deployment_type   = "BLUE_GREEN"
+  }
+  
+  autoscaling_groups = ["${aws_autoscaling_group.test.name}"]
+
+  load_balancer_info {
+    elb_info {
+      name = "acc-test-codedeploy-dep-group"
+    }
+  }
+  
+  blue_green_deployment_config {
+    deployment_ready_option {
+      action_on_timeout = "STOP_DEPLOYMENT"
+      wait_time_in_minutes = 60
+    }
+    
+    green_fleet_provisioning_option {
+      action = "COPY_AUTO_SCALING_GROUP"
+    }
+    
+    terminate_blue_instances_on_deployment_success {
+      action = "TERMINATE"
+      termination_wait_time_in_minutes = 120
+    }
+  }
+}
+
 data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
   most_recent = true
   owners      = ["amazon"]
@@ -3142,70 +3054,69 @@ data "aws_subnet" "test" {
   default_for_az    = "true"
 }
 
-resource "aws_launch_configuration" "foo_lc" {
+resource "aws_launch_configuration" "test" {
   image_id = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   instance_type = "t2.micro"
-  name_prefix = "foo-lc-"
+  name_prefix = "tf-acc-test-codedeploy-deployment-group-"
 
   lifecycle {
     create_before_destroy = true
   }
 }
 
-resource "aws_autoscaling_group" "foo_asg" {
-  name = "foo-asg-%s"
+resource "aws_autoscaling_group" "test" {
+  name = "tf-acc-test-codedeploy-deployment-group-%[1]s"
   max_size = 2
   min_size = 0
   desired_capacity = 1
 
   vpc_zone_identifier = ["${data.aws_subnet.test.id}"]
 
-  launch_configuration = "${aws_launch_configuration.foo_lc.name}"
+  launch_configuration = "${aws_launch_configuration.test.name}"
 
   lifecycle {
     create_before_destroy = true
   }
 }
-
-resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo-group-%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
-
-  deployment_style {
-	deployment_option = "WITH_TRAFFIC_CONTROL"
-	deployment_type   = "BLUE_GREEN"
-  }
-  
-  autoscaling_groups = ["${aws_autoscaling_group.foo_asg.name}"]
-
-  load_balancer_info {
-    elb_info {
-      name = "foo-elb"
-    }
-  }
-  
-  blue_green_deployment_config {
-    deployment_ready_option {
-      action_on_timeout = "STOP_DEPLOYMENT"
-      wait_time_in_minutes = 60
-    }
-    
-    green_fleet_provisioning_option {
-      action = "COPY_AUTO_SCALING_GROUP"
-    }
-    
-    terminate_blue_instances_on_deployment_success {
-      action = "TERMINATE"
-      termination_wait_time_in_minutes = 120
-    }
-  }
-}
-`, rName, rName) + baseCodeDeployConfig(rName)
+`, rName) + baseCodeDeployConfig(rName)
 }
 
 func test_config_blue_green_deployment_config_update_with_asg(rName string) string {
 	return fmt.Sprintf(`
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
+
+  deployment_style {
+	deployment_option = "WITH_TRAFFIC_CONTROL"
+	deployment_type   = "BLUE_GREEN"
+  }
+
+  autoscaling_groups = ["${aws_autoscaling_group.test.name}"]
+
+  load_balancer_info {
+    elb_info {
+      name = "acc-test-codedeploy-dep-group"
+    }
+  }
+
+  blue_green_deployment_config {
+    deployment_ready_option {
+      action_on_timeout = "STOP_DEPLOYMENT"
+      wait_time_in_minutes = 60
+    }
+
+    green_fleet_provisioning_option {
+      action = "COPY_AUTO_SCALING_GROUP"
+    }
+
+    terminate_blue_instances_on_deployment_success {
+      action = "KEEP_ALIVE"
+    }
+  }
+}
+
 data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
   most_recent = true
   owners      = ["amazon"]
@@ -3227,77 +3138,39 @@ data "aws_subnet" "test" {
   default_for_az    = "true"
 }
 
-resource "aws_launch_configuration" "foo_lc" {
+resource "aws_launch_configuration" "test" {
   image_id = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   instance_type = "t2.micro"
-  name_prefix = "foo-lc-"
+  name_prefix = "tf-acc-test-codedeploy-deployment-group-"
 
   lifecycle {
     create_before_destroy = true
   }
 }
 
-resource "aws_autoscaling_group" "foo_asg" {
-  name = "foo-asg-%s"
+resource "aws_autoscaling_group" "test" {
+  name = "tf-acc-test-codedeploy-deployment-group-%[1]s"
   max_size = 2
   min_size = 0
   desired_capacity = 1
 
   vpc_zone_identifier = ["${data.aws_subnet.test.id}"]
 
-  launch_configuration = "${aws_launch_configuration.foo_lc.name}"
+  launch_configuration = "${aws_launch_configuration.test.name}"
 
   lifecycle {
     create_before_destroy = true
   }
 }
-
-resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo-group-%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
-
-  deployment_style {
-	deployment_option = "WITH_TRAFFIC_CONTROL"
-	deployment_type   = "BLUE_GREEN"
-  }
-
-  autoscaling_groups = ["${aws_autoscaling_group.foo_asg.name}"]
-
-  load_balancer_info {
-    elb_info {
-      name = "foo-elb"
-    }
-  }
-
-  blue_green_deployment_config {
-    deployment_ready_option {
-      action_on_timeout = "STOP_DEPLOYMENT"
-      wait_time_in_minutes = 60
-    }
-
-    green_fleet_provisioning_option {
-      action = "COPY_AUTO_SCALING_GROUP"
-    }
-
-    terminate_blue_instances_on_deployment_success {
-      action = "KEEP_ALIVE"
-    }
-  }
-}
-
-`, rName, rName) + baseCodeDeployConfig(rName)
+`, rName) + baseCodeDeployConfig(rName)
 }
 
 func test_config_blue_green_deployment_config_create_no_asg(rName string) string {
 	return fmt.Sprintf(`
-
-  %s
-
-resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo-group-%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
 
   deployment_style {
 	deployment_option = "WITH_TRAFFIC_CONTROL"
@@ -3306,7 +3179,7 @@ resource "aws_codedeploy_deployment_group" "foo_group" {
 
   load_balancer_info {
     elb_info {
-      name = "foo-elb"
+      name = "acc-test-codedeploy-dep-group"
     }
   }
 
@@ -3326,18 +3199,15 @@ resource "aws_codedeploy_deployment_group" "foo_group" {
     }
   }
 }
-`, baseCodeDeployConfig(rName), rName)
+`, rName) + baseCodeDeployConfig(rName)
 }
 
 func test_config_blue_green_deployment_config_update_no_asg(rName string) string {
 	return fmt.Sprintf(`
-
-  %s
-
-resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo-group-%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
 
   deployment_style {
 	deployment_option = "WITH_TRAFFIC_CONTROL"
@@ -3346,7 +3216,7 @@ resource "aws_codedeploy_deployment_group" "foo_group" {
 
   load_balancer_info {
     elb_info {
-      name = "foo-elb"
+      name = "acc-test-codedeploy-dep-group"
     }
   }
 
@@ -3364,18 +3234,15 @@ resource "aws_codedeploy_deployment_group" "foo_group" {
     }
   }
 }
-`, baseCodeDeployConfig(rName), rName)
+`, rName) + baseCodeDeployConfig(rName)
 }
 
 func test_config_blue_green_deployment_complete(rName string) string {
 	return fmt.Sprintf(`
-
-  %s
-
-resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo-group-%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
 
   deployment_style {
     deployment_option = "WITH_TRAFFIC_CONTROL"
@@ -3384,7 +3251,7 @@ resource "aws_codedeploy_deployment_group" "foo_group" {
 
   load_balancer_info {
     elb_info {
-      name = "foo-elb"
+      name = "acc-test-codedeploy-dep-group"
     }
   }
 
@@ -3403,18 +3270,15 @@ resource "aws_codedeploy_deployment_group" "foo_group" {
     }
   }
 }
-`, baseCodeDeployConfig(rName), rName)
+`, rName) + baseCodeDeployConfig(rName)
 }
 
 func test_config_blue_green_deployment_complete_updated(rName string) string {
 	return fmt.Sprintf(`
-
-  %s
-
-resource "aws_codedeploy_deployment_group" "foo_group" {
-  app_name = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "foo-group-%s"
-  service_role_arn = "${aws_iam_role.foo_role.arn}"
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name = "${aws_codedeploy_app.test.name}"
+  deployment_group_name = "tf-acc-test-%[1]s"
+  service_role_arn = "${aws_iam_role.test.arn}"
 
   deployment_style {
     deployment_option = "WITH_TRAFFIC_CONTROL"
@@ -3423,7 +3287,7 @@ resource "aws_codedeploy_deployment_group" "foo_group" {
 
   load_balancer_info {
     elb_info {
-      name = "foo-elb"
+      name = "acc-test-codedeploy-dep-group"
     }
   }
 
@@ -3441,7 +3305,7 @@ resource "aws_codedeploy_deployment_group" "foo_group" {
     }
   }
 }
-`, baseCodeDeployConfig(rName), rName)
+`, rName) + baseCodeDeployConfig(rName)
 }
 
 func testAccAWSCodeDeployDeploymentGroupConfigEcsBase(rName string) string {
@@ -3469,7 +3333,7 @@ resource "aws_subnet" "test" {
 }
 
 resource "aws_security_group" "test" {
-  name   = %q
+  name   = %[1]q
   vpc_id = "${aws_vpc.test.id}"
 
   ingress {
@@ -3498,7 +3362,7 @@ resource "aws_lb_target_group" "green" {
 
 resource "aws_lb" "test" {
   internal = true
-  name     = %q
+  name     = %[1]q
   subnets  = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
 }
 
@@ -3514,12 +3378,12 @@ resource "aws_lb_listener" "test" {
 }
 
 resource "aws_ecs_cluster" "test" {
-  name = %q
+  name = %[1]q
 }
 
 resource "aws_ecs_task_definition" "test" {
   cpu                      = "256"
-  family                   = %q
+  family                   = %[1]q
   memory                   = "512"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
@@ -3548,7 +3412,7 @@ resource "aws_ecs_service" "test" {
   cluster         = "${aws_ecs_cluster.test.id}"
   desired_count   = 1
   launch_type     = "FARGATE"
-  name            = %q
+  name            = %[1]q
   task_definition = "${aws_ecs_task_definition.test.arn}"
 
   deployment_controller {
@@ -3570,11 +3434,11 @@ resource "aws_ecs_service" "test" {
 
 resource "aws_codedeploy_app" "test" {
   compute_platform = "ECS"
-  name             = %q
+  name             = %[1]q
 }
 
 resource "aws_iam_role" "test" {
-  name = %q
+  name = %[1]q
 
   assume_role_policy = <<POLICY
 {
@@ -3625,7 +3489,7 @@ resource "aws_iam_role_policy" "test" {
 }
 POLICY
 }
-`, rName, rName, rName, rName, rName, rName, rName)
+`, rName)
 }
 
 func testAccAWSCodeDeployDeploymentGroupConfigEcsBlueGreen(rName string) string {

--- a/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -866,8 +866,6 @@ func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_update(t *testing.T) {
 	})
 }
 
-// Removing deployment_style from configuration does not trigger an update
-// to the default state, but the previous state is instead retained...
 func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_delete(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
 
@@ -896,10 +894,10 @@ func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_delete(t *testing.T) {
 					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo_group", "deployment_style.#", "1"),
-					resource.TestCheckResourceAttrSet(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option"),
-					resource.TestCheckResourceAttrSet(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option", "WITHOUT_TRAFFIC_CONTROL"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type", "IN_PLACE"),
 				),
 			},
 			{

--- a/website/docs/r/codedeploy_deployment_group.html.markdown
+++ b/website/docs/r/codedeploy_deployment_group.html.markdown
@@ -258,8 +258,8 @@ You can configure how instances in the original environment are terminated when 
 
 You can configure the type of deployment, either in-place or blue/green, you want to run and whether to route deployment traffic behind a load balancer. `deployment_style` supports the following:
 
-* `deployment_option` - (Optional) Indicates whether to route deployment traffic behind a load balancer. Valid Values are `WITH_TRAFFIC_CONTROL` or `WITHOUT_TRAFFIC_CONTROL`.
-* `deployment_type` - (Optional) Indicates whether to run an in-place deployment or a blue/green deployment. Valid Values are `IN_PLACE` or `BLUE_GREEN`.
+* `deployment_option` - (Optional) Indicates whether to route deployment traffic behind a load balancer. Valid Values are `WITH_TRAFFIC_CONTROL` or `WITHOUT_TRAFFIC_CONTROL`. Default is `WITHOUT_TRAFFIC_CONTROL`.
+* `deployment_type` - (Optional) Indicates whether to run an in-place deployment or a blue/green deployment. Valid Values are `IN_PLACE` or `BLUE_GREEN`. Default is `IN_PLACE`.
 
 _Only one `deployment_style` is allowed_.
 


### PR DESCRIPTION
Unexpected behaviour occurs with some block attributes of `aws_codedeploy_deployment_group` when blocks are updated or deleted.

This PR now:
* Actually deletes `load_balancer_info` via the API and state when the block is removed from the resource configuration. This would also previously prevent setting values on `load_balancer_info` if it had been removed from the configuration. See #10836
* Now resets `deployment_style` to defaults if it is removed from configuration. Previously, this would do nothing to the resource in AWS.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10836

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_codedeploy_deployment_group: Fixes unexpected behaviour when removing block attributes
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCodeDeployDeploymentGroup_'

--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_default (47.18s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_create (49.10s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_delete (49.55s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeployment_complete (53.70s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple (53.85s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_delete (56.37s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_create (58.31s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_update (61.30s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete (62.70s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_in_place_deployment_with_traffic_control_create (62.74s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_update (62.94s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable (62.96s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_create (65.49s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_basic (69.96s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_update (71.69s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete (73.06s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_disappears (38.72s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable (87.97s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_update (87.97s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_in_place_deployment_with_traffic_control_update (89.99s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete (49.61s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create (43.70s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create (47.37s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_onPremiseTag (53.27s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update (44.53s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic (64.19s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_basic_tagSet (53.30s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_update (61.17s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete (64.07s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_create (137.16s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update_with_asg (177.98s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_ECS_BlueGreen (308.25s)
```
