### PR TITLE
service/ec2: Refactor aws_route_table(s) data sources and resource to use keyvaluetags package

### DIFF
--- a/aws/data_source_aws_route_table.go
+++ b/aws/data_source_aws_route_table.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func dataSourceAwsRouteTable() *schema.Resource {
@@ -150,7 +151,7 @@ func dataSourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error
 		},
 	)
 	req.Filters = append(req.Filters, buildEC2TagFilterList(
-		tagsFromMap(tags.(map[string]interface{})),
+		keyvaluetags.New(tags.(map[string]interface{})).Ec2Tags(),
 	)...)
 	req.Filters = append(req.Filters, buildEC2CustomFilterList(
 		filter.(*schema.Set),
@@ -173,7 +174,11 @@ func dataSourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error
 	d.SetId(aws.StringValue(rt.RouteTableId))
 	d.Set("route_table_id", rt.RouteTableId)
 	d.Set("vpc_id", rt.VpcId)
-	d.Set("tags", tagsToMap(rt.Tags))
+
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(rt.Tags).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
 	d.Set("owner_id", rt.OwnerId)
 	if err := d.Set("routes", dataSourceRoutesRead(rt.Routes)); err != nil {
 		return err

--- a/aws/data_source_aws_route_tables.go
+++ b/aws/data_source_aws_route_tables.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func dataSourceAwsRouteTables() *schema.Resource {
@@ -48,7 +49,7 @@ func dataSourceAwsRouteTablesRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	req.Filters = append(req.Filters, buildEC2TagFilterList(
-		tagsFromMap(d.Get("tags").(map[string]interface{})),
+		keyvaluetags.New(d.Get("tags").(map[string]interface{})).Ec2Tags(),
 	)...)
 
 	req.Filters = append(req.Filters, buildEC2CustomFilterList(

--- a/aws/resource_aws_route_table_test.go
+++ b/aws/resource_aws_route_table_test.go
@@ -597,6 +597,21 @@ resource "aws_route_table" "foo" {
 `
 
 const testAccRouteTableConfigInstance = `
+data "aws_ami" "amzn-ami-minimal-hvm" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name = "name"
+    values = ["amzn-ami-minimal-hvm-*"]
+  }
+
+  filter {
+    name = "root-device-type"
+    values = ["ebs"]
+  }
+}
+
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags = {
@@ -613,10 +628,9 @@ resource "aws_subnet" "foo" {
 }
 
 resource "aws_instance" "foo" {
-	# us-west-2
-	ami = "ami-4fccb37f"
-	instance_type = "m1.small"
-	subnet_id = "${aws_subnet.foo.id}"
+  ami           = "${data.aws_ami.amzn-ami-minimal-hvm.id}"
+  instance_type = "t2.micro"
+  subnet_id     = "${aws_subnet.foo.id}"
 }
 
 resource "aws_route_table" "foo" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/10688

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
--- PASS: TestAccAWSRouteTable_panicEmptyRoute (25.53s)
--- PASS: TestAccAWSRouteTable_ipv6 (39.37s)
--- PASS: TestAccAWSRouteTable_vpcPeering (50.45s)
--- PASS: TestAccAWSRouteTable_vgwRoutePropagation (54.85s)
--- PASS: TestAccAWSRouteTable_tags (56.74s)
--- PASS: TestAccAWSRouteTable_basic (71.67s)
--- PASS: TestAccAWSRouteTable_Route_ConfigMode (93.39s)
--- PASS: TestAccAWSRouteTable_instance (114.93s)
--- PASS: TestAccAWSRouteTable_Route_TransitGatewayID (332.43s)

--- PASS: TestAccDataSourceAwsRouteTable_main (32.43s)
--- PASS: TestAccDataSourceAwsRouteTable_basic (49.36s)

--- PASS: TestAccDataSourceAwsRouteTables (61.83s)
```