### PR TITLE
r/aws_backup_plan: Adding Copy Action support

### DIFF
--- a/aws/resource_aws_backup_plan.go
+++ b/aws/resource_aws_backup_plan.go
@@ -326,14 +326,12 @@ func flattenBackupPlanRules(rules []*backup.Rule) *schema.Set {
 			}
 		}
 
-		if actions := rule.CopyActions; actions != nil {
-			for _, action := range actions {
-				mRule["copy_action"] = []interface{}{
-					map[string]interface{}{
-						"lifecycle":             flattenBackupPlanCopyActionLifecycle(action.Lifecycle),
-						"destination_vault_arn": aws.StringValue(action.DestinationBackupVaultArn),
-					},
-				}
+		for _, action := range rule.CopyActions {
+			mRule["copy_action"] = []interface{}{
+				map[string]interface{}{
+					"lifecycle":             flattenBackupPlanCopyActionLifecycle(action.Lifecycle),
+					"destination_vault_arn": aws.StringValue(action.DestinationBackupVaultArn),
+				},
 			}
 		}
 

--- a/aws/resource_aws_backup_plan_test.go
+++ b/aws/resource_aws_backup_plan_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/backup"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
@@ -294,6 +295,134 @@ func TestAccAwsBackupPlan_withRecoveryPointTags(t *testing.T) {
 	})
 }
 
+func TestAccAwsBackupPlan_withCopyActions(t *testing.T) {
+	var plan backup.GetBackupPlanOutput
+	ruleNameMap := map[string]string{}
+	resourceName := "aws_backup_plan.test"
+	rName1 := fmt.Sprintf("tf-testacc-backup-%[1]s", acctest.RandString(14))
+	rName2 := fmt.Sprintf("tf-testacc-backup-%[1]s", acctest.RandString(14))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsBackupPlanDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsBackupPlanConfig_copyAction(rName1, rName2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBackupPlanExists(resourceName, &plan, &ruleNameMap),
+					resource.TestCheckResourceAttr(resourceName, "name", rName1),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "rule_name", rName1),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "lifecycle.#", "1"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "lifecycle.0.cold_storage_after", "30"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "lifecycle.0.delete_after", "180"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "copy_action.#", "1"),
+					testAccCheckAwsBackupPlanRuleAttrSet(resourceName, &ruleNameMap, rName1, "copy_action.0.destination_vault_arn"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "copy_action.0.lifecycle.#", "1"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "copy_action.0.lifecycle.0.cold_storage_after", "30"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "copy_action.0.lifecycle.0.delete_after", "180"),
+				),
+			},
+			{
+				Config: testAccAwsBackupPlanConfig_copyActionUpdated(rName1, rName2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBackupPlanExists(resourceName, &plan, &ruleNameMap),
+					resource.TestCheckResourceAttr(resourceName, "name", rName1),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "rule_name", rName1),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "lifecycle.#", "1"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "lifecycle.0.cold_storage_after", "30"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "lifecycle.0.delete_after", "180"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "copy_action.#", "1"),
+					testAccCheckAwsBackupPlanRuleAttrSet(resourceName, &ruleNameMap, rName1, "copy_action.0.destination_vault_arn"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "copy_action.0.lifecycle.#", "1"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "copy_action.0.lifecycle.0.cold_storage_after", "60"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "copy_action.0.lifecycle.0.delete_after", "365"),
+				),
+			},
+			{
+				Config: testAccAwsBackupPlanConfig_basic(rName1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBackupPlanExists(resourceName, &plan, &ruleNameMap),
+					resource.TestCheckResourceAttr(resourceName, "name", rName1),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "rule_name", rName1),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "lifecycle.#", "0"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "copy_action.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAwsBackupPlan_withCopyActionsCrossRegion(t *testing.T) {
+	var providers []*schema.Provider
+	var plan backup.GetBackupPlanOutput
+	ruleNameMap := map[string]string{}
+	resourceName := "aws_backup_plan.test"
+	rName1 := fmt.Sprintf("tf-testacc-backup-%[1]s", acctest.RandString(14))
+	rName2 := fmt.Sprintf("tf-testacc-backup-%[1]s", acctest.RandString(14))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSBackup(t)
+			testAccMultipleRegionsPreCheck(t)
+			testAccAlternateRegionPreCheck(t)
+		},
+		ProviderFactories: testAccProviderFactories(&providers),
+		CheckDestroy:      testAccCheckAwsBackupPlanDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsBackupPlanConfig_copyActionCrossRegion(rName1, rName2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBackupPlanExists(resourceName, &plan, &ruleNameMap),
+					resource.TestCheckResourceAttr(resourceName, "name", rName1),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "rule_name", rName1),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "lifecycle.#", "1"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "lifecycle.0.cold_storage_after", "30"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "lifecycle.0.delete_after", "180"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "copy_action.#", "1"),
+					testAccCheckAwsBackupPlanRuleAttrSet(resourceName, &ruleNameMap, rName1, "copy_action.0.destination_vault_arn"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "copy_action.0.lifecycle.#", "1"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "copy_action.0.lifecycle.0.cold_storage_after", "30"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "copy_action.0.lifecycle.0.delete_after", "180"),
+				),
+			},
+			{
+				Config: testAccAwsBackupPlanConfig_copyActionUpdated(rName1, rName2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBackupPlanExists(resourceName, &plan, &ruleNameMap),
+					resource.TestCheckResourceAttr(resourceName, "name", rName1),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "rule_name", rName1),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "lifecycle.#", "1"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "lifecycle.0.cold_storage_after", "30"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "lifecycle.0.delete_after", "180"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "copy_action.#", "1"),
+					testAccCheckAwsBackupPlanRuleAttrSet(resourceName, &ruleNameMap, rName1, "copy_action.0.destination_vault_arn"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "copy_action.0.lifecycle.#", "1"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "copy_action.0.lifecycle.0.cold_storage_after", "60"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "copy_action.0.lifecycle.0.delete_after", "365"),
+				),
+			},
+			{
+				Config: testAccAwsBackupPlanConfig_basic(rName1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBackupPlanExists(resourceName, &plan, &ruleNameMap),
+					resource.TestCheckResourceAttr(resourceName, "name", rName1),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "rule_name", rName1),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "lifecycle.#", "0"),
+					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName1, "copy_action.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAwsBackupPlan_disappears(t *testing.T) {
 	var plan backup.GetBackupPlanOutput
 	ruleNameMap := map[string]string{}
@@ -391,6 +520,12 @@ func testAccCheckAwsBackupPlanExists(name string, plan *backup.GetBackupPlanOutp
 func testAccCheckAwsBackupPlanRuleAttr(name string, ruleNameMap *map[string]string, ruleName, key, value string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		return resource.TestCheckResourceAttr(name, fmt.Sprintf("rule.%s.%s", (*ruleNameMap)[ruleName], key), value)(s)
+	}
+}
+
+func testAccCheckAwsBackupPlanRuleAttrSet(name string, ruleNameMap *map[string]string, ruleName, value string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		return resource.TestCheckResourceAttrSet(name, fmt.Sprintf("rule.%s.%s", (*ruleNameMap)[ruleName], value))(s)
 	}
 }
 
@@ -624,4 +759,110 @@ resource "aws_backup_plan" "test" {
   }
 }
 `, rName)
+}
+
+func testAccAwsBackupPlanConfig_copyAction(rName1 string, rName2 string) string {
+	return fmt.Sprintf(`
+resource "aws_backup_vault" "test" {
+  name = %[1]q
+}
+
+resource "aws_backup_vault" "test2" {
+  name = %[2]q
+}
+
+resource "aws_backup_plan" "test" {
+  name = %[1]q
+
+  rule {
+    rule_name         = %[1]q
+    target_vault_name = "${aws_backup_vault.test.name}"
+    schedule          = "cron(0 12 * * ? *)"
+
+    lifecycle {
+      cold_storage_after = 30
+      delete_after       = 180
+    }
+
+    copy_action {
+      lifecycle {
+        cold_storage_after = 30
+        delete_after       = 180
+	  }
+      destination_vault_arn = "${aws_backup_vault.test2.arn}"
+    }
+  }
+}
+`, rName1, rName2)
+}
+
+func testAccAwsBackupPlanConfig_copyActionUpdated(rName1 string, rName2 string) string {
+	return fmt.Sprintf(`
+resource "aws_backup_vault" "test" {
+  name = %[1]q
+}
+
+resource "aws_backup_vault" "test2" {
+  name = %[2]q
+}
+
+resource "aws_backup_plan" "test" {
+  name = %[1]q
+
+  rule {
+    rule_name         = %[1]q
+    target_vault_name = "${aws_backup_vault.test.name}"
+    schedule          = "cron(0 12 * * ? *)"
+
+    lifecycle {
+      cold_storage_after = 30
+      delete_after       = 180
+    }
+
+    copy_action {
+      lifecycle {
+        cold_storage_after = 60
+        delete_after       = 365
+	  }
+      destination_vault_arn = "${aws_backup_vault.test2.arn}"
+    }
+  }
+}
+`, rName1, rName2)
+}
+
+func testAccAwsBackupPlanConfig_copyActionCrossRegion(rName1 string, rName2 string) string {
+	return testAccAlternateRegionProviderConfig() + fmt.Sprintf(`
+resource "aws_backup_vault" "test" {
+  name = %[1]q
+}
+
+resource "aws_backup_vault" "test2" {
+  provider = "aws.alternate"
+  name     = %[2]q
+}
+
+resource "aws_backup_plan" "test" {
+  name = %[1]q
+
+  rule {
+    rule_name         = %[1]q
+    target_vault_name = "${aws_backup_vault.test.name}"
+    schedule          = "cron(0 12 * * ? *)"
+
+    lifecycle {
+      cold_storage_after = 30
+      delete_after       = 180
+    }
+
+    copy_action {
+      lifecycle {
+        cold_storage_after = 30
+        delete_after       = 180
+	  }
+      destination_vault_arn = "${aws_backup_vault.test2.arn}"
+    }
+  }
+}
+`, rName1, rName2)
 }

--- a/website/docs/r/backup_plan.html.markdown
+++ b/website/docs/r/backup_plan.html.markdown
@@ -36,18 +36,25 @@ The following arguments are supported:
 For **rule** the following attributes are supported:
 
 * `rule_name` - (Required) An display name for a backup rule.
-* `target_vault_name` (Required) - The name of a logical container where backups are stored.
-* `schedule` (Optional) - A CRON expression specifying when AWS Backup initiates a backup job.
-* `start_window` (Optional) - The amount of time in minutes before beginning a backup.
-* `completion_window` (Optional) - The amount of time AWS Backup attempts a backup before canceling the job and returning an error.
-* `lifecycle` (Optional) - The lifecycle defines when a protected resource is transitioned to cold storage and when it expires.  Fields documented below.
-* `recovery_point_tags` (Optional) - Metadata that you can assign to help organize the resources that you create.
+* `target_vault_name` - (Required) The name of a logical container where backups are stored.
+* `schedule` - (Optional) A CRON expression specifying when AWS Backup initiates a backup job.
+* `start_window` - (Optional) The amount of time in minutes before beginning a backup.
+* `completion_window` - (Optional) The amount of time AWS Backup attempts a backup before canceling the job and returning an error.
+* `lifecycle` - (Optional) The lifecycle defines when a protected resource is transitioned to cold storage and when it expires.  Fields documented below.
+* `recovery_point_tags` - (Optional) Metadata that you can assign to help organize the resources that you create.
+* `copy_action` - (Optional) 
 
 ### Lifecycle Arguments
 For **lifecycle** the following attributes are supported:
 
 * `cold_storage_after` - (Optional) Specifies the number of days after creation that a recovery point is moved to cold storage.
-* `delete_after` (Optional) - Specifies the number of days after creation that a recovery point is deleted. Must be 90 days greater than `cold_storage_after`.
+* `delete_after` - (Optional) Specifies the number of days after creation that a recovery point is deleted. Must be 90 days greater than `cold_storage_after`.
+
+### Copy Action Arguments
+For **copy_action** the following attributes are supported:
+
+* `lifecycle` - (Optional) The lifecycle defines when a protected resource is copied over to a backup vault and when it expires.  Fields documented above.
+* `destination_vault_arn` - (Required) An Amazon Resource Name (ARN) that uniquely identifies the destination backup vault for the copied backup.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #11589

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
r/aws_backup_plan: adding copy action support
```

Output from acceptance testing:

```
 make testacc TEST=./aws TESTARGS='-run=TestAccAwsBackupPlan_withCopyActions'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsBackupPlan_withCopyActions -timeout 120m
=== RUN   TestAccAwsBackupPlan_withCopyActions
=== PAUSE TestAccAwsBackupPlan_withCopyActions
=== RUN   TestAccAwsBackupPlan_withCopyActionsCrossRegion
=== PAUSE TestAccAwsBackupPlan_withCopyActionsCrossRegion
=== CONT  TestAccAwsBackupPlan_withCopyActions
=== CONT  TestAccAwsBackupPlan_withCopyActionsCrossRegion
--- PASS: TestAccAwsBackupPlan_withCopyActionsCrossRegion (24.55s)
--- PASS: TestAccAwsBackupPlan_withCopyActions (49.66s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	49.722s
```
