### PR TITLE
Fix placement group create delete

### DIFF
--- a/aws/resource_aws_placement_group.go
+++ b/aws/resource_aws_placement_group.go
@@ -190,6 +190,9 @@ func resourceAwsPlacementGroupDelete(d *schema.ResourceData, meta interface{}) e
 			}
 
 			pg := out.PlacementGroups[0]
+			if *pg.State == "available" {
+				log.Printf("[DEBUG] Accepted status when deleting EC2 Placement group: %q %v", d.Id(), *pg.State)
+			}
 
 			return out, *pg.State, nil
 		},

--- a/aws/resource_aws_placement_group.go
+++ b/aws/resource_aws_placement_group.go
@@ -168,7 +168,7 @@ func resourceAwsPlacementGroupDelete(d *schema.ResourceData, meta interface{}) e
 	}
 
 	wait := resource.StateChangeConf{
-		Pending:    []string{ec2.PlacementGroupStateDeleting},
+		Pending:    []string{ec2.PlacementGroupStateAvailable, ec2.PlacementGroupStateDeleting},
 		Target:     []string{ec2.PlacementGroupStateDeleted},
 		Timeout:    5 * time.Minute,
 		MinTimeout: 1 * time.Second,

--- a/aws/resource_aws_placement_group.go
+++ b/aws/resource_aws_placement_group.go
@@ -76,9 +76,7 @@ func resourceAwsPlacementGroupCreate(d *schema.ResourceData, meta interface{}) e
 			if err != nil {
 				// Fix timing issue where describe is called prior to
 				// create being effectively processed by AWS
-				awsErr := err.(awserr.Error)
-				if awsErr.Code() == "InvalidPlacementGroup.Unknown" {
-					log.Printf("[DEBUG] Resetting error creating EC2 Placement group: %q %v", d.Id(), awsErr)
+				if isAWSErr(err, "InvalidPlacementGroup.Unknown", "") {
 					return out, "pending", nil
 				}
 				return out, "", err


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9915 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* aws_placement_group.monitor_spread_placement_group: InvalidPlacementGroup.Unknown: The Placement Groups 'XXX' is unknown.
* aws_placement_group.monitor_spread_placement_group: unexpected state 'available', wanted target 'deleted'. last error: %!s(<nil>)
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ AWS_DEFAULT_REGION=eu-west-1 AWS_PROFILE=scratch gmake testacc TEST=./aws TESTARGS='-run=TestAccAWSPlacementGroup'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSPlacementGroup -timeout 120m
=== RUN   TestAccAWSPlacementGroup_basic
=== PAUSE TestAccAWSPlacementGroup_basic
=== RUN   TestAccAWSPlacementGroup_tags
=== PAUSE TestAccAWSPlacementGroup_tags
=== RUN   TestAccAWSPlacementGroup_disappears
=== PAUSE TestAccAWSPlacementGroup_disappears
=== CONT  TestAccAWSPlacementGroup_basic
=== CONT  TestAccAWSPlacementGroup_tags
=== CONT  TestAccAWSPlacementGroup_disappears
--- PASS: TestAccAWSPlacementGroup_disappears (16.32s)
--- PASS: TestAccAWSPlacementGroup_basic (20.93s)
--- PASS: TestAccAWSPlacementGroup_tags (49.45s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	49.562s
$
```
