### PR TITLE
rd/vpc_dhcp_options - refactor to use keyvaluetags

### DIFF
--- a/aws/data_source_aws_vpc_dhcp_options.go
+++ b/aws/data_source_aws_vpc_dhcp_options.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func dataSourceAwsVpcDhcpOptions() *schema.Resource {
@@ -122,7 +123,7 @@ func dataSourceAwsVpcDhcpOptionsRead(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 
-	if err := d.Set("tags", d.Set("tags", tagsToMap(output.DhcpOptions[0].Tags))); err != nil {
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(output.DhcpOptions[0].Tags).IgnoreAws().Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 	d.Set("owner_id", output.DhcpOptions[0].OwnerId)

--- a/aws/resource_aws_vpc_dhcp_options_test.go
+++ b/aws/resource_aws_vpc_dhcp_options_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
@@ -90,6 +90,7 @@ func testSweepVpcDhcpOptions(region string) error {
 func TestAccAWSDHCPOptions_basic(t *testing.T) {
 	var d ec2.DhcpOptions
 	resourceName := "aws_vpc_dhcp_options.test"
+	rName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -97,16 +98,16 @@ func TestAccAWSDHCPOptions_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDHCPOptionsDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDHCPOptionsConfig,
+				Config: testAccDHCPOptionsConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDHCPOptionsExists(resourceName, &d),
-					resource.TestCheckResourceAttr(resourceName, "domain_name", "service.consul"),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", fmt.Sprintf("service.%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "domain_name_servers.0", "127.0.0.1"),
 					resource.TestCheckResourceAttr(resourceName, "domain_name_servers.1", "10.0.0.2"),
 					resource.TestCheckResourceAttr(resourceName, "ntp_servers.0", "127.0.0.1"),
 					resource.TestCheckResourceAttr(resourceName, "netbios_name_servers.0", "127.0.0.1"),
 					resource.TestCheckResourceAttr(resourceName, "netbios_node_type", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", "test-name"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 				),
 			},
@@ -122,6 +123,7 @@ func TestAccAWSDHCPOptions_basic(t *testing.T) {
 func TestAccAWSDHCPOptions_deleteOptions(t *testing.T) {
 	var d ec2.DhcpOptions
 	resourceName := "aws_vpc_dhcp_options.test"
+	rName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -129,12 +131,56 @@ func TestAccAWSDHCPOptions_deleteOptions(t *testing.T) {
 		CheckDestroy: testAccCheckDHCPOptionsDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDHCPOptionsConfig,
+				Config: testAccDHCPOptionsConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDHCPOptionsExists(resourceName, &d),
 					testAccCheckDHCPOptionsDelete(resourceName),
 				),
 				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSDHCPOptions_tags(t *testing.T) {
+	var d ec2.DhcpOptions
+	resourceName := "aws_vpc_dhcp_options.test"
+	rName := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDHCPOptionsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDHCPOptionsConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDHCPOptionsExists(resourceName, &d),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDHCPOptionsConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDHCPOptionsExists(resourceName, &d),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccDHCPOptionsConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDHCPOptionsExists(resourceName, &d),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
 			},
 		},
 	})
@@ -154,7 +200,7 @@ func testAccCheckDHCPOptionsDestroy(s *terraform.State) error {
 				aws.String(rs.Primary.ID),
 			},
 		})
-		if ae, ok := err.(awserr.Error); ok && ae.Code() == "InvalidDhcpOptionID.NotFound" {
+		if isAWSErr(err, "InvalidDhcpOptionID.NotFound", "") {
 			continue
 		}
 		if err == nil {
@@ -165,12 +211,7 @@ func testAccCheckDHCPOptionsDestroy(s *terraform.State) error {
 			return nil
 		}
 
-		// Verify the error is what we want
-		ec2err, ok := err.(awserr.Error)
-		if !ok {
-			return err
-		}
-		if ec2err.Code() != "InvalidDhcpOptionsID.NotFound" {
+		if !isAWSErr(err, "InvalidDhcpOptionID.NotFound", "") {
 			return err
 		}
 	}
@@ -228,16 +269,47 @@ func testAccCheckDHCPOptionsDelete(n string) resource.TestCheckFunc {
 	}
 }
 
-const testAccDHCPOptionsConfig = `
+func testAccDHCPOptionsConfig(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_vpc_dhcp_options" "test" {
-	domain_name = "service.consul"
+	domain_name = "service.%s"
+	domain_name_servers = ["127.0.0.1", "10.0.0.2"]
+	ntp_servers = ["127.0.0.1"]
+	netbios_name_servers = ["127.0.0.1"]
+	netbios_node_type = 2
+}
+`, rName)
+}
+
+func testAccDHCPOptionsConfigTags1(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc_dhcp_options" "test" {
+	domain_name = "service.%[1]s"
 	domain_name_servers = ["127.0.0.1", "10.0.0.2"]
 	ntp_servers = ["127.0.0.1"]
 	netbios_name_servers = ["127.0.0.1"]
 	netbios_node_type = 2
 
-	tags = {
-		Name = "test-name"
-	}
+  tags = {
+    %[2]q = %[3]q
+  }
 }
-`
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccDHCPOptionsConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc_dhcp_options" "test" {
+	domain_name = "service.%[1]s"
+	domain_name_servers = ["127.0.0.1", "10.0.0.2"]
+	ntp_servers = ["127.0.0.1"]
+	netbios_name_servers = ["127.0.0.1"]
+	netbios_node_type = 2
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10688

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
None
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSDHCPOptions_'
--- PASS: TestAccAWSDHCPOptions_tags (102.68s)
--- PASS: TestAccAWSDHCPOptions_deleteOptions (33.53s)
--- PASS: TestAccAWSDHCPOptions_basic (44.62s)
```

```
$ make testacc TESTARGS='-run=TestAccDataSourceAwsVpcDhcpOptions_'
--- PASS: TestAccDataSourceAwsVpcDhcpOptions_basic (53.97s)
--- PASS: TestAccDataSourceAwsVpcDhcpOptions_Filter (72.23s)
```
