### PR TITLE
service/elastictranscoder: Fixes for tfproviderlint R002

### DIFF
--- a/aws/resource_aws_elastic_transcoder_pipeline.go
+++ b/aws/resource_aws_elastic_transcoder_pipeline.go
@@ -424,10 +424,10 @@ func resourceAwsElasticTranscoderPipelineRead(d *schema.ResourceData, meta inter
 
 	pipeline := resp.Pipeline
 
-	d.Set("arn", *pipeline.Arn)
+	d.Set("arn", pipeline.Arn)
 
 	if arn := pipeline.AwsKmsKeyArn; arn != nil {
-		d.Set("aws_kms_key_arn", *arn)
+		d.Set("aws_kms_key_arn", arn)
 	}
 
 	if pipeline.ContentConfig != nil {
@@ -444,8 +444,8 @@ func resourceAwsElasticTranscoderPipelineRead(d *schema.ResourceData, meta inter
 		}
 	}
 
-	d.Set("input_bucket", *pipeline.InputBucket)
-	d.Set("name", *pipeline.Name)
+	d.Set("input_bucket", pipeline.InputBucket)
+	d.Set("name", pipeline.Name)
 
 	notifications := flattenETNotifications(pipeline.Notifications)
 	if notifications != nil {
@@ -454,7 +454,7 @@ func resourceAwsElasticTranscoderPipelineRead(d *schema.ResourceData, meta inter
 		}
 	}
 
-	d.Set("role", *pipeline.Role)
+	d.Set("role", pipeline.Role)
 
 	if pipeline.ThumbnailConfig != nil {
 		err := d.Set("thumbnail_config", flattenETPipelineOutputConfig(pipeline.ThumbnailConfig))
@@ -471,7 +471,7 @@ func resourceAwsElasticTranscoderPipelineRead(d *schema.ResourceData, meta inter
 	}
 
 	if pipeline.OutputBucket != nil {
-		d.Set("output_bucket", *pipeline.OutputBucket)
+		d.Set("output_bucket", pipeline.OutputBucket)
 	}
 
 	return nil

--- a/aws/resource_aws_elastic_transcoder_preset.go
+++ b/aws/resource_aws_elastic_transcoder_preset.go
@@ -349,7 +349,7 @@ func resourceAwsElasticTranscoderPresetCreate(d *schema.ResourceData, meta inter
 	}
 
 	d.SetId(*resp.Preset.Id)
-	d.Set("arn", *resp.Preset.Arn)
+	d.Set("arn", resp.Preset.Arn)
 
 	return nil
 }
@@ -488,7 +488,7 @@ func resourceAwsElasticTranscoderPresetRead(d *schema.ResourceData, meta interfa
 	log.Printf("[DEBUG] Elastic Transcoder Preset Read response: %#v", resp)
 
 	preset := resp.Preset
-	d.Set("arn", *preset.Arn)
+	d.Set("arn", preset.Arn)
 
 	if preset.Audio != nil {
 		err := d.Set("audio", flattenETAudioParameters(preset.Audio))
@@ -501,9 +501,9 @@ func resourceAwsElasticTranscoderPresetRead(d *schema.ResourceData, meta interfa
 		}
 	}
 
-	d.Set("container", *preset.Container)
-	d.Set("name", *preset.Name)
-	d.Set("description", *preset.Description)
+	d.Set("container", preset.Container)
+	d.Set("name", preset.Name)
+	d.Set("description", preset.Description)
 
 	if preset.Thumbnails != nil {
 		err := d.Set("thumbnails", flattenETThumbnails(preset.Thumbnails))
@@ -512,7 +512,7 @@ func resourceAwsElasticTranscoderPresetRead(d *schema.ResourceData, meta interfa
 		}
 	}
 
-	d.Set("type", *preset.Type)
+	d.Set("type", preset.Type)
 
 	if preset.Video != nil {
 		err := d.Set("video", flattenETVideoParams(preset.Video))


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/9952

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Remove pointer value dereferences, which can cause potential panics and are extraneous as `Set()` automatically handles pointer types including when `nil`.

Previously:

```
aws/resource_aws_elastic_transcoder_pipeline.go:427:15: R002: ResourceData.Set() pointer value dereference is extraneous
aws/resource_aws_elastic_transcoder_pipeline.go:430:28: R002: ResourceData.Set() pointer value dereference is extraneous
aws/resource_aws_elastic_transcoder_pipeline.go:447:24: R002: ResourceData.Set() pointer value dereference is extraneous
aws/resource_aws_elastic_transcoder_pipeline.go:448:16: R002: ResourceData.Set() pointer value dereference is extraneous
aws/resource_aws_elastic_transcoder_pipeline.go:457:16: R002: ResourceData.Set() pointer value dereference is extraneous
aws/resource_aws_elastic_transcoder_pipeline.go:474:26: R002: ResourceData.Set() pointer value dereference is extraneous
aws/resource_aws_elastic_transcoder_preset.go:352:15: R002: ResourceData.Set() pointer value dereference is extraneous
aws/resource_aws_elastic_transcoder_preset.go:491:15: R002: ResourceData.Set() pointer value dereference is extraneous
aws/resource_aws_elastic_transcoder_preset.go:504:21: R002: ResourceData.Set() pointer value dereference is extraneous
aws/resource_aws_elastic_transcoder_preset.go:505:16: R002: ResourceData.Set() pointer value dereference is extraneous
aws/resource_aws_elastic_transcoder_preset.go:506:23: R002: ResourceData.Set() pointer value dereference is extraneous
aws/resource_aws_elastic_transcoder_preset.go:515:16: R002: ResourceData.Set() pointer value dereference is extraneous
```

Output from acceptance testing:

```
--- PASS: TestAccAWSElasticTranscoderPipeline_withPermissions (31.86s)
--- PASS: TestAccAWSElasticTranscoderPipeline_basic (34.73s)
--- PASS: TestAccAWSElasticTranscoderPipeline_withContentConfig (51.48s)
--- PASS: TestAccAWSElasticTranscoderPipeline_kmsKey (53.26s)
--- PASS: TestAccAWSElasticTranscoderPipeline_notifications (74.85s)

--- PASS: TestAccAWSElasticTranscoderPreset_basic (39.61s)
```