### PR TITLE
tests/service/elasticache: Replace deprecated cache.m1 with cache.t3, refactor data source testing

### DIFF
--- a/aws/data_source_aws_elasticache_cluster_test.go
+++ b/aws/data_source_aws_elasticache_cluster_test.go
@@ -9,63 +9,42 @@ import (
 )
 
 func TestAccAWSDataElasticacheCluster_basic(t *testing.T) {
-	rInt := acctest.RandInt()
-	rString := acctest.RandString(10)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_elasticache_cluster.test"
+	dataSourceName := "data.aws_elasticache_cluster.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSElastiCacheClusterConfigWithDataSource(rString, rInt),
+				Config: testAccAWSElastiCacheClusterConfigWithDataSource(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_elasticache_cluster.bar", "engine", "memcached"),
-					resource.TestCheckResourceAttr("data.aws_elasticache_cluster.bar", "node_type", "cache.m1.small"),
-					resource.TestCheckResourceAttr("data.aws_elasticache_cluster.bar", "port", "11211"),
-					resource.TestCheckResourceAttr("data.aws_elasticache_cluster.bar", "num_cache_nodes", "1"),
-					resource.TestCheckResourceAttrSet("data.aws_elasticache_cluster.bar", "configuration_endpoint"),
-					resource.TestCheckResourceAttrSet("data.aws_elasticache_cluster.bar", "cluster_address"),
-					resource.TestCheckResourceAttrSet("data.aws_elasticache_cluster.bar", "availability_zone"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "availability_zone", resourceName, "availability_zone"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "cluster_address", resourceName, "cluster_address"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "configuration_endpoint", resourceName, "configuration_endpoint"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "engine", resourceName, "engine"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "node_type", resourceName, "node_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "num_cache_nodes", resourceName, "num_cache_nodes"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "port", resourceName, "port"),
 				),
 			},
 		},
 	})
 }
 
-func testAccAWSElastiCacheClusterConfigWithDataSource(rString string, rInt int) string {
+func testAccAWSElastiCacheClusterConfigWithDataSource(rName string) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
-resource "aws_security_group" "bar" {
-  name        = "tf-test-security-group-%d"
-  description = "tf-test-security-group-descr"
-
-  ingress {
-    from_port = -1
-    to_port   = -1
-    protocol  = "icmp"
-    self      = true
-  }
-}
-
-resource "aws_elasticache_security_group" "bar" {
-  name                 = "tf-test-security-group-%d"
-  description          = "tf-test-security-group-descr"
-  security_group_names = ["${aws_security_group.bar.name}"]
-}
-
-resource "aws_elasticache_cluster" "bar" {
-  cluster_id           = "tf-%s"
+resource "aws_elasticache_cluster" "test" {
+  cluster_id           = %[1]q
   engine               = "memcached"
-  node_type            = "cache.m1.small"
+  node_type            = "cache.t3.small"
   num_cache_nodes      = 1
   port                 = 11211
-  security_group_names = ["${aws_elasticache_security_group.bar.name}"]
 }
 
-data "aws_elasticache_cluster" "bar" {
-  cluster_id = "${aws_elasticache_cluster.bar.cluster_id}"
+data "aws_elasticache_cluster" "test" {
+  cluster_id = aws_elasticache_cluster.test.cluster_id
 }
-`, rInt, rInt, rString)
+`, rName)
 }

--- a/aws/data_source_aws_elasticache_replication_group_test.go
+++ b/aws/data_source_aws_elasticache_replication_group_test.go
@@ -20,7 +20,7 @@ func TestAccDataSourceAwsElasticacheReplicationGroup_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsElasticacheReplicationGroupConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrPair(dataSourceName, "auth_token_enabled", resourceName, "auth_token_enabled"),
+					resource.TestCheckResourceAttr(dataSourceName, "auth_token_enabled", "false"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "automatic_failover_enabled", resourceName, "automatic_failover_enabled"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "member_clusters.#", resourceName, "member_clusters.#"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "node_type", resourceName, "node_type"),
@@ -48,7 +48,7 @@ func TestAccDataSourceAwsElasticacheReplicationGroup_ClusterMode(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsElasticacheReplicationGroupConfig_ClusterMode(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrPair(dataSourceName, "auth_token_enabled", resourceName, "auth_token_enabled"),
+					resource.TestCheckResourceAttr(dataSourceName, "auth_token_enabled", "false"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "automatic_failover_enabled", resourceName, "automatic_failover_enabled"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "configuration_endpoint_address", resourceName, "configuration_endpoint_address"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "node_type", resourceName, "node_type"),

--- a/aws/data_source_aws_elasticache_replication_group_test.go
+++ b/aws/data_source_aws_elasticache_replication_group_test.go
@@ -9,7 +9,10 @@ import (
 )
 
 func TestAccDataSourceAwsElasticacheReplicationGroup_basic(t *testing.T) {
-	rName := acctest.RandString(10)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_elasticache_replication_group.test"
+	dataSourceName := "data.aws_elasticache_replication_group.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -17,16 +20,16 @@ func TestAccDataSourceAwsElasticacheReplicationGroup_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsElasticacheReplicationGroupConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.bar", "replication_group_id", fmt.Sprintf("tf-%s", rName)),
-					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.bar", "replication_group_description", "test description"),
-					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.bar", "auth_token_enabled", "false"),
-					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.bar", "automatic_failover_enabled", "true"),
-					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.bar", "port", "6379"),
-					resource.TestCheckResourceAttrSet("data.aws_elasticache_replication_group.bar", "primary_endpoint_address"),
-					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.bar", "number_cache_clusters", "2"),
-					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.bar", "member_clusters.#", "2"),
-					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.bar", "node_type", "cache.m1.small"),
-					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.bar", "snapshot_window", "01:00-02:00"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "auth_token_enabled", resourceName, "auth_token_enabled"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "automatic_failover_enabled", resourceName, "automatic_failover_enabled"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "member_clusters.#", resourceName, "member_clusters.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "node_type", resourceName, "node_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "number_cache_clusters", resourceName, "number_cache_clusters"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "port", resourceName, "port"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "primary_endpoint_address", resourceName, "primary_endpoint_address"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "replication_group_description", resourceName, "replication_group_description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "replication_group_id", resourceName, "replication_group_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "snapshot_window", resourceName, "snapshot_window"),
 				),
 			},
 		},
@@ -34,7 +37,10 @@ func TestAccDataSourceAwsElasticacheReplicationGroup_basic(t *testing.T) {
 }
 
 func TestAccDataSourceAwsElasticacheReplicationGroup_ClusterMode(t *testing.T) {
-	rName := acctest.RandString(10)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_elasticache_replication_group.test"
+	dataSourceName := "data.aws_elasticache_replication_group.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -42,13 +48,13 @@ func TestAccDataSourceAwsElasticacheReplicationGroup_ClusterMode(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsElasticacheReplicationGroupConfig_ClusterMode(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.cluster", "replication_group_id", fmt.Sprintf("tf-%s", rName)),
-					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.cluster", "replication_group_description", "test description"),
-					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.cluster", "auth_token_enabled", "false"),
-					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.cluster", "automatic_failover_enabled", "true"),
-					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.cluster", "port", "6379"),
-					resource.TestCheckResourceAttrSet("data.aws_elasticache_replication_group.cluster", "configuration_endpoint_address"),
-					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.cluster", "node_type", "cache.m1.small"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "auth_token_enabled", resourceName, "auth_token_enabled"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "automatic_failover_enabled", resourceName, "automatic_failover_enabled"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "configuration_endpoint_address", resourceName, "configuration_endpoint_address"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "node_type", resourceName, "node_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "port", resourceName, "port"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "replication_group_description", resourceName, "replication_group_description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "replication_group_id", resourceName, "replication_group_id"),
 				),
 			},
 		},
@@ -59,29 +65,29 @@ func testAccDataSourceAwsElasticacheReplicationGroupConfig_basic(rName string) s
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {}
 
-resource "aws_elasticache_replication_group" "bar" {
-  replication_group_id          = "tf-%s"
+resource "aws_elasticache_replication_group" "test" {
+  replication_group_id          = %[1]q
   replication_group_description = "test description"
-  node_type                     = "cache.m1.small"
+  node_type                     = "cache.t3.small"
   number_cache_clusters         = 2
   port                          = 6379
-  availability_zones            = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}"]
+  availability_zones            = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
   automatic_failover_enabled    = true
   snapshot_window               = "01:00-02:00"
 }
 
-data "aws_elasticache_replication_group" "bar" {
-  replication_group_id = "${aws_elasticache_replication_group.bar.replication_group_id}"
+data "aws_elasticache_replication_group" "test" {
+  replication_group_id = aws_elasticache_replication_group.test.replication_group_id
 }
 `, rName)
 }
 
 func testAccDataSourceAwsElasticacheReplicationGroupConfig_ClusterMode(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_elasticache_replication_group" "cluster" {
-  replication_group_id          = "tf-%s"
+resource "aws_elasticache_replication_group" "test" {
+  replication_group_id          = %[1]q
   replication_group_description = "test description"
-  node_type                     = "cache.m1.small"
+  node_type                     = "cache.t3.small"
   port                          = 6379
   automatic_failover_enabled    = true
 
@@ -91,8 +97,8 @@ resource "aws_elasticache_replication_group" "cluster" {
   }
 }
 
-data "aws_elasticache_replication_group" "cluster" {
-  replication_group_id = "${aws_elasticache_replication_group.cluster.replication_group_id}"
+data "aws_elasticache_replication_group" "test" {
+  replication_group_id = aws_elasticache_replication_group.test.replication_group_id
 }
 `, rName)
 }

--- a/aws/resource_aws_elasticache_cluster_test.go
+++ b/aws/resource_aws_elasticache_cluster_test.go
@@ -928,7 +928,7 @@ func testAccAWSElasticacheClusterConfig_Engine_Memcached(rName string) string {
 resource "aws_elasticache_cluster" "test" {
   cluster_id      = "%s"
   engine          = "memcached"
-  node_type       = "cache.m1.small"
+  node_type       = "cache.t3.small"
   num_cache_nodes = 1
 }
 `, rName)
@@ -939,7 +939,7 @@ func testAccAWSElasticacheClusterConfig_Engine_Redis(rName string) string {
 resource "aws_elasticache_cluster" "test" {
   cluster_id      = "%s"
   engine          = "redis"
-  node_type       = "cache.m1.small"
+  node_type       = "cache.t3.small"
   num_cache_nodes = 1
 }
 `, rName)
@@ -951,7 +951,7 @@ resource "aws_elasticache_cluster" "test" {
   cluster_id           = %q
   engine               = %q
   engine_version       = %q
-  node_type            = "cache.m1.small"
+  node_type            = "cache.t3.small"
   num_cache_nodes      = 1
   parameter_group_name = %q
 }
@@ -963,7 +963,7 @@ func testAccAWSElasticacheClusterConfig_Port(rName string, port int) string {
 resource "aws_elasticache_cluster" "test" {
   cluster_id      = "%s"
   engine          = "memcached"
-  node_type       = "cache.m1.small"
+  node_type       = "cache.t3.small"
   num_cache_nodes = 1
   port            = %d
 }
@@ -998,7 +998,7 @@ resource "aws_elasticache_security_group" "test" {
 resource "aws_elasticache_cluster" "test" {
     cluster_id           = "tf-%s"
     engine               = "memcached"
-    node_type            = "cache.m1.small"
+    node_type            = "cache.t3.small"
     num_cache_nodes      = 1
     port                 = 11211
     security_group_names = ["${aws_elasticache_security_group.test.name}"]
@@ -1029,7 +1029,7 @@ resource "aws_elasticache_security_group" "test" {
 resource "aws_elasticache_cluster" "test" {
     cluster_id               = "tf-%s"
     engine                   = "redis"
-    node_type                = "cache.m1.small"
+    node_type                = "cache.t3.small"
     num_cache_nodes          = 1
     port                     = 6379
     security_group_names     = ["${aws_elasticache_security_group.test.name}"]
@@ -1062,7 +1062,7 @@ resource "aws_elasticache_security_group" "test" {
 resource "aws_elasticache_cluster" "test" {
     cluster_id               = "tf-%s"
     engine                   = "redis"
-    node_type                = "cache.m1.small"
+    node_type                = "cache.t3.small"
     num_cache_nodes          = 1
     port                     = 6379
     security_group_names     = ["${aws_elasticache_security_group.test.name}"]
@@ -1078,7 +1078,7 @@ resource "aws_elasticache_cluster" "test" {
   apply_immediately = true
   cluster_id        = "%s"
   engine            = "memcached"
-  node_type         = "cache.m1.small"
+  node_type         = "cache.t3.small"
   num_cache_nodes   = %d
 }
 `, rName, numCacheNodes)
@@ -1097,7 +1097,7 @@ resource "aws_elasticache_cluster" "test" {
   apply_immediately            = true
   cluster_id                   = "%s"
   engine                       = "memcached"
-  node_type                    = "cache.m1.small"
+  node_type                    = "cache.t3.small"
   num_cache_nodes              = %d
   preferred_availability_zones = [%s]
 }
@@ -1106,9 +1106,7 @@ resource "aws_elasticache_cluster" "test" {
 
 var testAccAWSElasticacheClusterInVPCConfig = fmt.Sprintf(`
 data "aws_availability_zones" "available" {
-    # InsufficientCacheClusterCapacity: cache.m1.small (VPC) is not currently supported in the availability zone us-east-1b
-    blacklisted_zone_ids = ["use1-az1"]
-    state                = "available"
+    state = "available"
 }
 
 resource "aws_vpc" "test" {
@@ -1150,7 +1148,7 @@ resource "aws_elasticache_cluster" "test" {
     // that we correctly handle the fact that the API
     // normalizes names to lowercase.
     cluster_id             = "tf-%s"
-    node_type              = "cache.m1.small"
+    node_type              = "cache.t3.small"
     num_cache_nodes        = 1
     engine                 = "redis"
     engine_version         = "2.8.19"
@@ -1169,9 +1167,7 @@ resource "aws_sns_topic" "test" {
 
 var testAccAWSElasticacheClusterMultiAZInVPCConfig = fmt.Sprintf(`
 data "aws_availability_zones" "available" {
-    # InsufficientCacheClusterCapacity: cache.m1.small (VPC) is not currently supported in the availability zone us-east-1b
-    blacklisted_zone_ids = ["use1-az1"]
-    state                = "available"
+    state = "available"
 }
 
 resource "aws_vpc" "test" {
@@ -1223,7 +1219,7 @@ resource "aws_security_group" "test" {
 resource "aws_elasticache_cluster" "test" {
     cluster_id         = "tf-%s"
     engine             = "memcached"
-    node_type          = "cache.m1.small"
+    node_type          = "cache.t3.small"
     num_cache_nodes    = 2
     port               = 11211
     subnet_group_name  = "${aws_elasticache_subnet_group.test.name}"

--- a/aws/resource_aws_elasticache_cluster_test.go
+++ b/aws/resource_aws_elasticache_cluster_test.go
@@ -242,10 +242,7 @@ func TestAccAWSElasticacheCluster_SecurityGroup(t *testing.T) {
 
 func TestAccAWSElasticacheCluster_snapshotsWithUpdates(t *testing.T) {
 	var ec elasticache.CacheCluster
-
-	ri := acctest.RandInt()
-	preConfig := fmt.Sprintf(testAccAWSElasticacheClusterConfig_snapshots, ri, ri, acctest.RandString(10))
-	postConfig := fmt.Sprintf(testAccAWSElasticacheClusterConfig_snapshotsUpdated, ri, ri, acctest.RandString(10))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -253,7 +250,7 @@ func TestAccAWSElasticacheCluster_snapshotsWithUpdates(t *testing.T) {
 		CheckDestroy: testAccCheckAWSElasticacheClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: preConfig,
+				Config: testAccAWSElasticacheClusterConfig_snapshots(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheClusterExists("aws_elasticache_cluster.test", &ec),
 					resource.TestCheckResourceAttr("aws_elasticache_cluster.test", "snapshot_window", "05:00-09:00"),
@@ -261,7 +258,7 @@ func TestAccAWSElasticacheCluster_snapshotsWithUpdates(t *testing.T) {
 				),
 			},
 			{
-				Config: postConfig,
+				Config: testAccAWSElasticacheClusterConfig_snapshotsUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheClusterExists("aws_elasticache_cluster.test", &ec),
 					resource.TestCheckResourceAttr("aws_elasticache_cluster.test", "snapshot_window", "07:00-09:00"),
@@ -948,7 +945,8 @@ resource "aws_elasticache_cluster" "test" {
 }
 `, acctest.RandInt(), acctest.RandInt(), acctest.RandString(10))
 
-var testAccAWSElasticacheClusterConfig_snapshots = `
+func testAccAWSElasticacheClusterConfig_snapshots(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_elasticache_cluster" "test" {
     cluster_id               = "tf-%s"
     engine                   = "redis"
@@ -958,9 +956,11 @@ resource "aws_elasticache_cluster" "test" {
     snapshot_window          = "05:00-09:00"
     snapshot_retention_limit = 3
 }
-`
+`, rName)
+}
 
-var testAccAWSElasticacheClusterConfig_snapshotsUpdated = `
+func testAccAWSElasticacheClusterConfig_snapshotsUpdated(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_elasticache_cluster" "test" {
     cluster_id               = "tf-%s"
     engine                   = "redis"
@@ -971,7 +971,8 @@ resource "aws_elasticache_cluster" "test" {
     snapshot_retention_limit = 7
     apply_immediately        = true
 }
-`
+`, rName)
+}
 
 func testAccAWSElasticacheClusterConfig_NumCacheNodes(rName string, numCacheNodes int) string {
 	return fmt.Sprintf(`

--- a/aws/resource_aws_elasticache_cluster_test.go
+++ b/aws/resource_aws_elasticache_cluster_test.go
@@ -67,17 +67,13 @@ func testSweepElasticacheClusters(region string) error {
 	return nil
 }
 
-func TestAccAWSElasticacheCluster_Engine_Memcached_Ec2Classic(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
+func TestAccAWSElasticacheCluster_Engine_Memcached(t *testing.T) {
 	var ec elasticache.CacheCluster
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSElasticacheClusterDestroy,
 		Steps: []resource.TestStep{
@@ -104,17 +100,13 @@ func TestAccAWSElasticacheCluster_Engine_Memcached_Ec2Classic(t *testing.T) {
 	})
 }
 
-func TestAccAWSElasticacheCluster_Engine_Redis_Ec2Classic(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
+func TestAccAWSElasticacheCluster_Engine_Redis(t *testing.T) {
 	var ec elasticache.CacheCluster
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSElasticacheClusterDestroy,
 		Steps: []resource.TestStep{
@@ -189,18 +181,14 @@ func TestAccAWSElasticacheCluster_ParameterGroupName_Default(t *testing.T) {
 	})
 }
 
-func TestAccAWSElasticacheCluster_Port_Ec2Classic(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
+func TestAccAWSElasticacheCluster_Port(t *testing.T) {
 	var ec elasticache.CacheCluster
 	port := 11212
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSElasticacheClusterDestroy,
 		Steps: []resource.TestStep{
@@ -228,9 +216,13 @@ func TestAccAWSElasticacheCluster_Port_Ec2Classic(t *testing.T) {
 }
 
 func TestAccAWSElasticacheCluster_SecurityGroup(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
 	var ec elasticache.CacheCluster
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSElasticacheClusterDestroy,
 		Steps: []resource.TestStep{
@@ -263,7 +255,6 @@ func TestAccAWSElasticacheCluster_snapshotsWithUpdates(t *testing.T) {
 			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheSecurityGroupExists("aws_elasticache_security_group.test"),
 					testAccCheckAWSElasticacheClusterExists("aws_elasticache_cluster.test", &ec),
 					resource.TestCheckResourceAttr("aws_elasticache_cluster.test", "snapshot_window", "05:00-09:00"),
 					resource.TestCheckResourceAttr("aws_elasticache_cluster.test", "snapshot_retention_limit", "3"),
@@ -272,7 +263,6 @@ func TestAccAWSElasticacheCluster_snapshotsWithUpdates(t *testing.T) {
 			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheSecurityGroupExists("aws_elasticache_security_group.test"),
 					testAccCheckAWSElasticacheClusterExists("aws_elasticache_cluster.test", &ec),
 					resource.TestCheckResourceAttr("aws_elasticache_cluster.test", "snapshot_window", "07:00-09:00"),
 					resource.TestCheckResourceAttr("aws_elasticache_cluster.test", "snapshot_retention_limit", "7"),
@@ -408,67 +398,59 @@ func TestAccAWSElasticacheCluster_multiAZInVpc(t *testing.T) {
 	})
 }
 
-func TestAccAWSElasticacheCluster_AZMode_Memcached_Ec2Classic(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
+func TestAccAWSElasticacheCluster_AZMode_Memcached(t *testing.T) {
 	var cluster elasticache.CacheCluster
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSElasticacheClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAWSElasticacheClusterConfig_AZMode_Memcached_Ec2Classic(rName, "unknown"),
+				Config:      testAccAWSElasticacheClusterConfig_AZMode_Memcached(rName, "unknown"),
 				ExpectError: regexp.MustCompile(`expected az_mode to be one of .*, got unknown`),
 			},
 			{
-				Config:      testAccAWSElasticacheClusterConfig_AZMode_Memcached_Ec2Classic(rName, "cross-az"),
+				Config:      testAccAWSElasticacheClusterConfig_AZMode_Memcached(rName, "cross-az"),
 				ExpectError: regexp.MustCompile(`az_mode "cross-az" is not supported with num_cache_nodes = 1`),
 			},
 			{
-				Config: testAccAWSElasticacheClusterConfig_AZMode_Memcached_Ec2Classic(rName, "single-az"),
+				Config: testAccAWSElasticacheClusterConfig_AZMode_Memcached(rName, "single-az"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheClusterExists(resourceName, &cluster),
 					resource.TestCheckResourceAttr(resourceName, "az_mode", "single-az"),
 				),
 			},
 			{
-				Config:      testAccAWSElasticacheClusterConfig_AZMode_Memcached_Ec2Classic(rName, "cross-az"),
+				Config:      testAccAWSElasticacheClusterConfig_AZMode_Memcached(rName, "cross-az"),
 				ExpectError: regexp.MustCompile(`az_mode "cross-az" is not supported with num_cache_nodes = 1`),
 			},
 		},
 	})
 }
 
-func TestAccAWSElasticacheCluster_AZMode_Redis_Ec2Classic(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
+func TestAccAWSElasticacheCluster_AZMode_Redis(t *testing.T) {
 	var cluster elasticache.CacheCluster
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSElasticacheClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAWSElasticacheClusterConfig_AZMode_Redis_Ec2Classic(rName, "unknown"),
+				Config:      testAccAWSElasticacheClusterConfig_AZMode_Redis(rName, "unknown"),
 				ExpectError: regexp.MustCompile(`expected az_mode to be one of .*, got unknown`),
 			},
 			{
-				Config:      testAccAWSElasticacheClusterConfig_AZMode_Redis_Ec2Classic(rName, "cross-az"),
+				Config:      testAccAWSElasticacheClusterConfig_AZMode_Redis(rName, "cross-az"),
 				ExpectError: regexp.MustCompile(`az_mode "cross-az" is not supported with num_cache_nodes = 1`),
 			},
 			{
-				Config: testAccAWSElasticacheClusterConfig_AZMode_Redis_Ec2Classic(rName, "single-az"),
+				Config: testAccAWSElasticacheClusterConfig_AZMode_Redis(rName, "single-az"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheClusterExists(resourceName, &cluster),
 					resource.TestCheckResourceAttr(resourceName, "az_mode", "single-az"),
@@ -478,29 +460,25 @@ func TestAccAWSElasticacheCluster_AZMode_Redis_Ec2Classic(t *testing.T) {
 	})
 }
 
-func TestAccAWSElasticacheCluster_EngineVersion_Memcached_Ec2Classic(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
+func TestAccAWSElasticacheCluster_EngineVersion_Memcached(t *testing.T) {
 	var pre, mid, post elasticache.CacheCluster
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSElasticacheClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSElasticacheClusterConfig_EngineVersion_Memcached_Ec2Classic(rName, "1.4.33"),
+				Config: testAccAWSElasticacheClusterConfig_EngineVersion_Memcached(rName, "1.4.33"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheClusterExists(resourceName, &pre),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "1.4.33"),
 				),
 			},
 			{
-				Config: testAccAWSElasticacheClusterConfig_EngineVersion_Memcached_Ec2Classic(rName, "1.4.24"),
+				Config: testAccAWSElasticacheClusterConfig_EngineVersion_Memcached(rName, "1.4.24"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheClusterExists(resourceName, &mid),
 					testAccCheckAWSElasticacheClusterRecreated(&pre, &mid),
@@ -508,7 +486,7 @@ func TestAccAWSElasticacheCluster_EngineVersion_Memcached_Ec2Classic(t *testing.
 				),
 			},
 			{
-				Config: testAccAWSElasticacheClusterConfig_EngineVersion_Memcached_Ec2Classic(rName, "1.4.34"),
+				Config: testAccAWSElasticacheClusterConfig_EngineVersion_Memcached(rName, "1.4.34"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheClusterExists(resourceName, &post),
 					testAccCheckAWSElasticacheClusterNotRecreated(&mid, &post),
@@ -519,29 +497,25 @@ func TestAccAWSElasticacheCluster_EngineVersion_Memcached_Ec2Classic(t *testing.
 	})
 }
 
-func TestAccAWSElasticacheCluster_EngineVersion_Redis_Ec2Classic(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
+func TestAccAWSElasticacheCluster_EngineVersion_Redis(t *testing.T) {
 	var pre, mid, post elasticache.CacheCluster
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSElasticacheClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSElasticacheClusterConfig_EngineVersion_Redis_Ec2Classic(rName, "3.2.6"),
+				Config: testAccAWSElasticacheClusterConfig_EngineVersion_Redis(rName, "3.2.6"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheClusterExists(resourceName, &pre),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "3.2.6"),
 				),
 			},
 			{
-				Config: testAccAWSElasticacheClusterConfig_EngineVersion_Redis_Ec2Classic(rName, "3.2.4"),
+				Config: testAccAWSElasticacheClusterConfig_EngineVersion_Redis(rName, "3.2.4"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheClusterExists(resourceName, &mid),
 					testAccCheckAWSElasticacheClusterRecreated(&pre, &mid),
@@ -549,7 +523,7 @@ func TestAccAWSElasticacheCluster_EngineVersion_Redis_Ec2Classic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSElasticacheClusterConfig_EngineVersion_Redis_Ec2Classic(rName, "3.2.10"),
+				Config: testAccAWSElasticacheClusterConfig_EngineVersion_Redis(rName, "3.2.10"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheClusterExists(resourceName, &post),
 					testAccCheckAWSElasticacheClusterNotRecreated(&mid, &post),
@@ -560,29 +534,25 @@ func TestAccAWSElasticacheCluster_EngineVersion_Redis_Ec2Classic(t *testing.T) {
 	})
 }
 
-func TestAccAWSElasticacheCluster_NodeTypeResize_Memcached_Ec2Classic(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
+func TestAccAWSElasticacheCluster_NodeTypeResize_Memcached(t *testing.T) {
 	var pre, post elasticache.CacheCluster
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSElasticacheClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSElasticacheClusterConfig_NodeType_Memcached_Ec2Classic(rName, "cache.m3.medium"),
+				Config: testAccAWSElasticacheClusterConfig_NodeType_Memcached(rName, "cache.m3.medium"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheClusterExists(resourceName, &pre),
 					resource.TestCheckResourceAttr(resourceName, "node_type", "cache.m3.medium"),
 				),
 			},
 			{
-				Config: testAccAWSElasticacheClusterConfig_NodeType_Memcached_Ec2Classic(rName, "cache.m3.large"),
+				Config: testAccAWSElasticacheClusterConfig_NodeType_Memcached(rName, "cache.m3.large"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheClusterExists(resourceName, &post),
 					testAccCheckAWSElasticacheClusterRecreated(&pre, &post),
@@ -593,29 +563,25 @@ func TestAccAWSElasticacheCluster_NodeTypeResize_Memcached_Ec2Classic(t *testing
 	})
 }
 
-func TestAccAWSElasticacheCluster_NodeTypeResize_Redis_Ec2Classic(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
+func TestAccAWSElasticacheCluster_NodeTypeResize_Redis(t *testing.T) {
 	var pre, post elasticache.CacheCluster
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSElasticacheClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSElasticacheClusterConfig_NodeType_Redis_Ec2Classic(rName, "cache.m3.medium"),
+				Config: testAccAWSElasticacheClusterConfig_NodeType_Redis(rName, "cache.m3.medium"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheClusterExists(resourceName, &pre),
 					resource.TestCheckResourceAttr(resourceName, "node_type", "cache.m3.medium"),
 				),
 			},
 			{
-				Config: testAccAWSElasticacheClusterConfig_NodeType_Redis_Ec2Classic(rName, "cache.m3.large"),
+				Config: testAccAWSElasticacheClusterConfig_NodeType_Redis(rName, "cache.m3.large"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheClusterExists(resourceName, &post),
 					testAccCheckAWSElasticacheClusterNotRecreated(&pre, &post),
@@ -626,20 +592,16 @@ func TestAccAWSElasticacheCluster_NodeTypeResize_Redis_Ec2Classic(t *testing.T) 
 	})
 }
 
-func TestAccAWSElasticacheCluster_NumCacheNodes_Redis_Ec2Classic(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
+func TestAccAWSElasticacheCluster_NumCacheNodes_Redis(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSElasticacheClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAWSElasticacheClusterConfig_NumCacheNodes_Redis_Ec2Classic(rName, 2),
+				Config:      testAccAWSElasticacheClusterConfig_NumCacheNodes_Redis(rName, 2),
 				ExpectError: regexp.MustCompile(`engine "redis" does not support num_cache_nodes > 1`),
 			},
 		},
@@ -647,14 +609,10 @@ func TestAccAWSElasticacheCluster_NumCacheNodes_Redis_Ec2Classic(t *testing.T) {
 }
 
 func TestAccAWSElasticacheCluster_ReplicationGroupID_InvalidAttributes(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSElasticacheClusterDestroy,
 		Steps: []resource.TestStep{
@@ -726,11 +684,7 @@ func TestAccAWSElasticacheCluster_ReplicationGroupID_InvalidAttributes(t *testin
 	})
 }
 
-func TestAccAWSElasticacheCluster_ReplicationGroupID_AvailabilityZone_Ec2Classic(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
+func TestAccAWSElasticacheCluster_ReplicationGroupID_AvailabilityZone(t *testing.T) {
 	var cluster elasticache.CacheCluster
 	var replicationGroup elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -738,12 +692,12 @@ func TestAccAWSElasticacheCluster_ReplicationGroupID_AvailabilityZone_Ec2Classic
 	replicationGroupResourceName := "aws_elasticache_replication_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSElasticacheClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSElasticacheClusterConfig_ReplicationGroupID_AvailabilityZone_Ec2Classic(rName),
+				Config: testAccAWSElasticacheClusterConfig_ReplicationGroupID_AvailabilityZone(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheReplicationGroupExists(replicationGroupResourceName, &replicationGroup),
 					testAccCheckAWSElasticacheClusterExists(clusterResourceName, &cluster),
@@ -754,11 +708,7 @@ func TestAccAWSElasticacheCluster_ReplicationGroupID_AvailabilityZone_Ec2Classic
 	})
 }
 
-func TestAccAWSElasticacheCluster_ReplicationGroupID_SingleReplica_Ec2Classic(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
+func TestAccAWSElasticacheCluster_ReplicationGroupID_SingleReplica(t *testing.T) {
 	var cluster elasticache.CacheCluster
 	var replicationGroup elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -766,12 +716,12 @@ func TestAccAWSElasticacheCluster_ReplicationGroupID_SingleReplica_Ec2Classic(t 
 	replicationGroupResourceName := "aws_elasticache_replication_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSElasticacheClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSElasticacheClusterConfig_ReplicationGroupID_Replica_Ec2Classic(rName, 1),
+				Config: testAccAWSElasticacheClusterConfig_ReplicationGroupID_Replica(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheReplicationGroupExists(replicationGroupResourceName, &replicationGroup),
 					testAccCheckAWSElasticacheClusterExists(clusterResourceName, &cluster),
@@ -785,11 +735,7 @@ func TestAccAWSElasticacheCluster_ReplicationGroupID_SingleReplica_Ec2Classic(t 
 	})
 }
 
-func TestAccAWSElasticacheCluster_ReplicationGroupID_MultipleReplica_Ec2Classic(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
+func TestAccAWSElasticacheCluster_ReplicationGroupID_MultipleReplica(t *testing.T) {
 	var cluster1, cluster2 elasticache.CacheCluster
 	var replicationGroup elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -798,12 +744,12 @@ func TestAccAWSElasticacheCluster_ReplicationGroupID_MultipleReplica_Ec2Classic(
 	replicationGroupResourceName := "aws_elasticache_replication_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSElasticacheClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSElasticacheClusterConfig_ReplicationGroupID_Replica_Ec2Classic(rName, 2),
+				Config: testAccAWSElasticacheClusterConfig_ReplicationGroupID_Replica(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheReplicationGroupExists(replicationGroupResourceName, &replicationGroup),
 					testAccCheckAWSElasticacheClusterExists(clusterResourceName1, &cluster1),
@@ -971,9 +917,6 @@ resource "aws_elasticache_cluster" "test" {
 }
 
 var testAccAWSElasticacheClusterConfig_SecurityGroup = fmt.Sprintf(`
-provider "aws" {
-    region = "us-east-1"
-}
 resource "aws_security_group" "test" {
     name        = "tf-test-security-group-%03d"
     description = "tf-test-security-group-descr"
@@ -998,7 +941,7 @@ resource "aws_elasticache_security_group" "test" {
 resource "aws_elasticache_cluster" "test" {
     cluster_id           = "tf-%s"
     engine               = "memcached"
-    node_type            = "cache.t3.small"
+    node_type            = "cache.m3.medium"
     num_cache_nodes      = 1
     port                 = 11211
     security_group_names = ["${aws_elasticache_security_group.test.name}"]
@@ -1006,66 +949,24 @@ resource "aws_elasticache_cluster" "test" {
 `, acctest.RandInt(), acctest.RandInt(), acctest.RandString(10))
 
 var testAccAWSElasticacheClusterConfig_snapshots = `
-provider "aws" {
-    region = "us-east-1"
-}
-resource "aws_security_group" "test" {
-    name        = "tf-test-security-group-%03d"
-    description = "tf-test-security-group-descr"
-    ingress {
-        from_port   = -1
-        to_port     = -1
-        protocol    = "icmp"
-        cidr_blocks = ["0.0.0.0/0"]
-    }
-}
-
-resource "aws_elasticache_security_group" "test" {
-    name                 = "tf-test-security-group-%03d"
-    description          = "tf-test-security-group-descr"
-    security_group_names = ["${aws_security_group.test.name}"]
-}
-
 resource "aws_elasticache_cluster" "test" {
     cluster_id               = "tf-%s"
     engine                   = "redis"
     node_type                = "cache.t3.small"
     num_cache_nodes          = 1
     port                     = 6379
-    security_group_names     = ["${aws_elasticache_security_group.test.name}"]
     snapshot_window          = "05:00-09:00"
     snapshot_retention_limit = 3
 }
 `
 
 var testAccAWSElasticacheClusterConfig_snapshotsUpdated = `
-provider "aws" {
-    region = "us-east-1"
-}
-resource "aws_security_group" "test" {
-    name        = "tf-test-security-group-%03d"
-    description = "tf-test-security-group-descr"
-    ingress {
-        from_port   = -1
-        to_port     = -1
-        protocol    = "icmp"
-        cidr_blocks = ["0.0.0.0/0"]
-    }
-}
-
-resource "aws_elasticache_security_group" "test" {
-    name                 = "tf-test-security-group-%03d"
-    description          = "tf-test-security-group-descr"
-    security_group_names = ["${aws_security_group.test.name}"]
-}
-
 resource "aws_elasticache_cluster" "test" {
     cluster_id               = "tf-%s"
     engine                   = "redis"
     node_type                = "cache.t3.small"
     num_cache_nodes          = 1
     port                     = 6379
-    security_group_names     = ["${aws_elasticache_security_group.test.name}"]
     snapshot_window          = "07:00-09:00"
     snapshot_retention_limit = 7
     apply_immediately        = true
@@ -1257,7 +1158,7 @@ resource "aws_elasticache_cluster" "test" {
 }
 `
 
-func testAccAWSElasticacheClusterConfig_AZMode_Memcached_Ec2Classic(rName, azMode string) string {
+func testAccAWSElasticacheClusterConfig_AZMode_Memcached(rName, azMode string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_cluster" "test" {
     apply_immediately = true
@@ -1271,7 +1172,7 @@ resource "aws_elasticache_cluster" "test" {
 `, rName, azMode)
 }
 
-func testAccAWSElasticacheClusterConfig_AZMode_Redis_Ec2Classic(rName, azMode string) string {
+func testAccAWSElasticacheClusterConfig_AZMode_Redis(rName, azMode string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_cluster" "test" {
     apply_immediately = true
@@ -1285,7 +1186,7 @@ resource "aws_elasticache_cluster" "test" {
 `, rName, azMode)
 }
 
-func testAccAWSElasticacheClusterConfig_EngineVersion_Memcached_Ec2Classic(rName, engineVersion string) string {
+func testAccAWSElasticacheClusterConfig_EngineVersion_Memcached(rName, engineVersion string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_cluster" "test" {
     apply_immediately = true
@@ -1299,7 +1200,7 @@ resource "aws_elasticache_cluster" "test" {
 `, rName, engineVersion)
 }
 
-func testAccAWSElasticacheClusterConfig_EngineVersion_Redis_Ec2Classic(rName, engineVersion string) string {
+func testAccAWSElasticacheClusterConfig_EngineVersion_Redis(rName, engineVersion string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_cluster" "test" {
     apply_immediately = true
@@ -1313,7 +1214,7 @@ resource "aws_elasticache_cluster" "test" {
 `, rName, engineVersion)
 }
 
-func testAccAWSElasticacheClusterConfig_NodeType_Memcached_Ec2Classic(rName, nodeType string) string {
+func testAccAWSElasticacheClusterConfig_NodeType_Memcached(rName, nodeType string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_cluster" "test" {
     apply_immediately = true
@@ -1326,7 +1227,7 @@ resource "aws_elasticache_cluster" "test" {
 `, rName, nodeType)
 }
 
-func testAccAWSElasticacheClusterConfig_NodeType_Redis_Ec2Classic(rName, nodeType string) string {
+func testAccAWSElasticacheClusterConfig_NodeType_Redis(rName, nodeType string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_cluster" "test" {
     apply_immediately = true
@@ -1339,7 +1240,7 @@ resource "aws_elasticache_cluster" "test" {
 `, rName, nodeType)
 }
 
-func testAccAWSElasticacheClusterConfig_NumCacheNodes_Redis_Ec2Classic(rName string, numCacheNodes int) string {
+func testAccAWSElasticacheClusterConfig_NumCacheNodes_Redis(rName string, numCacheNodes int) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_cluster" "test" {
     apply_immediately = true
@@ -1362,7 +1263,7 @@ resource "aws_elasticache_cluster" "test" {
 `, rName, attrName, attrValue)
 }
 
-func testAccAWSElasticacheClusterConfig_ReplicationGroupID_AvailabilityZone_Ec2Classic(rName string) string {
+func testAccAWSElasticacheClusterConfig_ReplicationGroupID_AvailabilityZone(rName string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {}
 
@@ -1386,7 +1287,7 @@ resource "aws_elasticache_cluster" "test" {
 `, rName)
 }
 
-func testAccAWSElasticacheClusterConfig_ReplicationGroupID_Replica_Ec2Classic(rName string, count int) string {
+func testAccAWSElasticacheClusterConfig_ReplicationGroupID_Replica(rName string, count int) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
     replication_group_description = "Terraform Acceptance Testing"

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -59,10 +58,6 @@ func testSweepElasticacheReplicationGroups(region string) error {
 }
 
 func TestAccAWSElasticacheReplicationGroup_basic(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	var rg elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_replication_group.test"
@@ -125,10 +120,6 @@ func TestAccAWSElasticacheReplicationGroup_Uppercase(t *testing.T) {
 }
 
 func TestAccAWSElasticacheReplicationGroup_updateDescription(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	var rg elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_replication_group.test"
@@ -173,10 +164,6 @@ func TestAccAWSElasticacheReplicationGroup_updateDescription(t *testing.T) {
 }
 
 func TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	var rg elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_replication_group.test"
@@ -213,10 +200,6 @@ func TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow(t *testing.T)
 }
 
 func TestAccAWSElasticacheReplicationGroup_updateNodeSize(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	var rg elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_replication_group.test"
@@ -492,10 +475,6 @@ func TestAccAWSElasticacheReplicationGroup_clusteringAndCacheNodesCausesError(t 
 }
 
 func TestAccAWSElasticacheReplicationGroup_enableSnapshotting(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	var rg elasticache.ReplicationGroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_elasticache_replication_group.test"
@@ -854,35 +833,12 @@ func testAccCheckAWSElasticacheReplicationDestroy(s *terraform.State) error {
 
 func testAccAWSElasticacheReplicationGroupConfig(rName string) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
-resource "aws_security_group" "test" {
-  name        = %[1]q
-  description = "tf-test-security-group-descr"
-
-  ingress {
-    from_port   = -1
-    to_port     = -1
-    protocol    = "icmp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}
-
-resource "aws_elasticache_security_group" "test" {
-  name                 = %[1]q
-  description          = "tf-test-security-group-descr"
-  security_group_names = ["${aws_security_group.test.name}"]
-}
-
 resource "aws_elasticache_replication_group" "test" {
   replication_group_id          = %[1]q
   replication_group_description = "test description"
   node_type                     = "cache.t3.small"
   number_cache_clusters         = 2
   port                          = 6379
-  security_group_names          = ["${aws_elasticache_security_group.test.name}"]
   apply_immediately             = true
   auto_minor_version_upgrade    = false
   maintenance_window            = "tue:06:30-tue:07:30"
@@ -935,35 +891,12 @@ resource "aws_elasticache_replication_group" "test" {
 
 func testAccAWSElasticacheReplicationGroupConfigEnableSnapshotting(rName string) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
-resource "aws_security_group" "test" {
-  name        = %[1]q
-  description = "tf-test-security-group-descr"
-
-  ingress {
-    from_port   = -1
-    to_port     = -1
-    protocol    = "icmp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}
-
-resource "aws_elasticache_security_group" "test" {
-  name                 = %[1]q
-  description          = "tf-test-security-group-descr"
-  security_group_names = ["${aws_security_group.test.name}"]
-}
-
 resource "aws_elasticache_replication_group" "test" {
   replication_group_id          = %[1]q
   replication_group_description = "test description"
   node_type                     = "cache.t3.small"
   number_cache_clusters         = 2
   port                          = 6379
-  security_group_names          = ["${aws_elasticache_security_group.test.name}"]
   apply_immediately             = true
   auto_minor_version_upgrade    = false
   maintenance_window            = "tue:06:30-tue:07:30"
@@ -1003,35 +936,12 @@ resource "aws_elasticache_replication_group" "test" {
 
 func testAccAWSElasticacheReplicationGroupConfigUpdatedDescription(rName string) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
-resource "aws_security_group" "test" {
-  name        = %[1]q
-  description = "tf-test-security-group-descr"
-
-  ingress {
-    from_port   = -1
-    to_port     = -1
-    protocol    = "icmp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}
-
-resource "aws_elasticache_security_group" "test" {
-  name                 = %[1]q
-  description          = "tf-test-security-group-descr"
-  security_group_names = ["${aws_security_group.test.name}"]
-}
-
 resource "aws_elasticache_replication_group" "test" {
   replication_group_id          = %[1]q
   replication_group_description = "updated description"
   node_type                     = "cache.t3.small"
   number_cache_clusters         = 2
   port                          = 6379
-  security_group_names          = ["${aws_elasticache_security_group.test.name}"]
   apply_immediately             = true
   auto_minor_version_upgrade    = true
 }
@@ -1040,35 +950,12 @@ resource "aws_elasticache_replication_group" "test" {
 
 func testAccAWSElasticacheReplicationGroupConfigUpdatedMaintenanceWindow(rName string) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
-resource "aws_security_group" "test" {
-  name        = %[1]q
-  description = "tf-test-security-group-descr"
-
-  ingress {
-    from_port   = -1
-    to_port     = -1
-    protocol    = "icmp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}
-
-resource "aws_elasticache_security_group" "test" {
-  name                 = %[1]q
-  description          = "tf-test-security-group-descr"
-  security_group_names = ["${aws_security_group.test.name}"]
-}
-
 resource "aws_elasticache_replication_group" "test" {
   replication_group_id          = %[1]q
   replication_group_description = "updated description"
   node_type                     = "cache.t3.small"
   number_cache_clusters         = 2
   port                          = 6379
-  security_group_names          = ["${aws_elasticache_security_group.test.name}"]
   apply_immediately             = true
   auto_minor_version_upgrade    = true
   maintenance_window            = "wed:03:00-wed:06:00"
@@ -1079,35 +966,12 @@ resource "aws_elasticache_replication_group" "test" {
 
 func testAccAWSElasticacheReplicationGroupConfigUpdatedNodeSize(rName string) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
-resource "aws_security_group" "test" {
-  name        = %[1]q
-  description = "tf-test-security-group-descr"
-
-  ingress {
-    from_port   = -1
-    to_port     = -1
-    protocol    = "icmp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}
-
-resource "aws_elasticache_security_group" "test" {
-  name                 = %[1]q
-  description          = "tf-test-security-group-descr"
-  security_group_names = ["${aws_security_group.test.name}"]
-}
-
 resource "aws_elasticache_replication_group" "test" {
   replication_group_id          = %[1]q
   replication_group_description = "updated description"
   node_type                     = "cache.t3.medium"
   number_cache_clusters         = 2
   port                          = 6379
-  security_group_names          = ["${aws_elasticache_security_group.test.name}"]
   apply_immediately             = true
 }
 `, rName)

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -233,7 +233,7 @@ func TestAccAWSElasticacheReplicationGroup_updateNodeSize(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						resourceName, "number_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(
-						resourceName, "node_type", "cache.m1.small"),
+						resourceName, "node_type", "cache.t3.small"),
 				),
 			},
 			{
@@ -249,7 +249,7 @@ func TestAccAWSElasticacheReplicationGroup_updateNodeSize(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						resourceName, "number_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(
-						resourceName, "node_type", "cache.m1.medium"),
+						resourceName, "node_type", "cache.t3.medium"),
 				),
 			},
 		},
@@ -879,7 +879,7 @@ resource "aws_elasticache_security_group" "test" {
 resource "aws_elasticache_replication_group" "test" {
   replication_group_id          = %[1]q
   replication_group_description = "test description"
-  node_type                     = "cache.m1.small"
+  node_type                     = "cache.t3.small"
   number_cache_clusters         = 2
   port                          = 6379
   security_group_names          = ["${aws_elasticache_security_group.test.name}"]
@@ -960,7 +960,7 @@ resource "aws_elasticache_security_group" "test" {
 resource "aws_elasticache_replication_group" "test" {
   replication_group_id          = %[1]q
   replication_group_description = "test description"
-  node_type                     = "cache.m1.small"
+  node_type                     = "cache.t3.small"
   number_cache_clusters         = 2
   port                          = 6379
   security_group_names          = ["${aws_elasticache_security_group.test.name}"]
@@ -992,7 +992,7 @@ resource "aws_elasticache_parameter_group" "test" {
 
 resource "aws_elasticache_replication_group" "test" {
   apply_immediately             = true
-  node_type                     = "cache.m1.small"
+  node_type                     = "cache.t3.small"
   number_cache_clusters         = 2
   parameter_group_name          = "${aws_elasticache_parameter_group.test.*.name[%[2]d]}"
   replication_group_description = "test description"
@@ -1028,7 +1028,7 @@ resource "aws_elasticache_security_group" "test" {
 resource "aws_elasticache_replication_group" "test" {
   replication_group_id          = %[1]q
   replication_group_description = "updated description"
-  node_type                     = "cache.m1.small"
+  node_type                     = "cache.t3.small"
   number_cache_clusters         = 2
   port                          = 6379
   security_group_names          = ["${aws_elasticache_security_group.test.name}"]
@@ -1065,7 +1065,7 @@ resource "aws_elasticache_security_group" "test" {
 resource "aws_elasticache_replication_group" "test" {
   replication_group_id          = %[1]q
   replication_group_description = "updated description"
-  node_type                     = "cache.m1.small"
+  node_type                     = "cache.t3.small"
   number_cache_clusters         = 2
   port                          = 6379
   security_group_names          = ["${aws_elasticache_security_group.test.name}"]
@@ -1104,7 +1104,7 @@ resource "aws_elasticache_security_group" "test" {
 resource "aws_elasticache_replication_group" "test" {
   replication_group_id          = %[1]q
   replication_group_description = "updated description"
-  node_type                     = "cache.m1.medium"
+  node_type                     = "cache.t3.medium"
   number_cache_clusters         = 2
   port                          = 6379
   security_group_names          = ["${aws_elasticache_security_group.test.name}"]
@@ -1115,9 +1115,7 @@ resource "aws_elasticache_replication_group" "test" {
 
 var testAccAWSElasticacheReplicationGroupInVPCConfig = fmt.Sprintf(`
 data "aws_availability_zones" "available" {
-  # InvalidParameterValue: Specified node type cache.m1.small is not available in AZ us-east-1b.
-  blacklisted_zone_ids = ["use1-az1"]
-  state                = "available"
+  state = "available"
 }
 
 resource "aws_vpc" "test" {
@@ -1157,7 +1155,7 @@ resource "aws_security_group" "test" {
 resource "aws_elasticache_replication_group" "test" {
     replication_group_id = "tf-%s"
     replication_group_description = "test description"
-    node_type = "cache.m1.small"
+    node_type = "cache.t3.small"
     number_cache_clusters = 1
     port = 6379
     subnet_group_name = "${aws_elasticache_subnet_group.test.name}"
@@ -1169,9 +1167,7 @@ resource "aws_elasticache_replication_group" "test" {
 
 var testAccAWSElasticacheReplicationGroupMultiAZInVPCConfig = fmt.Sprintf(`
 data "aws_availability_zones" "available" {
-  # InvalidParameterValue: Specified node type cache.m1.small is not available in AZ us-east-1b.
-  blacklisted_zone_ids = ["use1-az1"]
-  state                = "available"
+  state = "available"
 }
 resource "aws_vpc" "test" {
     cidr_block = "192.168.0.0/16"
@@ -1217,7 +1213,7 @@ resource "aws_security_group" "test" {
 resource "aws_elasticache_replication_group" "test" {
     replication_group_id = "tf-%s"
     replication_group_description = "test description"
-    node_type = "cache.m1.small"
+    node_type = "cache.t3.small"
     number_cache_clusters = 2
     port = 6379
     subnet_group_name = "${aws_elasticache_subnet_group.test.name}"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11543

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously (since Feb 5, 2020):

```
--- FAIL: TestAccAWSElasticacheReplicationGroup_basic (11.22s)
    testing.go:640: Step 0 error: errors during apply:

        Error: Error creating Elasticache Replication Group: InvalidParameterValue: Invalid Cache Node Type: cache.m1.small
```

This also includes #11543 fixes since updating the node type was causing trouble with the testing updates anyways:

```
--- FAIL: TestAccAWSElasticacheReplicationGroup_basic (10.94s)
    testing.go:640: Step 0 error: errors during apply:
        
        Error: Error creating Elasticache Replication Group: InvalidParameterCombination: Instance type cache.t3.small can only be created in a VPC.
```

Output from acceptance testing:

```
--- PASS: TestAccAWSDataElasticacheCluster_basic (539.25s)

--- PASS: TestAccDataSourceAwsElasticacheReplicationGroup_basic (761.67s)
--- PASS: TestAccDataSourceAwsElasticacheReplicationGroup_ClusterMode (1015.32s)

--- PASS: TestAccAWSElasticacheCluster_AZMode_Memcached (592.82s)
--- PASS: TestAccAWSElasticacheCluster_AZMode_Redis (597.77s)
--- PASS: TestAccAWSElasticacheCluster_Engine_Memcached (536.67s)
--- PASS: TestAccAWSElasticacheCluster_Engine_Redis (488.49s)
--- PASS: TestAccAWSElasticacheCluster_EngineVersion_Memcached (1501.93s)
--- PASS: TestAccAWSElasticacheCluster_EngineVersion_Redis (1405.75s)
--- PASS: TestAccAWSElasticacheCluster_multiAZInVpc (572.28s)
--- PASS: TestAccAWSElasticacheCluster_NodeTypeResize_Memcached (1065.47s)
--- PASS: TestAccAWSElasticacheCluster_NodeTypeResize_Redis (1097.75s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Decrease (692.50s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Increase (748.57s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_IncreaseWithPreferredAvailabilityZones (879.79s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Redis (2.71s)
--- PASS: TestAccAWSElasticacheCluster_ParameterGroupName_Default (518.54s)
--- PASS: TestAccAWSElasticacheCluster_Port (485.56s)
--- PASS: TestAccAWSElasticacheCluster_Port_Redis_Default (617.33s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_AvailabilityZone (1333.48s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_InvalidAttributes (3.82s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_MultipleReplica (1281.69s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_SingleReplica (1351.71s)
--- PASS: TestAccAWSElasticacheCluster_SecurityGroup (542.16s)
--- PASS: TestAccAWSElasticacheCluster_snapshotsWithUpdates (520.63s)
--- PASS: TestAccAWSElasticacheCluster_vpc (481.07s)

--- PASS: TestAccAWSElasticacheReplicationGroup_basic (695.88s)
--- PASS: TestAccAWSElasticacheReplicationGroup_clusteringAndCacheNodesCausesError (8.83s)
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_Basic (1164.68s)
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_NumNodeGroups (3259.22s)
--- PASS: TestAccAWSElasticacheReplicationGroup_enableAtRestEncryption (1082.55s)
--- PASS: TestAccAWSElasticacheReplicationGroup_enableAuthTokenTransitEncryption (1507.32s)
--- PASS: TestAccAWSElasticacheReplicationGroup_enableSnapshotting (1732.06s)
--- PASS: TestAccAWSElasticacheReplicationGroup_multiAzInVpc (1154.32s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters (1671.90s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverDisabled (1754.74s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverEnabled (2267.30s)
--- PASS: TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2 (1396.58s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateDescription (784.09s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow (1135.21s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateNodeSize (1821.73s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateParameterGroup (1662.28s)
--- PASS: TestAccAWSElasticacheReplicationGroup_Uppercase (1486.80s)
--- PASS: TestAccAWSElasticacheReplicationGroup_useCmkKmsKeyId (1434.22s)
--- PASS: TestAccAWSElasticacheReplicationGroup_vpc (1234.04s)
```
