### PR TITLE
service/ec2: Refactor Network ACL data source and resources to use keyvaluetags package

### DIFF
--- a/aws/data_source_aws_network_acls.go
+++ b/aws/data_source_aws_network_acls.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func dataSourceAwsNetworkAcls() *schema.Resource {
@@ -52,7 +53,7 @@ func dataSourceAwsNetworkAclsRead(d *schema.ResourceData, meta interface{}) erro
 
 	if tagsOk {
 		req.Filters = append(req.Filters, buildEC2TagFilterList(
-			tagsFromMap(tags.(map[string]interface{})),
+			keyvaluetags.New(tags.(map[string]interface{})).Ec2Tags(),
 		)...)
 	}
 

--- a/aws/resource_aws_default_network_acl.go
+++ b/aws/resource_aws_default_network_acl.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 // ACL Network ACLs all contain explicit deny-all rules that cannot be
@@ -232,10 +233,12 @@ func resourceAwsDefaultNetworkAclUpdate(d *schema.ResourceData, meta interface{}
 		}
 	}
 
-	if err := setTags(conn, d); err != nil {
-		return err
-	} else {
-		d.SetPartial("tags")
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.Ec2UpdateTags(conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("error updating EC2 Default Network ACL (%s) tags: %s", d.Id(), err)
+		}
 	}
 
 	d.Partial(false)

--- a/aws/resource_aws_default_network_acl_test.go
+++ b/aws/resource_aws_default_network_acl_test.go
@@ -440,10 +440,6 @@ resource "aws_default_network_acl" "default" {
 `
 
 const testAccAWSDefaultNetworkConfig_basicIpv6Vpc = `
-provider "aws" {
-  region = "us-east-2"
-}
-
 resource "aws_vpc" "tftestvpc" {
 	cidr_block = "10.1.0.0/16"
 	assign_generated_ipv6_cidr_block = true


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/10688

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (failure is reproducible locally but unrelated):

```
--- PASS: TestAccAWSNetworkAcl_ipv6ICMPRules (34.10s)
--- PASS: TestAccAWSNetworkAcl_disappears (34.71s)
--- PASS: TestAccAWSNetworkAcl_espProtocol (35.04s)
--- PASS: TestAccAWSNetworkAcl_basic (37.94s)
--- PASS: TestAccAWSNetworkAcl_ipv6VpcRules (38.32s)
--- PASS: TestAccAWSNetworkAcl_OnlyEgressRules (39.16s)
--- PASS: TestAccAWSNetworkAcl_EgressAndIngressRules (39.44s)
--- PASS: TestAccAWSNetworkAcl_CaseSensitivityNoChanges (43.76s)
--- PASS: TestAccAWSNetworkAcl_ipv6Rules (43.86s)
--- PASS: TestAccAWSNetworkAcl_OnlyIngressRules_basic (45.15s)
--- PASS: TestAccAWSNetworkAcl_OnlyIngressRules_update (70.53s)
--- PASS: TestAccAWSNetworkAcl_SubnetChange (70.90s)
--- PASS: TestAccAWSNetworkAcl_Subnets (75.73s)
--- PASS: TestAccAWSNetworkAcl_Ingress_ConfigMode (81.14s)
--- PASS: TestAccAWSNetworkAcl_Egress_ConfigMode (84.11s)

--- FAIL: TestAccAWSNetworkAcl_SubnetsDelete (61.78s)
    testing.go:640: Step 2 error: errors during apply:

        Error: InvalidAssociationID.NotFound: The association ID 'aclassoc-0680583195befd52d' does not exist

--- PASS: TestAccAWSDefaultNetworkAcl_basic (31.09s)
--- PASS: TestAccAWSDefaultNetworkAcl_deny_ingress (31.48s)
--- PASS: TestAccAWSDefaultNetworkAcl_withIpv6Ingress (31.55s)
--- PASS: TestAccAWSDefaultNetworkAcl_basicIpv6Vpc (32.62s)
--- PASS: TestAccAWSDefaultNetworkAcl_SubnetRemoval (62.43s)
--- PASS: TestAccAWSDefaultNetworkAcl_SubnetReassign (70.95s)

--- PASS: TestAccDataSourceAwsNetworkAcls_VpcID (36.42s)
--- PASS: TestAccDataSourceAwsNetworkAcls_Filter (37.19s)
--- PASS: TestAccDataSourceAwsNetworkAcls_Tags (38.04s)
--- PASS: TestAccDataSourceAwsNetworkAcls_basic (52.66s)
```
