### PR TITLE
refactor route53 zone data source to use keyvaluetags

### DIFF
--- a/aws/data_source_aws_route53_zone.go
+++ b/aws/data_source_aws_route53_zone.go
@@ -180,6 +180,10 @@ func dataSourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error finding Route 53 Hosted Zone: %v", err)
 	}
 
+	if err := d.Set("tags", tags.IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
 	return nil
 }
 

--- a/aws/data_source_aws_route53_zone.go
+++ b/aws/data_source_aws_route53_zone.go
@@ -3,11 +3,13 @@ package aws
 import (
 	"fmt"
 	"log"
+	"reflect"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func dataSourceAwsRoute53Zone() *schema.Resource {
@@ -72,7 +74,8 @@ func dataSourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) erro
 	name = hostedZoneName(name.(string))
 	id, idExists := d.GetOk("zone_id")
 	vpcId, vpcIdExists := d.GetOk("vpc_id")
-	tags := tagsFromMap(d.Get("tags").(map[string]interface{}))
+	tags := keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws()
+
 	if nameExists && idExists {
 		return fmt.Errorf("zone_id and name arguments can't be used together")
 	}
@@ -125,27 +128,12 @@ func dataSourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) erro
 				// we check if tags match
 				matchingTags := true
 				if len(tags) > 0 {
-					reqListTags := &route53.ListTagsForResourceInput{}
-					reqListTags.ResourceId = aws.String(hostedZoneId)
-					reqListTags.ResourceType = aws.String("hostedzone")
-					respListTags, errListTags := conn.ListTagsForResource(reqListTags)
+					listTags, err := keyvaluetags.Route53ListTags(conn, hostedZoneId, route53.TagResourceTypeHostedzone)
 
-					if errListTags != nil {
-						return fmt.Errorf("Error finding Route 53 Hosted Zone: %v", errListTags)
+					if err != nil {
+						return fmt.Errorf("Error finding Route 53 Hosted Zone: %v", err)
 					}
-					for _, tag := range tags {
-						found := false
-						for _, tagRequested := range respListTags.ResourceTagSet.Tags {
-							if *tag.Key == *tagRequested.Key && *tag.Value == *tagRequested.Value {
-								found = true
-							}
-						}
-
-						if !found {
-							matchingTags = false
-							break
-						}
-					}
+					matchingTags = reflect.DeepEqual(listTags, tags)
 				}
 
 				if matchingTags && matchingVPC {
@@ -185,6 +173,12 @@ func dataSourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error finding Route 53 Hosted Zone: %v", err)
 	}
 	d.Set("name_servers", nameServers)
+
+	tags, err = keyvaluetags.Route53ListTags(conn, idHostedZone, route53.TagResourceTypeHostedzone)
+
+	if err != nil {
+		return fmt.Errorf("Error finding Route 53 Hosted Zone: %v", err)
+	}
 
 	return nil
 }

--- a/aws/data_source_aws_route53_zone_test.go
+++ b/aws/data_source_aws_route53_zone_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -114,6 +115,8 @@ func TestAccDataSourceAwsRoute53Zone_serviceDiscovery(t *testing.T) {
 				Config: testAccDataSourceAwsRoute53ZoneConfigServiceDiscovery(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
+					resource.TestCheckResourceAttr(dataSourceName, "linked_service_principal", "servicediscovery.amazonaws.com"),
+					resource.TestMatchResourceAttr(dataSourceName, "linked_service_description", regexp.MustCompile(`^arn:[^:]+:servicediscovery:[^:]+:[^:]+:namespace/ns-\w+$`)),
 				),
 			},
 		},

--- a/aws/data_source_aws_route53_zone_test.go
+++ b/aws/data_source_aws_route53_zone_test.go
@@ -2,18 +2,16 @@ package aws
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceAwsRoute53Zone(t *testing.T) {
+func TestAccDataSourceAwsRoute53Zone_id(t *testing.T) {
 	rInt := acctest.RandInt()
-	publicResourceName := "aws_route53_zone.test"
-	privateResourceName := "aws_route53_zone.test_private"
-	serviceDiscoveryResourceName := "aws_service_discovery_private_dns_namespace.test_service_discovery"
+	resourceName := "aws_route53_zone.test"
+	dataSourceName := "data.aws_route53_zone.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -21,43 +19,175 @@ func TestAccDataSourceAwsRoute53Zone(t *testing.T) {
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsRoute53ZoneConfig(rInt),
+				Config: testAccDataSourceAwsRoute53ZoneConfigId(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair(publicResourceName, "id", "data.aws_route53_zone.by_zone_id", "id"),
-					resource.TestCheckResourceAttrPair(publicResourceName, "name", "data.aws_route53_zone.by_zone_id", "name"),
-					resource.TestCheckResourceAttrPair(publicResourceName, "name_servers", "data.aws_route53_zone.by_zone_id", "name_servers"),
-					resource.TestCheckResourceAttrPair(publicResourceName, "id", "data.aws_route53_zone.by_name", "id"),
-					resource.TestCheckResourceAttrPair(publicResourceName, "name", "data.aws_route53_zone.by_name", "name"),
-					resource.TestCheckResourceAttrPair(publicResourceName, "name_servers", "data.aws_route53_zone.by_name", "name_servers"),
-					resource.TestCheckResourceAttrPair(privateResourceName, "id", "data.aws_route53_zone.by_vpc", "id"),
-					resource.TestCheckResourceAttrPair(privateResourceName, "name", "data.aws_route53_zone.by_vpc", "name"),
-					resource.TestCheckResourceAttrPair(privateResourceName, "id", "data.aws_route53_zone.by_tag", "id"),
-					resource.TestCheckResourceAttrPair(privateResourceName, "name", "data.aws_route53_zone.by_tag", "name"),
-					resource.TestCheckResourceAttrPair(serviceDiscoveryResourceName, "hosted_zone", "data.aws_route53_zone.service_discovery_by_vpc", "id"),
-					resource.TestCheckResourceAttrPair(serviceDiscoveryResourceName, "name", "data.aws_route53_zone.service_discovery_by_vpc", "name"),
-					resource.TestCheckResourceAttr("data.aws_route53_zone.service_discovery_by_vpc", "linked_service_principal", "servicediscovery.amazonaws.com"),
-					resource.TestMatchResourceAttr("data.aws_route53_zone.service_discovery_by_vpc", "linked_service_description", regexp.MustCompile(`^arn:[^:]+:servicediscovery:[^:]+:[^:]+:namespace/ns-\w+$`)),
+					resource.TestCheckResourceAttrPair(resourceName, "id", dataSourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "name_servers", dataSourceName, "name_servers"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags", dataSourceName, "tags"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceAwsRoute53ZoneConfig(rInt int) string {
-	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
+func TestAccDataSourceAwsRoute53Zone_name(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "aws_route53_zone.test"
+	dataSourceName := "data.aws_route53_zone.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsRoute53ZoneConfigName(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "id", dataSourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "name_servers", dataSourceName, "name_servers"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags", dataSourceName, "tags"),
+				),
+			},
+		},
+	})
 }
 
+func TestAccDataSourceAwsRoute53Zone_tags(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "aws_route53_zone.test"
+	dataSourceName := "data.aws_route53_zone.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsRoute53ZoneConfigTagsPrivate(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "id", dataSourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "name_servers", dataSourceName, "name_servers"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags", dataSourceName, "tags"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsRoute53Zone_vpc(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "aws_route53_zone.test"
+	dataSourceName := "data.aws_route53_zone.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsRoute53ZoneConfigVpc(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "id", dataSourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "name_servers", dataSourceName, "name_servers"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags", dataSourceName, "tags"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsRoute53Zone_serviceDiscovery(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "aws_service_discovery_private_dns_namespace.test"
+	dataSourceName := "data.aws_route53_zone.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsRoute53ZoneConfigServiceDiscovery(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsRoute53ZoneConfigId(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_route53_zone" "test" {
+  name = "terraformtestacchz-%[1]d.com."
+}
+
+data "aws_route53_zone" "test" {
+  zone_id = "${aws_route53_zone.test.zone_id}"
+}
+`, rInt)
+}
+
+func testAccDataSourceAwsRoute53ZoneConfigName(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_route53_zone" "test" {
+  name = "terraformtestacchz-%[1]d.com."
+}
+
+data "aws_route53_zone" "test" {
+  name = "${aws_route53_zone.test.name}"
+}
+`, rInt)
+}
+
+func testAccDataSourceAwsRoute53ZoneConfigTagsPrivate(rInt int) string {
+	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
-  cidr_block = "172.16.0.0/16"
+  cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-r53-zone-data-source"
+    Name = "terraform-testacc-r53-zone-data-source-%[1]d"
   }
 }
 
-resource "aws_route53_zone" "test_private" {
+resource "aws_route53_zone" "test" {
+  name = "terraformtestacchz-%[1]d.com."
+  vpc {
+    vpc_id = "${aws_vpc.test.id}"
+  }
+
+  tags = {
+    Environment = "tf-acc-test-%[1]d"
+  }
+}
+
+data "aws_route53_zone" "test" {
+  name         = "${aws_route53_zone.test.name}"
+  private_zone = true
+  vpc_id = "${aws_vpc.test.id}"
+
+  tags = {
+    Environment = "tf-acc-test-%[1]d"
+  }
+}
+`, rInt)
+}
+
+func testAccDataSourceAwsRoute53ZoneConfigVpc(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "terraform-testacc-r53-zone-data-source-%[1]d"
+  }
+}
+
+resource "aws_route53_zone" "test" {
   name = "test.acc-%[1]d."
 
   vpc {
@@ -69,39 +199,31 @@ resource "aws_route53_zone" "test_private" {
   }
 }
 
-data "aws_route53_zone" "by_vpc" {
-  name   = "${aws_route53_zone.test_private.name}"
+data "aws_route53_zone" "test" {
+  name   = "${aws_route53_zone.test.name}"
+  private_zone = true
   vpc_id = "${aws_vpc.test.id}"
 }
+`, rInt)
+}
 
-data "aws_route53_zone" "by_tag" {
-  name         = "${aws_route53_zone.test_private.name}"
-  private_zone = true
+func testAccDataSourceAwsRoute53ZoneConfigServiceDiscovery(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
 
   tags = {
-    Environment = "dev-%[1]d"
+    Name = "terraform-testacc-r53-zone-data-source-%[1]d"
   }
 }
 
-resource "aws_route53_zone" "test" {
-  name = "terraformtestacchz-%[1]d.com."
-}
-
-data "aws_route53_zone" "by_zone_id" {
-  zone_id = "${aws_route53_zone.test.zone_id}"
-}
-
-data "aws_route53_zone" "by_name" {
-  name = "${data.aws_route53_zone.by_zone_id.name}"
-}
-
-resource "aws_service_discovery_private_dns_namespace" "test_service_discovery" {
+resource "aws_service_discovery_private_dns_namespace" "test" {
   name        = "test.acc-sd-%[1]d."
   vpc         = "${aws_vpc.test.id}"
 }
 
-data "aws_route53_zone" "service_discovery_by_vpc" {
-  name   = "${aws_service_discovery_private_dns_namespace.test_service_discovery.name}"
+data "aws_route53_zone" "test" {
+  name   = "${aws_service_discovery_private_dns_namespace.test.name}"
   vpc_id = "${aws_vpc.test.id}"
 }
 `, rInt)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10688

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
None
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccDataSourceAwsRoute53Zone_'
--- PASS: TestAccDataSourceAwsRoute53Zone_id (76.70s)
--- PASS: TestAccDataSourceAwsRoute53Zone_name (73.89s)
--- PASS: TestAccDataSourceAwsRoute53Zone_tags (152.70s)
--- PASS: TestAccDataSourceAwsRoute53Zone_vpc (137.42s)
--- PASS: TestAccDataSourceAwsRoute53Zone_serviceDiscovery (158.23s)
```
