### PR TITLE
r/aws_ssm_maintanance_window_target - add plan time validation to `resource_type` + docs and tests

### DIFF
--- a/aws/resource_aws_ssm_maintenance_window_target.go
+++ b/aws/resource_aws_ssm_maintenance_window_target.go
@@ -29,6 +29,10 @@ func resourceAwsSsmMaintenanceWindowTarget() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					ssm.MaintenanceWindowResourceTypeInstance,
+					ssm.MaintenanceWindowResourceTypeResourceGroup,
+				}, true),
 			},
 
 			"targets": {

--- a/aws/resource_aws_ssm_maintenance_window_target_test.go
+++ b/aws/resource_aws_ssm_maintenance_window_target_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -14,60 +13,53 @@ import (
 )
 
 func TestAccAWSSSMMaintenanceWindowTarget_basic(t *testing.T) {
-	name := acctest.RandString(10)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ssm_maintenance_window_target.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSSMMaintenanceWindowTargetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSSMMaintenanceWindowTargetBasicConfig(name),
+				Config: testAccAWSSSMMaintenanceWindowTargetBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMMaintenanceWindowTargetExists("aws_ssm_maintenance_window_target.target"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.0.key", "tag:Name"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.0.values.#", "1"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.0.values.0", "acceptance_test"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.1.key", "tag:Name2"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.1.values.#", "2"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.1.values.0", "acceptance_test"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.1.values.1", "acceptance_test2"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "name", "TestMaintenanceWindowTarget"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "description", "This resource is for test purpose only"),
+					testAccCheckAWSSSMMaintenanceWindowTargetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.key", "tag:Name"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.values.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.values.0", "acceptance_test"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.key", "tag:Name2"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.values.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.values.0", "acceptance_test"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.values.1", "acceptance_test2"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "This resource is for test purpose only"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type", ssm.MaintenanceWindowResourceTypeInstance),
 				),
-			},
-			{
-				ResourceName:      "aws_ssm_maintenance_window.foo",
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
 func TestAccAWSSSMMaintenanceWindowTarget_noNameOrDescription(t *testing.T) {
-	name := acctest.RandString(10)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ssm_maintenance_window_target.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSSMMaintenanceWindowTargetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSSMMaintenanceWindowTargetNoNameOrDescriptionConfig(name),
+				Config: testAccAWSSSMMaintenanceWindowTargetNoNameOrDescriptionConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMMaintenanceWindowTargetExists("aws_ssm_maintenance_window_target.target"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.0.key", "tag:Name"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.0.values.#", "1"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.0.values.0", "acceptance_test"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.1.key", "tag:Name2"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.1.values.#", "2"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.1.values.0", "acceptance_test"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.1.values.1", "acceptance_test2"),
+					testAccCheckAWSSSMMaintenanceWindowTargetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.key", "tag:Name"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.values.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.values.0", "acceptance_test"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.key", "tag:Name2"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.values.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.values.0", "acceptance_test"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.values.1", "acceptance_test2"),
 				),
-			},
-			{
-				ResourceName:      "aws_ssm_maintenance_window.foo",
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})
@@ -97,40 +89,69 @@ func TestAccAWSSSMMaintenanceWindowTarget_validation(t *testing.T) {
 }
 
 func TestAccAWSSSMMaintenanceWindowTarget_update(t *testing.T) {
-	name := acctest.RandString(10)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ssm_maintenance_window_target.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSSMMaintenanceWindowTargetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSSMMaintenanceWindowTargetBasicConfig(name),
+				Config: testAccAWSSSMMaintenanceWindowTargetBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMMaintenanceWindowTargetExists("aws_ssm_maintenance_window_target.target"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.0.key", "tag:Name"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.0.values.#", "1"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.0.values.0", "acceptance_test"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.1.key", "tag:Name2"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.1.values.#", "2"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.1.values.0", "acceptance_test"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.1.values.1", "acceptance_test2"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "name", "TestMaintenanceWindowTarget"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "description", "This resource is for test purpose only"),
+					testAccCheckAWSSSMMaintenanceWindowTargetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.key", "tag:Name"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.values.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.values.0", "acceptance_test"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.key", "tag:Name2"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.values.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.values.0", "acceptance_test"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.values.1", "acceptance_test2"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "This resource is for test purpose only"),
 				),
 			},
 			{
-				Config: testAccAWSSSMMaintenanceWindowTargetBasicConfigUpdated(name),
+				Config: testAccAWSSSMMaintenanceWindowTargetBasicConfigUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMMaintenanceWindowTargetExists("aws_ssm_maintenance_window_target.target"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "owner_information", "something"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.0.key", "tag:Name"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.0.values.#", "1"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.0.values.0", "acceptance_test"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.1.key", "tag:Updated"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.1.values.#", "1"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.1.values.0", "new-value"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "name", "TestMaintenanceWindowTarget"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "description", "This resource is for test purpose only - updated"),
+					testAccCheckAWSSSMMaintenanceWindowTargetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "owner_information", "something"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.key", "tag:Name"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.values.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.values.0", "acceptance_test"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.key", "tag:Updated"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.values.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.values.0", "new-value"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "This resource is for test purpose only - updated"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSSMMaintenanceWindowTarget_resourceGroup(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ssm_maintenance_window_target.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMMaintenanceWindowTargetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMMaintenanceWindowTargetBasicResourceGroupConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowTargetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.key", "resource-groups:ResourceTypeFilters"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.values.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.values.0", "AWS::EC2::INSTANCE"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.values.1", "AWS::EC2::VPC"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.key", "resource-groups:Name"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.values.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.values.0", "resource-group-name"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "This resource is for test purpose only"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type", ssm.MaintenanceWindowResourceTypeResourceGroup),
 				),
 			},
 		},
@@ -193,7 +214,7 @@ func testAccCheckAWSSSMMaintenanceWindowTargetDestroy(s *terraform.State) error 
 
 		if err != nil {
 			// Verify the error is what we want
-			if ae, ok := err.(awserr.Error); ok && ae.Code() == "DoesNotExistException" {
+			if isAWSErr(err, ssm.ErrCodeDoesNotExistException, "") {
 				continue
 			}
 			return err
@@ -211,17 +232,17 @@ func testAccCheckAWSSSMMaintenanceWindowTargetDestroy(s *terraform.State) error 
 
 func testAccAWSSSMMaintenanceWindowTargetBasicConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_ssm_maintenance_window" "foo" {
-  name     = "maintenance-window-%s"
+resource "aws_ssm_maintenance_window" "test" {
+  name     = %[1]q
   schedule = "cron(0 16 ? * TUE *)"
   duration = 3
   cutoff   = 1
 }
 
-resource "aws_ssm_maintenance_window_target" "target" {
-  name          = "TestMaintenanceWindowTarget"
+resource "aws_ssm_maintenance_window_target" "test" {
+  name          = %[1]q
   description   = "This resource is for test purpose only"
-  window_id     = "${aws_ssm_maintenance_window.foo.id}"
+  window_id     = "${aws_ssm_maintenance_window.test.id}"
   resource_type = "INSTANCE"
 
   targets {
@@ -237,17 +258,45 @@ resource "aws_ssm_maintenance_window_target" "target" {
 `, rName)
 }
 
-func testAccAWSSSMMaintenanceWindowTargetNoNameOrDescriptionConfig(rName string) string {
+func testAccAWSSSMMaintenanceWindowTargetBasicResourceGroupConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_ssm_maintenance_window" "foo" {
-  name     = "maintenance-window-%s"
+resource "aws_ssm_maintenance_window" "test" {
+  name     = %[1]q
   schedule = "cron(0 16 ? * TUE *)"
   duration = 3
   cutoff   = 1
 }
 
-resource "aws_ssm_maintenance_window_target" "target" {
-  window_id     = "${aws_ssm_maintenance_window.foo.id}"
+resource "aws_ssm_maintenance_window_target" "test" {
+  name          = %[1]q
+  description   = "This resource is for test purpose only"
+  window_id     = "${aws_ssm_maintenance_window.test.id}"
+  resource_type = "RESOURCE_GROUP"
+
+  targets {
+    key    = "resource-groups:ResourceTypeFilters"
+    values = ["AWS::EC2::INSTANCE","AWS::EC2::VPC"]
+  }
+
+  targets {
+    key    = "resource-groups:Name"
+    values = ["resource-group-name"]
+  }
+}
+`, rName)
+}
+
+func testAccAWSSSMMaintenanceWindowTargetNoNameOrDescriptionConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_maintenance_window" "test" {
+  name     = %[1]q
+  schedule = "cron(0 16 ? * TUE *)"
+  duration = 3
+  cutoff   = 1
+}
+
+resource "aws_ssm_maintenance_window_target" "test" {
+  window_id     = "${aws_ssm_maintenance_window.test.id}"
   resource_type = "INSTANCE"
 
   targets {
@@ -265,17 +314,17 @@ resource "aws_ssm_maintenance_window_target" "target" {
 
 func testAccAWSSSMMaintenanceWindowTargetBasicConfigUpdated(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_ssm_maintenance_window" "foo" {
-  name     = "maintenance-window-%s"
+resource "aws_ssm_maintenance_window" "test" {
+  name     = %[1]q
   schedule = "cron(0 16 ? * TUE *)"
   duration = 3
   cutoff   = 1
 }
 
-resource "aws_ssm_maintenance_window_target" "target" {
-  name              = "TestMaintenanceWindowTarget"
+resource "aws_ssm_maintenance_window_target" "test" {
+  name              = %[1]q
   description       = "This resource is for test purpose only - updated"
-  window_id         = "${aws_ssm_maintenance_window.foo.id}"
+  window_id         = "${aws_ssm_maintenance_window.test.id}"
   resource_type     = "INSTANCE"
   owner_information = "something"
 
@@ -294,17 +343,17 @@ resource "aws_ssm_maintenance_window_target" "target" {
 
 func testAccAWSSSMMaintenanceWindowTargetBasicConfigWithTarget(rName, tName, tDesc string) string {
 	return fmt.Sprintf(`
-resource "aws_ssm_maintenance_window" "foo" {
-  name     = "maintenance-window-%s"
+resource "aws_ssm_maintenance_window" "test" {
+  name     = %[1]q
   schedule = "cron(0 16 ? * TUE *)"
   duration = 3
   cutoff   = 1
 }
 
-resource "aws_ssm_maintenance_window_target" "target" {
-  name              = "%s"
-  description       = "%s"
-  window_id         = "${aws_ssm_maintenance_window.foo.id}"
+resource "aws_ssm_maintenance_window_target" "test" {
+  name              = %[2]q
+  description       = %[3]q
+  window_id         = "${aws_ssm_maintenance_window.test.id}"
   resource_type     = "INSTANCE"
   owner_information = "something"
 

--- a/website/docs/r/ssm_maintenance_window_target.html.markdown
+++ b/website/docs/r/ssm_maintenance_window_target.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides an SSM Maintenance Window Target resource
 
-## Example Usage
+## Instance Target Example Usage
 
 ```hcl
 resource "aws_ssm_maintenance_window" "window" {
@@ -29,6 +29,29 @@ resource "aws_ssm_maintenance_window_target" "target1" {
   targets {
     key    = "tag:Name"
     values = ["acceptance_test"]
+  }
+}
+```
+
+## Resource Group Target Example Usage
+
+```hcl
+resource "aws_ssm_maintenance_window" "window" {
+  name     = "maintenance-window-webapp"
+  schedule = "cron(0 16 ? * TUE *)"
+  duration = 3
+  cutoff   = 1
+}
+
+resource "aws_ssm_maintenance_window_target" "target1" {
+  window_id     = "${aws_ssm_maintenance_window.window.id}"
+  name          = "maintenance-window-target"
+  description   = "This is a maintenance window target"
+  resource_type = "RESOURCE_GROUP"
+
+  targets {
+    key    = "resource-groups:ResourceTypeFilters"
+    values = ["AWS::EC2::INSTANCE","AWS::EC2::VPC"]
   }
 }
 ```

--- a/website/docs/r/ssm_maintenance_window_target.html.markdown
+++ b/website/docs/r/ssm_maintenance_window_target.html.markdown
@@ -40,8 +40,9 @@ The following arguments are supported:
 * `window_id` - (Required) The Id of the maintenance window to register the target with.
 * `name` - (Optional) The name of the maintenance window target.
 * `description` - (Optional) The description of the maintenance window target.
-* `resource_type` - (Required) The type of target being registered with the Maintenance Window. Possible values `INSTANCE`.
-* `targets` - (Required) The targets (either instances or tags). Instances are specified using Key=InstanceIds,Values=InstanceId1,InstanceId2. Tags are specified using Key=tag name,Values=tag value.
+* `resource_type` - (Required) The type of target being registered with the Maintenance Window. Possible values are `INSTANCE` and `RESOURCE_GROUP`.
+* `targets` - (Required) The targets to register with the maintenance window. In other words, the instances to run commands on when the maintenance window runs. You can specify targets using instance IDs, resource group names, or tags that have been applied to instances. For more information about these examples formats see
+ (https://docs.aws.amazon.com/systems-manager/latest/userguide/mw-cli-tutorial-targets-examples.html)
 * `owner_information` - (Optional) User-provided value that will be included in any CloudWatch events raised while running tasks for these targets in this Maintenance Window.
 
 ## Attributes Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_ssm_maintanance_window_target: add plan time validation to `resource_type`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSSMMaintenanceWindowTarget_'
--- PASS: TestAccAWSSSMMaintenanceWindowTarget_disappears (38.93s)
--- PASS: TestAccAWSSSMMaintenanceWindowTarget_resourceGroup (40.89s)
--- PASS: TestAccAWSSSMMaintenanceWindowTarget_update (67.45s)
--- PASS: TestAccAWSSSMMaintenanceWindowTarget_validation (3.80s)
--- PASS: TestAccAWSSSMMaintenanceWindowTarget_noNameOrDescription (42.38s)
--- PASS: TestAccAWSSSMMaintenanceWindowTarget_basic (39.44s)
```
