### PR TITLE
tests/provider: Introduce testAccMatchResourceAttrRegionalHostname() for region and partition agnostic hostname testing

### DIFF
--- a/aws/resource_aws_efs_file_system_test.go
+++ b/aws/resource_aws_efs_file_system_test.go
@@ -98,11 +98,11 @@ func TestAccAWSEFSFileSystem_basic(t *testing.T) {
 				Config: testAccAWSEFSFileSystemConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "elasticfilesystem", regexp.MustCompile(`file-system/fs-.+`)),
+					testAccMatchResourceAttrRegionalHostname(resourceName, "dns_name", "efs", regexp.MustCompile(`[^.]+`)),
 					resource.TestCheckResourceAttr(resourceName, "performance_mode", "generalPurpose"),
 					resource.TestCheckResourceAttr(resourceName, "throughput_mode", efs.ThroughputModeBursting),
 					testAccCheckEfsFileSystem(resourceName, &desc),
 					testAccCheckEfsFileSystemPerformanceMode(resourceName, "generalPurpose"),
-					resource.TestMatchResourceAttr(resourceName, "dns_name", regexp.MustCompile("^[^.]+.efs.us-west-2.amazonaws.com$")),
 				),
 			},
 			{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously in the acceptance testing in AWS GovCloud (US):

```
--- FAIL: TestAccAWSEFSFileSystem_basic (27.99s)
    testing.go:640: Step 0 error: Check failed: Check 6/6 error: aws_efs_file_system.test: Attribute 'dns_name' didn't match "^[^.]+.efs.us-west-2.amazonaws.com$", got "fs-e91c94e8.efs.us-gov-west-1.amazonaws.com"
```

Preferring usage of this new `TestCheckFunc` will be checked via static analysis linter in the future.

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSEFSFileSystem_basic (42.46s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAWSEFSFileSystem_basic (49.75s)
```
