### PR TITLE
resource/aws_ec2_client_vpn_endpoint: Refactor to use keyvaluetags package

### DIFF
--- a/aws/resource_aws_ec2_client_vpn_endpoint.go
+++ b/aws/resource_aws_ec2_client_vpn_endpoint.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsEc2ClientVpnEndpoint() *schema.Resource {
@@ -240,7 +241,7 @@ func resourceAwsEc2ClientVpnEndpointRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("error setting connection_log_options: %s", err)
 	}
 
-	err = d.Set("tags", tagsToMap(result.ClientVpnEndpoints[0].Tags))
+	err = d.Set("tags", keyvaluetags.Ec2KeyValueTags(result.ClientVpnEndpoints[0].Tags).IgnoreAws().Map())
 	if err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
@@ -324,10 +325,13 @@ func resourceAwsEc2ClientVpnEndpointUpdate(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Error modifying Client VPN endpoint: %s", err)
 	}
 
-	if err := setTags(conn, d); err != nil {
-		return err
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.Ec2UpdateTags(conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("error updating EC2 Client VPN Endpoint (%s) tags: %s", d.Id(), err)
+		}
 	}
-	d.SetPartial("tags")
 
 	d.Partial(false)
 	return resourceAwsEc2ClientVpnEndpointRead(d, meta)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/10688

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
--- PASS: TestAccAwsEc2ClientVpnEndpoint_disappears (20.98s)
--- PASS: TestAccAwsEc2ClientVpnEndpoint_basic (32.30s)
--- PASS: TestAccAwsEc2ClientVpnEndpoint_withDNSServers (36.48s)
--- PASS: TestAccAwsEc2ClientVpnEndpoint_splitTunnel (39.03s)
--- PASS: TestAccAwsEc2ClientVpnEndpoint_withLogGroup (41.00s)
--- PASS: TestAccAwsEc2ClientVpnEndpoint_tags (51.32s)
--- PASS: TestAccAwsEc2ClientVpnEndpoint_msAD (1806.58s)
```
