### PR TITLE
service/cognito: Fixes for tfproviderlint R002

### DIFF
--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -732,22 +732,22 @@ func resourceAwsCognitoUserPoolRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("auto_verified_attributes", flattenStringList(resp.UserPool.AutoVerifiedAttributes))
 
 	if resp.UserPool.EmailVerificationSubject != nil {
-		d.Set("email_verification_subject", *resp.UserPool.EmailVerificationSubject)
+		d.Set("email_verification_subject", resp.UserPool.EmailVerificationSubject)
 	}
 	if resp.UserPool.EmailVerificationMessage != nil {
-		d.Set("email_verification_message", *resp.UserPool.EmailVerificationMessage)
+		d.Set("email_verification_message", resp.UserPool.EmailVerificationMessage)
 	}
 	if err := d.Set("lambda_config", flattenCognitoUserPoolLambdaConfig(resp.UserPool.LambdaConfig)); err != nil {
 		return fmt.Errorf("Failed setting lambda_config: %s", err)
 	}
 	if resp.UserPool.MfaConfiguration != nil {
-		d.Set("mfa_configuration", *resp.UserPool.MfaConfiguration)
+		d.Set("mfa_configuration", resp.UserPool.MfaConfiguration)
 	}
 	if resp.UserPool.SmsVerificationMessage != nil {
-		d.Set("sms_verification_message", *resp.UserPool.SmsVerificationMessage)
+		d.Set("sms_verification_message", resp.UserPool.SmsVerificationMessage)
 	}
 	if resp.UserPool.SmsAuthenticationMessage != nil {
-		d.Set("sms_authentication_message", *resp.UserPool.SmsAuthenticationMessage)
+		d.Set("sms_authentication_message", resp.UserPool.SmsAuthenticationMessage)
 	}
 
 	if err := d.Set("device_configuration", flattenCognitoUserPoolDeviceConfiguration(resp.UserPool.DeviceConfiguration)); err != nil {

--- a/aws/resource_aws_cognito_user_pool_client.go
+++ b/aws/resource_aws_cognito_user_pool_client.go
@@ -248,8 +248,8 @@ func resourceAwsCognitoUserPoolClientRead(d *schema.ResourceData, meta interface
 	}
 
 	d.SetId(*resp.UserPoolClient.ClientId)
-	d.Set("user_pool_id", *resp.UserPoolClient.UserPoolId)
-	d.Set("name", *resp.UserPoolClient.ClientName)
+	d.Set("user_pool_id", resp.UserPoolClient.UserPoolId)
+	d.Set("name", resp.UserPoolClient.ClientName)
 	d.Set("explicit_auth_flows", flattenStringList(resp.UserPoolClient.ExplicitAuthFlows))
 	d.Set("read_attributes", flattenStringList(resp.UserPoolClient.ReadAttributes))
 	d.Set("write_attributes", flattenStringList(resp.UserPoolClient.WriteAttributes))


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/9952

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Remove pointer value dereferences, which can cause potential panics and are extraneous as `Set()` automatically handles pointer types including when `nil`.

Previously:

```
aws/resource_aws_cognito_user_pool.go:735:39: R002: ResourceData.Set() pointer value dereference is extraneous
aws/resource_aws_cognito_user_pool.go:738:39: R002: ResourceData.Set() pointer value dereference is extraneous
aws/resource_aws_cognito_user_pool.go:744:30: R002: ResourceData.Set() pointer value dereference is extraneous
aws/resource_aws_cognito_user_pool.go:747:37: R002: ResourceData.Set() pointer value dereference is extraneous
aws/resource_aws_cognito_user_pool.go:750:39: R002: ResourceData.Set() pointer value dereference is extraneous
aws/resource_aws_cognito_user_pool_client.go:251:24: R002: ResourceData.Set() pointer value dereference is extraneous
aws/resource_aws_cognito_user_pool_client.go:252:16: R002: ResourceData.Set() pointer value dereference is extraneous
```

Output from acceptance testing:

```
--- PASS: TestAccAWSCognitoUserPool_basic (18.30s)
--- PASS: TestAccAWSCognitoUserPool_withSmsVerificationMessage (28.18s)
--- PASS: TestAccAWSCognitoUserPool_withPasswordPolicy (28.85s)
--- PASS: TestAccAWSCognitoUserPool_withAliasAttributes (29.04s)
--- PASS: TestAccAWSCognitoUserPool_withEmailVerificationMessage (29.21s)
--- PASS: TestAccAWSCognitoUserPool_withDeviceConfiguration (29.96s)
--- PASS: TestAccAWSCognitoUserPool_withSchemaAttributes (31.11s)
--- PASS: TestAccAWSCognitoUserPool_withVerificationMessageTemplate (33.36s)
--- PASS: TestAccAWSCognitoUserPool_withSmsConfiguration (35.03s)
--- PASS: TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration (40.00s)
--- PASS: TestAccAWSCognitoUserPool_withAdvancedSecurityMode (40.10s)
--- PASS: TestAccAWSCognitoUserPool_withTags (40.97s)
--- PASS: TestAccAWSCognitoUserPool_withSmsConfigurationUpdated (41.73s)
--- PASS: TestAccAWSCognitoUserPool_update (59.53s)
--- PASS: TestAccAWSCognitoUserPool_withLambdaConfig (63.83s)

--- PASS: TestAccAWSCognitoUserPoolClient_allFields (18.90s)
--- PASS: TestAccAWSCognitoUserPoolClient_basic (19.22s)
--- PASS: TestAccAWSCognitoUserPoolClient_Name (31.13s)
--- PASS: TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField (31.62s)
--- PASS: TestAccAWSCognitoUserPoolClient_RefreshTokenValidity (31.99s)
```
