### PR TITLE
r/ecs_task_definition: support EFS Volume

### DIFF
--- a/aws/resource_aws_ecs_task_definition.go
+++ b/aws/resource_aws_ecs_task_definition.go
@@ -464,6 +464,8 @@ func resourceAwsEcsTaskDefinitionRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("cpu", taskDefinition.Cpu)
 	d.Set("memory", taskDefinition.Memory)
 	d.Set("network_mode", taskDefinition.NetworkMode)
+	d.Set("ipc_mode", taskDefinition.IpcMode)
+	d.Set("pid_mode", taskDefinition.PidMode)
 
 	if err := d.Set("tags", keyvaluetags.EcsKeyValueTags(out.Tags).IgnoreAws().Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)

--- a/aws/resource_aws_ecs_task_definition.go
+++ b/aws/resource_aws_ecs_task_definition.go
@@ -86,15 +86,17 @@ func resourceAwsEcsTaskDefinition() *schema.Resource {
 			},
 
 			"task_role_arn": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
 			},
 
 			"execution_role_arn": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
 			},
 
 			"memory": {
@@ -177,6 +179,26 @@ func resourceAwsEcsTaskDefinition() *schema.Resource {
 								},
 							},
 						},
+						"efs_volume_configuration": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"file_system_id": {
+										Type:     schema.TypeString,
+										ForceNew: true,
+										Required: true,
+									},
+									"root_directory": {
+										Type:     schema.TypeString,
+										ForceNew: true,
+										Optional: true,
+									},
+								},
+							},
+						},
 					},
 				},
 				Set: resourceAwsEcsTaskDefinitionVolumeHash,
@@ -193,6 +215,9 @@ func resourceAwsEcsTaskDefinition() *schema.Resource {
 							Type:     schema.TypeString,
 							ForceNew: true,
 							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								ecs.TaskDefinitionPlacementConstraintTypeMemberOf,
+							}, false),
 						},
 						"expression": {
 							Type:     schema.TypeString,
@@ -414,7 +439,7 @@ func resourceAwsEcsTaskDefinitionRead(d *schema.ResourceData, meta interface{}) 
 
 	taskDefinition := out.TaskDefinition
 
-	if aws.StringValue(taskDefinition.Status) == "INACTIVE" {
+	if aws.StringValue(taskDefinition.Status) == ecs.TaskDefinitionStatusInactive {
 		log.Printf("[DEBUG] Removing ECS task definition %s because it's INACTIVE", aws.StringValue(out.TaskDefinition.Family))
 		d.SetId("")
 		return nil

--- a/aws/resource_aws_ecs_task_definition_test.go
+++ b/aws/resource_aws_ecs_task_definition_test.go
@@ -65,6 +65,12 @@ func TestAccAWSEcsTaskDefinition_withScratchVolume(t *testing.T) {
 					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &def),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSEcsTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -72,8 +78,7 @@ func TestAccAWSEcsTaskDefinition_withScratchVolume(t *testing.T) {
 func TestAccAWSEcsTaskDefinition_withDockerVolume(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	rString := acctest.RandString(8)
-	tdName := fmt.Sprintf("tf_acc_td_with_docker_volume_%s", rString)
+	tdName := acctest.RandomWithPrefix("tf-acc-td-with-docker-volume")
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -97,6 +102,12 @@ func TestAccAWSEcsTaskDefinition_withDockerVolume(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "volume.584193650.docker_volume_configuration.0.labels.stack", "april"),
 					resource.TestCheckResourceAttr(resourceName, "volume.584193650.docker_volume_configuration.0.labels.environment", "test"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSEcsTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -123,15 +134,20 @@ func TestAccAWSEcsTaskDefinition_withDockerVolumeMinimalConfig(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "volume.584193650.docker_volume_configuration.0.driver", "local"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSEcsTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
 
-func TestAccAWSEcsTaskDefinition_withEFSVolume(t *testing.T) {
+func TestAccAWSEcsTaskDefinition_withEFSVolumeMinimal(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	rString := acctest.RandString(8)
-	tdName := fmt.Sprintf("tf_acc_td_with_docker_volume_%s", rString)
+	tdName := acctest.RandomWithPrefix("tf-acc-td-with-efs-volume-min")
 	resourceName := "aws_ecs_task_definition.test"
 	efsResourceName := "aws_efs_file_system.test"
 
@@ -141,13 +157,51 @@ func TestAccAWSEcsTaskDefinition_withEFSVolume(t *testing.T) {
 		CheckDestroy: testAccCheckAWSEcsTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEcsTaskDefinitionWithEFSVolume(tdName),
+				Config: testAccAWSEcsTaskDefinitionWithEFSVolume(tdName, "/home/test"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &def),
+					resource.TestCheckResourceAttr(resourceName, "volume.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "volume.584193650.efs_volume_configuration.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "volume.584193650.efs_volume_configuration.0.file_system_id", efsResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "volume.584193650.efs_volume_configuration.0.root_directory", "/home/test"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSEcsTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSEcsTaskDefinition_withEFSVolume(t *testing.T) {
+	var def ecs.TaskDefinition
+
+	tdName := acctest.RandomWithPrefix("tf-acc-td-with-efs-volume")
+	resourceName := "aws_ecs_task_definition.test"
+	efsResourceName := "aws_efs_file_system.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcsTaskDefinitionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEcsTaskDefinitionWithEFSVolumeMinimal(tdName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "volume.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "volume.584193650.efs_volume_configuration.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "volume.584193650.efs_volume_configuration.0.file_system_id", efsResourceName, "id"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSEcsTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -156,8 +210,7 @@ func TestAccAWSEcsTaskDefinition_withEFSVolume(t *testing.T) {
 func TestAccAWSEcsTaskDefinition_withTaskScopedDockerVolume(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	rString := acctest.RandString(8)
-	tdName := fmt.Sprintf("tf_acc_td_with_docker_volume_%s", rString)
+	tdName := acctest.RandomWithPrefix("tf-acc-td-with-docker-volume")
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -175,6 +228,12 @@ func TestAccAWSEcsTaskDefinition_withTaskScopedDockerVolume(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "volume.584193650.docker_volume_configuration.0.scope", "task"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSEcsTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -184,10 +243,9 @@ func TestAccAWSEcsTaskDefinition_withEcsService(t *testing.T) {
 	var def ecs.TaskDefinition
 	var service ecs.Service
 
-	rString := acctest.RandString(8)
-	clusterName := fmt.Sprintf("tf_acc_cluster_with_ecs_service_%s", rString)
-	svcName := fmt.Sprintf("tf_acc_td_with_ecs_service_%s", rString)
-	tdName := fmt.Sprintf("tf_acc_td_with_ecs_service_%s", rString)
+	clusterName := acctest.RandomWithPrefix("tf-acc-cluster-with-ecs-service")
+	svcName := acctest.RandomWithPrefix("tf-acc-td-with-ecs-service")
+	tdName := acctest.RandomWithPrefix("tf-acc-td-with-ecs-service")
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -209,6 +267,12 @@ func TestAccAWSEcsTaskDefinition_withEcsService(t *testing.T) {
 					testAccCheckAWSEcsServiceExists("aws_ecs_service.test", &service),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSEcsTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -216,10 +280,9 @@ func TestAccAWSEcsTaskDefinition_withEcsService(t *testing.T) {
 func TestAccAWSEcsTaskDefinition_withTaskRoleArn(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	rString := acctest.RandString(8)
-	roleName := fmt.Sprintf("tf_acc_role_ecs_td_with_task_role_arn_%s", rString)
-	policyName := fmt.Sprintf("tf-acc-policy-ecs-td-with-task-role-arn-%s", rString)
-	tdName := fmt.Sprintf("tf_acc_td_with_task_role_arn_%s", rString)
+	roleName := acctest.RandomWithPrefix("tf-acc-role-ecs-td-with-task-role-arn")
+	policyName := acctest.RandomWithPrefix("tf-acc-policy-ecs-td-with-task-role-arn")
+	tdName := acctest.RandomWithPrefix("tf-acc-td-with-task-role-arn")
 	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -232,6 +295,12 @@ func TestAccAWSEcsTaskDefinition_withTaskRoleArn(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &def),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSEcsTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -257,6 +326,12 @@ func TestAccAWSEcsTaskDefinition_withNetworkMode(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "network_mode", "bridge"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSEcsTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -280,6 +355,12 @@ func TestAccAWSEcsTaskDefinition_withIPCMode(t *testing.T) {
 					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "ipc_mode", "host"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSEcsTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -305,6 +386,12 @@ func TestAccAWSEcsTaskDefinition_withPidMode(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "pid_mode", "host"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSEcsTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -327,6 +414,12 @@ func TestAccAWSEcsTaskDefinition_constraint(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "placement_constraints.#", "1"),
 					testAccCheckAWSTaskDefinitionConstraintsAttrs(&def),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSEcsTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -357,6 +450,12 @@ func TestAccAWSEcsTaskDefinition_changeVolumesForcesNewResource(t *testing.T) {
 					testAccCheckEcsTaskDefinitionRecreated(t, &before, &after),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSEcsTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -366,8 +465,7 @@ func TestAccAWSEcsTaskDefinition_arrays(t *testing.T) {
 	var conf ecs.TaskDefinition
 	resourceName := "aws_ecs_task_definition.test"
 
-	rString := acctest.RandString(8)
-	tdName := fmt.Sprintf("tf_acc_td_arrays_%s", rString)
+	tdName := acctest.RandomWithPrefix("tf-acc-td-arrays")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -379,6 +477,12 @@ func TestAccAWSEcsTaskDefinition_arrays(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &conf),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSEcsTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -403,6 +507,12 @@ func TestAccAWSEcsTaskDefinition_Fargate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cpu", "256"),
 					resource.TestCheckResourceAttr(resourceName, "memory", "512"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSEcsTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
 			},
 			{
 				ExpectNonEmptyPlan: false,
@@ -431,6 +541,12 @@ func TestAccAWSEcsTaskDefinition_ExecutionRole(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &conf),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSEcsTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -467,6 +583,12 @@ func TestAccAWSEcsTaskDefinition_Inactive(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSEcsTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+			{
 				Config:    testAccAWSEcsTaskDefinition(tdName),
 				PreConfig: markTaskDefinitionInactive,
 				Check:     resource.TestCheckResourceAttr(resourceName, "revision", "2"), // should get re-created
@@ -492,6 +614,12 @@ func TestAccAWSEcsTaskDefinition_Tags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSEcsTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSEcsTaskDefinitionConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
@@ -1247,7 +1375,7 @@ TASK_DEFINITION
 `, tdName)
 }
 
-func testAccAWSEcsTaskDefinitionWithEFSVolume(tdName string) string {
+func testAccAWSEcsTaskDefinitionWithEFSVolumeMinimal(tdName string) string {
 	return fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
 	creation_token = %[1]q
@@ -1278,6 +1406,40 @@ TASK_DEFINITION
   }
 }
 `, tdName)
+}
+
+func testAccAWSEcsTaskDefinitionWithEFSVolume(tdName, rDir string) string {
+	return fmt.Sprintf(`
+resource "aws_efs_file_system" "test" {
+	creation_token = %[1]q
+}
+
+resource "aws_ecs_task_definition" "test" {
+  family = %[1]q
+
+  container_definitions = <<TASK_DEFINITION
+[
+  {
+    "name": "sleep",
+    "image": "busybox",
+    "cpu": 10,
+    "command": ["sleep","360"],
+    "memory": 10,
+    "essential": true
+  }
+]
+TASK_DEFINITION
+
+  volume {
+    name = "database_scratch"
+
+    efs_volume_configuration {
+      file_system_id = "${aws_efs_file_system.test.id}"
+      root_directory = %[2]q
+    }
+  }
+}
+`, tdName, rDir)
 }
 
 func testAccAWSEcsTaskDefinitionWithTaskRoleArn(roleName, policyName, tdName string) string {

--- a/aws/resource_aws_ecs_task_definition_test.go
+++ b/aws/resource_aws_ecs_task_definition_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -14,9 +15,8 @@ import (
 func TestAccAWSEcsTaskDefinition_basic(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	rString := acctest.RandString(8)
-	tdName := fmt.Sprintf("tf_acc_td_basic_%s", rString)
-	resourceName := "aws_ecs_task_definition.jenkins"
+	tdName := acctest.RandomWithPrefix("tf-acc-td-basic")
+	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -27,12 +27,14 @@ func TestAccAWSEcsTaskDefinition_basic(t *testing.T) {
 				Config: testAccAWSEcsTaskDefinition(tdName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &def),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ecs", regexp.MustCompile(`task-definition/.+`)),
 				),
 			},
 			{
 				Config: testAccAWSEcsTaskDefinitionModified(tdName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &def),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ecs", regexp.MustCompile(`task-definition/.+`)),
 				),
 			},
 			{
@@ -49,8 +51,8 @@ func TestAccAWSEcsTaskDefinition_basic(t *testing.T) {
 func TestAccAWSEcsTaskDefinition_withScratchVolume(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	rString := acctest.RandString(8)
-	tdName := fmt.Sprintf("tf_acc_td_with_scratch_volume_%s", rString)
+	tdName := acctest.RandomWithPrefix("tf-acc-td-with-scratch-volume")
+	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -60,7 +62,7 @@ func TestAccAWSEcsTaskDefinition_withScratchVolume(t *testing.T) {
 			{
 				Config: testAccAWSEcsTaskDefinitionWithScratchVolume(tdName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEcsTaskDefinitionExists("aws_ecs_task_definition.sleep", &def),
+					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &def),
 				),
 			},
 		},
@@ -72,6 +74,7 @@ func TestAccAWSEcsTaskDefinition_withDockerVolume(t *testing.T) {
 
 	rString := acctest.RandString(8)
 	tdName := fmt.Sprintf("tf_acc_td_with_docker_volume_%s", rString)
+	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -81,29 +84,18 @@ func TestAccAWSEcsTaskDefinition_withDockerVolume(t *testing.T) {
 			{
 				Config: testAccAWSEcsTaskDefinitionWithDockerVolumes(tdName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEcsTaskDefinitionExists("aws_ecs_task_definition.sleep", &def),
-					resource.TestCheckResourceAttr(
-						"aws_ecs_task_definition.sleep", "volume.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_ecs_task_definition.sleep", "volume.584193650.docker_volume_configuration.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_ecs_task_definition.sleep", "volume.584193650.docker_volume_configuration.0.scope", "shared"),
-					resource.TestCheckResourceAttr(
-						"aws_ecs_task_definition.sleep", "volume.584193650.docker_volume_configuration.0.autoprovision", "true"),
-					resource.TestCheckResourceAttr(
-						"aws_ecs_task_definition.sleep", "volume.584193650.docker_volume_configuration.0.driver", "local"),
-					resource.TestCheckResourceAttr(
-						"aws_ecs_task_definition.sleep", "volume.584193650.docker_volume_configuration.0.driver_opts.%", "2"),
-					resource.TestCheckResourceAttr(
-						"aws_ecs_task_definition.sleep", "volume.584193650.docker_volume_configuration.0.driver_opts.uid", "1000"),
-					resource.TestCheckResourceAttr(
-						"aws_ecs_task_definition.sleep", "volume.584193650.docker_volume_configuration.0.driver_opts.device", "tmpfs"),
-					resource.TestCheckResourceAttr(
-						"aws_ecs_task_definition.sleep", "volume.584193650.docker_volume_configuration.0.labels.%", "2"),
-					resource.TestCheckResourceAttr(
-						"aws_ecs_task_definition.sleep", "volume.584193650.docker_volume_configuration.0.labels.stack", "april"),
-					resource.TestCheckResourceAttr(
-						"aws_ecs_task_definition.sleep", "volume.584193650.docker_volume_configuration.0.labels.environment", "test"),
+					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &def),
+					resource.TestCheckResourceAttr(resourceName, "volume.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "volume.584193650.docker_volume_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "volume.584193650.docker_volume_configuration.0.scope", "shared"),
+					resource.TestCheckResourceAttr(resourceName, "volume.584193650.docker_volume_configuration.0.autoprovision", "true"),
+					resource.TestCheckResourceAttr(resourceName, "volume.584193650.docker_volume_configuration.0.driver", "local"),
+					resource.TestCheckResourceAttr(resourceName, "volume.584193650.docker_volume_configuration.0.driver_opts.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "volume.584193650.docker_volume_configuration.0.driver_opts.uid", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "volume.584193650.docker_volume_configuration.0.driver_opts.device", "tmpfs"),
+					resource.TestCheckResourceAttr(resourceName, "volume.584193650.docker_volume_configuration.0.labels.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "volume.584193650.docker_volume_configuration.0.labels.stack", "april"),
+					resource.TestCheckResourceAttr(resourceName, "volume.584193650.docker_volume_configuration.0.labels.environment", "test"),
 				),
 			},
 		},
@@ -113,8 +105,8 @@ func TestAccAWSEcsTaskDefinition_withDockerVolume(t *testing.T) {
 func TestAccAWSEcsTaskDefinition_withDockerVolumeMinimalConfig(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	rString := acctest.RandString(8)
-	tdName := fmt.Sprintf("tf_acc_td_with_docker_volume_%s", rString)
+	tdName := acctest.RandomWithPrefix("tf-acc-td-with-docker-volume")
+	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -124,15 +116,37 @@ func TestAccAWSEcsTaskDefinition_withDockerVolumeMinimalConfig(t *testing.T) {
 			{
 				Config: testAccAWSEcsTaskDefinitionWithDockerVolumesMinimalConfig(tdName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEcsTaskDefinitionExists("aws_ecs_task_definition.sleep", &def),
-					resource.TestCheckResourceAttr(
-						"aws_ecs_task_definition.sleep", "volume.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_ecs_task_definition.sleep", "volume.584193650.docker_volume_configuration.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_ecs_task_definition.sleep", "volume.584193650.docker_volume_configuration.0.scope", "task"),
-					resource.TestCheckResourceAttr(
-						"aws_ecs_task_definition.sleep", "volume.584193650.docker_volume_configuration.0.driver", "local"),
+					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &def),
+					resource.TestCheckResourceAttr(resourceName, "volume.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "volume.584193650.docker_volume_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "volume.584193650.docker_volume_configuration.0.scope", "task"),
+					resource.TestCheckResourceAttr(resourceName, "volume.584193650.docker_volume_configuration.0.driver", "local"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEcsTaskDefinition_withEFSVolume(t *testing.T) {
+	var def ecs.TaskDefinition
+
+	rString := acctest.RandString(8)
+	tdName := fmt.Sprintf("tf_acc_td_with_docker_volume_%s", rString)
+	resourceName := "aws_ecs_task_definition.test"
+	efsResourceName := "aws_efs_file_system.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcsTaskDefinitionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEcsTaskDefinitionWithEFSVolume(tdName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &def),
+					resource.TestCheckResourceAttr(resourceName, "volume.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "volume.584193650.efs_volume_configuration.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "volume.584193650.efs_volume_configuration.0.file_system_id", efsResourceName, "id"),
 				),
 			},
 		},
@@ -144,6 +158,7 @@ func TestAccAWSEcsTaskDefinition_withTaskScopedDockerVolume(t *testing.T) {
 
 	rString := acctest.RandString(8)
 	tdName := fmt.Sprintf("tf_acc_td_with_docker_volume_%s", rString)
+	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -153,14 +168,11 @@ func TestAccAWSEcsTaskDefinition_withTaskScopedDockerVolume(t *testing.T) {
 			{
 				Config: testAccAWSEcsTaskDefinitionWithTaskScopedDockerVolume(tdName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEcsTaskDefinitionExists("aws_ecs_task_definition.sleep", &def),
+					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &def),
 					testAccCheckAWSTaskDefinitionDockerVolumeConfigurationAutoprovisionNil(&def),
-					resource.TestCheckResourceAttr(
-						"aws_ecs_task_definition.sleep", "volume.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_ecs_task_definition.sleep", "volume.584193650.docker_volume_configuration.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_ecs_task_definition.sleep", "volume.584193650.docker_volume_configuration.0.scope", "task"),
+					resource.TestCheckResourceAttr(resourceName, "volume.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "volume.584193650.docker_volume_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "volume.584193650.docker_volume_configuration.0.scope", "task"),
 				),
 			},
 		},
@@ -176,6 +188,7 @@ func TestAccAWSEcsTaskDefinition_withEcsService(t *testing.T) {
 	clusterName := fmt.Sprintf("tf_acc_cluster_with_ecs_service_%s", rString)
 	svcName := fmt.Sprintf("tf_acc_td_with_ecs_service_%s", rString)
 	tdName := fmt.Sprintf("tf_acc_td_with_ecs_service_%s", rString)
+	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -185,15 +198,15 @@ func TestAccAWSEcsTaskDefinition_withEcsService(t *testing.T) {
 			{
 				Config: testAccAWSEcsTaskDefinitionWithEcsService(clusterName, svcName, tdName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEcsTaskDefinitionExists("aws_ecs_task_definition.sleep", &def),
-					testAccCheckAWSEcsServiceExists("aws_ecs_service.sleep-svc", &service),
+					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &def),
+					testAccCheckAWSEcsServiceExists("aws_ecs_service.test", &service),
 				),
 			},
 			{
 				Config: testAccAWSEcsTaskDefinitionWithEcsServiceModified(clusterName, svcName, tdName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEcsTaskDefinitionExists("aws_ecs_task_definition.sleep", &def),
-					testAccCheckAWSEcsServiceExists("aws_ecs_service.sleep-svc", &service),
+					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &def),
+					testAccCheckAWSEcsServiceExists("aws_ecs_service.test", &service),
 				),
 			},
 		},
@@ -207,6 +220,7 @@ func TestAccAWSEcsTaskDefinition_withTaskRoleArn(t *testing.T) {
 	roleName := fmt.Sprintf("tf_acc_role_ecs_td_with_task_role_arn_%s", rString)
 	policyName := fmt.Sprintf("tf-acc-policy-ecs-td-with-task-role-arn-%s", rString)
 	tdName := fmt.Sprintf("tf_acc_td_with_task_role_arn_%s", rString)
+	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -216,7 +230,7 @@ func TestAccAWSEcsTaskDefinition_withTaskRoleArn(t *testing.T) {
 			{
 				Config: testAccAWSEcsTaskDefinitionWithTaskRoleArn(roleName, policyName, tdName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEcsTaskDefinitionExists("aws_ecs_task_definition.sleep", &def),
+					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &def),
 				),
 			},
 		},
@@ -226,10 +240,10 @@ func TestAccAWSEcsTaskDefinition_withTaskRoleArn(t *testing.T) {
 func TestAccAWSEcsTaskDefinition_withNetworkMode(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	rString := acctest.RandString(8)
-	roleName := fmt.Sprintf("tf_acc_ecs_td_with_network_mode_%s", rString)
-	policyName := fmt.Sprintf("tf_acc_ecs_td_with_network_mode_%s", rString)
-	tdName := fmt.Sprintf("tf_acc_td_with_network_mode_%s", rString)
+	roleName := acctest.RandomWithPrefix("tf-acc-ecs-td-with-network-mode")
+	policyName := acctest.RandomWithPrefix("tf-acc-ecs-td-with-network-mode")
+	tdName := acctest.RandomWithPrefix("tf-acc-td-with-network-mode")
+	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -239,9 +253,8 @@ func TestAccAWSEcsTaskDefinition_withNetworkMode(t *testing.T) {
 			{
 				Config: testAccAWSEcsTaskDefinitionWithNetworkMode(roleName, policyName, tdName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEcsTaskDefinitionExists("aws_ecs_task_definition.sleep", &def),
-					resource.TestCheckResourceAttr(
-						"aws_ecs_task_definition.sleep", "network_mode", "bridge"),
+					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &def),
+					resource.TestCheckResourceAttr(resourceName, "network_mode", "bridge"),
 				),
 			},
 		},
@@ -251,10 +264,10 @@ func TestAccAWSEcsTaskDefinition_withNetworkMode(t *testing.T) {
 func TestAccAWSEcsTaskDefinition_withIPCMode(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	rString := acctest.RandString(8)
-	roleName := fmt.Sprintf("tf_acc_ecs_td_with_ipc_mode_%s", rString)
-	policyName := fmt.Sprintf("tf_acc_ecs_td_with_ipc_mode_%s", rString)
-	tdName := fmt.Sprintf("tf_acc_td_with_ipc_mode_%s", rString)
+	roleName := acctest.RandomWithPrefix("tf-acc-ecs-td-with-ipc-mode")
+	policyName := acctest.RandomWithPrefix("tf-acc-ecs-td-with-ipc-mode")
+	tdName := acctest.RandomWithPrefix("tf-acc-td-with-ipc-mode")
+	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -264,9 +277,8 @@ func TestAccAWSEcsTaskDefinition_withIPCMode(t *testing.T) {
 			{
 				Config: testAccAWSEcsTaskDefinitionWithIpcMode(roleName, policyName, tdName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEcsTaskDefinitionExists("aws_ecs_task_definition.sleep", &def),
-					resource.TestCheckResourceAttr(
-						"aws_ecs_task_definition.sleep", "ipc_mode", "host"),
+					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &def),
+					resource.TestCheckResourceAttr(resourceName, "ipc_mode", "host"),
 				),
 			},
 		},
@@ -276,10 +288,10 @@ func TestAccAWSEcsTaskDefinition_withIPCMode(t *testing.T) {
 func TestAccAWSEcsTaskDefinition_withPidMode(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	rString := acctest.RandString(8)
-	roleName := fmt.Sprintf("tf_acc_ecs_td_with_pid_mode_%s", rString)
-	policyName := fmt.Sprintf("tf_acc_ecs_td_with_pid_mode_%s", rString)
-	tdName := fmt.Sprintf("tf_acc_td_with_pid_mode_%s", rString)
+	roleName := acctest.RandomWithPrefix("tf-acc-ecs-td-with-pid-mode")
+	policyName := acctest.RandomWithPrefix("tf-acc-ecs-td-with-pid-mode")
+	tdName := acctest.RandomWithPrefix("tf-acc-td-with-pid-mode")
+	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -289,9 +301,8 @@ func TestAccAWSEcsTaskDefinition_withPidMode(t *testing.T) {
 			{
 				Config: testAccAWSEcsTaskDefinitionWithPidMode(roleName, policyName, tdName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEcsTaskDefinitionExists("aws_ecs_task_definition.sleep", &def),
-					resource.TestCheckResourceAttr(
-						"aws_ecs_task_definition.sleep", "pid_mode", "host"),
+					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &def),
+					resource.TestCheckResourceAttr(resourceName, "pid_mode", "host"),
 				),
 			},
 		},
@@ -301,8 +312,8 @@ func TestAccAWSEcsTaskDefinition_withPidMode(t *testing.T) {
 func TestAccAWSEcsTaskDefinition_constraint(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	rString := acctest.RandString(8)
-	tdName := fmt.Sprintf("tf_acc_td_constraint_%s", rString)
+	tdName := acctest.RandomWithPrefix("tf-acc-td-constraint")
+	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -312,8 +323,8 @@ func TestAccAWSEcsTaskDefinition_constraint(t *testing.T) {
 			{
 				Config: testAccAWSEcsTaskDefinition_constraint(tdName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEcsTaskDefinitionExists("aws_ecs_task_definition.jenkins", &def),
-					resource.TestCheckResourceAttr("aws_ecs_task_definition.jenkins", "placement_constraints.#", "1"),
+					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &def),
+					resource.TestCheckResourceAttr(resourceName, "placement_constraints.#", "1"),
 					testAccCheckAWSTaskDefinitionConstraintsAttrs(&def),
 				),
 			},
@@ -325,8 +336,8 @@ func TestAccAWSEcsTaskDefinition_changeVolumesForcesNewResource(t *testing.T) {
 	var before ecs.TaskDefinition
 	var after ecs.TaskDefinition
 
-	rString := acctest.RandString(8)
-	tdName := fmt.Sprintf("tf_acc_td_change_vol_forces_new_resource_%s", rString)
+	tdName := acctest.RandomWithPrefix("tf-acc-td-change-vol-forces-new-resource")
+	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -336,13 +347,13 @@ func TestAccAWSEcsTaskDefinition_changeVolumesForcesNewResource(t *testing.T) {
 			{
 				Config: testAccAWSEcsTaskDefinition(tdName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEcsTaskDefinitionExists("aws_ecs_task_definition.jenkins", &before),
+					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &before),
 				),
 			},
 			{
 				Config: testAccAWSEcsTaskDefinitionUpdatedVolume(tdName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEcsTaskDefinitionExists("aws_ecs_task_definition.jenkins", &after),
+					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &after),
 					testAccCheckEcsTaskDefinitionRecreated(t, &before, &after),
 				),
 			},
@@ -353,6 +364,7 @@ func TestAccAWSEcsTaskDefinition_changeVolumesForcesNewResource(t *testing.T) {
 // Regression for https://github.com/terraform-providers/terraform-provider-aws/issues/2336
 func TestAccAWSEcsTaskDefinition_arrays(t *testing.T) {
 	var conf ecs.TaskDefinition
+	resourceName := "aws_ecs_task_definition.test"
 
 	rString := acctest.RandString(8)
 	tdName := fmt.Sprintf("tf_acc_td_arrays_%s", rString)
@@ -365,7 +377,7 @@ func TestAccAWSEcsTaskDefinition_arrays(t *testing.T) {
 			{
 				Config: testAccAWSEcsTaskDefinitionArrays(tdName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEcsTaskDefinitionExists("aws_ecs_task_definition.test", &conf),
+					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &conf),
 				),
 			},
 		},
@@ -375,8 +387,8 @@ func TestAccAWSEcsTaskDefinition_arrays(t *testing.T) {
 func TestAccAWSEcsTaskDefinition_Fargate(t *testing.T) {
 	var conf ecs.TaskDefinition
 
-	rString := acctest.RandString(8)
-	tdName := fmt.Sprintf("tf_acc_td_fargate_%s", rString)
+	tdName := acctest.RandomWithPrefix("tf-acc-td-fargate")
+	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -386,10 +398,10 @@ func TestAccAWSEcsTaskDefinition_Fargate(t *testing.T) {
 			{
 				Config: testAccAWSEcsTaskDefinitionFargate(tdName, `[{"protocol": "tcp", "containerPort": 8000}]`),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEcsTaskDefinitionExists("aws_ecs_task_definition.fargate", &conf),
-					resource.TestCheckResourceAttr("aws_ecs_task_definition.fargate", "requires_compatibilities.#", "1"),
-					resource.TestCheckResourceAttr("aws_ecs_task_definition.fargate", "cpu", "256"),
-					resource.TestCheckResourceAttr("aws_ecs_task_definition.fargate", "memory", "512"),
+					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "requires_compatibilities.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cpu", "256"),
+					resource.TestCheckResourceAttr(resourceName, "memory", "512"),
 				),
 			},
 			{
@@ -404,10 +416,10 @@ func TestAccAWSEcsTaskDefinition_Fargate(t *testing.T) {
 func TestAccAWSEcsTaskDefinition_ExecutionRole(t *testing.T) {
 	var conf ecs.TaskDefinition
 
-	rString := acctest.RandString(8)
-	roleName := fmt.Sprintf("tf_acc_role_ecs_td_execution_role_%s", rString)
-	policyName := fmt.Sprintf("tf-acc-policy-ecs-td-execution-role-%s", rString)
-	tdName := fmt.Sprintf("tf_acc_td_execution_role_%s", rString)
+	roleName := acctest.RandomWithPrefix("tf-acc-role-ecs-td-execution-role")
+	policyName := acctest.RandomWithPrefix("tf-acc-policy-ecs-td-execution-role")
+	tdName := acctest.RandomWithPrefix("tf-acc-td-execution-role")
+	resourceName := "aws_ecs_task_definition.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -417,7 +429,7 @@ func TestAccAWSEcsTaskDefinition_ExecutionRole(t *testing.T) {
 			{
 				Config: testAccAWSEcsTaskDefinitionExecutionRole(roleName, policyName, tdName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEcsTaskDefinitionExists("aws_ecs_task_definition.fargate", &conf),
+					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &conf),
 				),
 			},
 		},
@@ -428,8 +440,8 @@ func TestAccAWSEcsTaskDefinition_ExecutionRole(t *testing.T) {
 func TestAccAWSEcsTaskDefinition_Inactive(t *testing.T) {
 	var def ecs.TaskDefinition
 
-	rString := acctest.RandString(8)
-	tdName := fmt.Sprintf("tf_acc_td_basic_%s", rString)
+	tdName := acctest.RandomWithPrefix("tf-acc-td-basic")
+	resourceName := "aws_ecs_task_definition.test"
 
 	markTaskDefinitionInactive := func() {
 		conn := testAccProvider.Meta().(*AWSClient).ecsconn
@@ -451,13 +463,13 @@ func TestAccAWSEcsTaskDefinition_Inactive(t *testing.T) {
 			{
 				Config: testAccAWSEcsTaskDefinition(tdName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEcsTaskDefinitionExists("aws_ecs_task_definition.jenkins", &def),
+					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &def),
 				),
 			},
 			{
 				Config:    testAccAWSEcsTaskDefinition(tdName),
 				PreConfig: markTaskDefinitionInactive,
-				Check:     resource.TestCheckResourceAttr("aws_ecs_task_definition.jenkins", "revision", "2"), // should get re-created
+				Check:     resource.TestCheckResourceAttr(resourceName, "revision", "2"), // should get re-created
 			},
 		},
 	})
@@ -695,7 +707,7 @@ func testAccCheckAWSEcsTaskDefinitionDestroy(s *terraform.State) error {
 			return err
 		}
 
-		if out.TaskDefinition != nil && *out.TaskDefinition.Status != "INACTIVE" {
+		if out.TaskDefinition != nil && *out.TaskDefinition.Status != ecs.TaskDefinitionStatusInactive {
 			return fmt.Errorf("ECS task definition still exists:\n%#v", *out.TaskDefinition)
 		}
 	}
@@ -742,7 +754,7 @@ func testAccCheckAWSTaskDefinitionDockerVolumeConfigurationAutoprovisionNil(def 
 
 func testAccAWSEcsTaskDefinition_constraint(tdName string) string {
 	return fmt.Sprintf(`
-resource "aws_ecs_task_definition" "jenkins" {
+resource "aws_ecs_task_definition" "test" {
   family = "%s"
 
   container_definitions = <<TASK_DEFINITION
@@ -799,7 +811,7 @@ TASK_DEFINITION
 
 func testAccAWSEcsTaskDefinition(tdName string) string {
 	return fmt.Sprintf(`
-resource "aws_ecs_task_definition" "jenkins" {
+resource "aws_ecs_task_definition" "test" {
   family = "%s"
 
   container_definitions = <<TASK_DEFINITION
@@ -851,7 +863,7 @@ TASK_DEFINITION
 
 func testAccAWSEcsTaskDefinitionUpdatedVolume(tdName string) string {
 	return fmt.Sprintf(`
-resource "aws_ecs_task_definition" "jenkins" {
+resource "aws_ecs_task_definition" "test" {
   family = "%s"
 
   container_definitions = <<TASK_DEFINITION
@@ -1014,7 +1026,7 @@ TASK_DEFINITION
 
 func testAccAWSEcsTaskDefinitionFargate(tdName, portMappings string) string {
 	return fmt.Sprintf(`
-resource "aws_ecs_task_definition" "fargate" {
+resource "aws_ecs_task_definition" "test" {
   family                   = "%s"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
@@ -1040,7 +1052,7 @@ TASK_DEFINITION
 
 func testAccAWSEcsTaskDefinitionExecutionRole(roleName, policyName, tdName string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_role" "role" {
+resource "aws_iam_role" "test" {
   name = "%s"
 
   assume_role_policy = <<EOF
@@ -1060,7 +1072,7 @@ resource "aws_iam_role" "role" {
 EOF
 }
 
-resource "aws_iam_policy" "policy" {
+resource "aws_iam_policy" "test" {
   name        = "%s"
   description = "A test policy"
 
@@ -1085,14 +1097,14 @@ resource "aws_iam_policy" "policy" {
 EOF
 }
 
-resource "aws_iam_role_policy_attachment" "test-attach" {
-  role       = "${aws_iam_role.role.name}"
-  policy_arn = "${aws_iam_policy.policy.arn}"
+resource "aws_iam_role_policy_attachment" "test" {
+  role       = "${aws_iam_role.test.name}"
+  policy_arn = "${aws_iam_policy.test.arn}"
 }
 
-resource "aws_ecs_task_definition" "fargate" {
+resource "aws_ecs_task_definition" "test" {
   family             = "%s"
-  execution_role_arn = "${aws_iam_role.role.arn}"
+  execution_role_arn = "${aws_iam_role.test.arn}"
 
   container_definitions = <<TASK_DEFINITION
 [
@@ -1112,7 +1124,7 @@ TASK_DEFINITION
 
 func testAccAWSEcsTaskDefinitionWithScratchVolume(tdName string) string {
 	return fmt.Sprintf(`
-resource "aws_ecs_task_definition" "sleep" {
+resource "aws_ecs_task_definition" "test" {
   family = "%s"
 
   container_definitions = <<TASK_DEFINITION
@@ -1137,7 +1149,7 @@ TASK_DEFINITION
 
 func testAccAWSEcsTaskDefinitionWithDockerVolumes(tdName string) string {
 	return fmt.Sprintf(`
-resource "aws_ecs_task_definition" "sleep" {
+resource "aws_ecs_task_definition" "test" {
   family = "%s"
 
   container_definitions = <<TASK_DEFINITION
@@ -1179,7 +1191,7 @@ TASK_DEFINITION
 
 func testAccAWSEcsTaskDefinitionWithDockerVolumesMinimalConfig(tdName string) string {
 	return fmt.Sprintf(`
-resource "aws_ecs_task_definition" "sleep" {
+resource "aws_ecs_task_definition" "test" {
   family = "%s"
 
   container_definitions = <<TASK_DEFINITION
@@ -1208,7 +1220,7 @@ TASK_DEFINITION
 
 func testAccAWSEcsTaskDefinitionWithTaskScopedDockerVolume(tdName string) string {
 	return fmt.Sprintf(`
-resource "aws_ecs_task_definition" "sleep" {
+resource "aws_ecs_task_definition" "test" {
   family = "%s"
 
   container_definitions = <<TASK_DEFINITION
@@ -1235,9 +1247,42 @@ TASK_DEFINITION
 `, tdName)
 }
 
+func testAccAWSEcsTaskDefinitionWithEFSVolume(tdName string) string {
+	return fmt.Sprintf(`
+resource "aws_efs_file_system" "test" {
+	creation_token = %[1]q
+}
+
+resource "aws_ecs_task_definition" "test" {
+  family = %[1]q
+
+  container_definitions = <<TASK_DEFINITION
+[
+  {
+    "name": "sleep",
+    "image": "busybox",
+    "cpu": 10,
+    "command": ["sleep","360"],
+    "memory": 10,
+    "essential": true
+  }
+]
+TASK_DEFINITION
+
+  volume {
+    name = "database_scratch"
+
+    efs_volume_configuration {
+      file_system_id = "${aws_efs_file_system.test.id}"
+    }
+  }
+}
+`, tdName)
+}
+
 func testAccAWSEcsTaskDefinitionWithTaskRoleArn(roleName, policyName, tdName string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_role" "role_test" {
+resource "aws_iam_role" "test" {
   name = "%s"
   path = "/test/"
 
@@ -1258,9 +1303,9 @@ resource "aws_iam_role" "role_test" {
 EOF
 }
 
-resource "aws_iam_role_policy" "role_test" {
+resource "aws_iam_role_policy" "test" {
   name = "%s"
-  role = "${aws_iam_role.role_test.id}"
+  role = "${aws_iam_role.test.id}"
 
   policy = <<EOF
 {
@@ -1279,9 +1324,9 @@ resource "aws_iam_role_policy" "role_test" {
 EOF
 }
 
-resource "aws_ecs_task_definition" "sleep" {
+resource "aws_ecs_task_definition" "test" {
   family        = "%s"
-  task_role_arn = "${aws_iam_role.role_test.arn}"
+  task_role_arn = "${aws_iam_role.test.arn}"
 
   container_definitions = <<TASK_DEFINITION
 [
@@ -1305,7 +1350,7 @@ TASK_DEFINITION
 
 func testAccAWSEcsTaskDefinitionWithIpcMode(roleName, policyName, tdName string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_role" "role_test" {
+resource "aws_iam_role" "test" {
   name = "%s"
   path = "/test/"
 
@@ -1326,9 +1371,9 @@ resource "aws_iam_role" "role_test" {
 EOF
 }
 
-resource "aws_iam_role_policy" "role_test" {
+resource "aws_iam_role_policy" "test" {
   name = "%s"
-  role = "${aws_iam_role.role_test.id}"
+  role = "${aws_iam_role.test.id}"
 
   policy = <<EOF
 {
@@ -1347,9 +1392,9 @@ resource "aws_iam_role_policy" "role_test" {
  EOF
 }
 
-resource "aws_ecs_task_definition" "sleep" {
+resource "aws_ecs_task_definition" "test" {
   family        = "%s"
-  task_role_arn = "${aws_iam_role.role_test.arn}"
+  task_role_arn = "${aws_iam_role.test.arn}"
   network_mode  = "bridge"
   ipc_mode      = "host"
 
@@ -1375,7 +1420,7 @@ TASK_DEFINITION
 
 func testAccAWSEcsTaskDefinitionWithPidMode(roleName, policyName, tdName string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_role" "role_test" {
+resource "aws_iam_role" "test" {
   name = "%s"
   path = "/test/"
 
@@ -1396,9 +1441,9 @@ resource "aws_iam_role" "role_test" {
 EOF
 }
 
-resource "aws_iam_role_policy" "role_test" {
+resource "aws_iam_role_policy" "test" {
   name = "%s"
-  role = "${aws_iam_role.role_test.id}"
+  role = "${aws_iam_role.test.id}"
 
   policy = <<EOF
 {
@@ -1417,9 +1462,9 @@ resource "aws_iam_role_policy" "role_test" {
  EOF
 }
 
-resource "aws_ecs_task_definition" "sleep" {
+resource "aws_ecs_task_definition" "test" {
   family        = "%s"
-  task_role_arn = "${aws_iam_role.role_test.arn}"
+  task_role_arn = "${aws_iam_role.test.arn}"
   network_mode  = "bridge"
   pid_mode      = "host"
 
@@ -1445,7 +1490,7 @@ TASK_DEFINITION
 
 func testAccAWSEcsTaskDefinitionWithNetworkMode(roleName, policyName, tdName string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_role" "role_test" {
+resource "aws_iam_role" "test" {
   name = "%s"
   path = "/test/"
 
@@ -1466,9 +1511,9 @@ resource "aws_iam_role" "role_test" {
 EOF
 }
 
-resource "aws_iam_role_policy" "role_test" {
+resource "aws_iam_role_policy" "test" {
   name = "%s"
-  role = "${aws_iam_role.role_test.id}"
+  role = "${aws_iam_role.test.id}"
 
   policy = <<EOF
 {
@@ -1487,9 +1532,9 @@ resource "aws_iam_role_policy" "role_test" {
  EOF
 }
 
-resource "aws_ecs_task_definition" "sleep" {
+resource "aws_ecs_task_definition" "test" {
   family        = "%s"
-  task_role_arn = "${aws_iam_role.role_test.arn}"
+  task_role_arn = "${aws_iam_role.test.arn}"
   network_mode  = "bridge"
 
   container_definitions = <<TASK_DEFINITION
@@ -1514,18 +1559,18 @@ TASK_DEFINITION
 
 func testAccAWSEcsTaskDefinitionWithEcsService(clusterName, svcName, tdName string) string {
 	return fmt.Sprintf(`
-resource "aws_ecs_cluster" "default" {
+resource "aws_ecs_cluster" "test" {
   name = "%s"
 }
 
-resource "aws_ecs_service" "sleep-svc" {
+resource "aws_ecs_service" "test" {
   name            = "%s"
-  cluster         = "${aws_ecs_cluster.default.id}"
-  task_definition = "${aws_ecs_task_definition.sleep.arn}"
+  cluster         = "${aws_ecs_cluster.test.id}"
+  task_definition = "${aws_ecs_task_definition.test.arn}"
   desired_count   = 1
 }
 
-resource "aws_ecs_task_definition" "sleep" {
+resource "aws_ecs_task_definition" "test" {
   family = "%s"
 
   container_definitions = <<TASK_DEFINITION
@@ -1550,18 +1595,18 @@ TASK_DEFINITION
 
 func testAccAWSEcsTaskDefinitionWithEcsServiceModified(clusterName, svcName, tdName string) string {
 	return fmt.Sprintf(`
-resource "aws_ecs_cluster" "default" {
+resource "aws_ecs_cluster" "test" {
   name = "%s"
 }
 
-resource "aws_ecs_service" "sleep-svc" {
+resource "aws_ecs_service" "test" {
   name            = "%s"
-  cluster         = "${aws_ecs_cluster.default.id}"
-  task_definition = "${aws_ecs_task_definition.sleep.arn}"
+  cluster         = "${aws_ecs_cluster.test.id}"
+  task_definition = "${aws_ecs_task_definition.test.arn}"
   desired_count   = 1
 }
 
-resource "aws_ecs_task_definition" "sleep" {
+resource "aws_ecs_task_definition" "test" {
   family = "%s"
 
   container_definitions = <<TASK_DEFINITION
@@ -1586,7 +1631,7 @@ TASK_DEFINITION
 
 func testAccAWSEcsTaskDefinitionModified(tdName string) string {
 	return fmt.Sprintf(`
-resource "aws_ecs_task_definition" "jenkins" {
+resource "aws_ecs_task_definition" "test" {
   family = "%s"
 
   container_definitions = <<TASK_DEFINITION

--- a/aws/resource_aws_ecs_task_definition_test.go
+++ b/aws/resource_aws_ecs_task_definition_test.go
@@ -157,13 +157,12 @@ func TestAccAWSEcsTaskDefinition_withEFSVolumeMinimal(t *testing.T) {
 		CheckDestroy: testAccCheckAWSEcsTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEcsTaskDefinitionWithEFSVolume(tdName, "/home/test"),
+				Config: testAccAWSEcsTaskDefinitionWithEFSVolumeMinimal(tdName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "volume.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "volume.584193650.efs_volume_configuration.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "volume.584193650.efs_volume_configuration.0.file_system_id", efsResourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "volume.584193650.efs_volume_configuration.0.root_directory", "/home/test"),
 				),
 			},
 			{
@@ -189,12 +188,13 @@ func TestAccAWSEcsTaskDefinition_withEFSVolume(t *testing.T) {
 		CheckDestroy: testAccCheckAWSEcsTaskDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEcsTaskDefinitionWithEFSVolumeMinimal(tdName),
+				Config: testAccAWSEcsTaskDefinitionWithEFSVolume(tdName, "/home/test"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "volume.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "volume.584193650.efs_volume_configuration.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "volume.584193650.efs_volume_configuration.0.file_system_id", efsResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "volume.584193650.efs_volume_configuration.0.root_directory", "/home/test"),
 				),
 			},
 			{

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -147,6 +147,20 @@ func expandEcsVolumes(configured []interface{}) ([]*ecs.Volume, error) {
 			}
 		}
 
+		efsConfig, ok := data["efs_volume_configuration"].([]interface{})
+		if ok && len(efsConfig) > 0 {
+			config := efsConfig[0].(map[string]interface{})
+			l.EfsVolumeConfiguration = &ecs.EFSVolumeConfiguration{}
+
+			if v, ok := config["file_system_id"].(string); ok && v != "" {
+				l.EfsVolumeConfiguration.FileSystemId = aws.String(v)
+			}
+
+			if v, ok := config["root_directory"].(string); ok && v != "" {
+				l.EfsVolumeConfiguration.RootDirectory = aws.String(v)
+			}
+		}
+
 		volumes = append(volumes, l)
 	}
 
@@ -685,6 +699,10 @@ func flattenEcsVolumes(list []*ecs.Volume) []map[string]interface{} {
 			l["docker_volume_configuration"] = flattenDockerVolumeConfiguration(volume.DockerVolumeConfiguration)
 		}
 
+		if volume.DockerVolumeConfiguration != nil {
+			l["efs_volume_configuration"] = flattenEFSVolumeConfiguration(volume.EfsVolumeConfiguration)
+		}
+
 		result = append(result, l)
 	}
 	return result
@@ -694,24 +712,41 @@ func flattenDockerVolumeConfiguration(config *ecs.DockerVolumeConfiguration) []i
 	var items []interface{}
 	m := make(map[string]interface{})
 
-	if config.Scope != nil {
-		m["scope"] = aws.StringValue(config.Scope)
+	if v := config.Scope; v != nil {
+		m["scope"] = aws.StringValue(v)
 	}
 
-	if config.Autoprovision != nil {
-		m["autoprovision"] = aws.BoolValue(config.Autoprovision)
+	if v := config.Autoprovision; v != nil {
+		m["autoprovision"] = aws.BoolValue(v)
 	}
 
-	if config.Driver != nil {
-		m["driver"] = aws.StringValue(config.Driver)
+	if v := config.Driver; v != nil {
+		m["driver"] = aws.StringValue(v)
 	}
 
 	if config.DriverOpts != nil {
 		m["driver_opts"] = pointersMapToStringList(config.DriverOpts)
 	}
 
-	if config.Labels != nil {
-		m["labels"] = pointersMapToStringList(config.Labels)
+	if v := config.Labels; v != nil {
+		m["labels"] = pointersMapToStringList(v)
+	}
+
+	items = append(items, m)
+	return items
+}
+
+func flattenEFSVolumeConfiguration(config *ecs.EFSVolumeConfiguration) []interface{} {
+	var items []interface{}
+	m := make(map[string]interface{})
+	if config != nil {
+		if v := config.FileSystemId; v != nil {
+			m["file_system_id"] = aws.StringValue(v)
+		}
+
+		if v := config.RootDirectory; v != nil {
+			m["root_directory"] = aws.StringValue(v)
+		}
 	}
 
 	items = append(items, m)

--- a/website/docs/r/ecs_task_definition.html.markdown
+++ b/website/docs/r/ecs_task_definition.html.markdown
@@ -119,6 +119,7 @@ official [Developer Guide](https://docs.aws.amazon.com/AmazonECS/latest/develope
 parameter of container definition in the `mountPoints` section.
 * `host_path` - (Optional) The path on the host container instance that is presented to the container. If not set, ECS will create a nonpersistent data volume that starts empty and is deleted after the task has finished.
 * `docker_volume_configuration` - (Optional) Used to configure a [docker volume](#docker-volume-configuration-arguments)
+* `efs_volume_configuration` - (Optional) Used to configure a [EFS volume](#efs-volume-configuration-arguments). Can be used only with an EC2 type task.
 
 #### Docker Volume Configuration Arguments
 
@@ -129,6 +130,13 @@ For more information, see [Specifying a Docker volume in your Task Definition De
 * `driver` - (Optional) The Docker volume driver to use. The driver value must match the driver name provided by Docker because it is used for task placement.
 * `driver_opts` - (Optional) A map of Docker driver specific options.
 * `labels` - (Optional) A map of custom metadata to add to your Docker volume.
+
+#### EFS Volume Configuration Arguments
+For more information, see [Specifying an EFS volume in your Task Definition Developer Guide](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_efs.html)
+* `file_system_id` - (Required) The ID of the EFS File System.
+* `root_directory` - (Optional) The path to mount on the host
+
+
 
 ##### Example Usage:
 ```hcl

--- a/website/docs/r/ecs_task_definition.html.markdown
+++ b/website/docs/r/ecs_task_definition.html.markdown
@@ -136,8 +136,6 @@ For more information, see [Specifying an EFS volume in your Task Definition Deve
 * `file_system_id` - (Required) The ID of the EFS File System.
 * `root_directory` - (Optional) The path to mount on the host
 
-
-
 ##### Example Usage:
 ```hcl
 resource "aws_ecs_task_definition" "service" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_ecs_task_definition: add EFS Volume support, add plan time validation to `placement_constraints.type`, `task_role_arn` and `execution_role_arn`.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEcsTaskDefinition_'
--- PASS: TestAccAWSEcsTaskDefinition_basic (63.83s)
--- PASS: TestAccAWSEcsTaskDefinition_withScratchVolume (34.38s)
--- PASS: TestAccAWSEcsTaskDefinition_withDockerVolume (45.59s)
--- PASS: TestAccAWSEcsTaskDefinition_withDockerVolumeMinimalConfig (35.03s)
--- PASS: TestAccAWSEcsTaskDefinition_withEFSVolume (62.60s)
--- PASS: TestAccAWSEcsTaskDefinition_withEFSVolumeMinimal (62.59s)
--- PASS: TestAccAWSEcsTaskDefinition_withTaskScopedDockerVolume (45.90s)
--- PASS: TestAccAWSEcsTaskDefinition_withEcsService (137.22s)
--- PASS: TestAccAWSEcsTaskDefinition_withTaskRoleArn (58.24s)
--- PASS: TestAccAWSEcsTaskDefinition_withNetworkMode (55.05s)
--- PASS: TestAccAWSEcsTaskDefinition_withIPCMode (45.99s)
--- PASS: TestAccAWSEcsTaskDefinition_withPidMode (46.17s)
--- PASS: TestAccAWSEcsTaskDefinition_constraint (39.71s)
--- PASS: TestAccAWSEcsTaskDefinition_changeVolumesForcesNewResource (61.38s)
--- PASS: TestAccAWSEcsTaskDefinition_arrays (35.52s)
--- PASS: TestAccAWSEcsTaskDefinition_Fargate (50.31s)
--- PASS: TestAccAWSEcsTaskDefinition_ExecutionRole (44.48s)
--- PASS: TestAccAWSEcsTaskDefinition_Inactive (58.79s)
--- PASS: TestAccAWSEcsTaskDefinition_Tags (91.53s)
--- PASS: TestAccAWSEcsTaskDefinition_ProxyConfiguration (43.49s)
```
