### PR TITLE
tests/resource/aws_launch_template: Randomize naming in network interface test configurations

### DIFF
--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -528,6 +528,7 @@ func TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock(t *test
 
 func TestAccAWSLaunchTemplate_networkInterface(t *testing.T) {
 	var template ec2.LaunchTemplate
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_launch_template.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -536,7 +537,7 @@ func TestAccAWSLaunchTemplate_networkInterface(t *testing.T) {
 		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLaunchTemplateConfig_networkInterface,
+				Config: testAccAWSLaunchTemplateConfig_networkInterface(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.#", "1"),
@@ -605,6 +606,7 @@ func TestAccAWSLaunchTemplate_associatePublicIPAddress(t *testing.T) {
 
 func TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses(t *testing.T) {
 	var template ec2.LaunchTemplate
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_launch_template.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -613,7 +615,7 @@ func TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses(t *testing.T) {
 		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLaunchTemplateConfig_networkInterface_ipv6Addresses,
+				Config: testAccAWSLaunchTemplateConfig_networkInterface_ipv6Addresses(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.#", "1"),
@@ -1102,7 +1104,8 @@ resource "aws_launch_template" "test" {
 `, rName, description)
 }
 
-const testAccAWSLaunchTemplateConfig_networkInterface = `
+func testAccAWSLaunchTemplateConfig_networkInterface(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 }
@@ -1117,14 +1120,15 @@ resource "aws_network_interface" "test" {
 }
 
 resource "aws_launch_template" "test" {
-  name = "network-interface-launch-template"
+  name = %[1]q
 
   network_interfaces {
     network_interface_id = "${aws_network_interface.test.id}"
     ipv4_address_count = 2
   }
 }
-`
+`, rName)
+}
 
 func testAccAWSLaunchTemplateConfig_associatePublicIpAddress(rName, associatePublicIPAddress string) string {
 	return fmt.Sprintf(`
@@ -1153,9 +1157,10 @@ resource "aws_launch_template" "test" {
 `, rName, associatePublicIPAddress)
 }
 
-const testAccAWSLaunchTemplateConfig_networkInterface_ipv6Addresses = `
+func testAccAWSLaunchTemplateConfig_networkInterface_ipv6Addresses(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_launch_template" "test" {
-  name = "network-interface-ipv6-addresses-launch-template"
+  name = %[1]q
 
   network_interfaces {
     ipv6_addresses = [
@@ -1164,7 +1169,8 @@ resource "aws_launch_template" "test" {
     ]
   }
 }
-`
+`, rName)
+}
 
 const testAccAWSLaunchTemplateConfig_asg_basic = `
 data "aws_ami" "test_ami" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously in the acceptance testing:

```
--- FAIL: TestAccAWSLaunchTemplate_networkInterface (7.26s)
    testing.go:640: Step 0 error: errors during apply:

        Error: InvalidLaunchTemplateName.AlreadyExistsException: Launch template name already in use.
```

Output from acceptance testing:

```
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses (18.42s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface (37.60s)
```
