### PR TITLE
resource/aws_appautoscaling_target: Prevent state removal at creation

### DIFF
--- a/aws/resource_aws_appautoscaling_target.go
+++ b/aws/resource_aws_appautoscaling_target.go
@@ -102,11 +102,28 @@ func resourceAwsAppautoscalingTargetPut(d *schema.ResourceData, meta interface{}
 }
 
 func resourceAwsAppautoscalingTargetRead(d *schema.ResourceData, meta interface{}) error {
+	var t *applicationautoscaling.ScalableTarget
+
 	conn := meta.(*AWSClient).appautoscalingconn
 
 	namespace := d.Get("service_namespace").(string)
 	dimension := d.Get("scalable_dimension").(string)
-	t, err := getAwsAppautoscalingTarget(d.Id(), namespace, dimension, conn)
+
+	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+		var err error
+		t, err = getAwsAppautoscalingTarget(d.Id(), namespace, dimension, conn)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		if d.IsNewResource() && t == nil {
+			return resource.RetryableError(&resource.NotFoundError{})
+		}
+		return nil
+	})
+	if isResourceTimeoutError(err) {
+		t, err = getAwsAppautoscalingTarget(d.Id(), namespace, dimension, conn)
+	}
+
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #11811

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_appautoscaling_target: Prevent state removal of resource immediately after creation due to eventual consistency ([#10549](https://github.com/terraform-providers/terraform-provider-aws/issues/11811))
```

The AWS application-autoscaling service has eventual consistency considerations. The `aws_appautoscaling_target` resource immediately tries to read a scaling target after creation. If the target is not found, the application-autoscaling service returns a 200 OK with an empty list of scaling targets. Since no scaling target is present, the `aws_appautoscaling_target` resource removes the created resource from state, leading to a "produced an unexpected new value for was present,
but now absent" error.

With the changes in this commit, the empty list of scaling targets in the response for the newly created resource will result in a NotFoundError being returned and a retry of the read request. A subsequent retry should hopefully be successful, leading to the state being preserved.

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAppautoScalingTarget_'
...
--- PASS: TestAccAWSAppautoScalingTarget_multipleTargets (30.77s)
--- PASS: TestAccAWSAppautoScalingTarget_optionalRoleArn (32.50s)
--- PASS: TestAccAWSAppautoScalingTarget_spotFleetRequest (77.50s)
--- PASS: TestAccAWSAppautoScalingTarget_basic (107.66s)
--- PASS: TestAccAWSAppautoScalingTarget_emrCluster (783.20s)
```