### PR TITLE
resource/aws_ecs_cluster: Delay check of ECS Cluster status during creation for ECS eventual consistency

### DIFF
--- a/aws/resource_aws_ecs_cluster.go
+++ b/aws/resource_aws_ecs_cluster.go
@@ -138,7 +138,7 @@ func resourceAwsEcsClusterCreate(d *schema.ResourceData, meta interface{}) error
 	d.SetId(aws.StringValue(out.Cluster.ClusterArn))
 
 	if err = waitForEcsClusterActive(conn, clusterName, ecsClusterTimeoutCreate); err != nil {
-		return err
+		return fmt.Errorf("error waiting for ECS Cluster (%s) creation: %s", d.Id(), err)
 	}
 
 	return resourceAwsEcsClusterRead(d, meta)
@@ -244,7 +244,7 @@ func resourceAwsEcsClusterUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 
 		if err = waitForEcsClusterActive(conn, clusterName, ecsClusterTimeoutUpdate); err != nil {
-			return err
+			return fmt.Errorf("error waiting for ECS Cluster (%s) update: %s", d.Id(), err)
 		}
 	}
 
@@ -287,7 +287,7 @@ func resourceAwsEcsClusterUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 
 		if err = waitForEcsClusterActive(conn, clusterName, ecsClusterTimeoutUpdate); err != nil {
-			return err
+			return fmt.Errorf("error waiting for ECS Cluster (%s) update: %s", d.Id(), err)
 		}
 	}
 
@@ -352,6 +352,7 @@ func waitForEcsClusterActive(conn *ecs.ECS, clusterName string, timeout time.Dur
 		Target:  []string{"ACTIVE"},
 		Timeout: timeout,
 		Refresh: refreshEcsClusterStatus(conn, clusterName),
+		Delay:   10 * time.Second,
 	}
 	_, err := stateConf.WaitForState()
 	return err


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_ecs_cluster: Delay check of ECS Cluster status during creation for ECS eventual consistency
```

Previously in the acceptance testing (inconsistently):

```
--- FAIL: TestAccAWSAppautoScalingTarget_basic (5.62s)
    testing.go:640: Step 0 error: errors during apply:
        Error: ECS cluster "cluster-0bzcoev18m" missing

--- FAIL: TestAccAWSEcsService_withUnnormalizedPlacementStrategy (4.36s)
    testing.go:640: Step 0 error: errors during apply:

        Error: ECS cluster "tf-acc-cluster-svc-w-ups-ijnv7v74" missing
```

We also add error message context when returning this error to help operators and code maintainers.

Output from acceptance testing:

```
--- PASS: TestAccAWSEcsCluster_disappears (22.99s)
--- PASS: TestAccAWSEcsCluster_basic (27.66s)
--- PASS: TestAccAWSEcsCluster_Tags (46.07s)
--- PASS: TestAccAWSEcsCluster_CapacityProviders (49.88s)
--- PASS: TestAccAWSEcsCluster_CapacityProvidersNoStrategy (52.59s)
--- PASS: TestAccAWSEcsCluster_containerInsights (66.84s)
--- PASS: TestAccAWSEcsCluster_SingleCapacityProvider (73.76s)
--- PASS: TestAccAWSEcsCluster_CapacityProvidersUpdate (83.17s)

--- PASS: TestAccAWSAppautoScalingTarget_basic (54.12s)

--- PASS: TestAccAWSEcsService_withUnnormalizedPlacementStrategy (77.88s)
```