### PR TITLE
resource/aws_efs_file_system and resource/aws_efs_mount_target: Support for cn-north-1 and cn-northwest-1

### DIFF
--- a/aws/data_source_aws_efs_file_system.go
+++ b/aws/data_source_aws_efs_file_system.go
@@ -119,6 +119,7 @@ func dataSourceAwsEfsFileSystemRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("kms_key_id", fs.KmsKeyId)
 
 	region := meta.(*AWSClient).region
-	err = d.Set("dns_name", resourceAwsEfsDnsName(*fs.FileSystemId, region))
+	dnsSuffix := meta.(*AWSClient).dnsSuffix
+	err = d.Set("dns_name", resourceAwsEfsDnsName(*fs.FileSystemId, region, dnsSuffix))
 	return err
 }

--- a/aws/data_source_aws_efs_mount_target.go
+++ b/aws/data_source_aws_efs_mount_target.go
@@ -101,7 +101,7 @@ func dataSourceAwsEfsMountTargetRead(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	if err := d.Set("dns_name", resourceAwsEfsMountTargetDnsName(*mt.FileSystemId, meta.(*AWSClient).region)); err != nil {
+	if err := d.Set("dns_name", resourceAwsEfsMountTargetDnsName(*mt.FileSystemId, meta.(*AWSClient).region, meta.(*AWSClient).dnsSuffix)); err != nil {
 		return fmt.Errorf("Error setting dns_name error: %#v", err)
 	}
 

--- a/aws/resource_aws_efs_file_system.go
+++ b/aws/resource_aws_efs_file_system.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/efs"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -394,6 +395,9 @@ func hasEmptyFileSystems(fs *efs.DescribeFileSystemsOutput) bool {
 }
 
 func resourceAwsEfsDnsName(fileSystemId, region string) string {
+	if partition, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), region); ok && partition.ID() == endpoints.AwsCnPartitionID {
+		return fmt.Sprintf("%s.efs.%s.amazonaws.com.cn", fileSystemId, region)
+	}
 	return fmt.Sprintf("%s.efs.%s.amazonaws.com", fileSystemId, region)
 }
 

--- a/aws/resource_aws_efs_mount_target.go
+++ b/aws/resource_aws_efs_mount_target.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/efs"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -304,6 +305,9 @@ func waitForDeleteEfsMountTarget(conn *efs.EFS, id string, timeout time.Duration
 }
 
 func resourceAwsEfsMountTargetDnsName(fileSystemId, region string) string {
+	if partition, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), region); ok && partition.ID() == endpoints.AwsCnPartitionID {
+		return fmt.Sprintf("%s.efs.%s.amazonaws.com.cn", fileSystemId, region)
+	}
 	return fmt.Sprintf("%s.efs.%s.amazonaws.com", fileSystemId, region)
 }
 

--- a/aws/resource_aws_efs_mount_target_test.go
+++ b/aws/resource_aws_efs_mount_target_test.go
@@ -180,6 +180,16 @@ func TestResourceAWSEFSMountTarget_mountTargetDnsName(t *testing.T) {
 	}
 }
 
+func TestResourceAWSEFSMountTarget_mountTargetDnsNameCn(t *testing.T) {
+	actual := resourceAwsEfsMountTargetDnsName("fs-123456ab", "cn-north-1")
+
+	expected := "fs-123456ab.efs.cn-north-1.amazonaws.com.cn"
+	if actual != expected {
+		t.Fatalf("Expected EFS mount target DNS name to be %s, got %s",
+			expected, actual)
+	}
+}
+
 func TestResourceAWSEFSMountTarget_hasEmptyMountTargets(t *testing.T) {
 	mto := &efs.DescribeMountTargetsOutput{
 		MountTargets: []*efs.MountTargetDescription{},

--- a/aws/resource_aws_efs_mount_target_test.go
+++ b/aws/resource_aws_efs_mount_target_test.go
@@ -171,19 +171,9 @@ func TestAccAWSEFSMountTarget_disappears(t *testing.T) {
 }
 
 func TestResourceAWSEFSMountTarget_mountTargetDnsName(t *testing.T) {
-	actual := resourceAwsEfsMountTargetDnsName("fs-123456ab", "non-existent-1")
+	actual := resourceAwsEfsMountTargetDnsName("fs-123456ab", "us-west-2", "amazonaws.com")
 
-	expected := "fs-123456ab.efs.non-existent-1.amazonaws.com"
-	if actual != expected {
-		t.Fatalf("Expected EFS mount target DNS name to be %s, got %s",
-			expected, actual)
-	}
-}
-
-func TestResourceAWSEFSMountTarget_mountTargetDnsNameCn(t *testing.T) {
-	actual := resourceAwsEfsMountTargetDnsName("fs-123456ab", "cn-north-1")
-
-	expected := "fs-123456ab.efs.cn-north-1.amazonaws.com.cn"
+	expected := "fs-123456ab.efs.us-west-2.amazonaws.com"
 	if actual != expected {
 		t.Fatalf("Expected EFS mount target DNS name to be %s, got %s",
 			expected, actual)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_efs_file_system and resource/aws_efs_mount_target: Support for cn-north-1 and cn-northwest-1
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestResourceAWSEFSMountTarget_mountTargetDnsNameCn'
=== RUN   TestResourceAWSEFSMountTarget_mountTargetDnsNameCn
--- PASS: TestResourceAWSEFSMountTarget_mountTargetDnsNameCn (0.00s)
```
