### PR TITLE
d/acm_certificate: add `tags` attribute

### DIFF
--- a/aws/data_source_aws_acm_certificate.go
+++ b/aws/data_source_aws_acm_certificate.go
@@ -76,7 +76,7 @@ func dataSourceAwsAcmCertificateRead(d *schema.ResourceData, meta interface{}) e
 		statusStrings := statuses.([]interface{})
 		params.CertificateStatuses = expandStringList(statusStrings)
 	} else {
-		params.CertificateStatuses = []*string{aws.String("ISSUED")}
+		params.CertificateStatuses = []*string{aws.String(acm.CertificateStatusIssued)}
 	}
 
 	var arns []*string
@@ -171,7 +171,7 @@ func dataSourceAwsAcmCertificateRead(d *schema.ResourceData, meta interface{}) e
 	d.SetId(time.Now().UTC().String())
 	d.Set("arn", matchedCertificate.CertificateArn)
 
-	tags, err := keyvaluetags.AcmListTags(conn, d.Id())
+	tags, err := keyvaluetags.AcmListTags(conn, aws.StringValue(matchedCertificate.CertificateArn))
 
 	if err != nil {
 		return fmt.Errorf("error listing tags for ACM Certificate (%s): %s", d.Id(), err)

--- a/aws/data_source_aws_acm_certificate_test.go
+++ b/aws/data_source_aws_acm_certificate_test.go
@@ -191,6 +191,7 @@ func TestAccAWSAcmCertificateDataSource_KeyTypes(t *testing.T) {
 				Config: testAccAwsAcmCertificateDataSourceConfigKeyTypes(tlsPemEscapeNewlines(certificate), tlsPemEscapeNewlines(key)),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags", dataSourceName, "tags"),
 				),
 			},
 		},

--- a/aws/data_source_aws_acm_certificate_test.go
+++ b/aws/data_source_aws_acm_certificate_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/acm"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
@@ -182,13 +183,14 @@ func TestAccAWSAcmCertificateDataSource_KeyTypes(t *testing.T) {
 	dataSourceName := "data.aws_acm_certificate.test"
 	key := tlsRsaPrivateKeyPem(4096)
 	certificate := tlsRsaX509SelfSignedCertificatePem(key, "example.com")
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsAcmCertificateDataSourceConfigKeyTypes(tlsPemEscapeNewlines(certificate), tlsPemEscapeNewlines(key)),
+				Config: testAccAwsAcmCertificateDataSourceConfigKeyTypes(tlsPemEscapeNewlines(certificate), tlsPemEscapeNewlines(key), rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "tags", dataSourceName, "tags"),
@@ -253,16 +255,20 @@ data "aws_acm_certificate" "test" {
 `, domain, certType, mostRecent)
 }
 
-func testAccAwsAcmCertificateDataSourceConfigKeyTypes(certificate, key string) string {
+func testAccAwsAcmCertificateDataSourceConfigKeyTypes(certificate, key, rName string) string {
 	return fmt.Sprintf(`
 resource "aws_acm_certificate" "test" {
   certificate_body = "%[1]s"
   private_key      = "%[2]s"
+
+  tags = {
+    Name = %[3]q
+  }
 }
 
 data "aws_acm_certificate" "test" {
   domain    = "${aws_acm_certificate.test.domain_name}"
   key_types = ["RSA_4096"]
 }
-`, certificate, key)
+`, certificate, key, rName)
 }

--- a/website/docs/d/acm_certificate.html.markdown
+++ b/website/docs/d/acm_certificate.html.markdown
@@ -48,3 +48,5 @@ data "aws_acm_certificate" "example" {
 ## Attributes Reference
 
  * `arn` - Set to the ARN of the found certificate, suitable for referencing in other resources that support ACM certificates.
+ * `tags` - A mapping of tags for the resource.
+


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10688

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data_source_aws_acm_certificate: add `tags` attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSAcmCertificateDataSource_'
--- PASS: TestAccAWSAcmCertificateDataSource_KeyTypes (139.64s)
```
