### PR TITLE
Allows Batch Compute Environment to be in INVALID state for sweeping

### DIFF
--- a/aws/resource_aws_batch_compute_environment.go
+++ b/aws/resource_aws_batch_compute_environment.go
@@ -496,7 +496,7 @@ func deleteBatchComputeEnvironment(computeEnvironment string, timeout time.Durat
 	}
 
 	stateChangeConf := &resource.StateChangeConf{
-		Pending:    []string{batch.CEStatusDeleting},
+		Pending:    []string{batch.CEStatusDeleting, batch.CEStatusInvalid},
 		Target:     []string{batch.CEStatusDeleted},
 		Refresh:    resourceAwsBatchComputeEnvironmentDeleteRefreshFunc(computeEnvironment, conn),
 		Timeout:    timeout,


### PR DESCRIPTION
Allows the sweeper to run when the Batch Compute Environment is in INVALID state.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make sweep SWEEPARGS='-sweep-run=aws_batch_compute_environment'

Sweeper Tests ran successfully:
	- aws_batch_job_queue
	- aws_batch_compute_environment
```
