### PR TITLE
Read property dns_servers for resource resource_aws_ec2_client_vpn_endpoint

### DIFF
--- a/aws/resource_aws_ec2_client_vpn_endpoint.go
+++ b/aws/resource_aws_ec2_client_vpn_endpoint.go
@@ -223,6 +223,7 @@ func resourceAwsEc2ClientVpnEndpointRead(d *schema.ResourceData, meta interface{
 	d.Set("server_certificate_arn", result.ClientVpnEndpoints[0].ServerCertificateArn)
 	d.Set("transport_protocol", result.ClientVpnEndpoints[0].TransportProtocol)
 	d.Set("dns_name", result.ClientVpnEndpoints[0].DnsName)
+	d.Set("dns_servers", result.ClientVpnEndpoints[0].DnsServers)
 
 	if result.ClientVpnEndpoints[0].Status != nil {
 		d.Set("status", result.ClientVpnEndpoints[0].Status.Code)

--- a/aws/resource_aws_ec2_client_vpn_endpoint_test.go
+++ b/aws/resource_aws_ec2_client_vpn_endpoint_test.go
@@ -199,10 +199,9 @@ func TestAccAwsEc2ClientVpnEndpoint_withDNSServers(t *testing.T) {
 			},
 
 			{
-				ResourceName:            "aws_ec2_client_vpn_endpoint.test",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"dns_servers"},
+				ResourceName:      "aws_ec2_client_vpn_endpoint.test",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})


### PR DESCRIPTION
Currently, the provider cannot change the attribute `dns_servers` on the resource `resource_aws_ec2_client_vpn_endpoint` once the value has been set. This can be fixed by setting the attribute when refreshing state

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Update resource_aws_ec2_client_vpn_endpoint.dns_servers when refreshing state
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAwsEc2ClientVpnEndpoint_withDNSServers'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsEc2ClientVpnEndpoint_withDNSServers -timeout 120m
=== RUN   TestAccAwsEc2ClientVpnEndpoint_withDNSServers
=== PAUSE TestAccAwsEc2ClientVpnEndpoint_withDNSServers
=== CONT  TestAccAwsEc2ClientVpnEndpoint_withDNSServers
--- PASS: TestAccAwsEc2ClientVpnEndpoint_withDNSServers (34.31s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       36.043s

...
```
