### PR TITLE
docs/provider: Fix markdownlint MD032 failures and enable rule

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -6,13 +6,6 @@ default: true
 # Disabled Rules
 # https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md
 
-# Breaking rules (higher priority to fix)
-
-# Example: https://www.terraform.io/docs/providers/aws/d/ebs_default_kms_key.html
-MD032: false
-
-# Stylistic rules
-
 MD001: false
 MD003: false
 MD004: false

--- a/website/docs/d/ebs_default_kms_key.html.markdown
+++ b/website/docs/d/ebs_default_kms_key.html.markdown
@@ -7,6 +7,7 @@ description: |-
 ---
 
 # Data Source: aws_ebs_default_kms_key
+
 Use this data source to get the default EBS encryption KMS key in the current region.
 
 ## Example Usage
@@ -24,5 +25,7 @@ resource "aws_ebs_volume" "example" {
 ```
 
 ## Attributes Reference
+
 The following attributes are exported:
+
 * `key_arn` - Amazon Resource Name (ARN) of the default KMS key uses to encrypt an EBS volume in this region when no key is specified in an API call that creates the volume and encryption by default is enabled.

--- a/website/docs/d/organizations_organizational_units.html.markdown
+++ b/website/docs/d/organizations_organizational_units.html.markdown
@@ -20,9 +20,11 @@ data "aws_organizations_organizational_units" "ou" {
 ```
 
 ## Argument Reference
+
 * `parent_id` - (Required) The parent ID of the organizational unit.
 
 ## Attributes Reference
+
 * `children` - List of child organizational units, which have the following attributes:
   * `arn` - ARN of the organizational unit
   * `name` - Name of the organizational unit

--- a/website/docs/d/route53_zone.html.markdown
+++ b/website/docs/d/route53_zone.html.markdown
@@ -43,8 +43,8 @@ Hosted Zone. If you use `name` field for private Hosted Zone, you need to add `p
 * `name` - (Optional) The Hosted Zone name of the desired Hosted Zone.
 * `private_zone` - (Optional) Used with `name` field to get a private Hosted Zone.
 * `vpc_id` - (Optional) Used with `name` field to get a private Hosted Zone associated with the vpc_id (in this case, private_zone is not mandatory).
-* `tags` - (Optional) Used with `name` field. A mapping of tags, each pair of which must exactly match
-a pair on the desired Hosted Zone.
+* `tags` - (Optional) Used with `name` field. A mapping of tags, each pair of which must exactly match a pair on the desired Hosted Zone.
+
 ## Attributes Reference
 
 All of the argument attributes are also exported as

--- a/website/docs/r/autoscaling_schedule.html.markdown
+++ b/website/docs/r/autoscaling_schedule.html.markdown
@@ -55,6 +55,7 @@ Set to -1 if you don't want to change the maximum size at the scheduled time.
 ~> **NOTE:** When `start_time` and `end_time` are specified with `recurrence` , they form the boundaries of when the recurring action will start and stop.
 
 ## Attribute Reference
+
 * `arn` - The ARN assigned by AWS to the autoscaling schedule.
 
 ## Import

--- a/website/docs/r/db_option_group.html.markdown
+++ b/website/docs/r/db_option_group.html.markdown
@@ -9,6 +9,7 @@ description: |-
 # Resource: aws_db_option_group
 
 Provides an RDS DB option group resource. Documentation of the available options for various RDS engines can be found at:
+
 * [MariaDB Options](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.MariaDB.Options.html)
 * [Microsoft SQL Server Options](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.SQLServer.Options.html)
 * [MySQL Options](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.MySQL.Options.html)

--- a/website/docs/r/db_parameter_group.html.markdown
+++ b/website/docs/r/db_parameter_group.html.markdown
@@ -9,6 +9,7 @@ description: |-
 # Resource: aws_db_parameter_group
 
 Provides an RDS DB parameter group resource .Documentation of the available parameters for various RDS engines can be found at:
+
 * [Aurora MySQL Parameters](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AuroraMySQL.Reference.html)
 * [Aurora PostgreSQL Parameters](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AuroraPostgreSQL.Reference.html)
 * [MariaDB Parameters](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.MariaDB.Parameters.html)

--- a/website/docs/r/pinpoint_apns_channel.markdown
+++ b/website/docs/r/pinpoint_apns_channel.markdown
@@ -41,10 +41,12 @@ The following arguments are supported:
 One of the following sets of credentials is also required.
 
 If you choose to use __Certificate credentials__ you will have to provide:
+
 * `certificate` - (Required) The pem encoded TLS Certificate from Apple.
 * `private_key` - (Required) The Certificate Private Key file (ie. `.key` file).
 
 If you choose to use __Key credentials__ you will have to provide:
+
 * `bundle_id` - (Required) The ID assigned to your iOS app. To find this value, choose Certificates, IDs & Profiles, choose App IDs in the Identifiers section, and choose your app.
 * `team_id` - (Required) The ID assigned to your Apple developer account team. This value is provided on the Membership page.
 * `token_key` - (Required) The `.p8` file that you download from your Apple developer account when you create an authentication key. 

--- a/website/docs/r/pinpoint_apns_sandbox_channel.markdown
+++ b/website/docs/r/pinpoint_apns_sandbox_channel.markdown
@@ -41,10 +41,12 @@ The following arguments are supported:
 One of the following sets of credentials is also required.
 
 If you choose to use __Certificate credentials__ you will have to provide:
+
 * `certificate` - (Required) The pem encoded TLS Certificate from Apple.
 * `private_key` - (Required) The Certificate Private Key file (ie. `.key` file).
 
 If you choose to use __Key credentials__ you will have to provide:
+
 * `bundle_id` - (Required) The ID assigned to your iOS app. To find this value, choose Certificates, IDs & Profiles, choose App IDs in the Identifiers section, and choose your app.
 * `team_id` - (Required) The ID assigned to your Apple developer account team. This value is provided on the Membership page.
 * `token_key` - (Required) The `.p8` file that you download from your Apple developer account when you create an authentication key. 

--- a/website/docs/r/pinpoint_apns_voip_channel.markdown
+++ b/website/docs/r/pinpoint_apns_voip_channel.markdown
@@ -41,10 +41,12 @@ The following arguments are supported:
 One of the following sets of credentials is also required.
 
 If you choose to use __Certificate credentials__ you will have to provide:
+
 * `certificate` - (Required) The pem encoded TLS Certificate from Apple.
 * `private_key` - (Required) The Certificate Private Key file (ie. `.key` file).
 
 If you choose to use __Key credentials__ you will have to provide:
+
 * `bundle_id` - (Required) The ID assigned to your iOS app. To find this value, choose Certificates, IDs & Profiles, choose App IDs in the Identifiers section, and choose your app.
 * `team_id` - (Required) The ID assigned to your Apple developer account team. This value is provided on the Membership page.
 * `token_key` - (Required) The `.p8` file that you download from your Apple developer account when you create an authentication key. 

--- a/website/docs/r/pinpoint_apns_voip_sandbox_channel.markdown
+++ b/website/docs/r/pinpoint_apns_voip_sandbox_channel.markdown
@@ -41,10 +41,12 @@ The following arguments are supported:
 One of the following sets of credentials is also required.
 
 If you choose to use __Certificate credentials__ you will have to provide:
+
 * `certificate` - (Required) The pem encoded TLS Certificate from Apple.
 * `private_key` - (Required) The Certificate Private Key file (ie. `.key` file).
 
 If you choose to use __Key credentials__ you will have to provide:
+
 * `bundle_id` - (Required) The ID assigned to your iOS app. To find this value, choose Certificates, IDs & Profiles, choose App IDs in the Identifiers section, and choose your app.
 * `team_id` - (Required) The ID assigned to your Apple developer account team. This value is provided on the Membership page.
 * `token_key` - (Required) The `.p8` file that you download from your Apple developer account when you create an authentication key. 

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -416,6 +416,7 @@ The `rules` object supports the following:
 ~> **NOTE on `prefix` and `filter`:** Amazon S3's latest version of the replication configuration is V2, which includes the `filter` attribute for replication rules.
 With the `filter` attribute, you can specify object filters based on the object key prefix, tags, or both to scope the objects that the rule applies to.
 Replication configuration V1 supports filtering based on only the `prefix` attribute. For backwards compatibility, Amazon S3 continues to support the V1 configuration.
+
 * For a specific rule, `prefix` conflicts with `filter`
 * If any rule has `filter` specified then they all must
 * `priority` is optional (with a default value of `0`) but must be unique between multiple rules

--- a/website/docs/r/sagemaker_endpoint_configuration.html.markdown
+++ b/website/docs/r/sagemaker_endpoint_configuration.html.markdown
@@ -49,6 +49,7 @@ The `production_variants` block supports:
 * `initial_variant_weight` (Optional) - Determines initial traffic distribution among all of the models that you specify in the endpoint configuration. If unspecified, it defaults to 1.0.
 * `model_name` - (Required) The name of the model to use.
 * `variant_name` - (Optional) The name of the variant. If omitted, Terraform will assign a random, unique name.
+
 ## Attributes Reference
 
 The following attributes are exported:

--- a/website/docs/r/spot_datafeed_subscription.html.markdown
+++ b/website/docs/r/spot_datafeed_subscription.html.markdown
@@ -27,6 +27,7 @@ resource "aws_spot_datafeed_subscription" "default" {
 ```
 
 ## Argument Reference
+
 * `bucket` - (Required) The Amazon S3 bucket in which to store the Spot instance data feed.
 * `prefix` - (Optional) Path of folder inside bucket to place spot pricing data.
 

--- a/website/docs/r/vpc_dhcp_options.html.markdown
+++ b/website/docs/r/vpc_dhcp_options.html.markdown
@@ -48,6 +48,7 @@ The following arguments are supported:
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Remarks
+
 * Notice that all arguments are optional but you have to specify at least one argument.
 * `domain_name_servers`, `netbios_name_servers`, `ntp_servers` are limited by AWS to maximum four servers only.
 * To actually use the DHCP Options Set you need to associate it to a VPC using [`aws_vpc_dhcp_options_association`](/docs/providers/aws/r/vpc_dhcp_options_association.html).

--- a/website/docs/r/vpc_dhcp_options_association.html.markdown
+++ b/website/docs/r/vpc_dhcp_options_association.html.markdown
@@ -27,6 +27,7 @@ The following arguments are supported:
 * `dhcp_options_id` - (Required) The ID of the DHCP Options Set to associate to the VPC.
 
 ## Remarks
+
 * You can only associate one DHCP Options Set to a given VPC ID.
 * Removing the DHCP Options Association automatically sets AWS's `default` DHCP Options Set to the VPC.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/11838

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
website/docs/d/ebs_default_kms_key.html.markdown:28 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "* `key_arn` - Amazon Resource ..."]
website/docs/d/organizations_organizational_units.html.markdown:23 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "* `parent_id` - (Required) The..."]
website/docs/d/organizations_organizational_units.html.markdown:26 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "* `children` - List of child o..."]
website/docs/d/route53_zone.html.markdown:47 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "a pair on the desired Hosted Z..."]
website/docs/r/autoscaling_schedule.html.markdown:58 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "* `arn` - The ARN assigned by ..."]
website/docs/r/db_option_group.html.markdown:12 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "* [MariaDB Options](https://do..."]
website/docs/r/db_parameter_group.html.markdown:12 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "* [Aurora MySQL Parameters](ht..."]
website/docs/r/pinpoint_apns_channel.markdown:44 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "* `certificate` - (Required) T..."]
website/docs/r/pinpoint_apns_channel.markdown:48 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "* `bundle_id` - (Required) The..."]
website/docs/r/pinpoint_apns_sandbox_channel.markdown:44 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "* `certificate` - (Required) T..."]
website/docs/r/pinpoint_apns_sandbox_channel.markdown:48 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "* `bundle_id` - (Required) The..."]
website/docs/r/pinpoint_apns_voip_channel.markdown:44 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "* `certificate` - (Required) T..."]
website/docs/r/pinpoint_apns_voip_channel.markdown:48 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "* `bundle_id` - (Required) The..."]
website/docs/r/pinpoint_apns_voip_sandbox_channel.markdown:44 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "* `certificate` - (Required) T..."]
website/docs/r/pinpoint_apns_voip_sandbox_channel.markdown:48 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "* `bundle_id` - (Required) The..."]
website/docs/r/s3_bucket.html.markdown:419 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "* For a specific rule, `prefix..."]
website/docs/r/sagemaker_endpoint_configuration.html.markdown:51 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "* `variant_name` - (Optional) ..."]
website/docs/r/spot_datafeed_subscription.html.markdown:30 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "* `bucket` - (Required) The Am..."]
website/docs/r/vpc_dhcp_options_association.html.markdown:30 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "* You can only associate one D..."]
website/docs/r/vpc_dhcp_options.html.markdown:51 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "* Notice that all arguments ar..."]
```