### PR TITLE
service/ec2: Refactor aws_internet_gateway data source and resource to use keyvaluetags package

### DIFF
--- a/aws/data_source_aws_internet_gateway_test.go
+++ b/aws/data_source_aws_internet_gateway_test.go
@@ -39,10 +39,6 @@ func TestAccDataSourceAwsInternetGateway_typical(t *testing.T) {
 }
 
 const testAccDataSourceAwsInternetGatewayConfig = `
-provider "aws" {
-  region = "eu-central-1"
-}
-
 resource "aws_vpc" "test" {
   cidr_block = "172.16.0.0/16"
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/10688

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
--- PASS: TestAccAWSInternetGateway_delete (57.40s)
--- PASS: TestAccAWSInternetGateway_tags (60.09s)
--- PASS: TestAccAWSInternetGateway_basic (77.06s)

--- PASS: TestAccDataSourceAwsInternetGateway_typical (42.69s)
```
