### PR TITLE
Fix Route 53 resolver sweepers

### DIFF
--- a/aws/resource_aws_route53_resolver_endpoint_test.go
+++ b/aws/resource_aws_route53_resolver_endpoint_test.go
@@ -65,7 +65,6 @@ func testSweepRoute53ResolverEndpoints(region string) error {
 	})
 	if err != nil {
 		if testSweepSkipSweepError(err) {
-			panic(err)
 			log.Printf("[WARN] Skipping Route53 Resolver endpoint sweep for %s: %s", region, err)
 			return nil
 		}

--- a/aws/resource_aws_route53_resolver_endpoint_test.go
+++ b/aws/resource_aws_route53_resolver_endpoint_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53resolver"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -17,6 +18,9 @@ func init() {
 	resource.AddTestSweepers("aws_route53_resolver_endpoint", &resource.Sweeper{
 		Name: "aws_route53_resolver_endpoint",
 		F:    testSweepRoute53ResolverEndpoints,
+		Dependencies: []string{
+			"aws_route53_resolver_rule",
+		},
 	})
 }
 
@@ -27,6 +31,7 @@ func testSweepRoute53ResolverEndpoints(region string) error {
 	}
 	conn := client.(*AWSClient).route53resolverconn
 
+	var errors error
 	err = conn.ListResolverEndpointsPages(&route53resolver.ListResolverEndpointsInput{}, func(page *route53resolver.ListResolverEndpointsOutput, isLast bool) bool {
 		if page == nil {
 			return !isLast
@@ -43,7 +48,7 @@ func testSweepRoute53ResolverEndpoints(region string) error {
 				continue
 			}
 			if err != nil {
-				log.Printf("[ERROR] Error deleting Route53 Resolver endpoint (%s): %s", id, err)
+				errors = multierror.Append(errors, fmt.Errorf("error deleting Route53 Resolver endpoint (%s): %w", id, err))
 				continue
 			}
 
@@ -51,7 +56,8 @@ func testSweepRoute53ResolverEndpoints(region string) error {
 				[]string{route53resolver.ResolverEndpointStatusDeleting},
 				[]string{route53ResolverEndpointStatusDeleted})
 			if err != nil {
-				log.Printf("[ERROR] %s", err)
+				errors = multierror.Append(errors, err)
+				continue
 			}
 		}
 
@@ -59,13 +65,14 @@ func testSweepRoute53ResolverEndpoints(region string) error {
 	})
 	if err != nil {
 		if testSweepSkipSweepError(err) {
+			panic(err)
 			log.Printf("[WARN] Skipping Route53 Resolver endpoint sweep for %s: %s", region, err)
 			return nil
 		}
-		return fmt.Errorf("error retrievingRoute53 Resolver endpoints: %s", err)
+		errors = multierror.Append(errors, fmt.Errorf("error retrievingRoute53 Resolver endpoints: %w", err))
 	}
 
-	return nil
+	return errors
 }
 
 func TestAccAwsRoute53ResolverEndpoint_basicInbound(t *testing.T) {

--- a/aws/resource_aws_route53_resolver_rule_association_test.go
+++ b/aws/resource_aws_route53_resolver_rule_association_test.go
@@ -2,8 +2,11 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
+	"time"
 
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -11,6 +14,68 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53resolver"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_route53_resolver_rule_association", &resource.Sweeper{
+		Name: "aws_route53_resolver_rule_association",
+		F:    testSweepRoute53ResolverRuleAssociations,
+	})
+}
+
+func testSweepRoute53ResolverRuleAssociations(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).route53resolverconn
+
+	var errors error
+	err = conn.ListResolverRuleAssociationsPages(&route53resolver.ListResolverRuleAssociationsInput{}, func(page *route53resolver.ListResolverRuleAssociationsOutput, isLast bool) bool {
+		if page == nil {
+			return !isLast
+		}
+
+		for _, resolverRuleAssociation := range page.ResolverRuleAssociations {
+			id := aws.StringValue(resolverRuleAssociation.Id)
+
+			log.Printf("[INFO] Deleting Route53 Resolver rule association %q", id)
+			_, err := conn.DisassociateResolverRule(&route53resolver.DisassociateResolverRuleInput{
+				ResolverRuleId: resolverRuleAssociation.ResolverRuleId,
+				VPCId:          resolverRuleAssociation.VPCId,
+			})
+			if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
+				continue
+			}
+			if testSweepSkipSweepError(err) {
+				log.Printf("[INFO] Skipping Route53 Resolver rule association %q: %s", id, err)
+				continue
+			}
+			if err != nil {
+				errors = multierror.Append(errors, fmt.Errorf("error deleting Route53 Resolver rule association (%s): %w", id, err))
+				continue
+			}
+
+			err = route53ResolverRuleAssociationWaitUntilTargetState(conn, id, 10*time.Minute,
+				[]string{route53resolver.ResolverRuleAssociationStatusDeleting},
+				[]string{route53ResolverRuleAssociationStatusDeleted})
+			if err != nil {
+				errors = multierror.Append(errors, err)
+				continue
+			}
+		}
+
+		return !isLast
+	})
+	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Route53 Resolver rule association sweep for %s: %s", region, err)
+			return nil
+		}
+		errors = multierror.Append(errors, fmt.Errorf("error retrievingRoute53 Resolver rule associations: %w", err))
+	}
+
+	return errors
+}
 
 func TestAccAwsRoute53ResolverRuleAssociation_basic(t *testing.T) {
 	var assn route53resolver.ResolverRuleAssociation

--- a/aws/resource_aws_route53_resolver_rule_test.go
+++ b/aws/resource_aws_route53_resolver_rule_test.go
@@ -2,8 +2,11 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
+	"time"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -11,6 +14,73 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53resolver"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_route53_resolver_rule", &resource.Sweeper{
+		Name: "aws_route53_resolver_rule",
+		F:    testSweepRoute53ResolverRules,
+		Dependencies: []string{
+			"aws_route53_resolver_rule_association",
+		},
+	})
+}
+
+func testSweepRoute53ResolverRules(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).route53resolverconn
+
+	var errors error
+	err = conn.ListResolverRulesPages(&route53resolver.ListResolverRulesInput{}, func(page *route53resolver.ListResolverRulesOutput, isLast bool) bool {
+		if page == nil {
+			return !isLast
+		}
+
+		for _, resolverRule := range page.ResolverRules {
+			id := aws.StringValue(resolverRule.Id)
+
+			ownerID := aws.StringValue(resolverRule.OwnerId)
+			if ownerID != client.(*AWSClient).accountid {
+				log.Printf("[INFO] Skipping Route53 Resolver rule %q, owned by %q", id, ownerID)
+				continue
+			}
+
+			log.Printf("[INFO] Deleting Route53 Resolver rule %q", id)
+			_, err := conn.DeleteResolverRule(&route53resolver.DeleteResolverRuleInput{
+				ResolverRuleId: aws.String(id),
+			})
+			if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
+				continue
+			}
+			if err != nil {
+				errors = multierror.Append(errors, fmt.Errorf("error deleting Route53 Resolver rule (%s): %w", id, err))
+				continue
+			}
+
+			err = route53ResolverRuleWaitUntilTargetState(conn, id, 10*time.Minute,
+				[]string{route53resolver.ResolverRuleStatusDeleting},
+				[]string{route53ResolverRuleStatusDeleted})
+			if err != nil {
+				errors = multierror.Append(errors, err)
+				continue
+			}
+		}
+
+		return !isLast
+	})
+	if err != nil {
+		if testSweepSkipSweepError(err) {
+			panic(err)
+			log.Printf("[WARN] Skipping Route53 Resolver rule sweep for %s: %s", region, err)
+			return nil
+		}
+		errors = multierror.Append(errors, fmt.Errorf("error retrievingRoute53 Resolver rules: %w", err))
+	}
+
+	return errors
+}
 
 func TestAccAwsRoute53ResolverRule_basic(t *testing.T) {
 	var rule route53resolver.ResolverRule

--- a/aws/resource_aws_route53_resolver_rule_test.go
+++ b/aws/resource_aws_route53_resolver_rule_test.go
@@ -72,7 +72,6 @@ func testSweepRoute53ResolverRules(region string) error {
 	})
 	if err != nil {
 		if testSweepSkipSweepError(err) {
-			panic(err)
 			log.Printf("[WARN] Skipping Route53 Resolver rule sweep for %s: %s", region, err)
 			return nil
 		}


### PR DESCRIPTION
The Route 53 resolver endpoint sweeper was failing to sweep endpoints, but returning success. Sweeping also requires removing Route 53 resolver rules and resolver rule associations.

Previous sweeper output:

```
$ make sweep SWEEPARGS="-sweep-run=aws_route53_resolver_endpoint"
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./... -v -sweep=us-east-1,us-west-2 -sweep-run=aws_route53_resolver_endpoint -timeout 60m
2020/02/06 15:58:03 [DEBUG] Running Sweepers for region (us-east-1):
2020/02/06 15:58:03 [DEBUG] Running Sweeper (aws_route53_resolver_endpoint) in region (us-east-1)
2020/02/06 15:58:07 Sweeper Tests ran successfully:
	- aws_route53_resolver_endpoint
2020/02/06 15:58:07 [DEBUG] Running Sweepers for region (us-west-2):
2020/02/06 15:58:07 [DEBUG] Running Sweeper (aws_route53_resolver_endpoint) in region (us-west-2)
2020/02/06 15:58:09 [INFO] Deleting Route53 Resolver endpoint: rslvr-out-85fb86cd2e5643ceb
2020/02/06 15:58:09 [ERROR] Error deleting Route53 Resolver endpoint (rslvr-out-85fb86cd2e5643ceb): InvalidRequestException: [RSLVR-00600] Cannot delete resolver endpoint unless its related resolver rules are deleted. The following rules still exist for this resolver endpoint: "rslvr-rr-3456d673d7644bcbe"
2020/02/06 15:58:09 Sweeper Tests ran successfully:
	- aws_route53_resolver_endpoint
ok  	github.com/terraform-providers/terraform-provider-aws/aws	6.939s
```

Updated output:

```
$ make sweep SWEEPARGS="-sweep-run=aws_route53_resolver_endpoint"
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./... -v -sweep=us-east-1,us-west-2 -sweep-run=aws_route53_resolver_endpoint -timeout 60m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
2020/02/06 17:15:08 [DEBUG] Running Sweepers for region (us-east-1):
2020/02/06 17:15:18 Sweeper Tests ran successfully:
	- aws_route53_resolver_rule_association
	- aws_route53_resolver_rule
	- aws_route53_resolver_endpoint
2020/02/06 17:15:18 [DEBUG] Running Sweepers for region (us-west-2):
2020/02/06 17:17:03 Sweeper Tests ran successfully:
	- aws_route53_resolver_rule
	- aws_route53_resolver_endpoint
	- aws_route53_resolver_rule_association
ok  	github.com/terraform-providers/terraform-provider-aws/aws	116.224s
```

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
