### PR TITLE
tests/resource/aws_lb_target_group_attachment: Refactoring for region/partition agnostic and blacklist usw2-az4

### DIFF
--- a/aws/resource_aws_lb_target_group_attachment_test.go
+++ b/aws/resource_aws_lb_target_group_attachment_test.go
@@ -17,13 +17,12 @@ func TestAccAWSLBTargetGroupAttachment_basic(t *testing.T) {
 	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_lb_target_group.test",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupAttachmentDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupAttachmentConfig_basic(targetGroupName),
+				Config: testAccAWSLBTargetGroupAttachmentConfigTargetIdInstance(targetGroupName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupAttachmentExists("aws_lb_target_group_attachment.test"),
 				),
@@ -35,13 +34,12 @@ func TestAccAWSLBTargetGroupAttachment_basic(t *testing.T) {
 func TestAccAWSLBTargetGroupAttachment_disappears(t *testing.T) {
 	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_lb_target_group.test",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupAttachmentDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupAttachmentConfig_basic(targetGroupName),
+				Config: testAccAWSLBTargetGroupAttachmentConfigTargetIdInstance(targetGroupName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLBTargetGroupAttachmentExists("aws_lb_target_group_attachment.test"),
 					testAccCheckAWSLBTargetGroupAttachmentDisappears("aws_lb_target_group_attachment.test"),
@@ -56,10 +54,9 @@ func TestAccAWSLBTargetGroupAttachment_BackwardsCompatibility(t *testing.T) {
 	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_alb_target_group.test",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupAttachmentDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLBTargetGroupAttachmentConfigBackwardsCompatibility(targetGroupName),
@@ -71,17 +68,16 @@ func TestAccAWSLBTargetGroupAttachment_BackwardsCompatibility(t *testing.T) {
 	})
 }
 
-func TestAccAWSLBTargetGroupAttachment_withoutPort(t *testing.T) {
+func TestAccAWSLBTargetGroupAttachment_Port(t *testing.T) {
 	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_lb_target_group.test",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupAttachmentDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupAttachmentConfigWithoutPort(targetGroupName),
+				Config: testAccAWSLBTargetGroupAttachmentConfigPort(targetGroupName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupAttachmentExists("aws_lb_target_group_attachment.test"),
 				),
@@ -94,13 +90,12 @@ func TestAccAWSLBTargetGroupAttachment_ipAddress(t *testing.T) {
 	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_lb_target_group.test",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupAttachmentDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupAttachmentConfigWithIpAddress(targetGroupName),
+				Config: testAccAWSLBTargetGroupAttachmentConfigTargetIdIpAddress(targetGroupName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupAttachmentExists("aws_lb_target_group_attachment.test"),
 				),
@@ -113,13 +108,12 @@ func TestAccAWSLBTargetGroupAttachment_lambda(t *testing.T) {
 	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_lb_target_group.test",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLBTargetGroupAttachmentDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupAttachmentConfigWithLambda(targetGroupName),
+				Config: testAccAWSLBTargetGroupAttachmentConfigTargetIdLambda(targetGroupName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupAttachmentExists("aws_lb_target_group_attachment.test"),
 				),
@@ -243,49 +237,42 @@ func testAccCheckAWSLBTargetGroupAttachmentDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAWSLBTargetGroupAttachmentConfigWithoutPort(targetGroupName string) string {
+func testAccAWSLBTargetGroupAttachmentConfigInstanceBase() string {
 	return fmt.Sprintf(`
-resource "aws_lb_target_group_attachment" "test" {
-  target_group_arn = "${aws_lb_target_group.test.arn}"
-  target_id        = "${aws_instance.test.id}"
+data "aws_availability_zones" "available" {
+  # t2.micro instance type is not available in these Availability Zones
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
+}
+
+data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn-ami-minimal-hvm-*"]
+  }
+  
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
 }
 
 resource "aws_instance" "test" {
-  ami           = "ami-f701cb97"
+  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = "t2.micro"
-  subnet_id     = "${aws_subnet.subnet.id}"
+  subnet_id     = aws_subnet.test.id
 }
 
-resource "aws_lb_target_group" "test" {
-  name                 = "%s"
-  port                 = 443
-  protocol             = "HTTPS"
-  vpc_id               = "${aws_vpc.test.id}"
-  deregistration_delay = 200
-
-  stickiness {
-    type            = "lb_cookie"
-    cookie_duration = 10000
-  }
-
-  health_check {
-    path                = "/health"
-    interval            = 60
-    port                = 8081
-    protocol            = "HTTP"
-    timeout             = 3
-    healthy_threshold   = 3
-    unhealthy_threshold = 3
-    matcher             = "200-299"
-  }
-}
-
-resource "aws_subnet" "subnet" {
-  cidr_block = "10.0.1.0/24"
-  vpc_id     = "${aws_vpc.test.id}"
+resource "aws_subnet" "test" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+  cidr_block        = "10.0.1.0/24"
+  vpc_id            = aws_vpc.test.id
 
   tags = {
-    Name = "tf-acc-lb-target-group-attachment-without-port"
+    Name = "tf-acc-test-lb-target-group-attachment"
   }
 }
 
@@ -293,206 +280,102 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-lb-target-group-attachment-without-port"
+    Name = "tf-acc-test-lb-target-group-attachment"
   }
 }
-`, targetGroupName)
+`)
 }
 
-func testAccAWSLBTargetGroupAttachmentConfig_basic(targetGroupName string) string {
-	return fmt.Sprintf(`
+func testAccAWSLBTargetGroupAttachmentConfigTargetIdInstance(rName string) string {
+	return testAccAWSLBTargetGroupAttachmentConfigInstanceBase() + fmt.Sprintf(`
+resource "aws_lb_target_group" "test" {
+  name     = %[1]q
+  port     = 443
+  protocol = "HTTPS"
+  vpc_id   = aws_vpc.test.id
+}
+
 resource "aws_lb_target_group_attachment" "test" {
-  target_group_arn = "${aws_lb_target_group.test.arn}"
-  target_id        = "${aws_instance.test.id}"
+  target_group_arn = aws_lb_target_group.test.arn
+  target_id        = aws_instance.test.id
+}
+`, rName)
+}
+
+func testAccAWSLBTargetGroupAttachmentConfigPort(rName string) string {
+	return testAccAWSLBTargetGroupAttachmentConfigInstanceBase() + fmt.Sprintf(`
+resource "aws_lb_target_group" "test" {
+  name     = %[1]q
+  port     = 443
+  protocol = "HTTPS"
+  vpc_id   = aws_vpc.test.id
+}
+
+resource "aws_lb_target_group_attachment" "test" {
+  target_group_arn = aws_lb_target_group.test.arn
+  target_id        = aws_instance.test.id
   port             = 80
 }
-
-resource "aws_instance" "test" {
-  ami           = "ami-f701cb97"
-  instance_type = "t2.micro"
-  subnet_id     = "${aws_subnet.subnet.id}"
+`, rName)
 }
 
+func testAccAWSLBTargetGroupAttachmentConfigBackwardsCompatibility(rName string) string {
+	return testAccAWSLBTargetGroupAttachmentConfigInstanceBase() + fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
-  name                 = "%s"
-  port                 = 443
-  protocol             = "HTTPS"
-  vpc_id               = "${aws_vpc.test.id}"
-  deregistration_delay = 200
-
-  stickiness {
-    type            = "lb_cookie"
-    cookie_duration = 10000
-  }
-
-  health_check {
-    path                = "/health"
-    interval            = 60
-    port                = 8081
-    protocol            = "HTTP"
-    timeout             = 3
-    healthy_threshold   = 3
-    unhealthy_threshold = 3
-    matcher             = "200-299"
-  }
+  name     = %[1]q
+  port     = 443
+  protocol = "HTTPS"
+  vpc_id   = aws_vpc.test.id
 }
 
-resource "aws_subnet" "subnet" {
-  cidr_block = "10.0.1.0/24"
-  vpc_id     = "${aws_vpc.test.id}"
-
-  tags = {
-    Name = "tf-acc-lb-target-group-attachment-basic"
-  }
-}
-
-resource "aws_vpc" "test" {
-  cidr_block = "10.0.0.0/16"
-
-  tags = {
-    Name = "terraform-testacc-lb-target-group-attachment-basic"
-  }
-}
-`, targetGroupName)
-}
-
-func testAccAWSLBTargetGroupAttachmentConfigBackwardsCompatibility(targetGroupName string) string {
-	return fmt.Sprintf(`
 resource "aws_alb_target_group_attachment" "test" {
-  target_group_arn = "${aws_alb_target_group.test.arn}"
-  target_id        = "${aws_instance.test.id}"
+  target_group_arn = aws_lb_target_group.test.arn
+  target_id        = aws_instance.test.id
   port             = 80
 }
-
-resource "aws_instance" "test" {
-  ami           = "ami-f701cb97"
-  instance_type = "t2.micro"
-  subnet_id     = "${aws_subnet.subnet.id}"
+`, rName)
 }
 
-resource "aws_alb_target_group" "test" {
-  name                 = "%s"
-  port                 = 443
-  protocol             = "HTTPS"
-  vpc_id               = "${aws_vpc.test.id}"
-  deregistration_delay = 200
-
-  stickiness {
-    type            = "lb_cookie"
-    cookie_duration = 10000
-  }
-
-  health_check {
-    path                = "/health"
-    interval            = 60
-    port                = 8081
-    protocol            = "HTTP"
-    timeout             = 3
-    healthy_threshold   = 3
-    unhealthy_threshold = 3
-    matcher             = "200-299"
-  }
+func testAccAWSLBTargetGroupAttachmentConfigTargetIdIpAddress(rName string) string {
+	return testAccAWSLBTargetGroupAttachmentConfigInstanceBase() + fmt.Sprintf(`
+resource "aws_lb_target_group" "test" {
+  name        = %[1]q
+  port        = 443
+  protocol    = "HTTPS"
+  target_type = "ip"
+  vpc_id      = aws_vpc.test.id
 }
 
-resource "aws_subnet" "subnet" {
-  cidr_block = "10.0.1.0/24"
-  vpc_id     = "${aws_vpc.test.id}"
-
-  tags = {
-    Name = "tf-acc-lb-target-group-attachment-bc"
-  }
-}
-
-resource "aws_vpc" "test" {
-  cidr_block = "10.0.0.0/16"
-
-  tags = {
-    Name = "terraform-testacc-lb-target-group-attachment-bc"
-  }
-}
-`, targetGroupName)
-}
-
-func testAccAWSLBTargetGroupAttachmentConfigWithIpAddress(targetGroupName string) string {
-	return fmt.Sprintf(`
 resource "aws_lb_target_group_attachment" "test" {
-  target_group_arn  = "${aws_lb_target_group.test.arn}"
-  target_id         = "${aws_instance.test.private_ip}"
-  availability_zone = "${aws_instance.test.availability_zone}"
+  availability_zone = aws_instance.test.availability_zone
+  target_group_arn  = aws_lb_target_group.test.arn
+  target_id         = aws_instance.test.private_ip
+}
+`, rName)
 }
 
-resource "aws_instance" "test" {
-  ami           = "ami-f701cb97"
-  instance_type = "t2.micro"
-  subnet_id     = "${aws_subnet.subnet.id}"
-}
-
-resource "aws_lb_target_group" "test" {
-  name                 = "%s"
-  port                 = 443
-  protocol             = "HTTPS"
-  vpc_id               = "${aws_vpc.test.id}"
-  target_type          = "ip"
-  deregistration_delay = 200
-
-  stickiness {
-    type            = "lb_cookie"
-    cookie_duration = 10000
-  }
-
-  health_check {
-    path                = "/health"
-    interval            = 60
-    port                = 8081
-    protocol            = "HTTP"
-    timeout             = 3
-    healthy_threshold   = 3
-    unhealthy_threshold = 3
-    matcher             = "200-299"
-  }
-}
-
-resource "aws_subnet" "subnet" {
-  cidr_block = "10.0.1.0/24"
-  vpc_id     = "${aws_vpc.test.id}"
-
-  tags = {
-    Name = "tf-acc-lb-target-group-attachment-with-ip-address"
-  }
-}
-
-resource "aws_vpc" "test" {
-  cidr_block = "10.0.0.0/16"
-
-  tags = {
-    Name = "terraform-testacc-lb-target-group-attachment-with-ip-address"
-  }
-}
-`, targetGroupName)
-}
-
-func testAccAWSLBTargetGroupAttachmentConfigWithLambda(targetGroupName string) string {
-	funcName := fmt.Sprintf("tf_acc_lambda_func_%s", acctest.RandString(8))
-
+func testAccAWSLBTargetGroupAttachmentConfigTargetIdLambda(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_lambda_permission" "with_lb" {
-  statement_id  = "AllowExecutionFromlb"
+data "aws_partition" "current" {}
+
+resource "aws_lambda_permission" "test" {
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.test.arn}"
-  principal     = "elasticloadbalancing.amazonaws.com"
-  source_arn    = "${aws_lb_target_group.test.arn}"
-  qualifier     = "${aws_lambda_alias.test.name}"
+  function_name = aws_lambda_function.test.arn
+  principal     = "elasticloadbalancing.${data.aws_partition.current.dns_suffix}"
+  qualifier     = aws_lambda_alias.test.name
+  source_arn    = aws_lb_target_group.test.arn
+  statement_id  = "AllowExecutionFromlb"
 }
 
 resource "aws_lb_target_group" "test" {
-  name        = "%s"
+  name        = %[1]q
   target_type = "lambda"
 }
 
 resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambda_elb.zip"
-  function_name = "%s"
-  role          = "${aws_iam_role.iam_for_lambda.arn}"
+  function_name = %[1]q
+  role          = aws_iam_role.test.arn
   handler       = "lambda_elb.lambda_handler"
   runtime       = "python3.7"
 }
@@ -500,11 +383,11 @@ resource "aws_lambda_function" "test" {
 resource "aws_lambda_alias" "test" {
   name             = "test"
   description      = "a sample description"
-  function_name    = "${aws_lambda_function.test.function_name}"
+  function_name    = aws_lambda_function.test.function_name
   function_version = "$LATEST"
 }
 
-resource "aws_iam_role" "iam_for_lambda" {
+resource "aws_iam_role" "test" {
   assume_role_policy = <<EOF
 {
 		"Version": "2012-10-17",
@@ -512,7 +395,7 @@ resource "aws_iam_role" "iam_for_lambda" {
 			{
 				"Action": "sts:AssumeRole",
 				"Principal": {
-					"Service": "lambda.amazonaws.com"
+					"Service": "lambda.${data.aws_partition.current.dns_suffix}"
 				},
 				"Effect": "Allow",
 				"Sid": ""
@@ -523,9 +406,10 @@ resource "aws_iam_role" "iam_for_lambda" {
 }
 
 resource "aws_lb_target_group_attachment" "test" {
-  target_group_arn = "${aws_lb_target_group.test.arn}"
-  target_id        = "${aws_lambda_alias.test.arn}"
-  depends_on       = ["aws_lambda_permission.with_lb"]
+  depends_on = [aws_lambda_permission.test]
+
+  target_group_arn = aws_lb_target_group.test.arn
+  target_id        = aws_lambda_alias.test.arn
 }
-`, targetGroupName, funcName)
+`, rName)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously in the acceptance testing:

```
--- FAIL: TestAccAWSLBTargetGroupAttachment_basic (6.93s)
    testing.go:640: Step 0 error: errors during apply:

        Error: Error launching source instance: Unsupported: Your requested instance type (t2.micro) is not supported in your requested Availability Zone (us-west-2d). Please retry your request by not specifying an Availability Zone or choosing us-west-2a, us-west-2b, us-west-2c.
```

This refactors the base EC2 Instance and VPC configuration into a consolidated configuration with the `aws_ami` and `aws_partition` data sources so the testing is region and partition agnostic. Blacklists `usw2-az4` since the `t2.micro` EC2 Instance type is not available there. This also removes the errant and extraneous `IDRefreshName` configuration.

Output from acceptance testing:

```
--- PASS: TestAccAWSLBTargetGroupAttachment_lambda (49.63s)
--- PASS: TestAccAWSLBTargetGroupAttachment_ipAddress (112.10s)
--- PASS: TestAccAWSLBTargetGroupAttachment_disappears (122.51s)
--- PASS: TestAccAWSLBTargetGroupAttachment_basic (130.97s)
--- PASS: TestAccAWSLBTargetGroupAttachment_BackwardsCompatibility (131.18s)
--- PASS: TestAccAWSLBTargetGroupAttachment_Port (131.87s)
```
