### PR TITLE
resource/aws_cloudformation_stack_set: Wait for update operation completion and report any errors

### DIFF
--- a/aws/resource_aws_cloudformation_stack_set.go
+++ b/aws/resource_aws_cloudformation_stack_set.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
@@ -22,6 +23,10 @@ func resourceAwsCloudFormationStackSet() *schema.Resource {
 
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Update: schema.DefaultTimeout(30 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -228,10 +233,14 @@ func resourceAwsCloudFormationStackSetUpdate(d *schema.ResourceData, meta interf
 	}
 
 	log.Printf("[DEBUG] Updating CloudFormation Stack Set: %s", input)
-	_, err := conn.UpdateStackSet(input)
+	output, err := conn.UpdateStackSet(input)
 
 	if err != nil {
 		return fmt.Errorf("error updating CloudFormation Stack Set (%s): %s", d.Id(), err)
+	}
+
+	if err := waitForCloudFormationStackSetOperation(conn, d.Id(), aws.StringValue(output.OperationId), d.Timeout(schema.TimeoutUpdate)); err != nil {
+		return fmt.Errorf("error waiting for CloudFormation Stack Set (%s) update: %s", d.Id(), err)
 	}
 
 	return resourceAwsCloudFormationStackSetRead(d, meta)

--- a/website/docs/r/cloudformation_stack_set.html.markdown
+++ b/website/docs/r/cloudformation_stack_set.html.markdown
@@ -103,6 +103,12 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - Name of the Stack Set.
 * `stack_set_id` - Unique identifier of the Stack Set.
 
+## Timeouts
+
+`aws_cloudformation_stack_set` provides the following [Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+* `update` - (Default `30m`) How long to wait for a Stack Set to be updated.
+
 ## Import
 
 CloudFormation Stack Sets can be imported using the `name`, e.g.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_cloudformation_stack_set: Wait for update operation completion (default timeout of 30 minutes) and report any errors
```

Previously in the acceptance testing:

```
--- FAIL: TestAccAWSCloudFormationStackSet_Parameters (35.78s)
    testing.go:640: Step 4 error: errors during apply:

        Error: error updating CloudFormation Stack Set (tf-acc-test-5503547290025742409): OperationInProgressException: Another Operation on StackSet arn:aws:cloudformation:us-west-2:*******:stackset/tf-acc-test-5503547290025742409:55908c5e-ea0e-482f-b21c-2c1fb21fb1ac is in progress
        	status code: 409, request id: c123a6e4-3577-4c85-8964-a898d81c597d

          on /opt/teamcity-agent/temp/buildTmp/tf-test708526898/main.tf line 7:
          (source code not available)

    testing.go:701: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: errors during apply: error deleting CloudFormation Stack Set (tf-acc-test-5503547290025742409): OperationInProgressException: Operation terraform-20200122114208738100000003 on StackSet arn:aws:cloudformation:us-west-2:*******:stackset/tf-acc-test-5503547290025742409:55908c5e-ea0e-482f-b21c-2c1fb21fb1ac is in progress
        	status code: 409, request id: b8059f09-effd-494a-8f43-17a6cac30d81
```

There are no `StackSetOperation` associated with `CreateStackSet` or `DeleteStackSet`.

Output from acceptance testing:

```
--- PASS: TestAccAWSCloudFormationStackSet_Description (38.41s)
--- PASS: TestAccAWSCloudFormationStackSet_disappears (41.35s)
--- PASS: TestAccAWSCloudFormationStackSet_ExecutionRoleName (57.63s)
--- PASS: TestAccAWSCloudFormationStackSet_Name (61.53s)
--- PASS: TestAccAWSCloudFormationStackSet_basic (72.71s)
--- PASS: TestAccAWSCloudFormationStackSet_TemplateUrl (73.85s)
--- PASS: TestAccAWSCloudFormationStackSet_AdministrationRoleArn (78.93s)
--- PASS: TestAccAWSCloudFormationStackSet_Parameters (104.93s)
--- PASS: TestAccAWSCloudFormationStackSet_TemplateBody (108.84s)
--- PASS: TestAccAWSCloudFormationStackSet_Tags (134.72s)
```
