### PR TITLE
resource/aws_s3_bucket: Retry on PutBucketEncryption 409 Errors

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -1782,9 +1782,25 @@ func resourceAwsS3BucketServerSideEncryptionConfigurationUpdate(s3conn *s3.S3, d
 	}
 	log.Printf("[DEBUG] S3 put bucket replication configuration: %#v", i)
 
-	_, err := retryOnAwsCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
-		return s3conn.PutBucketEncryption(i)
+	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+		var err error
+		_, err = s3conn.PutBucketEncryption(i)
+
+		if isAWSErr(err, s3.ErrCodeNoSuchBucket, "") ||
+			(d.IsNewResource() && isAWSErr(err, "OperationAborted", "")) {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
 	})
+	if isResourceTimeoutError(err) {
+		_, err = s3conn.PutBucketEncryption(i)
+	}
+
 	if err != nil {
 		return fmt.Errorf("error putting S3 server side encryption configuration: %s", err)
 	}


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #11789

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
* resource/aws_s3_bucket: Retry on PutBucketEncryption 409 errors due to eventual consistency ([#11789](https://github.com/terraform-providers/terraform-provider-aws/issues/11789))
```

The AWS S3 service has eventual consistency considerations. If a PutBucketEncryption call is made to AWS to apply server side encryption configuration just after an S3 bucket is first created, AWS may return an HTTP 409 (Conflict) error with an `OperationAborted` error code.

Calls to the PutBucketEncryption API are already retried for up to 2 minutes in the event that AWS returns a `NoSuchBucket` error.  With the changes in this commit, PutBucketEncryption calls would additionally be retried within the 2 minute limit for any `OperationAborted` errors.

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSS3Bucket_'
...
--- PASS: TestAccAWSS3Bucket_shouldFailNotFound (19.30s)
--- PASS: TestAccAWSS3Bucket_forceDestroyWithEmptyPrefixes (25.24s)
--- PASS: TestAccAWSS3Bucket_forceDestroy (26.90s)
--- PASS: TestAccAWSS3Bucket_forceDestroyWithObjectLockEnabled (27.81s)
--- PASS: TestAccAWSS3Bucket_basic (30.60s)
--- PASS: TestAccAWSS3Bucket_Cors_Delete (30.88s)
--- PASS: TestAccAWSS3Bucket_Cors_EmptyOrigin (30.98s)
--- PASS: TestAccAWSS3Bucket_Logging (38.10s)
--- PASS: TestAccAWSS3Bucket_LifecycleBasic (65.19s)
--- PASS: TestAccAWSS3Bucket_objectLock (46.23s)
--- PASS: TestAccAWSS3Bucket_LifecycleExpireMarkerOnly (46.72s)
--- PASS: TestAccAWSS3Bucket_Cors_Update (47.07s)
--- PASS: TestAccAWSS3Bucket_generatedName (26.43s)
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical (54.26s)
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed (27.75s)
--- PASS: TestAccAWSS3Bucket_Versioning (63.99s)
--- PASS: TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled (45.61s)
--- PASS: TestAccAWSS3Bucket_Policy (65.74s)
--- PASS: TestAccAWSS3Bucket_namePrefix (27.11s)
--- PASS: TestAccAWSS3Bucket_WebsiteRoutingRules (45.35s)
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutStorageClass (75.75s)
--- PASS: TestAccAWSS3Bucket_RequestPayer (46.16s)
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutPrefix (77.93s)
--- PASS: TestAccAWSS3Bucket_acceleration (48.22s)
--- PASS: TestAccAWSS3Bucket_Bucket_EmptyString (27.29s)
--- PASS: TestAccAWSS3Bucket_WebsiteRedirect (63.41s)
--- PASS: TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError (43.06s)
--- PASS: TestAccAWSS3Bucket_UpdateAcl (44.57s)
--- PASS: TestAccAWSS3Bucket_Website_Simple (63.58s)
--- PASS: TestAccAWSS3Bucket_region (55.40s)
--- PASS: TestAccAWSS3Bucket_tagsWithNoSystemTags (81.89s)
--- PASS: TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation (157.61s)
--- PASS: TestAccAWSS3Bucket_tagsWithSystemTags (129.33s)
--- PASS: TestAccAWSS3Bucket_ReplicationSchemaV2 (226.86s)
--- PASS: TestAccAWSS3Bucket_Replication (251.12s)
```