### PR TITLE
tests/service/cloudformation: Add sweepers and export randomization

### DIFF
--- a/aws/data_source_aws_cloudformation_export_test.go
+++ b/aws/data_source_aws_cloudformation_export_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -11,31 +10,48 @@ import (
 
 func TestAccAWSCloudformationExportDataSource_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceName := "data.aws_cloudformation_export.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:                    testAccCheckAwsCloudformationExportConfig(rName),
+				Config:                    testAccCheckAwsCloudformationExportConfigStaticValue(rName),
 				PreventPostDestroyRefresh: true,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_cloudformation_export.waiter", "value", "waiter"),
-					resource.TestMatchResourceAttr("data.aws_cloudformation_export.vpc", "value",
-						regexp.MustCompile("^vpc-[a-z0-9]{8,}$")),
-					resource.TestMatchResourceAttr("data.aws_cloudformation_export.vpc", "exporting_stack_id",
-						regexp.MustCompile("^arn:aws:cloudformation")),
+					resource.TestCheckResourceAttr(dataSourceName, "value", "waiter"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckAwsCloudformationExportConfig(rName string) string {
+func TestAccAWSCloudformationExportDataSource_ResourceReference(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceName := "data.aws_cloudformation_export.test"
+	resourceName := "aws_cloudformation_stack.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:                    testAccCheckAwsCloudformationExportConfigResourceReference(rName),
+				PreventPostDestroyRefresh: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "exporting_stack_id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "value", resourceName, "outputs.MyVpcId"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsCloudformationExportConfigStaticValue(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_cloudformation_stack" "cfs" {
-  name               = "%s1"
-  timeout_in_minutes = 6
+resource "aws_cloudformation_stack" "test" {
+  name = %[1]q
 
   template_body = <<STACK
 {
@@ -50,7 +66,7 @@ resource "aws_cloudformation_stack" "cfs" {
       "Value": "waiter" ,
       "Description": "VPC ID",
       "Export": {
-        "Name": "waiter" 
+        "Name": %[1]q
       }
     }
   }
@@ -58,13 +74,21 @@ resource "aws_cloudformation_stack" "cfs" {
 STACK
 
   tags = {
-    TestExport = "waiter"
+    TestExport = %[1]q
     Second     = "meh"
   }
 }
 
-resource "aws_cloudformation_stack" "yaml" {
-  name = "%s2"
+data "aws_cloudformation_export" "test" {
+  name = aws_cloudformation_stack.test.tags["TestExport"]
+}
+`, rName)
+}
+
+func testAccCheckAwsCloudformationExportConfigResourceReference(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudformation_stack" "test" {
+  name = %[1]q
 
   parameters = {
     CIDR = "10.10.10.0/24"
@@ -92,21 +116,17 @@ Outputs:
     Value: !Ref myvpc
     Description: VPC ID
     Export:
-      Name: MyVpcId
+      Name: %[1]q
 STACK
 
   tags = {
-    TestExport = "MyVpcId"
+    TestExport = %[1]q
     Second     = "meh"
   }
 }
 
-data "aws_cloudformation_export" "vpc" {
-  name = "${aws_cloudformation_stack.yaml.tags["TestExport"]}"
+data "aws_cloudformation_export" "test" {
+  name = aws_cloudformation_stack.test.tags["TestExport"]
 }
-
-data "aws_cloudformation_export" "waiter" {
-  name = "${aws_cloudformation_stack.cfs.tags["TestExport"]}"
-}
-`, rName, rName)
+`, rName)
 }

--- a/aws/resource_aws_cloudformation_stack_set.go
+++ b/aws/resource_aws_cloudformation_stack_set.go
@@ -257,3 +257,28 @@ func resourceAwsCloudFormationStackSetDelete(d *schema.ResourceData, meta interf
 
 	return nil
 }
+
+func listCloudFormationStackSets(conn *cloudformation.CloudFormation) ([]*cloudformation.StackSetSummary, error) {
+	input := &cloudformation.ListStackSetsInput{
+		Status: aws.String(cloudformation.StackSetStatusActive),
+	}
+	result := make([]*cloudformation.StackSetSummary, 0)
+
+	for {
+		output, err := conn.ListStackSets(input)
+
+		if err != nil {
+			return result, err
+		}
+
+		result = append(result, output.Summaries...)
+
+		if aws.StringValue(output.NextToken) == "" {
+			break
+		}
+
+		input.NextToken = output.NextToken
+	}
+
+	return result, nil
+}

--- a/aws/resource_aws_cloudformation_stack_set_instance.go
+++ b/aws/resource_aws_cloudformation_stack_set_instance.go
@@ -250,6 +250,31 @@ func resourceAwsCloudFormationStackSetInstanceParseId(id string) (string, string
 	return parts[0], parts[1], parts[2], nil
 }
 
+func listCloudFormationStackSetInstances(conn *cloudformation.CloudFormation, stackSetName string) ([]*cloudformation.StackInstanceSummary, error) {
+	input := &cloudformation.ListStackInstancesInput{
+		StackSetName: aws.String(stackSetName),
+	}
+	result := make([]*cloudformation.StackInstanceSummary, 0)
+
+	for {
+		output, err := conn.ListStackInstances(input)
+
+		if err != nil {
+			return result, err
+		}
+
+		result = append(result, output.Summaries...)
+
+		if aws.StringValue(output.NextToken) == "" {
+			break
+		}
+
+		input.NextToken = output.NextToken
+	}
+
+	return result, nil
+}
+
 func refreshCloudformationStackSetOperation(conn *cloudformation.CloudFormation, stackSetName, operationID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		input := &cloudformation.DescribeStackSetOperationInput{

--- a/aws/resource_aws_iam_role_test.go
+++ b/aws/resource_aws_iam_role_test.go
@@ -20,6 +20,7 @@ func init() {
 		Name: "aws_iam_role",
 		Dependencies: []string{
 			"aws_batch_compute_environment",
+			"aws_cloudformation_stack_set_instance",
 			"aws_cognito_user_pool",
 			"aws_config_configuration_aggregator",
 			"aws_config_configuration_recorder",


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously in the acceptance testing:

```
--- FAIL: TestAccAWSCloudformationExportDataSource_basic (62.37s)
    testing.go:640: Step 0 error: errors during apply:

        Error: ROLLBACK_COMPLETE: ["Export with name waiter is already exported by stack tf-acc-test-38895184112636083521. Rollback requested by user."]
```

Exports are shared across active CloudFormation Stacks so here we randomize the export naming to prevent potential collisions.

Output from acceptance testing:

```
--- PASS: TestAccAWSCloudformationExportDataSource_basic (33.97s)
--- PASS: TestAccAWSCloudformationExportDataSource_ResourceReference (74.04s)
```

Output from sweepers:

```console
$ aws cloudformation list-stacks --stack-status-filter CREATE_COMPLETE IMPORT_COMPLETE ROLLBACK_COMPLETE UPDATE_COMPLETE | jq '.StackSummaries | length'
41
$ aws cloudformation list-stack-sets --status ACTIVE | jq '.Summaries | length'
93
$ go test ./aws -v -timeout=10h -sweep=us-west-2 -sweep-run=aws_cloudformation_stack,aws_cloudformation_stack_set -sweep-allow-failures
2020/01/22 20:28:36 [DEBUG] Running Sweepers for region (us-west-2):
2020/01/22 20:28:36 [DEBUG] Running Sweeper (aws_cloudformation_stack_set_instance) in region (us-west-2)
...
2020/01/22 20:28:40 [INFO] Deleting CloudFormation Stack Set Instance: tf-acc-test-2881910219948525356 / --OMITTED-- / us-west-2
...
2020/01/22 20:29:14 [INFO] Deleting CloudFormation Stack Set Instance: tf-acc-test-3340522403724533256 / --OMITTED-- / us-west-2
...
2020/01/22 20:29:49 [INFO] Deleting CloudFormation Stack Set Instance: tf-acc-test-3993748121930134008 / --OMITTED-- / us-west-2
...
2020/01/22 20:30:24 [INFO] Deleting CloudFormation Stack Set Instance: tf-acc-test-4090453630593047948 / --OMITTED-- / us-west-2
...
2020/01/22 20:30:58 [INFO] Deleting CloudFormation Stack Set Instance: tf-acc-test-5155795199068739258 / --OMITTED-- / us-west-2
...
2020/01/22 20:31:33 [INFO] Deleting CloudFormation Stack Set Instance: tf-acc-test-6372546011565745789 / --OMITTED-- / us-west-2
...
2020/01/22 20:32:08 [INFO] Deleting CloudFormation Stack Set Instance: tf-acc-test-6820169250462986145 / --OMITTED-- / us-west-2
...
2020/01/22 20:32:42 [INFO] Deleting CloudFormation Stack Set Instance: tf-acc-test-6874637500634692748 / --OMITTED-- / us-west-2
...
2020/01/22 20:33:27 [DEBUG] Sweeper (aws_cloudformation_stack) has dependency (aws_cloudformation_stack_set_instance), running..
2020/01/22 20:33:27 [DEBUG] Sweeper (aws_cloudformation_stack_set_instance) already ran in region (us-west-2)
2020/01/22 20:33:27 [DEBUG] Running Sweeper (aws_cloudformation_stack) in region (us-west-2)
...
2020/01/22 20:33:29 [INFO] Deleting CloudFormation Stack: tf-acc-test-s3tags-6321312072961934498
2020/01/22 20:33:30 [INFO] Deleting CloudFormation Stack: tf-acc-test-s3tags-7949902434600260276
2020/01/22 20:33:30 [INFO] Deleting CloudFormation Stack: StackSet-tf-acc-test-1646727646471833966-9ceb7bad-dca1-44a5-930d-558e9776809d
2020/01/22 20:33:31 [INFO] Deleting CloudFormation Stack: tf-acc-test-s3tags-4903187710294631207
2020/01/22 20:33:31 [INFO] Deleting CloudFormation Stack: tf-acc-test-s3tags-910044256175885731
2020/01/22 20:33:32 [INFO] Deleting CloudFormation Stack: tf-acc-test-s3tags-1686520734185663901
2020/01/22 20:33:32 [INFO] Deleting CloudFormation Stack: tf-acc-test-s3tags-3867305924253287722
2020/01/22 20:33:33 [INFO] Deleting CloudFormation Stack: tf-acc-test-90508645576171621012
2020/01/22 20:33:33 [INFO] Deleting CloudFormation Stack: tf-acc-test-90508645576171621011
2020/01/22 20:33:34 [INFO] Deleting CloudFormation Stack: StackSet-tf-acc-test-1773332007499659163-9b9eae3b-b031-4cc2-ae75-841aec028be6
2020/01/22 20:33:34 [INFO] Deleting CloudFormation Stack: tf-acc-ds-basic-55389185272653002
2020/01/22 20:33:35 [INFO] Deleting CloudFormation Stack: tf-acc-ds-basic-7813158390752904838
2020/01/22 20:33:35 [INFO] Deleting CloudFormation Stack: tf-acc-ds-yaml-8255492713875577306
2020/01/22 20:33:36 [INFO] Deleting CloudFormation Stack: tf-acc-ds-basic-6818865422926113135
2020/01/22 20:33:36 [INFO] Deleting CloudFormation Stack: tf-acc-ds-yaml-2792875247474377558
2020/01/22 20:33:37 [INFO] Deleting CloudFormation Stack: tf-acc-ds-basic-5074931548181917345
2020/01/22 20:33:37 [INFO] Deleting CloudFormation Stack: tf-acc-test-s3tags-2683457473612474517
2020/01/22 20:33:38 [INFO] Deleting CloudFormation Stack: StackSet-tf-acc-test-4887388094849677138-58049b35-2822-40a7-b9e1-c35bd28f3484
2020/01/22 20:33:38 [INFO] Deleting CloudFormation Stack: tf-acc-test-38895184112636083521
2020/01/22 20:33:39 [INFO] Deleting CloudFormation Stack: tf-acc-test-38895184112636083522
2020/01/22 20:33:39 [INFO] Deleting CloudFormation Stack: tf-acc-test-s3tags-3990884545323935307
2020/01/22 20:33:40 [INFO] Deleting CloudFormation Stack: tf-acc-test-s3tags-2697336824172157948
2020/01/22 20:33:40 [INFO] Deleting CloudFormation Stack: tf-acc-test-s3tags-5237290395841689733
2020/01/22 20:33:41 [INFO] Deleting CloudFormation Stack: tf-acc-test-s3tags-5597160963348782967
2020/01/22 20:33:42 [INFO] Deleting CloudFormation Stack: tf-acc-test-s3tags-4307371716714238094
2020/01/22 20:33:42 [INFO] Deleting CloudFormation Stack: StackSet-tf-acc-test-3926345700388647725-c87d1990-8cfe-422a-8bae-f64959ee1c19
2020/01/22 20:33:43 [INFO] Deleting CloudFormation Stack: StackSet-tf-acc-test-3750979215615596588-b92e8173-a2dd-4d65-a856-7f3b960f5f43
2020/01/22 20:33:43 [INFO] Deleting CloudFormation Stack: StackSet-tf-acc-test-3657003669524264781-1335a2c8-4eef-4b9c-943a-d766534763f5
2020/01/22 20:33:44 [INFO] Deleting CloudFormation Stack: aws-cloud9-tf-acc-env-basic-j1nbjhw9-7c91f37ef59341beb263624bfe3b42c9
2020/01/22 20:33:44 [INFO] Deleting CloudFormation Stack: aws-cloud9-tf-acc-api-doc-part-import-p3s8ydqr-8827d2ca631f48d4b55b67951d990ae5
2020/01/22 20:33:45 [INFO] Deleting CloudFormation Stack: aws-cloud9-tf-acc-env-basic-92yb8mi1-fbff8e1ce9fe46cfab7d509e80100710
2020/01/22 20:33:46 [DEBUG] Sweeper (aws_cloudformation_stack_set) has dependency (aws_cloudformation_stack_set_instance), running..
2020/01/22 20:33:46 [DEBUG] Sweeper (aws_cloudformation_stack_set_instance) already ran in region (us-west-2)
2020/01/22 20:33:46 [DEBUG] Running Sweeper (aws_cloudformation_stack_set) in region (us-west-2)
...
2020/01/22 20:33:47 [INFO] Deleting CloudFormation Stack Set: tf-acc-test-2307474257448478076
2020/01/22 20:33:48 [INFO] Deleting CloudFormation Stack Set: tf-acc-test-2881910219948525356
2020/01/22 20:33:49 [INFO] Deleting CloudFormation Stack Set: tf-acc-test-3340522403724533256
2020/01/22 20:33:50 [INFO] Deleting CloudFormation Stack Set: tf-acc-test-3993748121930134008
2020/01/22 20:33:50 [INFO] Deleting CloudFormation Stack Set: tf-acc-test-4090453630593047948
2020/01/22 20:33:51 [INFO] Deleting CloudFormation Stack Set: tf-acc-test-5155795199068739258
2020/01/22 20:33:52 [INFO] Deleting CloudFormation Stack Set: tf-acc-test-6372546011565745789
2020/01/22 20:33:52 [INFO] Deleting CloudFormation Stack Set: tf-acc-test-6820169250462986145
2020/01/22 20:33:53 [INFO] Deleting CloudFormation Stack Set: tf-acc-test-6874637500634692748
2020/01/22 20:36:39 Sweeper Tests ran successfully:
        - aws_cloudformation_stack
        - aws_cloudformation_stack_set
        - aws_cloudformation_stack_set_instance
ok      github.com/terraform-providers/terraform-provider-aws/aws 319.576s
$ aws cloudformation list-stack-sets --status ACTIVE | jq '.Summaries | length'
0
$ aws cloudformation list-stacks --stack-status-filter CREATE_COMPLETE IMPORT_COMPLETE ROLLBACK_COMPLETE UPDATE_COMPLETE | jq '.StackSummaries | length'
0
```
