### PR TITLE
Fix bluegreen deployment changes for ECS

### DIFF
--- a/aws/resource_aws_codedeploy_deployment_group.go
+++ b/aws/resource_aws_codedeploy_deployment_group.go
@@ -672,8 +672,8 @@ func resourceAwsCodeDeployDeploymentGroupUpdate(d *schema.ResourceData, meta int
 		input.DeploymentConfigName = aws.String(n.(string))
 	}
 
-	// include (original or new) autoscaling groups when blue_green_deployment_config changes
-	if d.HasChange("autoscaling_groups") || d.HasChange("blue_green_deployment_config") {
+	// include (original or new) autoscaling groups when blue_green_deployment_config changes except for ECS
+	if _, isEcs := d.GetOk("ecs_service"); d.HasChange("autoscaling_groups") || (d.HasChange("blue_green_deployment_config") && !isEcs) {
 		_, n := d.GetChange("autoscaling_groups")
 		input.AutoScalingGroups = expandStringList(n.(*schema.Set).List())
 	}

--- a/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -1662,6 +1662,30 @@ func TestAccAWSCodeDeployDeploymentGroup_ECS_BlueGreen(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_info.0.target_group_pair_info.0.target_group.0.name", lbTargetGroupBlueResourceName, "name"),
 					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_info.0.target_group_pair_info.0.target_group.1.name", lbTargetGroupGreenResourceName, "name"),
 					resource.TestCheckResourceAttr(resourceName, "load_balancer_info.0.target_group_pair_info.0.test_traffic_route.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "CONTINUE_DEPLOYMENT"),
+					resource.TestCheckResourceAttr(resourceName, "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "TERMINATE"),
+					resource.TestCheckResourceAttr(resourceName, "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "5"),
+				),
+			},
+			{
+				Config: testAccAWSCodeDeployDeploymentGroupConfigEcsBlueGreenUpdate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
+					resource.TestCheckResourceAttr(resourceName, "ecs_service.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "ecs_service.0.cluster_name", ecsClusterResourceName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "ecs_service.0.service_name", ecsServiceResourceName, "name"),
+					resource.TestCheckResourceAttr(resourceName, "load_balancer_info.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "load_balancer_info.0.target_group_pair_info.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "load_balancer_info.0.target_group_pair_info.0.prod_traffic_route.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "load_balancer_info.0.target_group_pair_info.0.prod_traffic_route.0.listener_arns.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "load_balancer_info.0.target_group_pair_info.0.target_group.#", "2"),
+					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_info.0.target_group_pair_info.0.target_group.0.name", lbTargetGroupBlueResourceName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_info.0.target_group_pair_info.0.target_group.1.name", lbTargetGroupGreenResourceName, "name"),
+					resource.TestCheckResourceAttr(resourceName, "load_balancer_info.0.target_group_pair_info.0.test_traffic_route.#", "0"),
+					resource.TestCheckResourceAttr("aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
+					resource.TestCheckResourceAttr("aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "30"),
+					resource.TestCheckResourceAttr("aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "TERMINATE"),
+					resource.TestCheckResourceAttr("aws_codedeploy_deployment_group.test", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "60"),
 				),
 			},
 			{
@@ -3579,6 +3603,60 @@ resource "aws_codedeploy_deployment_group" "test" {
     terminate_blue_instances_on_deployment_success {
       action                           = "TERMINATE"
       termination_wait_time_in_minutes = 5
+    }
+  }
+
+  deployment_style {
+    deployment_option = "WITH_TRAFFIC_CONTROL"
+    deployment_type   = "BLUE_GREEN"
+  }
+
+  ecs_service {
+    cluster_name = "${aws_ecs_cluster.test.name}"
+    service_name = "${aws_ecs_service.test.name}"
+  }
+
+  load_balancer_info {
+    target_group_pair_info {
+      prod_traffic_route {
+        listener_arns = ["${aws_lb_listener.test.arn}"]
+      }
+
+      target_group {
+        name = "${aws_lb_target_group.blue.name}"
+      }
+
+      target_group {
+        name = "${aws_lb_target_group.green.name}"
+      }
+    }
+  }
+}
+`, rName)
+}
+
+func testAccAWSCodeDeployDeploymentGroupConfigEcsBlueGreenUpdate(rName string) string {
+	return testAccAWSCodeDeployDeploymentGroupConfigEcsBase(rName) + fmt.Sprintf(`
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name               = "${aws_codedeploy_app.test.name}"
+  deployment_config_name = "CodeDeployDefault.ECSAllAtOnce"
+  deployment_group_name  = %q
+  service_role_arn       = "${aws_iam_role.test.arn}"
+
+  auto_rollback_configuration {
+    enabled = true
+    events  = ["DEPLOYMENT_FAILURE"]
+  }
+
+  blue_green_deployment_config {
+    deployment_ready_option {
+      action_on_timeout    = "STOP_DEPLOYMENT"
+      wait_time_in_minutes = 30
+    }
+
+    terminate_blue_instances_on_deployment_success {
+      action                           = "TERMINATE"
+      termination_wait_time_in_minutes = 60
     }
   }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #7128

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
resource/aws_codedeploy_deployment_group: Fix blue_green_deployment_config updates for ECS [#7128]
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCodeDeployDeploymentGroup*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCodeDeployDeploymentGroup* -timeout 120m
=== RUN   TestAccAWSCodeDeployDeploymentGroup_basic
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_basic
=== RUN   TestAccAWSCodeDeployDeploymentGroup_basic_tagSet
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_basic_tagSet
=== RUN   TestAccAWSCodeDeployDeploymentGroup_onPremiseTag
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_onPremiseTag
=== RUN   TestAccAWSCodeDeployDeploymentGroup_disappears
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_disappears
=== RUN   TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic
=== RUN   TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple
=== RUN   TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create
=== RUN   TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_update
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_update
=== RUN   TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete
=== RUN   TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable
=== RUN   TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create
=== RUN   TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_update
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_update
=== RUN   TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete
=== RUN   TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable
=== RUN   TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_default
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_default
=== RUN   TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_create
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_create
=== RUN   TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_update
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_update
=== RUN   TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_delete
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_delete
=== RUN   TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_create
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_create
=== RUN   TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_update
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_update
=== RUN   TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete
=== RUN   TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_create
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_create
=== RUN   TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_update
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_update
=== RUN   TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_delete
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_delete
=== RUN   TestAccAWSCodeDeployDeploymentGroup_in_place_deployment_with_traffic_control_create
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_in_place_deployment_with_traffic_control_create
=== RUN   TestAccAWSCodeDeployDeploymentGroup_in_place_deployment_with_traffic_control_update
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_in_place_deployment_with_traffic_control_update
=== RUN   TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_create
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_create
=== RUN   TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update_with_asg
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update_with_asg
=== RUN   TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update
=== RUN   TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete
=== RUN   TestAccAWSCodeDeployDeploymentGroup_blueGreenDeployment_complete
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_blueGreenDeployment_complete
=== RUN   TestAccAWSCodeDeployDeploymentGroup_ECS_BlueGreen
=== PAUSE TestAccAWSCodeDeployDeploymentGroup_ECS_BlueGreen
=== CONT  TestAccAWSCodeDeployDeploymentGroup_basic
=== CONT  TestAccAWSCodeDeployDeploymentGroup_in_place_deployment_with_traffic_control_update
=== CONT  TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_update
=== CONT  TestAccAWSCodeDeployDeploymentGroup_blueGreenDeployment_complete
=== CONT  TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_create
=== CONT  TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete
=== CONT  TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_update
=== CONT  TestAccAWSCodeDeployDeploymentGroup_in_place_deployment_with_traffic_control_create
=== CONT  TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_delete
=== CONT  TestAccAWSCodeDeployDeploymentGroup_ECS_BlueGreen
=== CONT  TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_create
=== CONT  TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete
=== CONT  TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_update
=== CONT  TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create
=== CONT  TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable
=== CONT  TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_create
=== CONT  TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_update
=== CONT  TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable
=== CONT  TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete
=== CONT  TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_default
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_default (50.23s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_delete
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete (67.11s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_delete (67.23s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update_with_asg
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_create (67.54s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_create
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable (67.76s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_update (68.10s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_update
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeployment_complete (68.25s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_update (70.15s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_onPremiseTag
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete (70.39s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_disappears
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_create (74.01s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_basic_tagSet
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete (79.31s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create (79.50s)
=== CONT  TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_create (82.92s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_in_place_deployment_with_traffic_control_update (83.51s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_update (83.59s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_in_place_deployment_with_traffic_control_create (84.43s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_update (84.98s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable (86.60s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_basic (95.24s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_onPremiseTag (40.99s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_disappears (41.95s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_delete (62.46s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update (58.47s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create (62.39s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_update (62.78s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete (63.55s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic (68.78s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple (69.30s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_basic_tagSet (75.84s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_create (199.27s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update_with_asg (210.17s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_ECS_BlueGreen (407.67s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       409.224s
```
