### PR TITLE
tests/service/rds: Acceptance test configuration fixes for deprecated Oracle instance class and for matching instance to option group engine version

### DIFF
--- a/aws/resource_aws_db_instance_role_association_test.go
+++ b/aws/resource_aws_db_instance_role_association_test.go
@@ -179,7 +179,7 @@ resource "aws_db_instance" "test" {
   allocated_storage   = 10
   engine              = "oracle-se"
   identifier          = %[1]q
-  instance_class      = "db.t2.micro"
+  instance_class      = "db.t3.micro"
   password            = "avoid-plaintext-passwords"
   username            = "tfacctest"
   skip_final_snapshot = true

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -2764,30 +2764,26 @@ resource "aws_db_instance" "bar" {
 
 func testAccAWSDBInstanceConfigWithOptionGroup(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_db_option_group" "bar" {
-  name                     = "%s"
-  option_group_description = "Test option group for terraform"
+resource "aws_db_option_group" "test" {
   engine_name              = "mysql"
   major_engine_version     = "5.6"
+  name                     = %[1]q
+  option_group_description = "Test option group for terraform"
 }
 
 resource "aws_db_instance" "bar" {
-  identifier = "foobarbaz-test-terraform-%d"
-
-  allocated_storage = 10
-  engine            = "MySQL"
-  instance_class    = "db.t2.micro"
-  name              = "baz"
-  password          = "barbarbarbar"
-  username          = "foo"
-
-  backup_retention_period = 0
-  skip_final_snapshot     = true
-
-  parameter_group_name = "default.mysql5.6"
-  option_group_name    = "${aws_db_option_group.bar.name}"
+  allocated_storage   = 10
+  engine              = aws_db_option_group.test.engine_name
+  engine_version      = aws_db_option_group.test.major_engine_version
+  identifier          = %[1]q
+  instance_class      = "db.t2.micro"
+  name                = "baz"
+  option_group_name   = aws_db_option_group.test.name
+  password            = "barbarbarbar"
+  skip_final_snapshot = true
+  username            = "foo"
 }
-`, rName, acctest.RandInt())
+`, rName)
 }
 
 func testAccCheckAWSDBIAMAuth(n int) string {
@@ -4271,7 +4267,7 @@ resource "aws_db_instance" "test" {
   enabled_cloudwatch_logs_exports = ["alert", "listener", "trace"]
   engine                          = "oracle-se"
   identifier                      = %q
-  instance_class                  = "db.t2.micro"
+  instance_class                  = "db.t3.micro"
   password                        = "avoid-plaintext-passwords"
   username                        = "tfacctest"
   skip_final_snapshot             = true


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Oracle.html#Oracle.Concepts.InstanceClasses

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously in the acceptance testing:

```
--- FAIL: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle (2.65s)
    testing.go:640: Step 0 error: errors during apply:

        Error: Error creating DB Instance: InvalidParameterCombination: RDS does not support creating a DB instance with the following combination: DBInstanceClass=db.t2.micro, Engine=oracle-se, EngineVersion=11.2.0.4.v22, LicenseModel=bring-your-own-license. For supported combinations of instance class and database engine version, see the documentation.

--- FAIL: TestAccAWSDbInstanceRoleAssociation_basic (6.44s)
    testing.go:640: Step 0 error: errors during apply:

        Error: Error creating DB Instance: InvalidParameterCombination: RDS does not support creating a DB instance with the following combination: DBInstanceClass=db.t2.micro, Engine=oracle-se, EngineVersion=11.2.0.4.v22, LicenseModel=bring-your-own-license. For supported combinations of instance class and database engine version, see the documentation.

--- FAIL: TestAccAWSDbInstanceRoleAssociation_disappears (7.24s)
    testing.go:640: Step 0 error: errors during apply:

        Error: Error creating DB Instance: InvalidParameterCombination: RDS does not support creating a DB instance with the following combination: DBInstanceClass=db.t2.micro, Engine=oracle-se, EngineVersion=11.2.0.4.v22, LicenseModel=bring-your-own-license. For supported combinations of instance class and database engine version, see the documentation.

--- FAIL: TestAccAWSDBInstance_optionGroup (4.95s)
    testing.go:640: Step 0 error: errors during apply:

        Error: Error creating DB Instance: InvalidParameterCombination: The option group tf-option-test-6882627030637036293 is for mysql 5.6, and your DB instance is mysql 5.7.
```

As noted by the RDS User Guide, the db.t2 instance class has been deprecated for db.t3. As for the option group testing, the testing configuration has been updated so the instance references the option group engine and engine version to ensure the two do not drift due to RDS changing the instance creation default.

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSDBInstance_optionGroup (522.01s)
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle (626.95s)
--- PASS: TestAccAWSDbInstanceRoleAssociation_disappears (727.60s)
--- PASS: TestAccAWSDbInstanceRoleAssociation_basic (741.36s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAWSDBInstance_optionGroup (494.57s)
--- PASS: TestAccAWSDbInstanceRoleAssociation_disappears (719.47s)
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle (785.29s)
--- PASS: TestAccAWSDbInstanceRoleAssociation_basic (841.34s)
```