### PR TITLE
r/ssm_activation - remove from state if removed manually

### DIFF
--- a/aws/resource_aws_ssm_activation.go
+++ b/aws/resource_aws_ssm_activation.go
@@ -18,6 +18,9 @@ func resourceAwsSsmActivation() *schema.Resource {
 		Create: resourceAwsSsmActivationCreate,
 		Read:   resourceAwsSsmActivationRead,
 		Delete: resourceAwsSsmActivationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -151,7 +154,9 @@ func resourceAwsSsmActivationRead(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error reading SSM activation: %s", err)
 	}
 	if resp.ActivationList == nil || len(resp.ActivationList) == 0 {
-		return fmt.Errorf("ActivationList was nil or empty")
+		log.Printf("[WARN] SSM Activation (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
 	}
 
 	activation := resp.ActivationList[0] // Only 1 result as MaxResults is 1 above

--- a/aws/resource_aws_ssm_activation.go
+++ b/aws/resource_aws_ssm_activation.go
@@ -18,9 +18,6 @@ func resourceAwsSsmActivation() *schema.Resource {
 		Create: resourceAwsSsmActivationCreate,
 		Read:   resourceAwsSsmActivationRead,
 		Delete: resourceAwsSsmActivationDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/aws/resource_aws_ssm_activation_test.go
+++ b/aws/resource_aws_ssm_activation_test.go
@@ -33,11 +33,6 @@ func TestAccAWSSSMActivation_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Name", tag)),
 			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
 		},
 	})
 }
@@ -60,11 +55,6 @@ func TestAccAWSSSMActivation_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Name", "My Activation"),
 				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSSSMActivationBasicConfig(name, "Foo"),
@@ -102,11 +92,6 @@ func TestAccAWSSSMActivation_expirationDate(t *testing.T) {
 					testAccCheckAWSSSMActivationExists(resourceName, &ssmActivation),
 					resource.TestCheckResourceAttr(resourceName, "expiration_date", expirationDateS),
 				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})

--- a/aws/resource_aws_ssm_activation_test.go
+++ b/aws/resource_aws_ssm_activation_test.go
@@ -15,8 +15,10 @@ import (
 
 func TestAccAWSSSMActivation_basic(t *testing.T) {
 	var ssmActivation ssm.Activation
-	name := acctest.RandString(10)
-	tag := acctest.RandString(10)
+	name := acctest.RandomWithPrefix("tf-acc")
+	tag := acctest.RandomWithPrefix("tf-acc")
+	resourceName := "aws_ssm_activation.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -25,11 +27,16 @@ func TestAccAWSSSMActivation_basic(t *testing.T) {
 			{
 				Config: testAccAWSSSMActivationBasicConfig(name, tag),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMActivationExists("aws_ssm_activation.foo", &ssmActivation),
-					resource.TestCheckResourceAttrSet("aws_ssm_activation.foo", "activation_code"),
-					testAccCheckResourceAttrRfc3339("aws_ssm_activation.foo", "expiration_date"),
-					resource.TestCheckResourceAttr("aws_ssm_activation.foo", "tags.%", "1"),
-					resource.TestCheckResourceAttr("aws_ssm_activation.foo", "tags.Name", tag)),
+					testAccCheckAWSSSMActivationExists(resourceName, &ssmActivation),
+					resource.TestCheckResourceAttrSet(resourceName, "activation_code"),
+					testAccCheckResourceAttrRfc3339(resourceName, "expiration_date"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", tag)),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -37,8 +44,9 @@ func TestAccAWSSSMActivation_basic(t *testing.T) {
 
 func TestAccAWSSSMActivation_update(t *testing.T) {
 	var ssmActivation1, ssmActivation2 ssm.Activation
-	name := acctest.RandString(10)
-	resourceName := "aws_ssm_activation.foo"
+	name := acctest.RandomWithPrefix("tf-acc")
+	resourceName := "aws_ssm_activation.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -52,6 +60,11 @@ func TestAccAWSSSMActivation_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Name", "My Activation"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSSSMActivationBasicConfig(name, "Foo"),
@@ -69,10 +82,10 @@ func TestAccAWSSSMActivation_update(t *testing.T) {
 
 func TestAccAWSSSMActivation_expirationDate(t *testing.T) {
 	var ssmActivation ssm.Activation
-	rName := acctest.RandString(10)
+	rName := acctest.RandomWithPrefix("tf-acc")
 	expirationTime := time.Now().Add(48 * time.Hour).UTC()
 	expirationDateS := expirationTime.Format(time.RFC3339)
-	resourceName := "aws_ssm_activation.foo"
+	resourceName := "aws_ssm_activation.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -89,6 +102,34 @@ func TestAccAWSSSMActivation_expirationDate(t *testing.T) {
 					testAccCheckAWSSSMActivationExists(resourceName, &ssmActivation),
 					resource.TestCheckResourceAttr(resourceName, "expiration_date", expirationDateS),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSSMActivation_disappears(t *testing.T) {
+	var ssmActivation ssm.Activation
+	name := acctest.RandomWithPrefix("tf-acc")
+	tag := acctest.RandomWithPrefix("tf-acc")
+	resourceName := "aws_ssm_activation.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMActivationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMActivationBasicConfig(name, tag),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMActivationExists(resourceName, &ssmActivation),
+					testAccCheckAWSSSMActivationDisappears(&ssmActivation),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -138,6 +179,19 @@ func testAccCheckAWSSSMActivationExists(n string, ssmActivation *ssm.Activation)
 	}
 }
 
+func testAccCheckAWSSSMActivationDisappears(a *ssm.Activation) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).ssmconn
+
+		input := &ssm.DeleteActivationInput{ActivationId: a.ActivationId}
+		_, err := conn.DeleteActivation(input)
+		if err != nil {
+			return fmt.Errorf("Error deleting SSM Activation: %s", err)
+		}
+		return nil
+	}
+}
+
 func testAccCheckAWSSSMActivationDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).ssmconn
 
@@ -158,24 +212,27 @@ func testAccCheckAWSSSMActivationDestroy(s *terraform.State) error {
 			MaxResults: aws.Int64(1),
 		})
 
-		if err != nil {
-			return err
+		if err == nil {
+			if len(out.ActivationList) != 0 &&
+				*out.ActivationList[0].ActivationId == rs.Primary.ID {
+				return fmt.Errorf("SSM Activation still exists")
+			}
 		}
 
-		if len(out.ActivationList) > 0 {
-			return fmt.Errorf("Expected AWS SSM Activation to be gone, but was still found")
+		if err != nil {
+			return err
 		}
 
 		return nil
 	}
 
-	return fmt.Errorf("Default error in SSM Activation Test")
+	return nil
 }
 
-func testAccAWSSSMActivationBasicConfig(rName string, rTag string) string {
+func testAccAWSSSMActivationBasicConfigBase(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test_role" {
-  name = "test_role-%s"
+  name = %[1]q
 
   assume_role_policy = <<EOF
 {
@@ -197,48 +254,28 @@ resource "aws_iam_role_policy_attachment" "test_attach" {
   role       = "${aws_iam_role.test_role.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
 }
+`, rName)
+}
 
-resource "aws_ssm_activation" "foo" {
-  name               = "test_ssm_activation-%s"
+func testAccAWSSSMActivationBasicConfig(rName string, rTag string) string {
+	return testAccAWSSSMActivationBasicConfigBase(rName) + fmt.Sprintf(`
+resource "aws_ssm_activation" "test" {
+  name               = %[1]q
   description        = "Test"
   iam_role           = "${aws_iam_role.test_role.name}"
   registration_limit = "5"
   depends_on         = ["aws_iam_role_policy_attachment.test_attach"]
 
   tags = {
-    Name = "%s"
+    Name = %[2]q
   }
 }
-`, rName, rName, rTag)
+`, rName, rTag)
 }
 
 func testAccAWSSSMActivationConfig_expirationDate(rName, expirationDate string) string {
-	return fmt.Sprintf(`
-resource "aws_iam_role" "test_role" {
-  name = "test_role-%[1]s"
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "ssm.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy_attachment" "test_attach" {
-  role       = "${aws_iam_role.test_role.name}"
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
-}
-
-resource "aws_ssm_activation" "foo" {
+	return testAccAWSSSMActivationBasicConfigBase(rName) + fmt.Sprintf(`
+resource "aws_ssm_activation" "test" {
   name               = "test_ssm_activation-%[1]s"
   description        = "Test"
   expiration_date    = "%[2]s"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11534

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_ssm_activation: remove from state if manually removed
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSSMActivation_'
--- PASS: TestAccAWSSSMActivation_basic (49.86s)
--- PASS: TestAccAWSSSMActivation_update (77.50s)
--- PASS: TestAccAWSSSMActivation_expirationDate (49.33s)
--- PASS: TestAccAWSSSMActivation_disappears (52.34s)
```
