### PR TITLE
data-source/aws_iam_server_certificate: Fixes for tfproviderlint R002

### DIFF
--- a/aws/data_source_aws_iam_server_certificate.go
+++ b/aws/data_source_aws_iam_server_certificate.go
@@ -139,9 +139,9 @@ func dataSourceAwsIAMServerCertificateRead(d *schema.ResourceData, meta interfac
 
 	metadata := metadatas[0]
 	d.SetId(*metadata.ServerCertificateId)
-	d.Set("arn", *metadata.Arn)
-	d.Set("path", *metadata.Path)
-	d.Set("name", *metadata.ServerCertificateName)
+	d.Set("arn", metadata.Arn)
+	d.Set("path", metadata.Path)
+	d.Set("name", metadata.ServerCertificateName)
 	if metadata.Expiration != nil {
 		d.Set("expiration_date", metadata.Expiration.Format(time.RFC3339))
 	}

--- a/aws/data_source_aws_iam_server_certificate_test.go
+++ b/aws/data_source_aws_iam_server_certificate_test.go
@@ -13,23 +13,19 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func timePtr(t time.Time) *time.Time {
-	return &t
-}
-
 func TestResourceSortByExpirationDate(t *testing.T) {
 	certs := []*iam.ServerCertificateMetadata{
 		{
 			ServerCertificateName: aws.String("oldest"),
-			Expiration:            timePtr(time.Now()),
+			Expiration:            aws.Time(time.Now()),
 		},
 		{
 			ServerCertificateName: aws.String("latest"),
-			Expiration:            timePtr(time.Now().Add(3 * time.Hour)),
+			Expiration:            aws.Time(time.Now().Add(3 * time.Hour)),
 		},
 		{
 			ServerCertificateName: aws.String("in between"),
-			Expiration:            timePtr(time.Now().Add(2 * time.Hour)),
+			Expiration:            aws.Time(time.Now().Add(2 * time.Hour)),
 		},
 	}
 	sort.Sort(certificateByExpiration(certs))


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/9952

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Remove pointer value dereferences, which cause potential panics and are extraneous as `Set()` automatically handles pointer types including when `nil`. Also drive-by removes extraneous time conversion function in the testing file.

Previously:

```
aws/data_source_aws_iam_server_certificate.go:142:15: R002: ResourceData.Set() pointer value dereference is extraneous
aws/data_source_aws_iam_server_certificate.go:143:16: R002: ResourceData.Set() pointer value dereference is extraneous
aws/data_source_aws_iam_server_certificate.go:144:16: R002: ResourceData.Set() pointer value dereference is extraneous
```

Output from acceptance testing:

```
--- PASS: TestAccAWSDataSourceIAMServerCertificate_matchNamePrefix (4.36s)
--- PASS: TestAccAWSDataSourceIAMServerCertificate_basic (16.79s)
--- PASS: TestAccAWSDataSourceIAMServerCertificate_path (17.37s)
```
