### PR TITLE
service/ec2: Refactor aws_customer_gateway data source and resource to use keyvaluetags package

### DIFF
--- a/aws/data_source_aws_customer_gateway.go
+++ b/aws/data_source_aws_customer_gateway.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func dataSourceAwsCustomerGateway() *schema.Resource {
@@ -83,7 +84,7 @@ func dataSourceAwsCustomerGatewayRead(d *schema.ResourceData, meta interface{}) 
 		d.Set("bgp_asn", int(asn))
 	}
 
-	if err := d.Set("tags", tagsToMap(cg.Tags)); err != nil {
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(cg.Tags).IgnoreAws().Map()); err != nil {
 		return fmt.Errorf("error setting tags for EC2 Customer Gateway %q: %s", aws.StringValue(cg.CustomerGatewayId), err)
 	}
 

--- a/aws/resource_aws_customer_gateway.go
+++ b/aws/resource_aws_customer_gateway.go
@@ -9,9 +9,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
-
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsCustomerGateway() *schema.Resource {
@@ -99,9 +99,10 @@ func resourceAwsCustomerGatewayCreate(d *schema.ResourceData, meta interface{}) 
 			*customerGateway.CustomerGatewayId, err)
 	}
 
-	// Create tags.
-	if err := setTags(conn, d); err != nil {
-		return err
+	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
+		if err := keyvaluetags.Ec2UpdateTags(conn, d.Id(), nil, v); err != nil {
+			return fmt.Errorf("error adding EC2 Customer Gateway (%s) tags: %s", d.Id(), err)
+		}
 	}
 
 	return nil
@@ -201,7 +202,10 @@ func resourceAwsCustomerGatewayRead(d *schema.ResourceData, meta interface{}) er
 	customerGateway := resp.CustomerGateways[0]
 	d.Set("ip_address", customerGateway.IpAddress)
 	d.Set("type", customerGateway.Type)
-	d.Set("tags", tagsToMap(customerGateway.Tags))
+
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(customerGateway.Tags).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
 
 	if *customerGateway.BgpAsn != "" {
 		val, err := strconv.ParseInt(*customerGateway.BgpAsn, 0, 0)
@@ -218,12 +222,13 @@ func resourceAwsCustomerGatewayRead(d *schema.ResourceData, meta interface{}) er
 func resourceAwsCustomerGatewayUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	// Update tags if required.
-	if err := setTags(conn, d); err != nil {
-		return err
-	}
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
 
-	d.SetPartial("tags")
+		if err := keyvaluetags.Ec2UpdateTags(conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("error updating EC2 Customer Gateway (%s) tags: %s", d.Id(), err)
+		}
+	}
 
 	return resourceAwsCustomerGatewayRead(d, meta)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/10688

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
--- PASS: TestAccAWSCustomerGateway_disappears (26.93s)
--- PASS: TestAccAWSCustomerGateway_similarAlreadyExists (34.50s)
--- PASS: TestAccAWSCustomerGateway_basic (64.40s)

--- PASS: TestAccAWSCustomerGatewayDataSource_ID (30.39s)
--- PASS: TestAccAWSCustomerGatewayDataSource_Filter (31.32s)
```