### PR TITLE
service/ec2: Refactor Spot Instance and Fleet resources to use keyvaluetags package

### DIFF
--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsSpotFleetRequest() *schema.Resource {
@@ -464,7 +465,7 @@ func buildSpotFleetLaunchSpecification(d map[string]interface{}, meta interface{
 	if m, ok := d["tags"].(map[string]interface{}); ok && len(m) > 0 {
 		tagsSpec := make([]*ec2.SpotFleetTagSpecification, 0)
 
-		tags := tagsFromMap(m)
+		tags := keyvaluetags.New(m).IgnoreAws().Ec2Tags()
 
 		spec := &ec2.SpotFleetTagSpecification{
 			ResourceType: aws.String("instance"),
@@ -1070,8 +1071,8 @@ func launchSpecToMap(l *ec2.SpotFleetLaunchSpecification, rootDevName *string) m
 	if l.TagSpecifications != nil {
 		for _, tagSpecs := range l.TagSpecifications {
 			// only "instance" tags are currently supported: http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_SpotFleetTagSpecification.html
-			if *(tagSpecs.ResourceType) == "instance" {
-				m["tags"] = tagsToMap(tagSpecs.Tags)
+			if aws.StringValue(tagSpecs.ResourceType) == ec2.ResourceTypeInstance {
+				m["tags"] = keyvaluetags.Ec2KeyValueTags(tagSpecs.Tags).IgnoreAws().Map()
 			}
 		}
 	}

--- a/aws/resource_aws_spot_instance_request.go
+++ b/aws/resource_aws_spot_instance_request.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsSpotInstanceRequest() *schema.Resource {
@@ -226,7 +227,13 @@ func resourceAwsSpotInstanceRequestCreate(d *schema.ResourceData, meta interface
 		}
 	}
 
-	return resourceAwsSpotInstanceRequestUpdate(d, meta)
+	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
+		if err := keyvaluetags.Ec2UpdateTags(conn, d.Id(), nil, v); err != nil {
+			return fmt.Errorf("error adding EC2 Spot Instance Request (%s) tags: %s", d.Id(), err)
+		}
+	}
+
+	return resourceAwsSpotInstanceRequestRead(d, meta)
 }
 
 // Update spot state, etc
@@ -277,7 +284,11 @@ func resourceAwsSpotInstanceRequestRead(d *schema.ResourceData, meta interface{}
 	d.Set("spot_request_state", request.State)
 	d.Set("launch_group", request.LaunchGroup)
 	d.Set("block_duration_minutes", request.BlockDurationMinutes)
-	d.Set("tags", tagsToMap(request.Tags))
+
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(request.Tags).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
 	d.Set("instance_interruption_behaviour", request.InstanceInterruptionBehavior)
 	d.Set("valid_from", aws.TimeValue(request.ValidFrom).Format(time.RFC3339))
 	d.Set("valid_until", aws.TimeValue(request.ValidUntil).Format(time.RFC3339))
@@ -373,14 +384,13 @@ func readInstance(d *schema.ResourceData, meta interface{}) error {
 func resourceAwsSpotInstanceRequestUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	d.Partial(true)
-	if err := setTags(conn, d); err != nil {
-		return err
-	} else {
-		d.SetPartial("tags")
-	}
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
 
-	d.Partial(false)
+		if err := keyvaluetags.Ec2UpdateTags(conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("error updating EC2 Spot Instance Request (%s) tags: %s", d.Id(), err)
+		}
+	}
 
 	return resourceAwsSpotInstanceRequestRead(d, meta)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/10688

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
--- PASS: TestAccAWSSpotFleetRequest_associatePublicIpAddress (274.60s)
--- PASS: TestAccAWSSpotFleetRequest_basic (283.14s)
--- PASS: TestAccAWSSpotFleetRequest_changePriceForcesNewRequest (522.10s)
--- PASS: TestAccAWSSpotFleetRequest_diversifiedAllocation (298.59s)
--- PASS: TestAccAWSSpotFleetRequest_fleetType (282.73s)
--- PASS: TestAccAWSSpotFleetRequest_iamInstanceProfileArn (276.40s)
--- PASS: TestAccAWSSpotFleetRequest_instanceInterruptionBehavior (274.55s)
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDevice_KmsKeyId (165.46s)
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDevice_KmsKeyId (174.06s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList (292.48s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion (290.78s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList (296.09s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstancePools (289.26s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz (297.04s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet (298.03s)
--- PASS: TestAccAWSSpotFleetRequest_overriddingSpotPrice (297.99s)
--- PASS: TestAccAWSSpotFleetRequest_placementTenancyAndGroup (62.05s)
--- PASS: TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy (482.51s)
--- PASS: TestAccAWSSpotFleetRequest_updateTargetCapacity (839.04s)
--- PASS: TestAccAWSSpotFleetRequest_withEBSDisk (281.29s)
--- PASS: TestAccAWSSpotFleetRequest_WithELBs (337.32s)
--- PASS: TestAccAWSSpotFleetRequest_withoutSpotPrice (255.23s)
--- PASS: TestAccAWSSpotFleetRequest_withTags (275.65s)
--- PASS: TestAccAWSSpotFleetRequest_WithTargetGroups (413.66s)
--- PASS: TestAccAWSSpotFleetRequest_withWeightedCapacity (369.73s)

--- PASS: TestAccAWSSpotInstanceRequest_withBlockDuration (83.23s)
--- PASS: TestAccAWSSpotInstanceRequest_validUntil (93.46s)
--- PASS: TestAccAWSSpotInstanceRequest_withoutSpotPrice (104.36s)
--- PASS: TestAccAWSSpotInstanceRequest_SubnetAndSGAndPublicIpAddress (113.97s)
--- PASS: TestAccAWSSpotInstanceRequest_basic (114.64s)
--- PASS: TestAccAWSSpotInstanceRequest_vpc (122.18s)
--- PASS: TestAccAWSSpotInstanceRequest_NetworkInterfaceAttributes (126.37s)
--- PASS: TestAccAWSSpotInstanceRequest_withLaunchGroup (126.68s)
--- PASS: TestAccAWSSpotInstanceRequest_getPasswordData (247.92s)
```