### PR TITLE
aws_ssm_association resource support AutomationTargetParameterName

### DIFF
--- a/aws/resource_aws_ssm_association.go
+++ b/aws/resource_aws_ssm_association.go
@@ -114,6 +114,10 @@ func resourceAwsSsmAssociation() *schema.Resource {
 					ssm.ComplianceSeverityCritical,
 				}, false),
 			},
+			"automation_target_parameter_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -167,6 +171,10 @@ func resourceAwsSsmAssociationCreate(d *schema.ResourceData, meta interface{}) e
 		associationInput.MaxErrors = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("automation_target_parameter_name"); ok {
+		associationInput.AutomationTargetParameterName = aws.String(v.(string))
+	}
+
 	resp, err := ssmconn.CreateAssociation(associationInput)
 	if err != nil {
 		return fmt.Errorf("Error creating SSM association: %s", err)
@@ -215,6 +223,7 @@ func resourceAwsSsmAssociationRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("compliance_severity", association.ComplianceSeverity)
 	d.Set("max_concurrency", association.MaxConcurrency)
 	d.Set("max_errors", association.MaxErrors)
+	d.Set("automation_target_parameter_name", association.AutomationTargetParameterName)
 
 	if err := d.Set("targets", flattenAwsSsmTargets(association.Targets)); err != nil {
 		return fmt.Errorf("Error setting targets error: %#v", err)
@@ -271,6 +280,10 @@ func resourceAwsSsmAssociationUpdate(d *schema.ResourceData, meta interface{}) e
 
 	if v, ok := d.GetOk("max_errors"); ok {
 		associationInput.MaxErrors = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("automation_target_parameter_name"); ok {
+		associationInput.AutomationTargetParameterName = aws.String(v.(string))
 	}
 
 	_, err := ssmconn.UpdateAssociation(associationInput)

--- a/website/docs/r/ssm_association.html.markdown
+++ b/website/docs/r/ssm_association.html.markdown
@@ -38,6 +38,7 @@ The following arguments are supported:
 * `compliance_severity` - (Optional) The compliance severity for the association. Can be one of the following: `UNSPECIFIED`, `LOW`, `MEDIUM`, `HIGH` or `CRITICAL`
 * `max_concurrency` - (Optional) The maximum number of targets allowed to run the association at the same time. You can specify a number, for example 10, or a percentage of the target set, for example 10%.
 * `max_errors` - (Optional) The number of errors that are allowed before the system stops sending requests to run the association on additional targets. You can specify a number, for example 10, or a percentage of the target set, for example 10%.
+* `automation_target_parameter_name` - (Optional) Specify the target for the association. This target is required for associations that use an `Automation` document and target resources by using rate controls.
 
 Output Location (`output_location`) is an S3 bucket where you want to store the results of this association:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10301

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_ssm_association: add `automation_target_parameter_name` argument.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSSMAssociation_withAutomationTargetParamName'
--- PASS: TestAccAWSSSMAssociation_withAutomationTargetParamName (226.61s)
...
```
