### PR TITLE
r/cloudhsmv2_cluster - support tag on create

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -407,14 +407,14 @@ More details about this code generation, including fixes for potential error mes
   }
   ```
 
-- Otherwise if the API does not support tagging on creation (the `Input` struct does not accept a `Tags` field), in the resource `Create` function, implement the logic to convert the configuration tags into the service API call to tag a resource, e.g. with CloudHSM v2 Clusters:
+- Otherwise if the API does not support tagging on creation (the `Input` struct does not accept a `Tags` field), in the resource `Create` function, implement the logic to convert the configuration tags into the service API call to tag a resource, e.g. with ElasticSearch Domain:
 
   ```go
-  if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
-    if err := keyvaluetags.Cloudhsmv2UpdateTags(conn, d.Id(), nil, v); err != nil {
-      return fmt.Errorf("error adding CloudHSM v2 Cluster (%s) tags: %s", d.Id(), err)
-    }
-  }
+if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
+	if err := keyvaluetags.ElasticsearchserviceUpdateTags(conn, d.Id(), nil, v); err != nil {
+		return fmt.Errorf("error adding Elasticsearch Cluster (%s) tags: %s", d.Id(), err)
+	}
+}
   ```
 
 - Some EC2 resources (for example [`aws_ec2_fleet`](https://www.terraform.io/docs/providers/aws/r/ec2_fleet.html)) have a `TagsSpecification` field in the `InputStruct` instead of a `Tags` field. In these cases the `ec2TagSpecificationsFromMap()` helper function should be used, e.g.:

--- a/aws/resource_aws_cloudhsm2_cluster_test.go
+++ b/aws/resource_aws_cloudhsm2_cluster_test.go
@@ -83,19 +83,18 @@ func testSweepCloudhsmv2Clusters(region string) error {
 	return nil
 }
 
-func TestAccAWSCloudHsmV2Cluster_basic(t *testing.T) {
-	var cluster cloudhsmv2.Cluster
+func TestAccAWSCloudHsm2Cluster_basic(t *testing.T) {
 	resourceName := "aws_cloudhsm_v2_cluster.cluster"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCloudHsmV2ClusterDestroy,
+		CheckDestroy: testAccCheckAWSCloudHsm2ClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudHsmV2ClusterConfig(),
+				Config: testAccAWSCloudHsm2ClusterConfig(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCloudHsmV2ClusterExists(resourceName, &cluster),
+					testAccCheckAWSCloudHsm2ClusterExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "cluster_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "security_group_id"),
@@ -113,19 +112,18 @@ func TestAccAWSCloudHsmV2Cluster_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSCloudHsmV2Cluster_Tags(t *testing.T) {
-	var cluster cloudhsmv2.Cluster
+func TestAccAWSCloudHsm2Cluster_Tags(t *testing.T) {
 	resourceName := "aws_cloudhsm_v2_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCloudHsmV2ClusterDestroy,
+		CheckDestroy: testAccCheckAWSCloudHsm2ClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudHsmV2ClusterConfigTags2("key1", "value1", "key2", "value2"),
+				Config: testAccAWSCloudHsm2ClusterConfigTags2("key1", "value1", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCloudHsmV2ClusterExists(resourceName, &cluster),
+					testAccCheckAWSCloudHsm2ClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
@@ -138,17 +136,17 @@ func TestAccAWSCloudHsmV2Cluster_Tags(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"cluster_certificates"},
 			},
 			{
-				Config: testAccAWSCloudHsmV2ClusterConfigTags1("key1", "value1updated"),
+				Config: testAccAWSCloudHsm2ClusterConfigTags1("key1", "value1updated"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCloudHsmV2ClusterExists(resourceName, &cluster),
+					testAccCheckAWSCloudHsm2ClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
 				),
 			},
 			{
-				Config: testAccAWSCloudHsmV2ClusterConfigTags2("key1", "value1updated", "key3", "value3"),
+				Config: testAccAWSCloudHsm2ClusterConfigTags2("key1", "value1updated", "key3", "value3"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCloudHsmV2ClusterExists(resourceName, &cluster),
+					testAccCheckAWSCloudHsm2ClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key3", "value3"),
@@ -158,28 +156,7 @@ func TestAccAWSCloudHsmV2Cluster_Tags(t *testing.T) {
 	})
 }
 
-func TestAccAWSCloudHsm2Cluster_disappears(t *testing.T) {
-	var cluster cloudhsmv2.Cluster
-	resourceName := "aws_cloudhsm_v2_cluster.cluster"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCloudHsmV2ClusterDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSCloudHsmV2ClusterConfig(),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCloudHsmV2ClusterExists(resourceName, &cluster),
-					testAccCheckAWSCloudHsmV2ClusterDisappears(&cluster),
-				),
-				ExpectNonEmptyPlan: true,
-			},
-		},
-	})
-}
-
-func testAccAWSCloudHsmV2ClusterConfigBase() string {
+func testAccAWSCloudHsm2ClusterConfigBase() string {
 	return fmt.Sprintf(`
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
@@ -188,7 +165,7 @@ variable "subnets" {
 
 data "aws_availability_zones" "available" {}
 
-resource "aws_vpc" "cloudhsm_v2_test_vpc" {
+resource "aws_vpc" "cloudhsm2_test_vpc" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
@@ -196,9 +173,9 @@ resource "aws_vpc" "cloudhsm_v2_test_vpc" {
   }
 }
 
-resource "aws_subnet" "cloudhsm_v2_test_subnets" {
+resource "aws_subnet" "cloudhsm2_test_subnets" {
   count                   = 2
-  vpc_id                  = "${aws_vpc.cloudhsm_v2_test_vpc.id}"
+  vpc_id                  = "${aws_vpc.cloudhsm2_test_vpc.id}"
   cidr_block              = "${element(var.subnets, count.index)}"
   map_public_ip_on_launch = false
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
@@ -210,20 +187,20 @@ resource "aws_subnet" "cloudhsm_v2_test_subnets" {
 `)
 }
 
-func testAccAWSCloudHsmV2ClusterConfig() string {
-	return testAccAWSCloudHsmV2ClusterConfigBase() + fmt.Sprintf(`
+func testAccAWSCloudHsm2ClusterConfig() string {
+	return testAccAWSCloudHsm2ClusterConfigBase() + fmt.Sprintf(`
 resource "aws_cloudhsm_v2_cluster" "cluster" {
   hsm_type   = "hsm1.medium"
-  subnet_ids = ["${aws_subnet.cloudhsm_v2_test_subnets.*.id[0]}", "${aws_subnet.cloudhsm_v2_test_subnets.*.id[1]}"]
+  subnet_ids = ["${aws_subnet.cloudhsm2_test_subnets.*.id[0]}", "${aws_subnet.cloudhsm2_test_subnets.*.id[1]}"]
 }
 `)
 }
 
-func testAccAWSCloudHsmV2ClusterConfigTags1(tagKey1, tagValue1 string) string {
-	return testAccAWSCloudHsmV2ClusterConfigBase() + fmt.Sprintf(`
+func testAccAWSCloudHsm2ClusterConfigTags1(tagKey1, tagValue1 string) string {
+	return testAccAWSCloudHsm2ClusterConfigBase() + fmt.Sprintf(`
 resource "aws_cloudhsm_v2_cluster" "test" {
   hsm_type   = "hsm1.medium"
-  subnet_ids = ["${aws_subnet.cloudhsm_v2_test_subnets.*.id[0]}", "${aws_subnet.cloudhsm_v2_test_subnets.*.id[1]}"]
+  subnet_ids = ["${aws_subnet.cloudhsm2_test_subnets.*.id[0]}", "${aws_subnet.cloudhsm2_test_subnets.*.id[1]}"]
 
   tags = {
     %[1]q = %[2]q
@@ -232,11 +209,11 @@ resource "aws_cloudhsm_v2_cluster" "test" {
 `, tagKey1, tagValue1)
 }
 
-func testAccAWSCloudHsmV2ClusterConfigTags2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return testAccAWSCloudHsmV2ClusterConfigBase() + fmt.Sprintf(`
+func testAccAWSCloudHsm2ClusterConfigTags2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return testAccAWSCloudHsm2ClusterConfigBase() + fmt.Sprintf(`
 resource "aws_cloudhsm_v2_cluster" "test" {
   hsm_type   = "hsm1.medium"
-  subnet_ids = ["${aws_subnet.cloudhsm_v2_test_subnets.*.id[0]}", "${aws_subnet.cloudhsm_v2_test_subnets.*.id[1]}"]
+  subnet_ids = ["${aws_subnet.cloudhsm2_test_subnets.*.id[0]}", "${aws_subnet.cloudhsm2_test_subnets.*.id[1]}"]
 
   tags = {
     %[1]q = %[2]q
@@ -246,12 +223,12 @@ resource "aws_cloudhsm_v2_cluster" "test" {
 `, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccCheckAWSCloudHsmV2ClusterDestroy(s *terraform.State) error {
+func testAccCheckAWSCloudHsm2ClusterDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_cloudhsm_v2_cluster" {
 			continue
 		}
-		cluster, err := describeCloudHsmV2Cluster(testAccProvider.Meta().(*AWSClient).cloudhsmv2conn, rs.Primary.ID)
+		cluster, err := describeCloudHsm2Cluster(testAccProvider.Meta().(*AWSClient).cloudhsmv2conn, rs.Primary.ID)
 
 		if err != nil {
 			return err
@@ -265,7 +242,7 @@ func testAccCheckAWSCloudHsmV2ClusterDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAWSCloudHsmV2ClusterExists(name string, cluster *cloudhsmv2.Cluster) resource.TestCheckFunc {
+func testAccCheckAWSCloudHsm2ClusterExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).cloudhsmv2conn
 		it, ok := s.RootModule().Resources[name]
@@ -273,24 +250,12 @@ func testAccCheckAWSCloudHsmV2ClusterExists(name string, cluster *cloudhsmv2.Clu
 			return fmt.Errorf("Not found: %s", name)
 		}
 
-		resp, err := describeCloudHsmV2Cluster(conn, it.Primary.ID)
+		_, err := describeCloudHsm2Cluster(conn, it.Primary.ID)
 
 		if err != nil {
 			return fmt.Errorf("CloudHSM cluster not found: %s", err)
 		}
 
-		*cluster = *resp
-
 		return nil
-	}
-}
-
-func testAccCheckAWSCloudHsmV2ClusterDisappears(cluster *cloudhsmv2.Cluster) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).cloudhsmv2conn
-		input := &cloudhsmv2.DeleteClusterInput{ClusterId: cluster.ClusterId}
-
-		_, err := conn.DeleteCluster(input)
-		return err
 	}
 }

--- a/aws/resource_aws_cloudhsm2_cluster_test.go
+++ b/aws/resource_aws_cloudhsm2_cluster_test.go
@@ -83,18 +83,18 @@ func testSweepCloudhsmv2Clusters(region string) error {
 	return nil
 }
 
-func TestAccAWSCloudHsm2Cluster_basic(t *testing.T) {
-	resourceName := "aws_cloudhsm_v2_cluster.cluster"
+func TestAccAWSCloudHsmV2Cluster_basic(t *testing.T) {
+	resourceName := "aws_cloudhsm_v2_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCloudHsm2ClusterDestroy,
+		CheckDestroy: testAccCheckAWSCloudHsmV2ClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudHsm2ClusterConfig(),
+				Config: testAccAWSCloudHsmV2ClusterConfig(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCloudHsm2ClusterExists(resourceName),
+					testAccCheckAWSCloudHsmV2ClusterExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "cluster_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "security_group_id"),
@@ -112,18 +112,18 @@ func TestAccAWSCloudHsm2Cluster_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSCloudHsm2Cluster_Tags(t *testing.T) {
+func TestAccAWSCloudHsmV2Cluster_Tags(t *testing.T) {
 	resourceName := "aws_cloudhsm_v2_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCloudHsm2ClusterDestroy,
+		CheckDestroy: testAccCheckAWSCloudHsmV2ClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudHsm2ClusterConfigTags2("key1", "value1", "key2", "value2"),
+				Config: testAccAWSCloudHsmV2ClusterConfigTags2("key1", "value1", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCloudHsm2ClusterExists(resourceName),
+					testAccCheckAWSCloudHsmV2ClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
@@ -136,17 +136,17 @@ func TestAccAWSCloudHsm2Cluster_Tags(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"cluster_certificates"},
 			},
 			{
-				Config: testAccAWSCloudHsm2ClusterConfigTags1("key1", "value1updated"),
+				Config: testAccAWSCloudHsmV2ClusterConfigTags1("key1", "value1updated"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCloudHsm2ClusterExists(resourceName),
+					testAccCheckAWSCloudHsmV2ClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
 				),
 			},
 			{
-				Config: testAccAWSCloudHsm2ClusterConfigTags2("key1", "value1updated", "key3", "value3"),
+				Config: testAccAWSCloudHsmV2ClusterConfigTags2("key1", "value1updated", "key3", "value3"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCloudHsm2ClusterExists(resourceName),
+					testAccCheckAWSCloudHsmV2ClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key3", "value3"),
@@ -156,7 +156,7 @@ func TestAccAWSCloudHsm2Cluster_Tags(t *testing.T) {
 	})
 }
 
-func testAccAWSCloudHsm2ClusterConfigBase() string {
+func testAccAWSCloudHsmV2ClusterConfigBase() string {
 	return fmt.Sprintf(`
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
@@ -165,7 +165,7 @@ variable "subnets" {
 
 data "aws_availability_zones" "available" {}
 
-resource "aws_vpc" "cloudhsm2_test_vpc" {
+resource "aws_vpc" "cloudhsm_v2_test_vpc" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
@@ -173,9 +173,9 @@ resource "aws_vpc" "cloudhsm2_test_vpc" {
   }
 }
 
-resource "aws_subnet" "cloudhsm2_test_subnets" {
+resource "aws_subnet" "cloudhsm_v2_test_subnets" {
   count                   = 2
-  vpc_id                  = "${aws_vpc.cloudhsm2_test_vpc.id}"
+  vpc_id                  = "${aws_vpc.cloudhsm_v2_test_vpc.id}"
   cidr_block              = "${element(var.subnets, count.index)}"
   map_public_ip_on_launch = false
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
@@ -187,20 +187,20 @@ resource "aws_subnet" "cloudhsm2_test_subnets" {
 `)
 }
 
-func testAccAWSCloudHsm2ClusterConfig() string {
-	return testAccAWSCloudHsm2ClusterConfigBase() + fmt.Sprintf(`
+func testAccAWSCloudHsmV2ClusterConfig() string {
+	return testAccAWSCloudHsmV2ClusterConfigBase() + fmt.Sprintf(`
 resource "aws_cloudhsm_v2_cluster" "cluster" {
   hsm_type   = "hsm1.medium"
-  subnet_ids = ["${aws_subnet.cloudhsm2_test_subnets.*.id[0]}", "${aws_subnet.cloudhsm2_test_subnets.*.id[1]}"]
+  subnet_ids = ["${aws_subnet.cloudhsm_v2_test_subnets.*.id[0]}", "${aws_subnet.cloudhsm_v2_test_subnets.*.id[1]}"]
 }
 `)
 }
 
-func testAccAWSCloudHsm2ClusterConfigTags1(tagKey1, tagValue1 string) string {
-	return testAccAWSCloudHsm2ClusterConfigBase() + fmt.Sprintf(`
+func testAccAWSCloudHsmV2ClusterConfigTags1(tagKey1, tagValue1 string) string {
+	return testAccAWSCloudHsmV2ClusterConfigBase() + fmt.Sprintf(`
 resource "aws_cloudhsm_v2_cluster" "test" {
   hsm_type   = "hsm1.medium"
-  subnet_ids = ["${aws_subnet.cloudhsm2_test_subnets.*.id[0]}", "${aws_subnet.cloudhsm2_test_subnets.*.id[1]}"]
+  subnet_ids = ["${aws_subnet.cloudhsm_v2_test_subnets.*.id[0]}", "${aws_subnet.cloudhsm_v2_test_subnets.*.id[1]}"]
 
   tags = {
     %[1]q = %[2]q
@@ -209,11 +209,11 @@ resource "aws_cloudhsm_v2_cluster" "test" {
 `, tagKey1, tagValue1)
 }
 
-func testAccAWSCloudHsm2ClusterConfigTags2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return testAccAWSCloudHsm2ClusterConfigBase() + fmt.Sprintf(`
+func testAccAWSCloudHsmV2ClusterConfigTags2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return testAccAWSCloudHsmV2ClusterConfigBase() + fmt.Sprintf(`
 resource "aws_cloudhsm_v2_cluster" "test" {
   hsm_type   = "hsm1.medium"
-  subnet_ids = ["${aws_subnet.cloudhsm2_test_subnets.*.id[0]}", "${aws_subnet.cloudhsm2_test_subnets.*.id[1]}"]
+  subnet_ids = ["${aws_subnet.cloudhsm_v2_test_subnets.*.id[0]}", "${aws_subnet.cloudhsm_v2_test_subnets.*.id[1]}"]
 
   tags = {
     %[1]q = %[2]q
@@ -223,12 +223,12 @@ resource "aws_cloudhsm_v2_cluster" "test" {
 `, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccCheckAWSCloudHsm2ClusterDestroy(s *terraform.State) error {
+func testAccCheckAWSCloudHsmV2ClusterDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_cloudhsm_v2_cluster" {
 			continue
 		}
-		cluster, err := describeCloudHsm2Cluster(testAccProvider.Meta().(*AWSClient).cloudhsmv2conn, rs.Primary.ID)
+		cluster, err := describeCloudHsmV2Cluster(testAccProvider.Meta().(*AWSClient).cloudhsmv2conn, rs.Primary.ID)
 
 		if err != nil {
 			return err
@@ -242,7 +242,7 @@ func testAccCheckAWSCloudHsm2ClusterDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAWSCloudHsm2ClusterExists(name string) resource.TestCheckFunc {
+func testAccCheckAWSCloudHsmV2ClusterExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).cloudhsmv2conn
 		it, ok := s.RootModule().Resources[name]
@@ -250,7 +250,7 @@ func testAccCheckAWSCloudHsm2ClusterExists(name string) resource.TestCheckFunc {
 			return fmt.Errorf("Not found: %s", name)
 		}
 
-		_, err := describeCloudHsm2Cluster(conn, it.Primary.ID)
+		_, err := describeCloudHsmV2Cluster(conn, it.Primary.ID)
 
 		if err != nil {
 			return fmt.Errorf("CloudHSM cluster not found: %s", err)

--- a/aws/resource_aws_cloudhsm2_cluster_test.go
+++ b/aws/resource_aws_cloudhsm2_cluster_test.go
@@ -84,7 +84,7 @@ func testSweepCloudhsmv2Clusters(region string) error {
 }
 
 func TestAccAWSCloudHsmV2Cluster_basic(t *testing.T) {
-	resourceName := "aws_cloudhsm_v2_cluster.test"
+	resourceName := "aws_cloudhsm_v2_cluster.cluster"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_cloudhsmv2_cluster: support tag on create
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCloudHsm2Cluster_'
--- PASS: TestAccAWSCloudHsm2Cluster_basic (345.82s)
--- PASS: TestAccAWSCloudHsm2Cluster_Tags (441.26s)

```
