### PR TITLE
r/neptune_cluster - support delete protection

### DIFF
--- a/aws/resource_aws_neptune_cluster.go
+++ b/aws/resource_aws_neptune_cluster.go
@@ -256,7 +256,7 @@ func resourceAwsNeptuneCluster() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
-			"delete_protection": {
+			"deletion_protection": {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
@@ -290,7 +290,7 @@ func resourceAwsNeptuneClusterCreate(d *schema.ResourceData, meta interface{}) e
 		Engine:              aws.String(d.Get("engine").(string)),
 		Port:                aws.Int64(int64(d.Get("port").(int))),
 		StorageEncrypted:    aws.Bool(d.Get("storage_encrypted").(bool)),
-		DeletionProtection:  aws.Bool(d.Get("delete_protection").(bool)),
+		DeletionProtection:  aws.Bool(d.Get("deletion_protection").(bool)),
 		Tags:                tags,
 	}
 	restoreDBClusterFromSnapshotInput := &neptune.RestoreDBClusterFromSnapshotInput{
@@ -298,7 +298,7 @@ func resourceAwsNeptuneClusterCreate(d *schema.ResourceData, meta interface{}) e
 		Engine:              aws.String(d.Get("engine").(string)),
 		Port:                aws.Int64(int64(d.Get("port").(int))),
 		SnapshotIdentifier:  aws.String(d.Get("snapshot_identifier").(string)),
-		DeletionProtection:  aws.Bool(d.Get("delete_protection").(bool)),
+		DeletionProtection:  aws.Bool(d.Get("deletion_protection").(bool)),
 		Tags:                tags,
 	}
 
@@ -496,7 +496,7 @@ func flattenAwsNeptuneClusterResource(d *schema.ResourceData, meta interface{}, 
 	d.Set("reader_endpoint", dbc.ReaderEndpoint)
 	d.Set("replication_source_identifier", dbc.ReplicationSourceIdentifier)
 	d.Set("storage_encrypted", dbc.StorageEncrypted)
-	d.Set("delete_protection", dbc.DeletionProtection)
+	d.Set("deletion_protection", dbc.DeletionProtection)
 
 	var sg []string
 	for _, g := range dbc.VpcSecurityGroups {
@@ -603,8 +603,8 @@ func resourceAwsNeptuneClusterUpdate(d *schema.ResourceData, meta interface{}) e
 		req.EnableIAMDatabaseAuthentication = aws.Bool(d.Get("iam_database_authentication_enabled").(bool))
 		requestUpdate = true
 	}
-	if d.HasChange("delete_protection") {
-		req.DeletionProtection = aws.Bool(d.Get("delete_protection").(bool))
+	if d.HasChange("deletion_protection") {
+		req.DeletionProtection = aws.Bool(d.Get("deletion_protection").(bool))
 		requestUpdate = true
 	}
 

--- a/aws/resource_aws_neptune_cluster_test.go
+++ b/aws/resource_aws_neptune_cluster_test.go
@@ -964,7 +964,7 @@ resource "aws_neptune_cluster" "test" {
 
 func testAccAWSNeptuneClusterConfig_cloudwatchLogsExports(rName string) string {
 	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
-resource "aws_neptune_cluster" "default" {
+resource "aws_neptune_cluster" "test" {
   cluster_identifier                   = %q
   availability_zones                  = "${slice(data.aws_availability_zones.test.names,0,3)}"
   skip_final_snapshot                  = true

--- a/aws/resource_aws_neptune_cluster_test.go
+++ b/aws/resource_aws_neptune_cluster_test.go
@@ -18,8 +18,8 @@ import (
 
 func TestAccAWSNeptuneCluster_basic(t *testing.T) {
 	var dbCluster neptune.DBCluster
-	rInt := acctest.RandInt()
-	resourceName := "aws_neptune_cluster.default"
+	rName := acctest.RandomWithPrefix("tf-acc")
+	resourceName := "aws_neptune_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -27,7 +27,7 @@ func TestAccAWSNeptuneCluster_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSNeptuneClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSNeptuneClusterConfig(rInt),
+				Config: testAccAWSNeptuneClusterConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSNeptuneClusterExists(resourceName, &dbCluster),
 					resource.TestCheckResourceAttr(resourceName, "storage_encrypted", "false"),
@@ -37,6 +37,7 @@ func TestAccAWSNeptuneCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "engine", "neptune"),
 					resource.TestCheckResourceAttrSet(resourceName, "engine_version"),
 					resource.TestCheckResourceAttrSet(resourceName, "hosted_zone_id"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "0"),
 				),
 			},
 			{
@@ -56,6 +57,8 @@ func TestAccAWSNeptuneCluster_basic(t *testing.T) {
 
 func TestAccAWSNeptuneCluster_namePrefix(t *testing.T) {
 	var v neptune.DBCluster
+	rName := "tf-test-"
+	resourceName := "aws_neptune_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -63,15 +66,14 @@ func TestAccAWSNeptuneCluster_namePrefix(t *testing.T) {
 		CheckDestroy: testAccCheckAWSNeptuneClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSNeptuneClusterConfig_namePrefix(),
+				Config: testAccAWSNeptuneClusterConfig_namePrefix(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneClusterExists("aws_neptune_cluster.test", &v),
-					resource.TestMatchResourceAttr(
-						"aws_neptune_cluster.test", "cluster_identifier", regexp.MustCompile("^tf-test-")),
+					testAccCheckAWSNeptuneClusterExists(resourceName, &v),
+					resource.TestMatchResourceAttr(resourceName, "cluster_identifier", regexp.MustCompile("^tf-test-")),
 				),
 			},
 			{
-				ResourceName:      "aws_neptune_cluster.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -87,21 +89,22 @@ func TestAccAWSNeptuneCluster_namePrefix(t *testing.T) {
 
 func TestAccAWSNeptuneCluster_takeFinalSnapshot(t *testing.T) {
 	var v neptune.DBCluster
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc")
+	resourceName := "aws_neptune_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSNeptuneClusterSnapshot(rInt),
+		CheckDestroy: testAccCheckAWSNeptuneClusterSnapshot(rName),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSNeptuneClusterConfigWithFinalSnapshot(rInt),
+				Config: testAccAWSNeptuneClusterConfigWithFinalSnapshot(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneClusterExists("aws_neptune_cluster.default", &v),
+					testAccCheckAWSNeptuneClusterExists(resourceName, &v),
 				),
 			},
 			{
-				ResourceName:      "aws_neptune_cluster.default",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -115,9 +118,10 @@ func TestAccAWSNeptuneCluster_takeFinalSnapshot(t *testing.T) {
 	})
 }
 
-func TestAccAWSNeptuneCluster_updateTags(t *testing.T) {
+func TestAccAWSNeptuneCluster_tags(t *testing.T) {
 	var v neptune.DBCluster
-	ri := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc")
+	resourceName := "aws_neptune_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -125,23 +129,15 @@ func TestAccAWSNeptuneCluster_updateTags(t *testing.T) {
 		CheckDestroy: testAccCheckAWSNeptuneClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSNeptuneClusterConfig(ri),
+				Config: testAccAWSNeptuneClusterConfigTags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneClusterExists("aws_neptune_cluster.default", &v),
-					resource.TestCheckResourceAttr(
-						"aws_neptune_cluster.default", "tags.%", "1"),
+					testAccCheckAWSNeptuneClusterExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
 			},
 			{
-				Config: testAccAWSNeptuneClusterConfigUpdatedTags(ri),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneClusterExists("aws_neptune_cluster.default", &v),
-					resource.TestCheckResourceAttr(
-						"aws_neptune_cluster.default", "tags.%", "2"),
-				),
-			},
-			{
-				ResourceName:      "aws_neptune_cluster.default",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -150,6 +146,23 @@ func TestAccAWSNeptuneCluster_updateTags(t *testing.T) {
 					"final_snapshot_identifier",
 					"skip_final_snapshot",
 				},
+			},
+			{
+				Config: testAccAWSNeptuneClusterConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSNeptuneClusterExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSNeptuneClusterConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSNeptuneClusterExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
 			},
 		},
 	})
@@ -157,7 +170,8 @@ func TestAccAWSNeptuneCluster_updateTags(t *testing.T) {
 
 func TestAccAWSNeptuneCluster_updateIamRoles(t *testing.T) {
 	var v neptune.DBCluster
-	ri := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc")
+	resourceName := "aws_neptune_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -165,29 +179,27 @@ func TestAccAWSNeptuneCluster_updateIamRoles(t *testing.T) {
 		CheckDestroy: testAccCheckAWSNeptuneClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSNeptuneClusterConfigIncludingIamRoles(ri),
+				Config: testAccAWSNeptuneClusterConfigIncludingIamRoles(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneClusterExists("aws_neptune_cluster.default", &v),
+					testAccCheckAWSNeptuneClusterExists(resourceName, &v),
 				),
 			},
 			{
-				Config: testAccAWSNeptuneClusterConfigAddIamRoles(ri),
+				Config: testAccAWSNeptuneClusterConfigAddIamRoles(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneClusterExists("aws_neptune_cluster.default", &v),
-					resource.TestCheckResourceAttr(
-						"aws_neptune_cluster.default", "iam_roles.#", "2"),
+					testAccCheckAWSNeptuneClusterExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "iam_roles.#", "2"),
 				),
 			},
 			{
-				Config: testAccAWSNeptuneClusterConfigRemoveIamRoles(ri),
+				Config: testAccAWSNeptuneClusterConfigRemoveIamRoles(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneClusterExists("aws_neptune_cluster.default", &v),
-					resource.TestCheckResourceAttr(
-						"aws_neptune_cluster.default", "iam_roles.#", "1"),
+					testAccCheckAWSNeptuneClusterExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "iam_roles.#", "1"),
 				),
 			},
 			{
-				ResourceName:      "aws_neptune_cluster.default",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -203,7 +215,9 @@ func TestAccAWSNeptuneCluster_updateIamRoles(t *testing.T) {
 
 func TestAccAWSNeptuneCluster_kmsKey(t *testing.T) {
 	var v neptune.DBCluster
-	keyRegex := regexp.MustCompile("^arn:aws:kms:")
+	resourceName := "aws_neptune_cluster.test"
+	keyResourceName := "aws_kms_key.test"
+	rName := acctest.RandomWithPrefix("tf-acc")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -211,15 +225,14 @@ func TestAccAWSNeptuneCluster_kmsKey(t *testing.T) {
 		CheckDestroy: testAccCheckAWSNeptuneClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSNeptuneClusterConfig_kmsKey(acctest.RandInt()),
+				Config: testAccAWSNeptuneClusterConfig_kmsKey(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneClusterExists("aws_neptune_cluster.default", &v),
-					resource.TestMatchResourceAttr(
-						"aws_neptune_cluster.default", "kms_key_arn", keyRegex),
+					testAccCheckAWSNeptuneClusterExists(resourceName, &v),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_arn", keyResourceName, "arn"),
 				),
 			},
 			{
-				ResourceName:      "aws_neptune_cluster.default",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -235,6 +248,8 @@ func TestAccAWSNeptuneCluster_kmsKey(t *testing.T) {
 
 func TestAccAWSNeptuneCluster_encrypted(t *testing.T) {
 	var v neptune.DBCluster
+	resourceName := "aws_neptune_cluster.test"
+	rName := acctest.RandomWithPrefix("tf-acc")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -242,15 +257,14 @@ func TestAccAWSNeptuneCluster_encrypted(t *testing.T) {
 		CheckDestroy: testAccCheckAWSNeptuneClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSNeptuneClusterConfig_encrypted(acctest.RandInt()),
+				Config: testAccAWSNeptuneClusterConfig_encrypted(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneClusterExists("aws_neptune_cluster.default", &v),
-					resource.TestCheckResourceAttr(
-						"aws_neptune_cluster.default", "storage_encrypted", "true"),
+					testAccCheckAWSNeptuneClusterExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "storage_encrypted", "true"),
 				),
 			},
 			{
-				ResourceName:      "aws_neptune_cluster.default",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -266,39 +280,34 @@ func TestAccAWSNeptuneCluster_encrypted(t *testing.T) {
 
 func TestAccAWSNeptuneCluster_backupsUpdate(t *testing.T) {
 	var v neptune.DBCluster
+	resourceName := "aws_neptune_cluster.test"
+	rName := acctest.RandomWithPrefix("tf-acc")
 
-	ri := acctest.RandInt()
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSNeptuneClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSNeptuneClusterConfig_backups(ri),
+				Config: testAccAWSNeptuneClusterConfig_backups(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneClusterExists("aws_neptune_cluster.default", &v),
-					resource.TestCheckResourceAttr(
-						"aws_neptune_cluster.default", "preferred_backup_window", "07:00-09:00"),
-					resource.TestCheckResourceAttr(
-						"aws_neptune_cluster.default", "backup_retention_period", "5"),
-					resource.TestCheckResourceAttr(
-						"aws_neptune_cluster.default", "preferred_maintenance_window", "tue:04:00-tue:04:30"),
+					testAccCheckAWSNeptuneClusterExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "preferred_backup_window", "07:00-09:00"),
+					resource.TestCheckResourceAttr(resourceName, "backup_retention_period", "5"),
+					resource.TestCheckResourceAttr(resourceName, "preferred_maintenance_window", "tue:04:00-tue:04:30"),
 				),
 			},
 			{
-				Config: testAccAWSNeptuneClusterConfig_backupsUpdate(ri),
+				Config: testAccAWSNeptuneClusterConfig_backupsUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneClusterExists("aws_neptune_cluster.default", &v),
-					resource.TestCheckResourceAttr(
-						"aws_neptune_cluster.default", "preferred_backup_window", "03:00-09:00"),
-					resource.TestCheckResourceAttr(
-						"aws_neptune_cluster.default", "backup_retention_period", "10"),
-					resource.TestCheckResourceAttr(
-						"aws_neptune_cluster.default", "preferred_maintenance_window", "wed:01:00-wed:01:30"),
+					testAccCheckAWSNeptuneClusterExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "preferred_backup_window", "03:00-09:00"),
+					resource.TestCheckResourceAttr(resourceName, "backup_retention_period", "10"),
+					resource.TestCheckResourceAttr(resourceName, "preferred_maintenance_window", "wed:01:00-wed:01:30"),
 				),
 			},
 			{
-				ResourceName:      "aws_neptune_cluster.default",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -314,6 +323,8 @@ func TestAccAWSNeptuneCluster_backupsUpdate(t *testing.T) {
 
 func TestAccAWSNeptuneCluster_iamAuth(t *testing.T) {
 	var v neptune.DBCluster
+	resourceName := "aws_neptune_cluster.test"
+	rName := acctest.RandomWithPrefix("tf-acc")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -321,15 +332,14 @@ func TestAccAWSNeptuneCluster_iamAuth(t *testing.T) {
 		CheckDestroy: testAccCheckAWSNeptuneClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSNeptuneClusterConfig_iamAuth(acctest.RandInt()),
+				Config: testAccAWSNeptuneClusterConfig_iamAuth(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneClusterExists("aws_neptune_cluster.default", &v),
-					resource.TestCheckResourceAttr(
-						"aws_neptune_cluster.default", "iam_database_authentication_enabled", "true"),
+					testAccCheckAWSNeptuneClusterExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "iam_database_authentication_enabled", "true"),
 				),
 			},
 			{
-				ResourceName:      "aws_neptune_cluster.default",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -466,23 +476,20 @@ func testAccCheckAWSNeptuneClusterExistsWithProvider(n string, v *neptune.DBClus
 	}
 }
 
-func testAccCheckAWSNeptuneClusterSnapshot(rInt int) resource.TestCheckFunc {
+func testAccCheckAWSNeptuneClusterSnapshot(rName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_neptune_cluster" {
 				continue
 			}
 
-			// Try and delete the snapshot before we check for the cluster not found
-			snapshot_identifier := fmt.Sprintf("tf-acctest-neptunecluster-snapshot-%d", rInt)
-
 			awsClient := testAccProvider.Meta().(*AWSClient)
 			conn := awsClient.neptuneconn
 
-			log.Printf("[INFO] Deleting the Snapshot %s", snapshot_identifier)
+			log.Printf("[INFO] Deleting the Snapshot %s", rName)
 			_, snapDeleteErr := conn.DeleteDBClusterSnapshot(
 				&neptune.DeleteDBClusterSnapshotInput{
-					DBClusterSnapshotIdentifier: aws.String(snapshot_identifier),
+					DBClusterSnapshotIdentifier: aws.String(rName),
 				})
 			if snapDeleteErr != nil {
 				return snapDeleteErr
@@ -516,68 +523,170 @@ func testAccCheckAWSNeptuneClusterSnapshot(rInt int) resource.TestCheckFunc {
 	}
 }
 
-func testAccAWSNeptuneClusterConfig(n int) string {
-	return fmt.Sprintf(`
-resource "aws_neptune_cluster" "default" {
-  cluster_identifier                   = "tf-neptune-cluster-%d"
-  availability_zones                   = ["us-west-2a", "us-west-2b", "us-west-2c"]
+var testAccAWSNeptuneClusterConfigBase = `
+data "aws_availability_zones" "test" {
+  state = "available"
+}
+`
+
+func testAccAWSNeptuneClusterConfig(rName string) string {
+	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
+resource "aws_neptune_cluster" "test" {
+  cluster_identifier                   = %q
+  availability_zones                   = "${slice(data.aws_availability_zones.test.names,0,3)}"
   engine                               = "neptune"
   neptune_cluster_parameter_group_name = "default.neptune1"
   skip_final_snapshot                  = true
-
-  tags = {
-    Environment = "production"
-  }
 }
-`, n)
+`, rName)
 }
 
-func testAccAWSNeptuneClusterConfig_namePrefix() string {
+func testAccAWSNeptuneClusterConfig_namePrefix(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_neptune_cluster" "test" {
-  cluster_identifier_prefix            = "tf-test-"
+  cluster_identifier_prefix            = %q
   engine                               = "neptune"
   neptune_cluster_parameter_group_name = "default.neptune1"
   skip_final_snapshot                  = true
 }
-`)
+`, rName)
 }
 
-func testAccAWSNeptuneClusterConfigWithFinalSnapshot(n int) string {
-	return fmt.Sprintf(`
-resource "aws_neptune_cluster" "default" {
-  cluster_identifier                   = "tf-neptune-cluster-%d"
-  availability_zones                   = ["us-west-2a", "us-west-2b", "us-west-2c"]
+func testAccAWSNeptuneClusterConfigWithFinalSnapshot(rName string) string {
+	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
+resource "aws_neptune_cluster" "test" {
+  cluster_identifier                   = %[1]q
+  availability_zones                   = "${slice(data.aws_availability_zones.test.names,0,3)}"
   neptune_cluster_parameter_group_name = "default.neptune1"
-  final_snapshot_identifier            = "tf-acctest-neptunecluster-snapshot-%d"
-
-  tags = {
-    Environment = "production"
-  }
+  final_snapshot_identifier            = %[1]q
 }
-`, n, n)
+`, rName)
 }
 
-func testAccAWSNeptuneClusterConfigUpdatedTags(n int) string {
-	return fmt.Sprintf(`
-resource "aws_neptune_cluster" "default" {
-  cluster_identifier                   = "tf-neptune-cluster-%d"
-  availability_zones                   = ["us-west-2a", "us-west-2b", "us-west-2c"]
+func testAccAWSNeptuneClusterConfigTags1(rName, tagKey1, tagValue1 string) string {
+	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
+resource "aws_neptune_cluster" "test" {
+  cluster_identifier                   = %[1]q
+  availability_zones                   = "${slice(data.aws_availability_zones.test.names,0,3)}"
+  engine                               = "neptune"
   neptune_cluster_parameter_group_name = "default.neptune1"
   skip_final_snapshot                  = true
 
   tags = {
-    Environment = "production"
-    AnotherTag  = "test"
+    %[2]q = %[3]q
   }
 }
-`, n)
+`, rName, tagKey1, tagValue1)
 }
 
-func testAccAWSNeptuneClusterConfigIncludingIamRoles(n int) string {
-	return fmt.Sprintf(`
-resource "aws_iam_role" "neptune_sample_role" {
-  name = "neptune_sample_role_%d"
+func testAccAWSNeptuneClusterConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
+resource "aws_neptune_cluster" "test" {
+  cluster_identifier                   = %[1]q
+  availability_zones                   = "${slice(data.aws_availability_zones.test.names,0,3)}"
+  engine                               = "neptune"
+  neptune_cluster_parameter_group_name = "default.neptune1"
+  skip_final_snapshot                  = true
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}
+
+func testAccAWSNeptuneClusterConfigIncludingIamRoles(rName string) string {
+	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  name = %[1]q
+  path = "/"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "rds.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "test" {
+  name = %[1]q
+  role = "${aws_iam_role.test.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Action": "*",
+    "Resource": "*"
+  }
+}
+EOF
+}
+
+resource "aws_iam_role" "test-2" {
+  name = "%[1]s-2"
+  path = "/"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "rds.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "test-2" {
+  name = "%[1]s-2"
+  role = "${aws_iam_role.test-2.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Action": "*",
+    "Resource": "*"
+  }
+}
+EOF
+}
+
+resource "aws_neptune_cluster" "test" {
+  cluster_identifier                   = %[1]q
+  availability_zones                   = "${slice(data.aws_availability_zones.test.names,0,3)}"
+  neptune_cluster_parameter_group_name = "default.neptune1"
+  skip_final_snapshot                  = true
+
+  depends_on = ["aws_iam_role.test", "aws_iam_role.test-2"]
+}
+`, rName)
+}
+
+func testAccAWSNeptuneClusterConfigAddIamRoles(rName string) string {
+	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  name = %[1]q
   path = "/"
 
   assume_role_policy = <<EOF
@@ -598,8 +707,8 @@ EOF
 }
 
 resource "aws_iam_role_policy" "neptune_policy" {
-  name = "neptune_sample_role_policy_%d"
-  role = "${aws_iam_role.neptune_sample_role.name}"
+  name = %[1]q
+  role = "${aws_iam_role.test.name}"
 
   policy = <<EOF
 {
@@ -613,8 +722,8 @@ resource "aws_iam_role_policy" "neptune_policy" {
 EOF
 }
 
-resource "aws_iam_role" "another_neptune_sample_role" {
-  name = "another_neptune_sample_role_%d"
+resource "aws_iam_role" "test-2" {
+  name = "%[1]s-2"
   path = "/"
 
   assume_role_policy = <<EOF
@@ -634,9 +743,9 @@ resource "aws_iam_role" "another_neptune_sample_role" {
 EOF
 }
 
-resource "aws_iam_role_policy" "another_neptune_policy" {
-  name = "another_neptune_sample_role_policy_%d"
-  role = "${aws_iam_role.another_neptune_sample_role.name}"
+resource "aws_iam_role_policy" "test-2" {
+  name = "%[1]s-2"
+  role = "${aws_iam_role.test-2.name}"
 
   policy = <<EOF
 {
@@ -650,116 +759,21 @@ resource "aws_iam_role_policy" "another_neptune_policy" {
 EOF
 }
 
-resource "aws_neptune_cluster" "default" {
-  cluster_identifier                   = "tf-neptune-cluster-%d"
-  availability_zones                   = ["us-west-2a", "us-west-2b", "us-west-2c"]
-  neptune_cluster_parameter_group_name = "default.neptune1"
-  skip_final_snapshot                  = true
-
-  tags = {
-    Environment = "production"
-  }
-
-  depends_on = ["aws_iam_role.another_neptune_sample_role", "aws_iam_role.neptune_sample_role"]
-}
-`, n, n, n, n, n)
-}
-
-func testAccAWSNeptuneClusterConfigAddIamRoles(n int) string {
-	return fmt.Sprintf(`
-resource "aws_iam_role" "neptune_sample_role" {
-  name = "neptune_sample_role_%d"
-  path = "/"
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "rds.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy" "neptune_policy" {
-  name = "neptune_sample_role_policy_%d"
-  role = "${aws_iam_role.neptune_sample_role.name}"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": {
-    "Effect": "Allow",
-    "Action": "*",
-    "Resource": "*"
-  }
-}
-EOF
-}
-
-resource "aws_iam_role" "another_neptune_sample_role" {
-  name = "another_neptune_sample_role_%d"
-  path = "/"
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "rds.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy" "another_neptune_policy" {
-  name = "another_neptune_sample_role_policy_%d"
-  role = "${aws_iam_role.another_neptune_sample_role.name}"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": {
-    "Effect": "Allow",
-    "Action": "*",
-    "Resource": "*"
-  }
-}
-EOF
-}
-
-resource "aws_neptune_cluster" "default" {
-  cluster_identifier  = "tf-neptune-cluster-%d"
-  availability_zones  = ["us-west-2a", "us-west-2b", "us-west-2c"]
+resource "aws_neptune_cluster" "test" {
+  cluster_identifier  = %[1]q
+  availability_zones  = "${slice(data.aws_availability_zones.test.names,0,3)}"
   skip_final_snapshot = true
-  iam_roles           = ["${aws_iam_role.neptune_sample_role.arn}", "${aws_iam_role.another_neptune_sample_role.arn}"]
+  iam_roles           = ["${aws_iam_role.test.arn}", "${aws_iam_role.test-2.arn}"]
 
-  tags = {
-    Environment = "production"
-  }
-
-  depends_on = ["aws_iam_role.another_neptune_sample_role", "aws_iam_role.neptune_sample_role"]
+  depends_on = ["aws_iam_role.test", "aws_iam_role.test-2"]
 }
-`, n, n, n, n, n)
+`, rName)
 }
 
-func testAccAWSNeptuneClusterConfigRemoveIamRoles(n int) string {
-	return fmt.Sprintf(`
-resource "aws_iam_role" "another_neptune_sample_role" {
-  name = "another_neptune_sample_role_%d"
+func testAccAWSNeptuneClusterConfigRemoveIamRoles(rName string) string {
+	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  name = %[1]q
   path = "/"
 
   assume_role_policy = <<EOF
@@ -779,9 +793,9 @@ resource "aws_iam_role" "another_neptune_sample_role" {
 EOF
 }
 
-resource "aws_iam_role_policy" "another_neptune_policy" {
-  name = "another_neptune_sample_role_policy_%d"
-  role = "${aws_iam_role.another_neptune_sample_role.name}"
+resource "aws_iam_role_policy" "test" {
+  name = %[1]q
+  role = "${aws_iam_role.test.name}"
 
   policy = <<EOF
 {
@@ -795,26 +809,22 @@ resource "aws_iam_role_policy" "another_neptune_policy" {
 EOF
 }
 
-resource "aws_neptune_cluster" "default" {
-  cluster_identifier  = "tf-neptune-cluster-%d"
-  availability_zones  = ["us-west-2a", "us-west-2b", "us-west-2c"]
+resource "aws_neptune_cluster" "test" {
+  cluster_identifier  = %[1]q
+  availability_zones  = "${slice(data.aws_availability_zones.test.names,0,3)}"
   skip_final_snapshot = true
-  iam_roles           = ["${aws_iam_role.another_neptune_sample_role.arn}"]
+  iam_roles           = ["${aws_iam_role.test.arn}"]
 
-  tags = {
-    Environment = "production"
-  }
-
-  depends_on = ["aws_iam_role.another_neptune_sample_role"]
+  depends_on = ["aws_iam_role.test"]
 }
-`, n, n, n)
+`, rName)
 }
 
-func testAccAWSNeptuneClusterConfig_kmsKey(n int) string {
-	return fmt.Sprintf(`
+func testAccAWSNeptuneClusterConfig_kmsKey(rName string) string {
+	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
 
- resource "aws_kms_key" "foo" {
-     description = "Terraform acc test %d"
+ resource "aws_kms_key" "test" {
+     description = "Terraform acc test"
      policy = <<POLICY
  {
    "Version": "2012-10-17",
@@ -834,63 +844,63 @@ func testAccAWSNeptuneClusterConfig_kmsKey(n int) string {
  POLICY
  }
 
- resource "aws_neptune_cluster" "default" {
-   cluster_identifier = "tf-neptune-cluster-%d"
-   availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
+ resource "aws_neptune_cluster" "test" {
+   cluster_identifier                   = %q
+   availability_zones                   = "${slice(data.aws_availability_zones.test.names,0,3)}"
    neptune_cluster_parameter_group_name = "default.neptune1"
-   storage_encrypted = true
-   kms_key_arn = "${aws_kms_key.foo.arn}"
-   skip_final_snapshot = true
- }`, n, n)
+   storage_encrypted                    = true
+   kms_key_arn                          = "${aws_kms_key.test.arn}"
+   skip_final_snapshot                  = true
+ }`, rName)
 }
 
-func testAccAWSNeptuneClusterConfig_encrypted(n int) string {
-	return fmt.Sprintf(`
-resource "aws_neptune_cluster" "default" {
-  cluster_identifier = "tf-neptune-cluster-%d"
-  availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
+func testAccAWSNeptuneClusterConfig_encrypted(rName string) string {
+	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
+resource "aws_neptune_cluster" "test" {
+  cluster_identifier = %q
+  availability_zones = "${slice(data.aws_availability_zones.test.names,0,3)}"
   storage_encrypted = true
   skip_final_snapshot = true
 }
-`, n)
+`, rName)
 }
 
-func testAccAWSNeptuneClusterConfig_backups(n int) string {
-	return fmt.Sprintf(`
-resource "aws_neptune_cluster" "default" {
-  cluster_identifier           = "tf-neptune-cluster-%d"
-  availability_zones           = ["us-west-2a", "us-west-2b", "us-west-2c"]
+func testAccAWSNeptuneClusterConfig_backups(rName string) string {
+	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
+resource "aws_neptune_cluster" "test" {
+  cluster_identifier           = %q
+  availability_zones           = "${slice(data.aws_availability_zones.test.names,0,3)}"
   backup_retention_period      = 5
   preferred_backup_window      = "07:00-09:00"
   preferred_maintenance_window = "tue:04:00-tue:04:30"
   skip_final_snapshot          = true
 }
-`, n)
+`, rName)
 }
 
-func testAccAWSNeptuneClusterConfig_backupsUpdate(n int) string {
-	return fmt.Sprintf(`
-resource "aws_neptune_cluster" "default" {
-  cluster_identifier           = "tf-neptune-cluster-%d"
-  availability_zones           = ["us-west-2a", "us-west-2b", "us-west-2c"]
+func testAccAWSNeptuneClusterConfig_backupsUpdate(rName string) string {
+	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
+resource "aws_neptune_cluster" "test" {
+  cluster_identifier           = %q
+  availability_zones           = "${slice(data.aws_availability_zones.test.names,0,3)}"
   backup_retention_period      = 10
   preferred_backup_window      = "03:00-09:00"
   preferred_maintenance_window = "wed:01:00-wed:01:30"
   apply_immediately            = true
   skip_final_snapshot          = true
 }
-`, n)
+`, rName)
 }
 
-func testAccAWSNeptuneClusterConfig_iamAuth(n int) string {
-	return fmt.Sprintf(`
-resource "aws_neptune_cluster" "default" {
-  cluster_identifier                  = "tf-neptune-cluster-%d"
-  availability_zones                  = ["us-west-2a", "us-west-2b", "us-west-2c"]
+func testAccAWSNeptuneClusterConfig_iamAuth(rName string) string {
+	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
+resource "aws_neptune_cluster" "test" {
+  cluster_identifier                  = %q
+  availability_zones                  = "${slice(data.aws_availability_zones.test.names,0,3)}"
   iam_database_authentication_enabled = true
   skip_final_snapshot                 = true
 }
-`, n)
+`, rName)
 }
 
 func testAccAWSNeptuneClusterConfig_cloudwatchLogsExports(n int) string {

--- a/website/docs/r/neptune_cluster.html.markdown
+++ b/website/docs/r/neptune_cluster.html.markdown
@@ -62,6 +62,7 @@ The following arguments are supported:
 * `storage_encrypted` - (Optional) Specifies whether the Neptune cluster is encrypted. The default is `false` if not specified.
 * `tags` - (Optional) A mapping of tags to assign to the Neptune cluster.
 * `vpc_security_group_ids` - (Optional) List of VPC security groups to associate with the Cluster
+* `delete_protection` - (Optional) A value that indicates whether the DB cluster has deletion protection enabled.The database can't be deleted when deletion protection is enabled. By default, deletion protection is disabled.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_neptune_cluster: add `deletion_protection` argument.
resource_aws_neptune_cluster: add plan time validation for `iam_roles`.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSNeptuneCluster_'
--- PASS: TestAccAWSNeptuneCluster_basic (164.67s)
--- PASS: TestAccAWSNeptuneCluster_tags (227.02s)
--- PASS: TestAccAWSNeptuneCluster_kmsKey (197.13s)
--- PASS: TestAccAWSNeptuneCluster_encrypted (183.68s)
--- PASS: TestAccAWSNeptuneCluster_backupsUpdate (180.87s)
--- PASS: TestAccAWSNeptuneCluster_iamAuth (129.55s)
--- PASS: TestAccAWSNeptuneCluster_takeFinalSnapshot (230.35s)
--- PASS: TestAccAWSNeptuneCluster_namePrefix (156.87s)
--- PASS: TestAccAWSNeptuneCluster_updateIamRoles (236.64s)
--- PASS: TestAccAWSNeptuneCluster_basic (173.67s)
--- PASS: TestAccAWSNeptuneCluster_deleteProtection (272.79s)
--- PASS: TestAccAWSNeptuneCluster_updateCloudwatchLogsExports (253.75s)
```
