### PR TITLE
r/mq_configuration - add import tests + remove call to list tags

### DIFF
--- a/aws/resource_aws_mq_configuration.go
+++ b/aws/resource_aws_mq_configuration.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/mq"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
@@ -53,6 +54,9 @@ func resourceAwsMqConfiguration() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					mq.EngineTypeActivemq,
+				}, true),
 			},
 			"engine_version": {
 				Type:     schema.TypeString,
@@ -106,7 +110,7 @@ func resourceAwsMqConfigurationRead(d *schema.ResourceData, meta interface{}) er
 		ConfigurationId: aws.String(d.Id()),
 	})
 	if err != nil {
-		if isAWSErr(err, "NotFoundException", "") {
+		if isAWSErr(err, mq.ErrCodeNotFoundException, "") {
 			log.Printf("[WARN] MQ Configuration %q not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
@@ -136,11 +140,7 @@ func resourceAwsMqConfigurationRead(d *schema.ResourceData, meta interface{}) er
 
 	d.Set("data", string(b))
 
-	tags, err := keyvaluetags.MqListTags(conn, aws.StringValue(out.Arn))
-	if err != nil {
-		return fmt.Errorf("error listing tags for MQ Configuration (%s): %s", d.Id(), err)
-	}
-	if err := d.Set("tags", tags.IgnoreAws().Map()); err != nil {
+	if err := d.Set("tags", keyvaluetags.MqKeyValueTags(out.Tags).IgnoreAws().Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 

--- a/aws/resource_aws_mq_configuration_test.go
+++ b/aws/resource_aws_mq_configuration_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -13,6 +14,7 @@ import (
 
 func TestAccAWSMqConfiguration_basic(t *testing.T) {
 	configurationName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "aws_mq_configuration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
@@ -22,25 +24,30 @@ func TestAccAWSMqConfiguration_basic(t *testing.T) {
 			{
 				Config: testAccMqConfigurationConfig(configurationName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsMqConfigurationExists("aws_mq_configuration.test"),
-					resource.TestCheckResourceAttrSet("aws_mq_configuration.test", "arn"),
-					resource.TestCheckResourceAttr("aws_mq_configuration.test", "description", "TfAccTest MQ Configuration"),
-					resource.TestCheckResourceAttr("aws_mq_configuration.test", "engine_type", "ActiveMQ"),
-					resource.TestCheckResourceAttr("aws_mq_configuration.test", "engine_version", "5.15.0"),
-					resource.TestCheckResourceAttr("aws_mq_configuration.test", "latest_revision", "2"),
-					resource.TestCheckResourceAttr("aws_mq_configuration.test", "name", configurationName),
+					testAccCheckAwsMqConfigurationExists(resourceName),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "mq", regexp.MustCompile(`configuration:+.`)),
+					resource.TestCheckResourceAttr(resourceName, "description", "TfAccTest MQ Configuration"),
+					resource.TestCheckResourceAttr(resourceName, "engine_type", "ActiveMQ"),
+					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.15.0"),
+					resource.TestCheckResourceAttr(resourceName, "latest_revision", "2"),
+					resource.TestCheckResourceAttr(resourceName, "name", configurationName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccMqConfigurationConfig_descriptionUpdated(configurationName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsMqConfigurationExists("aws_mq_configuration.test"),
-					resource.TestCheckResourceAttrSet("aws_mq_configuration.test", "arn"),
-					resource.TestCheckResourceAttr("aws_mq_configuration.test", "description", "TfAccTest MQ Configuration Updated"),
-					resource.TestCheckResourceAttr("aws_mq_configuration.test", "engine_type", "ActiveMQ"),
-					resource.TestCheckResourceAttr("aws_mq_configuration.test", "engine_version", "5.15.0"),
-					resource.TestCheckResourceAttr("aws_mq_configuration.test", "latest_revision", "3"),
-					resource.TestCheckResourceAttr("aws_mq_configuration.test", "name", configurationName),
+					testAccCheckAwsMqConfigurationExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "description", "TfAccTest MQ Configuration Updated"),
+					resource.TestCheckResourceAttr(resourceName, "engine_type", "ActiveMQ"),
+					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.15.0"),
+					resource.TestCheckResourceAttr(resourceName, "latest_revision", "3"),
+					resource.TestCheckResourceAttr(resourceName, "name", configurationName),
 				),
 			},
 		},
@@ -49,6 +56,7 @@ func TestAccAWSMqConfiguration_basic(t *testing.T) {
 
 func TestAccAWSMqConfiguration_withData(t *testing.T) {
 	configurationName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "aws_mq_configuration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
@@ -58,14 +66,19 @@ func TestAccAWSMqConfiguration_withData(t *testing.T) {
 			{
 				Config: testAccMqConfigurationWithDataConfig(configurationName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsMqConfigurationExists("aws_mq_configuration.test"),
-					resource.TestCheckResourceAttrSet("aws_mq_configuration.test", "arn"),
-					resource.TestCheckResourceAttr("aws_mq_configuration.test", "description", "TfAccTest MQ Configuration"),
-					resource.TestCheckResourceAttr("aws_mq_configuration.test", "engine_type", "ActiveMQ"),
-					resource.TestCheckResourceAttr("aws_mq_configuration.test", "engine_version", "5.15.0"),
-					resource.TestCheckResourceAttr("aws_mq_configuration.test", "latest_revision", "2"),
-					resource.TestCheckResourceAttr("aws_mq_configuration.test", "name", configurationName),
+					testAccCheckAwsMqConfigurationExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "description", "TfAccTest MQ Configuration"),
+					resource.TestCheckResourceAttr(resourceName, "engine_type", "ActiveMQ"),
+					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.15.0"),
+					resource.TestCheckResourceAttr(resourceName, "latest_revision", "2"),
+					resource.TestCheckResourceAttr(resourceName, "name", configurationName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -73,6 +86,7 @@ func TestAccAWSMqConfiguration_withData(t *testing.T) {
 
 func TestAccAWSMqConfiguration_updateTags(t *testing.T) {
 	configurationName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "aws_mq_configuration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
@@ -82,26 +96,31 @@ func TestAccAWSMqConfiguration_updateTags(t *testing.T) {
 			{
 				Config: testAccMqConfigurationConfig_updateTags1(configurationName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsMqConfigurationExists("aws_mq_configuration.test"),
-					resource.TestCheckResourceAttr("aws_mq_configuration.test", "tags.%", "1"),
-					resource.TestCheckResourceAttr("aws_mq_configuration.test", "tags.env", "test"),
+					testAccCheckAwsMqConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.env", "test"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccMqConfigurationConfig_updateTags2(configurationName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsMqConfigurationExists("aws_mq_configuration.test"),
-					resource.TestCheckResourceAttr("aws_mq_configuration.test", "tags.%", "2"),
-					resource.TestCheckResourceAttr("aws_mq_configuration.test", "tags.env", "test2"),
-					resource.TestCheckResourceAttr("aws_mq_configuration.test", "tags.role", "test-role"),
+					testAccCheckAwsMqConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.env", "test2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.role", "test-role"),
 				),
 			},
 			{
 				Config: testAccMqConfigurationConfig_updateTags3(configurationName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsMqConfigurationExists("aws_mq_configuration.test"),
-					resource.TestCheckResourceAttr("aws_mq_configuration.test", "tags.%", "1"),
-					resource.TestCheckResourceAttr("aws_mq_configuration.test", "tags.role", "test-role"),
+					testAccCheckAwsMqConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.role", "test-role"),
 				),
 			},
 		},
@@ -122,7 +141,7 @@ func testAccCheckAwsMqConfigurationDestroy(s *terraform.State) error {
 
 		_, err := conn.DescribeConfiguration(input)
 		if err != nil {
-			if isAWSErr(err, "NotFoundException", "") {
+			if isAWSErr(err, mq.ErrCodeNotFoundException, "") {
 				return nil
 			}
 			return err

--- a/aws/resource_aws_mq_configuration_test.go
+++ b/aws/resource_aws_mq_configuration_test.go
@@ -42,7 +42,7 @@ func TestAccAWSMqConfiguration_basic(t *testing.T) {
 				Config: testAccMqConfigurationConfig_descriptionUpdated(configurationName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqConfigurationExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "mq", regexp.MustCompile(`configuration:+.`)),
 					resource.TestCheckResourceAttr(resourceName, "description", "TfAccTest MQ Configuration Updated"),
 					resource.TestCheckResourceAttr(resourceName, "engine_type", "ActiveMQ"),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.15.0"),
@@ -67,7 +67,7 @@ func TestAccAWSMqConfiguration_withData(t *testing.T) {
 				Config: testAccMqConfigurationWithDataConfig(configurationName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMqConfigurationExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "mq", regexp.MustCompile(`configuration:+.`)),
 					resource.TestCheckResourceAttr(resourceName, "description", "TfAccTest MQ Configuration"),
 					resource.TestCheckResourceAttr(resourceName, "engine_type", "ActiveMQ"),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.15.0"),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_mq_configuration: add plan time validation to `engine_type`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSMqConfiguration_'
--- PASS: TestAccAWSMqConfiguration_basic (66.84s)
--- PASS: TestAccAWSMqConfiguration_withData (41.95s)
--- PASS: TestAccAWSMqConfiguration_updateTags (97.18s)
```
