### PR TITLE
tests/provider: Add markdownlint to website-lint target

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,39 @@
+# Configuration for markdownlint
+# https://github.com/DavidAnson/markdownlint#configuration
+
+default: true
+
+# Disabled Rules
+# https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md
+
+# Breaking rules (higher priority to fix)
+
+# Example: https://www.terraform.io/docs/providers/aws/r/ssm_patch_baseline.html
+MD031: false
+# Example: https://www.terraform.io/docs/providers/aws/d/ebs_default_kms_key.html
+MD032: false
+
+# Stylistic rules
+
+MD001: false
+MD003: false
+MD004: false
+MD006: false
+MD007: false
+MD009: false
+MD010: false
+MD012: false
+MD013: false
+MD014: false
+MD018: false
+MD019: false
+MD022: false
+MD024: false
+MD026: false
+MD030: false
+MD033: false
+MD034: false
+MD038: false
+MD040: false
+MD046: false
+MD047: false

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -99,6 +99,7 @@ endif
 website-lint:
 	@echo "==> Checking website against linters..."
 	@misspell -error -source=text website/
+	@docker run -v $(PWD):/markdown 06kellyjac/markdownlint-cli website/docs/
 
 website-test:
 ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://www.terraform.io/docs/providers/aws/d/ebs_default_kms_key.html
Reference: https://www.terraform.io/docs/providers/aws/r/ssm_patch_baseline.html
Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/11825

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Disables all failing rules to start. MD031 and MD032 should be fixed and enabled shortly as they can cause formatting failures in terraform.io documentation.

Breakdown of all these disabled rules:

```console
$ docker run -v $(pwd):/markdown 06kellyjac/markdownlint-cli website/docs/ |& cut -d ' ' -f 2 | cut -d '/' -f 1 | sort | uniq -c
  10 MD001
   1 MD003
 246 MD004
 223 MD006
 263 MD007
  70 MD009
 243 MD010
 147 MD012
4968 MD013
 447 MD014
   1 MD018
   1 MD019
  51 MD022
   9 MD024
   8 MD026
   2 MD030
  20 MD031
  20 MD032
   7 MD033
  31 MD034
  10 MD038
 418 MD040
   2 MD046
  10 MD047
```
