### PR TITLE
r/aws_efs_file_system - refactor tagging and tests

### DIFF
--- a/aws/internal/keyvaluetags/generators/updatetags/main.go
+++ b/aws/internal/keyvaluetags/generators/updatetags/main.go
@@ -381,8 +381,6 @@ func ServiceTagFunction(serviceName string) string {
 		return "AddTagsToResource"
 	case "ec2":
 		return "CreateTags"
-	case "efs":
-		return "CreateTags"
 	case "elasticache":
 		return "AddTagsToResource"
 	case "elasticbeanstalk":
@@ -472,7 +470,7 @@ func ServiceTagInputIdentifierField(serviceName string) string {
 	case "ec2":
 		return "Resources"
 	case "efs":
-		return "FileSystemId"
+		return "ResourceId"
 	case "elasticache":
 		return "ResourceName"
 	case "elasticsearchservice":
@@ -624,8 +622,6 @@ func ServiceUntagFunction(serviceName string) string {
 	case "docdb":
 		return "RemoveTagsFromResource"
 	case "ec2":
-		return "DeleteTags"
-	case "efs":
 		return "DeleteTags"
 	case "elasticache":
 		return "RemoveTagsFromResource"

--- a/aws/internal/keyvaluetags/update_tags_gen.go
+++ b/aws/internal/keyvaluetags/update_tags_gen.go
@@ -1442,12 +1442,12 @@ func EfsUpdateTags(conn *efs.EFS, identifier string, oldTagsMap interface{}, new
 	newTags := New(newTagsMap)
 
 	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
-		input := &efs.DeleteTagsInput{
-			FileSystemId: aws.String(identifier),
-			TagKeys:      aws.StringSlice(removedTags.IgnoreAws().Keys()),
+		input := &efs.UntagResourceInput{
+			ResourceId: aws.String(identifier),
+			TagKeys:    aws.StringSlice(removedTags.IgnoreAws().Keys()),
 		}
 
-		_, err := conn.DeleteTags(input)
+		_, err := conn.UntagResource(input)
 
 		if err != nil {
 			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
@@ -1455,12 +1455,12 @@ func EfsUpdateTags(conn *efs.EFS, identifier string, oldTagsMap interface{}, new
 	}
 
 	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
-		input := &efs.CreateTagsInput{
-			FileSystemId: aws.String(identifier),
-			Tags:         updatedTags.IgnoreAws().EfsTags(),
+		input := &efs.TagResourceInput{
+			ResourceId: aws.String(identifier),
+			Tags:       updatedTags.IgnoreAws().EfsTags(),
 		}
 
-		_, err := conn.CreateTags(input)
+		_, err := conn.TagResource(input)
 
 		if err != nil {
 			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEFSFileSystem_'
--- PASS: TestAccAWSEFSFileSystem_kmsConfigurationWithoutEncryption (58.26s)
--- PASS: TestAccAWSEFSFileSystem_lifecyclePolicy (98.61s)
--- PASS: TestAccAWSEFSFileSystem_ProvisionedThroughputInMibps (102.44s)
--- PASS: TestAccAWSEFSFileSystem_lifecyclePolicy_update (108.44s)
--- PASS: TestAccAWSEFSFileSystem_lifecyclePolicy_removal (110.03s)
--- PASS: TestAccAWSEFSFileSystem_basic (113.80s)
--- PASS: TestAccAWSEFSFileSystem_pagedTags (120.53s)
--- PASS: TestAccAWSEFSFileSystem_ThroughputMode (126.65s)
--- PASS: TestAccAWSEFSFileSystem_kmsKey (127.22s)
--- PASS: TestAccAWSEFSFileSystem_tags (164.91s)
--- PASS: TestAccAWSEFSFileSystem_disappears (87.66s)
```
