### PR TITLE
Add option to encrypt Firehose Streams with customer managed keys

### DIFF
--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -239,7 +239,7 @@ func TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithSSEAndCMK(t *testing.T) 
 					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.kms_key_type", "CUSTOMER_MANAGED_CMK"),
-					resource.TestMatchResourceAttr(resourceName, "server_side_encryption.0.kms_key_arn", regexp.MustCompile(`^arn:[^:]+:kms:[^:]+:[^:]+:key/.+$`)),
+					resource.TestCheckResourceAttrPair(resourceName, "server_side_encryption.0.kms_key_arn", "aws_kms_key.fh_test", "arn"),
 				),
 			},
 			{

--- a/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
@@ -356,6 +356,8 @@ The `kinesis_source_configuration` object supports the following:
 The `server_side_encryption` object supports the following:
 
 * `enabled` - (Optional) Whether to enable encryption at rest. Default is `false`.
+* `kms_key_type`- (Required, when `enabled` is `true`) The type of encryption. Valid values are `AWS_OWNED_CMK` and `CUSTOMER_MANAGED_CMK`
+* `kms_key_arn` - (Required, when `kms_key_type` is `CUSTOMER_MANAGED_CMK`) The ARN of the key used for encryption.
 
 The `s3_configuration` object supports the following:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11721 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_kinesis_firehose_delivery_stream: add customer managed key option to server-side encryption
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithSSE
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithSSE
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithSSE
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithSSE (359.61s)

```
