### PR TITLE
resource/aws_elastic_beanstalk_environment: Fixes for tfproviderlint R002

### DIFF
--- a/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/aws/resource_aws_elastic_beanstalk_environment.go
@@ -589,7 +589,7 @@ func resourceAwsElasticBeanstalkEnvironmentRead(d *schema.ResourceData, meta int
 		return err
 	}
 
-	if err := d.Set("tier", *env.Tier.Name); err != nil {
+	if err := d.Set("tier", env.Tier.Name); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/9952

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Remove pointer value dereferences, which can cause potential panics and are extraneous as `Set()` automatically handles pointer types including when `nil`.

Previously:

```
aws/resource_aws_elastic_beanstalk_environment.go:592:26: R002: ResourceData.Set() pointer value dereference is extraneous
```

Output from acceptance testing:

```
--- PASS: TestAccAWSBeanstalkEnv_resource (374.31s)
--- PASS: TestAccAWSBeanstalkEnv_cname_prefix (396.88s)
--- PASS: TestAccAWSBeanstalkEnv_platformArn (407.51s)
--- PASS: TestAccAWSBeanstalkEnv_basic (470.63s)
--- PASS: TestAccAWSBeanstalkEnv_settingWithJsonValue (510.72s)
--- PASS: TestAccAWSBeanstalkEnv_tier (539.81s)
--- PASS: TestAccAWSBeanstalkEnv_config (573.89s)
--- PASS: TestAccAWSBeanstalkEnv_template_change (637.28s)
--- PASS: TestAccAWSBeanstalkEnv_version_label (640.37s)
--- PASS: TestAccAWSBeanstalkEnv_tags (711.19s)
--- PASS: TestAccAWSBeanstalkEnv_settings_update (890.65s)
```