### PR TITLE
resource/aws_glacier_vault: Fixes for tfproviderlint R002

### DIFF
--- a/aws/resource_aws_glacier_vault.go
+++ b/aws/resource_aws_glacier_vault.go
@@ -102,7 +102,7 @@ func resourceAwsGlacierVaultCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	d.SetId(d.Get("name").(string))
-	d.Set("location", *out.Location)
+	d.Set("location", out.Location)
 
 	return resourceAwsGlacierVaultUpdate(d, meta)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/9952

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Remove pointer value dereferences, which can cause potential panics and are extraneous as `Set()` automatically handles pointer types including when `nil`.

Previously:

```
aws/resource_aws_glacier_vault.go:105:20: R002: ResourceData.Set() pointer value dereference is extraneous
```

Output from acceptance testing:

```
--- PASS: TestAccAWSGlacierVault_basic (22.38s)
--- PASS: TestAccAWSGlacierVault_full (26.27s)
--- PASS: TestAccAWSGlacierVault_RemoveNotifications (38.22s)
```
