### PR TITLE
Add dns_name, hosted_zone_id attributes to Global Accelerator for Route53 ALIASes

### DIFF
--- a/aws/resource_aws_globalaccelerator_accelerator.go
+++ b/aws/resource_aws_globalaccelerator_accelerator.go
@@ -13,6 +13,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
+// Global Route53 Zone ID for Global Accelerators, exported as a
+// convenience attribute for Route53 aliases.
+const globalAcceleratorRoute53ZoneID = "Z2BJ6XQ5FK7U4H"
+
 func resourceAwsGlobalAcceleratorAccelerator() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsGlobalAcceleratorAcceleratorCreate,
@@ -41,6 +45,14 @@ func resourceAwsGlobalAcceleratorAccelerator() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
+			},
+			"dns_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"hosted_zone_id": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"ip_sets": {
 				Type:     schema.TypeList,
@@ -146,6 +158,8 @@ func resourceAwsGlobalAcceleratorAcceleratorRead(d *schema.ResourceData, meta in
 	d.Set("name", accelerator.Name)
 	d.Set("ip_address_type", accelerator.IpAddressType)
 	d.Set("enabled", accelerator.Enabled)
+	d.Set("dns_name", accelerator.DnsName)
+	d.Set("hosted_zone_id", globalAcceleratorRoute53ZoneID)
 	if err := d.Set("ip_sets", resourceAwsGlobalAcceleratorAcceleratorFlattenIpSets(accelerator.IpSets)); err != nil {
 		return fmt.Errorf("Error setting Global Accelerator accelerator ip_sets: %s", err)
 	}

--- a/aws/resource_aws_globalaccelerator_accelerator.go
+++ b/aws/resource_aws_globalaccelerator_accelerator.go
@@ -14,7 +14,8 @@ import (
 )
 
 // Global Route53 Zone ID for Global Accelerators, exported as a
-// convenience attribute for Route53 aliases.
+// convenience attribute for Route53 aliases (see 
+// https://docs.aws.amazon.com/Route53/latest/APIReference/API_AliasTarget.html).
 const globalAcceleratorRoute53ZoneID = "Z2BJ6XQ5FK7U4H"
 
 func resourceAwsGlobalAcceleratorAccelerator() *schema.Resource {

--- a/aws/resource_aws_globalaccelerator_accelerator_test.go
+++ b/aws/resource_aws_globalaccelerator_accelerator_test.go
@@ -174,6 +174,7 @@ func TestAccAwsGlobalAcceleratorAccelerator_basic(t *testing.T) {
 	resourceName := "aws_globalaccelerator_accelerator.example"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	ipRegex := regexp.MustCompile(`\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}`)
+	dnsNameRegex := regexp.MustCompile(`^a[a-f0-9]{16}\.awsglobalaccelerator\.com$`)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -191,6 +192,8 @@ func TestAccAwsGlobalAcceleratorAccelerator_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "attributes.0.flow_logs_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "attributes.0.flow_logs_s3_bucket", ""),
 					resource.TestCheckResourceAttr(resourceName, "attributes.0.flow_logs_s3_prefix", ""),
+					resource.TestMatchResourceAttr(resourceName, "dns_name", dnsNameRegex),
+					resource.TestCheckResourceAttr(resourceName, "hosted_zone_id", "Z2BJ6XQ5FK7U4H"),
 					resource.TestCheckResourceAttr(resourceName, "ip_sets.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "ip_sets.0.ip_addresses.#", "2"),
 					resource.TestMatchResourceAttr(resourceName, "ip_sets.0.ip_addresses.0", ipRegex),

--- a/website/docs/r/globalaccelerator_accelerator.markdown
+++ b/website/docs/r/globalaccelerator_accelerator.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Resource: aws_globalaccelerator_accelerator
 
-Provides a Global Accelerator accelerator.
+Creates a Global Accelerator accelerator.
 
 ## Example Usage
 
@@ -46,12 +46,18 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The Amazon Resource Name (ARN) of the accelerator.
+* `dns_name` - The DNS name of the accelerator. For example, `a5d53ff5ee6bca4ce.awsglobalaccelerator.com`.
+* `hosted_zone_id` --  The Global Accelerator Route 53 zone ID that can be used to
+  route an [Alias Resource Record Set][1] to the Global Accelerator. This attribute
+  is simply an alias for the zone ID `Z2BJ6XQ5FK7U4H`.
 * `ip_sets` - IP address set associated with the accelerator.
 
 **ip_sets** exports the following attributes:
 
-* `ip_addresses` - The array of IP addresses in the IP address set.
+* `ip_addresses` - A list of IP addresses in the IP address set.
 * `ip_family` - The types of IP addresses included in this IP set.
+
+[1]: http://docs.aws.amazon.com/Route53/latest/APIReference/CreateAliasRRSAPI.html
 
 ## Import
 

--- a/website/docs/r/globalaccelerator_accelerator.markdown
+++ b/website/docs/r/globalaccelerator_accelerator.markdown
@@ -57,7 +57,7 @@ In addition to all arguments above, the following attributes are exported:
 * `ip_addresses` - A list of IP addresses in the IP address set.
 * `ip_family` - The types of IP addresses included in this IP set.
 
-[1]: http://docs.aws.amazon.com/Route53/latest/APIReference/CreateAliasRRSAPI.html
+[1]: https://docs.aws.amazon.com/Route53/latest/APIReference/API_AliasTarget.html
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11579

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
ENHANCEMENTS
* resource/aws_globalaccelerator_accelerator: Add `dns_name` and `hosted_zone_id` attributes [GH-11579]
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=GlobalAcceleratorAccelerator'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=GlobalAcceleratorAccelerator -timeout 120m
=== RUN   TestAccAwsGlobalAcceleratorAccelerator_basic
=== PAUSE TestAccAwsGlobalAcceleratorAccelerator_basic
=== RUN   TestAccAwsGlobalAcceleratorAccelerator_update
=== PAUSE TestAccAwsGlobalAcceleratorAccelerator_update
=== RUN   TestAccAwsGlobalAcceleratorAccelerator_attributes
=== PAUSE TestAccAwsGlobalAcceleratorAccelerator_attributes
=== CONT  TestAccAwsGlobalAcceleratorAccelerator_basic
=== CONT  TestAccAwsGlobalAcceleratorAccelerator_update
=== CONT  TestAccAwsGlobalAcceleratorAccelerator_attributes
--- PASS: TestAccAwsGlobalAcceleratorAccelerator_basic (82.84s)
--- PASS: TestAccAwsGlobalAcceleratorAccelerator_attributes (86.71s)
--- PASS: TestAccAwsGlobalAcceleratorAccelerator_update (116.89s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	117.005
```
