### PR TITLE
resource/aws_dynamodb_table: Skip ResourceNotFoundException during deletion

### DIFF
--- a/aws/resource_aws_dynamodb_table.go
+++ b/aws/resource_aws_dynamodb_table.go
@@ -680,13 +680,12 @@ func deleteAwsDynamoDbTable(tableName string, conn *dynamodb.DynamoDB) error {
 		}
 		return nil
 	})
+
 	if isResourceTimeoutError(err) {
 		_, err = conn.DeleteTable(input)
 	}
-	if err != nil {
-		return fmt.Errorf("Error deleting DynamoDB table: %s", err)
-	}
-	return nil
+
+	return err
 }
 
 func waitForDynamodbTableDeletion(conn *dynamodb.DynamoDB, tableName string, timeout time.Duration) error {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_dynamodb_table: Skip `ResourceNotFoundException` error during deletion
```

Previously in the acceptance testing:

```
--- FAIL: TestAccAWSDynamoDbGlobalTable_multipleRegions (67.39s)
    testing.go:701: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: errors during apply: error deleting DynamoDB Table (tf-acc-test-tyuvv): Error deleting DynamoDB table: ResourceNotFoundException: Requested resource not found: Table: tf-acc-test-tyuvv not found
```

The prior code would wrap the `awserr.Error` in a `fmt.Errorf()` which meant the error was returned by value. The calling code already handles the error message context, so we remove the error wrapping so consumers can work with the AWS error type correctly. Another solution here would be instead using the Go 1.13 `%w` format verb, which will be part of a future linting check.

Output from acceptance testing:

```
--- PASS: TestAccAWSDynamoDbGlobalTable_basic (86.21s)
--- PASS: TestAccAWSDynamoDbGlobalTable_multipleRegions (106.17s)

--- PASS: TestAccAWSDynamoDbTable_attributeUpdate (463.78s)
--- PASS: TestAccAWSDynamoDbTable_attributeUpdateValidation (6.14s)
--- PASS: TestAccAWSDynamoDbTable_basic (27.57s)
--- PASS: TestAccAWSDynamoDbTable_BillingMode_GSI_PayPerRequestToProvisioned (57.72s)
--- PASS: TestAccAWSDynamoDbTable_BillingMode_GSI_ProvisionedToPayPerRequest (1149.43s)
--- PASS: TestAccAWSDynamoDbTable_BillingMode_PayPerRequestToProvisioned (45.62s)
--- PASS: TestAccAWSDynamoDbTable_BillingMode_ProvisionedToPayPerRequest (1325.53s)
--- PASS: TestAccAWSDynamoDbTable_disappears (19.40s)
--- PASS: TestAccAWSDynamoDbTable_disappears_PayPerRequestWithGSI (100.90s)
--- PASS: TestAccAWSDynamoDbTable_enablePitr (133.02s)
--- PASS: TestAccAWSDynamoDbTable_encryption (62.77s)
--- PASS: TestAccAWSDynamoDbTable_extended (195.41s)
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateCapacity (56.73s)
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateNonKeyAttributes (157.72s)
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateOtherAttributes (465.18s)
--- PASS: TestAccAWSDynamoDbTable_streamSpecification (67.08s)
--- PASS: TestAccAWSDynamoDbTable_streamSpecificationValidation (4.85s)
--- PASS: TestAccAWSDynamoDbTable_tags (36.51s)
--- PASS: TestAccAWSDynamoDbTable_Ttl_Disabled (41.27s)
--- PASS: TestAccAWSDynamoDbTable_Ttl_Enabled (29.97s)
```
