### PR TITLE
aws_default_security_group : missing description attribute

### DIFF
--- a/aws/resource_aws_default_security_group.go
+++ b/aws/resource_aws_default_security_group.go
@@ -15,8 +15,11 @@ func resourceAwsDefaultSecurityGroup() *schema.Resource {
 	dsg.Create = resourceAwsDefaultSecurityGroupCreate
 	dsg.Delete = resourceAwsDefaultSecurityGroupDelete
 
-	// Descriptions cannot be updated
-	delete(dsg.Schema, "description")
+	// description is a computed value for Default Security Groups and cannot be changed
+	dsg.Schema["description"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Computed: true,
+	}
 
 	// name is a computed value for Default Security Groups and cannot be changed
 	delete(dsg.Schema, "name_prefix")

--- a/aws/resource_aws_default_security_group_test.go
+++ b/aws/resource_aws_default_security_group_test.go
@@ -28,6 +28,8 @@ func TestAccAWSDefaultSecurityGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_default_security_group.web", "name", "default"),
 					resource.TestCheckResourceAttr(
+						"aws_default_security_group.web", "description", "default VPC security group"),
+					resource.TestCheckResourceAttr(
 						"aws_default_security_group.web", "ingress.3629188364.protocol", "tcp"),
 					resource.TestCheckResourceAttr(
 						"aws_default_security_group.web", "ingress.3629188364.from_port", "80"),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

The terraform aws provider supports as an output (and detailed in the documentation) the description of the default security group, but there is an error when the output is used

The description should be computed and not allowed to be amended

PR corrects this issue and allows default security group description output on apply. No change to description in a terraform plan after the first apply.  

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11564 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
resource aws_default_security_group : missing description attribute
-->
```
resource aws_default_security_group : missing description attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSDefaultSecurityGroup_basic'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSDefaultSecurityGroup_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSDefaultSecurityGroup_basic
=== PAUSE TestAccAWSDefaultSecurityGroup_basic
=== CONT  TestAccAWSDefaultSecurityGroup_basic
--- PASS: TestAccAWSDefaultSecurityGroup_basic (68.33s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	68.380s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.008s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.020s [no tests to run]

...
```
