### PR TITLE
Add launch_template to aws_autoscaling_group data source

### DIFF
--- a/aws/data_source_aws_autoscaling_group.go
+++ b/aws/data_source_aws_autoscaling_group.go
@@ -51,6 +51,10 @@ func dataSourceAwsAutoscalingGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"launch_template": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"load_balancers": {
 				Type:     schema.TypeSet,
 				Computed: true,
@@ -160,6 +164,9 @@ func groupDescriptionAttributes(d *schema.ResourceData, group *autoscaling.Group
 	d.Set("health_check_grace_period", group.HealthCheckGracePeriod)
 	d.Set("health_check_type", group.HealthCheckType)
 	d.Set("launch_configuration", group.LaunchConfigurationName)
+	if group.LaunchTemplate != nil {
+		d.Set("launch_template", group.LaunchTemplate.LaunchTemplateName)
+	}
 	if err := d.Set("load_balancers", aws.StringValueSlice(group.LoadBalancerNames)); err != nil {
 		return err
 	}

--- a/website/docs/d/autoscaling_group.html.markdown
+++ b/website/docs/d/autoscaling_group.html.markdown
@@ -35,6 +35,7 @@ interpolation.
 * `health_check_grace_period` - The amount of time, in seconds, that Amazon EC2 Auto Scaling waits before checking the health status of an EC2 instance that has come into service.
 * `health_check_type` - The service to use for the health checks. The valid values are EC2 and ELB.
 * `launch_configuration` - The name of the associated launch configuration.
+* `launch_template` - The name of the associated launch template.
 * `load_balancers` - One or more load balancers associated with the group.
 * `max_size` - The maximum size of the group.
 * `min_size` - The minimum size of the group.


### PR DESCRIPTION
The `aws_autoscaling_group` data source was missing this field even though the `aws_autoscaling_group` resource already supports this.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data-source/aws_autoscaling_group: Add `launch_template` attribute
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAwsAutoScalingGroupDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsAutoScalingGroupDataSource_basic -timeout 120m
=== RUN   TestAccAwsAutoScalingGroupDataSource_basic
=== PAUSE TestAccAwsAutoScalingGroupDataSource_basic
=== CONT  TestAccAwsAutoScalingGroupDataSource_basic
--- PASS: TestAccAwsAutoScalingGroupDataSource_basic (57.67s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	57.708s

...
```
