### PR TITLE
Opswork layers tagging support

### DIFF
--- a/aws/opsworks_layers.go
+++ b/aws/opsworks_layers.go
@@ -59,8 +59,9 @@ func (lt *opsworksLayerType) SchemaResource() *schema.Resource {
 		},
 
 		"custom_instance_profile_arn": {
-			Type:     schema.TypeString,
-			Optional: true,
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: validateArn,
 		},
 
 		"elastic_load_balancer": {

--- a/aws/opsworks_layers.go
+++ b/aws/opsworks_layers.go
@@ -5,13 +5,13 @@ import (
 	"log"
 	"strconv"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/opsworks"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/service/opsworks"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/structure"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 // OpsWorks has a single concept of "layer" which represents several different
@@ -208,6 +208,11 @@ func (lt *opsworksLayerType) SchemaResource() *schema.Resource {
 				return hashcode.String(m["mount_point"].(string))
 			},
 		},
+		"arn": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"tags": tagsSchema(),
 	}
 
 	if lt.CustomShortName {
@@ -246,7 +251,7 @@ func (lt *opsworksLayerType) SchemaResource() *schema.Resource {
 		},
 		Create: func(d *schema.ResourceData, meta interface{}) error {
 			client := meta.(*AWSClient).opsworksconn
-			return lt.Create(d, client)
+			return lt.Create(d, client, meta)
 		},
 		Update: func(d *schema.ResourceData, meta interface{}) error {
 			client := meta.(*AWSClient).opsworksconn
@@ -276,11 +281,9 @@ func (lt *opsworksLayerType) Read(d *schema.ResourceData, client *opsworks.OpsWo
 
 	resp, err := client.DescribeLayers(req)
 	if err != nil {
-		if awserr, ok := err.(awserr.Error); ok {
-			if awserr.Code() == "ResourceNotFoundException" {
-				d.SetId("")
-				return nil
-			}
+		if isAWSErr(err, opsworks.ErrCodeResourceNotFoundException, "") {
+			d.SetId("")
+			return nil
 		}
 		return err
 	}
@@ -337,10 +340,22 @@ func (lt *opsworksLayerType) Read(d *schema.ResourceData, client *opsworks.OpsWo
 		}
 	}
 
+	arn := aws.StringValue(layer.Arn)
+	d.Set("arn", arn)
+	tags, err := keyvaluetags.OpsworksListTags(client, arn)
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for Opsworks Layer (%s): %s", arn, err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
 	return nil
 }
 
-func (lt *opsworksLayerType) Create(d *schema.ResourceData, client *opsworks.OpsWorks) error {
+func (lt *opsworksLayerType) Create(d *schema.ResourceData, client *opsworks.OpsWorks, meta interface{}) error {
 
 	req := &opsworks.CreateLayerInput{
 		AutoAssignElasticIps:        aws.Bool(d.Get("auto_assign_elastic_ips").(bool)),
@@ -387,6 +402,20 @@ func (lt *opsworksLayerType) Create(d *schema.ResourceData, client *opsworks.Ops
 		})
 		if err != nil {
 			return err
+		}
+	}
+
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Region:    meta.(*AWSClient).region,
+		Service:   "opsworks",
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("layer/%s/", d.Id()),
+	}.String()
+
+	if v, ok := d.GetOk("tags"); ok {
+		if err := keyvaluetags.OpsworksUpdateTags(client, arn, nil, v.(map[string]interface{})); err != nil {
+			return fmt.Errorf("error updating Opsworks stack (%s) tags: %s", arn, err)
 		}
 	}
 
@@ -454,6 +483,15 @@ func (lt *opsworksLayerType) Update(d *schema.ResourceData, client *opsworks.Ops
 	_, err := client.UpdateLayer(req)
 	if err != nil {
 		return err
+	}
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		arn := d.Get("arn").(string)
+		if err := keyvaluetags.OpsworksUpdateTags(client, arn, o, n); err != nil {
+			return fmt.Errorf("error updating Opsworks Layer (%s) tags: %s", arn, err)
+		}
 	}
 
 	return lt.Read(d, client)

--- a/aws/opsworks_layers.go
+++ b/aws/opsworks_layers.go
@@ -410,7 +410,7 @@ func (lt *opsworksLayerType) Create(d *schema.ResourceData, client *opsworks.Ops
 		Region:    meta.(*AWSClient).region,
 		Service:   "opsworks",
 		AccountID: meta.(*AWSClient).accountid,
-		Resource:  fmt.Sprintf("layer/%s/", d.Id()),
+		Resource:  fmt.Sprintf("layer/%s", d.Id()),
 	}.String()
 
 	if v, ok := d.GetOk("tags"); ok {

--- a/aws/resource_aws_opsworks_custom_layer.go
+++ b/aws/resource_aws_opsworks_custom_layer.go
@@ -1,12 +1,13 @@
 package aws
 
 import (
+	"github.com/aws/aws-sdk-go/service/opsworks"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func resourceAwsOpsworksCustomLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
-		TypeName:        "custom",
+		TypeName:        opsworks.LayerTypeCustom,
 		CustomShortName: true,
 
 		// The "custom" layer type has no additional attributes

--- a/aws/resource_aws_opsworks_custom_layer_test.go
+++ b/aws/resource_aws_opsworks_custom_layer_test.go
@@ -254,10 +254,10 @@ func testAccCheckAWSOpsworksCreateLayerAttributes(
 	}
 }
 
-func testAccCheckAwsOpsworksCustomLayerDestroy(s *terraform.State) error {
+func testAccCheckAwsOpsworksLayerDestroy(resourceType string, s *terraform.State) error {
 	opsworksconn := testAccProvider.Meta().(*AWSClient).opsworksconn
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_opsworks_custom_layer" {
+		if rs.Type != resourceType {
 			continue
 		}
 		req := &opsworks.DescribeLayersInput{
@@ -275,7 +275,11 @@ func testAccCheckAwsOpsworksCustomLayerDestroy(s *terraform.State) error {
 		}
 	}
 
-	return fmt.Errorf("Fall through error on OpsWorks custom layer test")
+	return fmt.Errorf("Fall through error on OpsWorks layer test")
+}
+
+func testAccCheckAwsOpsworksCustomLayerDestroy(s *terraform.State) error {
+	return testAccCheckAwsOpsworksLayerDestroy("aws_opsworks_custom_layer", s)
 }
 
 func testAccAwsOpsworksCustomLayerSecurityGroups(name string) string {

--- a/aws/resource_aws_opsworks_custom_layer_test.go
+++ b/aws/resource_aws_opsworks_custom_layer_test.go
@@ -28,7 +28,7 @@ func TestAccAWSOpsworksCustomLayer_basic(t *testing.T) {
 			{
 				Config: testAccAwsOpsworksCustomLayerConfigVpcCreate(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSOpsworksCustomLayerExists(resourceName, &opslayer),
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "auto_assign_elastic_ips", "false"),
 					resource.TestCheckResourceAttr(resourceName, "auto_healing", "true"),
@@ -68,7 +68,7 @@ func TestAccAWSOpsworksCustomLayer_tags(t *testing.T) {
 			{
 				Config: testAccAwsOpsworksCustomLayerConfigTags1(name, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSOpsworksCustomLayerExists(resourceName, &opslayer),
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
@@ -81,7 +81,7 @@ func TestAccAWSOpsworksCustomLayer_tags(t *testing.T) {
 			{
 				Config: testAccAwsOpsworksCustomLayerConfigTags2(name, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSOpsworksCustomLayerExists(resourceName, &opslayer),
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
@@ -90,7 +90,7 @@ func TestAccAWSOpsworksCustomLayer_tags(t *testing.T) {
 			{
 				Config: testAccAwsOpsworksCustomLayerConfigTags1(name, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSOpsworksCustomLayerExists(resourceName, &opslayer),
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
@@ -112,7 +112,7 @@ func TestAccAWSOpsworksCustomLayer_noVPC(t *testing.T) {
 			{
 				Config: testAccAwsOpsworksCustomLayerConfigNoVpcCreate(stackName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSOpsworksCustomLayerExists(resourceName, &opslayer),
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
 					testAccCheckAWSOpsworksCreateLayerAttributes(&opslayer, stackName),
 					resource.TestCheckResourceAttr(resourceName, "name", stackName),
 					resource.TestCheckResourceAttr(resourceName, "auto_assign_elastic_ips", "false"),
@@ -161,8 +161,7 @@ func TestAccAWSOpsworksCustomLayer_noVPC(t *testing.T) {
 	})
 }
 
-func testAccCheckAWSOpsworksCustomLayerExists(
-	n string, opslayer *opsworks.Layer) resource.TestCheckFunc {
+func testAccCheckAWSOpsworksLayerExists(n string, opslayer *opsworks.Layer) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {

--- a/aws/resource_aws_opsworks_ganglia_layer.go
+++ b/aws/resource_aws_opsworks_ganglia_layer.go
@@ -1,27 +1,28 @@
 package aws
 
 import (
+	"github.com/aws/aws-sdk-go/service/opsworks"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func resourceAwsOpsworksGangliaLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
-		TypeName:         "monitoring-master",
+		TypeName:         opsworks.LayerTypeMonitoringMaster,
 		DefaultLayerName: "Ganglia",
 
 		Attributes: map[string]*opsworksLayerTypeAttribute{
 			"url": {
-				AttrName: "GangliaUrl",
+				AttrName: opsworks.LayerAttributesKeysGangliaUrl,
 				Type:     schema.TypeString,
 				Default:  "/ganglia",
 			},
 			"username": {
-				AttrName: "GangliaUser",
+				AttrName: opsworks.LayerAttributesKeysGangliaUser,
 				Type:     schema.TypeString,
 				Default:  "opsworks",
 			},
 			"password": {
-				AttrName:  "GangliaPassword",
+				AttrName:  opsworks.LayerAttributesKeysGangliaPassword,
 				Type:      schema.TypeString,
 				Required:  true,
 				WriteOnly: true,

--- a/aws/resource_aws_opsworks_ganglia_layer_test.go
+++ b/aws/resource_aws_opsworks_ganglia_layer_test.go
@@ -1,0 +1,133 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/opsworks"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccAWSOpsworksGangliaLayer_basic(t *testing.T) {
+	var opslayer opsworks.Layer
+	stackName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_opsworks_ganglia_layer.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsOpsworksGangliaLayerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsOpsworksGangliaLayerConfigVpcCreate(stackName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "name", stackName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSOpsworksGangliaLayer_tags(t *testing.T) {
+	var opslayer opsworks.Layer
+	stackName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_opsworks_ganglia_layer.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsOpsworksGangliaLayerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsOpsworksGangliaLayerConfigTags1(stackName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				Config: testAccAwsOpsworksGangliaLayerConfigTags2(stackName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAwsOpsworksGangliaLayerConfigTags1(stackName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsOpsworksGangliaLayerDestroy(s *terraform.State) error {
+	return testAccCheckAwsOpsworksLayerDestroy("aws_opsworks_ganglia_layer", s)
+}
+
+func testAccAwsOpsworksGangliaLayerConfigVpcCreate(name string) string {
+	return testAccAwsOpsworksStackConfigVpcCreate(name) +
+		testAccAwsOpsworksCustomLayerSecurityGroups(name) +
+		fmt.Sprintf(`
+resource "aws_opsworks_ganglia_layer" "test" {
+  stack_id = "${aws_opsworks_stack.tf-acc.id}"
+  name     = %[1]q
+  password = %[1]q
+
+  custom_security_group_ids = [
+    "${aws_security_group.tf-ops-acc-layer1.id}",
+    "${aws_security_group.tf-ops-acc-layer2.id}",
+  ]
+}
+`, name)
+}
+
+func testAccAwsOpsworksGangliaLayerConfigTags1(name, tagKey1, tagValue1 string) string {
+	return testAccAwsOpsworksStackConfigVpcCreate(name) +
+		testAccAwsOpsworksCustomLayerSecurityGroups(name) +
+		fmt.Sprintf(`
+resource "aws_opsworks_ganglia_layer" "test" {
+  stack_id = "${aws_opsworks_stack.tf-acc.id}"
+  name     = %[1]q
+  password = %[1]q
+
+  custom_security_group_ids = [
+    "${aws_security_group.tf-ops-acc-layer1.id}",
+    "${aws_security_group.tf-ops-acc-layer2.id}",
+  ]
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, name, tagKey1, tagValue1)
+}
+
+func testAccAwsOpsworksGangliaLayerConfigTags2(name, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return testAccAwsOpsworksStackConfigVpcCreate(name) +
+		testAccAwsOpsworksCustomLayerSecurityGroups(name) +
+		fmt.Sprintf(`
+resource "aws_opsworks_ganglia_layer" "test" {
+  stack_id = "${aws_opsworks_stack.tf-acc.id}"
+  name     = %[1]q
+  password = %[1]q
+
+  custom_security_group_ids = [
+    "${aws_security_group.tf-ops-acc-layer1.id}",
+    "${aws_security_group.tf-ops-acc-layer2.id}",
+  ]
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, name, tagKey1, tagValue1, tagKey2, tagValue2)
+}

--- a/aws/resource_aws_opsworks_haproxy_layer.go
+++ b/aws/resource_aws_opsworks_haproxy_layer.go
@@ -1,43 +1,44 @@
 package aws
 
 import (
+	"github.com/aws/aws-sdk-go/service/opsworks"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func resourceAwsOpsworksHaproxyLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
-		TypeName:         "lb",
+		TypeName:         opsworks.LayerTypeLb,
 		DefaultLayerName: "HAProxy",
 
 		Attributes: map[string]*opsworksLayerTypeAttribute{
 			"stats_enabled": {
-				AttrName: "EnableHaproxyStats",
+				AttrName: opsworks.LayerAttributesKeysEnableHaproxyStats,
 				Type:     schema.TypeBool,
 				Default:  true,
 			},
 			"stats_url": {
-				AttrName: "HaproxyStatsUrl",
+				AttrName: opsworks.LayerAttributesKeysHaproxyStatsUrl,
 				Type:     schema.TypeString,
 				Default:  "/haproxy?stats",
 			},
 			"stats_user": {
-				AttrName: "HaproxyStatsUser",
+				AttrName: opsworks.LayerAttributesKeysHaproxyStatsUser,
 				Type:     schema.TypeString,
 				Default:  "opsworks",
 			},
 			"stats_password": {
-				AttrName:  "HaproxyStatsPassword",
+				AttrName:  opsworks.LayerAttributesKeysHaproxyStatsPassword,
 				Type:      schema.TypeString,
 				WriteOnly: true,
 				Required:  true,
 			},
 			"healthcheck_url": {
-				AttrName: "HaproxyHealthCheckUrl",
+				AttrName: opsworks.LayerAttributesKeysHaproxyHealthCheckUrl,
 				Type:     schema.TypeString,
 				Default:  "/",
 			},
 			"healthcheck_method": {
-				AttrName: "HaproxyHealthCheckMethod",
+				AttrName: opsworks.LayerAttributesKeysHaproxyHealthCheckMethod,
 				Type:     schema.TypeString,
 				Default:  "OPTIONS",
 			},

--- a/aws/resource_aws_opsworks_haproxy_layer_test.go
+++ b/aws/resource_aws_opsworks_haproxy_layer_test.go
@@ -1,0 +1,133 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/opsworks"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccAWSOpsworksHAProxyLayer_basic(t *testing.T) {
+	var opslayer opsworks.Layer
+	stackName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_opsworks_haproxy_layer.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsOpsworksHAProxyLayerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsOpsworksHAProxyLayerConfigVpcCreate(stackName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "name", stackName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSOpsworksHAProxyLayer_tags(t *testing.T) {
+	var opslayer opsworks.Layer
+	stackName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_opsworks_haproxy_layer.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsOpsworksHAProxyLayerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsOpsworksHAProxyLayerConfigTags1(stackName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				Config: testAccAwsOpsworksHAProxyLayerConfigTags2(stackName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAwsOpsworksHAProxyLayerConfigTags1(stackName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsOpsworksHAProxyLayerDestroy(s *terraform.State) error {
+	return testAccCheckAwsOpsworksLayerDestroy("aws_opsworks_haproxy_layer", s)
+}
+
+func testAccAwsOpsworksHAProxyLayerConfigVpcCreate(name string) string {
+	return testAccAwsOpsworksStackConfigVpcCreate(name) +
+		testAccAwsOpsworksCustomLayerSecurityGroups(name) +
+		fmt.Sprintf(`
+resource "aws_opsworks_haproxy_layer" "test" {
+  stack_id       = "${aws_opsworks_stack.tf-acc.id}"
+  name           = %[1]q
+  stats_password = %[1]q
+
+  custom_security_group_ids = [
+    "${aws_security_group.tf-ops-acc-layer1.id}",
+    "${aws_security_group.tf-ops-acc-layer2.id}",
+  ]
+}
+`, name)
+}
+
+func testAccAwsOpsworksHAProxyLayerConfigTags1(name, tagKey1, tagValue1 string) string {
+	return testAccAwsOpsworksStackConfigVpcCreate(name) +
+		testAccAwsOpsworksCustomLayerSecurityGroups(name) +
+		fmt.Sprintf(`
+resource "aws_opsworks_haproxy_layer" "test" {
+  stack_id       = "${aws_opsworks_stack.tf-acc.id}"
+  name           = %[1]q
+  stats_password = %[1]q
+
+  custom_security_group_ids = [
+    "${aws_security_group.tf-ops-acc-layer1.id}",
+    "${aws_security_group.tf-ops-acc-layer2.id}",
+  ]
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, name, tagKey1, tagValue1)
+}
+
+func testAccAwsOpsworksHAProxyLayerConfigTags2(name, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return testAccAwsOpsworksStackConfigVpcCreate(name) +
+		testAccAwsOpsworksCustomLayerSecurityGroups(name) +
+		fmt.Sprintf(`
+resource "aws_opsworks_haproxy_layer" "test" {
+  stack_id       = "${aws_opsworks_stack.tf-acc.id}"
+  name           = %[1]q
+  stats_password = %[1]q
+
+  custom_security_group_ids = [
+    "${aws_security_group.tf-ops-acc-layer1.id}",
+    "${aws_security_group.tf-ops-acc-layer2.id}",
+  ]
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, name, tagKey1, tagValue1, tagKey2, tagValue2)
+}

--- a/aws/resource_aws_opsworks_java_app_layer.go
+++ b/aws/resource_aws_opsworks_java_app_layer.go
@@ -1,37 +1,38 @@
 package aws
 
 import (
+	"github.com/aws/aws-sdk-go/service/opsworks"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func resourceAwsOpsworksJavaAppLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
-		TypeName:         "java-app",
+		TypeName:         opsworks.LayerTypeJavaApp,
 		DefaultLayerName: "Java App Server",
 
 		Attributes: map[string]*opsworksLayerTypeAttribute{
 			"jvm_type": {
-				AttrName: "Jvm",
+				AttrName: opsworks.LayerAttributesKeysJvm,
 				Type:     schema.TypeString,
 				Default:  "openjdk",
 			},
 			"jvm_version": {
-				AttrName: "JvmVersion",
+				AttrName: opsworks.LayerAttributesKeysJvmVersion,
 				Type:     schema.TypeString,
 				Default:  "7",
 			},
 			"jvm_options": {
-				AttrName: "JvmOptions",
+				AttrName: opsworks.LayerAttributesKeysJvmOptions,
 				Type:     schema.TypeString,
 				Default:  "",
 			},
 			"app_server": {
-				AttrName: "JavaAppServer",
+				AttrName: opsworks.LayerAttributesKeysJavaAppServer,
 				Type:     schema.TypeString,
 				Default:  "tomcat",
 			},
 			"app_server_version": {
-				AttrName: "JavaAppServerVersion",
+				AttrName: opsworks.LayerAttributesKeysJavaAppServerVersion,
 				Type:     schema.TypeString,
 				Default:  "7",
 			},

--- a/aws/resource_aws_opsworks_java_app_layer_test.go
+++ b/aws/resource_aws_opsworks_java_app_layer_test.go
@@ -1,0 +1,132 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/opsworks"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+// These tests assume the existence of predefined Opsworks IAM roles named `aws-opsworks-ec2-role`
+// and `aws-opsworks-service-role`.
+
+func TestAccAWSOpsworksJavaAppLayer_basic(t *testing.T) {
+	var opslayer opsworks.Layer
+	stackName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_opsworks_java_app_layer.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsOpsworksJavaAppLayerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsOpsworksJavaAppLayerConfigVpcCreate(stackName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "name", stackName)),
+			},
+		},
+	})
+}
+
+func TestAccAWSOpsworksJavaAppLayer_tags(t *testing.T) {
+	var opslayer opsworks.Layer
+	stackName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_opsworks_java_app_layer.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsOpsworksJavaAppLayerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsOpsworksJavaAppLayerConfigTags1(stackName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				Config: testAccAwsOpsworksJavaAppLayerConfigTags2(stackName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAwsOpsworksJavaAppLayerConfigTags1(stackName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsOpsworksJavaAppLayerDestroy(s *terraform.State) error {
+	return testAccCheckAwsOpsworksLayerDestroy("aws_opsworks_java_app_layer", s)
+}
+
+func testAccAwsOpsworksJavaAppLayerConfigVpcCreate(name string) string {
+	return testAccAwsOpsworksStackConfigVpcCreate(name) +
+		testAccAwsOpsworksCustomLayerSecurityGroups(name) +
+		fmt.Sprintf(`
+resource "aws_opsworks_java_app_layer" "test" {
+  stack_id = "${aws_opsworks_stack.tf-acc.id}"
+  name     = "%s"
+
+  custom_security_group_ids = [
+    "${aws_security_group.tf-ops-acc-layer1.id}",
+    "${aws_security_group.tf-ops-acc-layer2.id}",
+  ]
+}
+`, name)
+}
+
+func testAccAwsOpsworksJavaAppLayerConfigTags1(name, tagKey1, tagValue1 string) string {
+	return testAccAwsOpsworksStackConfigVpcCreate(name) +
+		testAccAwsOpsworksCustomLayerSecurityGroups(name) +
+		fmt.Sprintf(`
+resource "aws_opsworks_java_app_layer" "test" {
+  stack_id = "${aws_opsworks_stack.tf-acc.id}"
+  name     = "%s"
+
+  custom_security_group_ids = [
+    "${aws_security_group.tf-ops-acc-layer1.id}",
+    "${aws_security_group.tf-ops-acc-layer2.id}",
+  ]
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, name, tagKey1, tagValue1)
+}
+
+func testAccAwsOpsworksJavaAppLayerConfigTags2(name, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return testAccAwsOpsworksStackConfigVpcCreate(name) +
+		testAccAwsOpsworksCustomLayerSecurityGroups(name) +
+		fmt.Sprintf(`
+resource "aws_opsworks_java_app_layer" "test" {
+  stack_id = "${aws_opsworks_stack.tf-acc.id}"
+  name     = "%s"
+
+  custom_security_group_ids = [
+    "${aws_security_group.tf-ops-acc-layer1.id}",
+    "${aws_security_group.tf-ops-acc-layer2.id}",
+  ]
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, name, tagKey1, tagValue1, tagKey2, tagValue2)
+}

--- a/aws/resource_aws_opsworks_memcached_layer.go
+++ b/aws/resource_aws_opsworks_memcached_layer.go
@@ -1,17 +1,18 @@
 package aws
 
 import (
+	"github.com/aws/aws-sdk-go/service/opsworks"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func resourceAwsOpsworksMemcachedLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
-		TypeName:         "memcached",
+		TypeName:         opsworks.LayerTypeMemcached,
 		DefaultLayerName: "Memcached",
 
 		Attributes: map[string]*opsworksLayerTypeAttribute{
 			"allocated_memory": {
-				AttrName: "MemcachedMemory",
+				AttrName: opsworks.LayerAttributesKeysMemcachedMemory,
 				Type:     schema.TypeInt,
 				Default:  512,
 			},

--- a/aws/resource_aws_opsworks_memcached_layer_test.go
+++ b/aws/resource_aws_opsworks_memcached_layer_test.go
@@ -1,0 +1,132 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/opsworks"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+// These tests assume the existence of predefined Opsworks IAM roles named `aws-opsworks-ec2-role`
+// and `aws-opsworks-service-role`.
+
+func TestAccAWSOpsworksMemcachedLayer_basic(t *testing.T) {
+	var opslayer opsworks.Layer
+	stackName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_opsworks_memcached_layer.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsOpsworksMemcachedLayerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsOpsworksMemcachedLayerConfigVpcCreate(stackName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "name", stackName)),
+			},
+		},
+	})
+}
+
+func TestAccAWSOpsworksMemcachedLayer_tags(t *testing.T) {
+	var opslayer opsworks.Layer
+	stackName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_opsworks_memcached_layer.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsOpsworksMemcachedLayerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsOpsworksMemcachedLayerConfigTags1(stackName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				Config: testAccAwsOpsworksMemcachedLayerConfigTags2(stackName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAwsOpsworksMemcachedLayerConfigTags1(stackName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsOpsworksMemcachedLayerDestroy(s *terraform.State) error {
+	return testAccCheckAwsOpsworksLayerDestroy("aws_opsworks_memcached_layer", s)
+}
+
+func testAccAwsOpsworksMemcachedLayerConfigVpcCreate(name string) string {
+	return testAccAwsOpsworksStackConfigVpcCreate(name) +
+		testAccAwsOpsworksCustomLayerSecurityGroups(name) +
+		fmt.Sprintf(`
+resource "aws_opsworks_memcached_layer" "test" {
+  stack_id = "${aws_opsworks_stack.tf-acc.id}"
+  name     = "%s"
+
+  custom_security_group_ids = [
+    "${aws_security_group.tf-ops-acc-layer1.id}",
+    "${aws_security_group.tf-ops-acc-layer2.id}",
+  ]
+}
+`, name)
+}
+
+func testAccAwsOpsworksMemcachedLayerConfigTags1(name, tagKey1, tagValue1 string) string {
+	return testAccAwsOpsworksStackConfigVpcCreate(name) +
+		testAccAwsOpsworksCustomLayerSecurityGroups(name) +
+		fmt.Sprintf(`
+resource "aws_opsworks_memcached_layer" "test" {
+  stack_id = "${aws_opsworks_stack.tf-acc.id}"
+  name     = "%s"
+
+  custom_security_group_ids = [
+    "${aws_security_group.tf-ops-acc-layer1.id}",
+    "${aws_security_group.tf-ops-acc-layer2.id}",
+  ]
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, name, tagKey1, tagValue1)
+}
+
+func testAccAwsOpsworksMemcachedLayerConfigTags2(name, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return testAccAwsOpsworksStackConfigVpcCreate(name) +
+		testAccAwsOpsworksCustomLayerSecurityGroups(name) +
+		fmt.Sprintf(`
+resource "aws_opsworks_memcached_layer" "test" {
+  stack_id = "${aws_opsworks_stack.tf-acc.id}"
+  name     = "%s"
+
+  custom_security_group_ids = [
+    "${aws_security_group.tf-ops-acc-layer1.id}",
+    "${aws_security_group.tf-ops-acc-layer2.id}",
+  ]
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, name, tagKey1, tagValue1, tagKey2, tagValue2)
+}

--- a/aws/resource_aws_opsworks_mysql_layer.go
+++ b/aws/resource_aws_opsworks_mysql_layer.go
@@ -1,22 +1,23 @@
 package aws
 
 import (
+	"github.com/aws/aws-sdk-go/service/opsworks"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func resourceAwsOpsworksMysqlLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
-		TypeName:         "db-master",
+		TypeName:         opsworks.LayerTypeDbMaster,
 		DefaultLayerName: "MySQL",
 
 		Attributes: map[string]*opsworksLayerTypeAttribute{
 			"root_password": {
-				AttrName:  "MysqlRootPassword",
+				AttrName:  opsworks.LayerAttributesKeysMysqlRootPassword,
 				Type:      schema.TypeString,
 				WriteOnly: true,
 			},
 			"root_password_on_all_instances": {
-				AttrName: "MysqlRootPasswordUbiquitous",
+				AttrName: opsworks.LayerAttributesKeysMysqlRootPasswordUbiquitous,
 				Type:     schema.TypeBool,
 				Default:  true,
 			},

--- a/aws/resource_aws_opsworks_mysql_layer_test.go
+++ b/aws/resource_aws_opsworks_mysql_layer_test.go
@@ -1,0 +1,132 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/opsworks"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+// These tests assume the existence of predefined Opsworks IAM roles named `aws-opsworks-ec2-role`
+// and `aws-opsworks-service-role`.
+
+func TestAccAWSOpsworksMysqlLayer_basic(t *testing.T) {
+	var opslayer opsworks.Layer
+	stackName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_opsworks_mysql_layer.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsOpsworksMysqlLayerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsOpsworksMysqlLayerConfigVpcCreate(stackName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "name", stackName)),
+			},
+		},
+	})
+}
+
+func TestAccAWSOpsworksMysqlLayer_tags(t *testing.T) {
+	var opslayer opsworks.Layer
+	stackName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_opsworks_mysql_layer.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsOpsworksMysqlLayerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsOpsworksMysqlLayerConfigTags1(stackName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				Config: testAccAwsOpsworksMysqlLayerConfigTags2(stackName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAwsOpsworksMysqlLayerConfigTags1(stackName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsOpsworksMysqlLayerDestroy(s *terraform.State) error {
+	return testAccCheckAwsOpsworksLayerDestroy("aws_opsworks_mysql_layer", s)
+}
+
+func testAccAwsOpsworksMysqlLayerConfigVpcCreate(name string) string {
+	return testAccAwsOpsworksStackConfigVpcCreate(name) +
+		testAccAwsOpsworksCustomLayerSecurityGroups(name) +
+		fmt.Sprintf(`
+resource "aws_opsworks_mysql_layer" "test" {
+  stack_id = "${aws_opsworks_stack.tf-acc.id}"
+  name     = "%s"
+
+  custom_security_group_ids = [
+    "${aws_security_group.tf-ops-acc-layer1.id}",
+    "${aws_security_group.tf-ops-acc-layer2.id}",
+  ]
+}
+`, name)
+}
+
+func testAccAwsOpsworksMysqlLayerConfigTags1(name, tagKey1, tagValue1 string) string {
+	return testAccAwsOpsworksStackConfigVpcCreate(name) +
+		testAccAwsOpsworksCustomLayerSecurityGroups(name) +
+		fmt.Sprintf(`
+resource "aws_opsworks_mysql_layer" "test" {
+  stack_id = "${aws_opsworks_stack.tf-acc.id}"
+  name     = "%s"
+
+  custom_security_group_ids = [
+    "${aws_security_group.tf-ops-acc-layer1.id}",
+    "${aws_security_group.tf-ops-acc-layer2.id}",
+  ]
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, name, tagKey1, tagValue1)
+}
+
+func testAccAwsOpsworksMysqlLayerConfigTags2(name, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return testAccAwsOpsworksStackConfigVpcCreate(name) +
+		testAccAwsOpsworksCustomLayerSecurityGroups(name) +
+		fmt.Sprintf(`
+resource "aws_opsworks_mysql_layer" "test" {
+  stack_id = "${aws_opsworks_stack.tf-acc.id}"
+  name     = "%s"
+
+  custom_security_group_ids = [
+    "${aws_security_group.tf-ops-acc-layer1.id}",
+    "${aws_security_group.tf-ops-acc-layer2.id}",
+  ]
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, name, tagKey1, tagValue1, tagKey2, tagValue2)
+}

--- a/aws/resource_aws_opsworks_nodejs_app_layer.go
+++ b/aws/resource_aws_opsworks_nodejs_app_layer.go
@@ -1,17 +1,18 @@
 package aws
 
 import (
+	"github.com/aws/aws-sdk-go/service/opsworks"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func resourceAwsOpsworksNodejsAppLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
-		TypeName:         "nodejs-app",
+		TypeName:         opsworks.LayerTypeNodejsApp,
 		DefaultLayerName: "Node.js App Server",
 
 		Attributes: map[string]*opsworksLayerTypeAttribute{
 			"nodejs_version": {
-				AttrName: "NodejsVersion",
+				AttrName: opsworks.LayerAttributesKeysNodejsVersion,
 				Type:     schema.TypeString,
 				Default:  "0.10.38",
 			},

--- a/aws/resource_aws_opsworks_nodejs_app_layer_test.go
+++ b/aws/resource_aws_opsworks_nodejs_app_layer_test.go
@@ -1,0 +1,132 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/opsworks"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+// These tests assume the existence of predefined Opsworks IAM roles named `aws-opsworks-ec2-role`
+// and `aws-opsworks-service-role`.
+
+func TestAccAWSOpsworksNodejsAppLayer_basic(t *testing.T) {
+	var opslayer opsworks.Layer
+	stackName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_opsworks_nodejs_app_layer.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsOpsworksNodejsAppLayerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsOpsworksNodejsAppLayerConfigVpcCreate(stackName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "name", stackName)),
+			},
+		},
+	})
+}
+
+func TestAccAWSOpsworksNodejsAppLayer_tags(t *testing.T) {
+	var opslayer opsworks.Layer
+	stackName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_opsworks_nodejs_app_layer.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsOpsworksNodejsAppLayerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsOpsworksNodejsAppLayerConfigTags1(stackName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				Config: testAccAwsOpsworksNodejsAppLayerConfigTags2(stackName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAwsOpsworksNodejsAppLayerConfigTags1(stackName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsOpsworksNodejsAppLayerDestroy(s *terraform.State) error {
+	return testAccCheckAwsOpsworksLayerDestroy("aws_opsworks_nodejs_app_layer", s)
+}
+
+func testAccAwsOpsworksNodejsAppLayerConfigVpcCreate(name string) string {
+	return testAccAwsOpsworksStackConfigVpcCreate(name) +
+		testAccAwsOpsworksCustomLayerSecurityGroups(name) +
+		fmt.Sprintf(`
+resource "aws_opsworks_nodejs_app_layer" "test" {
+  stack_id = "${aws_opsworks_stack.tf-acc.id}"
+  name     = "%s"
+
+  custom_security_group_ids = [
+    "${aws_security_group.tf-ops-acc-layer1.id}",
+    "${aws_security_group.tf-ops-acc-layer2.id}",
+  ]
+}
+`, name)
+}
+
+func testAccAwsOpsworksNodejsAppLayerConfigTags1(name, tagKey1, tagValue1 string) string {
+	return testAccAwsOpsworksStackConfigVpcCreate(name) +
+		testAccAwsOpsworksCustomLayerSecurityGroups(name) +
+		fmt.Sprintf(`
+resource "aws_opsworks_nodejs_app_layer" "test" {
+  stack_id = "${aws_opsworks_stack.tf-acc.id}"
+  name     = "%s"
+
+  custom_security_group_ids = [
+    "${aws_security_group.tf-ops-acc-layer1.id}",
+    "${aws_security_group.tf-ops-acc-layer2.id}",
+  ]
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, name, tagKey1, tagValue1)
+}
+
+func testAccAwsOpsworksNodejsAppLayerConfigTags2(name, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return testAccAwsOpsworksStackConfigVpcCreate(name) +
+		testAccAwsOpsworksCustomLayerSecurityGroups(name) +
+		fmt.Sprintf(`
+resource "aws_opsworks_nodejs_app_layer" "test" {
+  stack_id = "${aws_opsworks_stack.tf-acc.id}"
+  name     = "%s"
+
+  custom_security_group_ids = [
+    "${aws_security_group.tf-ops-acc-layer1.id}",
+    "${aws_security_group.tf-ops-acc-layer2.id}",
+  ]
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, name, tagKey1, tagValue1, tagKey2, tagValue2)
+}

--- a/aws/resource_aws_opsworks_php_app_layer.go
+++ b/aws/resource_aws_opsworks_php_app_layer.go
@@ -1,12 +1,13 @@
 package aws
 
 import (
+	"github.com/aws/aws-sdk-go/service/opsworks"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func resourceAwsOpsworksPhpAppLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
-		TypeName:         "php-app",
+		TypeName:         opsworks.LayerTypePhpApp,
 		DefaultLayerName: "PHP App Server",
 
 		Attributes: map[string]*opsworksLayerTypeAttribute{},

--- a/aws/resource_aws_opsworks_php_app_layer_test.go
+++ b/aws/resource_aws_opsworks_php_app_layer_test.go
@@ -1,0 +1,142 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/opsworks"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+// These tests assume the existence of predefined Opsworks IAM roles named `aws-opsworks-ec2-role`
+// and `aws-opsworks-service-role`.
+
+func TestAccAWSOpsworksPhpAppLayer_basic(t *testing.T) {
+	var opslayer opsworks.Layer
+	stackName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_opsworks_php_app_layer.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsOpsworksPhpAppLayerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsOpsworksPhpAppLayerConfigVpcCreate(stackName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "name", stackName)),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSOpsworksPhpAppLayer_tags(t *testing.T) {
+	var opslayer opsworks.Layer
+	stackName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_opsworks_php_app_layer.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsOpsworksPhpAppLayerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsOpsworksPhpAppLayerConfigTags1(stackName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAwsOpsworksPhpAppLayerConfigTags2(stackName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAwsOpsworksPhpAppLayerConfigTags1(stackName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsOpsworksPhpAppLayerDestroy(s *terraform.State) error {
+	return testAccCheckAwsOpsworksLayerDestroy("aws_opsworks_php_app_layer", s)
+}
+
+func testAccAwsOpsworksPhpAppLayerConfigVpcCreate(name string) string {
+	return testAccAwsOpsworksStackConfigVpcCreate(name) +
+		testAccAwsOpsworksCustomLayerSecurityGroups(name) +
+		fmt.Sprintf(`
+resource "aws_opsworks_php_app_layer" "test" {
+  stack_id = "${aws_opsworks_stack.tf-acc.id}"
+  name     = "%s"
+
+  custom_security_group_ids = [
+    "${aws_security_group.tf-ops-acc-layer1.id}",
+    "${aws_security_group.tf-ops-acc-layer2.id}",
+  ]
+}
+`, name)
+}
+
+func testAccAwsOpsworksPhpAppLayerConfigTags1(name, tagKey1, tagValue1 string) string {
+	return testAccAwsOpsworksStackConfigVpcCreate(name) +
+		testAccAwsOpsworksCustomLayerSecurityGroups(name) +
+		fmt.Sprintf(`
+resource "aws_opsworks_php_app_layer" "test" {
+  stack_id = "${aws_opsworks_stack.tf-acc.id}"
+  name     = "%s"
+
+  custom_security_group_ids = [
+    "${aws_security_group.tf-ops-acc-layer1.id}",
+    "${aws_security_group.tf-ops-acc-layer2.id}",
+  ]
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, name, tagKey1, tagValue1)
+}
+
+func testAccAwsOpsworksPhpAppLayerConfigTags2(name, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return testAccAwsOpsworksStackConfigVpcCreate(name) +
+		testAccAwsOpsworksCustomLayerSecurityGroups(name) +
+		fmt.Sprintf(`
+resource "aws_opsworks_php_app_layer" "test" {
+  stack_id = "${aws_opsworks_stack.tf-acc.id}"
+  name     = "%s"
+
+  custom_security_group_ids = [
+    "${aws_security_group.tf-ops-acc-layer1.id}",
+    "${aws_security_group.tf-ops-acc-layer2.id}",
+  ]
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, name, tagKey1, tagValue1, tagKey2, tagValue2)
+}

--- a/aws/resource_aws_opsworks_rails_app_layer.go
+++ b/aws/resource_aws_opsworks_rails_app_layer.go
@@ -12,32 +12,32 @@ func resourceAwsOpsworksRailsAppLayer() *schema.Resource {
 
 		Attributes: map[string]*opsworksLayerTypeAttribute{
 			"ruby_version": {
-				AttrName: "RubyVersion",
+				AttrName: opsworks.LayerAttributesKeysRubyVersion,
 				Type:     schema.TypeString,
 				Default:  "2.0.0",
 			},
 			"app_server": {
-				AttrName: "RailsStack",
+				AttrName: opsworks.LayerAttributesKeysRailsStack,
 				Type:     schema.TypeString,
 				Default:  "apache_passenger",
 			},
 			"passenger_version": {
-				AttrName: "PassengerVersion",
+				AttrName: opsworks.LayerAttributesKeysPassengerVersion,
 				Type:     schema.TypeString,
 				Default:  "4.0.46",
 			},
 			"rubygems_version": {
-				AttrName: "RubygemsVersion",
+				AttrName: opsworks.LayerAttributesKeysRubygemsVersion,
 				Type:     schema.TypeString,
 				Default:  "2.2.2",
 			},
 			"manage_bundler": {
-				AttrName: "ManageBundler",
+				AttrName: opsworks.LayerAttributesKeysManageBundler,
 				Type:     schema.TypeBool,
 				Default:  true,
 			},
 			"bundler_version": {
-				AttrName: "BundlerVersion",
+				AttrName: opsworks.LayerAttributesKeysBundlerVersion,
 				Type:     schema.TypeString,
 				Default:  "1.5.3",
 			},

--- a/aws/resource_aws_opsworks_rails_app_layer.go
+++ b/aws/resource_aws_opsworks_rails_app_layer.go
@@ -1,12 +1,13 @@
 package aws
 
 import (
+	"github.com/aws/aws-sdk-go/service/opsworks"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func resourceAwsOpsworksRailsAppLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
-		TypeName:         "rails-app",
+		TypeName:         opsworks.LayerTypeRailsApp,
 		DefaultLayerName: "Rails App Server",
 
 		Attributes: map[string]*opsworksLayerTypeAttribute{

--- a/aws/resource_aws_opsworks_rails_app_layer_test.go
+++ b/aws/resource_aws_opsworks_rails_app_layer_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/opsworks"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -15,8 +13,10 @@ import (
 // These tests assume the existence of predefined Opsworks IAM roles named `aws-opsworks-ec2-role`
 // and `aws-opsworks-service-role`.
 
-func TestAccAWSOpsworksRailsAppLayer(t *testing.T) {
-	stackName := fmt.Sprintf("tf-%d", acctest.RandInt())
+func TestAccAWSOpsworksRailsAppLayer_basic(t *testing.T) {
+	var opslayer opsworks.Layer
+	stackName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_opsworks_rails_app_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -25,23 +25,55 @@ func TestAccAWSOpsworksRailsAppLayer(t *testing.T) {
 			{
 				Config: testAccAwsOpsworksRailsAppLayerConfigVpcCreate(stackName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_rails_app_layer.tf-acc", "name", stackName,
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_rails_app_layer.tf-acc", "manage_bundler", "true",
-					),
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "name", stackName),
+					resource.TestCheckResourceAttr(resourceName, "manage_bundler", "true"),
 				),
 			},
 			{
 				Config: testAccAwsOpsworksRailsAppLayerNoManageBundlerConfigVpcCreate(stackName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_rails_app_layer.tf-acc", "name", stackName,
-					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_rails_app_layer.tf-acc", "manage_bundler", "false",
-					),
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "name", stackName),
+					resource.TestCheckResourceAttr(resourceName, "manage_bundler", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSOpsworksRailsAppLayer_tags(t *testing.T) {
+	var opslayer opsworks.Layer
+	stackName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_opsworks_rails_app_layer.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsOpsworksRailsAppLayerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsOpsworksRailsAppLayerConfigTags1(stackName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				Config: testAccAwsOpsworksRailsAppLayerConfigTags2(stackName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAwsOpsworksRailsAppLayerConfigTags1(stackName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
 			},
 		},
@@ -49,35 +81,14 @@ func TestAccAWSOpsworksRailsAppLayer(t *testing.T) {
 }
 
 func testAccCheckAwsOpsworksRailsAppLayerDestroy(s *terraform.State) error {
-	opsworksconn := testAccProvider.Meta().(*AWSClient).opsworksconn
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_opsworks_rails_app_layer" {
-			continue
-		}
-		req := &opsworks.DescribeLayersInput{
-			LayerIds: []*string{
-				aws.String(rs.Primary.ID),
-			},
-		}
-
-		_, err := opsworksconn.DescribeLayers(req)
-		if err != nil {
-			if awserr, ok := err.(awserr.Error); ok {
-				if awserr.Code() == "ResourceNotFoundException" {
-					// not found, good to go
-					return nil
-				}
-			}
-			return err
-		}
-	}
-
-	return fmt.Errorf("Fall through error on OpsWorks custom layer test")
+	return testAccCheckAwsOpsworksLayerDestroy("aws_opsworks_rails_app_layer", s)
 }
 
 func testAccAwsOpsworksRailsAppLayerConfigVpcCreate(name string) string {
-	return fmt.Sprintf(`
-resource "aws_opsworks_rails_app_layer" "tf-acc" {
+	return testAccAwsOpsworksStackConfigVpcCreate(name) +
+		testAccAwsOpsworksCustomLayerSecurityGroups(name) +
+		fmt.Sprintf(`
+resource "aws_opsworks_rails_app_layer" "test" {
   stack_id = "${aws_opsworks_stack.tf-acc.id}"
   name     = "%s"
 
@@ -86,18 +97,14 @@ resource "aws_opsworks_rails_app_layer" "tf-acc" {
     "${aws_security_group.tf-ops-acc-layer2.id}",
   ]
 }
-
-%s
-
-
-%s
-
-`, name, testAccAwsOpsworksStackConfigVpcCreate(name), testAccAwsOpsworksCustomLayerSecurityGroups(name))
+`, name)
 }
 
 func testAccAwsOpsworksRailsAppLayerNoManageBundlerConfigVpcCreate(name string) string {
-	return fmt.Sprintf(`
-resource "aws_opsworks_rails_app_layer" "tf-acc" {
+	return testAccAwsOpsworksStackConfigVpcCreate(name) +
+		testAccAwsOpsworksCustomLayerSecurityGroups(name) +
+		fmt.Sprintf(`
+resource "aws_opsworks_rails_app_layer" "test" {
   stack_id = "${aws_opsworks_stack.tf-acc.id}"
   name     = "%s"
 
@@ -108,11 +115,46 @@ resource "aws_opsworks_rails_app_layer" "tf-acc" {
 
   manage_bundler = false
 }
+`, name)
+}
 
-%s
+func testAccAwsOpsworksRailsAppLayerConfigTags1(name, tagKey1, tagValue1 string) string {
+	return testAccAwsOpsworksStackConfigVpcCreate(name) +
+		testAccAwsOpsworksCustomLayerSecurityGroups(name) +
+		fmt.Sprintf(`
+resource "aws_opsworks_rails_app_layer" "test" {
+  stack_id = "${aws_opsworks_stack.tf-acc.id}"
+  name     = "%s"
 
+  custom_security_group_ids = [
+    "${aws_security_group.tf-ops-acc-layer1.id}",
+    "${aws_security_group.tf-ops-acc-layer2.id}",
+  ]
 
-%s
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, name, tagKey1, tagValue1)
+}
 
-`, name, testAccAwsOpsworksStackConfigVpcCreate(name), testAccAwsOpsworksCustomLayerSecurityGroups(name))
+func testAccAwsOpsworksRailsAppLayerConfigTags2(name, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return testAccAwsOpsworksStackConfigVpcCreate(name) +
+		testAccAwsOpsworksCustomLayerSecurityGroups(name) +
+		fmt.Sprintf(`
+resource "aws_opsworks_rails_app_layer" "test" {
+  stack_id = "${aws_opsworks_stack.tf-acc.id}"
+  name     = "%s"
+
+  custom_security_group_ids = [
+    "${aws_security_group.tf-ops-acc-layer1.id}",
+    "${aws_security_group.tf-ops-acc-layer2.id}",
+  ]
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, name, tagKey1, tagValue1, tagKey2, tagValue2)
 }

--- a/aws/resource_aws_opsworks_stack_test.go
+++ b/aws/resource_aws_opsworks_stack_test.go
@@ -303,7 +303,7 @@ EOT
 
 resource "aws_iam_instance_profile" "opsworks_instance" {
   name  = "%s_profile"
-  roles = ["${aws_iam_role.opsworks_instance.name}"]
+  role  = "${aws_iam_role.opsworks_instance.name}"
 }
 `, rName, rInt, rInt, rInt, rName)
 }
@@ -389,7 +389,7 @@ EOT
 
 resource "aws_iam_instance_profile" "opsworks_instance" {
   name  = "%s_profile"
-  roles = ["${aws_iam_role.opsworks_instance.name}"]
+  role  = "${aws_iam_role.opsworks_instance.name}"
 }
 `, rName, rInt, rInt, rInt, rName)
 }
@@ -801,7 +801,7 @@ EOT
 
 resource "aws_iam_instance_profile" "opsworks_instance" {
   name  = "%s_opsworks_instance"
-  roles = ["${aws_iam_role.opsworks_instance.name}"]
+  role  = "${aws_iam_role.opsworks_instance.name}"
 }
 `, name, name, name, name, name)
 }
@@ -890,7 +890,7 @@ EOT
 
 resource "aws_iam_instance_profile" "opsworks_instance" {
   name  = "%s_opsworks_instance"
-  roles = ["${aws_iam_role.opsworks_instance.name}"]
+  role  = "${aws_iam_role.opsworks_instance.name}"
 }
 `, name, name, name, name, name)
 }
@@ -979,7 +979,7 @@ EOT
 
 resource "aws_iam_instance_profile" "opsworks_instance" {
   name  = "%s_opsworks_instance"
-  roles = ["${aws_iam_role.opsworks_instance.name}"]
+  role  = "${aws_iam_role.opsworks_instance.name}"
 }
 `, name, name, name, name, name)
 }
@@ -1111,7 +1111,7 @@ EOT
 
 resource "aws_iam_instance_profile" "opsworks_instance" {
   name  = "%s_opsworks_instance"
-  roles = ["${aws_iam_role.opsworks_instance.name}"]
+  role  = "${aws_iam_role.opsworks_instance.name}"
 }
 `, name, name, name, name, name, name, name)
 }
@@ -1219,7 +1219,7 @@ EOT
 
 resource "aws_iam_instance_profile" "opsworks_instance" {
   name  = "%s_opsworks_instance"
-  roles = ["${aws_iam_role.opsworks_instance.name}"]
+  role  = "${aws_iam_role.opsworks_instance.name}"
 }
 `, name, name, name, name, name)
 }
@@ -1331,7 +1331,7 @@ EOT
 
 resource "aws_iam_instance_profile" "opsworks_instance" {
   name  = "%s_opsworks_instance"
-  roles = ["${aws_iam_role.opsworks_instance.name}"]
+  role  = "${aws_iam_role.opsworks_instance.name}"
 }
 `, name, name, name, name, name)
 }
@@ -1450,7 +1450,7 @@ EOT
 
 resource "aws_iam_instance_profile" "opsworks_instance" {
   name  = "%s_opsworks_instance"
-  roles = ["${aws_iam_role.opsworks_instance.name}"]
+  role  = "${aws_iam_role.opsworks_instance.name}"
 }
 `, name, sshKey, name, name, name, name)
 }

--- a/aws/resource_aws_opsworks_static_web_layer.go
+++ b/aws/resource_aws_opsworks_static_web_layer.go
@@ -1,12 +1,13 @@
 package aws
 
 import (
+	"github.com/aws/aws-sdk-go/service/opsworks"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func resourceAwsOpsworksStaticWebLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
-		TypeName:         "web",
+		TypeName:         opsworks.LayerTypeWeb,
 		DefaultLayerName: "Static Web Server",
 
 		Attributes: map[string]*opsworksLayerTypeAttribute{},

--- a/aws/resource_aws_opsworks_static_web_layer_test.go
+++ b/aws/resource_aws_opsworks_static_web_layer_test.go
@@ -1,0 +1,142 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/opsworks"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+// These tests assume the existence of predefined Opsworks IAM roles named `aws-opsworks-ec2-role`
+// and `aws-opsworks-service-role`.
+
+func TestAccAWSOpsworksStaticWebLayer_basic(t *testing.T) {
+	var opslayer opsworks.Layer
+	stackName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_opsworks_static_web_layer.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsOpsworksStaticWebLayerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsOpsworksStaticWebLayerConfigVpcCreate(stackName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "name", stackName)),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSOpsworksStaticWebLayer_tags(t *testing.T) {
+	var opslayer opsworks.Layer
+	stackName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_opsworks_static_web_layer.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsOpsworksStaticWebLayerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsOpsworksStaticWebLayerConfigTags1(stackName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAwsOpsworksStaticWebLayerConfigTags2(stackName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAwsOpsworksStaticWebLayerConfigTags1(stackName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksLayerExists(resourceName, &opslayer),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsOpsworksStaticWebLayerDestroy(s *terraform.State) error {
+	return testAccCheckAwsOpsworksLayerDestroy("aws_opsworks_static_web_layer", s)
+}
+
+func testAccAwsOpsworksStaticWebLayerConfigVpcCreate(name string) string {
+	return testAccAwsOpsworksStackConfigVpcCreate(name) +
+		testAccAwsOpsworksCustomLayerSecurityGroups(name) +
+		fmt.Sprintf(`
+resource "aws_opsworks_static_web_layer" "test" {
+  stack_id = "${aws_opsworks_stack.tf-acc.id}"
+  name     = "%s"
+
+  custom_security_group_ids = [
+    "${aws_security_group.tf-ops-acc-layer1.id}",
+    "${aws_security_group.tf-ops-acc-layer2.id}",
+  ]
+}
+`, name)
+}
+
+func testAccAwsOpsworksStaticWebLayerConfigTags1(name, tagKey1, tagValue1 string) string {
+	return testAccAwsOpsworksStackConfigVpcCreate(name) +
+		testAccAwsOpsworksCustomLayerSecurityGroups(name) +
+		fmt.Sprintf(`
+resource "aws_opsworks_static_web_layer" "test" {
+  stack_id = "${aws_opsworks_stack.tf-acc.id}"
+  name     = "%s"
+
+  custom_security_group_ids = [
+    "${aws_security_group.tf-ops-acc-layer1.id}",
+    "${aws_security_group.tf-ops-acc-layer2.id}",
+  ]
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, name, tagKey1, tagValue1)
+}
+
+func testAccAwsOpsworksStaticWebLayerConfigTags2(name, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return testAccAwsOpsworksStackConfigVpcCreate(name) +
+		testAccAwsOpsworksCustomLayerSecurityGroups(name) +
+		fmt.Sprintf(`
+resource "aws_opsworks_static_web_layer" "test" {
+  stack_id = "${aws_opsworks_stack.tf-acc.id}"
+  name     = "%s"
+
+  custom_security_group_ids = [
+    "${aws_security_group.tf-ops-acc-layer1.id}",
+    "${aws_security_group.tf-ops-acc-layer2.id}",
+  ]
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, name, tagKey1, tagValue1, tagKey2, tagValue2)
+}

--- a/website/docs/r/opsworks_custom_layer.html.markdown
+++ b/website/docs/r/opsworks_custom_layer.html.markdown
@@ -67,6 +67,7 @@ An `ebs_volume` block supports the following arguments:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The id of the layer.
+* `arn` - The Amazon Resource Name(ARN) of the layer.
 
 ## Import
 

--- a/website/docs/r/opsworks_custom_layer.html.markdown
+++ b/website/docs/r/opsworks_custom_layer.html.markdown
@@ -40,6 +40,7 @@ The following arguments are supported:
 * `use_ebs_optimized_instances` - (Optional) Whether to use EBS-optimized instances.
 * `ebs_volume` - (Optional) `ebs_volume` blocks, as described below, will each create an EBS volume and connect it to the layer's instances.
 * `custom_json` - (Optional) Custom JSON attributes to apply to the layer.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 The following extra optional arguments, all lists of Chef recipe names, allow
 custom Chef recipes to be applied to layer instances at the five different

--- a/website/docs/r/opsworks_ganglia_layer.html.markdown
+++ b/website/docs/r/opsworks_ganglia_layer.html.markdown
@@ -41,6 +41,7 @@ The following arguments are supported:
 * `use_ebs_optimized_instances` - (Optional) Whether to use EBS-optimized instances.
 * `ebs_volume` - (Optional) `ebs_volume` blocks, as described below, will each create an EBS volume and connect it to the layer's instances.
 * `custom_json` - (Optional) Custom JSON attributes to apply to the layer.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 The following extra optional arguments, all lists of Chef recipe names, allow
 custom Chef recipes to be applied to layer instances at the five different
@@ -66,3 +67,4 @@ An `ebs_volume` block supports the following arguments:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The id of the layer.
+* `arn` - The Amazon Resource Name(ARN) of the layer.

--- a/website/docs/r/opsworks_haproxy_layer.html.markdown
+++ b/website/docs/r/opsworks_haproxy_layer.html.markdown
@@ -44,6 +44,7 @@ The following arguments are supported:
 * `use_ebs_optimized_instances` - (Optional) Whether to use EBS-optimized instances.
 * `ebs_volume` - (Optional) `ebs_volume` blocks, as described below, will each create an EBS volume and connect it to the layer's instances.
 * `custom_json` - (Optional) Custom JSON attributes to apply to the layer.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 The following extra optional arguments, all lists of Chef recipe names, allow
 custom Chef recipes to be applied to layer instances at the five different
@@ -69,3 +70,4 @@ An `ebs_volume` block supports the following arguments:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The id of the layer.
+* `arn` - The Amazon Resource Name(ARN) of the layer.

--- a/website/docs/r/opsworks_java_app_layer.html.markdown
+++ b/website/docs/r/opsworks_java_app_layer.html.markdown
@@ -42,6 +42,7 @@ The following arguments are supported:
 * `use_ebs_optimized_instances` - (Optional) Whether to use EBS-optimized instances.
 * `ebs_volume` - (Optional) `ebs_volume` blocks, as described below, will each create an EBS volume and connect it to the layer's instances.
 * `custom_json` - (Optional) Custom JSON attributes to apply to the layer.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 The following extra optional arguments, all lists of Chef recipe names, allow
 custom Chef recipes to be applied to layer instances at the five different
@@ -67,3 +68,4 @@ An `ebs_volume` block supports the following arguments:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The id of the layer.
+* `arn` - The Amazon Resource Name(ARN) of the layer.

--- a/website/docs/r/opsworks_memcached_layer.html.markdown
+++ b/website/docs/r/opsworks_memcached_layer.html.markdown
@@ -38,6 +38,7 @@ The following arguments are supported:
 * `use_ebs_optimized_instances` - (Optional) Whether to use EBS-optimized instances.
 * `ebs_volume` - (Optional) `ebs_volume` blocks, as described below, will each create an EBS volume and connect it to the layer's instances.
 * `custom_json` - (Optional) Custom JSON attributes to apply to the layer.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 The following extra optional arguments, all lists of Chef recipe names, allow
 custom Chef recipes to be applied to layer instances at the five different
@@ -63,3 +64,4 @@ An `ebs_volume` block supports the following arguments:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The id of the layer.
+* `arn` - The Amazon Resource Name(ARN) of the layer.

--- a/website/docs/r/opsworks_mysql_layer.html.markdown
+++ b/website/docs/r/opsworks_mysql_layer.html.markdown
@@ -42,6 +42,7 @@ The following arguments are supported:
 * `use_ebs_optimized_instances` - (Optional) Whether to use EBS-optimized instances.
 * `ebs_volume` - (Optional) `ebs_volume` blocks, as described below, will each create an EBS volume and connect it to the layer's instances.
 * `custom_json` - (Optional) Custom JSON attributes to apply to the layer.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 The following extra optional arguments, all lists of Chef recipe names, allow
 custom Chef recipes to be applied to layer instances at the five different
@@ -67,3 +68,4 @@ An `ebs_volume` block supports the following arguments:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The id of the layer.
+* `arn` - The Amazon Resource Name(ARN) of the layer.

--- a/website/docs/r/opsworks_nodejs_app_layer.html.markdown
+++ b/website/docs/r/opsworks_nodejs_app_layer.html.markdown
@@ -38,6 +38,7 @@ The following arguments are supported:
 * `use_ebs_optimized_instances` - (Optional) Whether to use EBS-optimized instances.
 * `ebs_volume` - (Optional) `ebs_volume` blocks, as described below, will each create an EBS volume and connect it to the layer's instances.
 * `custom_json` - (Optional) Custom JSON attributes to apply to the layer.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 The following extra optional arguments, all lists of Chef recipe names, allow
 custom Chef recipes to be applied to layer instances at the five different
@@ -63,3 +64,4 @@ An `ebs_volume` block supports the following arguments:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The id of the layer.
+* `arn` - The Amazon Resource Name(ARN) of the layer.

--- a/website/docs/r/opsworks_php_app_layer.html.markdown
+++ b/website/docs/r/opsworks_php_app_layer.html.markdown
@@ -37,6 +37,7 @@ The following arguments are supported:
 * `use_ebs_optimized_instances` - (Optional) Whether to use EBS-optimized instances.
 * `ebs_volume` - (Optional) `ebs_volume` blocks, as described below, will each create an EBS volume and connect it to the layer's instances.
 * `custom_json` - (Optional) Custom JSON attributes to apply to the layer.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 The following extra optional arguments, all lists of Chef recipe names, allow
 custom Chef recipes to be applied to layer instances at the five different
@@ -62,3 +63,12 @@ An `ebs_volume` block supports the following arguments:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The id of the layer.
+* `arn` - The Amazon Resource Name(ARN) of the layer.
+
+## Import
+
+OpsWorks PHP Application Layers can be imported using the `id`, e.g.
+
+```
+$ terraform import aws_opsworks_php_app_layer.bar 00000000-0000-0000-0000-000000000000
+```

--- a/website/docs/r/opsworks_rails_app_layer.html.markdown
+++ b/website/docs/r/opsworks_rails_app_layer.html.markdown
@@ -43,6 +43,7 @@ The following arguments are supported:
 * `use_ebs_optimized_instances` - (Optional) Whether to use EBS-optimized instances.
 * `ebs_volume` - (Optional) `ebs_volume` blocks, as described below, will each create an EBS volume and connect it to the layer's instances.
 * `custom_json` - (Optional) Custom JSON attributes to apply to the layer.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 The following extra optional arguments, all lists of Chef recipe names, allow
 custom Chef recipes to be applied to layer instances at the five different
@@ -68,3 +69,4 @@ An `ebs_volume` block supports the following arguments:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The id of the layer.
+* `arn` - The Amazon Resource Name(ARN) of the layer.

--- a/website/docs/r/opsworks_static_web_layer.html.markdown
+++ b/website/docs/r/opsworks_static_web_layer.html.markdown
@@ -36,6 +36,7 @@ The following arguments are supported:
 * `system_packages` - (Optional) Names of a set of system packages to install on the layer's instances.
 * `use_ebs_optimized_instances` - (Optional) Whether to use EBS-optimized instances.
 * `ebs_volume` - (Optional) `ebs_volume` blocks, as described below, will each create an EBS volume and connect it to the layer's instances.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 The following extra optional arguments, all lists of Chef recipe names, allow
 custom Chef recipes to be applied to layer instances at the five different
@@ -61,3 +62,12 @@ An `ebs_volume` block supports the following arguments:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The id of the layer.
+* `arn` - The Amazon Resource Name(ARN) of the layer.
+
+## Import
+
+OpsWorks static web server Layers can be imported using the `id`, e.g.
+
+```
+$ terraform import aws_opsworks_static_web_layer.bar 00000000-0000-0000-0000-000000000000
+```


### PR DESCRIPTION
Unfortunately all layers resource are coupled so i cant break this apart

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #3546 and Relates #10688 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
aws_resource_opsworks_custom_layer: add `tags` argument and `arn` attribute + plan time validation to `custom_instance_profile_arn` argument.

aws_resource_opsworks_rails_app_layer: add `tags` argument and `arn` attribute + plan time validation to `custom_instance_profile_arn` argument.

aws_resource_opsworks_ganglia_layer: add `tags` argument and `arn` attribute + plan time validation to `custom_instance_profile_arn` argument.

aws_resource_opsworks_haproxy_layer: add `tags` argument and `arn` attribute + plan time validation to `custom_instance_profile_arn` argument.

aws_resource_opsworks_php_app_layer: add `tags` argument and `arn` attribute + plan time validation to `custom_instance_profile_arn` argument.

aws_resource_opsworks_static_web_layer: add `tags` argument and `arn` attribute + plan time validation to `custom_instance_profile_arn` argument.

aws_resource_opsworks_java_app_layer: add `tags` argument and `arn` attribute + plan time validation to `custom_instance_profile_arn` argument.

aws_resource_opsworks_memcached_layer: add `tags` argument and `arn` attribute + plan time validation to `custom_instance_profile_arn` argument.

aws_resource_opsworks_noejs_app_layer: add `tags` argument and `arn` attribute + plan time validation to `custom_instance_profile_arn` argument.

aws_resource_opsworks_mysql_layer: add `tags` argument and `arn` attribute + plan time validation to `custom_instance_profile_arn` argument.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
--- PASS: TestAccAWSOpsworksCustomLayer_basic (98.36s)
--- PASS: TestAccAWSOpsworksCustomLayer_tags (205.81s)
--- PASS: TestAccAWSOpsworksCustomLayer_noVPC (91.78s)

--- PASS: TestAccAWSOpsworksRailsAppLayer_basic (141.03s)
--- PASS: TestAccAWSOpsworksRailsAppLayer_tags (198.98s)

--- PASS: TestAccAWSOpsworksGangliaLayer_basic (148.00s)
--- PASS: TestAccAWSOpsworksGangliaLayer_tags (296.36s)

--- PASS: TestAccAWSOpsworksHAProxyLayer_basic (99.43s)
--- PASS: TestAccAWSOpsworksHAProxyLayer_tags (212.06s)

--- PASS: TestAccAWSOpsworksPhpAppLayer_basic (118.05s)
--- PASS: TestAccAWSOpsworksPhpAppLayer_tags (232.10s)

--- PASS: TestAccAWSOpsworksStaticWebLayer_basic (97.15s)
--- PASS: TestAccAWSOpsworksStaticWebLayer_tags (215.67s)

--- PASS: TestAccAWSOpsworksJavaAppLayer_basic (91.78s)
--- PASS: TestAccAWSOpsworksJavaAppLayer_tags (206.72s)

--- PASS: TestAccAWSOpsworksMysqlLayer_basic (100.69s)
--- PASS: TestAccAWSOpsworksMysqlLayer_tags (217.03s)

--- PASS: TestAccAWSOpsworksNodejsAppLayer_basic (102.87s)
--- PASS: TestAccAWSOpsworksNodejsAppLayer_tags (212.98s)

--- PASS: TestAccAWSOpsworksMemcachedLayer_basic (98.90s)
--- PASS: TestAccAWSOpsworksMemcachedLayer_tags (232.82s)
```
