### PR TITLE
tests/resource/aws_api_gateway_deployment: Fix TestAccAWSAPIGatewayDeployment_StageName_EmptyString check

### DIFF
--- a/aws/resource_aws_api_gateway_deployment_test.go
+++ b/aws/resource_aws_api_gateway_deployment_test.go
@@ -188,7 +188,7 @@ func TestAccAWSAPIGatewayDeployment_StageName_EmptyString(t *testing.T) {
 				Config: testAccAWSAPIGatewayDeploymentConfigStageName(""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayDeploymentExists(resourceName, &deployment),
-					resource.TestCheckNoResourceAttr(resourceName, "stage_name"),
+					resource.TestCheckResourceAttr(resourceName, "stage_name", ""),
 				),
 			},
 		},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously in the acceptance testing:

```
--- FAIL: TestAccAWSAPIGatewayDeployment_StageName_EmptyString (449.53s)
    testing.go:640: Step 0 error: Check failed: Check 2/2 error: aws_api_gateway_deployment.test: Attribute 'stage_name' found when not expected
```

If I recall correctly, this check was being swapped back-and-forth in the Terraform 0.12 acceptance testing framework when the Terraform 0.11 shims were being implemented. We landed on supporting the old empty string implementation (the new implementation here) rather than forcing all similar test checks being updated across all Terraform Providers (with the old implementation here), however this particular instance was never reverted and is needlessly failing.

Output from acceptance testing:

```
--- PASS: TestAccAWSAPIGatewayDeployment_StageName_EmptyString (25.78s)
```
