### PR TITLE
service/cloudwatchlogs: Fixes for tfproviderlint R002

### DIFF
--- a/aws/resource_aws_cloudwatch_log_destination_policy.go
+++ b/aws/resource_aws_cloudwatch_log_destination_policy.go
@@ -2,11 +2,11 @@ package aws
 
 import (
 	"fmt"
-
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func resourceAwsCloudWatchLogDestinationPolicy() *schema.Resource {
@@ -67,17 +67,13 @@ func resourceAwsCloudWatchLogDestinationPolicyRead(d *schema.ResourceData, meta 
 		return err
 	}
 
-	if !exists {
+	if !exists || destination.AccessPolicy == nil {
+		log.Printf("[WARN] CloudWatch Log Destination Policy (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
-	if destination.AccessPolicy != nil {
-		d.SetId(destination_name)
-		d.Set("access_policy", *destination.AccessPolicy)
-	} else {
-		d.SetId("")
-	}
+	d.Set("access_policy", destination.AccessPolicy)
 
 	return nil
 }

--- a/aws/resource_aws_cloudwatch_log_resource_policy.go
+++ b/aws/resource_aws_cloudwatch_log_resource_policy.go
@@ -73,8 +73,7 @@ func resourceAwsCloudWatchLogResourcePolicyRead(d *schema.ResourceData, meta int
 		return nil
 	}
 
-	d.SetId(policyName)
-	d.Set("policy_document", *resourcePolicy.PolicyDocument)
+	d.Set("policy_document", resourcePolicy.PolicyDocument)
 
 	return nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/9952

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Remove pointer value dereferences, which can cause potential panics and are extraneous as `Set()` automatically handles pointer types including when `nil`.

Previously:

```
aws/resource_aws_cloudwatch_log_destination_policy.go:77:26: R002: ResourceData.Set() pointer value dereference is extraneous
aws/resource_aws_cloudwatch_log_resource_policy.go:77:27: R002: ResourceData.Set() pointer value dereference is extraneous
```

Output from acceptance testing:

```
--- PASS: TestAccAWSCloudwatchLogDestinationPolicy_basic (86.97s)

--- PASS: TestAccAWSCloudWatchLogResourcePolicy_basic (31.10s)
```