### PR TITLE
service/neptune: enable CloudwatchLogsExports of type audit

### DIFF
--- a/website/docs/r/neptune_cluster.html.markdown
+++ b/website/docs/r/neptune_cluster.html.markdown
@@ -44,6 +44,7 @@ The following arguments are supported:
 * `backup_retention_period` - (Optional) The days to retain backups for. Default `1`
 * `cluster_identifier` - (Optional, Forces new resources) The cluster identifier. If omitted, Terraform will assign a random, unique identifier.
 * `cluster_identifier_prefix` - (Optional, Forces new resource) Creates a unique cluster identifier beginning with the specified prefix. Conflicts with `cluster_identifier`.
+* `enable_cloudwatch_logs_exports` - (Optional) A list of the log types this DB cluster is configured to export to Cloudwatch Logs. Currently only supports `audit`.
 * `engine` - (Optional) The name of the database engine to be used for this Neptune cluster. Defaults to `neptune`.
 * `engine_version` - (Optional) The database engine version.
 * `final_snapshot_identifier` - (Optional) The name of your final Neptune snapshot when this Neptune cluster is deleted. If omitted, no final snapshot will be made.


### PR DESCRIPTION
## Overview

Add a new schema property to allow users to ship audit logs for their Neptune cluster to Cloudwatch. 

## Notes

The glob pattern (e.g., `TestAccAWSNeptuneCluster` ) to run all the acceptance tests for this resource causes failures since each of the test cases use `acctest.RandInt()` in the resource name, causing non-unique resource names and resource contention.

If appropriate, I can amend the PR to generate unique resource names via `acctest.RandString()` to allow all the acceptance tests to run in parallel successfully. (I haven't made enough contributions to this repo yet to familiarize myself with the conventions regarding best practices for resource naming in test cases or "appropriately sized PRs").

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9094 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_neptune_cloudwatch_cluster: enable audit type CloudwatchLogsExports
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSNeptuneCluster_updateCloudwatchLogsExports'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSNeptuneCluster_updateCloudwatchLogsExports -timeout 120m
=== RUN   TestAccAWSNeptuneCluster_updateCloudwatchLogsExports
=== PAUSE TestAccAWSNeptuneCluster_updateCloudwatchLogsExports
=== CONT  TestAccAWSNeptuneCluster_updateCloudwatchLogsExports
--- PASS: TestAccAWSNeptuneCluster_updateCloudwatchLogsExports (215.32s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       215.530s...
```
