### PR TITLE
r/aws_waf_sql_injection_match_set - import support

### DIFF
--- a/aws/resource_aws_waf_sql_injection_match_set.go
+++ b/aws/resource_aws_waf_sql_injection_match_set.go
@@ -5,7 +5,6 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
@@ -16,6 +15,9 @@ func resourceAwsWafSqlInjectionMatchSet() *schema.Resource {
 		Read:   resourceAwsWafSqlInjectionMatchSetRead,
 		Update: resourceAwsWafSqlInjectionMatchSetUpdate,
 		Delete: resourceAwsWafSqlInjectionMatchSetDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -88,7 +90,7 @@ func resourceAwsWafSqlInjectionMatchSetRead(d *schema.ResourceData, meta interfa
 
 	resp, err := conn.GetSqlInjectionMatchSet(params)
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "WAFNonexistentItemException" {
+		if isAWSErr(err, waf.ErrCodeNonexistentItemException, "") {
 			log.Printf("[WARN] WAF IPSet (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil

--- a/aws/resource_aws_waf_sql_injection_match_set_test.go
+++ b/aws/resource_aws_waf_sql_injection_match_set_test.go
@@ -63,6 +63,11 @@ func TestAccAWSWafSqlInjectionMatchSet_changeNameForceNew(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAWSWafSqlInjectionMatchSetConfigChangeName(rNameNew),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafSqlInjectionMatchSetExists(resourceName, &after),
@@ -119,6 +124,11 @@ func TestAccAWSWafSqlInjectionMatchSet_changeTuples(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAWSWafSqlInjectionMatchSetConfig_changeTuples(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSWafSqlInjectionMatchSetExists(resourceName, &after),
@@ -147,6 +157,11 @@ func TestAccAWSWafSqlInjectionMatchSet_noTuples(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "sql_injection_match_tuples.#", "0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/aws/resource_aws_waf_sql_injection_match_set_test.go
+++ b/aws/resource_aws_waf_sql_injection_match_set_test.go
@@ -8,14 +8,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 )
 
 func TestAccAWSWafSqlInjectionMatchSet_basic(t *testing.T) {
 	var v waf.SqlInjectionMatchSet
-	sqlInjectionMatchSet := fmt.Sprintf("sqlInjectionMatchSet-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_waf_sql_injection_match_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWaf(t) },
@@ -23,22 +23,21 @@ func TestAccAWSWafSqlInjectionMatchSet_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSWafSqlInjectionMatchSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSWafSqlInjectionMatchSetConfig(sqlInjectionMatchSet),
+				Config: testAccAWSWafSqlInjectionMatchSetConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafSqlInjectionMatchSetExists("aws_waf_sql_injection_match_set.sql_injection_match_set", &v),
-					resource.TestCheckResourceAttr(
-						"aws_waf_sql_injection_match_set.sql_injection_match_set", "name", sqlInjectionMatchSet),
-					resource.TestCheckResourceAttr(
-						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.3367958210.field_to_match.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.3367958210.field_to_match.2316364334.data", ""),
-					resource.TestCheckResourceAttr(
-						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.3367958210.field_to_match.2316364334.type", "QUERY_STRING"),
-					resource.TestCheckResourceAttr(
-						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.3367958210.text_transformation", "URL_DECODE"),
+					testAccCheckAWSWafSqlInjectionMatchSetExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "sql_injection_match_tuples.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sql_injection_match_tuples.3367958210.field_to_match.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sql_injection_match_tuples.3367958210.field_to_match.2316364334.data", ""),
+					resource.TestCheckResourceAttr(resourceName, "sql_injection_match_tuples.3367958210.field_to_match.2316364334.type", "QUERY_STRING"),
+					resource.TestCheckResourceAttr(resourceName, "sql_injection_match_tuples.3367958210.text_transformation", "URL_DECODE"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -46,8 +45,9 @@ func TestAccAWSWafSqlInjectionMatchSet_basic(t *testing.T) {
 
 func TestAccAWSWafSqlInjectionMatchSet_changeNameForceNew(t *testing.T) {
 	var before, after waf.SqlInjectionMatchSet
-	sqlInjectionMatchSet := fmt.Sprintf("sqlInjectionMatchSet-%s", acctest.RandString(5))
-	sqlInjectionMatchSetNewName := fmt.Sprintf("sqlInjectionMatchSetNewName-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rNameNew := acctest.RandomWithPrefix("tf-acc-test-new")
+	resourceName := "aws_waf_sql_injection_match_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWaf(t) },
@@ -55,23 +55,19 @@ func TestAccAWSWafSqlInjectionMatchSet_changeNameForceNew(t *testing.T) {
 		CheckDestroy: testAccCheckAWSWafSqlInjectionMatchSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSWafSqlInjectionMatchSetConfig(sqlInjectionMatchSet),
+				Config: testAccAWSWafSqlInjectionMatchSetConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafSqlInjectionMatchSetExists("aws_waf_sql_injection_match_set.sql_injection_match_set", &before),
-					resource.TestCheckResourceAttr(
-						"aws_waf_sql_injection_match_set.sql_injection_match_set", "name", sqlInjectionMatchSet),
-					resource.TestCheckResourceAttr(
-						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.#", "1"),
+					testAccCheckAWSWafSqlInjectionMatchSetExists(resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "sql_injection_match_tuples.#", "1"),
 				),
 			},
 			{
-				Config: testAccAWSWafSqlInjectionMatchSetConfigChangeName(sqlInjectionMatchSetNewName),
+				Config: testAccAWSWafSqlInjectionMatchSetConfigChangeName(rNameNew),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafSqlInjectionMatchSetExists("aws_waf_sql_injection_match_set.sql_injection_match_set", &after),
-					resource.TestCheckResourceAttr(
-						"aws_waf_sql_injection_match_set.sql_injection_match_set", "name", sqlInjectionMatchSetNewName),
-					resource.TestCheckResourceAttr(
-						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.#", "1"),
+					testAccCheckAWSWafSqlInjectionMatchSetExists(resourceName, &after),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameNew),
+					resource.TestCheckResourceAttr(resourceName, "sql_injection_match_tuples.#", "1"),
 				),
 			},
 		},
@@ -80,7 +76,8 @@ func TestAccAWSWafSqlInjectionMatchSet_changeNameForceNew(t *testing.T) {
 
 func TestAccAWSWafSqlInjectionMatchSet_disappears(t *testing.T) {
 	var v waf.SqlInjectionMatchSet
-	sqlInjectionMatchSet := fmt.Sprintf("sqlInjectionMatchSet-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_waf_sql_injection_match_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWaf(t) },
@@ -88,9 +85,9 @@ func TestAccAWSWafSqlInjectionMatchSet_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAWSWafSqlInjectionMatchSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSWafSqlInjectionMatchSetConfig(sqlInjectionMatchSet),
+				Config: testAccAWSWafSqlInjectionMatchSetConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafSqlInjectionMatchSetExists("aws_waf_sql_injection_match_set.sql_injection_match_set", &v),
+					testAccCheckAWSWafSqlInjectionMatchSetExists(resourceName, &v),
 					testAccCheckAWSWafSqlInjectionMatchSetDisappears(&v),
 				),
 				ExpectNonEmptyPlan: true,
@@ -101,7 +98,8 @@ func TestAccAWSWafSqlInjectionMatchSet_disappears(t *testing.T) {
 
 func TestAccAWSWafSqlInjectionMatchSet_changeTuples(t *testing.T) {
 	var before, after waf.SqlInjectionMatchSet
-	setName := fmt.Sprintf("sqlInjectionMatchSet-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_waf_sql_injection_match_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWaf(t) },
@@ -109,31 +107,23 @@ func TestAccAWSWafSqlInjectionMatchSet_changeTuples(t *testing.T) {
 		CheckDestroy: testAccCheckAWSWafSqlInjectionMatchSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSWafSqlInjectionMatchSetConfig(setName),
+				Config: testAccAWSWafSqlInjectionMatchSetConfig(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafSqlInjectionMatchSetExists("aws_waf_sql_injection_match_set.sql_injection_match_set", &before),
-					resource.TestCheckResourceAttr(
-						"aws_waf_sql_injection_match_set.sql_injection_match_set", "name", setName),
-					resource.TestCheckResourceAttr(
-						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.3367958210.field_to_match.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.3367958210.field_to_match.2316364334.data", ""),
-					resource.TestCheckResourceAttr(
-						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.3367958210.field_to_match.2316364334.type", "QUERY_STRING"),
-					resource.TestCheckResourceAttr(
-						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.3367958210.text_transformation", "URL_DECODE"),
+					testAccCheckAWSWafSqlInjectionMatchSetExists(resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "sql_injection_match_tuples.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sql_injection_match_tuples.3367958210.field_to_match.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sql_injection_match_tuples.3367958210.field_to_match.2316364334.data", ""),
+					resource.TestCheckResourceAttr(resourceName, "sql_injection_match_tuples.3367958210.field_to_match.2316364334.type", "QUERY_STRING"),
+					resource.TestCheckResourceAttr(resourceName, "sql_injection_match_tuples.3367958210.text_transformation", "URL_DECODE"),
 				),
 			},
 			{
-				Config: testAccAWSWafSqlInjectionMatchSetConfig_changeTuples(setName),
+				Config: testAccAWSWafSqlInjectionMatchSetConfig_changeTuples(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafSqlInjectionMatchSetExists("aws_waf_sql_injection_match_set.sql_injection_match_set", &after),
-					resource.TestCheckResourceAttr(
-						"aws_waf_sql_injection_match_set.sql_injection_match_set", "name", setName),
-					resource.TestCheckResourceAttr(
-						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.#", "1"),
+					testAccCheckAWSWafSqlInjectionMatchSetExists(resourceName, &after),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "sql_injection_match_tuples.#", "1"),
 				),
 			},
 		},
@@ -141,8 +131,9 @@ func TestAccAWSWafSqlInjectionMatchSet_changeTuples(t *testing.T) {
 }
 
 func TestAccAWSWafSqlInjectionMatchSet_noTuples(t *testing.T) {
-	var ipset waf.SqlInjectionMatchSet
-	setName := fmt.Sprintf("sqlInjectionMatchSet-%s", acctest.RandString(5))
+	var sqlSet waf.SqlInjectionMatchSet
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_waf_sql_injection_match_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWaf(t) },
@@ -150,13 +141,11 @@ func TestAccAWSWafSqlInjectionMatchSet_noTuples(t *testing.T) {
 		CheckDestroy: testAccCheckAWSWafSqlInjectionMatchSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSWafSqlInjectionMatchSetConfig_noTuples(setName),
+				Config: testAccAWSWafSqlInjectionMatchSetConfig_noTuples(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafSqlInjectionMatchSetExists("aws_waf_sql_injection_match_set.sql_injection_match_set", &ipset),
-					resource.TestCheckResourceAttr(
-						"aws_waf_sql_injection_match_set.sql_injection_match_set", "name", setName),
-					resource.TestCheckResourceAttr(
-						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.#", "0"),
+					testAccCheckAWSWafSqlInjectionMatchSetExists(resourceName, &sqlSet),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "sql_injection_match_tuples.#", "0"),
 				),
 			},
 		},
@@ -176,7 +165,7 @@ func testAccCheckAWSWafSqlInjectionMatchSetDisappears(v *waf.SqlInjectionMatchSe
 
 			for _, sqlInjectionMatchTuple := range v.SqlInjectionMatchTuples {
 				sqlInjectionMatchTupleUpdate := &waf.SqlInjectionMatchSetUpdate{
-					Action: aws.String("DELETE"),
+					Action: aws.String(waf.ChangeActionDelete),
 					SqlInjectionMatchTuple: &waf.SqlInjectionMatchTuple{
 						FieldToMatch:       sqlInjectionMatchTuple.FieldToMatch,
 						TextTransformation: sqlInjectionMatchTuple.TextTransformation,
@@ -235,7 +224,7 @@ func testAccCheckAWSWafSqlInjectionMatchSetExists(n string, v *waf.SqlInjectionM
 
 func testAccCheckAWSWafSqlInjectionMatchSetDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_waf_byte_match_set" {
+		if rs.Type != "aws_waf_sql_injection_match_set" {
 			continue
 		}
 
@@ -252,10 +241,8 @@ func testAccCheckAWSWafSqlInjectionMatchSetDestroy(s *terraform.State) error {
 		}
 
 		// Return nil if the SqlInjectionMatchSet is already destroyed
-		if awsErr, ok := err.(awserr.Error); ok {
-			if awsErr.Code() == "WAFNonexistentItemException" {
-				return nil
-			}
+		if isAWSErr(err, waf.ErrCodeNonexistentItemException, "") {
+			return nil
 		}
 
 		return err
@@ -266,7 +253,7 @@ func testAccCheckAWSWafSqlInjectionMatchSetDestroy(s *terraform.State) error {
 
 func testAccAWSWafSqlInjectionMatchSetConfig(name string) string {
 	return fmt.Sprintf(`
-resource "aws_waf_sql_injection_match_set" "sql_injection_match_set" {
+resource "aws_waf_sql_injection_match_set" "test" {
   name = "%s"
 
   sql_injection_match_tuples {
@@ -282,7 +269,7 @@ resource "aws_waf_sql_injection_match_set" "sql_injection_match_set" {
 
 func testAccAWSWafSqlInjectionMatchSetConfigChangeName(name string) string {
 	return fmt.Sprintf(`
-resource "aws_waf_sql_injection_match_set" "sql_injection_match_set" {
+resource "aws_waf_sql_injection_match_set" "test" {
   name = "%s"
 
   sql_injection_match_tuples {
@@ -298,7 +285,7 @@ resource "aws_waf_sql_injection_match_set" "sql_injection_match_set" {
 
 func testAccAWSWafSqlInjectionMatchSetConfig_changeTuples(name string) string {
 	return fmt.Sprintf(`
-resource "aws_waf_sql_injection_match_set" "sql_injection_match_set" {
+resource "aws_waf_sql_injection_match_set" "test" {
   name = "%s"
 
   sql_injection_match_tuples {
@@ -314,7 +301,7 @@ resource "aws_waf_sql_injection_match_set" "sql_injection_match_set" {
 
 func testAccAWSWafSqlInjectionMatchSetConfig_noTuples(name string) string {
 	return fmt.Sprintf(`
-resource "aws_waf_sql_injection_match_set" "sql_injection_match_set" {
+resource "aws_waf_sql_injection_match_set" "test" {
   name = "%s"
 }
 `, name)

--- a/website/docs/r/waf_sql_injection_match_set.html.markdown
+++ b/website/docs/r/waf_sql_injection_match_set.html.markdown
@@ -63,3 +63,11 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the WAF SQL Injection Match Set.
+
+## Import
+
+AWS WAF SQL Injection Match Set can be imported using their ID, e.g.
+
+```
+$ terraform import aws_waf_sql_injection_match_set.example a1b2c3d4-d5f6-7777-8888-9999aaaabbbbcccc
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_waf_sql_injection_match_set: import support
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSWafSqlInjectionMatchSet_'
--- PASS: TestAccAWSWafSqlInjectionMatchSet_basic (41.96s)
--- PASS: TestAccAWSWafSqlInjectionMatchSet_disappears (35.69s)
--- PASS: TestAccAWSWafSqlInjectionMatchSet_changeTuples (77.31s)
--- PASS: TestAccAWSWafSqlInjectionMatchSet_noTuples (42.55s)
--- PASS: TestAccAWSWafSqlInjectionMatchSet_changeNameForceNew (85.43s)
```
