### PR TITLE
tests/resource/aws_ec2_client_vpn_network_association: Blacklist usw2-az4 which does not support this functionality

### DIFF
--- a/aws/resource_aws_ec2_client_vpn_network_association_test.go
+++ b/aws/resource_aws_ec2_client_vpn_network_association_test.go
@@ -148,6 +148,12 @@ resource "aws_acm_certificate" "test" {
 
 func testAccEc2ClientVpnNetworkAssociationConfig(rName string) string {
 	return testAccEc2ClientVpnNetworkAssociationConfigAcmCertificateBase() + fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  # InvalidParameterValue: AZ us-west-2d is not currently supported. Please choose another az in this region
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
+}
+
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
@@ -157,6 +163,7 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
+  availability_zone       = data.aws_availability_zones.available.names[0]
   cidr_block              = "10.1.1.0/24"
   vpc_id                  = "${aws_vpc.test.id}"
   map_public_ip_on_launch = true


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously in the acceptance testing:

```
--- FAIL: TestAccAwsEc2ClientVpnNetworkAssociation_disappears (8.09s)
    testing.go:640: Step 0 error: errors during apply:

        Error: Error creating Client VPN network association: InvalidParameterValue: AZ us-west-2d is not currently supported. Please choose another az in this region
```

Output from acceptance testing:

```
--- PASS: TestAccAwsEc2ClientVpnNetworkAssociation_basic (521.82s)
--- PASS: TestAccAwsEc2ClientVpnNetworkAssociation_disappears (570.58s)
```
