### PR TITLE
Fix ES domain creation when transient errors occur

### DIFF
--- a/aws/resource_aws_elasticsearch_domain.go
+++ b/aws/resource_aws_elasticsearch_domain.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"regexp"
@@ -473,20 +472,11 @@ func resourceAwsElasticSearchDomainCreate(d *schema.ResourceData, meta interface
 			if isAWSErr(err, "ValidationException", "The passed role has not propagated yet") {
 				return resource.RetryableError(err)
 			}
-			if isAWSErr(err, "ValidationException", "Authentication error") ||
-				isAWSErr(err, "ValidationException", "Unauthorized Operation: Elasticsearch must be authorised to describeVpcs") ||
-				isAWSErr(err, "ValidationException", "Unauthorized Operation: Elasticsearch must be authorised to describeSubnets") ||
-				isAWSErr(err, "ValidationException", "Before you can proceed, you must enable a service-linked role to give Amazon ES permissions to access your VPC") {
-				log.Printf("[DEBUG] Retrying creation of ElasticSearch domain %s (transient error)", aws.StringValue(input.DomainName))
+			if isAWSErr(err, "ValidationException", "Authentication error") {
 				return resource.RetryableError(err)
 			}
-			// New transient AWS error
-			var awsErr awserr.Error
-			if errors.As(err, &awsErr) {
-				if awsErr.Code() == "ValidationException" && len(awsErr.Message()) == 0 {
-					log.Printf("[DEBUG] Empty ValidationException ElasticSearch domain %s (transient error)", aws.StringValue(input.DomainName))
-					return resource.RetryableError(err)
-				}
+			if isAWSErr(err, "ValidationException", "Unauthorized Operation: Elasticsearch must be authorised to describe") {
+				return resource.RetryableError(err)
 			}
 
 			return resource.NonRetryableError(err)

--- a/aws/resource_aws_elasticsearch_domain.go
+++ b/aws/resource_aws_elasticsearch_domain.go
@@ -478,6 +478,9 @@ func resourceAwsElasticSearchDomainCreate(d *schema.ResourceData, meta interface
 			if isAWSErr(err, "ValidationException", "Unauthorized Operation: Elasticsearch must be authorised to describe") {
 				return resource.RetryableError(err)
 			}
+			if isAWSErr(err, "ValidationException", "The passed role must authorize Amazon Elasticsearch to describe") {
+				return resource.RetryableError(err)
+			}
 
 			return resource.NonRetryableError(err)
 		}


### PR DESCRIPTION
Fix for issue #7725

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #7725 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* aws_elasticsearch_domain failed with ValidationException: Authentication error status code: 400
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ $ AWS_DEFAULT_REGION=eu-west-1 AWS_PROFILE=scratch gmake testacc TEST=./aws TESTARGS='-run=TestAccAWSElasticSearchDomain'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSElasticSearchDomain -timeout 120m
=== RUN   TestAccAWSElasticSearchDomainPolicy_basic
=== PAUSE TestAccAWSElasticSearchDomainPolicy_basic
=== RUN   TestAccAWSElasticSearchDomain_basic
=== PAUSE TestAccAWSElasticSearchDomain_basic
=== RUN   TestAccAWSElasticSearchDomain_ClusterConfig_ZoneAwarenessConfig
=== PAUSE TestAccAWSElasticSearchDomain_ClusterConfig_ZoneAwarenessConfig
=== RUN   TestAccAWSElasticSearchDomain_withDedicatedMaster
=== PAUSE TestAccAWSElasticSearchDomain_withDedicatedMaster
=== RUN   TestAccAWSElasticSearchDomain_duplicate
=== PAUSE TestAccAWSElasticSearchDomain_duplicate
=== RUN   TestAccAWSElasticSearchDomain_v23
=== PAUSE TestAccAWSElasticSearchDomain_v23
=== RUN   TestAccAWSElasticSearchDomain_complex
=== PAUSE TestAccAWSElasticSearchDomain_complex
=== RUN   TestAccAWSElasticSearchDomain_vpc
=== PAUSE TestAccAWSElasticSearchDomain_vpc
=== RUN   TestAccAWSElasticSearchDomain_vpc_update
=== PAUSE TestAccAWSElasticSearchDomain_vpc_update
=== RUN   TestAccAWSElasticSearchDomain_internetToVpcEndpoint
=== PAUSE TestAccAWSElasticSearchDomain_internetToVpcEndpoint
=== RUN   TestAccAWSElasticSearchDomain_LogPublishingOptions
=== PAUSE TestAccAWSElasticSearchDomain_LogPublishingOptions
=== RUN   TestAccAWSElasticSearchDomain_CognitoOptionsCreateAndRemove
=== PAUSE TestAccAWSElasticSearchDomain_CognitoOptionsCreateAndRemove
=== RUN   TestAccAWSElasticSearchDomain_CognitoOptionsUpdate
=== PAUSE TestAccAWSElasticSearchDomain_CognitoOptionsUpdate
=== RUN   TestAccAWSElasticSearchDomain_policy
=== PAUSE TestAccAWSElasticSearchDomain_policy
=== RUN   TestAccAWSElasticSearchDomain_encrypt_at_rest_default_key
=== PAUSE TestAccAWSElasticSearchDomain_encrypt_at_rest_default_key
=== RUN   TestAccAWSElasticSearchDomain_encrypt_at_rest_specify_key
=== PAUSE TestAccAWSElasticSearchDomain_encrypt_at_rest_specify_key
=== RUN   TestAccAWSElasticSearchDomain_NodeToNodeEncryption
=== PAUSE TestAccAWSElasticSearchDomain_NodeToNodeEncryption
=== RUN   TestAccAWSElasticSearchDomain_tags
=== PAUSE TestAccAWSElasticSearchDomain_tags
=== RUN   TestAccAWSElasticSearchDomain_update
=== PAUSE TestAccAWSElasticSearchDomain_update
=== RUN   TestAccAWSElasticSearchDomain_update_volume_type
=== PAUSE TestAccAWSElasticSearchDomain_update_volume_type
=== RUN   TestAccAWSElasticSearchDomain_update_version
=== PAUSE TestAccAWSElasticSearchDomain_update_version
=== CONT  TestAccAWSElasticSearchDomainPolicy_basic
=== CONT  TestAccAWSElasticSearchDomain_CognitoOptionsCreateAndRemove
=== CONT  TestAccAWSElasticSearchDomain_LogPublishingOptions
=== CONT  TestAccAWSElasticSearchDomain_policy
=== CONT  TestAccAWSElasticSearchDomain_v23
=== CONT  TestAccAWSElasticSearchDomain_withDedicatedMaster
=== CONT  TestAccAWSElasticSearchDomain_CognitoOptionsUpdate
=== CONT  TestAccAWSElasticSearchDomain_update_version
=== CONT  TestAccAWSElasticSearchDomain_complex
=== CONT  TestAccAWSElasticSearchDomain_update
=== CONT  TestAccAWSElasticSearchDomain_vpc_update
=== CONT  TestAccAWSElasticSearchDomain_internetToVpcEndpoint
=== CONT  TestAccAWSElasticSearchDomain_vpc
=== CONT  TestAccAWSElasticSearchDomain_encrypt_at_rest_default_key
=== CONT  TestAccAWSElasticSearchDomain_NodeToNodeEncryption
=== CONT  TestAccAWSElasticSearchDomain_encrypt_at_rest_specify_key
=== CONT  TestAccAWSElasticSearchDomain_duplicate
=== CONT  TestAccAWSElasticSearchDomain_ClusterConfig_ZoneAwarenessConfig
=== CONT  TestAccAWSElasticSearchDomain_tags
=== CONT  TestAccAWSElasticSearchDomain_update_volume_type
--- PASS: TestAccAWSElasticSearchDomain_duplicate (500.07s)
=== CONT  TestAccAWSElasticSearchDomain_basic
--- PASS: TestAccAWSElasticSearchDomain_tags (819.89s)
--- PASS: TestAccAWSElasticSearchDomain_encrypt_at_rest_default_key (839.54s)
--- PASS: TestAccAWSElasticSearchDomain_policy (1075.47s)
--- PASS: TestAccAWSElasticSearchDomain_complex (1098.33s)
--- PASS: TestAccAWSElasticSearchDomain_v23 (1104.13s)
--- PASS: TestAccAWSElasticSearchDomain_LogPublishingOptions (1185.27s)
--- PASS: TestAccAWSElasticSearchDomain_encrypt_at_rest_specify_key (1257.04s)
--- PASS: TestAccAWSElasticSearchDomain_basic (884.73s)
--- PASS: TestAccAWSElasticSearchDomainPolicy_basic (1414.86s)
--- PASS: TestAccAWSElasticSearchDomain_NodeToNodeEncryption (1446.40s)
--- PASS: TestAccAWSElasticSearchDomain_vpc (1650.59s)
--- PASS: TestAccAWSElasticSearchDomain_CognitoOptionsUpdate (1812.42s)
--- PASS: TestAccAWSElasticSearchDomain_internetToVpcEndpoint (2266.66s)
--- PASS: TestAccAWSElasticSearchDomain_CognitoOptionsCreateAndRemove (2341.65s)
--- PASS: TestAccAWSElasticSearchDomain_update (2789.07s)
--- PASS: TestAccAWSElasticSearchDomain_vpc_update (2904.30s)
--- PASS: TestAccAWSElasticSearchDomain_withDedicatedMaster (3019.82s)
--- PASS: TestAccAWSElasticSearchDomain_update_version (3148.25s)
--- PASS: TestAccAWSElasticSearchDomain_update_volume_type (3173.39s)
--- PASS: TestAccAWSElasticSearchDomain_ClusterConfig_ZoneAwarenessConfig (4686.86s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	4686.955s
$
```
