### PR TITLE
aws_route53_record: add create,update,delete timeout options for the resource

### DIFF
--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -344,15 +344,15 @@ func resourceAwsRoute53RecordUpdate(d *schema.ResourceData, meta interface{}) er
 		},
 	}
 
-	req := &route53.ChangeResourceRecordSetsInput{
+	input := &route53.ChangeResourceRecordSetsInput{
 		HostedZoneId: aws.String(cleanZoneID(*zoneRecord.HostedZone.Id)),
 		ChangeBatch:  changeBatch,
 	}
 
 	log.Printf("[DEBUG] Updating resource records for zone: %s, name: %s\n\n%s",
-		zone, *rec.Name, req)
+		zone, *rec.Name, input)
 
-	respRaw, err := changeRoute53RecordSet(conn, req)
+	respRaw, err := changeRoute53RecordSet(conn, input)
 	if err != nil {
 		return fmt.Errorf("[ERR]: Error building changeset: %s", err)
 	}
@@ -459,30 +459,24 @@ func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) er
 }
 
 func changeRoute53RecordSet(conn *route53.Route53, input *route53.ChangeResourceRecordSetsInput) (interface{}, error) {
-	wait := resource.StateChangeConf{
-		Pending:    []string{"rejected"},
-		Target:     []string{"accepted"},
-		Timeout:    5 * time.Minute,
-		MinTimeout: 1 * time.Second,
-		Refresh: func() (interface{}, string, error) {
-			resp, err := conn.ChangeResourceRecordSets(input)
-			if err != nil {
-				if r53err, ok := err.(awserr.Error); ok {
-					if r53err.Code() == "PriorRequestNotComplete" {
-						// There is some pending operation, so just retry
-						// in a bit.
-						return nil, "rejected", nil
-					}
-				}
-
-				return nil, "failure", err
-			}
-
-			return resp, "accepted", nil
-		},
+	var out *route53.ChangeResourceRecordSetsOutput
+	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+		var err error
+		out, err = conn.ChangeResourceRecordSets(input)
+		if isAWSErr(err, "NoSuchHostedZone", "") {
+			log.Print("[DEBUG] Hosted Zone not found, retrying...")
+			return resource.RetryableError(err)
+		}
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if isResourceTimeoutError(err) {
+		out, err = conn.ChangeResourceRecordSets(input)
 	}
 
-	return wait.WaitForState()
+	return out, err
 }
 
 func waitForRoute53RecordSetToSync(conn *route53.Route53, requestId string) error {
@@ -754,35 +748,12 @@ func resourceAwsRoute53RecordDelete(d *schema.ResourceData, meta interface{}) er
 }
 
 func deleteRoute53RecordSet(conn *route53.Route53, input *route53.ChangeResourceRecordSetsInput) (interface{}, error) {
-	wait := resource.StateChangeConf{
-		Pending:    []string{"rejected"},
-		Target:     []string{"accepted"},
-		Timeout:    5 * time.Minute,
-		MinTimeout: 1 * time.Second,
-		Refresh: func() (interface{}, string, error) {
-			resp, err := conn.ChangeResourceRecordSets(input)
-			if err != nil {
-				if r53err, ok := err.(awserr.Error); ok {
-					if r53err.Code() == "PriorRequestNotComplete" {
-						// There is some pending operation, so just retry
-						// in a bit.
-						return 42, "rejected", nil
-					}
-
-					if r53err.Code() == "InvalidChangeBatch" {
-						// This means that the record is already gone.
-						return resp, "accepted", nil
-					}
-				}
-
-				return 42, "failure", err
-			}
-
-			return resp, "accepted", nil
-		},
+	out, err := conn.ChangeResourceRecordSets(input)
+	if isAWSErr(err, "InvalidChangeBatch", "") {
+		return out, nil
 	}
 
-	return wait.WaitForState()
+	return out, err
 }
 
 func resourceAwsRoute53RecordBuildSet(d *schema.ResourceData, zoneName string) (*route53.ResourceRecordSet, error) {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

ChangeRecordSets now uses the AWS SDKs inbuilt retry method instead of StateConf change retry loop for 5 minutes.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* ChangeRecordSets now uses the AWS SDKs inbuilt retry method instead of StateConf change retry loop for 5 minutes.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

Closes https://github.com/terraform-providers/terraform-provider-aws/issues/11896