### PR TITLE
service/ec2: Refactor aws_vpn_gateway data source and resource to use keyvaluetags package

### DIFF
--- a/aws/data_source_aws_vpn_gateway.go
+++ b/aws/data_source_aws_vpn_gateway.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func dataSourceAwsVpnGateway() *schema.Resource {
@@ -77,7 +78,7 @@ func dataSourceAwsVpnGatewayRead(d *schema.ResourceData, meta interface{}) error
 		)...)
 	}
 	req.Filters = append(req.Filters, buildEC2TagFilterList(
-		tagsFromMap(d.Get("tags").(map[string]interface{})),
+		keyvaluetags.New(d.Get("tags").(map[string]interface{})).Ec2Tags(),
 	)...)
 	req.Filters = append(req.Filters, buildEC2CustomFilterList(
 		d.Get("filter").(*schema.Set),
@@ -105,7 +106,10 @@ func dataSourceAwsVpnGatewayRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("state", vgw.State)
 	d.Set("availability_zone", vgw.AvailabilityZone)
 	d.Set("amazon_side_asn", strconv.FormatInt(aws.Int64Value(vgw.AmazonSideAsn), 10))
-	d.Set("tags", tagsToMap(vgw.Tags))
+
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(vgw.Tags).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
 
 	for _, attachment := range vgw.VpcAttachments {
 		if *attachment.State == "attached" {

--- a/aws/resource_aws_vpn_gateway.go
+++ b/aws/resource_aws_vpn_gateway.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsVpnGateway() *schema.Resource {
@@ -71,13 +72,21 @@ func resourceAwsVpnGatewayCreate(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Error creating VPN gateway: %s", err)
 	}
 
-	// Get the ID and store it
-	vpnGateway := resp.VpnGateway
-	d.SetId(*vpnGateway.VpnGatewayId)
-	log.Printf("[INFO] VPN Gateway ID: %s", *vpnGateway.VpnGatewayId)
+	d.SetId(aws.StringValue(resp.VpnGateway.VpnGatewayId))
 
-	// Attach the VPN gateway to the correct VPC
-	return resourceAwsVpnGatewayUpdate(d, meta)
+	if _, ok := d.GetOk("vpc_id"); ok {
+		if err := resourceAwsVpnGatewayAttach(d, meta); err != nil {
+			return fmt.Errorf("error attaching EC2 VPN Gateway (%s) to VPC: %s", d.Id(), err)
+		}
+	}
+
+	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
+		if err := keyvaluetags.Ec2UpdateTags(conn, d.Id(), nil, v); err != nil {
+			return fmt.Errorf("error adding EC2 VPN Gateway (%s) tags: %s", d.Id(), err)
+		}
+	}
+
+	return resourceAwsVpnGatewayRead(d, meta)
 }
 
 func resourceAwsVpnGatewayRead(d *schema.ResourceData, meta interface{}) error {
@@ -115,7 +124,10 @@ func resourceAwsVpnGatewayRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("availability_zone", vpnGateway.AvailabilityZone)
 	}
 	d.Set("amazon_side_asn", strconv.FormatInt(aws.Int64Value(vpnGateway.AmazonSideAsn), 10))
-	d.Set("tags", tagsToMap(vpnGateway.Tags))
+
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(vpnGateway.Tags).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
 
 	return nil
 }
@@ -135,11 +147,13 @@ func resourceAwsVpnGatewayUpdate(d *schema.ResourceData, meta interface{}) error
 
 	conn := meta.(*AWSClient).ec2conn
 
-	if err := setTags(conn, d); err != nil {
-		return err
-	}
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
 
-	d.SetPartial("tags")
+		if err := keyvaluetags.Ec2UpdateTags(conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("error updating EC2 VPN Gateway (%s) tags: %s", d.Id(), err)
+		}
+	}
 
 	return resourceAwsVpnGatewayRead(d, meta)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/10688

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
--- PASS: TestAccAWSVpnGateway_disappears (43.96s)
--- PASS: TestAccAWSVpnGateway_withAvailabilityZoneSetToState (45.27s)
--- PASS: TestAccAWSVpnGateway_withAmazonSideAsnSetToState (57.28s)
--- PASS: TestAccAWSVpnGateway_tags (66.12s)
--- PASS: TestAccAWSVpnGateway_delete (67.27s)
--- PASS: TestAccAWSVpnGateway_basic (74.69s)
--- PASS: TestAccAWSVpnGateway_reattach (114.06s)

--- PASS: TestAccDataSourceAwsVpnGateway_unattached (18.47s)
--- PASS: TestAccDataSourceAwsVpnGateway_attached (54.18s)
```