### PR TITLE
Fixes root_resource_id not being set on Api Gateway Rest API data source

### DIFF
--- a/aws/data_source_aws_api_gateway_rest_api.go
+++ b/aws/data_source_aws_api_gateway_rest_api.go
@@ -55,18 +55,22 @@ func dataSourceAwsApiGatewayRestApiRead(d *schema.ResourceData, meta interface{}
 
 	d.SetId(*match.Id)
 
-	resp, err := conn.GetResources(&apigateway.GetResourcesInput{
+	resourceParams := &apigateway.GetResourcesInput{
 		RestApiId: aws.String(d.Id()),
-	})
-	if err != nil {
-		return err
 	}
 
-	for _, item := range resp.Items {
-		if *item.Path == "/" {
-			d.Set("root_resource_id", item.Id)
-			break
+	err = conn.GetResourcesPages(resourceParams, func(page *apigateway.GetResourcesOutput, lastPage bool) bool {
+		for _, item := range page.Items {
+			if *item.Path == "/" {
+				d.Set("root_resource_id", item.Id)
+				return false
+			}
 		}
+		return !lastPage
+	})
+
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/aws/data_source_aws_api_gateway_rest_api.go
+++ b/aws/data_source_aws_api_gateway_rest_api.go
@@ -69,9 +69,5 @@ func dataSourceAwsApiGatewayRestApiRead(d *schema.ResourceData, meta interface{}
 		return !lastPage
 	})
 
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11695 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* Fixes a bug in aws_api_gateway_rest_api data source where root_resource_id attribute would fail to be set for some APIs with more than 25 routes.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsApiGatewayRestApi'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsApiGatewayRestApi -timeout 120m
=== RUN   TestAccDataSourceAwsApiGatewayRestApi
=== PAUSE TestAccDataSourceAwsApiGatewayRestApi
=== CONT  TestAccDataSourceAwsApiGatewayRestApi
--- PASS: TestAccDataSourceAwsApiGatewayRestApi (15.27s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	15.364s
...
```
