### PR TITLE
r/aws_backup_vault: remove from state if manually deleted

### DIFF
--- a/aws/resource_aws_backup_vault.go
+++ b/aws/resource_aws_backup_vault.go
@@ -84,6 +84,12 @@ func resourceAwsBackupVaultRead(d *schema.ResourceData, meta interface{}) error 
 		d.SetId("")
 		return nil
 	}
+	if isAWSErr(err, "AccessDeniedException", "") {
+		log.Printf("[WARN] Backup Vault %s not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
 		return fmt.Errorf("error reading Backup Vault (%s): %s", d.Id(), err)
 	}

--- a/aws/resource_aws_backup_vault_test.go
+++ b/aws/resource_aws_backup_vault_test.go
@@ -110,6 +110,28 @@ func TestAccAwsBackupVault_withTags(t *testing.T) {
 	})
 }
 
+func TestAccAwsBackupVault_disappears(t *testing.T) {
+	var vault backup.DescribeBackupVaultOutput
+
+	rInt := acctest.RandInt()
+	resourceName := "aws_backup_vault.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsBackupVaultDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBackupVaultConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBackupVaultExists(resourceName, &vault),
+					testAccCheckAwsBackupVaultDisappears(&vault),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAwsBackupVaultDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).backupconn
 	for _, rs := range s.RootModule().Resources {
@@ -152,6 +174,18 @@ func testAccCheckAwsBackupVaultExists(name string, vault *backup.DescribeBackupV
 		*vault = *resp
 
 		return nil
+	}
+}
+
+func testAccCheckAwsBackupVaultDisappears(vault *backup.DescribeBackupVaultOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).backupconn
+		params := &backup.DeleteBackupVaultInput{
+			BackupVaultName: vault.BackupVaultName,
+		}
+		_, err := conn.DeleteBackupVault(params)
+
+		return err
 	}
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11840

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_backup_vault: remove from state if deleted
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
--- PASS: TestAccAwsBackupVault_disappears (58.47s)
```
