### PR TITLE
Refactor S3 Bucket resource to use keyvaluetags package

### DIFF
--- a/aws/internal/keyvaluetags/key_value_tags.go
+++ b/aws/internal/keyvaluetags/key_value_tags.go
@@ -140,17 +140,6 @@ func (tags KeyValueTags) Map() map[string]string {
 	return result
 }
 
-// RawMap returns tag keys mapped to their "raw" values.
-func (tags KeyValueTags) RawMap() map[string]interface{} {
-	result := make(map[string]interface{}, len(tags))
-
-	for k, v := range tags {
-		result[k] = *v
-	}
-
-	return result
-}
-
 // Merge adds missing and updates existing tags.
 func (tags KeyValueTags) Merge(mergeTags KeyValueTags) KeyValueTags {
 	result := make(KeyValueTags)

--- a/aws/internal/keyvaluetags/key_value_tags.go
+++ b/aws/internal/keyvaluetags/key_value_tags.go
@@ -137,6 +137,17 @@ func (tags KeyValueTags) Map() map[string]string {
 	return result
 }
 
+// RawMap returns tag keys mapped to their "raw" values.
+func (tags KeyValueTags) RawMap() map[string]interface{} {
+	result := make(map[string]interface{}, len(tags))
+
+	for k, v := range tags {
+		result[k] = *v
+	}
+
+	return result
+}
+
 // Merge adds missing and updates existing tags.
 func (tags KeyValueTags) Merge(mergeTags KeyValueTags) KeyValueTags {
 	result := make(KeyValueTags)

--- a/aws/internal/keyvaluetags/key_value_tags.go
+++ b/aws/internal/keyvaluetags/key_value_tags.go
@@ -5,7 +5,10 @@
 package keyvaluetags
 
 import (
+	"fmt"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 )
 
 const (
@@ -207,6 +210,17 @@ func (tags KeyValueTags) Chunks(size int) []KeyValueTags {
 	}
 
 	return result
+}
+
+// Hash returns a stable hash value.
+// The returned value may be negative (i.e. not suitable for a 'Set' function).
+func (tags KeyValueTags) Hash() int {
+	hash := 0
+	for k, v := range tags {
+		hash = hash ^ hashcode.String(fmt.Sprintf("%s-%s", k, *v))
+	}
+
+	return hash
 }
 
 // New creates KeyValueTags from common Terraform Provider SDK types.

--- a/aws/internal/keyvaluetags/key_value_tags_test.go
+++ b/aws/internal/keyvaluetags/key_value_tags_test.go
@@ -896,6 +896,40 @@ func TestKeyValueTagsChunks(t *testing.T) {
 	}
 }
 
+func TestKeyValueTagsHash(t *testing.T) {
+	testCases := []struct {
+		name string
+		tags KeyValueTags
+		zero bool
+	}{
+		{
+			name: "empty",
+			tags: New(map[string]string{}),
+			zero: true,
+		},
+		{
+			name: "not_empty",
+			tags: New(map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+				"key4": "value4",
+			}),
+			zero: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := testCase.tags.Hash()
+
+			if (got == 0 && !testCase.zero) || (got != 0 && testCase.zero) {
+				t.Errorf("unexpected hash code: %d", got)
+			}
+		})
+	}
+}
+
 func testKeyValueTagsVerifyKeys(t *testing.T, got []string, want []string) {
 	for _, g := range got {
 		found := false

--- a/aws/internal/keyvaluetags/key_value_tags_test.go
+++ b/aws/internal/keyvaluetags/key_value_tags_test.go
@@ -514,6 +514,77 @@ func TestKeyValueTagsMap(t *testing.T) {
 	}
 }
 
+func TestKeyValueTagsRawMap(t *testing.T) {
+	testCases := []struct {
+		name string
+		tags KeyValueTags
+		want map[string]string
+	}{
+		{
+			name: "empty_map_string_interface",
+			tags: New(map[string]interface{}{}),
+			want: map[string]string{},
+		},
+		{
+			name: "empty_map_string_string",
+			tags: New(map[string]string{}),
+			want: map[string]string{},
+		},
+		{
+			name: "empty_map_string_stringPointer",
+			tags: New(map[string]*string{}),
+			want: map[string]string{},
+		},
+		{
+			name: "non_empty_map_string_interface",
+			tags: New(map[string]interface{}{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			}),
+			want: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			},
+		},
+		{
+			name: "non_empty_map_string_string",
+			tags: New(map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			}),
+			want: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			},
+		},
+		{
+			name: "non_empty_map_string_stringPointer",
+			tags: New(map[string]*string{
+				"key1": testStringPtr("value1"),
+				"key2": testStringPtr("value2"),
+				"key3": testStringPtr("value3"),
+			}),
+			want: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := testCase.tags.RawMap()
+
+			testKeyValueTagsVerifyRawMap(t, got, testCase.want)
+		})
+	}
+}
+
 func TestKeyValueTagsMerge(t *testing.T) {
 	testCases := []struct {
 		name      string
@@ -864,6 +935,33 @@ func testKeyValueTagsVerifyMap(t *testing.T, got map[string]string, want map[str
 		if !ok {
 			t.Errorf("want missing key: %s", k)
 			continue
+		}
+
+		if gotV != wantV {
+			t.Errorf("got key (%s) value %s; want value %s", k, gotV, wantV)
+		}
+	}
+
+	for k := range got {
+		if _, ok := want[k]; !ok {
+			t.Errorf("got extra key: %s", k)
+		}
+	}
+}
+
+func testKeyValueTagsVerifyRawMap(t *testing.T, got map[string]interface{}, want map[string]string) {
+	for k, wantV := range want {
+		gotRaw, ok := got[k]
+
+		if !ok {
+			t.Errorf("want missing key: %s", k)
+			continue
+		}
+
+		gotV, ok := gotRaw.(string)
+
+		if !ok {
+			t.Errorf("got key (%s) value %v of type %T; want string", k, gotRaw, gotRaw)
 		}
 
 		if gotV != wantV {

--- a/aws/internal/keyvaluetags/key_value_tags_test.go
+++ b/aws/internal/keyvaluetags/key_value_tags_test.go
@@ -514,77 +514,6 @@ func TestKeyValueTagsMap(t *testing.T) {
 	}
 }
 
-func TestKeyValueTagsRawMap(t *testing.T) {
-	testCases := []struct {
-		name string
-		tags KeyValueTags
-		want map[string]string
-	}{
-		{
-			name: "empty_map_string_interface",
-			tags: New(map[string]interface{}{}),
-			want: map[string]string{},
-		},
-		{
-			name: "empty_map_string_string",
-			tags: New(map[string]string{}),
-			want: map[string]string{},
-		},
-		{
-			name: "empty_map_string_stringPointer",
-			tags: New(map[string]*string{}),
-			want: map[string]string{},
-		},
-		{
-			name: "non_empty_map_string_interface",
-			tags: New(map[string]interface{}{
-				"key1": "value1",
-				"key2": "value2",
-				"key3": "value3",
-			}),
-			want: map[string]string{
-				"key1": "value1",
-				"key2": "value2",
-				"key3": "value3",
-			},
-		},
-		{
-			name: "non_empty_map_string_string",
-			tags: New(map[string]string{
-				"key1": "value1",
-				"key2": "value2",
-				"key3": "value3",
-			}),
-			want: map[string]string{
-				"key1": "value1",
-				"key2": "value2",
-				"key3": "value3",
-			},
-		},
-		{
-			name: "non_empty_map_string_stringPointer",
-			tags: New(map[string]*string{
-				"key1": testStringPtr("value1"),
-				"key2": testStringPtr("value2"),
-				"key3": testStringPtr("value3"),
-			}),
-			want: map[string]string{
-				"key1": "value1",
-				"key2": "value2",
-				"key3": "value3",
-			},
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			got := testCase.tags.RawMap()
-
-			testKeyValueTagsVerifyRawMap(t, got, testCase.want)
-		})
-	}
-}
-
 func TestKeyValueTagsMerge(t *testing.T) {
 	testCases := []struct {
 		name      string
@@ -969,33 +898,6 @@ func testKeyValueTagsVerifyMap(t *testing.T, got map[string]string, want map[str
 		if !ok {
 			t.Errorf("want missing key: %s", k)
 			continue
-		}
-
-		if gotV != wantV {
-			t.Errorf("got key (%s) value %s; want value %s", k, gotV, wantV)
-		}
-	}
-
-	for k := range got {
-		if _, ok := want[k]; !ok {
-			t.Errorf("got extra key: %s", k)
-		}
-	}
-}
-
-func testKeyValueTagsVerifyRawMap(t *testing.T, got map[string]interface{}, want map[string]string) {
-	for k, wantV := range want {
-		gotRaw, ok := got[k]
-
-		if !ok {
-			t.Errorf("want missing key: %s", k)
-			continue
-		}
-
-		gotV, ok := gotRaw.(string)
-
-		if !ok {
-			t.Errorf("got key (%s) value %v of type %T; want string", k, gotRaw, gotRaw)
 		}
 
 		if gotV != wantV {

--- a/aws/internal/keyvaluetags/s3_tags.go
+++ b/aws/internal/keyvaluetags/s3_tags.go
@@ -1,0 +1,81 @@
+// +build !generate
+
+package keyvaluetags
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	awsbase "github.com/hashicorp/aws-sdk-go-base"
+)
+
+// Custom S3 tag service update functions using the same format as generated code.
+
+// S3BucketListTags lists S3 bucket tags.
+// The identifier is the bucket name.
+func S3BucketListTags(conn *s3.S3, identifier string) (KeyValueTags, error) {
+	input := &s3.GetBucketTaggingInput{
+		Bucket: aws.String(identifier),
+	}
+
+	output, err := conn.GetBucketTagging(input)
+
+	// S3 API Reference (https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketTagging.html)
+	// lists the special error as NoSuchTagSetError, however the existing logic used NoSuchTagSet
+	// and the AWS Go SDK has neither as a constant.
+	if awsbase.IsAWSErr(err, "NoSuchTagSet", "") {
+		return New(nil), nil
+	}
+
+	if err != nil {
+		return New(nil), err
+	}
+
+	return S3KeyValueTags(output.TagSet), nil
+}
+
+// S3BucketUpdateTags updates S3 bucket tags.
+// The identifier is the bucket name.
+func S3BucketUpdateTags(conn *s3.S3, identifier string, oldTagsMap interface{}, newTagsMap interface{}) error {
+	oldTags := New(oldTagsMap)
+	newTags := New(newTagsMap)
+
+	// We need to also consider any existing system tags.
+	allTags, err := S3BucketListTags(conn, identifier)
+
+	if err != nil {
+		return fmt.Errorf("error listing resource tags (%s): %w", identifier, err)
+	}
+
+	sysTags := allTags.Removed(allTags.IgnoreAws())
+
+	// TODO RetryOnAwsCodes([]string{"NoSuchBucket", "OperationAborted"})?
+
+	if len(newTags)+len(sysTags) > 0 {
+		input := &s3.PutBucketTaggingInput{
+			Bucket: aws.String(identifier),
+			Tagging: &s3.Tagging{
+				TagSet: newTags.Merge(sysTags).S3Tags(),
+			},
+		}
+
+		_, err := conn.PutBucketTagging(input)
+
+		if err != nil {
+			return fmt.Errorf("error setting resource tags (%s): %w", identifier, err)
+		}
+	} else if len(oldTags) > 0 && len(sysTags) == 0 {
+		input := &s3.DeleteBucketTaggingInput{
+			Bucket: aws.String(identifier),
+		}
+
+		_, err := conn.DeleteBucketTagging(input)
+
+		if err != nil {
+			return fmt.Errorf("error deleting resource tags (%s): %w", identifier, err)
+		}
+	}
+
+	return nil
+}

--- a/aws/internal/keyvaluetags/s3_tags.go
+++ b/aws/internal/keyvaluetags/s3_tags.go
@@ -50,8 +50,6 @@ func S3BucketUpdateTags(conn *s3.S3, identifier string, oldTagsMap interface{}, 
 
 	sysTags := allTags.Removed(allTags.IgnoreAws())
 
-	// TODO RetryOnAwsCodes([]string{"NoSuchBucket", "OperationAborted"})?
-
 	if len(newTags)+len(sysTags) > 0 {
 		input := &s3.PutBucketTaggingInput{
 			Bucket: aws.String(identifier),

--- a/aws/internal/keyvaluetags/s3_tags.go
+++ b/aws/internal/keyvaluetags/s3_tags.go
@@ -79,19 +79,3 @@ func S3BucketUpdateTags(conn *s3.S3, identifier string, oldTagsMap interface{}, 
 
 	return nil
 }
-
-// S3ObjectListTags lists S3 object tags.
-func S3ObjectListTags(conn *s3.S3, bucket, key string) (KeyValueTags, error) {
-	input := &s3.GetObjectTaggingInput{
-		Bucket: aws.String(bucket),
-		Key:    aws.String(key),
-	}
-
-	output, err := conn.GetObjectTagging(input)
-
-	if err != nil {
-		return New(nil), err
-	}
-
-	return S3KeyValueTags(output.TagSet), nil
-}

--- a/aws/internal/keyvaluetags/s3_tags.go
+++ b/aws/internal/keyvaluetags/s3_tags.go
@@ -79,3 +79,19 @@ func S3BucketUpdateTags(conn *s3.S3, identifier string, oldTagsMap interface{}, 
 
 	return nil
 }
+
+// S3ObjectListTags lists S3 object tags.
+func S3ObjectListTags(conn *s3.S3, bucket, key string) (KeyValueTags, error) {
+	input := &s3.GetObjectTaggingInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	}
+
+	output, err := conn.GetObjectTagging(input)
+
+	if err != nil {
+		return New(nil), err
+	}
+
+	return S3KeyValueTags(output.TagSet), nil
+}

--- a/aws/resource_aws_backup_plan.go
+++ b/aws/resource_aws_backup_plan.go
@@ -291,7 +291,7 @@ func backupBackupPlanHash(vRule interface{}) int {
 	}
 
 	if vRecoveryPointTags, ok := mRule["recovery_point_tags"].(map[string]interface{}); ok && len(vRecoveryPointTags) > 0 {
-		buf.WriteString(fmt.Sprintf("%d-", tagsMapToHash(vRecoveryPointTags)))
+		buf.WriteString(fmt.Sprintf("%d-", keyvaluetags.New(vRecoveryPointTags).Hash()))
 	}
 
 	if vLifecycle, ok := mRule["lifecycle"].([]interface{}); ok && len(vLifecycle) > 0 && vLifecycle[0] != nil {

--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -2382,7 +2382,7 @@ func replicationRuleFilterHash(v interface{}) int {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
 	}
 	if v, ok := m["tags"]; ok {
-		buf.WriteString(fmt.Sprintf("%d-", tagsMapToHash(v.(map[string]interface{}))))
+		buf.WriteString(fmt.Sprintf("%d-", keyvaluetags.New(v).Hash()))
 	}
 	return hashcode.String(buf.String())
 }

--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -1921,11 +1921,11 @@ func resourceAwsS3BucketReplicationConfigurationUpdate(s3conn *s3.S3, d *schema.
 			rcRule.Priority = aws.Int64(int64(rr["priority"].(int)))
 			rcRule.Filter = &s3.ReplicationRuleFilter{}
 			filter := f[0].(map[string]interface{})
-			tags := filter["tags"].(map[string]interface{})
+			tags := keyvaluetags.New(filter["tags"]).IgnoreAws().S3Tags()
 			if len(tags) > 0 {
 				rcRule.Filter.And = &s3.ReplicationRuleAndOperator{
 					Prefix: aws.String(filter["prefix"].(string)),
-					Tags:   keyvaluetags.New(tags).IgnoreAws().S3Tags(),
+					Tags:   tags,
 				}
 			} else {
 				rcRule.Filter.Prefix = aws.String(filter["prefix"].(string))
@@ -1993,12 +1993,12 @@ func resourceAwsS3BucketLifecycleUpdate(s3conn *s3.S3, d *schema.ResourceData) e
 		rule := &s3.LifecycleRule{}
 
 		// Filter
-		tags := r["tags"].(map[string]interface{})
+		tags := keyvaluetags.New(r["tags"]).IgnoreAws().S3Tags()
 		filter := &s3.LifecycleRuleFilter{}
 		if len(tags) > 0 {
 			lifecycleRuleAndOp := &s3.LifecycleRuleAndOperator{}
 			lifecycleRuleAndOp.SetPrefix(r["prefix"].(string))
-			lifecycleRuleAndOp.SetTags(keyvaluetags.New(tags).IgnoreAws().S3Tags())
+			lifecycleRuleAndOp.SetTags(tags)
 			filter.SetAnd(lifecycleRuleAndOp)
 		} else {
 			filter.SetPrefix(r["prefix"].(string))
@@ -2212,11 +2212,11 @@ func flattenAwsS3BucketReplicationConfiguration(r *s3.ReplicationConfiguration) 
 				m["prefix"] = aws.StringValue(f.Prefix)
 			}
 			if t := f.Tag; t != nil {
-				m["tags"] = keyvaluetags.S3KeyValueTags([]*s3.Tag{t}).IgnoreAws().RawMap()
+				m["tags"] = keyvaluetags.S3KeyValueTags([]*s3.Tag{t}).IgnoreAws().Map()
 			}
 			if a := f.And; a != nil {
 				m["prefix"] = aws.StringValue(a.Prefix)
-				m["tags"] = keyvaluetags.S3KeyValueTags(a.Tags).IgnoreAws().RawMap()
+				m["tags"] = keyvaluetags.S3KeyValueTags(a.Tags).IgnoreAws().Map()
 			}
 			t["filter"] = []interface{}{m}
 		}

--- a/aws/resource_aws_s3_bucket_object.go
+++ b/aws/resource_aws_s3_bucket_object.go
@@ -11,14 +11,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/mitchellh/go-homedir"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	"github.com/mitchellh/go-homedir"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsS3BucketObject() *schema.Resource {
@@ -390,17 +390,8 @@ func resourceAwsS3BucketObjectRead(d *schema.ResourceData, meta interface{}) err
 		d.Set("storage_class", resp.StorageClass)
 	}
 
-	// Retry due to S3 eventual consistency
-	tags, err := retryOnAwsCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
-		return keyvaluetags.S3ObjectListTags(s3conn, bucket, key)
-	})
-
-	if err != nil {
-		return fmt.Errorf("error listing tags for S3 Bucket (%s)n Object (%s): %s", bucket, key, err)
-	}
-
-	if err := d.Set("tags", tags.(keyvaluetags.KeyValueTags).IgnoreAws().Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+	if err := getTagsS3Object(s3conn, d); err != nil {
+		return fmt.Errorf("error getting S3 object tags (bucket: %s, key: %s): %s", bucket, key, err)
 	}
 
 	return nil

--- a/aws/s3_tags.go
+++ b/aws/s3_tags.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"fmt"
 	"log"
 	"regexp"
 
@@ -9,88 +8,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
-
-// return a slice of s3 tags associated with the given s3 bucket. Essentially
-// s3.GetBucketTagging, except returns an empty slice instead of an error when
-// there are no tags.
-func getTagSetS3Bucket(conn *s3.S3, bucket string) ([]*s3.Tag, error) {
-	input := &s3.GetBucketTaggingInput{
-		Bucket: aws.String(bucket),
-	}
-
-	// Retry due to S3 eventual consistency
-	outputRaw, err := retryOnAwsCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
-		return conn.GetBucketTagging(input)
-	})
-
-	// S3 API Reference (https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketTagging.html)
-	// lists the special error as NoSuchTagSetError, however the existing logic used NoSuchTagSet
-	// and the AWS Go SDK has neither as a constant.
-	if isAWSErr(err, "NoSuchTagSet", "") {
-		return nil, nil
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	var tagSet []*s3.Tag
-	if output, ok := outputRaw.(*s3.GetBucketTaggingOutput); ok {
-		tagSet = output.TagSet
-	}
-
-	return tagSet, nil
-}
-
-// setTags is a helper to set the tags for a resource. It expects the
-// tags field to be named "tags"
-func setTagsS3Bucket(conn *s3.S3, d *schema.ResourceData) error {
-	if d.HasChange("tags") {
-		oraw, nraw := d.GetChange("tags")
-		o := oraw.(map[string]interface{})
-		n := nraw.(map[string]interface{})
-
-		// Get any existing system tags.
-		var sysTagSet []*s3.Tag
-		oTagSet, err := getTagSetS3Bucket(conn, d.Get("bucket").(string))
-		if err != nil {
-			return fmt.Errorf("error getting S3 bucket tags: %s", err)
-		}
-		for _, tag := range oTagSet {
-			if tagIgnoredS3(tag) {
-				sysTagSet = append(sysTagSet, tag)
-			}
-		}
-
-		if len(n)+len(sysTagSet) > 0 {
-			// The bucket's tag set must include any system tags that Terraform ignores.
-			nTagSet := append(tagsFromMapS3(n), sysTagSet...)
-
-			req := &s3.PutBucketTaggingInput{
-				Bucket: aws.String(d.Get("bucket").(string)),
-				Tagging: &s3.Tagging{
-					TagSet: nTagSet,
-				},
-			}
-			if _, err := RetryOnAwsCodes([]string{"NoSuchBucket", "OperationAborted"}, func() (interface{}, error) {
-				return conn.PutBucketTagging(req)
-			}); err != nil {
-				return fmt.Errorf("error setting S3 bucket tags: %s", err)
-			}
-		} else if len(o) > 0 && len(sysTagSet) == 0 {
-			req := &s3.DeleteBucketTaggingInput{
-				Bucket: aws.String(d.Get("bucket").(string)),
-			}
-			if _, err := RetryOnAwsCodes([]string{"NoSuchBucket", "OperationAborted"}, func() (interface{}, error) {
-				return conn.DeleteBucketTagging(req)
-			}); err != nil {
-				return fmt.Errorf("error deleting S3 bucket tags: %s", err)
-			}
-		}
-	}
-
-	return nil
-}
 
 func getTagsS3Object(conn *s3.S3, d *schema.ResourceData) error {
 	resp, err := retryOnAwsCode(s3.ErrCodeNoSuchKey, func() (interface{}, error) {

--- a/aws/s3_tags.go
+++ b/aws/s3_tags.go
@@ -9,24 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
-func getTagsS3Object(conn *s3.S3, d *schema.ResourceData) error {
-	resp, err := retryOnAwsCode(s3.ErrCodeNoSuchKey, func() (interface{}, error) {
-		return conn.GetObjectTagging(&s3.GetObjectTaggingInput{
-			Bucket: aws.String(d.Get("bucket").(string)),
-			Key:    aws.String(d.Get("key").(string)),
-		})
-	})
-	if err != nil {
-		return err
-	}
-
-	if err := d.Set("tags", tagsToMapS3(resp.(*s3.GetObjectTaggingOutput).TagSet)); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func setTagsS3Object(conn *s3.S3, d *schema.ResourceData) error {
 	if d.HasChange("tags") {
 		oraw, nraw := d.GetChange("tags")

--- a/aws/tags.go
+++ b/aws/tags.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"fmt"
 	"log"
 	"regexp"
 	"strings"
@@ -10,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
@@ -186,16 +184,6 @@ func tagIgnored(t *ec2.Tag) bool {
 		}
 	}
 	return false
-}
-
-// tagsMapToHash returns a stable hash value for a raw tags map.
-// The returned value map be negative (i.e. not suitable for a 'Set' function).
-func tagsMapToHash(tags map[string]interface{}) int {
-	total := 0
-	for k, v := range tags {
-		total = total ^ hashcode.String(fmt.Sprintf("%s-%s", k, v))
-	}
-	return total
 }
 
 // ec2TagsFromTagDescriptions returns the tags from the given tag descriptions.

--- a/aws/tags.go
+++ b/aws/tags.go
@@ -198,16 +198,6 @@ func tagsMapToHash(tags map[string]interface{}) int {
 	return total
 }
 
-// tagsMapToRaw converts a tags map to its "raw" type.
-func tagsMapToRaw(m map[string]string) map[string]interface{} {
-	raw := make(map[string]interface{})
-	for k, v := range m {
-		raw[k] = v
-	}
-
-	return raw
-}
-
 // ec2TagsFromTagDescriptions returns the tags from the given tag descriptions.
 // No attempt is made to remove duplicates.
 func ec2TagsFromTagDescriptions(tds []*ec2.TagDescription) []*ec2.Tag {

--- a/aws/tags_test.go
+++ b/aws/tags_test.go
@@ -112,50 +112,6 @@ func TestIgnoringTags(t *testing.T) {
 	}
 }
 
-func TestTagsMapToHash(t *testing.T) {
-	cases := []struct {
-		Left, Right map[string]interface{}
-		MustBeEqual bool
-	}{
-		{
-			Left:        map[string]interface{}{},
-			Right:       map[string]interface{}{},
-			MustBeEqual: true,
-		},
-		{
-			Left: map[string]interface{}{
-				"foo": "bar",
-				"bar": "baz",
-			},
-			Right: map[string]interface{}{
-				"bar": "baz",
-				"foo": "bar",
-			},
-			MustBeEqual: true,
-		},
-		{
-			Left: map[string]interface{}{
-				"foo": "bar",
-			},
-			Right: map[string]interface{}{
-				"bar": "baz",
-			},
-			MustBeEqual: false,
-		},
-	}
-
-	for i, tc := range cases {
-		l := tagsMapToHash(tc.Left)
-		r := tagsMapToHash(tc.Right)
-		if tc.MustBeEqual && (l != r) {
-			t.Fatalf("%d: Hashes don't match", i)
-		}
-		if !tc.MustBeEqual && (l == r) {
-			t.Logf("%d: Hashes match", i)
-		}
-	}
-}
-
 // testAccCheckTags can be used to check the tags on a resource.
 func testAccCheckTags(
 	ts *[]*ec2.Tag, key string, value string) resource.TestCheckFunc {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10688.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSS3Bucket_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 2 -run=TestAccAWSS3Bucket_ -timeout 120m
=== RUN   TestAccAWSS3Bucket_basic
=== PAUSE TestAccAWSS3Bucket_basic
=== RUN   TestAccAWSS3Bucket_Bucket_EmptyString
=== PAUSE TestAccAWSS3Bucket_Bucket_EmptyString
=== RUN   TestAccAWSS3Bucket_tagsWithNoSystemTags
=== PAUSE TestAccAWSS3Bucket_tagsWithNoSystemTags
=== RUN   TestAccAWSS3Bucket_tagsWithSystemTags
=== PAUSE TestAccAWSS3Bucket_tagsWithSystemTags
=== RUN   TestAccAWSS3Bucket_namePrefix
=== PAUSE TestAccAWSS3Bucket_namePrefix
=== RUN   TestAccAWSS3Bucket_generatedName
=== PAUSE TestAccAWSS3Bucket_generatedName
=== RUN   TestAccAWSS3Bucket_region
=== PAUSE TestAccAWSS3Bucket_region
=== RUN   TestAccAWSS3Bucket_acceleration
=== PAUSE TestAccAWSS3Bucket_acceleration
=== RUN   TestAccAWSS3Bucket_RequestPayer
=== PAUSE TestAccAWSS3Bucket_RequestPayer
=== RUN   TestAccAWSS3Bucket_Policy
=== PAUSE TestAccAWSS3Bucket_Policy
=== RUN   TestAccAWSS3Bucket_UpdateAcl
=== PAUSE TestAccAWSS3Bucket_UpdateAcl
=== RUN   TestAccAWSS3Bucket_Website_Simple
=== PAUSE TestAccAWSS3Bucket_Website_Simple
=== RUN   TestAccAWSS3Bucket_WebsiteRedirect
=== PAUSE TestAccAWSS3Bucket_WebsiteRedirect
=== RUN   TestAccAWSS3Bucket_WebsiteRoutingRules
=== PAUSE TestAccAWSS3Bucket_WebsiteRoutingRules
=== RUN   TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical
=== PAUSE TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical
=== RUN   TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed
=== PAUSE TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed
=== RUN   TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled
=== PAUSE TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled
=== RUN   TestAccAWSS3Bucket_shouldFailNotFound
=== PAUSE TestAccAWSS3Bucket_shouldFailNotFound
=== RUN   TestAccAWSS3Bucket_Versioning
=== PAUSE TestAccAWSS3Bucket_Versioning
=== RUN   TestAccAWSS3Bucket_Cors_Update
=== PAUSE TestAccAWSS3Bucket_Cors_Update
=== RUN   TestAccAWSS3Bucket_Cors_Delete
=== PAUSE TestAccAWSS3Bucket_Cors_Delete
=== RUN   TestAccAWSS3Bucket_Cors_EmptyOrigin
=== PAUSE TestAccAWSS3Bucket_Cors_EmptyOrigin
=== RUN   TestAccAWSS3Bucket_Logging
=== PAUSE TestAccAWSS3Bucket_Logging
=== RUN   TestAccAWSS3Bucket_LifecycleBasic
=== PAUSE TestAccAWSS3Bucket_LifecycleBasic
=== RUN   TestAccAWSS3Bucket_LifecycleExpireMarkerOnly
=== PAUSE TestAccAWSS3Bucket_LifecycleExpireMarkerOnly
=== RUN   TestAccAWSS3Bucket_Replication
=== PAUSE TestAccAWSS3Bucket_Replication
=== RUN   TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation
=== PAUSE TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation
=== RUN   TestAccAWSS3Bucket_ReplicationWithoutStorageClass
=== PAUSE TestAccAWSS3Bucket_ReplicationWithoutStorageClass
=== RUN   TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError
=== PAUSE TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError
=== RUN   TestAccAWSS3Bucket_ReplicationWithoutPrefix
=== PAUSE TestAccAWSS3Bucket_ReplicationWithoutPrefix
=== RUN   TestAccAWSS3Bucket_ReplicationSchemaV2
=== PAUSE TestAccAWSS3Bucket_ReplicationSchemaV2
=== RUN   TestAccAWSS3Bucket_objectLock
=== PAUSE TestAccAWSS3Bucket_objectLock
=== RUN   TestAccAWSS3Bucket_forceDestroy
=== PAUSE TestAccAWSS3Bucket_forceDestroy
=== RUN   TestAccAWSS3Bucket_forceDestroyWithEmptyPrefixes
=== PAUSE TestAccAWSS3Bucket_forceDestroyWithEmptyPrefixes
=== RUN   TestAccAWSS3Bucket_forceDestroyWithObjectLockEnabled
=== PAUSE TestAccAWSS3Bucket_forceDestroyWithObjectLockEnabled
=== CONT  TestAccAWSS3Bucket_basic
=== CONT  TestAccAWSS3Bucket_Versioning
--- PASS: TestAccAWSS3Bucket_basic (42.66s)
=== CONT  TestAccAWSS3Bucket_forceDestroyWithObjectLockEnabled
--- PASS: TestAccAWSS3Bucket_forceDestroyWithObjectLockEnabled (41.42s)
=== CONT  TestAccAWSS3Bucket_forceDestroyWithEmptyPrefixes
--- PASS: TestAccAWSS3Bucket_Versioning (101.43s)
=== CONT  TestAccAWSS3Bucket_forceDestroy
--- PASS: TestAccAWSS3Bucket_forceDestroyWithEmptyPrefixes (38.02s)
=== CONT  TestAccAWSS3Bucket_objectLock
--- PASS: TestAccAWSS3Bucket_forceDestroy (38.09s)
=== CONT  TestAccAWSS3Bucket_ReplicationSchemaV2
--- PASS: TestAccAWSS3Bucket_objectLock (72.24s)
=== CONT  TestAccAWSS3Bucket_ReplicationWithoutPrefix
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutPrefix (84.14s)
=== CONT  TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError
--- PASS: TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError (41.94s)
=== CONT  TestAccAWSS3Bucket_ReplicationWithoutStorageClass
--- PASS: TestAccAWSS3Bucket_ReplicationSchemaV2 (252.85s)
=== CONT  TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutStorageClass (84.58s)
=== CONT  TestAccAWSS3Bucket_Replication
--- PASS: TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation (168.49s)
=== CONT  TestAccAWSS3Bucket_LifecycleExpireMarkerOnly
--- PASS: TestAccAWSS3Bucket_LifecycleExpireMarkerOnly (72.19s)
=== CONT  TestAccAWSS3Bucket_LifecycleBasic
--- PASS: TestAccAWSS3Bucket_Replication (262.74s)
=== CONT  TestAccAWSS3Bucket_Logging
--- PASS: TestAccAWSS3Bucket_Logging (59.90s)
=== CONT  TestAccAWSS3Bucket_Cors_EmptyOrigin
--- PASS: TestAccAWSS3Bucket_LifecycleBasic (101.20s)
=== CONT  TestAccAWSS3Bucket_Cors_Delete
--- PASS: TestAccAWSS3Bucket_Cors_Delete (35.92s)
=== CONT  TestAccAWSS3Bucket_Cors_Update
--- PASS: TestAccAWSS3Bucket_Cors_EmptyOrigin (42.94s)
=== CONT  TestAccAWSS3Bucket_Policy
--- PASS: TestAccAWSS3Bucket_Cors_Update (73.53s)
=== CONT  TestAccAWSS3Bucket_shouldFailNotFound
--- PASS: TestAccAWSS3Bucket_shouldFailNotFound (22.16s)
=== CONT  TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled
--- PASS: TestAccAWSS3Bucket_Policy (97.61s)
=== CONT  TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed (42.29s)
=== CONT  TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical
--- PASS: TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled (71.02s)
=== CONT  TestAccAWSS3Bucket_WebsiteRoutingRules
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical (71.13s)
=== CONT  TestAccAWSS3Bucket_WebsiteRedirect
--- PASS: TestAccAWSS3Bucket_WebsiteRoutingRules (73.91s)
=== CONT  TestAccAWSS3Bucket_Website_Simple
--- PASS: TestAccAWSS3Bucket_WebsiteRedirect (104.91s)
=== CONT  TestAccAWSS3Bucket_UpdateAcl
--- PASS: TestAccAWSS3Bucket_Website_Simple (101.95s)
=== CONT  TestAccAWSS3Bucket_generatedName
--- PASS: TestAccAWSS3Bucket_generatedName (41.60s)
=== CONT  TestAccAWSS3Bucket_RequestPayer
--- PASS: TestAccAWSS3Bucket_UpdateAcl (70.20s)
=== CONT  TestAccAWSS3Bucket_acceleration
--- PASS: TestAccAWSS3Bucket_RequestPayer (71.51s)
=== CONT  TestAccAWSS3Bucket_region
--- PASS: TestAccAWSS3Bucket_acceleration (73.49s)
=== CONT  TestAccAWSS3Bucket_tagsWithSystemTags
--- PASS: TestAccAWSS3Bucket_region (40.50s)
=== CONT  TestAccAWSS3Bucket_namePrefix
--- PASS: TestAccAWSS3Bucket_namePrefix (41.18s)
=== CONT  TestAccAWSS3Bucket_tagsWithNoSystemTags
--- PASS: TestAccAWSS3Bucket_tagsWithSystemTags (179.88s)
=== CONT  TestAccAWSS3Bucket_Bucket_EmptyString
--- PASS: TestAccAWSS3Bucket_tagsWithNoSystemTags (130.40s)
--- PASS: TestAccAWSS3Bucket_Bucket_EmptyString (42.52s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1452.765s
```
