### PR TITLE
resource/aws_rds_global_database: Allow Aurora MySQL 5.7 as a Global Database Engine

### DIFF
--- a/aws/resource_aws_rds_global_cluster.go
+++ b/aws/resource_aws_rds_global_cluster.go
@@ -44,6 +44,7 @@ func resourceAwsRDSGlobalCluster() *schema.Resource {
 				Default:  "aurora",
 				ValidateFunc: validation.StringInSlice([]string{
 					"aurora",
+					"aurora-mysql",
 				}, false),
 			},
 			"engine_version": {

--- a/aws/resource_aws_rds_global_cluster_test.go
+++ b/aws/resource_aws_rds_global_cluster_test.go
@@ -244,6 +244,32 @@ func TestAccAWSRdsGlobalCluster_EngineVersion_Aurora(t *testing.T) {
 	})
 }
 
+func TestAccAWSRdsGlobalCluster_EngineVersion_AuroraMySQL(t *testing.T) {
+	var globalCluster1 rds.GlobalCluster
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_rds_global_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsGlobalCluster(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRdsGlobalClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRdsGlobalClusterConfigEngineVersion(rName, "aurora-mysql", "5.7.mysql_aurora.2.07.1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRdsGlobalClusterExists(resourceName, &globalCluster1),
+					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.7.mysql_aurora.2.07.1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSRdsGlobalCluster_StorageEncrypted(t *testing.T) {
 	var globalCluster1, globalCluster2 rds.GlobalCluster
 	rName := acctest.RandomWithPrefix("tf-acc-test")

--- a/website/docs/r/rds_global_cluster.html.markdown
+++ b/website/docs/r/rds_global_cluster.html.markdown
@@ -12,8 +12,6 @@ Manages a RDS Global Cluster, which is an Aurora global database spread across m
 
 More information about Aurora global databases can be found in the [Aurora User Guide](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-global-database.html#aurora-global-database-creating).
 
-~> **NOTE:** RDS only supports the `aurora` engine (MySQL 5.6 compatible) for Global Clusters at this time.
-
 ## Example Usage
 
 ```hcl
@@ -69,11 +67,12 @@ resource "aws_rds_cluster_instance" "secondary" {
 
 The following arguments are supported:
 
-*  `global_cluster_identifier` - (Required, Forces new resources) The global cluster identifier.
+* `global_cluster_identifier` - (Required, Forces new resources) The global cluster identifier.
 * `database_name` - (Optional, Forces new resources) Name for an automatically created database on cluster creation.
 * `deletion_protection` - (Optional) If the Global Cluster should have deletion protection enabled. The database can't be deleted when this value is set to `true`. The default is `false`.
-* `engine` - (Optional, Forces new resources) Name of the database engine to be used for this DB cluster. Valid values: `aurora`. Defaults to `aurora`.
+* `engine` - (Optional, Forces new resources) Name of the database engine to be used for this DB cluster. Valid values: `aurora`, `aurora-mysql`. Defaults to `aurora`.
 * `engine_version` - (Optional, Forces new resources) Engine version of the Aurora global database.
+  * **NOTE:** When the engine is set to `aurora-mysql`, an engine version compatible with global database is required. The earliest available version is `5.7.mysql_aurora.2.06.0`.
 * `storage_encrypted` - (Optional, Forces new resources) Specifies whether the DB cluster is encrypted. The default is `false`.
 
 ## Attribute Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11453

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_rds_global_database: allow `aurora-mysql` to be used for the engine
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSRdsGlobalCluster_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSRdsGlobalCluster_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSRdsGlobalCluster_basic
=== PAUSE TestAccAWSRdsGlobalCluster_basic
=== RUN   TestAccAWSRdsGlobalCluster_disappears
=== PAUSE TestAccAWSRdsGlobalCluster_disappears
=== RUN   TestAccAWSRdsGlobalCluster_DatabaseName
=== PAUSE TestAccAWSRdsGlobalCluster_DatabaseName
=== RUN   TestAccAWSRdsGlobalCluster_DeletionProtection
=== PAUSE TestAccAWSRdsGlobalCluster_DeletionProtection
=== RUN   TestAccAWSRdsGlobalCluster_Engine_Aurora
=== PAUSE TestAccAWSRdsGlobalCluster_Engine_Aurora
=== RUN   TestAccAWSRdsGlobalCluster_EngineVersion_Aurora
=== PAUSE TestAccAWSRdsGlobalCluster_EngineVersion_Aurora
=== RUN   TestAccAWSRdsGlobalCluster_EngineVersion_AuroraMySQL
=== PAUSE TestAccAWSRdsGlobalCluster_EngineVersion_AuroraMySQL
=== RUN   TestAccAWSRdsGlobalCluster_StorageEncrypted
=== PAUSE TestAccAWSRdsGlobalCluster_StorageEncrypted
=== CONT  TestAccAWSRdsGlobalCluster_basic
=== CONT  TestAccAWSRdsGlobalCluster_EngineVersion_Aurora
=== CONT  TestAccAWSRdsGlobalCluster_DeletionProtection
=== CONT  TestAccAWSRdsGlobalCluster_Engine_Aurora
=== CONT  TestAccAWSRdsGlobalCluster_EngineVersion_AuroraMySQL
=== CONT  TestAccAWSRdsGlobalCluster_StorageEncrypted
=== CONT  TestAccAWSRdsGlobalCluster_DatabaseName
=== CONT  TestAccAWSRdsGlobalCluster_disappears
--- PASS: TestAccAWSRdsGlobalCluster_disappears (14.57s)
--- PASS: TestAccAWSRdsGlobalCluster_EngineVersion_Aurora (17.83s)
--- PASS: TestAccAWSRdsGlobalCluster_EngineVersion_AuroraMySQL (17.91s)
--- PASS: TestAccAWSRdsGlobalCluster_basic (18.01s)
--- PASS: TestAccAWSRdsGlobalCluster_Engine_Aurora (18.39s)
--- PASS: TestAccAWSRdsGlobalCluster_DeletionProtection (28.66s)
--- PASS: TestAccAWSRdsGlobalCluster_StorageEncrypted (30.44s)
--- PASS: TestAccAWSRdsGlobalCluster_DatabaseName (30.55s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	30.609s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.007s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.014s [no tests to run]
```
