### PR TITLE
resource/aws_vpc_peering_connection: Refactor to use keyvaluetags package

### DIFF
--- a/aws/resource_aws_vpc_peering_connection.go
+++ b/aws/resource_aws_vpc_peering_connection.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsVpcPeeringConnection() *schema.Resource {
@@ -161,7 +162,7 @@ func resourceAwsVPCPeeringRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error setting VPC Peering Connection requester information: %s", err)
 	}
 
-	err = d.Set("tags", tagsToMap(pc.Tags))
+	err = d.Set("tags", keyvaluetags.Ec2KeyValueTags(pc.Tags).IgnoreAws().Map())
 	if err != nil {
 		return fmt.Errorf("Error setting VPC Peering Connection tags: %s", err)
 	}
@@ -202,10 +203,12 @@ func resourceAwsVpcPeeringConnectionModifyOptions(d *schema.ResourceData, meta i
 func resourceAwsVPCPeeringUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	if err := setTags(conn, d); err != nil {
-		return err
-	} else {
-		d.SetPartial("tags")
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.Ec2UpdateTags(conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("error updating EC2 VPC Peering Connection (%s) tags: %s", d.Id(), err)
+		}
 	}
 
 	pcRaw, statusCode, err := vpcPeeringConnectionRefreshState(conn, d.Id())()


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/10688

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
--- PASS: TestAccAWSVPCPeeringConnection_peerRegionAutoAccept (18.18s)
--- PASS: TestAccAWSVPCPeeringConnection_failedState (18.90s)
--- PASS: TestAccAWSVPCPeeringConnection_optionsNoAutoAccept (22.54s)
--- PASS: TestAccAWSVPCPeeringConnection_plan (30.03s)
--- PASS: TestAccAWSVPCPeeringConnection_basic (32.13s)
--- PASS: TestAccAWSVPCPeeringConnection_tags (33.94s)
--- PASS: TestAccAWSVPCPeeringConnection_region (35.88s)
--- PASS: TestAccAWSVPCPeeringConnection_options (57.71s)
--- PASS: TestAccAWSVPCPeeringConnection_accept (68.21s)
```
