### PR TITLE
service/ec2: Refactor aws_network_interface(s) data sources and resource to use keyvaluetags package

### DIFF
--- a/aws/data_source_aws_network_interface.go
+++ b/aws/data_source_aws_network_interface.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func dataSourceAwsNetworkInterface() *schema.Resource {
@@ -180,6 +181,10 @@ func dataSourceAwsNetworkInterfaceRead(d *schema.ResourceData, meta interface{})
 	d.Set("requester_id", eni.RequesterId)
 	d.Set("subnet_id", eni.SubnetId)
 	d.Set("vpc_id", eni.VpcId)
-	d.Set("tags", tagsToMap(eni.TagSet))
+
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(eni.TagSet).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
 	return nil
 }

--- a/aws/data_source_aws_network_interfaces.go
+++ b/aws/data_source_aws_network_interfaces.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func dataSourceAwsNetworkInterfaces() *schema.Resource {
@@ -40,7 +41,7 @@ func dataSourceAwsNetworkInterfacesRead(d *schema.ResourceData, meta interface{}
 
 	if tagsOk {
 		req.Filters = buildEC2TagFilterList(
-			tagsFromMap(tags.(map[string]interface{})),
+			keyvaluetags.New(tags.(map[string]interface{})).Ec2Tags(),
 		)
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/10688

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
--- PASS: TestAccAWSENI_computedIPs (40.42s)
--- PASS: TestAccAWSENI_disappears (41.08s)
--- PASS: TestAccAWSENI_sourceDestCheck (41.52s)
--- PASS: TestAccAWSENI_basic (44.39s)
--- PASS: TestAccAWSENI_updatedDescription (71.87s)
--- PASS: TestAccAWSENI_PrivateIpsCount (110.97s)
--- PASS: TestAccAWSENI_ignoreExternalAttachment (113.13s)
--- PASS: TestAccAWSENI_attached (241.64s)

--- PASS: TestAccDataSourceAwsNetworkInterface_filters (44.99s)
--- PASS: TestAccDataSourceAwsNetworkInterface_basic (45.00s)

--- PASS: TestAccDataSourceAwsNetworkInterfaces_Filter (41.65s)
--- PASS: TestAccDataSourceAwsNetworkInterfaces_Tags (41.69s)
```
