### PR TITLE
Allows deletion of managed CloudWatch event rules and event targets

### DIFF
--- a/aws/resource_aws_cloudwatch_event_rule_test.go
+++ b/aws/resource_aws_cloudwatch_event_rule_test.go
@@ -52,7 +52,8 @@ func testSweepCloudWatchEventRules(region string) error {
 
 			log.Printf("[INFO] Deleting CloudWatch Event Rule %s", name)
 			_, err := conn.DeleteRule(&events.DeleteRuleInput{
-				Name: aws.String(name),
+				Name:  aws.String(name),
+				Force: aws.Bool(true),
 			})
 			if err != nil {
 				return fmt.Errorf("Error deleting CloudWatch Event Rule %s: %s", name, err)

--- a/aws/resource_aws_cloudwatch_event_target_test.go
+++ b/aws/resource_aws_cloudwatch_event_target_test.go
@@ -57,8 +57,9 @@ func testSweepCloudWatchEventTargets(region string) error {
 
 				for _, target := range listTargetsByRuleOutput.Targets {
 					removeTargetsInput := &events.RemoveTargetsInput{
-						Ids:  []*string{target.Id},
-						Rule: rule.Name,
+						Ids:   []*string{target.Id},
+						Rule:  rule.Name,
+						Force: aws.Bool(true),
 					}
 					targetID := aws.StringValue(target.Id)
 


### PR DESCRIPTION
Managed CloudWatch event rules and targets were blocking sweepers.

Before change

```
$ make sweep SWEEPARGS="-sweep-run=aws_cloudwatch_event_rule"

2020/02/04 15:23:52 [INFO] Deleting CloudWatch Event Rule (awscodestarnotifications-rule) Target: codestar-notifications-events-target
2020/02/04 15:23:53 [ERROR] Error running Sweeper (aws_cloudwatch_event_target) in region (us-west-2): Error deleting CloudWatch Event Rule (awscodestarnotifications-rule) Target codestar-notifications-events-target: ManagedRuleException: awscodestarnotifications-rule is a managed rule. Set 'force' parameter to true to override.
```

After change

```
$ make sweep SWEEPARGS="-sweep-run=aws_cloudwatch_event_rule"

2020/02/04 15:39:01 [INFO] Deleting CloudWatch Event Rule (awscodestarnotifications-rule) Target: codestar-notifications-events-target
2020/02/04 15:39:02 [INFO] Deleting CloudWatch Event Rule awscodestarnotifications-rule
2020/02/04 15:39:03 Sweeper Tests ran successfully:
	- aws_cloudwatch_event_target
	- aws_cloudwatch_event_rule
```

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
