### PR TITLE
r/vpc_endpoint- refactor to use keyvaluetags

### DIFF
--- a/aws/resource_aws_vpc_endpoint_test.go
+++ b/aws/resource_aws_vpc_endpoint_test.go
@@ -84,7 +84,7 @@ func testSweepEc2VpcEndpoints(region string) error {
 func TestAccAWSVpcEndpoint_gatewayBasic(t *testing.T) {
 	var endpoint ec2.VpcEndpoint
 	resourceName := "aws_vpc_endpoint.test"
-	rName := fmt.Sprintf("tf-testacc-vpce-%s", acctest.RandStringFromCharSet(16, acctest.CharSetAlphaNum))
+	rName := acctest.RandomWithPrefix("tf-testacc-vpce")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -107,6 +107,11 @@ func TestAccAWSVpcEndpoint_gatewayBasic(t *testing.T) {
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -116,7 +121,7 @@ func TestAccAWSVpcEndpoint_gatewayWithRouteTableAndPolicyAndTags(t *testing.T) {
 	var routeTable ec2.RouteTable
 	resourceName := "aws_vpc_endpoint.test"
 	resourceNameRt := "aws_route_table.test"
-	rName := fmt.Sprintf("tf-testacc-vpce-%s", acctest.RandStringFromCharSet(16, acctest.CharSetAlphaNum))
+	rName := acctest.RandomWithPrefix("tf-testacc-vpce")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -205,7 +210,7 @@ func TestAccAWSVpcEndpoint_gatewayPolicy(t *testing.T) {
 }
 `
 	resourceName := "aws_vpc_endpoint.test"
-	rName := fmt.Sprintf("tf-testacc-vpce-%s", acctest.RandStringFromCharSet(16, acctest.CharSetAlphaNum))
+	rName := acctest.RandomWithPrefix("tf-testacc-vpce")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -236,7 +241,7 @@ func TestAccAWSVpcEndpoint_gatewayPolicy(t *testing.T) {
 func TestAccAWSVpcEndpoint_interfaceBasic(t *testing.T) {
 	var endpoint ec2.VpcEndpoint
 	resourceName := "aws_vpc_endpoint.test"
-	rName := fmt.Sprintf("tf-testacc-vpce-%s", acctest.RandStringFromCharSet(16, acctest.CharSetAlphaNum))
+	rName := acctest.RandomWithPrefix("tf-testacc-vpce")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -260,6 +265,11 @@ func TestAccAWSVpcEndpoint_interfaceBasic(t *testing.T) {
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -267,7 +277,7 @@ func TestAccAWSVpcEndpoint_interfaceBasic(t *testing.T) {
 func TestAccAWSVpcEndpoint_interfaceWithSubnetAndSecurityGroup(t *testing.T) {
 	var endpoint ec2.VpcEndpoint
 	resourceName := "aws_vpc_endpoint.test"
-	rName := fmt.Sprintf("tf-testacc-vpce-%s", acctest.RandStringFromCharSet(16, acctest.CharSetAlphaNum))
+	rName := acctest.RandomWithPrefix("tf-testacc-vpce")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -321,7 +331,7 @@ func TestAccAWSVpcEndpoint_interfaceWithSubnetAndSecurityGroup(t *testing.T) {
 func TestAccAWSVpcEndpoint_interfaceNonAWSService(t *testing.T) {
 	var endpoint ec2.VpcEndpoint
 	resourceName := "aws_vpc_endpoint.test"
-	rName := fmt.Sprintf("tf-testacc-vpce-%s", acctest.RandStringFromCharSet(16, acctest.CharSetAlphaNum))
+	rName := acctest.RandomWithPrefix("tf-acc-vpce")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -347,6 +357,11 @@ func TestAccAWSVpcEndpoint_interfaceNonAWSService(t *testing.T) {
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -354,19 +369,7 @@ func TestAccAWSVpcEndpoint_interfaceNonAWSService(t *testing.T) {
 func TestAccAWSVpcEndpoint_removed(t *testing.T) {
 	var endpoint ec2.VpcEndpoint
 	resourceName := "aws_vpc_endpoint.test"
-	rName := fmt.Sprintf("tf-testacc-vpce-%s", acctest.RandStringFromCharSet(16, acctest.CharSetAlphaNum))
-
-	// reach out and DELETE the VPC Endpoint outside of Terraform
-	testDestroy := func(*terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).ec2conn
-		input := &ec2.DeleteVpcEndpointsInput{
-			VpcEndpointIds: []*string{endpoint.VpcEndpointId},
-		}
-
-		_, err := conn.DeleteVpcEndpoints(input)
-
-		return err
-	}
+	rName := acctest.RandomWithPrefix("tf-testacc-vpce")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -377,12 +380,25 @@ func TestAccAWSVpcEndpoint_removed(t *testing.T) {
 				Config: testAccVpcEndpointConfig_gatewayWithoutRouteTableOrPolicyOrTags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpcEndpointExists(resourceName, &endpoint),
-					testDestroy,
+					testAccCheckVpcEndpointDisappears(&endpoint),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
+}
+
+func testAccCheckVpcEndpointDisappears(endpoint *ec2.VpcEndpoint) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+		input := &ec2.DeleteVpcEndpointsInput{
+			VpcEndpointIds: []*string{endpoint.VpcEndpointId},
+		}
+
+		_, err := conn.DeleteVpcEndpoints(input)
+
+		return err
+	}
 }
 
 func testAccCheckVpcEndpointDestroy(s *terraform.State) error {

--- a/aws/resource_aws_vpc_endpoint_test.go
+++ b/aws/resource_aws_vpc_endpoint_test.go
@@ -358,9 +358,10 @@ func TestAccAWSVpcEndpoint_interfaceNonAWSService(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"auto_accept"},
 			},
 		},
 	})


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10688
Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
None
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSVpcEndpoint_'
--- PASS: TestAccAWSVpcEndpoint_gatewayBasic (89.15s)
--- PASS: TestAccAWSVpcEndpoint_gatewayWithRouteTableAndPolicyAndTags (167.35s)
--- PASS: TestAccAWSVpcEndpoint_gatewayPolicy (148.46s)
--- PASS: TestAccAWSVpcEndpoint_interfaceBasic (90.80s)
--- PASS: TestAccAWSVpcEndpoint_interfaceWithSubnetAndSecurityGroup (502.10s)
--- PASS: TestAccAWSVpcEndpoint_interfaceNonAWSService (400.81s)
--- PASS: TestAccAWSVpcEndpoint_removed (76.59s)
```
