### PR TITLE
docs/provider: Fix markdownlint MD031 failures and enable rule

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -8,8 +8,6 @@ default: true
 
 # Breaking rules (higher priority to fix)
 
-# Example: https://www.terraform.io/docs/providers/aws/r/ssm_patch_baseline.html
-MD031: false
 # Example: https://www.terraform.io/docs/providers/aws/d/ebs_default_kms_key.html
 MD032: false
 

--- a/website/docs/d/cloudhsm_v2_cluster.html.markdown
+++ b/website/docs/d/cloudhsm_v2_cluster.html.markdown
@@ -17,6 +17,7 @@ data "aws_cloudhsm_v2_cluster" "cluster" {
   cluster_id = "cluster-testclusterid"
 }
 ```
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/website/docs/d/ebs_default_kms_key.html.markdown
+++ b/website/docs/d/ebs_default_kms_key.html.markdown
@@ -10,6 +10,7 @@ description: |-
 Use this data source to get the default EBS encryption KMS key in the current region.
 
 ## Example Usage
+
 ```hcl
 data "aws_ebs_default_kms_key" "current" { }
 

--- a/website/docs/d/ram_resource_share.html.markdown
+++ b/website/docs/d/ram_resource_share.html.markdown
@@ -11,6 +11,7 @@ description: |-
 `aws_ram_resource_share` Retrieve information about a RAM Resource Share.
 
 ## Example Usage
+
 ```hcl
 data "aws_ram_resource_share" "example" {
   name = "example"
@@ -19,6 +20,7 @@ data "aws_ram_resource_share" "example" {
 ```
 
 ## Search by filters
+
 ```hcl
 data "aws_ram_resource_share" "tag_filter" {
   name           = "MyResourceName"

--- a/website/docs/d/security_groups.html.markdown
+++ b/website/docs/d/security_groups.html.markdown
@@ -12,6 +12,7 @@ Use this data source to get IDs and VPC membership of Security Groups that are c
 outside of Terraform.
 
 ## Example Usage
+
 ```hcl
 data "aws_security_groups" "test" {
   tags = {

--- a/website/docs/d/ssm_document.html.markdown
+++ b/website/docs/d/ssm_document.html.markdown
@@ -24,6 +24,7 @@ output "content" {
   value = "${data.aws_ssm_document.foo.content}"
 }
 ```
+
 To get the contents of the custom document.
 
 ```hcl

--- a/website/docs/r/api_gateway_method.html.markdown
+++ b/website/docs/r/api_gateway_method.html.markdown
@@ -33,6 +33,7 @@ resource "aws_api_gateway_method" "MyDemoMethod" {
 ```
 
 ## Usage with Cognito User Pool Authorizer
+
 ```hcl
 variable "cognito_user_pool_name" {}
 

--- a/website/docs/r/appsync_graphql_api.html.markdown
+++ b/website/docs/r/appsync_graphql_api.html.markdown
@@ -46,6 +46,7 @@ resource "aws_appsync_graphql_api" "example" {
 ```
 
 ### With Schema
+
 ```hcl
 resource "aws_appsync_graphql_api" "example" {
   authentication_type = "AWS_IAM"

--- a/website/docs/r/cloudhsm_v2_cluster.html.markdown
+++ b/website/docs/r/cloudhsm_v2_cluster.html.markdown
@@ -59,6 +59,7 @@ resource "aws_cloudhsm_v2_cluster" "cloudhsm_v2_cluster" {
   }
 }
 ```
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/website/docs/r/cloudhsm_v2_hsm.html.markdown
+++ b/website/docs/r/cloudhsm_v2_hsm.html.markdown
@@ -24,6 +24,7 @@ resource "aws_cloudhsm_v2_hsm" "cloudhsm_v2_hsm" {
   cluster_id = "${data.aws_cloudhsm_v2_cluster.cluster.cluster_id}"
 }
 ```
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/website/docs/r/cognito_user_pool_client.markdown
+++ b/website/docs/r/cognito_user_pool_client.markdown
@@ -27,6 +27,7 @@ resource "aws_cognito_user_pool_client" "client" {
 ```
 
 ### Create a user pool client with no SRP authentication
+
 ```hcl
 resource "aws_cognito_user_pool" "pool" {
   name = "pool"

--- a/website/docs/r/cognito_user_pool_domain.markdown
+++ b/website/docs/r/cognito_user_pool_domain.markdown
@@ -13,6 +13,7 @@ Provides a Cognito User Pool Domain resource.
 ## Example Usage
 
 ### Amazon Cognito domain
+
 ```hcl
 resource "aws_cognito_user_pool_domain" "main" {
   domain       = "example-domain"
@@ -23,7 +24,9 @@ resource "aws_cognito_user_pool" "example" {
   name = "example-pool"
 }
 ```
+
 ### Custom Cognito domain
+
 ```hcl
 resource "aws_cognito_user_pool_domain" "main" {
   domain          = "example-domain.example.com"

--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -110,6 +110,7 @@ resource "aws_elasticsearch_domain" "example" {
   }
 }
 ```
+
 ### VPC based ES
 
 ```hcl

--- a/website/docs/r/iot_certificate.html.markdown
+++ b/website/docs/r/iot_certificate.html.markdown
@@ -11,14 +11,18 @@ description: |-
 Creates and manages an AWS IoT certificate.
 
 ## Example Usage
+
 ### With CSR
+
 ```hcl
 resource "aws_iot_certificate" "cert" {
   csr    = "${file("/my/csr.pem")}"
   active = true
 }
 ```
+
 ### Without CSR
+
 ```hcl
 resource "aws_iot_certificate" "cert" {
   active = true

--- a/website/docs/r/ssm_maintenance_window.html.markdown
+++ b/website/docs/r/ssm_maintenance_window.html.markdown
@@ -44,7 +44,9 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The ID of the maintenance window.
 
 ## Import
+
 SSM  Maintenance Windows can be imported using the `maintenance window id`, e.g.
+
 ```
 $ terraform import aws_ssm_maintenance_window.imported-window mw-0123456789
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/11838

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
website/docs/d/cloudhsm_v2_cluster.html.markdown:19 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```"]
website/docs/d/ebs_default_kms_key.html.markdown:13 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```hcl"]
website/docs/d/ram_resource_share.html.markdown:14 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```hcl"]
website/docs/d/ram_resource_share.html.markdown:22 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```hcl"]
website/docs/d/security_groups.html.markdown:15 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```hcl"]
website/docs/d/ssm_document.html.markdown:26 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```"]
website/docs/r/api_gateway_method.html.markdown:36 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```hcl"]
website/docs/r/appsync_graphql_api.html.markdown:49 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```hcl"]
website/docs/r/cloudhsm_v2_cluster.html.markdown:61 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```"]
website/docs/r/cloudhsm_v2_hsm.html.markdown:26 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```"]
website/docs/r/cognito_user_pool_client.markdown:30 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```hcl"]
website/docs/r/cognito_user_pool_domain.markdown:16 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```hcl"]
website/docs/r/cognito_user_pool_domain.markdown:25 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```"]
website/docs/r/cognito_user_pool_domain.markdown:27 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```hcl"]
website/docs/r/elasticsearch_domain.html.markdown:112 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```"]
website/docs/r/iot_certificate.html.markdown:15 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```hcl"]
website/docs/r/iot_certificate.html.markdown:20 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```"]
website/docs/r/iot_certificate.html.markdown:22 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```hcl"]
website/docs/r/ssm_maintenance_window.html.markdown:48 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```"]
```