### PR TITLE
r/aws_workspaces_directory: Fix panic if previously registered directory is no longer registered

### DIFF
--- a/aws/resource_aws_workspaces_directory_test.go
+++ b/aws/resource_aws_workspaces_directory_test.go
@@ -54,8 +54,9 @@ func testSweepWorkspacesDirectories(region string) error {
 // These tests need to be serialized, because they all rely on the IAM Role `workspaces_DefaultRole`.
 func TestAccAwsWorkspacesDirectory(t *testing.T) {
 	testCases := map[string]func(t *testing.T){
-		"basic":     testAccAwsWorkspacesDirectory_basic,
-		"subnetIds": testAccAwsWorkspacesDirectory_subnetIds,
+		"basic":      testAccAwsWorkspacesDirectory_basic,
+		"disappears": testAccAwsWorkspacesDirectory_disappears,
+		"subnetIds":  testAccAwsWorkspacesDirectory_subnetIds,
 	}
 	for name, tc := range testCases {
 		tc := tc
@@ -66,6 +67,7 @@ func TestAccAwsWorkspacesDirectory(t *testing.T) {
 }
 
 func testAccAwsWorkspacesDirectory_basic(t *testing.T) {
+	var v workspaces.WorkspaceDirectory
 	booster := acctest.RandString(8)
 	resourceName := "aws_workspaces_directory.main"
 
@@ -77,7 +79,7 @@ func testAccAwsWorkspacesDirectory_basic(t *testing.T) {
 			{
 				Config: testAccWorkspacesDirectoryConfigA(booster),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAwsWorkspacesDirectoryExists(resourceName),
+					testAccCheckAwsWorkspacesDirectoryExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "self_service_permissions.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "self_service_permissions.0.change_compute_type", "false"),
@@ -94,7 +96,7 @@ func testAccAwsWorkspacesDirectory_basic(t *testing.T) {
 			{
 				Config: testAccWorkspacesDirectoryConfigB(booster),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAwsWorkspacesDirectoryExists(resourceName),
+					testAccCheckAwsWorkspacesDirectoryExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "self_service_permissions.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "self_service_permissions.0.change_compute_type", "false"),
 					resource.TestCheckResourceAttr(resourceName, "self_service_permissions.0.increase_volume_size", "true"),
@@ -109,7 +111,7 @@ func testAccAwsWorkspacesDirectory_basic(t *testing.T) {
 			{
 				Config: testAccWorkspacesDirectoryConfigC(booster),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAwsWorkspacesDirectoryExists(resourceName),
+					testAccCheckAwsWorkspacesDirectoryExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "self_service_permissions.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "self_service_permissions.0.change_compute_type", "true"),
 					resource.TestCheckResourceAttr(resourceName, "self_service_permissions.0.increase_volume_size", "false"),
@@ -128,7 +130,30 @@ func testAccAwsWorkspacesDirectory_basic(t *testing.T) {
 	})
 }
 
+func testAccAwsWorkspacesDirectory_disappears(t *testing.T) {
+	var v workspaces.WorkspaceDirectory
+	booster := acctest.RandString(8)
+	resourceName := "aws_workspaces_directory.main"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsWorkspacesDirectoryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkspacesDirectoryConfigA(booster),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAwsWorkspacesDirectoryExists(resourceName, &v),
+					testAccCheckAwsWorkspacesDirectoryDisappears(&v),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccAwsWorkspacesDirectory_subnetIds(t *testing.T) {
+	var v workspaces.WorkspaceDirectory
 	booster := acctest.RandString(8)
 	resourceName := "aws_workspaces_directory.main"
 
@@ -140,7 +165,7 @@ func testAccAwsWorkspacesDirectory_subnetIds(t *testing.T) {
 			{
 				Config: testAccWorkspacesDirectoryConfig_subnetIds(booster),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsWorkspacesDirectoryExists(resourceName),
+					testAccCheckAwsWorkspacesDirectoryExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "2"),
 				),
 			},
@@ -181,7 +206,13 @@ func testAccCheckAwsWorkspacesDirectoryDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAwsWorkspacesDirectoryExists(n string) resource.TestCheckFunc {
+func testAccCheckAwsWorkspacesDirectoryDisappears(v *workspaces.WorkspaceDirectory) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		return workspacesDirectoryDelete(aws.StringValue(v.DirectoryId), testAccProvider.Meta().(*AWSClient).workspacesconn)
+	}
+}
+
+func testAccCheckAwsWorkspacesDirectoryExists(n string, v *workspaces.WorkspaceDirectory) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -201,6 +232,8 @@ func testAccCheckAwsWorkspacesDirectoryExists(n string) resource.TestCheckFunc {
 		}
 
 		if *resp.Directories[0].DirectoryId == rs.Primary.ID {
+			*v = *resp.Directories[0]
+
 			return nil
 		}
 
@@ -310,7 +343,7 @@ locals {
      Name = "tf-testacc-workspaces-directory-%s"
    }
  }
- 
+
  resource "aws_subnet" "primary" {
    vpc_id = "${aws_vpc.main.id}"
    availability_zone_id = "${local.workspaces_az_ids[0]}"
@@ -320,7 +353,7 @@ locals {
      Name = "tf-testacc-workspaces-directory-%s-primary"
    }
  }
- 
+
  resource "aws_subnet" "secondary" {
    vpc_id = "${aws_vpc.main.id}"
    availability_zone_id = "${local.workspaces_az_ids[1]}"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/11814.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_workspaces_directory: Fix panic if previously registered directory is no longer registered
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAwsWorkspacesDirectory'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAwsWorkspacesDirectory -timeout 120m
=== RUN   TestAccAwsWorkspacesDirectory
=== RUN   TestAccAwsWorkspacesDirectory/basic
=== RUN   TestAccAwsWorkspacesDirectory/disappears
=== RUN   TestAccAwsWorkspacesDirectory/subnetIds
--- PASS: TestAccAwsWorkspacesDirectory (2056.41s)
    --- PASS: TestAccAwsWorkspacesDirectory/basic (662.88s)
    --- PASS: TestAccAwsWorkspacesDirectory/disappears (784.63s)
    --- PASS: TestAccAwsWorkspacesDirectory/subnetIds (608.90s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2056.456s
```
