### PR TITLE
tests/resource/aws_launch_template: Add sweeper

### DIFF
--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -8,10 +8,70 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_launch_template", &resource.Sweeper{
+		Name: "aws_launch_template",
+		Dependencies: []string{
+			"aws_autoscaling_group",
+			"aws_batch_compute_environment",
+		},
+		F: testSweepLaunchTemplates,
+	})
+}
+
+func testSweepLaunchTemplates(region string) error {
+	client, err := sharedClientForRegion(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+
+	conn := client.(*AWSClient).ec2conn
+	input := &ec2.DescribeLaunchTemplatesInput{}
+	var sweeperErrs *multierror.Error
+
+	err = conn.DescribeLaunchTemplatesPages(input, func(page *ec2.DescribeLaunchTemplatesOutput, lastPage bool) bool {
+		for _, launchTemplate := range page.LaunchTemplates {
+			id := aws.StringValue(launchTemplate.LaunchTemplateId)
+			input := &ec2.DeleteLaunchTemplateInput{
+				LaunchTemplateId: launchTemplate.LaunchTemplateId,
+			}
+
+			log.Printf("[INFO] Deleting EC2 Launch Template: %s", id)
+			_, err := conn.DeleteLaunchTemplate(input)
+
+			if isAWSErr(err, "InvalidLaunchTemplateId.NotFound", "") {
+				continue
+			}
+
+			if err != nil {
+				sweeperErr := fmt.Errorf("error deleting EC2 Launch Template (%s): %w", id, err)
+				log.Printf("[ERROR] %s", sweeperErr)
+				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+				continue
+			}
+		}
+
+		return !lastPage
+	})
+
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping EC2 Launch Template sweep for %s: %s", region, err)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("Error describing EC2 Launch Templates: %w", err)
+	}
+
+	return sweeperErrs.ErrorOrNil()
+}
 
 func TestAccAWSLaunchTemplate_basic(t *testing.T) {
 	var template ec2.LaunchTemplate


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from sweeper:

```console
$ aws ec2 describe-launch-templates | jq '.LaunchTemplates | length'
50
$ go test ./aws -v -timeout=10h -sweep=us-west-2 -sweep-run=aws_launch_template -sweep-allow-failures
...
2020/02/07 12:33:07 [INFO] Deleting EC2 Launch Template: lt-0511a175a5af1ceb9
2020/02/07 12:33:07 [INFO] Deleting EC2 Launch Template: lt-02d7c2696320c5509
2020/02/07 12:33:07 [INFO] Deleting EC2 Launch Template: lt-0a7e3bf1bbc102080
2020/02/07 12:33:08 [INFO] Deleting EC2 Launch Template: lt-07bb4393d1b4eef93
2020/02/07 12:33:08 [INFO] Deleting EC2 Launch Template: lt-0c5694492b057483b
2020/02/07 12:33:09 [INFO] Deleting EC2 Launch Template: lt-00e28c55258b2d52a
2020/02/07 12:33:09 [INFO] Deleting EC2 Launch Template: lt-01758a1128a3094fb
2020/02/07 12:33:10 [INFO] Deleting EC2 Launch Template: lt-0dda91684ce225be2
2020/02/07 12:33:10 [INFO] Deleting EC2 Launch Template: lt-00e5c5fa5bc78e12b
2020/02/07 12:33:10 [INFO] Deleting EC2 Launch Template: lt-0013242fbdd7e7567
2020/02/07 12:33:11 [INFO] Deleting EC2 Launch Template: lt-0edd6a4aff0097c18
2020/02/07 12:33:11 [INFO] Deleting EC2 Launch Template: lt-0cae6d7914dda85ce
2020/02/07 12:33:12 [INFO] Deleting EC2 Launch Template: lt-0a614dee406fba067
2020/02/07 12:33:13 [INFO] Deleting EC2 Launch Template: lt-03aaca249d074b0ec
2020/02/07 12:33:13 [INFO] Deleting EC2 Launch Template: lt-0208d2bda0432f5f5
2020/02/07 12:33:14 [INFO] Deleting EC2 Launch Template: lt-065a3aab7dfe9cd0e
2020/02/07 12:33:14 [INFO] Deleting EC2 Launch Template: lt-036b943b097045274
2020/02/07 12:33:15 [INFO] Deleting EC2 Launch Template: lt-087345f75f4acf224
2020/02/07 12:33:15 [INFO] Deleting EC2 Launch Template: lt-048fdfff5f0fe65e5
2020/02/07 12:33:15 [INFO] Deleting EC2 Launch Template: lt-03c0f64b9687db804
2020/02/07 12:33:16 [INFO] Deleting EC2 Launch Template: lt-0ba99c9bec77dbd38
2020/02/07 12:33:16 [INFO] Deleting EC2 Launch Template: lt-0e6c753ed4a537b23
2020/02/07 12:33:17 [INFO] Deleting EC2 Launch Template: lt-065d0acd32241103c
2020/02/07 12:33:17 [INFO] Deleting EC2 Launch Template: lt-04bb60ff157989cd0
2020/02/07 12:33:18 [INFO] Deleting EC2 Launch Template: lt-09cd4a59a28ef468b
2020/02/07 12:33:18 [INFO] Deleting EC2 Launch Template: lt-04459b25711c9fb10
2020/02/07 12:33:18 [INFO] Deleting EC2 Launch Template: lt-0ab5b9f5673e361b5
2020/02/07 12:33:19 [INFO] Deleting EC2 Launch Template: lt-073ca9c0f3cde86db
2020/02/07 12:33:19 [INFO] Deleting EC2 Launch Template: lt-02e88bb59b4453f01
2020/02/07 12:33:20 [INFO] Deleting EC2 Launch Template: lt-07a2528f139e413e1
2020/02/07 12:33:20 [INFO] Deleting EC2 Launch Template: lt-0034094bc548d4e05
2020/02/07 12:33:21 [INFO] Deleting EC2 Launch Template: lt-0b04e1ff77b472500
2020/02/07 12:33:21 [INFO] Deleting EC2 Launch Template: lt-056bd583dad9d2bc3
2020/02/07 12:33:22 [INFO] Deleting EC2 Launch Template: lt-04d3471e3c3fc5777
2020/02/07 12:33:22 [INFO] Deleting EC2 Launch Template: lt-008fac996b23cc923
2020/02/07 12:33:22 [INFO] Deleting EC2 Launch Template: lt-031441f0135267e93
2020/02/07 12:33:23 [INFO] Deleting EC2 Launch Template: lt-0b2cb7ff64feaf53e
2020/02/07 12:33:23 [INFO] Deleting EC2 Launch Template: lt-042b74c9ed600df17
2020/02/07 12:33:24 [INFO] Deleting EC2 Launch Template: lt-0544c41ccefc5f71d
2020/02/07 12:33:24 [INFO] Deleting EC2 Launch Template: lt-0c69292976fd3a0d1
2020/02/07 12:33:25 [INFO] Deleting EC2 Launch Template: lt-0b9d739e3c927fc69
2020/02/07 12:33:25 [INFO] Deleting EC2 Launch Template: lt-0d51fc14863ffaacd
2020/02/07 12:33:26 [INFO] Deleting EC2 Launch Template: lt-00a6f18d9ec199093
2020/02/07 12:33:26 [INFO] Deleting EC2 Launch Template: lt-056f63cb37a4e7f2c
2020/02/07 12:33:26 [INFO] Deleting EC2 Launch Template: lt-0a78c42ab5fb7b38c
2020/02/07 12:33:27 [INFO] Deleting EC2 Launch Template: lt-03288e290d396cc5f
2020/02/07 12:33:27 [INFO] Deleting EC2 Launch Template: lt-0b37843f481f8b398
2020/02/07 12:33:28 [INFO] Deleting EC2 Launch Template: lt-0ff482c127e15a2a1
2020/02/07 12:33:28 [INFO] Deleting EC2 Launch Template: lt-00b29e71301a13273
2020/02/07 12:33:29 [INFO] Deleting EC2 Launch Template: lt-0e7f40b184aa8f6e3
2020/02/07 12:33:30 [DEBUG] Sweeper (aws_autoscaling_group) already ran in region (us-west-2)
2020/02/07 12:33:30 Sweeper Tests ran successfully:
	- aws_batch_compute_environment
	- aws_autoscaling_group
	- aws_launch_template
	- aws_batch_job_queue
ok  	github.com/terraform-providers/terraform-provider-aws/aws	32.645s
$ aws ec2 describe-launch-templates | jq '.LaunchTemplates | length'
0
```
