### PR TITLE
service/ec2: Automatically retry on DetachVpnGateway calls receiving `InvalidParameterValue: This call cannot be completed because there are pending VPNs or Virtual Interfaces`

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -648,7 +648,7 @@ func (c *Config) Client() (interface{}, error) {
 			}
 		}
 
-		if r.Operation.Name == "AttachVpnGateway" {
+		if r.Operation.Name == "AttachVpnGateway" || r.Operation.Name == "DetachVpnGateway" {
 			if isAWSErr(r.Error, "InvalidParameterValue", "This call cannot be completed because there are pending VPNs or Virtual Interfaces") {
 				r.Retryable = aws.Bool(true)
 			}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_vpn_gateway: Automatically retry on `DetachVpnGateway` calls receiving `InvalidParameterValue: This call cannot be completed because there are pending VPNs or Virtual Interfaces`
* resource/aws_vpn_gateway_attachment: Automatically retry on `DetachVpnGateway` calls receiving `InvalidParameterValue: This call cannot be completed because there are pending VPNs or Virtual Interfaces`
```

Previously in the acceptance testing (inconsistently):

```
--- FAIL: TestAccAwsDxGateway_complex (1395.94s)
    testing.go:696: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: errors during apply: Error detaching VPN Gateway "vgw-0cdff63748b555ce1" from VPC "vpc-03b0d4f907a594a7e": InvalidParameterValue: This call cannot be completed because there are pending VPNs or Virtual Interfaces

--- FAIL: TestAccAwsDxGatewayAssociation_basicVpnGatewaySingleAccount (753.92s)
    testing.go:696: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: errors during apply: Error detaching VPN Gateway "vgw-0347d6f94f7b41c56" from VPC "vpc-09e6a66d7f16b1df8": InvalidParameterValue: This call cannot be completed because there are pending VPNs or Virtual Interfaces

--- FAIL: TestAccAwsDxGatewayAssociation_multiVpnGatewaysSingleAccount (1394.16s)
    testing.go:701: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: errors during apply: Error detaching VPN Gateway "vgw-0ff7518e32f5e9a41" from VPC "vpc-00285431f07f5bc9d": InvalidParameterValue: This call cannot be completed because there are pending VPNs or Virtual Interfaces
```

Example debug logging:

```
2019/12/18 06:09:29 [DEBUG] [aws-sdk-go] DEBUG: Response ec2/DetachVpnGateway Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 400 Bad Request
Connection: close
Transfer-Encoding: chunked
Date: Wed, 18 Dec 2019 06:09:29 GMT
Server: AmazonEC2

-----------------------------------------------------
2019/12/18 06:09:29 [DEBUG] [aws-sdk-go] <?xml version="1.0" encoding="UTF-8"?>
<Response><Errors><Error><Code>InvalidParameterValue</Code><Message>This call cannot be completed because there are pending VPNs or Virtual Interfaces</Message></Error></Errors><RequestID>f951ecbf-328e-4fe3-be78-f02e8902da90</RequestID></Response>
2019/12/18 06:09:29 [DEBUG] [aws-sdk-go] DEBUG: Validate Response ec2/DetachVpnGateway failed, attempt 0/25, error InvalidParameterValue: This call cannot be completed because there are pending VPNs or Virtual Interfaces
  status code: 400, request id: f951ecbf-328e-4fe3-be78-f02e8902da90
```

Here we allow the retryable logic that applies to the `AttachVpnGateway` call to also apply to the `DetachVpnGateway` call.

Output from acceptance testing:

```
--- PASS: TestAccAwsDxGateway_basic (75.94s)
--- PASS: TestAccAwsDxGateway_complex (1442.22s)

--- PASS: TestAccAwsDxGatewayAssociation_allowedPrefixesVpnGatewayCrossAccount (1741.64s)
--- PASS: TestAccAwsDxGatewayAssociation_allowedPrefixesVpnGatewaySingleAccount (1561.21s)
--- PASS: TestAccAwsDxGatewayAssociation_basicTransitGatewayCrossAccount (1067.31s)
--- PASS: TestAccAwsDxGatewayAssociation_basicTransitGatewaySingleAccount (1064.09s)
--- PASS: TestAccAwsDxGatewayAssociation_basicVpnGatewayCrossAccount (1135.38s)
--- PASS: TestAccAwsDxGatewayAssociation_basicVpnGatewaySingleAccount (1164.79s)
--- PASS: TestAccAwsDxGatewayAssociation_deprecatedSingleAccount (1450.04s)
--- PASS: TestAccAwsDxGatewayAssociation_multiVpnGatewaysSingleAccount (1160.43s)

--- PASS: TestAccAWSVpnGateway_basic (97.92s)
--- PASS: TestAccAWSVpnGateway_delete (67.50s)
--- PASS: TestAccAWSVpnGateway_disappears (56.04s)
--- PASS: TestAccAWSVpnGateway_reattach (128.44s)
--- PASS: TestAccAWSVpnGateway_tags (68.82s)
--- PASS: TestAccAWSVpnGateway_withAmazonSideAsnSetToState (51.51s)
--- PASS: TestAccAWSVpnGateway_withAvailabilityZoneSetToState (48.04s)

--- PASS: TestAccAWSVpnGatewayAttachment_basic (50.52s)
--- PASS: TestAccAWSVpnGatewayAttachment_deleted (63.85s)
```
