### PR TITLE
Update error message wording to reflect change in AWS API

### DIFF
--- a/aws/resource_aws_api_gateway_account.go
+++ b/aws/resource_aws_api_gateway_account.go
@@ -93,7 +93,7 @@ func resourceAwsApiGatewayAccountUpdate(d *schema.ResourceData, meta interface{}
 	log.Printf("[INFO] Updating API Gateway Account: %s", input)
 
 	// Retry due to eventual consistency of IAM
-	expectedErrMsg := "The role ARN does not have required permissions set to API Gateway"
+	expectedErrMsg := "The role ARN does not have required permissions"
 	otherErrMsg := "API Gateway could not successfully write to CloudWatch Logs using the ARN specified"
 	var out *apigateway.Account
 	var err error


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11711 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix  "BadRequestException" error while updating an API Gateway account.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAPIGatewayAccount'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAPIGatewayAccount -timeout 120m
=== RUN   TestAccAWSAPIGatewayAccount_basic
=== PAUSE TestAccAWSAPIGatewayAccount_basic
=== CONT  TestAccAWSAPIGatewayAccount_basic
--- PASS: TestAccAWSAPIGatewayAccount_basic (102.99s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       107.050s
```
