### PR TITLE
tests/resource/aws_ssm_maintenance_window: Add sweeper

### DIFF
--- a/aws/resource_aws_ssm_maintenance_window_test.go
+++ b/aws/resource_aws_ssm_maintenance_window_test.go
@@ -2,15 +2,79 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_ssm_maintenance_window", &resource.Sweeper{
+		Name: "aws_ssm_maintenance_window",
+		F:    testSweepSsmMaintenanceWindows,
+	})
+}
+
+func testSweepSsmMaintenanceWindows(region string) error {
+	client, err := sharedClientForRegion(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+
+	conn := client.(*AWSClient).ssmconn
+	input := &ssm.DescribeMaintenanceWindowsInput{}
+	var sweeperErrs *multierror.Error
+
+	for {
+		output, err := conn.DescribeMaintenanceWindows(input)
+
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping SSM Maintenance Window sweep for %s: %s", region, err)
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("Error retrieving SSM Maintenance Windows: %s", err)
+		}
+
+		for _, window := range output.WindowIdentities {
+			id := aws.StringValue(window.WindowId)
+			input := &ssm.DeleteMaintenanceWindowInput{
+				WindowId: window.WindowId,
+			}
+
+			log.Printf("[INFO] Deleting SSM Maintenance Window: %s", id)
+
+			_, err := conn.DeleteMaintenanceWindow(input)
+
+			if isAWSErr(err, ssm.ErrCodeDoesNotExistException, "") {
+				continue
+			}
+
+			if err != nil {
+				sweeperErr := fmt.Errorf("error deleting SSM Maintenance Window (%s): %w", id, err)
+				log.Printf("[ERROR] %s", sweeperErr)
+				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+				continue
+			}
+		}
+
+		if aws.StringValue(output.NextToken) == "" {
+			break
+		}
+
+		input.NextToken = output.NextToken
+	}
+
+	return nil
+}
 
 func TestAccAWSSSMMaintenanceWindow_basic(t *testing.T) {
 	var winId ssm.MaintenanceWindowIdentity


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously in acceptance testing:

```
--- FAIL: TestAccAWSSSMMaintenanceWindow_Schedule (5.72s)
    testing.go:640: Step 0 error: errors during apply:

        Error: error creating SSM Maintenance Window: ResourceLimitExceededException: Window limit exceeded.
```

Output from sweeper in AWS Commercial:

```console
$ aws ssm describe-maintenance-windows | jq '.WindowIdentities | length'
47
$ go test ./aws -v -timeout=10h -sweep=us-west-2 -sweep-run=aws_ssm_maintenance_window -sweep-allow-failures
2020/01/21 09:15:42 [DEBUG] Running Sweepers for region (us-west-2):
2020/01/21 09:15:42 [DEBUG] Running Sweeper (aws_ssm_maintenance_window) in region (us-west-2)
...
2020/01/21 09:15:45 [INFO] Deleting SSM Maintenance Window: mw-0011d970655f367d9
...
2020/01/21 09:16:05 [INFO] Deleting SSM Maintenance Window: mw-0f1252954f94ae52c
2020/01/21 09:16:06 Sweeper Tests ran successfully:
	- aws_ssm_maintenance_window
ok  	github.com/terraform-providers/terraform-provider-aws/aws	25.323s
$ aws ssm describe-maintenance-windows | jq '.WindowIdentities | length'
0
```

Output from sweeper in AWS GovCloud (US):

```console
$ go test ./aws -v -timeout=10h -sweep=us-gov-west-1 -sweep-run=aws_ssm_maintenance_window -sweep-allow-failures
2020/01/21 09:19:12 [DEBUG] Running Sweepers for region (us-gov-west-1):
2020/01/21 09:19:12 [DEBUG] Running Sweeper (aws_ssm_maintenance_window) in region (us-gov-west-1)
...
2020/01/21 09:19:15 Sweeper Tests ran successfully:
	- aws_ssm_maintenance_window
ok  	github.com/terraform-providers/terraform-provider-aws/aws	4.883s
```
