### PR TITLE
service/ec2: Fixes for tfproviderlint R002

### DIFF
--- a/aws/resource_aws_route_table_association.go
+++ b/aws/resource_aws_route_table_association.go
@@ -115,10 +115,10 @@ func resourceAwsRouteTableAssociationRead(d *schema.ResourceData, meta interface
 		if *a.RouteTableAssociationId == d.Id() {
 			found = true
 			if a.SubnetId != nil {
-				d.Set("subnet_id", *a.SubnetId)
+				d.Set("subnet_id", a.SubnetId)
 			}
 			if a.GatewayId != nil {
-				d.Set("gateway_id", *a.GatewayId)
+				d.Set("gateway_id", a.GatewayId)
 			}
 			break
 		}

--- a/aws/resource_aws_security_group_rule.go
+++ b/aws/resource_aws_security_group_rule.go
@@ -759,9 +759,9 @@ func setFromIPPerm(d *schema.ResourceData, sg *ec2.SecurityGroup, rule *ec2.IpPe
 		s := rule.UserIdGroupPairs[0]
 
 		if isVPC {
-			d.Set("source_security_group_id", *s.GroupId)
+			d.Set("source_security_group_id", s.GroupId)
 		} else {
-			d.Set("source_security_group_id", *s.GroupName)
+			d.Set("source_security_group_id", s.GroupName)
 		}
 	}
 

--- a/aws/resource_aws_spot_instance_request.go
+++ b/aws/resource_aws_spot_instance_request.go
@@ -264,10 +264,10 @@ func resourceAwsSpotInstanceRequestRead(d *schema.ResourceData, meta interface{}
 		return nil
 	}
 
-	d.Set("spot_bid_status", *request.Status.Code)
+	d.Set("spot_bid_status", request.Status.Code)
 	// Instance ID is not set if the request is still pending
 	if request.InstanceId != nil {
-		d.Set("spot_instance_id", *request.InstanceId)
+		d.Set("spot_instance_id", request.InstanceId)
 		// Read the instance data, setting up connection information
 		if err := readInstance(d, meta); err != nil {
 			return fmt.Errorf("Error reading Spot Instance Data: %s", err)

--- a/aws/resource_aws_vpn_gateway.go
+++ b/aws/resource_aws_vpn_gateway.go
@@ -117,7 +117,7 @@ func resourceAwsVpnGatewayRead(d *schema.ResourceData, meta interface{}) error {
 		// Gateway exists but not attached to the VPC
 		d.Set("vpc_id", "")
 	} else {
-		d.Set("vpc_id", *vpnAttachment.VpcId)
+		d.Set("vpc_id", vpnAttachment.VpcId)
 	}
 
 	if vpnGateway.AvailabilityZone != nil && *vpnGateway.AvailabilityZone != "" {

--- a/aws/resource_aws_vpn_gateway_attachment.go
+++ b/aws/resource_aws_vpn_gateway_attachment.go
@@ -106,7 +106,7 @@ func resourceAwsVpnGatewayAttachmentRead(d *schema.ResourceData, meta interface{
 		return nil
 	}
 
-	d.Set("vpc_id", *vga.VpcId)
+	d.Set("vpc_id", vga.VpcId)
 	return nil
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/9952

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Remove pointer value dereferences, which can cause potential panics and are extraneous as `Set()` automatically handles pointer types including when `nil`.

Previously:

```
aws/resource_aws_route_table_association.go:118:24: R002: ResourceData.Set() pointer value dereference is extraneous
aws/resource_aws_route_table_association.go:121:25: R002: ResourceData.Set() pointer value dereference is extraneous
aws/resource_aws_security_group_rule.go:762:38: R002: ResourceData.Set() pointer value dereference is extraneous
aws/resource_aws_security_group_rule.go:764:38: R002: ResourceData.Set() pointer value dereference is extraneous
aws/resource_aws_spot_instance_request.go:267:27: R002: ResourceData.Set() pointer value dereference is extraneous
aws/resource_aws_spot_instance_request.go:270:29: R002: ResourceData.Set() pointer value dereference is extraneous
aws/resource_aws_vpn_gateway.go:111:19: R002: ResourceData.Set() pointer value dereference is extraneous
aws/resource_aws_vpn_gateway_attachment.go:109:18: R002: ResourceData.Set() pointer value dereference is extraneous
```

Output from acceptance testing:

```
--- PASS: TestAccAWSRouteTableAssociation_disappears (45.48s)
--- PASS: TestAccAWSRouteTableAssociation_Gateway_basic (49.52s)
--- PASS: TestAccAWSRouteTableAssociation_Subnet_basic (50.05s)
--- PASS: TestAccAWSRouteTableAssociation_Subnet_ChangeSubnet (66.29s)
--- PASS: TestAccAWSRouteTableAssociation_Subnet_ChangeRouteTable (68.18s)
--- PASS: TestAccAWSRouteTableAssociation_Gateway_ChangeRouteTable (72.08s)
--- PASS: TestAccAWSRouteTableAssociation_Gateway_ChangeGateway (84.97s)

--- PASS: TestAccAWSSecurityGroupRule_ExpectInvalidTypeError (2.06s)
--- PASS: TestAccAWSSecurityGroupRule_ExpectInvalidCIDR (2.32s)
--- PASS: TestAccAWSSecurityGroupRule_Ingress_VPC (24.60s)
--- PASS: TestAccAWSSecurityGroupRule_EgressDescription (25.25s)
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Classic (25.41s)
--- PASS: TestAccAWSSecurityGroupRule_Issue5310 (26.12s)
--- PASS: TestAccAWSSecurityGroupRule_MultiIngress (26.15s)
--- PASS: TestAccAWSSecurityGroupRule_MultipleRuleSearching_AllProtocolCrash (26.33s)
--- PASS: TestAccAWSSecurityGroupRule_IngressDescription (24.08s)
--- PASS: TestAccAWSSecurityGroupRule_Egress (27.56s)
--- PASS: TestAccAWSSecurityGroupRule_EgressDescription_updates (34.23s)
--- PASS: TestAccAWSSecurityGroupRule_Description_AllPorts_NonZeroPorts (36.67s)
--- PASS: TestAccAWSSecurityGroupRule_Description_AllPorts (37.03s)
--- PASS: TestAccAWSSecurityGroupRule_IngressDescription_updates (34.98s)
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Ipv6 (37.73s)
--- PASS: TestAccAWSSecurityGroupRule_SelfSource (38.09s)
--- PASS: TestAccAWSSecurityGroupRule_SelfReference (38.82s)
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Protocol (39.77s)
--- PASS: TestAccAWSSecurityGroupRule_PartialMatching_Source (41.93s)
--- PASS: TestAccAWSSecurityGroupRule_PartialMatching_basic (46.51s)
--- PASS: TestAccAWSSecurityGroupRule_PrefixListEgress (46.06s)
--- PASS: TestAccAWSSecurityGroupRule_MultiDescription (90.18s)
--- PASS: TestAccAWSSecurityGroupRule_Race (258.80s)

--- PASS: TestAccAWSSpotInstanceRequest_withLaunchGroup (83.19s)
--- PASS: TestAccAWSSpotInstanceRequest_basic (83.78s)
--- PASS: TestAccAWSSpotInstanceRequest_vpc (102.73s)
--- PASS: TestAccAWSSpotInstanceRequest_withBlockDuration (104.39s)
--- PASS: TestAccAWSSpotInstanceRequest_withoutSpotPrice (104.43s)
--- PASS: TestAccAWSSpotInstanceRequest_validUntil (115.07s)
--- PASS: TestAccAWSSpotInstanceRequest_SubnetAndSGAndPublicIpAddress (125.03s)
--- PASS: TestAccAWSSpotInstanceRequest_NetworkInterfaceAttributes (136.48s)
--- PASS: TestAccAWSSpotInstanceRequest_getPasswordData (266.98s)

--- PASS: TestAccAWSVpnGateway_disappears (45.89s)
--- PASS: TestAccAWSVpnGateway_withAmazonSideAsnSetToState (48.07s)
--- PASS: TestAccAWSVpnGateway_withAvailabilityZoneSetToState (57.53s)
--- PASS: TestAccAWSVpnGateway_tags (66.51s)
--- PASS: TestAccAWSVpnGateway_delete (73.68s)
--- PASS: TestAccAWSVpnGateway_basic (97.77s)
--- PASS: TestAccAWSVpnGateway_reattach (137.08s)

--- PASS: TestAccAWSVpnGatewayAttachment_basic (51.22s)
--- PASS: TestAccAWSVpnGatewayAttachment_deleted (67.20s)
```