### PR TITLE
d/aws_route53_zone: Filter on tags is containment, not exact equality

### DIFF
--- a/aws/data_source_aws_route53_zone.go
+++ b/aws/data_source_aws_route53_zone.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"reflect"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -133,7 +132,7 @@ func dataSourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) erro
 					if err != nil {
 						return fmt.Errorf("Error finding Route 53 Hosted Zone: %v", err)
 					}
-					matchingTags = reflect.DeepEqual(listTags, tags)
+					matchingTags = listTags.ContainsAll(tags)
 				}
 
 				if matchingTags && matchingVPC {

--- a/aws/data_source_aws_route53_zone_test.go
+++ b/aws/data_source_aws_route53_zone_test.go
@@ -164,7 +164,8 @@ resource "aws_route53_zone" "test" {
   }
 
   tags = {
-    Environment = "tf-acc-test-%[1]d"
+	Environment = "tf-acc-test-%[1]d"
+	Name        = "tf-acc-test-%[1]d"
   }
 }
 

--- a/aws/internal/keyvaluetags/key_value_tags.go
+++ b/aws/internal/keyvaluetags/key_value_tags.go
@@ -201,10 +201,22 @@ func (tags KeyValueTags) Chunks(size int) []KeyValueTags {
 	return result
 }
 
+// ContainsAll returns whether or not all the target tags are contained.
+func (tags KeyValueTags) ContainsAll(target KeyValueTags) bool {
+	for key, value := range target {
+		if v, ok := tags[key]; !ok || *v != *value {
+			return false
+		}
+	}
+
+	return true
+}
+
 // Hash returns a stable hash value.
 // The returned value may be negative (i.e. not suitable for a 'Set' function).
 func (tags KeyValueTags) Hash() int {
 	hash := 0
+
 	for k, v := range tags {
 		hash = hash ^ hashcode.String(fmt.Sprintf("%s-%s", k, *v))
 	}

--- a/aws/internal/keyvaluetags/key_value_tags_test.go
+++ b/aws/internal/keyvaluetags/key_value_tags_test.go
@@ -825,6 +825,86 @@ func TestKeyValueTagsChunks(t *testing.T) {
 	}
 }
 
+func TestKeyValueTagsContainsAll(t *testing.T) {
+	testCases := []struct {
+		name   string
+		source KeyValueTags
+		target KeyValueTags
+		want   bool
+	}{
+		{
+			name:   "empty",
+			source: New(map[string]string{}),
+			target: New(map[string]string{}),
+			want:   true,
+		},
+		{
+			name:   "source_empty",
+			source: New(map[string]string{}),
+			target: New(map[string]string{
+				"key1": "value1",
+			}),
+			want: false,
+		},
+		{
+			name: "target_empty",
+			source: New(map[string]string{
+				"key1": "value1",
+			}),
+			target: New(map[string]string{}),
+			want:   true,
+		},
+		{
+			name: "exact_match",
+			source: New(map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			}),
+			target: New(map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			}),
+			want: true,
+		},
+		{
+			name: "source_contains_all",
+			source: New(map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			}),
+			target: New(map[string]string{
+				"key1": "value1",
+				"key3": "value3",
+			}),
+			want: true,
+		},
+		{
+			name: "source_does_not_contain_all",
+			source: New(map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			}),
+			target: New(map[string]string{
+				"key1": "value1",
+				"key4": "value4",
+			}),
+			want: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := testCase.source.ContainsAll(testCase.target)
+
+			if got != testCase.want {
+				t.Errorf("unexpected ContainsAll: %t", got)
+			}
+		})
+	}
+}
+
 func TestKeyValueTagsHash(t *testing.T) {
 	testCases := []struct {
 		name string


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/11950.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data-source/aws_route53_zone: Fixes regression from version 2.48.0 when filtering using `tags`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsRoute53Zone_tags'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsRoute53Zone_tags -timeout 120m
=== RUN   TestAccDataSourceAwsRoute53Zone_tags
=== PAUSE TestAccDataSourceAwsRoute53Zone_tags
=== CONT  TestAccDataSourceAwsRoute53Zone_tags
--- PASS: TestAccDataSourceAwsRoute53Zone_tags (96.01s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	96.044s
```
