### PR TITLE
resource/aws_iam_service_linked_role: Allow aws_service_name validation to accept values in AWS partitions outside AWS Commercial and AWS GovCloud (US)

### DIFF
--- a/aws/resource_aws_iam_service_linked_role.go
+++ b/aws/resource_aws_iam_service_linked_role.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 func resourceAwsIamServiceLinkedRole() *schema.Resource {
@@ -25,17 +27,10 @@ func resourceAwsIamServiceLinkedRole() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"aws_service_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
-					value := v.(string)
-					if !strings.HasSuffix(value, ".amazonaws.com") {
-						es = append(es, fmt.Errorf(
-							"%q must be a service URL e.g. elasticbeanstalk.amazonaws.com", k))
-					}
-					return
-				},
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`\.`), "must be a full service hostname e.g. elasticbeanstalk.amazonaws.com"),
 			},
 
 			"name": {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10754

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_iam_service_linked_role: Allow `aws_service_name` argument validation to accept values in AWS partitions outside AWS Commercial and AWS GovCloud (US)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSIAMServiceLinkedRole_basic (23.90s)
--- PASS: TestAccAWSIAMServiceLinkedRole_CustomSuffix (24.77s)
--- PASS: TestAccAWSIAMServiceLinkedRole_CustomSuffix_DiffSuppressFunc (25.00s)
--- PASS: TestAccAWSIAMServiceLinkedRole_Description (31.36s)
```
