### PR TITLE
tests/resource/aws_autoscaling_group: Fix typo in TestAccAWSAutoScalingGroup_LoadBalancers configuration

### DIFF
--- a/aws/resource_aws_autoscaling_group_test.go
+++ b/aws/resource_aws_autoscaling_group_test.go
@@ -3631,7 +3631,6 @@ data "aws_availability_zones" "available" {
   blacklisted_zone_ids = ["usw2-az4"]
   state                = "available"
 }
-}
 
 resource "aws_launch_template" "test" {
   image_id      = data.aws_ami.test.id


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/commit/3716d83741c8f4f67a01364f538a72305fa1a789


Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously in the acceptance testing:

```
--- FAIL: TestAccAWSAutoScalingGroup_LoadBalancers (1.02s)
    testing.go:640: Step 0 error: Argument or block definition required: On /opt/teamcity-agent/temp/buildTmp/tf-test387330890/main.tf line 17: An argument or block definition is required here.
```

Output from acceptance testing:

```
--- PASS: TestAccAWSAutoScalingGroup_LoadBalancers (667.70s)
```
