### PR TITLE
r/cloudtrail - add support for exclude_management_event_sources to event_selector

### DIFF
--- a/aws/resource_aws_cloudtrail.go
+++ b/aws/resource_aws_cloudtrail.go
@@ -384,7 +384,7 @@ func resourceAwsCloudTrailUpdate(d *schema.ResourceData, meta interface{}) error
 		o, n := d.GetChange("tags")
 
 		if err := keyvaluetags.CloudtrailUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
-			return fmt.Errorf("error updating ECR Repository (%s) tags: %s", d.Get("arn").(string), err)
+			return fmt.Errorf("error updating Cloudtrail (%s) tags: %s", d.Get("arn").(string), err)
 		}
 	}
 

--- a/aws/resource_aws_cloudtrail.go
+++ b/aws/resource_aws_cloudtrail.go
@@ -366,7 +366,7 @@ func resourceAwsCloudTrailUpdate(d *schema.ResourceData, meta interface{}) error
 			if isAWSErr(err, cloudtrail.ErrCodeInvalidCloudWatchLogsRoleArnException, "Access denied.") {
 				return resource.RetryableError(err)
 			}
-			if isAWSErr(err, cloudtrail.ErrCodeInvalidCloudWatchLogsLogGroupArnException, "Access denied.") {
+			if isAWSErr(err, cloudtrail.ErrCodeInvalidCloudWatchLogsLogGroupArnException, "") {
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)

--- a/aws/resource_aws_cloudtrail_test.go
+++ b/aws/resource_aws_cloudtrail_test.go
@@ -3,9 +3,8 @@ package aws
 import (
 	"fmt"
 	"log"
-	"testing"
-
 	"regexp"
+	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudtrail"
@@ -124,7 +123,7 @@ func TestAccAWSCloudTrail_serial(t *testing.T) {
 
 func testAccAWSCloudTrail_basic(t *testing.T) {
 	var trail cloudtrail.Trail
-	cloudTrailRandInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
@@ -133,7 +132,7 @@ func testAccAWSCloudTrail_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudTrailConfig(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "include_global_service_events", "true"),
@@ -148,7 +147,7 @@ func testAccAWSCloudTrail_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCloudTrailConfigModified(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailConfigModified(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "s3_key_prefix", "prefix"),
@@ -163,7 +162,7 @@ func testAccAWSCloudTrail_basic(t *testing.T) {
 
 func testAccAWSCloudTrail_cloudwatch(t *testing.T) {
 	var trail cloudtrail.Trail
-	randInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test-cw")
 	resourceName := "aws_cloudtrail.test"
 	cwResourceName := "aws_cloudwatch_log_group.test"
 	roleResourceName := "aws_iam_role.test"
@@ -174,7 +173,7 @@ func testAccAWSCloudTrail_cloudwatch(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudTrailConfigCloudWatch(randInt),
+				Config: testAccAWSCloudTrailConfigCloudWatch(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttrPair(resourceName, "cloud_watch_logs_group_arn", cwResourceName, "arn"),
@@ -187,7 +186,7 @@ func testAccAWSCloudTrail_cloudwatch(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCloudTrailConfigCloudWatchModified(randInt),
+				Config: testAccAWSCloudTrailConfigCloudWatchModified(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttrPair(resourceName, "cloud_watch_logs_group_arn", cwResourceName, "arn"),
@@ -200,7 +199,7 @@ func testAccAWSCloudTrail_cloudwatch(t *testing.T) {
 
 func testAccAWSCloudTrail_enable_logging(t *testing.T) {
 	var trail cloudtrail.Trail
-	cloudTrailRandInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test-log")
 	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
@@ -209,7 +208,7 @@ func testAccAWSCloudTrail_enable_logging(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudTrailConfig(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					// AWS will create the trail with logging turned off.
@@ -225,7 +224,7 @@ func testAccAWSCloudTrail_enable_logging(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCloudTrailConfigModified(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailConfigModified(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					testAccCheckCloudTrailLoggingEnabled(resourceName, false),
@@ -234,7 +233,7 @@ func testAccAWSCloudTrail_enable_logging(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSCloudTrailConfig(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					testAccCheckCloudTrailLoggingEnabled(resourceName, true),
@@ -248,7 +247,7 @@ func testAccAWSCloudTrail_enable_logging(t *testing.T) {
 
 func testAccAWSCloudTrail_is_multi_region(t *testing.T) {
 	var trail cloudtrail.Trail
-	cloudTrailRandInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test-multi")
 	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
@@ -257,7 +256,7 @@ func testAccAWSCloudTrail_is_multi_region(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudTrailConfig(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "is_multi_region_trail", "false"),
@@ -266,7 +265,7 @@ func testAccAWSCloudTrail_is_multi_region(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSCloudTrailConfigMultiRegion(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailConfigMultiRegion(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "is_multi_region_trail", "true"),
@@ -280,7 +279,7 @@ func testAccAWSCloudTrail_is_multi_region(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCloudTrailConfig(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "is_multi_region_trail", "false"),
@@ -294,7 +293,7 @@ func testAccAWSCloudTrail_is_multi_region(t *testing.T) {
 
 func testAccAWSCloudTrail_is_organization(t *testing.T) {
 	var trail cloudtrail.Trail
-	cloudTrailRandInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test-org")
 	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
@@ -303,7 +302,7 @@ func testAccAWSCloudTrail_is_organization(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudTrailConfigOrganization(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailConfigOrganization(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "is_organization_trail", "true"),
@@ -317,7 +316,7 @@ func testAccAWSCloudTrail_is_organization(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCloudTrailConfig(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "is_organization_trail", "false"),
@@ -331,7 +330,7 @@ func testAccAWSCloudTrail_is_organization(t *testing.T) {
 
 func testAccAWSCloudTrail_logValidation(t *testing.T) {
 	var trail cloudtrail.Trail
-	cloudTrailRandInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test-log-val")
 	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
@@ -340,7 +339,7 @@ func testAccAWSCloudTrail_logValidation(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudTrailConfig_logValidation(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailConfig_logValidation(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "s3_key_prefix", ""),
@@ -355,7 +354,7 @@ func testAccAWSCloudTrail_logValidation(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCloudTrailConfig_logValidationModified(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailConfig_logValidationModified(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "s3_key_prefix", ""),
@@ -370,7 +369,7 @@ func testAccAWSCloudTrail_logValidation(t *testing.T) {
 
 func testAccAWSCloudTrail_kmsKey(t *testing.T) {
 	var trail cloudtrail.Trail
-	cloudTrailRandInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test-kms")
 	resourceName := "aws_cloudtrail.test"
 	kmsResourceName := "aws_kms_key.foo"
 
@@ -380,7 +379,7 @@ func testAccAWSCloudTrail_kmsKey(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudTrailConfig_kmsKey(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailConfig_kmsKey(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "s3_key_prefix", ""),
@@ -456,7 +455,7 @@ func testAccAWSCloudTrail_tags(t *testing.T) {
 
 func testAccAWSCloudTrail_include_global_service_events(t *testing.T) {
 	var trail cloudtrail.Trail
-	cloudTrailRandInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test-events")
 	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
@@ -465,7 +464,7 @@ func testAccAWSCloudTrail_include_global_service_events(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudTrailConfig_include_global_service_events(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailConfig_include_global_service_events(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "include_global_service_events", "false"),
@@ -481,7 +480,7 @@ func testAccAWSCloudTrail_include_global_service_events(t *testing.T) {
 }
 
 func testAccAWSCloudTrail_event_selector(t *testing.T) {
-	cloudTrailRandInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test-event")
 	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
@@ -490,16 +489,14 @@ func testAccAWSCloudTrail_event_selector(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudTrailConfig_eventSelector(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailConfig_eventSelector(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "event_selector.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.data_resource.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.data_resource.0.type", "AWS::S3::Object"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.data_resource.0.values.#", "2"),
-					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.0.data_resource.0.values.0", "s3", "foobar"),
-					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.0.data_resource.0.values.1", "s3", "baz"),
-					//resource.TestMatchResourceAttr(resourceName, "event_selector.0.data_resource.0.values.0", regexp.MustCompile(`^arn:[^:]+:s3:::.+/foobar$`)),
-					//resource.TestMatchResourceAttr(resourceName, "event_selector.0.data_resource.0.values.1", regexp.MustCompile(`^arn:[^:]+:s3:::.+/baz$`)),
+					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.0.data_resource.0.values.0", "s3", fmt.Sprintf("%s/foobar", rName)),
+					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.0.data_resource.0.values.1", "s3", fmt.Sprintf("%s/baz", rName)),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.include_management_events", "false"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.read_write_type", "ReadOnly"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.exclude_management_event_sources.#", "0"),
@@ -519,25 +516,21 @@ func testAccAWSCloudTrail_event_selector(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSCloudTrailConfig_eventSelectorModified(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailConfig_eventSelectorModified(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "event_selector.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.data_resource.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.data_resource.0.type", "AWS::S3::Object"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.data_resource.0.values.#", "2"),
-					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.0.data_resource.0.values.0", "s3", "foobar"),
-					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.0.data_resource.0.values.1", "s3", "baz"),
-					//resource.TestMatchResourceAttr(resourceName, "event_selector.0.data_resource.0.values.0", regexp.MustCompile(`^arn:[^:]+:s3:::.+/foobar$`)),
-					//resource.TestMatchResourceAttr(resourceName, "event_selector.0.data_resource.0.values.1", regexp.MustCompile(`^arn:[^:]+:s3:::.+/baz$`)),
+					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.0.data_resource.0.values.0", "s3", fmt.Sprintf("%s/foobar", rName)),
+					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.0.data_resource.0.values.1", "s3", fmt.Sprintf("%s/baz", rName)),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.include_management_events", "true"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.read_write_type", "ReadOnly"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.1.data_resource.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.1.data_resource.0.type", "AWS::S3::Object"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.1.data_resource.0.values.#", "2"),
-					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.0.data_resource.0.values.0", "s3", "tf1"),
-					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.0.data_resource.0.values.1", "s3", "tf2"),
-					//resource.TestMatchResourceAttr(resourceName, "event_selector.1.data_resource.0.values.0", regexp.MustCompile(`^arn:[^:]+:s3:::.+/tf1$`)),
-					//resource.TestMatchResourceAttr(resourceName, "event_selector.1.data_resource.0.values.1", regexp.MustCompile(`^arn:[^:]+:s3:::.+/tf2$`)),
+					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.1.data_resource.0.values.0", "s3", fmt.Sprintf("%s/tf1", rName)),
+					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.1.data_resource.0.values.1", "s3", fmt.Sprintf("%s/tf2", rName)),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.1.data_resource.1.type", "AWS::Lambda::Function"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.1.data_resource.1.values.#", "1"),
 					testAccMatchResourceAttrRegionalARN(resourceName, "event_selector.1.data_resource.1.values.0", "lambda", regexp.MustCompile(`tf-test-trail-event-select-\d+$`)),
@@ -551,7 +544,7 @@ func testAccAWSCloudTrail_event_selector(t *testing.T) {
 }
 
 func testAccAWSCloudTrail_event_selector_exclude(t *testing.T) {
-	cloudTrailRandInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test-exclude")
 	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
@@ -560,16 +553,14 @@ func testAccAWSCloudTrail_event_selector_exclude(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudTrailConfig_eventSelectorExclude(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailConfig_eventSelectorExclude(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "event_selector.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.data_resource.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.data_resource.0.type", "AWS::S3::Object"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.data_resource.0.values.#", "2"),
-					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.0.data_resource.0.values.0", "s3", "foobar"),
-					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.0.data_resource.0.values.1", "s3", "baz"),
-					//resource.TestMatchResourceAttr(resourceName, "event_selector.0.data_resource.0.values.0", regexp.MustCompile(`^arn:[^:]+:s3:::.+/foobar$`)),
-					//resource.TestMatchResourceAttr(resourceName, "event_selector.0.data_resource.0.values.1", regexp.MustCompile(`^arn:[^:]+:s3:::.+/baz$`)),
+					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.0.data_resource.0.values.0", "s3", fmt.Sprintf("%s/foobar", rName)),
+					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.0.data_resource.0.values.1", "s3", fmt.Sprintf("%s/baz", rName)),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.include_management_events", "true"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.read_write_type", "ReadOnly"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.exclude_management_event_sources.#", "1"),
@@ -587,7 +578,7 @@ func testAccAWSCloudTrail_event_selector_exclude(t *testing.T) {
 
 func testAccAWSCloudTrail_disappears(t *testing.T) {
 	var trail cloudtrail.Trail
-	cloudTrailRandInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test-disappears")
 	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
@@ -596,7 +587,7 @@ func testAccAWSCloudTrail_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudTrailConfig(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					testAccCheckCloudTrailDisappears(&trail),
@@ -747,15 +738,10 @@ func testAccCheckCloudTrailLoadTags(trail *cloudtrail.Trail, tags *[]*cloudtrail
 	}
 }
 
-func testAccAWSCloudTrailConfig(cloudTrailRandInt int) string {
+func testAccAWSCloudTrailConfigS3Base(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_cloudtrail" "test" {
-  name           = "tf-trail-test-%d"
-  s3_bucket_name = "${aws_s3_bucket.foo.id}"
-}
-
-resource "aws_s3_bucket" "foo" {
-  bucket        = "tf-test-trail-%d"
+resource "aws_s3_bucket" "test" {
+  bucket        = "%[1]stest"
   force_destroy = true
 
   policy = <<POLICY
@@ -767,14 +753,14 @@ resource "aws_s3_bucket" "foo" {
 			"Effect": "Allow",
 			"Principal": "*",
 			"Action": "s3:GetBucketAcl",
-			"Resource": "arn:aws:s3:::tf-test-trail-%d"
+			"Resource": "arn:aws:s3:::%[1]s"
 		},
 		{
 			"Sid": "AWSCloudTrailWrite",
 			"Effect": "Allow",
 			"Principal": "*",
 			"Action": "s3:PutObject",
-			"Resource": "arn:aws:s3:::tf-test-trail-%d/*",
+			"Resource": "arn:aws:s3:::%[1]s/*",
 			"Condition": {
 				"StringEquals": {
 					"s3:x-amz-acl": "bucket-owner-full-control"
@@ -785,101 +771,46 @@ resource "aws_s3_bucket" "foo" {
 }
 POLICY
 }
-`, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
+`, rName)
 }
 
-func testAccAWSCloudTrailConfigModified(cloudTrailRandInt int) string {
-	return fmt.Sprintf(`
+func testAccAWSCloudTrailConfig(rName string) string {
+	return testAccAWSCloudTrailConfigS3Base(rName) + fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
-  name                          = "tf-trail-test-%d"
-  s3_bucket_name                = "${aws_s3_bucket.foo.id}"
+  name           = %[1]q
+  s3_bucket_name = "${aws_s3_bucket.test.id}"
+}
+`, rName)
+}
+
+func testAccAWSCloudTrailConfigModified(rName string) string {
+	return testAccAWSCloudTrailConfigS3Base(rName) + fmt.Sprintf(`
+resource "aws_cloudtrail" "test" {
+  name                          = %[1]q
+  s3_bucket_name                = "${aws_s3_bucket.test.id}"
   s3_key_prefix                 = "prefix"
   include_global_service_events = false
   enable_logging                = false
 }
-
-resource "aws_s3_bucket" "foo" {
-  bucket        = "tf-test-trail-%d"
-  force_destroy = true
-
-  policy = <<POLICY
-{
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-			"Sid": "AWSCloudTrailAclCheck",
-			"Effect": "Allow",
-			"Principal": "*",
-			"Action": "s3:GetBucketAcl",
-			"Resource": "arn:aws:s3:::tf-test-trail-%d"
-		},
-		{
-			"Sid": "AWSCloudTrailWrite",
-			"Effect": "Allow",
-			"Principal": "*",
-			"Action": "s3:PutObject",
-			"Resource": "arn:aws:s3:::tf-test-trail-%d/*",
-			"Condition": {
-				"StringEquals": {
-					"s3:x-amz-acl": "bucket-owner-full-control"
-				}
-			}
-		}
-	]
-}
-POLICY
-}
-`, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
+`, rName)
 }
 
-func testAccAWSCloudTrailConfigCloudWatch(randInt int) string {
-	return fmt.Sprintf(`
+func testAccAWSCloudTrailConfigCloudWatch(rName string) string {
+	return testAccAWSCloudTrailConfigS3Base(rName) + fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
-  name           = "tf-acc-test-%d"
+  name           = %[1]q
   s3_bucket_name = "${aws_s3_bucket.test.id}"
 
   cloud_watch_logs_group_arn = "${aws_cloudwatch_log_group.test.arn}"
   cloud_watch_logs_role_arn  = "${aws_iam_role.test.arn}"
 }
 
-resource "aws_s3_bucket" "test" {
-  bucket        = "tf-test-trail-%d"
-  force_destroy = true
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AWSCloudTrailAclCheck",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:GetBucketAcl",
-      "Resource": "arn:aws:s3:::tf-test-trail-%d"
-    },
-    {
-      "Sid": "AWSCloudTrailWrite",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:PutObject",
-      "Resource": "arn:aws:s3:::tf-test-trail-%d/*",
-      "Condition": {
-        "StringEquals": {
-          "s3:x-amz-acl": "bucket-owner-full-control"
-        }
-      }
-    }
-  ]
-}
-POLICY
-}
-
 resource "aws_cloudwatch_log_group" "test" {
-  name = "tf-acc-test-cloudtrail-%d"
+  name = %[1]q
 }
 
 resource "aws_iam_role" "test" {
-  name = "tf-acc-test-cloudtrail-%d"
+  name = %[1]q
 
   assume_role_policy = <<POLICY
 {
@@ -899,7 +830,7 @@ POLICY
 }
 
 resource "aws_iam_role_policy" "test" {
-  name = "tf-acc-test-cloudtrail-%d"
+  name = %[1]q
   role = "${aws_iam_role.test.id}"
 
   policy = <<POLICY
@@ -919,61 +850,30 @@ resource "aws_iam_role_policy" "test" {
 }
 POLICY
 }
-`, randInt, randInt, randInt, randInt, randInt, randInt, randInt)
+`, rName)
 }
 
-func testAccAWSCloudTrailConfigCloudWatchModified(randInt int) string {
-	return fmt.Sprintf(`
+func testAccAWSCloudTrailConfigCloudWatchModified(rName string) string {
+	return testAccAWSCloudTrailConfigS3Base(rName) + fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
-  name           = "tf-acc-test-%d"
+  name           = %[1]q
   s3_bucket_name = "${aws_s3_bucket.test.id}"
 
   cloud_watch_logs_group_arn = "${aws_cloudwatch_log_group.second.arn}"
   cloud_watch_logs_role_arn  = "${aws_iam_role.test.arn}"
 }
 
-resource "aws_s3_bucket" "test" {
-  bucket        = "tf-test-trail-%d"
-  force_destroy = true
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AWSCloudTrailAclCheck",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:GetBucketAcl",
-      "Resource": "arn:aws:s3:::tf-test-trail-%d"
-    },
-    {
-      "Sid": "AWSCloudTrailWrite",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:PutObject",
-      "Resource": "arn:aws:s3:::tf-test-trail-%d/*",
-      "Condition": {
-        "StringEquals": {
-          "s3:x-amz-acl": "bucket-owner-full-control"
-        }
-      }
-    }
-  ]
-}
-POLICY
-}
 
 resource "aws_cloudwatch_log_group" "test" {
-  name = "tf-acc-test-cloudtrail-%d"
+  name = %[1]q
 }
 
 resource "aws_cloudwatch_log_group" "second" {
-  name = "tf-acc-test-cloudtrail-second-%d"
+  name = "%[1]s-2"
 }
 
 resource "aws_iam_role" "test" {
-  name = "tf-acc-test-cloudtrail-%d"
+  name = %[1]q
 
   assume_role_policy = <<POLICY
 {
@@ -993,7 +893,7 @@ POLICY
 }
 
 resource "aws_iam_role_policy" "test" {
-  name = "tf-acc-test-cloudtrail-%d"
+  name = %[1]q
   role = "${aws_iam_role.test.id}"
 
   policy = <<POLICY
@@ -1013,187 +913,59 @@ resource "aws_iam_role_policy" "test" {
 }
 POLICY
 }
-`, randInt, randInt, randInt, randInt, randInt, randInt, randInt, randInt)
+`, rName)
 }
 
-func testAccAWSCloudTrailConfigMultiRegion(cloudTrailRandInt int) string {
-	return fmt.Sprintf(`
+func testAccAWSCloudTrailConfigMultiRegion(rName string) string {
+	return testAccAWSCloudTrailConfigS3Base(rName) + fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
-  name                  = "tf-trail-test-%d"
-  s3_bucket_name        = "${aws_s3_bucket.foo.id}"
+  name                  = %[1]q
+  s3_bucket_name        = "${aws_s3_bucket.test.id}"
   is_multi_region_trail = true
 }
-
-resource "aws_s3_bucket" "foo" {
-  bucket        = "tf-test-trail-%d"
-  force_destroy = true
-
-  policy = <<POLICY
-{
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-			"Sid": "AWSCloudTrailAclCheck",
-			"Effect": "Allow",
-			"Principal": "*",
-			"Action": "s3:GetBucketAcl",
-			"Resource": "arn:aws:s3:::tf-test-trail-%d"
-		},
-		{
-			"Sid": "AWSCloudTrailWrite",
-			"Effect": "Allow",
-			"Principal": "*",
-			"Action": "s3:PutObject",
-			"Resource": "arn:aws:s3:::tf-test-trail-%d/*",
-			"Condition": {
-				"StringEquals": {
-					"s3:x-amz-acl": "bucket-owner-full-control"
-				}
-			}
-		}
-	]
-}
-POLICY
-}
-`, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
+`, rName)
 }
 
-func testAccAWSCloudTrailConfigOrganization(cloudTrailRandInt int) string {
-	return fmt.Sprintf(`
+func testAccAWSCloudTrailConfigOrganization(rName string) string {
+	return testAccAWSCloudTrailConfigS3Base(rName) + fmt.Sprintf(`
 resource "aws_organizations_organization" "test" {
   aws_service_access_principals = ["cloudtrail.amazonaws.com"]
 }
 
 resource "aws_cloudtrail" "test" {
   is_organization_trail = true
-  name                  = "tf-trail-test-%d"
-  s3_bucket_name        = "${aws_s3_bucket.foo.id}"
+  name                  = %q
+  s3_bucket_name        = "${aws_s3_bucket.test.id}"
+}
+`, rName)
 }
 
-resource "aws_s3_bucket" "foo" {
-  bucket        = "tf-test-trail-%d"
-  force_destroy = true
-
-  policy = <<POLICY
-{
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-			"Sid": "AWSCloudTrailAclCheck",
-			"Effect": "Allow",
-			"Principal": "*",
-			"Action": "s3:GetBucketAcl",
-			"Resource": "arn:aws:s3:::tf-test-trail-%d"
-		},
-		{
-			"Sid": "AWSCloudTrailWrite",
-			"Effect": "Allow",
-			"Principal": "*",
-			"Action": "s3:PutObject",
-			"Resource": "arn:aws:s3:::tf-test-trail-%d/*",
-			"Condition": {
-				"StringEquals": {
-					"s3:x-amz-acl": "bucket-owner-full-control"
-				}
-			}
-		}
-	]
-}
-POLICY
-}
-`, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
-}
-
-func testAccAWSCloudTrailConfig_logValidation(cloudTrailRandInt int) string {
-	return fmt.Sprintf(`
+func testAccAWSCloudTrailConfig_logValidation(rName string) string {
+	return testAccAWSCloudTrailConfigS3Base(rName) + fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
-  name                          = "tf-acc-trail-log-validation-test-%d"
-  s3_bucket_name                = "${aws_s3_bucket.foo.id}"
+  name                          = %q
+  s3_bucket_name                = "${aws_s3_bucket.test.id}"
   is_multi_region_trail         = true
   include_global_service_events = true
   enable_log_file_validation    = true
 }
-
-resource "aws_s3_bucket" "foo" {
-  bucket        = "tf-test-trail-%d"
-  force_destroy = true
-
-  policy = <<POLICY
-{
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-			"Sid": "AWSCloudTrailAclCheck",
-			"Effect": "Allow",
-			"Principal": "*",
-			"Action": "s3:GetBucketAcl",
-			"Resource": "arn:aws:s3:::tf-test-trail-%d"
-		},
-		{
-			"Sid": "AWSCloudTrailWrite",
-			"Effect": "Allow",
-			"Principal": "*",
-			"Action": "s3:PutObject",
-			"Resource": "arn:aws:s3:::tf-test-trail-%d/*",
-			"Condition": {
-				"StringEquals": {
-					"s3:x-amz-acl": "bucket-owner-full-control"
-				}
-			}
-		}
-	]
-}
-POLICY
-}
-`, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
+`, rName)
 }
 
-func testAccAWSCloudTrailConfig_logValidationModified(cloudTrailRandInt int) string {
-	return fmt.Sprintf(`
+func testAccAWSCloudTrailConfig_logValidationModified(rName string) string {
+	return testAccAWSCloudTrailConfigS3Base(rName) + fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
-  name                          = "tf-acc-trail-log-validation-test-%d"
-  s3_bucket_name                = "${aws_s3_bucket.foo.id}"
+  name                          = %[1]q
+  s3_bucket_name                = "${aws_s3_bucket.test.id}"
   include_global_service_events = true
 }
-
-resource "aws_s3_bucket" "foo" {
-  bucket        = "tf-test-trail-%d"
-  force_destroy = true
-
-  policy = <<POLICY
-{
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-			"Sid": "AWSCloudTrailAclCheck",
-			"Effect": "Allow",
-			"Principal": "*",
-			"Action": "s3:GetBucketAcl",
-			"Resource": "arn:aws:s3:::tf-test-trail-%d"
-		},
-		{
-			"Sid": "AWSCloudTrailWrite",
-			"Effect": "Allow",
-			"Principal": "*",
-			"Action": "s3:PutObject",
-			"Resource": "arn:aws:s3:::tf-test-trail-%d/*",
-			"Condition": {
-				"StringEquals": {
-					"s3:x-amz-acl": "bucket-owner-full-control"
-				}
-			}
-		}
-	]
-}
-POLICY
-}
-`, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
+`, rName)
 }
 
-func testAccAWSCloudTrailConfig_kmsKey(cloudTrailRandInt int) string {
-	return fmt.Sprintf(`
-resource "aws_kms_key" "foo" {
-  description = "Terraform acc test %d"
+func testAccAWSCloudTrailConfig_kmsKey(rName string) string {
+	return testAccAWSCloudTrailConfigS3Base(rName) + fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  description = "Terraform acc test"
 
   policy = <<POLICY
 {
@@ -1215,55 +987,23 @@ POLICY
 }
 
 resource "aws_cloudtrail" "test" {
-  name                          = "tf-acc-trail-log-validation-test-%d"
-  s3_bucket_name                = "${aws_s3_bucket.foo.id}"
+  name                          = %[1]q
+  s3_bucket_name                = "${aws_s3_bucket.test.id}"
   include_global_service_events = true
-  kms_key_id                    = "${aws_kms_key.foo.arn}"
+  kms_key_id                    = "${aws_kms_key.test.arn}"
 }
-
-resource "aws_s3_bucket" "foo" {
-  bucket        = "tf-test-trail-%d"
-  force_destroy = true
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-   {
-     "Sid": "AWSCloudTrailAclCheck",
-     "Effect": "Allow",
-     "Principal": "*",
-     "Action": "s3:GetBucketAcl",
-     "Resource": "arn:aws:s3:::tf-test-trail-%d"
-   },
-   {
-     "Sid": "AWSCloudTrailWrite",
-     "Effect": "Allow",
-     "Principal": "*",
-     "Action": "s3:PutObject",
-     "Resource": "arn:aws:s3:::tf-test-trail-%d/*",
-     "Condition": {
-       "StringEquals": {
-         "s3:x-amz-acl": "bucket-owner-full-control"
-       }
-     }
-   }
-  ]
-}
-POLICY
-}
-`, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
+`, rName)
 }
 
 var testAccAWSCloudTrailConfig_tags_tpl = `
 resource "aws_cloudtrail" "test" {
     name = "tf-acc-trail-log-validation-test-%d"
-    s3_bucket_name = "${aws_s3_bucket.foo.id}"
+    s3_bucket_name = "${aws_s3_bucket.test.id}"
     %s
 }
 
-resource "aws_s3_bucket" "foo" {
-	bucket = "tf-test-trail-%d"
+resource "aws_s3_bucket" "test" {
+	bucket = %[1]q
 	force_destroy = true
 	policy = <<POLICY
 {
@@ -1274,14 +1014,14 @@ resource "aws_s3_bucket" "foo" {
 			"Effect": "Allow",
 			"Principal": "*",
 			"Action": "s3:GetBucketAcl",
-			"Resource": "arn:aws:s3:::tf-test-trail-%d"
+			"Resource": "arn:aws:s3:::%[1]s"
 		},
 		{
 			"Sid": "AWSCloudTrailWrite",
 			"Effect": "Allow",
 			"Principal": "*",
 			"Action": "s3:PutObject",
-			"Resource": "arn:aws:s3:::tf-test-trail-%d/*",
+			"Resource": "arn:aws:s3:::%[1]s/*",
 			"Condition": {
 				"StringEquals": {
 					"s3:x-amz-acl": "bucket-owner-full-control"
@@ -1294,46 +1034,14 @@ POLICY
 }
 `
 
-func testAccAWSCloudTrailConfig_include_global_service_events(cloudTrailRandInt int) string {
-	return fmt.Sprintf(`
+func testAccAWSCloudTrailConfig_include_global_service_events(rName string) string {
+	return testAccAWSCloudTrailConfigS3Base(rName) + fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
-  name                          = "tf-trail-test-%d"
-  s3_bucket_name                = "${aws_s3_bucket.foo.id}"
+  name                          = %q
+  s3_bucket_name                = "${aws_s3_bucket.test.id}"
   include_global_service_events = false
 }
-
-resource "aws_s3_bucket" "foo" {
-  bucket        = "tf-test-trail-%d"
-  force_destroy = true
-
-  policy = <<POLICY
-{
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-			"Sid": "AWSCloudTrailAclCheck",
-			"Effect": "Allow",
-			"Principal": "*",
-			"Action": "s3:GetBucketAcl",
-			"Resource": "arn:aws:s3:::tf-test-trail-%d"
-		},
-		{
-			"Sid": "AWSCloudTrailWrite",
-			"Effect": "Allow",
-			"Principal": "*",
-			"Action": "s3:PutObject",
-			"Resource": "arn:aws:s3:::tf-test-trail-%d/*",
-			"Condition": {
-				"StringEquals": {
-					"s3:x-amz-acl": "bucket-owner-full-control"
-				}
-			}
-		}
-	]
-}
-POLICY
-}
-`, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
+`, rName)
 }
 
 func testAccAWSCloudTrailConfig_tags(cloudTrailRandInt int) string {
@@ -1368,11 +1076,11 @@ func testAccAWSCloudTrailConfig_tagsModifiedAgain(cloudTrailRandInt int) string 
 		cloudTrailRandInt, "", cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
 }
 
-func testAccAWSCloudTrailConfig_eventSelector(cloudTrailRandInt int) string {
-	return fmt.Sprintf(`
+func testAccAWSCloudTrailConfig_eventSelector(rName string) string {
+	return testAccAWSCloudTrailConfigS3Base(rName) + fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
-  name           = "tf-trail-test-%d"
-  s3_bucket_name = "${aws_s3_bucket.foo.id}"
+  name           = %[1]q
+  s3_bucket_name = "${aws_s3_bucket.test.id}"
 
   event_selector {
     read_write_type           = "ReadOnly"
@@ -1382,50 +1090,18 @@ resource "aws_cloudtrail" "test" {
       type = "AWS::S3::Object"
 
       values = [
-        "${aws_s3_bucket.bar.arn}/foobar",
+        "${aws_s3_bucket.bar.arn}/testbar",
         "${aws_s3_bucket.bar.arn}/baz",
       ]
     }
   }
 }
 
-resource "aws_s3_bucket" "foo" {
-  bucket        = "tf-test-trail-%d"
-  force_destroy = true
-
-  policy = <<POLICY
-{
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-			"Sid": "AWSCloudTrailAclCheck",
-			"Effect": "Allow",
-			"Principal": "*",
-			"Action": "s3:GetBucketAcl",
-			"Resource": "arn:aws:s3:::tf-test-trail-%d"
-		},
-		{
-			"Sid": "AWSCloudTrailWrite",
-			"Effect": "Allow",
-			"Principal": "*",
-			"Action": "s3:PutObject",
-			"Resource": "arn:aws:s3:::tf-test-trail-%d/*",
-			"Condition": {
-				"StringEquals": {
-					"s3:x-amz-acl": "bucket-owner-full-control"
-				}
-			}
-		}
-	]
-}
-POLICY
-}
-
 resource "aws_s3_bucket" "bar" {
-  bucket        = "tf-test-trail-event-select-%d"
+  bucket        = "%[1]s"
   force_destroy = true
 }
-`, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
+`, rName)
 }
 
 func testAccAWSCloudTrailConfig_eventSelectorReadWriteType(cloudTrailRandInt int) string {
@@ -1473,11 +1149,11 @@ POLICY
 `, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
 }
 
-func testAccAWSCloudTrailConfig_eventSelectorExclude(cloudTrailRandInt int) string {
-	return fmt.Sprintf(`
+func testAccAWSCloudTrailConfig_eventSelectorExclude(rName string) string {
+	return testAccAWSCloudTrailConfigS3Base(rName) + fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
-  name           = "tf-trail-test-%d"
-  s3_bucket_name = "${aws_s3_bucket.foo.id}"
+  name           = %[1]q
+  s3_bucket_name = "${aws_s3_bucket.test.id}"
 
   event_selector {
     read_write_type                  = "ReadOnly"
@@ -1496,50 +1172,18 @@ resource "aws_cloudtrail" "test" {
   }
 }
 
-resource "aws_s3_bucket" "foo" {
-  bucket        = "tf-test-trail-%d"
-  force_destroy = true
-
-  policy = <<POLICY
-{
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-			"Sid": "AWSCloudTrailAclCheck",
-			"Effect": "Allow",
-			"Principal": "*",
-			"Action": "s3:GetBucketAcl",
-			"Resource": "arn:aws:s3:::tf-test-trail-%d"
-		},
-		{
-			"Sid": "AWSCloudTrailWrite",
-			"Effect": "Allow",
-			"Principal": "*",
-			"Action": "s3:PutObject",
-			"Resource": "arn:aws:s3:::tf-test-trail-%d/*",
-			"Condition": {
-				"StringEquals": {
-					"s3:x-amz-acl": "bucket-owner-full-control"
-				}
-			}
-		}
-	]
-}
-POLICY
-}
-
 resource "aws_s3_bucket" "bar" {
-  bucket        = "tf-test-trail-event-select-%d"
+  bucket        = "%[1]s"
   force_destroy = true
 }
-`, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
+`, rName)
 }
 
-func testAccAWSCloudTrailConfig_eventSelectorModified(cloudTrailRandInt int) string {
-	return fmt.Sprintf(`
+func testAccAWSCloudTrailConfig_eventSelectorModified(rName string) string {
+	return testAccAWSCloudTrailConfigS3Base(rName) + fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
-  name           = "tf-trail-test-%d"
-  s3_bucket_name = "${aws_s3_bucket.foo.id}"
+  name           = %[1]q
+  s3_bucket_name = "${aws_s3_bucket.test.id}"
 
   event_selector {
     read_write_type           = "ReadOnly"
@@ -1578,45 +1222,13 @@ resource "aws_cloudtrail" "test" {
   }
 }
 
-resource "aws_s3_bucket" "foo" {
-  bucket        = "tf-test-trail-%d"
-  force_destroy = true
-
-  policy = <<POLICY
-{
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-			"Sid": "AWSCloudTrailAclCheck",
-			"Effect": "Allow",
-			"Principal": "*",
-			"Action": "s3:GetBucketAcl",
-			"Resource": "arn:aws:s3:::tf-test-trail-%d"
-		},
-		{
-			"Sid": "AWSCloudTrailWrite",
-			"Effect": "Allow",
-			"Principal": "*",
-			"Action": "s3:PutObject",
-			"Resource": "arn:aws:s3:::tf-test-trail-%d/*",
-			"Condition": {
-				"StringEquals": {
-					"s3:x-amz-acl": "bucket-owner-full-control"
-				}
-			}
-		}
-	]
-}
-POLICY
-}
-
 resource "aws_s3_bucket" "bar" {
-  bucket        = "tf-test-trail-event-select-%d"
+  bucket        = "%[1]s"
   force_destroy = true
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
-  name = "tf-test-trail-event-select-%d"
+  name = %[1]q
 
   assume_role_policy = <<EOF
 {
@@ -1637,12 +1249,12 @@ EOF
 
 resource "aws_lambda_function" "lambda_function_test" {
   filename      = "test-fixtures/lambdatest.zip"
-  function_name = "tf-test-trail-event-select-%d"
+  function_name = %[1]q
   role          = "${aws_iam_role.iam_for_lambda.arn}"
   handler       = "exports.example"
   runtime       = "nodejs12.x"
 }
-`, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
+`, rName)
 }
 
 func testAccAWSCloudTrailConfig_eventSelectorNone(cloudTrailRandInt int) string {

--- a/aws/resource_aws_cloudtrail_test.go
+++ b/aws/resource_aws_cloudtrail_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 	"testing"
 
@@ -676,7 +677,7 @@ func testAccAWSCloudTrail_disappears(t *testing.T) {
 				Config: testAccAWSCloudTrailConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
-					testAccCheckCloudTrailDisappears(&trail),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsCloudTrail(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -711,17 +712,6 @@ func testAccCheckCloudTrailExists(n string, trail *cloudtrail.Trail) resource.Te
 		*trail = *resp.TrailList[0]
 
 		return nil
-	}
-}
-
-func testAccCheckCloudTrailDisappears(trail *cloudtrail.Trail) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).cloudtrailconn
-
-		input := &cloudtrail.DeleteTrailInput{Name: trail.Name}
-		_, err := conn.DeleteTrail(input)
-
-		return err
 	}
 }
 

--- a/aws/resource_aws_cloudtrail_test.go
+++ b/aws/resource_aws_cloudtrail_test.go
@@ -1277,6 +1277,7 @@ resource "aws_cloudtrail" "test" {
 
   tags = {
     %[2]q = %[3]q
+    %[4]q = %[5]q
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)

--- a/aws/resource_aws_cloudtrail_test.go
+++ b/aws/resource_aws_cloudtrail_test.go
@@ -577,7 +577,7 @@ func testAccAWSCloudTrail_event_selector(t *testing.T) {
 					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.1.data_resource.0.values.1", "s3", fmt.Sprintf("%s/tf2", rName)),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.1.data_resource.1.type", "AWS::Lambda::Function"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.1.data_resource.1.values.#", "1"),
-					testAccMatchResourceAttrRegionalARN(resourceName, "event_selector.1.data_resource.1.values.0", "lambda", regexp.MustCompile(fmt.Sprintf(`%s.+`, rName))),
+					testAccMatchResourceAttrRegionalARN(resourceName, "event_selector.1.data_resource.1.values.0", "lambda", regexp.MustCompile(`function:.+`)),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.1.include_management_events", "false"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.1.read_write_type", "All"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.exclude_management_event_sources.#", "0"),

--- a/aws/resource_aws_cloudtrail_test.go
+++ b/aws/resource_aws_cloudtrail_test.go
@@ -135,6 +135,7 @@ func testAccAWSCloudTrail_basic(t *testing.T) {
 				Config: testAccAWSCloudTrailConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "cloudtrail", fmt.Sprintf("trail/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "include_global_service_events", "true"),
 					resource.TestCheckResourceAttr(resourceName, "is_organization_trail", "false"),
 					testAccCheckCloudTrailLogValidationEnabled(resourceName, false, &trail),

--- a/aws/resource_aws_cloudtrail_test.go
+++ b/aws/resource_aws_cloudtrail_test.go
@@ -123,7 +123,7 @@ func TestAccAWSCloudTrail_serial(t *testing.T) {
 
 func testAccAWSCloudTrail_basic(t *testing.T) {
 	var trail cloudtrail.Trail
-	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rName := acctest.RandomWithPrefix("tf-cloudtrail-test")
 	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
@@ -162,7 +162,7 @@ func testAccAWSCloudTrail_basic(t *testing.T) {
 
 func testAccAWSCloudTrail_cloudwatch(t *testing.T) {
 	var trail cloudtrail.Trail
-	rName := acctest.RandomWithPrefix("tf-acc-test-cw")
+	rName := acctest.RandomWithPrefix("tf-cloudtrail-test-cw")
 	resourceName := "aws_cloudtrail.test"
 	cwResourceName := "aws_cloudwatch_log_group.test"
 	roleResourceName := "aws_iam_role.test"
@@ -199,7 +199,7 @@ func testAccAWSCloudTrail_cloudwatch(t *testing.T) {
 
 func testAccAWSCloudTrail_enable_logging(t *testing.T) {
 	var trail cloudtrail.Trail
-	rName := acctest.RandomWithPrefix("tf-acc-test-log")
+	rName := acctest.RandomWithPrefix("tf-cloudtrail-test-log")
 	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
@@ -247,7 +247,7 @@ func testAccAWSCloudTrail_enable_logging(t *testing.T) {
 
 func testAccAWSCloudTrail_tags(t *testing.T) {
 	var trail cloudtrail.Trail
-	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rName := acctest.RandomWithPrefix("tf-cloudtrail-test")
 	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
@@ -291,7 +291,7 @@ func testAccAWSCloudTrail_tags(t *testing.T) {
 
 func testAccAWSCloudTrail_is_multi_region(t *testing.T) {
 	var trail cloudtrail.Trail
-	rName := acctest.RandomWithPrefix("tf-acc-test-multi")
+	rName := acctest.RandomWithPrefix("tf-cloudtrail-test-multi")
 	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
@@ -337,7 +337,7 @@ func testAccAWSCloudTrail_is_multi_region(t *testing.T) {
 
 func testAccAWSCloudTrail_is_organization(t *testing.T) {
 	var trail cloudtrail.Trail
-	rName := acctest.RandomWithPrefix("tf-acc-test-org")
+	rName := acctest.RandomWithPrefix("tf-cloudtrail-test-org")
 	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
@@ -374,7 +374,7 @@ func testAccAWSCloudTrail_is_organization(t *testing.T) {
 
 func testAccAWSCloudTrail_logValidation(t *testing.T) {
 	var trail cloudtrail.Trail
-	rName := acctest.RandomWithPrefix("tf-acc-test-log-val")
+	rName := acctest.RandomWithPrefix("tf-cloudtrail-test-log-val")
 	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
@@ -413,7 +413,7 @@ func testAccAWSCloudTrail_logValidation(t *testing.T) {
 
 func testAccAWSCloudTrail_kmsKey(t *testing.T) {
 	var trail cloudtrail.Trail
-	rName := acctest.RandomWithPrefix("tf-acc-test-kms")
+	rName := acctest.RandomWithPrefix("tf-cloudtrail-test-kms")
 	resourceName := "aws_cloudtrail.test"
 	kmsResourceName := "aws_kms_key.foo"
 
@@ -499,7 +499,7 @@ func testAccAWSCloudTrail_tags(t *testing.T) {
 
 func testAccAWSCloudTrail_include_global_service_events(t *testing.T) {
 	var trail cloudtrail.Trail
-	rName := acctest.RandomWithPrefix("tf-acc-test-events")
+	rName := acctest.RandomWithPrefix("tf-cloudtrail-test-events")
 	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
@@ -524,7 +524,7 @@ func testAccAWSCloudTrail_include_global_service_events(t *testing.T) {
 }
 
 func testAccAWSCloudTrail_event_selector(t *testing.T) {
-	rName := acctest.RandomWithPrefix("tf-acc-test-event")
+	rName := acctest.RandomWithPrefix("tf-cloudtrail-test-event")
 	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
@@ -577,7 +577,7 @@ func testAccAWSCloudTrail_event_selector(t *testing.T) {
 					testAccCheckResourceAttrGlobalARNNoAccount(resourceName, "event_selector.1.data_resource.0.values.1", "s3", fmt.Sprintf("%s/tf2", rName)),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.1.data_resource.1.type", "AWS::Lambda::Function"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.1.data_resource.1.values.#", "1"),
-					testAccMatchResourceAttrRegionalARN(resourceName, "event_selector.1.data_resource.1.values.0", "lambda", regexp.MustCompile(fmt.Sprintf(`%s-\d+$`, rName))),
+					testAccMatchResourceAttrRegionalARN(resourceName, "event_selector.1.data_resource.1.values.0", "lambda", regexp.MustCompile(fmt.Sprintf(`%s.+`, rName))),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.1.include_management_events", "false"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.1.read_write_type", "All"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.exclude_management_event_sources.#", "0"),
@@ -588,7 +588,7 @@ func testAccAWSCloudTrail_event_selector(t *testing.T) {
 }
 
 func testAccAWSCloudTrail_event_selector_exclude(t *testing.T) {
-	rName := acctest.RandomWithPrefix("tf-acc-test-exclude")
+	rName := acctest.RandomWithPrefix("tf-cloudtrail-test-exclude")
 	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
@@ -622,7 +622,7 @@ func testAccAWSCloudTrail_event_selector_exclude(t *testing.T) {
 
 func testAccAWSCloudTrail_disappears(t *testing.T) {
 	var trail cloudtrail.Trail
-	rName := acctest.RandomWithPrefix("tf-acc-test-disappears")
+	rName := acctest.RandomWithPrefix("tf-cloudtrail-test-disappears")
 	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{

--- a/aws/resource_aws_cloudtrail_test.go
+++ b/aws/resource_aws_cloudtrail_test.go
@@ -104,6 +104,7 @@ func TestAccAWSCloudTrail_serial(t *testing.T) {
 			"kmsKey":                     testAccAWSCloudTrail_kmsKey,
 			"tags":                       testAccAWSCloudTrail_tags,
 			"eventSelector":              testAccAWSCloudTrail_event_selector,
+			"eventSelectorWExclude":      testAccAWSCloudTrail_event_selector_exclude,
 		},
 	}
 
@@ -123,7 +124,7 @@ func TestAccAWSCloudTrail_serial(t *testing.T) {
 func testAccAWSCloudTrail_basic(t *testing.T) {
 	var trail cloudtrail.Trail
 	cloudTrailRandInt := acctest.RandInt()
-	resourceName := "aws_cloudtrail.foobar"
+	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -197,7 +198,7 @@ func testAccAWSCloudTrail_cloudwatch(t *testing.T) {
 func testAccAWSCloudTrail_enable_logging(t *testing.T) {
 	var trail cloudtrail.Trail
 	cloudTrailRandInt := acctest.RandInt()
-	resourceName := "aws_cloudtrail.foobar"
+	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -245,7 +246,7 @@ func testAccAWSCloudTrail_enable_logging(t *testing.T) {
 func testAccAWSCloudTrail_is_multi_region(t *testing.T) {
 	var trail cloudtrail.Trail
 	cloudTrailRandInt := acctest.RandInt()
-	resourceName := "aws_cloudtrail.foobar"
+	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -291,7 +292,7 @@ func testAccAWSCloudTrail_is_multi_region(t *testing.T) {
 func testAccAWSCloudTrail_is_organization(t *testing.T) {
 	var trail cloudtrail.Trail
 	cloudTrailRandInt := acctest.RandInt()
-	resourceName := "aws_cloudtrail.foobar"
+	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },
@@ -328,7 +329,7 @@ func testAccAWSCloudTrail_is_organization(t *testing.T) {
 func testAccAWSCloudTrail_logValidation(t *testing.T) {
 	var trail cloudtrail.Trail
 	cloudTrailRandInt := acctest.RandInt()
-	resourceName := "aws_cloudtrail.foobar"
+	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -368,7 +369,7 @@ func testAccAWSCloudTrail_kmsKey(t *testing.T) {
 	var trail cloudtrail.Trail
 	cloudTrailRandInt := acctest.RandInt()
 
-	resourceName := "aws_cloudtrail.foobar"
+	resourceName := "aws_cloudtrail.test"
 	kmsResourceName := "aws_kms_key.foo"
 
 	resource.Test(t, resource.TestCase{
@@ -400,7 +401,7 @@ func testAccAWSCloudTrail_tags(t *testing.T) {
 	var trailTags []*cloudtrail.Tag
 	var trailTagsModified []*cloudtrail.Tag
 	cloudTrailRandInt := acctest.RandInt()
-	resourceName := "aws_cloudtrail.foobar"
+	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -454,7 +455,7 @@ func testAccAWSCloudTrail_tags(t *testing.T) {
 func testAccAWSCloudTrail_include_global_service_events(t *testing.T) {
 	var trail cloudtrail.Trail
 	cloudTrailRandInt := acctest.RandInt()
-	resourceName := "aws_cloudtrail.foobar"
+	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -479,7 +480,7 @@ func testAccAWSCloudTrail_include_global_service_events(t *testing.T) {
 
 func testAccAWSCloudTrail_event_selector(t *testing.T) {
 	cloudTrailRandInt := acctest.RandInt()
-	resourceName := "aws_cloudtrail.foobar"
+	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -497,6 +498,7 @@ func testAccAWSCloudTrail_event_selector(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceName, "event_selector.0.data_resource.0.values.1", regexp.MustCompile(`^arn:[^:]+:s3:::.+/baz$`)),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.include_management_events", "false"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.read_write_type", "ReadOnly"),
+					resource.TestCheckResourceAttr(resourceName, "event_selector.0.exclude_management_event_sources.#", "0"),
 				),
 			},
 			{
@@ -533,6 +535,34 @@ func testAccAWSCloudTrail_event_selector(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceName, "event_selector.1.data_resource.1.values.0", regexp.MustCompile(`^arn:[^:]+:lambda:.+:tf-test-trail-event-select-\d+$`)),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.1.include_management_events", "false"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.1.read_write_type", "All"),
+					resource.TestCheckResourceAttr(resourceName, "event_selector.0.exclude_management_event_sources.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSCloudTrail_event_selector_exclude(t *testing.T) {
+	cloudTrailRandInt := acctest.RandInt()
+	resourceName := "aws_cloudtrail.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudTrailConfig_eventSelectorExclude(cloudTrailRandInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "event_selector.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "event_selector.0.data_resource.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "event_selector.0.data_resource.0.type", "AWS::S3::Object"),
+					resource.TestCheckResourceAttr(resourceName, "event_selector.0.data_resource.0.values.#", "2"),
+					resource.TestMatchResourceAttr(resourceName, "event_selector.0.data_resource.0.values.0", regexp.MustCompile(`^arn:[^:]+:s3:::.+/foobar$`)),
+					resource.TestMatchResourceAttr(resourceName, "event_selector.0.data_resource.0.values.1", regexp.MustCompile(`^arn:[^:]+:s3:::.+/baz$`)),
+					resource.TestCheckResourceAttr(resourceName, "event_selector.0.include_management_events", "true"),
+					resource.TestCheckResourceAttr(resourceName, "event_selector.0.read_write_type", "ReadOnly"),
+					resource.TestCheckResourceAttr(resourceName, "event_selector.0.exclude_management_event_sources.#", "1"),
 				),
 			},
 			{
@@ -670,8 +700,8 @@ func testAccCheckCloudTrailLoadTags(trail *cloudtrail.Trail, tags *[]*cloudtrail
 
 func testAccAWSCloudTrailConfig(cloudTrailRandInt int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudtrail" "foobar" {
-  name           = "tf-trail-foobar-%d"
+resource "aws_cloudtrail" "test" {
+  name           = "tf-trail-test-%d"
   s3_bucket_name = "${aws_s3_bucket.foo.id}"
 }
 
@@ -711,8 +741,8 @@ POLICY
 
 func testAccAWSCloudTrailConfigModified(cloudTrailRandInt int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudtrail" "foobar" {
-  name                          = "tf-trail-foobar-%d"
+resource "aws_cloudtrail" "test" {
+  name                          = "tf-trail-test-%d"
   s3_bucket_name                = "${aws_s3_bucket.foo.id}"
   s3_key_prefix                 = "prefix"
   include_global_service_events = false
@@ -939,8 +969,8 @@ POLICY
 
 func testAccAWSCloudTrailConfigMultiRegion(cloudTrailRandInt int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudtrail" "foobar" {
-  name                  = "tf-trail-foobar-%d"
+resource "aws_cloudtrail" "test" {
+  name                  = "tf-trail-test-%d"
   s3_bucket_name        = "${aws_s3_bucket.foo.id}"
   is_multi_region_trail = true
 }
@@ -985,9 +1015,9 @@ resource "aws_organizations_organization" "test" {
   aws_service_access_principals = ["cloudtrail.amazonaws.com"]
 }
 
-resource "aws_cloudtrail" "foobar" {
+resource "aws_cloudtrail" "test" {
   is_organization_trail = true
-  name                  = "tf-trail-foobar-%d"
+  name                  = "tf-trail-test-%d"
   s3_bucket_name        = "${aws_s3_bucket.foo.id}"
 }
 
@@ -1027,7 +1057,7 @@ POLICY
 
 func testAccAWSCloudTrailConfig_logValidation(cloudTrailRandInt int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudtrail" "foobar" {
+resource "aws_cloudtrail" "test" {
   name                          = "tf-acc-trail-log-validation-test-%d"
   s3_bucket_name                = "${aws_s3_bucket.foo.id}"
   is_multi_region_trail         = true
@@ -1071,7 +1101,7 @@ POLICY
 
 func testAccAWSCloudTrailConfig_logValidationModified(cloudTrailRandInt int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudtrail" "foobar" {
+resource "aws_cloudtrail" "test" {
   name                          = "tf-acc-trail-log-validation-test-%d"
   s3_bucket_name                = "${aws_s3_bucket.foo.id}"
   include_global_service_events = true
@@ -1135,7 +1165,7 @@ resource "aws_kms_key" "foo" {
 POLICY
 }
 
-resource "aws_cloudtrail" "foobar" {
+resource "aws_cloudtrail" "test" {
   name                          = "tf-acc-trail-log-validation-test-%d"
   s3_bucket_name                = "${aws_s3_bucket.foo.id}"
   include_global_service_events = true
@@ -1177,7 +1207,7 @@ POLICY
 }
 
 var testAccAWSCloudTrailConfig_tags_tpl = `
-resource "aws_cloudtrail" "foobar" {
+resource "aws_cloudtrail" "test" {
     name = "tf-acc-trail-log-validation-test-%d"
     s3_bucket_name = "${aws_s3_bucket.foo.id}"
     %s
@@ -1217,8 +1247,8 @@ POLICY
 
 func testAccAWSCloudTrailConfig_include_global_service_events(cloudTrailRandInt int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudtrail" "foobar" {
-  name                          = "tf-trail-foobar-%d"
+resource "aws_cloudtrail" "test" {
+  name                          = "tf-trail-test-%d"
   s3_bucket_name                = "${aws_s3_bucket.foo.id}"
   include_global_service_events = false
 }
@@ -1291,8 +1321,8 @@ func testAccAWSCloudTrailConfig_tagsModifiedAgain(cloudTrailRandInt int) string 
 
 func testAccAWSCloudTrailConfig_eventSelector(cloudTrailRandInt int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudtrail" "foobar" {
-  name           = "tf-trail-foobar-%d"
+resource "aws_cloudtrail" "test" {
+  name           = "tf-trail-test-%d"
   s3_bucket_name = "${aws_s3_bucket.foo.id}"
 
   event_selector {
@@ -1394,10 +1424,72 @@ POLICY
 `, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
 }
 
+func testAccAWSCloudTrailConfig_eventSelectorExclude(cloudTrailRandInt int) string {
+	return fmt.Sprintf(`
+resource "aws_cloudtrail" "test" {
+  name           = "tf-trail-test-%d"
+  s3_bucket_name = "${aws_s3_bucket.foo.id}"
+
+  event_selector {
+    read_write_type                  = "ReadOnly"
+    include_management_events        = true
+    exclude_management_event_sources = ["kms.amazonaws.com"]
+
+
+    data_resource {
+      type = "AWS::S3::Object"
+
+      values = [
+        "${aws_s3_bucket.bar.arn}/foobar",
+        "${aws_s3_bucket.bar.arn}/baz",
+      ]
+    }
+  }
+}
+
+resource "aws_s3_bucket" "foo" {
+  bucket        = "tf-test-trail-%d"
+  force_destroy = true
+
+  policy = <<POLICY
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "AWSCloudTrailAclCheck",
+			"Effect": "Allow",
+			"Principal": "*",
+			"Action": "s3:GetBucketAcl",
+			"Resource": "arn:aws:s3:::tf-test-trail-%d"
+		},
+		{
+			"Sid": "AWSCloudTrailWrite",
+			"Effect": "Allow",
+			"Principal": "*",
+			"Action": "s3:PutObject",
+			"Resource": "arn:aws:s3:::tf-test-trail-%d/*",
+			"Condition": {
+				"StringEquals": {
+					"s3:x-amz-acl": "bucket-owner-full-control"
+				}
+			}
+		}
+	]
+}
+POLICY
+}
+
+resource "aws_s3_bucket" "bar" {
+  bucket        = "tf-test-trail-event-select-%d"
+  force_destroy = true
+}
+`, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
+}
+
 func testAccAWSCloudTrailConfig_eventSelectorModified(cloudTrailRandInt int) string {
 	return fmt.Sprintf(`
-resource "aws_cloudtrail" "foobar" {
-  name           = "tf-trail-foobar-%d"
+resource "aws_cloudtrail" "test" {
+  name           = "tf-trail-test-%d"
   s3_bucket_name = "${aws_s3_bucket.foo.id}"
 
   event_selector {

--- a/aws/resource_aws_cloudtrail_test.go
+++ b/aws/resource_aws_cloudtrail_test.go
@@ -165,6 +165,7 @@ func testAccAWSCloudTrail_cloudwatch(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-cloudtrail-test-cw")
 	resourceName := "aws_cloudtrail.test"
 	cwResourceName := "aws_cloudwatch_log_group.test"
+	cwChangeResourceName := "aws_cloudwatch_log_group.second"
 	roleResourceName := "aws_iam_role.test"
 
 	resource.Test(t, resource.TestCase{
@@ -189,7 +190,7 @@ func testAccAWSCloudTrail_cloudwatch(t *testing.T) {
 				Config: testAccAWSCloudTrailConfigCloudWatchModified(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
-					resource.TestCheckResourceAttrPair(resourceName, "cloud_watch_logs_group_arn", cwResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "cloud_watch_logs_group_arn", cwChangeResourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "cloud_watch_logs_role_arn", roleResourceName, "arn"),
 				),
 			},
@@ -836,6 +837,18 @@ resource "aws_cloudtrail" "test" {
   include_global_service_events = false
   enable_logging                = false
 }
+`, rName)
+}
+
+func testAccAWSCloudTrailConfigSNS(rName string) string {
+	return testAccAWSCloudTrailConfigS3Base(rName) + fmt.Sprintf(`
+resource "aws_cloudtrail" "test" {
+  name           = %[1]q
+  s3_bucket_name = "${aws_s3_bucket.test.id}"
+  sns_topic_name = "${aws_sns_topic.test.name}"
+}
+
+resource "aws_sns_topic" "test" {}
 `, rName)
 }
 

--- a/aws/resource_aws_cloudtrail_test.go
+++ b/aws/resource_aws_cloudtrail_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"log"
 	"regexp"
 	"testing"
 
@@ -105,6 +104,7 @@ func TestAccAWSCloudTrail_serial(t *testing.T) {
 			"eventSelector":              testAccAWSCloudTrail_event_selector,
 			"eventSelectorWExclude":      testAccAWSCloudTrail_event_selector_exclude,
 			"disappears":                 testAccAWSCloudTrail_disappears,
+			"sns":                        testAccAWSCloudTrail_sns,
 		},
 	}
 
@@ -154,6 +154,46 @@ func testAccAWSCloudTrail_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "include_global_service_events", "false"),
 					testAccCheckCloudTrailLogValidationEnabled(resourceName, false, &trail),
 					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSCloudTrail_sns(t *testing.T) {
+	var trail cloudtrail.Trail
+	rName := acctest.RandomWithPrefix("tf-cloudtrail-test-sns")
+	resourceName := "aws_cloudtrail.test"
+	topicResourceName := "aws_sns_topic.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudTrailConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudTrailExists(resourceName, &trail),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSCloudTrailConfigSNS(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudTrailExists(resourceName, &trail),
+					resource.TestCheckResourceAttrPair(resourceName, "sns_topic_name", topicResourceName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "sns_topic_arn", topicResourceName, "arn"),
+				),
+			},
+			{
+				Config: testAccAWSCloudTrailConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudTrailExists(resourceName, &trail),
 				),
 			},
 		},
@@ -764,25 +804,6 @@ func testAccCheckAWSCloudTrailDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckCloudTrailLoadTags(trail *cloudtrail.Trail, tags *[]*cloudtrail.Tag) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).cloudtrailconn
-		input := cloudtrail.ListTagsInput{
-			ResourceIdList: []*string{trail.TrailARN},
-		}
-		out, err := conn.ListTags(&input)
-		if err != nil {
-			return err
-		}
-		log.Printf("[DEBUG] Received CloudTrail tags during test: %s", out)
-		if len(out.ResourceTagList) > 0 {
-			*tags = out.ResourceTagList[0].TagsList
-		}
-		log.Printf("[DEBUG] Loading CloudTrail tags into a var: %s", *tags)
-		return nil
-	}
-}
-
 func testAccAWSCloudTrailConfigS3Base(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
@@ -848,7 +869,29 @@ resource "aws_cloudtrail" "test" {
   sns_topic_name = "${aws_sns_topic.test.name}"
 }
 
-resource "aws_sns_topic" "test" {}
+resource "aws_sns_topic" "test" {
+  name   = %[1]q
+}
+
+resource "aws_sns_topic_policy" "test" {
+  arn = "${aws_sns_topic.test.arn}"
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AWSCloudTrailSNSPolicy20131101",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "cloudtrail.amazonaws.com"
+            },
+            "Action": "SNS:Publish",
+            "Resource": "${aws_sns_topic.test.arn}"
+        }
+    ]
+}
+POLICY
+}
 `, rName)
 }
 

--- a/aws/resource_aws_cloudtrail_test.go
+++ b/aws/resource_aws_cloudtrail_test.go
@@ -458,7 +458,7 @@ func testAccAWSCloudTrail_kmsKey(t *testing.T) {
 	var trail cloudtrail.Trail
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cloudtrail.test"
-	kmsResourceName := "aws_kms_key.foo"
+	kmsResourceName := "aws_kms_key.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/aws/resource_aws_cloudtrail_test.go
+++ b/aws/resource_aws_cloudtrail_test.go
@@ -124,7 +124,7 @@ func TestAccAWSCloudTrail_serial(t *testing.T) {
 
 func testAccAWSCloudTrail_basic(t *testing.T) {
 	var trail cloudtrail.Trail
-	rName := acctest.RandomWithPrefix("tf-cloudtrail-test")
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
@@ -164,7 +164,7 @@ func testAccAWSCloudTrail_basic(t *testing.T) {
 
 func testAccAWSCloudTrail_sns(t *testing.T) {
 	var trail cloudtrail.Trail
-	rName := acctest.RandomWithPrefix("tf-cloudtrail-test-sns")
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cloudtrail.test"
 	topicResourceName := "aws_sns_topic.test"
 
@@ -204,7 +204,7 @@ func testAccAWSCloudTrail_sns(t *testing.T) {
 
 func testAccAWSCloudTrail_cloudwatch(t *testing.T) {
 	var trail cloudtrail.Trail
-	rName := acctest.RandomWithPrefix("tf-cloudtrail-test-cw")
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cloudtrail.test"
 	cwResourceName := "aws_cloudwatch_log_group.test"
 	cwChangeResourceName := "aws_cloudwatch_log_group.second"
@@ -242,7 +242,7 @@ func testAccAWSCloudTrail_cloudwatch(t *testing.T) {
 
 func testAccAWSCloudTrail_enable_logging(t *testing.T) {
 	var trail cloudtrail.Trail
-	rName := acctest.RandomWithPrefix("tf-cloudtrail-test-log")
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
@@ -290,7 +290,7 @@ func testAccAWSCloudTrail_enable_logging(t *testing.T) {
 
 func testAccAWSCloudTrail_tags(t *testing.T) {
 	var trail cloudtrail.Trail
-	rName := acctest.RandomWithPrefix("tf-cloudtrail-test")
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
@@ -334,7 +334,7 @@ func testAccAWSCloudTrail_tags(t *testing.T) {
 
 func testAccAWSCloudTrail_is_multi_region(t *testing.T) {
 	var trail cloudtrail.Trail
-	rName := acctest.RandomWithPrefix("tf-cloudtrail-test-multi")
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
@@ -380,7 +380,7 @@ func testAccAWSCloudTrail_is_multi_region(t *testing.T) {
 
 func testAccAWSCloudTrail_is_organization(t *testing.T) {
 	var trail cloudtrail.Trail
-	rName := acctest.RandomWithPrefix("tf-cloudtrail-test-org")
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
@@ -417,7 +417,7 @@ func testAccAWSCloudTrail_is_organization(t *testing.T) {
 
 func testAccAWSCloudTrail_logValidation(t *testing.T) {
 	var trail cloudtrail.Trail
-	rName := acctest.RandomWithPrefix("tf-cloudtrail-test-log-val")
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
@@ -456,7 +456,7 @@ func testAccAWSCloudTrail_logValidation(t *testing.T) {
 
 func testAccAWSCloudTrail_kmsKey(t *testing.T) {
 	var trail cloudtrail.Trail
-	rName := acctest.RandomWithPrefix("tf-cloudtrail-test-kms")
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cloudtrail.test"
 	kmsResourceName := "aws_kms_key.foo"
 
@@ -484,65 +484,9 @@ func testAccAWSCloudTrail_kmsKey(t *testing.T) {
 	})
 }
 
-func testAccAWSCloudTrail_tags(t *testing.T) {
-	var trail cloudtrail.Trail
-	var trailTags []*cloudtrail.Tag
-	var trailTagsModified []*cloudtrail.Tag
-	cloudTrailRandInt := acctest.RandInt()
-	resourceName := "aws_cloudtrail.test"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSCloudTrailConfig_tags(cloudTrailRandInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudTrailExists(resourceName, &trail),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-					testAccCheckCloudTrailLoadTags(&trail, &trailTags),
-					resource.TestCheckResourceAttr(resourceName, "tags.Foo", "moo"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Pooh", "hi"),
-					testAccCheckCloudTrailLogValidationEnabled(resourceName, false, &trail),
-					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccAWSCloudTrailConfig_tagsModified(cloudTrailRandInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudTrailExists(resourceName, &trail),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
-					testAccCheckCloudTrailLoadTags(&trail, &trailTagsModified),
-					resource.TestCheckResourceAttr(resourceName, "tags.Foo", "moo"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Moo", "boom"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Pooh", "hi"),
-					testAccCheckCloudTrailLogValidationEnabled(resourceName, false, &trail),
-					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
-				),
-			},
-			{
-				Config: testAccAWSCloudTrailConfig_tagsModifiedAgain(cloudTrailRandInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudTrailExists(resourceName, &trail),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-					testAccCheckCloudTrailLoadTags(&trail, &trailTagsModified),
-					testAccCheckCloudTrailLogValidationEnabled(resourceName, false, &trail),
-					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
-				),
-			},
-		},
-	})
-}
-
 func testAccAWSCloudTrail_include_global_service_events(t *testing.T) {
 	var trail cloudtrail.Trail
-	rName := acctest.RandomWithPrefix("tf-cloudtrail-test-events")
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
@@ -567,7 +511,7 @@ func testAccAWSCloudTrail_include_global_service_events(t *testing.T) {
 }
 
 func testAccAWSCloudTrail_event_selector(t *testing.T) {
-	rName := acctest.RandomWithPrefix("tf-cloudtrail-test-event")
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
@@ -595,7 +539,7 @@ func testAccAWSCloudTrail_event_selector(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCloudTrailConfig_eventSelectorReadWriteType(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailConfig_eventSelectorReadWriteType(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "event_selector.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.include_management_events", "true"),
@@ -626,12 +570,18 @@ func testAccAWSCloudTrail_event_selector(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.exclude_management_event_sources.#", "0"),
 				),
 			},
+			{
+				Config: testAccAWSCloudTrailConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "event_selector.#", "0"),
+				),
+			},
 		},
 	})
 }
 
 func testAccAWSCloudTrail_event_selector_exclude(t *testing.T) {
-	rName := acctest.RandomWithPrefix("tf-cloudtrail-test-exclude")
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
@@ -665,7 +615,7 @@ func testAccAWSCloudTrail_event_selector_exclude(t *testing.T) {
 
 func testAccAWSCloudTrail_disappears(t *testing.T) {
 	var trail cloudtrail.Trail
-	rName := acctest.RandomWithPrefix("tf-cloudtrail-test-disappears")
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cloudtrail.test"
 
 	resource.Test(t, resource.TestCase{
@@ -680,12 +630,6 @@ func testAccAWSCloudTrail_disappears(t *testing.T) {
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsCloudTrail(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
-			},
-			{
-				Config: testAccAWSCloudTrailConfig_eventSelectorNone(cloudTrailRandInt),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "event_selector.#", "0"),
-				),
 			},
 		},
 	})
@@ -732,7 +676,7 @@ func testAccCheckCloudTrailLoggingEnabled(n string, desired bool) resource.TestC
 			return err
 		}
 		if *resp.IsLogging != desired {
-			return fmt.Errorf("Expected logging status %t, given %t", desired, *resp.IsLogging)
+			return fmt.Errorf("Expected logging status %t, given %t", desired, aws.BoolValue(resp.IsLogging))
 		}
 
 		return nil
@@ -750,9 +694,9 @@ func testAccCheckCloudTrailLogValidationEnabled(n string, desired bool, trail *c
 			return fmt.Errorf("No LogFileValidationEnabled attribute present in trail: %s", trail)
 		}
 
-		if *trail.LogFileValidationEnabled != desired {
+		if aws.BoolValue(trail.LogFileValidationEnabled) != desired {
 			return fmt.Errorf("Expected log validation status %t, given %t", desired,
-				*trail.LogFileValidationEnabled)
+				aws.BoolValue(trail.LogFileValidationEnabled))
 		}
 
 		// local state comparison
@@ -786,7 +730,7 @@ func testAccCheckAWSCloudTrailDestroy(s *terraform.State) error {
 
 		if err == nil {
 			if len(resp.TrailList) != 0 &&
-				*resp.TrailList[0].Name == rs.Primary.ID {
+				aws.StringValue(resp.TrailList[0].Name) == rs.Primary.ID {
 				return fmt.Errorf("CloudTrail still exists: %s", rs.Primary.ID)
 			}
 		}
@@ -1119,49 +1063,18 @@ resource "aws_cloudtrail" "test" {
 `, rName)
 }
 
-func testAccAWSCloudTrailConfig_eventSelectorReadWriteType(cloudTrailRandInt int) string {
-	return fmt.Sprintf(`
-resource "aws_cloudtrail" "foobar" {
-    name = "tf-trail-foobar-%d"
-    s3_bucket_name = "${aws_s3_bucket.foo.id}"
+func testAccAWSCloudTrailConfig_eventSelectorReadWriteType(rName string) string {
+	return testAccAWSCloudTrailConfigS3Base(rName) + fmt.Sprintf(`
+resource "aws_cloudtrail" "test" {
+  name = %[1]q
+  s3_bucket_name = "${aws_s3_bucket.test.id}"
 
-	event_selector {
-		read_write_type = "WriteOnly"
-		include_management_events = true
-	}
+  event_selector {
+    read_write_type = "WriteOnly"
+    include_management_events = true
+  }
 }
-
-resource "aws_s3_bucket" "foo" {
-	bucket = "tf-test-trail-%d"
-	force_destroy = true
-	policy = <<POLICY
-{
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-			"Sid": "AWSCloudTrailAclCheck",
-			"Effect": "Allow",
-			"Principal": "*",
-			"Action": "s3:GetBucketAcl",
-			"Resource": "arn:aws:s3:::tf-test-trail-%d"
-		},
-		{
-			"Sid": "AWSCloudTrailWrite",
-			"Effect": "Allow",
-			"Principal": "*",
-			"Action": "s3:PutObject",
-			"Resource": "arn:aws:s3:::tf-test-trail-%d/*",
-			"Condition": {
-				"StringEquals": {
-					"s3:x-amz-acl": "bucket-owner-full-control"
-				}
-			}
-		}
-	]
-}
-POLICY
-}
-`, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
+`, rName)
 }
 
 func testAccAWSCloudTrailConfig_eventSelectorExclude(rName string) string {
@@ -1261,46 +1174,6 @@ resource "aws_lambda_function" "test" {
   runtime       = "nodejs12.x"
 }
 `, rName)
-}
-
-func testAccAWSCloudTrailConfig_eventSelectorNone(cloudTrailRandInt int) string {
-	return fmt.Sprintf(`
-resource "aws_cloudtrail" "foobar" {
-  name           = "tf-trail-foobar-%d"
-  s3_bucket_name = "${aws_s3_bucket.foo.id}"
-}
-
-resource "aws_s3_bucket" "foo" {
-  bucket        = "tf-test-trail-%d"
-  force_destroy = true
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AWSCloudTrailAclCheck",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:GetBucketAcl",
-      "Resource": "arn:aws:s3:::tf-test-trail-%d"
-    },
-    {
-      "Sid": "AWSCloudTrailWrite",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:PutObject",
-      "Resource": "arn:aws:s3:::tf-test-trail-%d/*",
-      "Condition": {
-        "StringEquals": {
-          "s3:x-amz-acl": "bucket-owner-full-control"
-        }
-      }
-    }
-  ]
-}
-POLICY
-}
-`, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
 }
 
 func testAccAWSCloudTrailConfigTags1(rName, tagKey1, tagValue1 string) string {

--- a/website/docs/r/cloudtrail.html.markdown
+++ b/website/docs/r/cloudtrail.html.markdown
@@ -166,6 +166,7 @@ For **event_selector** the following attributes are supported.
 * `read_write_type` (Optional) - Specify if you want your trail to log read-only events, write-only events, or all. By default, the value is All. You can specify only the following value: "ReadOnly", "WriteOnly", "All". Defaults to `All`.
 * `include_management_events` (Optional) - Specify if you want your event selector to include management events for your trail.
 * `data_resource` (Optional) - Specifies logging data events. Fields documented below.
+* `exclude_management_event_sources`  (Optional) -  A list of event sources to exclude (currently only "kms.amazonaws.com"). `include_management_events` has to be `true` to allow this.
 
 #### Data Resource Arguments
 For **data_resource** the following attributes are supported.

--- a/website/docs/r/cloudtrail.html.markdown
+++ b/website/docs/r/cloudtrail.html.markdown
@@ -181,6 +181,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The name of the trail.
 * `home_region` - The region in which the trail was created.
 * `arn` - The Amazon Resource Name of the trail.
+* `sns_topic_arn` - The Amazon Resource Name of the Amazon SNS topic defined for notification of log file delivery.
 
 
 ## Import


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11448 , Relates #11682

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_cloudtrail: add support for `exclude_management_event_sources` argument in `event_selector` block.

resource_aws_cloudtrail: added plan time validations to `cloud_watch_logs_role_arn`, `cloud_watch_logs_group_arn`, `sns_topic_name`, `event_selector.data_resource.values`.

resource_aws_cloudtrail: added `sns_topic_arn` attribute.

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCloudTrail/Trail'
        --- PASS: TestAccAWSCloudTrail/Trail/disappears (102.18s)
        --- PASS: TestAccAWSCloudTrail/Trail/includeGlobalServiceEvents (118.36s)
        --- PASS: TestAccAWSCloudTrail/Trail/logValidation (181.54s)
        --- PASS: TestAccAWSCloudTrail/Trail/kmsKey (130.94s)
        --- PASS: TestAccAWSCloudTrail/Trail/basic (165.84s)
        --- PASS: TestAccAWSCloudTrail/Trail/enableLogging (234.62s)
        --- PASS: TestAccAWSCloudTrail/Trail/isMultiRegion (229.30s)
	--- PASS: TestAccAWSCloudTrail/Trail/eventSelectorWExclude (106.84s)
        --- PASS: TestAccAWSCloudTrail/Trail/eventSelector (187.04s)
        --- PASS: TestAccAWSCloudTrail/Trail/tags (228.16s)
        --- PASS: TestAccAWSCloudTrail/Trail/sns (229.32s)
        --- PASS: TestAccAWSCloudTrail/Trail/cloudwatch (181.60s)
        --- SKIP: TestAccAWSCloudTrail/Trail/isOrganization (4.11s)
```
