### PR TITLE
service/ec2: Refactor VPC Endpoint (Service) data sources and resource to use keyvaluetags package

### DIFF
--- a/aws/data_source_aws_vpc_endpoint.go
+++ b/aws/data_source_aws_vpc_endpoint.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/structure"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func dataSourceAwsVpcEndpoint() *schema.Resource {
@@ -127,7 +128,7 @@ func dataSourceAwsVpcEndpointRead(d *schema.ResourceData, meta interface{}) erro
 		},
 	)
 	req.Filters = append(req.Filters, buildEC2TagFilterList(
-		tagsFromMap(d.Get("tags").(map[string]interface{})),
+		keyvaluetags.New(d.Get("tags").(map[string]interface{})).Ec2Tags(),
 	)...)
 	req.Filters = append(req.Filters, buildEC2CustomFilterList(
 		d.Get("filter").(*schema.Set),
@@ -207,7 +208,7 @@ func dataSourceAwsVpcEndpointRead(d *schema.ResourceData, meta interface{}) erro
 	if err != nil {
 		return fmt.Errorf("error setting subnet_ids: %s", err)
 	}
-	err = d.Set("tags", tagsToMap(vpce.Tags))
+	err = d.Set("tags", keyvaluetags.Ec2KeyValueTags(vpce.Tags).IgnoreAws().Map())
 	if err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}

--- a/aws/data_source_aws_vpc_endpoint_service.go
+++ b/aws/data_source_aws_vpc_endpoint_service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func dataSourceAwsVpcEndpointService() *schema.Resource {
@@ -137,7 +138,7 @@ func dataSourceAwsVpcEndpointServiceRead(d *schema.ResourceData, meta interface{
 	d.Set("private_dns_name", sd.PrivateDnsName)
 	d.Set("service_id", sd.ServiceId)
 	d.Set("service_type", sd.ServiceType[0].ServiceType)
-	err = d.Set("tags", tagsToMap(sd.Tags))
+	err = d.Set("tags", keyvaluetags.Ec2KeyValueTags(sd.Tags).IgnoreAws().Map())
 	if err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/10688

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
--- PASS: TestAccAWSVpcEndpointService_removed (402.00s)
--- PASS: TestAccAWSVpcEndpointService_basic (496.96s)
--- PASS: TestAccAWSVpcEndpointService_AllowedPrincipalsAndTags (552.52s)

--- PASS: TestAccDataSourceAwsVpcEndpoint_byId (42.27s)
--- PASS: TestAccDataSourceAwsVpcEndpoint_byFilter (42.46s)
--- PASS: TestAccDataSourceAwsVpcEndpoint_gatewayBasic (42.52s)
--- PASS: TestAccDataSourceAwsVpcEndpoint_byTags (47.33s)
--- PASS: TestAccDataSourceAwsVpcEndpoint_gatewayWithRouteTableAndTags (53.17s)
--- PASS: TestAccDataSourceAwsVpcEndpoint_interface (198.80s)

--- PASS: TestAccDataSourceAwsVpcEndpointService_interface (15.12s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_gateway (15.52s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_custom (275.50s)
```