### PR TITLE
Implement error_action on aws_iot_topic_rule

### DIFF
--- a/aws/resource_aws_iot_topic_rule.go
+++ b/aws/resource_aws_iot_topic_rule.go
@@ -11,421 +11,6 @@ import (
 )
 
 func resourceAwsIotTopicRule() *schema.Resource {
-	actionsSchema := map[string]*schema.Schema{
-		"cloudwatch_alarm": {
-			Type:     schema.TypeSet,
-			Optional: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"alarm_name": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"role_arn": {
-						Type:         schema.TypeString,
-						Required:     true,
-						ValidateFunc: validateArn,
-					},
-					"state_reason": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"state_value": {
-						Type:         schema.TypeString,
-						Required:     true,
-						ValidateFunc: validateIoTTopicRuleCloudWatchAlarmStateValue,
-					},
-				},
-			},
-		},
-		"cloudwatch_metric": {
-			Type:     schema.TypeSet,
-			Optional: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"metric_name": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"metric_namespace": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"metric_timestamp": {
-						Type:         schema.TypeString,
-						Optional:     true,
-						ValidateFunc: validateIoTTopicRuleCloudWatchMetricTimestamp,
-					},
-					"metric_unit": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"metric_value": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"role_arn": {
-						Type:         schema.TypeString,
-						Required:     true,
-						ValidateFunc: validateArn,
-					},
-				},
-			},
-		},
-		"dynamodb": {
-			Type:     schema.TypeSet,
-			Optional: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"hash_key_field": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"hash_key_value": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"hash_key_type": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"operation": {
-						Type:     schema.TypeString,
-						Optional: true,
-						ValidateFunc: validation.StringInSlice([]string{
-							"DELETE",
-							"INSERT",
-							"UPDATE",
-						}, false),
-					},
-					"payload_field": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"range_key_field": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"range_key_value": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"range_key_type": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"role_arn": {
-						Type:         schema.TypeString,
-						Required:     true,
-						ValidateFunc: validateArn,
-					},
-					"table_name": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-				},
-			},
-		},
-		"dynamodbv2": {
-			Type:     schema.TypeSet,
-			Optional: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"put_item": {
-						Type:     schema.TypeList,
-						Optional: true,
-						MaxItems: 1,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"table_name": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-							},
-						},
-					},
-					"role_arn": {
-						Type:         schema.TypeString,
-						Required:     true,
-						ValidateFunc: validateArn,
-					},
-				},
-			},
-		},
-		"elasticsearch": {
-			Type:     schema.TypeSet,
-			Optional: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"endpoint": {
-						Type:         schema.TypeString,
-						Required:     true,
-						ValidateFunc: validateIoTTopicRuleElasticSearchEndpoint,
-					},
-					"id": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"index": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"role_arn": {
-						Type:         schema.TypeString,
-						Required:     true,
-						ValidateFunc: validateArn,
-					},
-					"type": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-				},
-			},
-		},
-		"firehose": {
-			Type:     schema.TypeSet,
-			Optional: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"delivery_stream_name": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"role_arn": {
-						Type:         schema.TypeString,
-						Required:     true,
-						ValidateFunc: validateArn,
-					},
-					"separator": {
-						Type:         schema.TypeString,
-						Optional:     true,
-						ValidateFunc: validateIoTTopicRuleFirehoseSeparator,
-					},
-				},
-			},
-		},
-		"iot_analytics": {
-			Type:     schema.TypeSet,
-			Optional: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"channel_name": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"role_arn": {
-						Type:         schema.TypeString,
-						Required:     true,
-						ValidateFunc: validateArn,
-					},
-				},
-			},
-		},
-		"iot_events": {
-			Type:     schema.TypeSet,
-			Optional: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"input_name": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"message_id": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"role_arn": {
-						Type:         schema.TypeString,
-						Required:     true,
-						ValidateFunc: validateArn,
-					},
-				},
-			},
-		},
-		"kinesis": {
-			Type:     schema.TypeSet,
-			Optional: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"partition_key": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"role_arn": {
-						Type:         schema.TypeString,
-						Required:     true,
-						ValidateFunc: validateArn,
-					},
-					"stream_name": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-				},
-			},
-		},
-		"lambda": {
-			Type:     schema.TypeSet,
-			Optional: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"function_arn": {
-						Type:         schema.TypeString,
-						Required:     true,
-						ValidateFunc: validateArn,
-					},
-				},
-			},
-		},
-		"republish": {
-			Type:     schema.TypeSet,
-			Optional: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"qos": {
-						Type:         schema.TypeInt,
-						Optional:     true,
-						Default:      0,
-						ValidateFunc: validation.IntBetween(0, 1),
-					},
-					"role_arn": {
-						Type:         schema.TypeString,
-						Required:     true,
-						ValidateFunc: validateArn,
-					},
-					"topic": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-				},
-			},
-		},
-		"s3": {
-			Type:     schema.TypeSet,
-			Optional: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"bucket_name": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"key": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"role_arn": {
-						Type:         schema.TypeString,
-						Required:     true,
-						ValidateFunc: validateArn,
-					},
-				},
-			},
-		},
-		"step_functions": {
-			Type:     schema.TypeSet,
-			Optional: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"execution_name_prefix": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"state_machine_name": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"role_arn": {
-						Type:         schema.TypeString,
-						Required:     true,
-						ValidateFunc: validateArn,
-					},
-				},
-			},
-		},
-		"sns": {
-			Type:     schema.TypeSet,
-			Optional: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"message_format": {
-						Type:     schema.TypeString,
-						Default:  iot.MessageFormatRaw,
-						Optional: true,
-					},
-					"target_arn": {
-						Type:         schema.TypeString,
-						Required:     true,
-						ValidateFunc: validateArn,
-					},
-					"role_arn": {
-						Type:         schema.TypeString,
-						Required:     true,
-						ValidateFunc: validateArn,
-					},
-				},
-			},
-		},
-		"sqs": {
-			Type:     schema.TypeSet,
-			Optional: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"queue_url": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"role_arn": {
-						Type:         schema.TypeString,
-						Required:     true,
-						ValidateFunc: validateArn,
-					},
-					"use_base64": {
-						Type:     schema.TypeBool,
-						Required: true,
-					},
-				},
-			},
-		},
-	}
-
-	s := map[string]*schema.Schema{
-		"arn": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"description": {
-			Type:     schema.TypeString,
-			Optional: true,
-		},
-		"enabled": {
-			Type:     schema.TypeBool,
-			Required: true,
-		},
-		"name": {
-			Type:         schema.TypeString,
-			Required:     true,
-			ForceNew:     true,
-			ValidateFunc: validateIoTTopicRuleName,
-		},
-		"sql": {
-			Type:     schema.TypeString,
-			Required: true,
-		},
-		"sql_version": {
-			Type:     schema.TypeString,
-			Required: true,
-		},
-		"tags": tagsSchema(),
-		"error_action": {
-			Type:     schema.TypeSet,
-			Optional: true,
-			Elem: &schema.Resource{
-				Schema: actionsSchema,
-			},
-		},
-	}
-	for k, v := range actionsSchema {
-		s[k] = v
-	}
 	return &schema.Resource{
 		Create: resourceAwsIotTopicRuleCreate,
 		Read:   resourceAwsIotTopicRuleRead,
@@ -436,7 +21,1060 @@ func resourceAwsIotTopicRule() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
-		Schema: s,
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cloudwatch_alarm": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"alarm_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"role_arn": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateArn,
+						},
+						"state_reason": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"state_value": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateIoTTopicRuleCloudWatchAlarmStateValue,
+						},
+					},
+				},
+			},
+			"cloudwatch_metric": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"metric_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"metric_namespace": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"metric_timestamp": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validateIoTTopicRuleCloudWatchMetricTimestamp,
+						},
+						"metric_unit": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"metric_value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"role_arn": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateArn,
+						},
+					},
+				},
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"dynamodb": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"hash_key_field": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"hash_key_value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"hash_key_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"operation": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"DELETE",
+								"INSERT",
+								"UPDATE",
+							}, false),
+						},
+						"payload_field": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"range_key_field": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"range_key_value": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"range_key_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"role_arn": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateArn,
+						},
+						"table_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"dynamodbv2": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"put_item": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"table_name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+						"role_arn": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateArn,
+						},
+					},
+				},
+			},
+			"elasticsearch": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"endpoint": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateIoTTopicRuleElasticSearchEndpoint,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"index": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"role_arn": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateArn,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+			"firehose": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"delivery_stream_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"role_arn": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateArn,
+						},
+						"separator": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validateIoTTopicRuleFirehoseSeparator,
+						},
+					},
+				},
+			},
+			"iot_analytics": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"channel_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"role_arn": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateArn,
+						},
+					},
+				},
+			},
+			"iot_events": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"input_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"message_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"role_arn": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateArn,
+						},
+					},
+				},
+			},
+			"kinesis": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"partition_key": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"role_arn": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateArn,
+						},
+						"stream_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"lambda": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"function_arn": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateArn,
+						},
+					},
+				},
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateIoTTopicRuleName,
+			},
+			"republish": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"qos": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      0,
+							ValidateFunc: validation.IntBetween(0, 1),
+						},
+						"role_arn": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateArn,
+						},
+						"topic": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"s3": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"bucket_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"key": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"role_arn": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateArn,
+						},
+					},
+				},
+			},
+			"step_functions": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"execution_name_prefix": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"state_machine_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"role_arn": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateArn,
+						},
+					},
+				},
+			},
+			"sns": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"message_format": {
+							Type:     schema.TypeString,
+							Default:  iot.MessageFormatRaw,
+							Optional: true,
+						},
+						"target_arn": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateArn,
+						},
+						"role_arn": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateArn,
+						},
+					},
+				},
+			},
+			"sql": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"sql_version": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"sqs": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"queue_url": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"role_arn": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateArn,
+						},
+						"use_base64": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+					},
+				},
+			},
+			"tags": tagsSchema(),
+			"error_action": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cloudwatch_alarm": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"alarm_name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"role_arn": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validateArn,
+									},
+									"state_reason": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"state_value": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validateIoTTopicRuleCloudWatchAlarmStateValue,
+									},
+								},
+							},
+							ExactlyOneOf: []string{
+								"error_action.0.cloudwatch_alarm",
+								"error_action.0.cloudwatch_metric",
+								"error_action.0.dynamodb",
+								"error_action.0.dynamodbv2",
+								"error_action.0.elasticsearch",
+								"error_action.0.firehose",
+								"error_action.0.iot_analytics",
+								"error_action.0.iot_events",
+								"error_action.0.kinesis",
+								"error_action.0.lambda",
+								"error_action.0.republish",
+								"error_action.0.s3",
+								"error_action.0.step_functions",
+								"error_action.0.sns",
+								"error_action.0.sqs",
+							},
+						},
+						"cloudwatch_metric": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"metric_name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"metric_namespace": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"metric_timestamp": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validateIoTTopicRuleCloudWatchMetricTimestamp,
+									},
+									"metric_unit": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"metric_value": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"role_arn": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validateArn,
+									},
+								},
+							},
+							ExactlyOneOf: []string{
+								"error_action.0.cloudwatch_alarm",
+								"error_action.0.cloudwatch_metric",
+								"error_action.0.dynamodb",
+								"error_action.0.dynamodbv2",
+								"error_action.0.elasticsearch",
+								"error_action.0.firehose",
+								"error_action.0.iot_analytics",
+								"error_action.0.iot_events",
+								"error_action.0.kinesis",
+								"error_action.0.lambda",
+								"error_action.0.republish",
+								"error_action.0.s3",
+								"error_action.0.step_functions",
+								"error_action.0.sns",
+								"error_action.0.sqs",
+							},
+						},
+						"dynamodb": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"hash_key_field": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"hash_key_value": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"hash_key_type": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"operation": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											"DELETE",
+											"INSERT",
+											"UPDATE",
+										}, false),
+									},
+									"payload_field": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"range_key_field": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"range_key_value": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"range_key_type": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"role_arn": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validateArn,
+									},
+									"table_name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+							ExactlyOneOf: []string{
+								"error_action.0.cloudwatch_alarm",
+								"error_action.0.cloudwatch_metric",
+								"error_action.0.dynamodb",
+								"error_action.0.dynamodbv2",
+								"error_action.0.elasticsearch",
+								"error_action.0.firehose",
+								"error_action.0.iot_analytics",
+								"error_action.0.iot_events",
+								"error_action.0.kinesis",
+								"error_action.0.lambda",
+								"error_action.0.republish",
+								"error_action.0.s3",
+								"error_action.0.step_functions",
+								"error_action.0.sns",
+								"error_action.0.sqs",
+							},
+						},
+						"dynamodbv2": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"put_item": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"table_name": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+											},
+										},
+									},
+									"role_arn": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validateArn,
+									},
+								},
+							},
+							ExactlyOneOf: []string{
+								"error_action.0.cloudwatch_alarm",
+								"error_action.0.cloudwatch_metric",
+								"error_action.0.dynamodb",
+								"error_action.0.dynamodbv2",
+								"error_action.0.elasticsearch",
+								"error_action.0.firehose",
+								"error_action.0.iot_analytics",
+								"error_action.0.iot_events",
+								"error_action.0.kinesis",
+								"error_action.0.lambda",
+								"error_action.0.republish",
+								"error_action.0.s3",
+								"error_action.0.step_functions",
+								"error_action.0.sns",
+								"error_action.0.sqs",
+							},
+						},
+						"elasticsearch": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"endpoint": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validateIoTTopicRuleElasticSearchEndpoint,
+									},
+									"id": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"index": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"role_arn": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validateArn,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+							ExactlyOneOf: []string{
+								"error_action.0.cloudwatch_alarm",
+								"error_action.0.cloudwatch_metric",
+								"error_action.0.dynamodb",
+								"error_action.0.dynamodbv2",
+								"error_action.0.elasticsearch",
+								"error_action.0.firehose",
+								"error_action.0.iot_analytics",
+								"error_action.0.iot_events",
+								"error_action.0.kinesis",
+								"error_action.0.lambda",
+								"error_action.0.republish",
+								"error_action.0.s3",
+								"error_action.0.step_functions",
+								"error_action.0.sns",
+								"error_action.0.sqs",
+							},
+						},
+						"firehose": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"delivery_stream_name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"role_arn": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validateArn,
+									},
+									"separator": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validateIoTTopicRuleFirehoseSeparator,
+									},
+								},
+							},
+							ExactlyOneOf: []string{
+								"error_action.0.cloudwatch_alarm",
+								"error_action.0.cloudwatch_metric",
+								"error_action.0.dynamodb",
+								"error_action.0.dynamodbv2",
+								"error_action.0.elasticsearch",
+								"error_action.0.firehose",
+								"error_action.0.iot_analytics",
+								"error_action.0.iot_events",
+								"error_action.0.kinesis",
+								"error_action.0.lambda",
+								"error_action.0.republish",
+								"error_action.0.s3",
+								"error_action.0.step_functions",
+								"error_action.0.sns",
+								"error_action.0.sqs",
+							},
+						},
+						"iot_analytics": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"channel_name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"role_arn": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validateArn,
+									},
+								},
+							},
+							ExactlyOneOf: []string{
+								"error_action.0.cloudwatch_alarm",
+								"error_action.0.cloudwatch_metric",
+								"error_action.0.dynamodb",
+								"error_action.0.dynamodbv2",
+								"error_action.0.elasticsearch",
+								"error_action.0.firehose",
+								"error_action.0.iot_analytics",
+								"error_action.0.iot_events",
+								"error_action.0.kinesis",
+								"error_action.0.lambda",
+								"error_action.0.republish",
+								"error_action.0.s3",
+								"error_action.0.step_functions",
+								"error_action.0.sns",
+								"error_action.0.sqs",
+							},
+						},
+						"iot_events": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"input_name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"message_id": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"role_arn": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validateArn,
+									},
+								},
+							},
+							ExactlyOneOf: []string{
+								"error_action.0.cloudwatch_alarm",
+								"error_action.0.cloudwatch_metric",
+								"error_action.0.dynamodb",
+								"error_action.0.dynamodbv2",
+								"error_action.0.elasticsearch",
+								"error_action.0.firehose",
+								"error_action.0.iot_analytics",
+								"error_action.0.iot_events",
+								"error_action.0.kinesis",
+								"error_action.0.lambda",
+								"error_action.0.republish",
+								"error_action.0.s3",
+								"error_action.0.step_functions",
+								"error_action.0.sns",
+								"error_action.0.sqs",
+							},
+						},
+						"kinesis": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"partition_key": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"role_arn": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validateArn,
+									},
+									"stream_name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+							ExactlyOneOf: []string{
+								"error_action.0.cloudwatch_alarm",
+								"error_action.0.cloudwatch_metric",
+								"error_action.0.dynamodb",
+								"error_action.0.dynamodbv2",
+								"error_action.0.elasticsearch",
+								"error_action.0.firehose",
+								"error_action.0.iot_analytics",
+								"error_action.0.iot_events",
+								"error_action.0.kinesis",
+								"error_action.0.lambda",
+								"error_action.0.republish",
+								"error_action.0.s3",
+								"error_action.0.step_functions",
+								"error_action.0.sns",
+								"error_action.0.sqs",
+							},
+						},
+						"lambda": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"function_arn": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validateArn,
+									},
+								},
+							},
+							ExactlyOneOf: []string{
+								"error_action.0.cloudwatch_alarm",
+								"error_action.0.cloudwatch_metric",
+								"error_action.0.dynamodb",
+								"error_action.0.dynamodbv2",
+								"error_action.0.elasticsearch",
+								"error_action.0.firehose",
+								"error_action.0.iot_analytics",
+								"error_action.0.iot_events",
+								"error_action.0.kinesis",
+								"error_action.0.lambda",
+								"error_action.0.republish",
+								"error_action.0.s3",
+								"error_action.0.step_functions",
+								"error_action.0.sns",
+								"error_action.0.sqs",
+							},
+						},
+						"republish": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"qos": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      0,
+										ValidateFunc: validation.IntBetween(0, 1),
+									},
+									"role_arn": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validateArn,
+									},
+									"topic": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+							ExactlyOneOf: []string{
+								"error_action.0.cloudwatch_alarm",
+								"error_action.0.cloudwatch_metric",
+								"error_action.0.dynamodb",
+								"error_action.0.dynamodbv2",
+								"error_action.0.elasticsearch",
+								"error_action.0.firehose",
+								"error_action.0.iot_analytics",
+								"error_action.0.iot_events",
+								"error_action.0.kinesis",
+								"error_action.0.lambda",
+								"error_action.0.republish",
+								"error_action.0.s3",
+								"error_action.0.step_functions",
+								"error_action.0.sns",
+								"error_action.0.sqs",
+							},
+						},
+						"s3": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"bucket_name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"key": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"role_arn": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validateArn,
+									},
+								},
+							},
+							ExactlyOneOf: []string{
+								"error_action.0.cloudwatch_alarm",
+								"error_action.0.cloudwatch_metric",
+								"error_action.0.dynamodb",
+								"error_action.0.dynamodbv2",
+								"error_action.0.elasticsearch",
+								"error_action.0.firehose",
+								"error_action.0.iot_analytics",
+								"error_action.0.iot_events",
+								"error_action.0.kinesis",
+								"error_action.0.lambda",
+								"error_action.0.republish",
+								"error_action.0.s3",
+								"error_action.0.step_functions",
+								"error_action.0.sns",
+								"error_action.0.sqs",
+							},
+						},
+						"step_functions": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"execution_name_prefix": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"state_machine_name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"role_arn": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validateArn,
+									},
+								},
+							},
+							ExactlyOneOf: []string{
+								"error_action.0.cloudwatch_alarm",
+								"error_action.0.cloudwatch_metric",
+								"error_action.0.dynamodb",
+								"error_action.0.dynamodbv2",
+								"error_action.0.elasticsearch",
+								"error_action.0.firehose",
+								"error_action.0.iot_analytics",
+								"error_action.0.iot_events",
+								"error_action.0.kinesis",
+								"error_action.0.lambda",
+								"error_action.0.republish",
+								"error_action.0.s3",
+								"error_action.0.step_functions",
+								"error_action.0.sns",
+								"error_action.0.sqs",
+							},
+						},
+						"sns": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"message_format": {
+										Type:     schema.TypeString,
+										Default:  iot.MessageFormatRaw,
+										Optional: true,
+									},
+									"target_arn": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validateArn,
+									},
+									"role_arn": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validateArn,
+									},
+								},
+							},
+							ExactlyOneOf: []string{
+								"error_action.0.cloudwatch_alarm",
+								"error_action.0.cloudwatch_metric",
+								"error_action.0.dynamodb",
+								"error_action.0.dynamodbv2",
+								"error_action.0.elasticsearch",
+								"error_action.0.firehose",
+								"error_action.0.iot_analytics",
+								"error_action.0.iot_events",
+								"error_action.0.kinesis",
+								"error_action.0.lambda",
+								"error_action.0.republish",
+								"error_action.0.s3",
+								"error_action.0.step_functions",
+								"error_action.0.sns",
+								"error_action.0.sqs",
+							},
+						},
+						"sqs": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"queue_url": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"role_arn": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validateArn,
+									},
+									"use_base64": {
+										Type:     schema.TypeBool,
+										Required: true,
+									},
+								},
+							},
+							ExactlyOneOf: []string{
+								"error_action.0.cloudwatch_alarm",
+								"error_action.0.cloudwatch_metric",
+								"error_action.0.dynamodb",
+								"error_action.0.dynamodbv2",
+								"error_action.0.elasticsearch",
+								"error_action.0.firehose",
+								"error_action.0.iot_analytics",
+								"error_action.0.iot_events",
+								"error_action.0.kinesis",
+								"error_action.0.lambda",
+								"error_action.0.republish",
+								"error_action.0.s3",
+								"error_action.0.step_functions",
+								"error_action.0.sns",
+								"error_action.0.sqs",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -1194,11 +1832,12 @@ func expandIotTopicRulePayload(d *schema.ResourceData) *iot.TopicRulePayload {
 	}
 
 	var iotErrorAction *iot.Action
-	errorAction := d.Get("error_action").(*schema.Set).List()
+	errorAction := d.Get("error_action").([]interface{})
 	if len(errorAction) > 0 {
 		for k, v := range errorAction[0].(map[string]interface{}) {
-			if k == "cloudwatch_alarm" {
-				for _, tfMapRaw := range v.(*schema.Set).List() {
+			switch k {
+			case "cloudwatch_alarm":
+				for _, tfMapRaw := range v.([]interface{}) {
 					action := expandIotCloudwatchAlarmAction([]interface{}{tfMapRaw})
 					if action == nil {
 						continue
@@ -1207,8 +1846,8 @@ func expandIotTopicRulePayload(d *schema.ResourceData) *iot.TopicRulePayload {
 					iotErrorAction = &iot.Action{CloudwatchAlarm: action}
 
 				}
-			} else if k == "cloudwatch_metric" {
-				for _, tfMapRaw := range v.(*schema.Set).List() {
+			case "cloudwatch_metric":
+				for _, tfMapRaw := range v.([]interface{}) {
 					action := expandIotCloudwatchMetricAction([]interface{}{tfMapRaw})
 
 					if action == nil {
@@ -1217,8 +1856,8 @@ func expandIotTopicRulePayload(d *schema.ResourceData) *iot.TopicRulePayload {
 
 					iotErrorAction = &iot.Action{CloudwatchMetric: action}
 				}
-			} else if k == "dynamodb" {
-				for _, tfMapRaw := range v.(*schema.Set).List() {
+			case "dynamodb":
+				for _, tfMapRaw := range v.([]interface{}) {
 					action := expandIotDynamoDBAction([]interface{}{tfMapRaw})
 
 					if action == nil {
@@ -1227,8 +1866,8 @@ func expandIotTopicRulePayload(d *schema.ResourceData) *iot.TopicRulePayload {
 
 					iotErrorAction = &iot.Action{DynamoDB: action}
 				}
-			} else if k == "dynamodbv2" {
-				for _, tfMapRaw := range v.(*schema.Set).List() {
+			case "dynamodbv2":
+				for _, tfMapRaw := range v.([]interface{}) {
 					action := expandIotDynamoDBv2Action([]interface{}{tfMapRaw})
 
 					if action == nil {
@@ -1237,8 +1876,8 @@ func expandIotTopicRulePayload(d *schema.ResourceData) *iot.TopicRulePayload {
 
 					iotErrorAction = &iot.Action{DynamoDBv2: action}
 				}
-			} else if k == "elasticsearch" {
-				for _, tfMapRaw := range v.(*schema.Set).List() {
+			case "elasticsearch":
+				for _, tfMapRaw := range v.([]interface{}) {
 					action := expandIotElasticsearchAction([]interface{}{tfMapRaw})
 
 					if action == nil {
@@ -1247,8 +1886,8 @@ func expandIotTopicRulePayload(d *schema.ResourceData) *iot.TopicRulePayload {
 
 					iotErrorAction = &iot.Action{Elasticsearch: action}
 				}
-			} else if k == "firehose" {
-				for _, tfMapRaw := range v.(*schema.Set).List() {
+			case "firehose":
+				for _, tfMapRaw := range v.([]interface{}) {
 					action := expandIotFirehoseAction([]interface{}{tfMapRaw})
 
 					if action == nil {
@@ -1257,8 +1896,8 @@ func expandIotTopicRulePayload(d *schema.ResourceData) *iot.TopicRulePayload {
 
 					iotErrorAction = &iot.Action{Firehose: action}
 				}
-			} else if k == "iot_analytics" {
-				for _, tfMapRaw := range v.(*schema.Set).List() {
+			case "iot_analytics":
+				for _, tfMapRaw := range v.([]interface{}) {
 					action := expandIotIotAnalyticsAction([]interface{}{tfMapRaw})
 
 					if action == nil {
@@ -1267,8 +1906,8 @@ func expandIotTopicRulePayload(d *schema.ResourceData) *iot.TopicRulePayload {
 
 					iotErrorAction = &iot.Action{IotAnalytics: action}
 				}
-			} else if k == "iot_events" {
-				for _, tfMapRaw := range v.(*schema.Set).List() {
+			case "iot_events":
+				for _, tfMapRaw := range v.([]interface{}) {
 					action := expandIotIotEventsAction([]interface{}{tfMapRaw})
 
 					if action == nil {
@@ -1277,8 +1916,8 @@ func expandIotTopicRulePayload(d *schema.ResourceData) *iot.TopicRulePayload {
 
 					iotErrorAction = &iot.Action{IotEvents: action}
 				}
-			} else if k == "kinesis" {
-				for _, tfMapRaw := range v.(*schema.Set).List() {
+			case "kinesis":
+				for _, tfMapRaw := range v.([]interface{}) {
 					action := expandIotKinesisAction([]interface{}{tfMapRaw})
 
 					if action == nil {
@@ -1287,8 +1926,8 @@ func expandIotTopicRulePayload(d *schema.ResourceData) *iot.TopicRulePayload {
 
 					iotErrorAction = &iot.Action{Kinesis: action}
 				}
-			} else if k == "lambda" {
-				for _, tfMapRaw := range v.(*schema.Set).List() {
+			case "lambda":
+				for _, tfMapRaw := range v.([]interface{}) {
 					action := expandIotLambdaAction([]interface{}{tfMapRaw})
 
 					if action == nil {
@@ -1297,8 +1936,8 @@ func expandIotTopicRulePayload(d *schema.ResourceData) *iot.TopicRulePayload {
 
 					iotErrorAction = &iot.Action{Lambda: action}
 				}
-			} else if k == "republish" {
-				for _, tfMapRaw := range v.(*schema.Set).List() {
+			case "republish":
+				for _, tfMapRaw := range v.([]interface{}) {
 					action := expandIotRepublishAction([]interface{}{tfMapRaw})
 
 					if action == nil {
@@ -1307,8 +1946,8 @@ func expandIotTopicRulePayload(d *schema.ResourceData) *iot.TopicRulePayload {
 
 					iotErrorAction = &iot.Action{Republish: action}
 				}
-			} else if k == "s3" {
-				for _, tfMapRaw := range v.(*schema.Set).List() {
+			case "s3":
+				for _, tfMapRaw := range v.([]interface{}) {
 					action := expandIotS3Action([]interface{}{tfMapRaw})
 
 					if action == nil {
@@ -1317,8 +1956,8 @@ func expandIotTopicRulePayload(d *schema.ResourceData) *iot.TopicRulePayload {
 
 					iotErrorAction = &iot.Action{S3: action}
 				}
-			} else if k == "sns" {
-				for _, tfMapRaw := range v.(*schema.Set).List() {
+			case "sns":
+				for _, tfMapRaw := range v.([]interface{}) {
 					action := expandIotSnsAction([]interface{}{tfMapRaw})
 
 					if action == nil {
@@ -1327,8 +1966,8 @@ func expandIotTopicRulePayload(d *schema.ResourceData) *iot.TopicRulePayload {
 
 					iotErrorAction = &iot.Action{Sns: action}
 				}
-			} else if k == "sqs" {
-				for _, tfMapRaw := range v.(*schema.Set).List() {
+			case "sqs":
+				for _, tfMapRaw := range v.([]interface{}) {
 					action := expandIotSqsAction([]interface{}{tfMapRaw})
 
 					if action == nil {
@@ -1337,8 +1976,8 @@ func expandIotTopicRulePayload(d *schema.ResourceData) *iot.TopicRulePayload {
 
 					iotErrorAction = &iot.Action{Sqs: action}
 				}
-			} else if k == "step_functions" {
-				for _, tfMapRaw := range v.(*schema.Set).List() {
+			case "step_functions":
+				for _, tfMapRaw := range v.([]interface{}) {
 					action := expandIotStepFunctionsAction([]interface{}{tfMapRaw})
 
 					if action == nil {

--- a/aws/resource_aws_iot_topic_rule_test.go
+++ b/aws/resource_aws_iot_topic_rule_test.go
@@ -542,6 +542,30 @@ func TestAccAWSIoTTopicRule_Tags(t *testing.T) {
 	})
 }
 
+func TestAccAWSIoTTopicRule_errorAction(t *testing.T) {
+	rName := acctest.RandString(5)
+	resourceName := "aws_iot_topic_rule.rule"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSIoTTopicRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSIoTTopicRule_errorAction(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSIoTTopicRuleExists("aws_iot_topic_rule.rule"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAWSIoTTopicRuleDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).iotconn
 
@@ -1011,4 +1035,26 @@ resource "aws_iot_topic_rule" "test" {
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}
+
+func testAccAWSIoTTopicRule_errorAction(rName string) string {
+	return fmt.Sprintf(testAccAWSIoTTopicRuleRole+`
+resource "aws_iot_topic_rule" "rule" {
+  name        = "test_rule_%[1]s"
+  description = "Example rule"
+  enabled     = true
+  sql         = "SELECT * FROM 'topic/test'"
+  sql_version = "2015-10-08"
+  kinesis {
+    stream_name = "mystream"
+    role_arn    = "${aws_iam_role.iot_role.arn}"
+  }
+  error_action {
+    kinesis {
+      stream_name = "mystream"
+      role_arn    = "${aws_iam_role.iot_role.arn}"
+    }
+  }
+}
+`, rName)
 }

--- a/website/docs/r/iot_topic_rule.html.markdown
+++ b/website/docs/r/iot_topic_rule.html.markdown
@@ -88,7 +88,7 @@ EOF
 * `enabled` - (Required) Specifies whether the rule is enabled.
 * `sql` - (Required) The SQL statement used to query the topic. For more information, see AWS IoT SQL Reference (http://docs.aws.amazon.com/iot/latest/developerguide/iot-rules.html#aws-iot-sql-reference) in the AWS IoT Developer Guide.
 * `sql_version` - (Required) The version of the SQL rules engine to use when evaluating the rule.
-* `error_action` - (Optional) The error action to be associated with the rule.
+* `error_action` - (Optional) Configuration block with error action to be associated with the rule. See the documentation for `cloudwatch_alarm`, `cloudwatch_metric`, `dynamodb`, `dynamodbv2`, `elasticsearch`, `firehose`, `iot_analytics`, `iot_events`, `kinesis`, `lambda`, `republish`, `s3`, `step_functions`, `sns`, `sqs` configuration blocks for further configuration details.
 * `tags` - (Optional) Key-value map of resource tags
 
 The `cloudwatch_alarm` object takes the following arguments:

--- a/website/docs/r/iot_topic_rule.html.markdown
+++ b/website/docs/r/iot_topic_rule.html.markdown
@@ -23,10 +23,22 @@ resource "aws_iot_topic_rule" "rule" {
     role_arn       = "${aws_iam_role.role.arn}"
     target_arn     = "${aws_sns_topic.mytopic.arn}"
   }
+
+  error_action {
+    sns {
+      message_format = "RAW"
+      role_arn       = "${aws_iam_role.role.arn}"
+      target_arn     = "${aws_sns_topic.myerrortopic.arn}"
+    }
+  }
 }
 
 resource "aws_sns_topic" "mytopic" {
   name = "mytopic"
+}
+
+resource "aws_sns_topic" "myerrortopic" {
+  name = "myerrortopic"
 }
 
 resource "aws_iam_role" "role" {
@@ -76,6 +88,7 @@ EOF
 * `enabled` - (Required) Specifies whether the rule is enabled.
 * `sql` - (Required) The SQL statement used to query the topic. For more information, see AWS IoT SQL Reference (http://docs.aws.amazon.com/iot/latest/developerguide/iot-rules.html#aws-iot-sql-reference) in the AWS IoT Developer Guide.
 * `sql_version` - (Required) The version of the SQL rules engine to use when evaluating the rule.
+* `error_action` - (Optional) The error action to be associated with the rule.
 * `tags` - (Optional) Key-value map of resource tags
 
 The `cloudwatch_alarm` object takes the following arguments:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #7147

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add `error_action` configuration block to `aws_iot_topic_rule`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSIoTTopicRule'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSIoTTopicRule -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSIoTTopicRule_basic
=== PAUSE TestAccAWSIoTTopicRule_basic
=== RUN   TestAccAWSIoTTopicRule_cloudwatchalarm
=== PAUSE TestAccAWSIoTTopicRule_cloudwatchalarm
=== RUN   TestAccAWSIoTTopicRule_cloudwatchmetric
=== PAUSE TestAccAWSIoTTopicRule_cloudwatchmetric
=== RUN   TestAccAWSIoTTopicRule_dynamodb
=== PAUSE TestAccAWSIoTTopicRule_dynamodb
=== RUN   TestAccAWSIoTTopicRule_dynamoDbv2
=== PAUSE TestAccAWSIoTTopicRule_dynamoDbv2
=== RUN   TestAccAWSIoTTopicRule_elasticsearch
=== PAUSE TestAccAWSIoTTopicRule_elasticsearch
=== RUN   TestAccAWSIoTTopicRule_firehose
=== PAUSE TestAccAWSIoTTopicRule_firehose
=== RUN   TestAccAWSIoTTopicRule_firehose_separator
=== PAUSE TestAccAWSIoTTopicRule_firehose_separator
=== RUN   TestAccAWSIoTTopicRule_kinesis
=== PAUSE TestAccAWSIoTTopicRule_kinesis
=== RUN   TestAccAWSIoTTopicRule_lambda
=== PAUSE TestAccAWSIoTTopicRule_lambda
=== RUN   TestAccAWSIoTTopicRule_republish
=== PAUSE TestAccAWSIoTTopicRule_republish
=== RUN   TestAccAWSIoTTopicRule_republish_with_qos
=== PAUSE TestAccAWSIoTTopicRule_republish_with_qos
=== RUN   TestAccAWSIoTTopicRule_s3
=== PAUSE TestAccAWSIoTTopicRule_s3
=== RUN   TestAccAWSIoTTopicRule_sns
=== PAUSE TestAccAWSIoTTopicRule_sns
=== RUN   TestAccAWSIoTTopicRule_sqs
=== PAUSE TestAccAWSIoTTopicRule_sqs
=== RUN   TestAccAWSIoTTopicRule_step_functions
=== PAUSE TestAccAWSIoTTopicRule_step_functions
=== RUN   TestAccAWSIoTTopicRule_iot_analytics
=== PAUSE TestAccAWSIoTTopicRule_iot_analytics
=== RUN   TestAccAWSIoTTopicRule_iot_events
=== PAUSE TestAccAWSIoTTopicRule_iot_events
=== RUN   TestAccAWSIoTTopicRule_Tags
=== PAUSE TestAccAWSIoTTopicRule_Tags
=== RUN   TestAccAWSIoTTopicRule_errorAction
=== PAUSE TestAccAWSIoTTopicRule_errorAction
=== CONT  TestAccAWSIoTTopicRule_basic
=== CONT  TestAccAWSIoTTopicRule_republish_with_qos
=== CONT  TestAccAWSIoTTopicRule_republish
=== CONT  TestAccAWSIoTTopicRule_errorAction
=== CONT  TestAccAWSIoTTopicRule_lambda
=== CONT  TestAccAWSIoTTopicRule_Tags
=== CONT  TestAccAWSIoTTopicRule_iot_events
=== CONT  TestAccAWSIoTTopicRule_sqs
=== CONT  TestAccAWSIoTTopicRule_sns
=== CONT  TestAccAWSIoTTopicRule_s3
=== CONT  TestAccAWSIoTTopicRule_elasticsearch
=== CONT  TestAccAWSIoTTopicRule_kinesis
=== CONT  TestAccAWSIoTTopicRule_firehose_separator
=== CONT  TestAccAWSIoTTopicRule_firehose
=== CONT  TestAccAWSIoTTopicRule_step_functions
=== CONT  TestAccAWSIoTTopicRule_iot_analytics
=== CONT  TestAccAWSIoTTopicRule_dynamodb
=== CONT  TestAccAWSIoTTopicRule_dynamoDbv2
=== CONT  TestAccAWSIoTTopicRule_cloudwatchmetric
=== CONT  TestAccAWSIoTTopicRule_cloudwatchalarm
--- PASS: TestAccAWSIoTTopicRule_iot_events (57.80s)
--- PASS: TestAccAWSIoTTopicRule_iot_analytics (57.88s)
--- PASS: TestAccAWSIoTTopicRule_dynamoDbv2 (57.89s)
--- PASS: TestAccAWSIoTTopicRule_republish (62.16s)
--- PASS: TestAccAWSIoTTopicRule_basic (62.31s)
--- PASS: TestAccAWSIoTTopicRule_sqs (63.13s)
--- PASS: TestAccAWSIoTTopicRule_s3 (63.25s)
--- PASS: TestAccAWSIoTTopicRule_kinesis (63.72s)
--- PASS: TestAccAWSIoTTopicRule_cloudwatchalarm (63.95s)
--- PASS: TestAccAWSIoTTopicRule_firehose (64.39s)
--- PASS: TestAccAWSIoTTopicRule_republish_with_qos (64.41s)
--- PASS: TestAccAWSIoTTopicRule_cloudwatchmetric (64.46s)
--- PASS: TestAccAWSIoTTopicRule_errorAction (64.54s)
--- PASS: TestAccAWSIoTTopicRule_sns (64.57s)
--- PASS: TestAccAWSIoTTopicRule_step_functions (64.61s)
--- PASS: TestAccAWSIoTTopicRule_lambda (64.66s)
--- PASS: TestAccAWSIoTTopicRule_elasticsearch (67.20s)
--- PASS: TestAccAWSIoTTopicRule_dynamodb (99.45s)
--- PASS: TestAccAWSIoTTopicRule_firehose_separator (99.75s)
--- PASS: TestAccAWSIoTTopicRule_Tags (140.39s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       140.509s
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap      0.027s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags 0.057s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/naming       0.012s [no tests to run]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/apigatewayv2/waiter [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/service/batch/equivalency   0.033s [no tests to run]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/waiter   [no test files]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ecs/waiter   [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks/token    0.017s [no tests to run]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/guardduty/waiter    [no test files]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter   [no test files]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/kinesisanalytics/waiter      [no test files]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/kms/waiter   [no test files]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/neptune/waiter      [no test files]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/rds/waiter   [no test files]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/secretsmanager/waiter[no test files]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicediscovery/waiter      [no test files]
?       github.com/terraform-providers/terraform-provider-aws/aws/internal/service/workspaces/waiter   [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource        0.034s [no tests to run]
?       github.com/terraform-providers/terraform-provider-aws/awsproviderlint   [no test files]
?       github.com/terraform-providers/terraform-provider-aws/awsproviderlint/helper/awsprovidertype/keyvaluetags       [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes    0.019s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSAT001   0.014s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSR001    0.017s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSR002    0.011s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/fmtsprintfcallexpr0.001s [no tests to run]
```