### PR TITLE
tests/resource/aws_elastic_beanstalk_environment: Refactoring and modernization

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -109,6 +109,19 @@ func testAccCheckResourceAttrRegionalARN(resourceName, attributeName, arnService
 	}
 }
 
+// testAccCheckResourceAttrRegionalARNNoAccount ensures the Terraform state exactly matches a formatted ARN with region but without account ID
+func testAccCheckResourceAttrRegionalARNNoAccount(resourceName, attributeName, arnService, arnResource string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		attributeValue := arn.ARN{
+			Partition: testAccGetPartition(),
+			Region:    testAccGetRegion(),
+			Resource:  arnResource,
+			Service:   arnService,
+		}.String()
+		return resource.TestCheckResourceAttr(resourceName, attributeName, attributeValue)(s)
+	}
+}
+
 // testAccMatchResourceAttrRegionalARN ensures the Terraform state regexp matches a formatted ARN with region
 func testAccMatchResourceAttrRegionalARN(resourceName, attributeName, arnService string, arnResourceRegexp *regexp.Regexp) resource.TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/aws/resource_aws_elastic_beanstalk_environment_test.go
+++ b/aws/resource_aws_elastic_beanstalk_environment_test.go
@@ -96,50 +96,17 @@ func testSweepBeanstalkEnvironments(region string) error {
 	return nil
 }
 
-func TestAWSElasticBeanstalkEnvironment_importBasic(t *testing.T) {
-	resourceName := "aws_elastic_beanstalk_application.tftest"
-
-	applicationName := fmt.Sprintf("tf-test-name-%d", acctest.RandInt())
-	environmentName := fmt.Sprintf("tf-test-env-name-%d", acctest.RandInt())
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckBeanstalkAppDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccBeanstalkEnvImportConfig(applicationName, environmentName),
-			},
-
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func testAccBeanstalkEnvImportConfig(appName, envName string) string {
-	return fmt.Sprintf(`
-resource "aws_elastic_beanstalk_application" "tftest" {
-	  name = "%s"
-	  description = "tf-test-desc"
-	}
-
-	resource "aws_elastic_beanstalk_environment" "tfenvtest" {
-	  name = "%s"
-	  application = "${aws_elastic_beanstalk_application.tftest.name}"
-	  solution_stack_name = "64bit Amazon Linux running Python"
-	}`, appName, envName)
-}
-
 func TestAccAWSBeanstalkEnv_basic(t *testing.T) {
 	var app elasticbeanstalk.EnvironmentDescription
 
-	rString := acctest.RandString(8)
-	appName := fmt.Sprintf("tf_acc_app_env_basic_%s", rString)
-	envName := fmt.Sprintf("tf-acc-env-basic-%s", rString)
+	resourceName := "aws_elastic_beanstalk_environment.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	beanstalkAsgNameRegexp := regexp.MustCompile("awseb.+?AutoScalingGroup[^,]+")
+	beanstalkElbNameRegexp := regexp.MustCompile("awseb.+?EBLoa[^,]+")
+	beanstalkInstancesNameRegexp := regexp.MustCompile("i-([0-9a-fA-F]{8}|[0-9a-fA-F]{17})")
+	beanstalkLcNameRegexp := regexp.MustCompile("awseb.+?AutoScalingLaunch[^,]+")
+	beanstalkEndpointUrl := regexp.MustCompile("awseb.+?EBLoa[^,].+?elb.amazonaws.com")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -147,13 +114,25 @@ func TestAccAWSBeanstalkEnv_basic(t *testing.T) {
 		CheckDestroy: testAccCheckBeanstalkEnvDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBeanstalkEnvConfig(appName, envName),
+				Config: testAccBeanstalkEnvConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBeanstalkEnvExists("aws_elastic_beanstalk_environment.tfenvtest", &app),
-					resource.TestMatchResourceAttr(
-						"aws_elastic_beanstalk_environment.tfenvtest", "arn",
-						regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:elasticbeanstalk:[^:]+:[^:]+:environment/%s/%s$", appName, envName))),
+					testAccCheckBeanstalkEnvExists(resourceName, &app),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "elasticbeanstalk", fmt.Sprintf("environment/%s/%s", rName, rName)),
+					resource.TestMatchResourceAttr(resourceName, "autoscaling_groups.0", beanstalkAsgNameRegexp),
+					resource.TestMatchResourceAttr(resourceName, "endpoint_url", beanstalkEndpointUrl),
+					resource.TestMatchResourceAttr(resourceName, "instances.0", beanstalkInstancesNameRegexp),
+					resource.TestMatchResourceAttr(resourceName, "launch_configurations.0", beanstalkLcNameRegexp),
+					resource.TestMatchResourceAttr(resourceName, "load_balancers.0", beanstalkElbNameRegexp),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"setting",
+					"wait_for_ready_timeout",
+				},
 			},
 		},
 	})
@@ -163,12 +142,8 @@ func TestAccAWSBeanstalkEnv_tier(t *testing.T) {
 	var app elasticbeanstalk.EnvironmentDescription
 	beanstalkQueuesNameRegexp := regexp.MustCompile("https://sqs.+?awseb[^,]+")
 
-	rString := acctest.RandString(8)
-	instanceProfileName := fmt.Sprintf("tf_acc_profile_beanstalk_env_tier_%s", rString)
-	roleName := fmt.Sprintf("tf_acc_role_beanstalk_env_tier_%s", rString)
-	policyName := fmt.Sprintf("tf_acc_policy_beanstalk_env_tier_%s", rString)
-	appName := fmt.Sprintf("tf_acc_app_env_tier_%s", rString)
-	envName := fmt.Sprintf("tf-acc-env-tier-%s", rString)
+	resourceName := "aws_elastic_beanstalk_environment.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -176,50 +151,20 @@ func TestAccAWSBeanstalkEnv_tier(t *testing.T) {
 		CheckDestroy: testAccCheckBeanstalkEnvDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBeanstalkWorkerEnvConfig(instanceProfileName, roleName, policyName, appName, envName),
+				Config: testAccBeanstalkWorkerEnvConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBeanstalkEnvTier("aws_elastic_beanstalk_environment.tfenvtest", &app),
-					resource.TestMatchResourceAttr(
-						"aws_elastic_beanstalk_environment.tfenvtest", "queues.0", beanstalkQueuesNameRegexp),
+					testAccCheckBeanstalkEnvTier(resourceName, &app),
+					resource.TestMatchResourceAttr(resourceName, "queues.0", beanstalkQueuesNameRegexp),
 				),
 			},
-		},
-	})
-}
-
-func TestAccAWSBeanstalkEnv_outputs(t *testing.T) {
-	var app elasticbeanstalk.EnvironmentDescription
-
-	beanstalkAsgNameRegexp := regexp.MustCompile("awseb.+?AutoScalingGroup[^,]+")
-	beanstalkElbNameRegexp := regexp.MustCompile("awseb.+?EBLoa[^,]+")
-	beanstalkInstancesNameRegexp := regexp.MustCompile("i-([0-9a-fA-F]{8}|[0-9a-fA-F]{17})")
-	beanstalkLcNameRegexp := regexp.MustCompile("awseb.+?AutoScalingLaunch[^,]+")
-	beanstalkEndpointUrl := regexp.MustCompile("awseb.+?EBLoa[^,].+?elb.amazonaws.com")
-
-	rString := acctest.RandString(8)
-	appName := fmt.Sprintf("tf_acc_app_env_outputs_%s", rString)
-	envName := fmt.Sprintf("tf-acc-env-outputs-%s", rString)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckBeanstalkEnvDestroy,
-		Steps: []resource.TestStep{
 			{
-				Config: testAccBeanstalkEnvConfig(appName, envName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBeanstalkEnvExists("aws_elastic_beanstalk_environment.tfenvtest", &app),
-					resource.TestMatchResourceAttr(
-						"aws_elastic_beanstalk_environment.tfenvtest", "autoscaling_groups.0", beanstalkAsgNameRegexp),
-					resource.TestMatchResourceAttr(
-						"aws_elastic_beanstalk_environment.tfenvtest", "load_balancers.0", beanstalkElbNameRegexp),
-					resource.TestMatchResourceAttr(
-						"aws_elastic_beanstalk_environment.tfenvtest", "instances.0", beanstalkInstancesNameRegexp),
-					resource.TestMatchResourceAttr(
-						"aws_elastic_beanstalk_environment.tfenvtest", "launch_configurations.0", beanstalkLcNameRegexp),
-					resource.TestMatchResourceAttr(
-						"aws_elastic_beanstalk_environment.tfenvtest", "endpoint_url", beanstalkEndpointUrl),
-				),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"setting",
+					"wait_for_ready_timeout",
+				},
 			},
 		},
 	})
@@ -228,12 +173,10 @@ func TestAccAWSBeanstalkEnv_outputs(t *testing.T) {
 func TestAccAWSBeanstalkEnv_cname_prefix(t *testing.T) {
 	var app elasticbeanstalk.EnvironmentDescription
 
-	rString := acctest.RandString(8)
-	appName := fmt.Sprintf("tf_acc_app_env_cname_prefix_%s", rString)
-	envName := fmt.Sprintf("tf-acc-env-cname-prefix-%s", rString)
-	cnamePrefix := fmt.Sprintf("tf-acc-cname-%s", rString)
+	resourceName := "aws_elastic_beanstalk_environment.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
-	beanstalkCnameRegexp := regexp.MustCompile("^" + cnamePrefix + ".+?elasticbeanstalk.com$")
+	beanstalkCnameRegexp := regexp.MustCompile("^" + rName + ".+?elasticbeanstalk.com$")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -241,12 +184,20 @@ func TestAccAWSBeanstalkEnv_cname_prefix(t *testing.T) {
 		CheckDestroy: testAccCheckBeanstalkEnvDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBeanstalkEnvCnamePrefixConfig(appName, envName, cnamePrefix),
+				Config: testAccBeanstalkEnvCnamePrefixConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBeanstalkEnvExists("aws_elastic_beanstalk_environment.tfenvtest", &app),
-					resource.TestMatchResourceAttr(
-						"aws_elastic_beanstalk_environment.tfenvtest", "cname", beanstalkCnameRegexp),
+					testAccCheckBeanstalkEnvExists(resourceName, &app),
+					resource.TestMatchResourceAttr(resourceName, "cname", beanstalkCnameRegexp),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"setting",
+					"wait_for_ready_timeout",
+				},
 			},
 		},
 	})
@@ -255,10 +206,8 @@ func TestAccAWSBeanstalkEnv_cname_prefix(t *testing.T) {
 func TestAccAWSBeanstalkEnv_config(t *testing.T) {
 	var app elasticbeanstalk.EnvironmentDescription
 
-	rString := acctest.RandString(8)
-	appName := fmt.Sprintf("tf_acc_app_env_config_%s", rString)
-	envName := fmt.Sprintf("tf-acc-env-config-%s", rString)
-	cfgTplName := fmt.Sprintf("tf_acc_cfg_tpl_config_%s", rString)
+	resourceName := "aws_elastic_beanstalk_environment.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -266,26 +215,34 @@ func TestAccAWSBeanstalkEnv_config(t *testing.T) {
 		CheckDestroy: testAccCheckBeanstalkEnvDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBeanstalkConfigTemplate(appName, envName, cfgTplName, 1),
+				Config: testAccBeanstalkConfigTemplate(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBeanstalkEnvExists("aws_elastic_beanstalk_environment.tftest", &app),
-					testAccCheckBeanstalkEnvConfigValue("aws_elastic_beanstalk_environment.tftest", "1"),
+					testAccCheckBeanstalkEnvExists(resourceName, &app),
+					testAccCheckBeanstalkEnvConfigValue(resourceName, "1"),
 				),
 			},
-
 			{
-				Config: testAccBeanstalkConfigTemplate(appName, envName, cfgTplName, 2),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"setting",
+					"template_name",
+					"wait_for_ready_timeout",
+				},
+			},
+			{
+				Config: testAccBeanstalkConfigTemplate(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBeanstalkEnvExists("aws_elastic_beanstalk_environment.tftest", &app),
-					testAccCheckBeanstalkEnvConfigValue("aws_elastic_beanstalk_environment.tftest", "2"),
+					testAccCheckBeanstalkEnvExists(resourceName, &app),
+					testAccCheckBeanstalkEnvConfigValue(resourceName, "2"),
 				),
 			},
-
 			{
-				Config: testAccBeanstalkConfigTemplate(appName, envName, cfgTplName, 3),
+				Config: testAccBeanstalkConfigTemplate(rName, 3),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBeanstalkEnvExists("aws_elastic_beanstalk_environment.tftest", &app),
-					testAccCheckBeanstalkEnvConfigValue("aws_elastic_beanstalk_environment.tftest", "3"),
+					testAccCheckBeanstalkEnvExists(resourceName, &app),
+					testAccCheckBeanstalkEnvConfigValue(resourceName, "3"),
 				),
 			},
 		},
@@ -295,9 +252,8 @@ func TestAccAWSBeanstalkEnv_config(t *testing.T) {
 func TestAccAWSBeanstalkEnv_resource(t *testing.T) {
 	var app elasticbeanstalk.EnvironmentDescription
 
-	rString := acctest.RandString(8)
-	appName := fmt.Sprintf("tf_acc_app_env_resource_%s", rString)
-	envName := fmt.Sprintf("tf-acc-env-resource-%s", rString)
+	resourceName := "aws_elastic_beanstalk_environment.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -305,10 +261,19 @@ func TestAccAWSBeanstalkEnv_resource(t *testing.T) {
 		CheckDestroy: testAccCheckBeanstalkEnvDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBeanstalkResourceOptionSetting(appName, envName),
+				Config: testAccBeanstalkResourceOptionSetting(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBeanstalkEnvExists("aws_elastic_beanstalk_environment.tfenvtest", &app),
+					testAccCheckBeanstalkEnvExists(resourceName, &app),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"setting",
+					"wait_for_ready_timeout",
+				},
 			},
 		},
 	})
@@ -317,9 +282,8 @@ func TestAccAWSBeanstalkEnv_resource(t *testing.T) {
 func TestAccAWSBeanstalkEnv_tags(t *testing.T) {
 	var app elasticbeanstalk.EnvironmentDescription
 
-	rString := acctest.RandString(8)
-	appName := fmt.Sprintf("tf_acc_app_env_resource_%s", rString)
-	envName := fmt.Sprintf("tf-acc-env-resource-%s", rString)
+	resourceName := "aws_elastic_beanstalk_environment.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -327,59 +291,33 @@ func TestAccAWSBeanstalkEnv_tags(t *testing.T) {
 		CheckDestroy: testAccCheckBeanstalkEnvDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBeanstalkEnvConfig_empty_settings(appName, envName),
+				Config: testAccBeanstalkTagsTemplate(rName, "test1", "test2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBeanstalkEnvExists("aws_elastic_beanstalk_environment.tfenvtest", &app),
-					testAccCheckBeanstalkEnvTagsMatch(&app, map[string]string{}),
-				),
-			},
-
-			{
-				Config: testAccBeanstalkTagsTemplate(appName, envName, "test1", "test2"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBeanstalkEnvExists("aws_elastic_beanstalk_environment.tfenvtest", &app),
+					testAccCheckBeanstalkEnvExists(resourceName, &app),
 					testAccCheckBeanstalkEnvTagsMatch(&app, map[string]string{"firstTag": "test1", "secondTag": "test2"}),
 				),
 			},
-
 			{
-				Config: testAccBeanstalkTagsTemplate(appName, envName, "test2", "test1"),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"setting",
+					"wait_for_ready_timeout",
+				},
+			},
+			{
+				Config: testAccBeanstalkTagsTemplate(rName, "test2", "test1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBeanstalkEnvExists("aws_elastic_beanstalk_environment.tfenvtest", &app),
+					testAccCheckBeanstalkEnvExists(resourceName, &app),
 					testAccCheckBeanstalkEnvTagsMatch(&app, map[string]string{"firstTag": "test2", "secondTag": "test1"}),
 				),
 			},
-
 			{
-				Config: testAccBeanstalkEnvConfig_empty_settings(appName, envName),
+				Config: testAccBeanstalkEnvConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBeanstalkEnvExists("aws_elastic_beanstalk_environment.tfenvtest", &app),
+					testAccCheckBeanstalkEnvExists(resourceName, &app),
 					testAccCheckBeanstalkEnvTagsMatch(&app, map[string]string{}),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSBeanstalkEnv_vpc(t *testing.T) {
-	var app elasticbeanstalk.EnvironmentDescription
-
-	rString := acctest.RandString(8)
-	sgName := fmt.Sprintf("tf_acc_sg_beanstalk_env_vpc_%s", rString)
-	appName := fmt.Sprintf("tf_acc_app_env_vpc_%s", rString)
-	envName := fmt.Sprintf("tf-acc-env-vpc-%s", rString)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckBeanstalkEnvDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccBeanstalkEnv_VPC(sgName, appName, envName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBeanstalkEnvExists("aws_elastic_beanstalk_environment.default", &app),
 				),
 			},
 		},
@@ -389,10 +327,8 @@ func TestAccAWSBeanstalkEnv_vpc(t *testing.T) {
 func TestAccAWSBeanstalkEnv_template_change(t *testing.T) {
 	var app elasticbeanstalk.EnvironmentDescription
 
-	rString := acctest.RandString(8)
-	appName := fmt.Sprintf("tf_acc_app_env_tpl_change_%s", rString)
-	envName := fmt.Sprintf("tf-acc-env-tpl-change-%s", rString)
-	cfgTplName := fmt.Sprintf("tf_acc_tpl_env_tpl_change_%s", rString)
+	resourceName := "aws_elastic_beanstalk_environment.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -402,33 +338,32 @@ func TestAccAWSBeanstalkEnv_template_change(t *testing.T) {
 		CheckDestroy: testAccCheckBeanstalkEnvDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBeanstalkEnv_TemplateChange_stack(appName, envName, cfgTplName),
+				Config: testAccBeanstalkEnv_TemplateChange_stack(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBeanstalkEnvExists("aws_elastic_beanstalk_environment.environment", &app),
+					testAccCheckBeanstalkEnvExists(resourceName, &app),
 				),
 			},
 			{
-				Config: testAccBeanstalkEnv_TemplateChange_temp(appName, envName, cfgTplName),
+				Config: testAccBeanstalkEnv_TemplateChange_temp(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBeanstalkEnvExists("aws_elastic_beanstalk_environment.environment", &app),
+					testAccCheckBeanstalkEnvExists(resourceName, &app),
 				),
 			},
 			{
-				Config: testAccBeanstalkEnv_TemplateChange_stack(appName, envName, cfgTplName),
+				Config: testAccBeanstalkEnv_TemplateChange_stack(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBeanstalkEnvExists("aws_elastic_beanstalk_environment.environment", &app),
+					testAccCheckBeanstalkEnvExists(resourceName, &app),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAWSBeanstalkEnv_basic_settings_update(t *testing.T) {
+func TestAccAWSBeanstalkEnv_settings_update(t *testing.T) {
 	var app elasticbeanstalk.EnvironmentDescription
 
-	rString := acctest.RandString(8)
-	appName := fmt.Sprintf("tf_acc_app_env_basic_settings_upd_%s", rString)
-	envName := fmt.Sprintf("tf-acc-env-basic-settings-upd-%s", rString)
+	resourceName := "aws_elastic_beanstalk_environment.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -436,30 +371,30 @@ func TestAccAWSBeanstalkEnv_basic_settings_update(t *testing.T) {
 		CheckDestroy: testAccCheckBeanstalkEnvDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBeanstalkEnvConfig_empty_settings(appName, envName),
+				Config: testAccBeanstalkEnvConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBeanstalkEnvExists("aws_elastic_beanstalk_environment.tfenvtest", &app),
+					testAccCheckBeanstalkEnvExists(resourceName, &app),
 					testAccVerifyBeanstalkConfig(&app, []string{}),
 				),
 			},
 			{
-				Config: testAccBeanstalkEnvConfig_settings(appName, envName),
+				Config: testAccBeanstalkEnvConfig_settings(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBeanstalkEnvExists("aws_elastic_beanstalk_environment.tfenvtest", &app),
+					testAccCheckBeanstalkEnvExists(resourceName, &app),
 					testAccVerifyBeanstalkConfig(&app, []string{"ENV_STATIC", "ENV_UPDATE"}),
 				),
 			},
 			{
-				Config: testAccBeanstalkEnvConfig_settings(appName, envName),
+				Config: testAccBeanstalkEnvConfig_settings(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBeanstalkEnvExists("aws_elastic_beanstalk_environment.tfenvtest", &app),
+					testAccCheckBeanstalkEnvExists(resourceName, &app),
 					testAccVerifyBeanstalkConfig(&app, []string{"ENV_STATIC", "ENV_UPDATE"}),
 				),
 			},
 			{
-				Config: testAccBeanstalkEnvConfig_empty_settings(appName, envName),
+				Config: testAccBeanstalkEnvConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBeanstalkEnvExists("aws_elastic_beanstalk_environment.tfenvtest", &app),
+					testAccCheckBeanstalkEnvExists(resourceName, &app),
 					testAccVerifyBeanstalkConfig(&app, []string{}),
 				),
 			},
@@ -470,12 +405,8 @@ func TestAccAWSBeanstalkEnv_basic_settings_update(t *testing.T) {
 func TestAccAWSBeanstalkEnv_version_label(t *testing.T) {
 	var app elasticbeanstalk.EnvironmentDescription
 
-	rString := acctest.RandString(8)
-	bucketName := fmt.Sprintf("tf-acc-bucket-beanstalk-env-version-label-%s", rString)
-	appName := fmt.Sprintf("tf_acc_app_env_version_label_%s", rString)
-	appVersionName := fmt.Sprintf("tf_acc_version_env_version_label_%s", rString)
-	uAppVersionName := fmt.Sprintf("tf_acc_version_env_version_label_v2_%s", rString)
-	envName := fmt.Sprintf("tf-acc-env-version-label-%s", rString)
+	resourceName := "aws_elastic_beanstalk_environment.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -483,15 +414,24 @@ func TestAccAWSBeanstalkEnv_version_label(t *testing.T) {
 		CheckDestroy: testAccCheckBeanstalkEnvDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBeanstalkEnvApplicationVersionConfig(bucketName, appName, appVersionName, envName),
+				Config: testAccBeanstalkEnvApplicationVersionConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBeanstalkApplicationVersionDeployed("aws_elastic_beanstalk_environment.default", &app),
+					testAccCheckBeanstalkApplicationVersionDeployed(resourceName, &app),
 				),
 			},
 			{
-				Config: testAccBeanstalkEnvApplicationVersionConfig(bucketName, appName, uAppVersionName, envName),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"setting",
+					"wait_for_ready_timeout",
+				},
+			},
+			{
+				Config: testAccBeanstalkEnvApplicationVersionConfigUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBeanstalkApplicationVersionDeployed("aws_elastic_beanstalk_environment.default", &app),
+					testAccCheckBeanstalkApplicationVersionDeployed(resourceName, &app),
 				),
 			},
 		},
@@ -501,14 +441,8 @@ func TestAccAWSBeanstalkEnv_version_label(t *testing.T) {
 func TestAccAWSBeanstalkEnv_settingWithJsonValue(t *testing.T) {
 	var app elasticbeanstalk.EnvironmentDescription
 
-	rString := acctest.RandString(8)
-	appName := fmt.Sprintf("tf_acc_app_env_setting_w_json_value_%s", rString)
-	queueName := fmt.Sprintf("tf_acc_queue_beanstalk_env_setting_w_json_value_%s", rString)
-	keyPairName := fmt.Sprintf("tf_acc_keypair_beanstalk_env_setting_w_json_value_%s", rString)
-	instanceProfileName := fmt.Sprintf("tf_acc_profile_beanstalk_env_setting_w_json_value_%s", rString)
-	roleName := fmt.Sprintf("tf_acc_role_beanstalk_env_setting_w_json_value_%s", rString)
-	policyName := fmt.Sprintf("tf-acc-policy-beanstalk-env-setting-w-json-value-%s", rString)
-	envName := fmt.Sprintf("tf-acc-env-setting-w-json-value-%s", rString)
+	resourceName := "aws_elastic_beanstalk_environment.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -516,10 +450,19 @@ func TestAccAWSBeanstalkEnv_settingWithJsonValue(t *testing.T) {
 		CheckDestroy: testAccCheckBeanstalkEnvDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBeanstalkEnvSettingJsonValue(appName, queueName, keyPairName, instanceProfileName, roleName, policyName, envName),
+				Config: testAccBeanstalkEnvSettingJsonValue(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBeanstalkEnvExists("aws_elastic_beanstalk_environment.default", &app),
+					testAccCheckBeanstalkEnvExists(resourceName, &app),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"setting",
+					"wait_for_ready_timeout",
+				},
 			},
 		},
 	})
@@ -528,10 +471,8 @@ func TestAccAWSBeanstalkEnv_settingWithJsonValue(t *testing.T) {
 func TestAccAWSBeanstalkEnv_platformArn(t *testing.T) {
 	var app elasticbeanstalk.EnvironmentDescription
 
-	rString := acctest.RandString(8)
-	appName := fmt.Sprintf("tf_acc_app_env_platform_arn_%s", rString)
-	envName := fmt.Sprintf("tf-acc-env-platform-arn-%s", rString)
-	platformArn := "arn:aws:elasticbeanstalk:us-east-1::platform/Go 1 running on 64bit Amazon Linux/2.9.0"
+	resourceName := "aws_elastic_beanstalk_environment.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -539,11 +480,20 @@ func TestAccAWSBeanstalkEnv_platformArn(t *testing.T) {
 		CheckDestroy: testAccCheckBeanstalkEnvDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBeanstalkEnvConfig_platform_arn(appName, envName, platformArn),
+				Config: testAccBeanstalkEnvConfig_platform_arn(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBeanstalkEnvExists("aws_elastic_beanstalk_environment.tfenvtest", &app),
-					resource.TestCheckResourceAttr("aws_elastic_beanstalk_environment.tfenvtest", "platform_arn", platformArn),
+					testAccCheckBeanstalkEnvExists(resourceName, &app),
+					testAccCheckResourceAttrRegionalARNNoAccount(resourceName, "platform_arn", "elasticbeanstalk", "platform/Python 3.6 running on 64bit Amazon Linux/2.9.4"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"setting",
+					"wait_for_ready_timeout",
+				},
 			},
 		},
 	})
@@ -804,71 +754,163 @@ func describeBeanstalkEnv(conn *elasticbeanstalk.ElasticBeanstalk,
 	return resp.Environments[0], nil
 }
 
-func testAccBeanstalkEnvConfig(appName, envName string) string {
+func testAccBeanstalkEnvConfigBase(rName string) string {
 	return fmt.Sprintf(`
- resource "aws_elastic_beanstalk_application" "tftest" {
-	 name = "%s"
-	 description = "tf-test-desc"
- }
-
- resource "aws_elastic_beanstalk_environment" "tfenvtest" {
-	 name = "%s"
-	 application = "${aws_elastic_beanstalk_application.tftest.name}"
-	 solution_stack_name = "64bit Amazon Linux running Python"
-	 depends_on = ["aws_elastic_beanstalk_application.tftest"]
- }
-`, appName, envName)
+data "aws_availability_zones" "available" {
+  # Default instance type of t2.micro is not available in this Availability Zone
+  # The failure will occur during Elastic Beanstalk CloudFormation Template handling
+  # after waiting upwards of one hour to initialize the Auto Scaling Group.
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
 }
 
-func testAccBeanstalkEnvConfig_platform_arn(appName, envName, platformArn string) string {
-	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
+data "aws_elastic_beanstalk_solution_stack" "test" {
+  most_recent = true
+  name_regex  = "64bit Amazon Linux .* running Python .*"
 }
 
-resource "aws_elastic_beanstalk_application" "tftest" {
-  name        = "%s"
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "terraform-testacc-elastic-beanstalk-env-vpc"
+  }
+}
+
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+}
+
+resource "aws_route" "test" {
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.test.id
+  route_table_id         = aws_vpc.test.main_route_table_id
+}
+
+resource "aws_subnet" "test" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+  cidr_block        = "10.0.0.0/24"
+  vpc_id            = aws_vpc.test.id
+
+  tags = {
+    Name = "tf-acc-elastic-beanstalk-env-vpc"
+  }
+}
+
+resource "aws_security_group" "test" {
+  name   = %[1]q
+  vpc_id = aws_vpc.test.id
+}
+
+resource "aws_elastic_beanstalk_application" "test" {
   description = "tf-test-desc"
+  name        = %[1]q
+}
+`, rName)
 }
 
-resource "aws_elastic_beanstalk_environment" "tfenvtest" {
-  name         = "%s"
-  application  = "${aws_elastic_beanstalk_application.tftest.name}"
-  platform_arn = "%s"
+func testAccBeanstalkEnvConfig(rName string) string {
+	return testAccBeanstalkEnvConfigBase(rName) + fmt.Sprintf(`
+resource "aws_elastic_beanstalk_environment" "test" {
+  application         = aws_elastic_beanstalk_application.test.name
+  name                = %[1]q
+  solution_stack_name = data.aws_elastic_beanstalk_solution_stack.test.name
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "VPCId"
+    value     = aws_vpc.test.id
+  }
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "Subnets"
+    value     = aws_subnet.test.id
+  }
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "AssociatePublicIpAddress"
+    value     = "true"
+  }
+
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "SecurityGroups"
+    value     = aws_security_group.test.id
+  }
 }
-`, appName, envName, platformArn)
+`, rName)
 }
 
-func testAccBeanstalkEnvConfig_empty_settings(appName, envName string) string {
-	return fmt.Sprintf(`
-resource "aws_elastic_beanstalk_application" "tftest" {
-  name        = "%s"
-  description = "tf-test-desc"
+func testAccBeanstalkEnvConfig_platform_arn(rName string) string {
+	return testAccBeanstalkEnvConfigBase(rName) + fmt.Sprintf(`
+resource "aws_elastic_beanstalk_environment" "test" {
+  application  = aws_elastic_beanstalk_application.test.name
+  name         = %[1]q
+  platform_arn = "arn:${data.aws_partition.current.partition}:elasticbeanstalk:${data.aws_region.current.name}::platform/Python 3.6 running on 64bit Amazon Linux/2.9.4"
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "VPCId"
+    value     = aws_vpc.test.id
+  }
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "Subnets"
+    value     = aws_subnet.test.id
+  }
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "AssociatePublicIpAddress"
+    value     = "true"
+  }
+
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "SecurityGroups"
+    value     = aws_security_group.test.id
+  }
+}
+`, rName)
 }
 
-resource "aws_elastic_beanstalk_environment" "tfenvtest" {
-  name                = "%s"
-  application         = "${aws_elastic_beanstalk_application.tftest.name}"
-  solution_stack_name = "64bit Amazon Linux running Python"
+func testAccBeanstalkEnvConfig_settings(rName string) string {
+	return testAccBeanstalkEnvConfigBase(rName) + fmt.Sprintf(`
+resource "aws_elastic_beanstalk_environment" "test" {
+  application         = aws_elastic_beanstalk_application.test.name
+  name                = %[1]q
+  solution_stack_name = data.aws_elastic_beanstalk_solution_stack.test.name
 
-  wait_for_ready_timeout = "15m"
-}
-`, appName, envName)
-}
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "VPCId"
+    value     = aws_vpc.test.id
+  }
 
-func testAccBeanstalkEnvConfig_settings(appName, envName string) string {
-	return fmt.Sprintf(`
-resource "aws_elastic_beanstalk_application" "tftest" {
-  name        = "%s"
-  description = "tf-test-desc"
-}
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "Subnets"
+    value     = aws_subnet.test.id
+  }
 
-resource "aws_elastic_beanstalk_environment" "tfenvtest" {
-  name                = "%s"
-  application         = "${aws_elastic_beanstalk_application.tftest.name}"
-  solution_stack_name = "64bit Amazon Linux running Python"
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "AssociatePublicIpAddress"
+    value     = "true"
+  }
 
-  wait_for_ready_timeout = "15m"
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "SecurityGroups"
+    value     = aws_security_group.test.id
+  }
 
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
@@ -909,101 +951,176 @@ resource "aws_elastic_beanstalk_environment" "tfenvtest" {
     value     = "2016-07-28T04:07:02Z"
   }
 }
-`, appName, envName)
+`, rName)
 }
 
-func testAccBeanstalkWorkerEnvConfig(instanceProfileName, roleName, policyName, appName, envName string) string {
-	return fmt.Sprintf(`
- resource "aws_iam_instance_profile" "tftest" {
-	 name = "%s"
-	 roles = ["${aws_iam_role.tftest.name}"]
- }
-
- resource "aws_iam_role" "tftest" {
-	 name = "%s"
-	 path = "/"
-	 assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"},\"Effect\":\"Allow\",\"Sid\":\"\"}]}"
- }
-
- resource "aws_iam_role_policy" "tftest" {
-	 name = "%s"
-	 role = "${aws_iam_role.tftest.id}"
-	 policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"QueueAccess\",\"Action\":[\"sqs:ChangeMessageVisibility\",\"sqs:DeleteMessage\",\"sqs:ReceiveMessage\"],\"Effect\":\"Allow\",\"Resource\":\"*\"}]}"
- }
-
- resource "aws_elastic_beanstalk_application" "tftest" {
-	 name = "%s"
-	 description = "tf-test-desc"
- }
-
- resource "aws_elastic_beanstalk_environment" "tfenvtest" {
-	 name = "%s"
-	 application = "${aws_elastic_beanstalk_application.tftest.name}"
-	 tier = "Worker"
-	 solution_stack_name = "64bit Amazon Linux running Python"
-
-	 setting {
-		 namespace = "aws:autoscaling:launchconfiguration"
-		 name      = "IamInstanceProfile"
-		 value     = "${aws_iam_instance_profile.tftest.name}"
-	 }
- }`, instanceProfileName, roleName, policyName, appName, envName)
+func testAccBeanstalkWorkerEnvConfig(rName string) string {
+	return testAccBeanstalkEnvConfigBase(rName) + fmt.Sprintf(`
+resource "aws_iam_instance_profile" "test" {
+  name  = %[1]q
+  roles = [aws_iam_role.test.name]
 }
 
-func testAccBeanstalkEnvCnamePrefixConfig(appName, envName, cnamePrefix string) string {
-	return fmt.Sprintf(`
-resource "aws_elastic_beanstalk_application" "tftest" {
-  name = "%s"
-  description = "tf-test-desc"
+resource "aws_iam_role" "test" {
+  assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"ec2.${data.aws_partition.current.dns_suffix}\"},\"Effect\":\"Allow\",\"Sid\":\"\"}]}"
+  name               = %[1]q
 }
 
-resource "aws_elastic_beanstalk_environment" "tfenvtest" {
-  name = "%s"
-  application = "${aws_elastic_beanstalk_application.tftest.name}"
-  cname_prefix = "%s"
-  solution_stack_name = "64bit Amazon Linux running Python"
-}
-`, appName, envName, cnamePrefix)
+resource "aws_iam_role_policy_attachment" "test" {
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AWSElasticBeanstalkWorkerTier"
+  role       = aws_iam_role.test.id
 }
 
-func testAccBeanstalkConfigTemplate(appName, envName, cfgTplName string, cfgTplValue int) string {
-	return fmt.Sprintf(`
-resource "aws_elastic_beanstalk_application" "tftest" {
-  name        = "%s"
-  description = "tf-test-desc"
+resource "aws_elastic_beanstalk_environment" "test" {
+  application         = aws_elastic_beanstalk_application.test.name
+  name                = %[1]q
+  solution_stack_name = data.aws_elastic_beanstalk_solution_stack.test.name
+  tier                = "Worker"
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "VPCId"
+    value     = aws_vpc.test.id
+  }
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "Subnets"
+    value     = aws_subnet.test.id
+  }
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "AssociatePublicIpAddress"
+    value     = "true"
+  }
+
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "SecurityGroups"
+    value     = aws_security_group.test.id
+  }
+
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "IamInstanceProfile"
+    value     = aws_iam_instance_profile.test.name
+  }
+}
+`, rName)
 }
 
-resource "aws_elastic_beanstalk_environment" "tftest" {
-  name          = "%s"
-  application   = "${aws_elastic_beanstalk_application.tftest.name}"
-  template_name = "${aws_elastic_beanstalk_configuration_template.tftest.name}"
+func testAccBeanstalkEnvCnamePrefixConfig(rName string) string {
+	return testAccBeanstalkEnvConfigBase(rName) + fmt.Sprintf(`
+resource "aws_elastic_beanstalk_environment" "test" {
+  application         = aws_elastic_beanstalk_application.test.name
+  cname_prefix        = %[1]q
+  name                = %[1]q
+  solution_stack_name = data.aws_elastic_beanstalk_solution_stack.test.name
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "VPCId"
+    value     = aws_vpc.test.id
+  }
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "Subnets"
+    value     = aws_subnet.test.id
+  }
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "AssociatePublicIpAddress"
+    value     = "true"
+  }
+
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "SecurityGroups"
+    value     = aws_security_group.test.id
+  }
+}
+`, rName)
 }
 
-resource "aws_elastic_beanstalk_configuration_template" "tftest" {
-  name                = "%s"
-  application         = "${aws_elastic_beanstalk_application.tftest.name}"
-  solution_stack_name = "64bit Amazon Linux running Python"
+func testAccBeanstalkConfigTemplate(rName string, cfgTplValue int) string {
+	return testAccBeanstalkEnvConfigBase(rName) + fmt.Sprintf(`
+resource "aws_elastic_beanstalk_environment" "test" {
+  application   = aws_elastic_beanstalk_application.test.name
+  name          = %[1]q
+  template_name = aws_elastic_beanstalk_configuration_template.test.name
+}
+
+resource "aws_elastic_beanstalk_configuration_template" "test" {
+  application         = aws_elastic_beanstalk_application.test.name
+  name                = %[1]q
+  solution_stack_name = data.aws_elastic_beanstalk_solution_stack.test.name
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "VPCId"
+    value     = aws_vpc.test.id
+  }
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "Subnets"
+    value     = aws_subnet.test.id
+  }
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "AssociatePublicIpAddress"
+    value     = "true"
+  }
+
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "SecurityGroups"
+    value     = aws_security_group.test.id
+  }
 
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "TEMPLATE"
-    value     = "%d"
+    value     = %[2]d
   }
 }
-`, appName, envName, cfgTplName, cfgTplValue)
+`, rName, cfgTplValue)
 }
 
-func testAccBeanstalkResourceOptionSetting(appName, envName string) string {
-	return fmt.Sprintf(`
-resource "aws_elastic_beanstalk_application" "tftest" {
-  name        = "%s"
-  description = "tf-test-desc"
-}
+func testAccBeanstalkResourceOptionSetting(rName string) string {
+	return testAccBeanstalkEnvConfigBase(rName) + fmt.Sprintf(`
+resource "aws_elastic_beanstalk_environment" "test" {
+  application         = aws_elastic_beanstalk_application.test.name
+  name                = %[1]q
+  solution_stack_name = data.aws_elastic_beanstalk_solution_stack.test.name
 
-resource "aws_elastic_beanstalk_environment" "tfenvtest" {
-  name                = "%s"
-  application         = "${aws_elastic_beanstalk_application.tftest.name}"
-  solution_stack_name = "64bit Amazon Linux running Python"
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "VPCId"
+    value     = aws_vpc.test.id
+  }
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "Subnets"
+    value     = aws_subnet.test.id
+  }
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "AssociatePublicIpAddress"
+    value     = "true"
+  }
+
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "SecurityGroups"
+    value     = aws_security_group.test.id
+  }
 
   setting {
     namespace = "aws:autoscaling:scheduledaction"
@@ -1026,85 +1143,26 @@ resource "aws_elastic_beanstalk_environment" "tfenvtest" {
     value     = "0 8 * * *"
   }
 }
-`, appName, envName)
+`, rName)
 }
 
-func testAccBeanstalkTagsTemplate(appName, envName, firstTag, secondTag string) string {
-	return fmt.Sprintf(`
-resource "aws_elastic_beanstalk_application" "tftest" {
-  name        = "%s"
-  description = "tf-test-desc"
-}
-
-resource "aws_elastic_beanstalk_environment" "tfenvtest" {
-  name                = "%s"
-  application         = "${aws_elastic_beanstalk_application.tftest.name}"
-  solution_stack_name = "64bit Amazon Linux running Python"
-
-  wait_for_ready_timeout = "15m"
-
-  tags = {
-    firstTag  = "%s"
-    secondTag = "%s"
-  }
-}
-`, appName, envName, firstTag, secondTag)
-}
-
-func testAccBeanstalkEnv_VPC(sgName, appName, envName string) string {
-	return fmt.Sprintf(`
-resource "aws_vpc" "tf_b_test" {
-  cidr_block = "10.0.0.0/16"
-
-  tags = {
-    Name = "terraform-testacc-elastic-beanstalk-env-vpc"
-  }
-}
-
-resource "aws_internet_gateway" "tf_b_test" {
-  vpc_id = "${aws_vpc.tf_b_test.id}"
-}
-
-resource "aws_route" "r" {
-  route_table_id         = "${aws_vpc.tf_b_test.main_route_table_id}"
-  destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = "${aws_internet_gateway.tf_b_test.id}"
-}
-
-resource "aws_subnet" "main" {
-  vpc_id     = "${aws_vpc.tf_b_test.id}"
-  cidr_block = "10.0.0.0/24"
-
-  tags = {
-    Name = "tf-acc-elastic-beanstalk-env-vpc"
-  }
-}
-
-resource "aws_security_group" "default" {
-  name   = "%s"
-  vpc_id = "${aws_vpc.tf_b_test.id}"
-}
-
-resource "aws_elastic_beanstalk_application" "default" {
-  name        = "%s"
-  description = "tf-test-desc"
-}
-
-resource "aws_elastic_beanstalk_environment" "default" {
-  name                = "%s"
-  application         = "${aws_elastic_beanstalk_application.default.name}"
-  solution_stack_name = "64bit Amazon Linux running Python"
+func testAccBeanstalkTagsTemplate(rName, firstTag, secondTag string) string {
+	return testAccBeanstalkEnvConfigBase(rName) + fmt.Sprintf(`
+resource "aws_elastic_beanstalk_environment" "test" {
+  application         = aws_elastic_beanstalk_application.test.name
+  name                = %[1]q
+  solution_stack_name = data.aws_elastic_beanstalk_solution_stack.test.name
 
   setting {
     namespace = "aws:ec2:vpc"
     name      = "VPCId"
-    value     = "${aws_vpc.tf_b_test.id}"
+    value     = aws_vpc.test.id
   }
 
   setting {
     namespace = "aws:ec2:vpc"
     name      = "Subnets"
-    value     = "${aws_subnet.main.id}"
+    value     = aws_subnet.test.id
   }
 
   setting {
@@ -1116,127 +1174,219 @@ resource "aws_elastic_beanstalk_environment" "default" {
   setting {
     namespace = "aws:autoscaling:launchconfiguration"
     name      = "SecurityGroups"
-    value     = "${aws_security_group.default.id}"
+    value     = aws_security_group.test.id
+  }
+
+  tags = {
+    firstTag  = %[2]q
+    secondTag = %[3]q
   }
 }
-`, sgName, appName, envName)
+`, rName, firstTag, secondTag)
 }
 
-func testAccBeanstalkEnv_TemplateChange_stack(appName, envName, cfgTplName string) string {
-	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
+func testAccBeanstalkEnv_TemplateChange_stack(rName string) string {
+	return testAccBeanstalkEnvConfigBase(rName) + fmt.Sprintf(`
+resource "aws_elastic_beanstalk_environment" "test" {
+  application         = aws_elastic_beanstalk_application.test.name
+  name                = %[1]q
+  solution_stack_name = data.aws_elastic_beanstalk_solution_stack.test.name
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "VPCId"
+    value     = aws_vpc.test.id
+  }
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "Subnets"
+    value     = aws_subnet.test.id
+  }
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "AssociatePublicIpAddress"
+    value     = "true"
+  }
+
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "SecurityGroups"
+    value     = aws_security_group.test.id
+  }
 }
 
-resource "aws_elastic_beanstalk_application" "app" {
-  name        = "%s"
-  description = ""
+resource "aws_elastic_beanstalk_configuration_template" "test" {
+  application         = aws_elastic_beanstalk_application.test.name
+  name                = %[1]q
+  solution_stack_name = data.aws_elastic_beanstalk_solution_stack.test.name
+}
+`, rName)
 }
 
-resource "aws_elastic_beanstalk_environment" "environment" {
-  name        = "%s"
-  application = "${aws_elastic_beanstalk_application.app.name}"
+func testAccBeanstalkEnv_TemplateChange_temp(rName string) string {
+	return testAccBeanstalkEnvConfigBase(rName) + fmt.Sprintf(`
+resource "aws_elastic_beanstalk_environment" "test" {
+  application   = aws_elastic_beanstalk_application.test.name
+  name          = %[1]q
+  template_name = aws_elastic_beanstalk_configuration_template.test.name
 
-  # Go 1.4
-  solution_stack_name = "64bit Amazon Linux 2016.03 v2.1.0 running Go 1.4"
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "VPCId"
+    value     = aws_vpc.test.id
+  }
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "Subnets"
+    value     = aws_subnet.test.id
+  }
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "AssociatePublicIpAddress"
+    value     = "true"
+  }
+
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "SecurityGroups"
+    value     = aws_security_group.test.id
+  }
 }
 
-resource "aws_elastic_beanstalk_configuration_template" "template" {
-  name        = "%s"
-  application = "${aws_elastic_beanstalk_application.app.name}"
-
-  # Go 1.5
-  solution_stack_name = "64bit Amazon Linux 2016.03 v2.1.3 running Go 1.5"
+resource "aws_elastic_beanstalk_configuration_template" "test" {
+  application         = aws_elastic_beanstalk_application.test.name
+  name                = %[1]q
+  solution_stack_name = data.aws_elastic_beanstalk_solution_stack.test.name
 }
-`, appName, envName, cfgTplName)
+`, rName)
 }
 
-func testAccBeanstalkEnv_TemplateChange_temp(appName, envName, cfgTplName string) string {
-	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
+func testAccBeanstalkEnvApplicationVersionConfig(rName string) string {
+	return testAccBeanstalkEnvConfigBase(rName) + fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
 }
 
-resource "aws_elastic_beanstalk_application" "app" {
-  name        = "%s"
-  description = ""
-}
-
-resource "aws_elastic_beanstalk_environment" "environment" {
-  name        = "%s"
-  application = "${aws_elastic_beanstalk_application.app.name}"
-
-  # Go 1.4
-  template_name = "${aws_elastic_beanstalk_configuration_template.template.name}"
-}
-
-resource "aws_elastic_beanstalk_configuration_template" "template" {
-  name        = "%s"
-  application = "${aws_elastic_beanstalk_application.app.name}"
-
-  # Go 1.5
-  solution_stack_name = "64bit Amazon Linux 2016.03 v2.1.3 running Go 1.5"
-}
-`, appName, envName, cfgTplName)
-}
-
-func testAccBeanstalkEnvApplicationVersionConfig(bucketName, appName, appVersionName, envName string) string {
-	return fmt.Sprintf(`
-resource "aws_s3_bucket" "default" {
-  bucket = "%s"
-}
-
-resource "aws_s3_bucket_object" "default" {
-  bucket = "${aws_s3_bucket.default.id}"
+resource "aws_s3_bucket_object" "test" {
+  bucket = aws_s3_bucket.test.id
   key    = "python-v1.zip"
   source = "test-fixtures/python-v1.zip"
 }
 
-resource "aws_elastic_beanstalk_application" "default" {
-  name        = "%s"
-  description = "tf-test-desc"
+resource "aws_elastic_beanstalk_application_version" "test" {
+  application = aws_elastic_beanstalk_application.test.name
+  bucket      = aws_s3_bucket.test.id
+  key         = aws_s3_bucket_object.test.id
+  name        = "%[1]s-1"
 }
 
-resource "aws_elastic_beanstalk_application_version" "default" {
-  application = "${aws_elastic_beanstalk_application.default.name}"
-  name        = "%s"
-  bucket      = "${aws_s3_bucket.default.id}"
-  key         = "${aws_s3_bucket_object.default.id}"
+resource "aws_elastic_beanstalk_environment" "test" {
+  application         = aws_elastic_beanstalk_application.test.name
+  name                = %[1]q
+  solution_stack_name = data.aws_elastic_beanstalk_solution_stack.test.name
+  version_label       = aws_elastic_beanstalk_application_version.test.name
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "VPCId"
+    value     = aws_vpc.test.id
+  }
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "Subnets"
+    value     = aws_subnet.test.id
+  }
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "AssociatePublicIpAddress"
+    value     = "true"
+  }
+
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "SecurityGroups"
+    value     = aws_security_group.test.id
+  }
+}
+`, rName)
 }
 
-resource "aws_elastic_beanstalk_environment" "default" {
-  name                = "%s"
-  application         = "${aws_elastic_beanstalk_application.default.name}"
-  version_label       = "${aws_elastic_beanstalk_application_version.default.name}"
-  solution_stack_name = "64bit Amazon Linux running Python"
-}
-`, bucketName, appName, appVersionName, envName)
+func testAccBeanstalkEnvApplicationVersionConfigUpdate(rName string) string {
+	return testAccBeanstalkEnvConfigBase(rName) + fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
 }
 
-func testAccBeanstalkEnvSettingJsonValue(appName, queueName, keyPairName, instanceProfileName, roleName, policyName, envName string) string {
-	return fmt.Sprintf(`
-resource "aws_elastic_beanstalk_application" "app" {
-  name        = "%s"
-  description = "This is a description"
+resource "aws_s3_bucket_object" "test" {
+  bucket = aws_s3_bucket.test.id
+  key    = "python-v1.zip"
+  source = "test-fixtures/python-v1.zip"
 }
 
+resource "aws_elastic_beanstalk_application_version" "test" {
+  application = aws_elastic_beanstalk_application.test.name
+  bucket      = aws_s3_bucket.test.id
+  key         = aws_s3_bucket_object.test.id
+  name        = "%[1]s-2"
+}
+
+resource "aws_elastic_beanstalk_environment" "test" {
+  application         = aws_elastic_beanstalk_application.test.name
+  name                = %[1]q
+  solution_stack_name = data.aws_elastic_beanstalk_solution_stack.test.name
+  version_label       = aws_elastic_beanstalk_application_version.test.name
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "VPCId"
+    value     = aws_vpc.test.id
+  }
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "Subnets"
+    value     = aws_subnet.test.id
+  }
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "AssociatePublicIpAddress"
+    value     = "true"
+  }
+
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "SecurityGroups"
+    value     = aws_security_group.test.id
+  }
+}
+`, rName)
+}
+
+func testAccBeanstalkEnvSettingJsonValue(rName string) string {
+	return testAccBeanstalkEnvConfigBase(rName) + fmt.Sprintf(`
 resource "aws_sqs_queue" "test" {
-  name = "%s"
+  name = %[1]q
 }
 
 resource "aws_key_pair" "test" {
-  key_name   = "%s"
+  key_name   = %[1]q
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 email@example.com"
 }
 
-resource "aws_iam_instance_profile" "app" {
-  name = "%s"
-  role = "${aws_iam_role.test.name}"
+resource "aws_iam_instance_profile" "test" {
+  name = %[1]q
+  role = aws_iam_role.test.name
 }
 
 resource "aws_iam_role" "test" {
-  name = "%s"
-  path = "/"
+  name = %[1]q
 
   assume_role_policy = <<EOF
 {
@@ -1245,7 +1395,7 @@ resource "aws_iam_role" "test" {
         {
             "Action": "sts:AssumeRole",
             "Principal": {
-               "Service": "ec2.amazonaws.com"
+               "Service": "ec2.${data.aws_partition.current.dns_suffix}"
             },
             "Effect": "Allow",
             "Sid": ""
@@ -1255,153 +1405,162 @@ resource "aws_iam_role" "test" {
 EOF
 }
 
-resource "aws_iam_role_policy" "test" {
-  name = "%s"
-  role = "${aws_iam_role.test.id}"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "dynamodb:*"
-      ],
-      "Effect": "Allow",
-      "Resource": "*"
-    }
-  ]
-}
-EOF
+resource "aws_iam_role_policy_attachment" "test" {
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AWSElasticBeanstalkWorkerTier"
+  role       = aws_iam_role.test.id
 }
 
-resource "aws_elastic_beanstalk_environment" "default" {
-  name                = "%s"
-  application         = "${aws_elastic_beanstalk_application.app.name}"
+resource "aws_elastic_beanstalk_environment" "test" {
+  application         = aws_elastic_beanstalk_application.test.name
+  name                = %[1]q
+  solution_stack_name = data.aws_elastic_beanstalk_solution_stack.test.name
   tier                = "Worker"
-  solution_stack_name = "64bit Amazon Linux 2016.03 v2.1.0 running Docker 1.9.1"
 
-  setting = {
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "VPCId"
+    value     = aws_vpc.test.id
+  }
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "Subnets"
+    value     = aws_subnet.test.id
+  }
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "AssociatePublicIpAddress"
+    value     = "true"
+  }
+
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "SecurityGroups"
+    value     = aws_security_group.test.id
+  }
+
+  setting {
     namespace = "aws:elasticbeanstalk:command"
     name      = "BatchSize"
     value     = "30"
   }
 
-  setting = {
+  setting {
     namespace = "aws:elasticbeanstalk:command"
     name      = "BatchSizeType"
     value     = "Percentage"
   }
 
-  setting = {
+  setting {
     namespace = "aws:elasticbeanstalk:command"
     name      = "DeploymentPolicy"
     value     = "Rolling"
   }
 
-  setting = {
+  setting {
     namespace = "aws:elasticbeanstalk:sns:topics"
     name      = "Notification Endpoint"
     value     = "example@example.com"
   }
 
-  setting = {
+  setting {
     namespace = "aws:elasticbeanstalk:sqsd"
     name      = "ErrorVisibilityTimeout"
     value     = "2"
   }
 
-  setting = {
+  setting {
     namespace = "aws:elasticbeanstalk:sqsd"
     name      = "HttpPath"
     value     = "/event-message"
   }
 
-  setting = {
+  setting {
     namespace = "aws:elasticbeanstalk:sqsd"
     name      = "WorkerQueueURL"
-    value     = "${aws_sqs_queue.test.id}"
+    value     = aws_sqs_queue.test.id
   }
 
-  setting = {
+  setting {
     namespace = "aws:elasticbeanstalk:sqsd"
     name      = "VisibilityTimeout"
     value     = "300"
   }
 
-  setting = {
+  setting {
     namespace = "aws:elasticbeanstalk:sqsd"
     name      = "HttpConnections"
     value     = "10"
   }
 
-  setting = {
+  setting {
     namespace = "aws:elasticbeanstalk:sqsd"
     name      = "InactivityTimeout"
     value     = "299"
   }
 
-  setting = {
+  setting {
     namespace = "aws:elasticbeanstalk:sqsd"
     name      = "MimeType"
     value     = "application/json"
   }
 
-  setting = {
+  setting {
     namespace = "aws:elasticbeanstalk:environment"
     name      = "ServiceRole"
     value     = "aws-elasticbeanstalk-service-role"
   }
 
-  setting = {
+  setting {
     namespace = "aws:elasticbeanstalk:environment"
     name      = "EnvironmentType"
     value     = "LoadBalanced"
   }
 
-  setting = {
+  setting {
     namespace = "aws:elasticbeanstalk:application"
     name      = "Application Healthcheck URL"
     value     = "/health"
   }
 
-  setting = {
+  setting {
     namespace = "aws:elasticbeanstalk:healthreporting:system"
     name      = "SystemType"
     value     = "enhanced"
   }
 
-  setting = {
+  setting {
     namespace = "aws:elasticbeanstalk:healthreporting:system"
     name      = "HealthCheckSuccessThreshold"
     value     = "Ok"
   }
 
-  setting = {
+  setting {
     namespace = "aws:autoscaling:launchconfiguration"
     name      = "IamInstanceProfile"
-    value     = "${aws_iam_instance_profile.app.name}"
+    value     = aws_iam_instance_profile.test.name
   }
 
-  setting = {
+  setting {
     namespace = "aws:autoscaling:launchconfiguration"
     name      = "InstanceType"
     value     = "t2.micro"
   }
 
-  setting = {
+  setting {
     namespace = "aws:autoscaling:launchconfiguration"
     name      = "EC2KeyName"
-    value     = "${aws_key_pair.test.key_name}"
+    value     = aws_key_pair.test.key_name
   }
 
-  setting = {
+  setting {
     namespace = "aws:autoscaling:updatepolicy:rollingupdate"
     name      = "RollingUpdateEnabled"
     value     = "false"
   }
 
-  setting = {
+  setting {
     namespace = "aws:elasticbeanstalk:healthreporting:system"
     name      = "ConfigDocument"
 
@@ -1422,5 +1581,5 @@ resource "aws_elastic_beanstalk_environment" "default" {
 EOF
   }
 }
-`, appName, queueName, keyPairName, instanceProfileName, roleName, policyName, envName)
+`, rName)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously in the acceptance testing (across entire resource):

```
--- FAIL: TestAccAWSBeanstalkEnv_basic (20.78s)
    testing.go:640: Step 0 error: errors during apply:

        Error: Error waiting for Elastic Beanstalk Environment (e-mua2t3mjij) to become ready: 2 errors occurred:
        	* 2020-01-21 07:33:24.327 +0000 UTC (e-mua2t3mjij) : Service:AmazonCloudFormation, Message:Parameter InstanceType failed to satisfy constraint: must be a valid EC2 instance type.
        	* 2020-01-21 07:33:24.426 +0000 UTC (e-mua2t3mjij) : Failed to launch environment.

--- FAIL: TestAccAWSBeanstalkEnv_settingWithJsonValue (0.73s)
    testing.go:640: Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test536039886/main.tf:74,3-10: Attribute redefined; The argument "setting" was already set at /opt/teamcity-agent/temp/buildTmp/tf-test536039886/main.tf:68,3-10. Each argument may be set only once., and 19 other diagnostic(s)
```

The test configurations were previously written to expect either a Elastic Beanstalk compatible Default VPC (IGW, map public IPs on launch Subnets, and permissive ingress/egress NACL) or EC2-Classic. We have moved away from these expectations and the majority of this refactor is centered on supplying self-contained VPC configurations to each test.

Other changes include:

- Blocking usw2-az4 as the default instance type for EB is t2.micro and that instance type is not available in that Availability Zone, always (when that subnet is selected) triggering a launch error
- Migrating to import testing in most tests
- Migrating to resources named "test" in configurations and single resourceName variable in functions
- Migrating to single rName variable for randomization
- Using helper TestCheckFunc for ARNs
- Removing duplicate test functions and configurations

Especially given the new import testing, there are potential further fixes that could be done to this resource including properly setting the `setting` and `template_name` attributes into the Terraform state during refresh, however those changes to the resource logic are out of scope for these test fixes.

Output from acceptance testing:

```
--- PASS: TestAccAWSBeanstalkEnv_platformArn (410.22s)
--- PASS: TestAccAWSBeanstalkEnv_resource (439.66s)
--- PASS: TestAccAWSBeanstalkEnv_basic (489.82s)
--- PASS: TestAccAWSBeanstalkEnv_settingWithJsonValue (558.85s)
--- PASS: TestAccAWSBeanstalkEnv_cname_prefix (577.42s)
--- PASS: TestAccAWSBeanstalkEnv_version_label (618.65s)
--- PASS: TestAccAWSBeanstalkEnv_config (628.04s)
--- PASS: TestAccAWSBeanstalkEnv_tier (630.63s)
--- PASS: TestAccAWSBeanstalkEnv_tags (667.96s)
--- PASS: TestAccAWSBeanstalkEnv_settings_update (744.56s)
--- PASS: TestAccAWSBeanstalkEnv_template_change (768.69s)
```