### PR TITLE
Refactor S3 Bucket Metric resource to use keyvaluetags package.

### DIFF
--- a/aws/resource_aws_s3_bucket_metric.go
+++ b/aws/resource_aws_s3_bucket_metric.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsS3BucketMetric() *schema.Resource {
@@ -165,7 +166,7 @@ func expandS3MetricsFilter(m map[string]interface{}) *s3.MetricsFilter {
 
 	var tags []*s3.Tag
 	if v, ok := m["tags"]; ok {
-		tags = tagsFromMapS3(v.(map[string]interface{}))
+		tags = keyvaluetags.New(v).IgnoreAws().S3Tags()
 	}
 
 	metricsFilter := &s3.MetricsFilter{}
@@ -195,7 +196,7 @@ func flattenS3MetricsFilter(metricsFilter *s3.MetricsFilter) map[string]interfac
 			m["prefix"] = *and.Prefix
 		}
 		if and.Tags != nil {
-			m["tags"] = tagsToMapS3(and.Tags)
+			m["tags"] = keyvaluetags.S3KeyValueTags(and.Tags).IgnoreAws().Map()
 		}
 	} else if metricsFilter.Prefix != nil {
 		m["prefix"] = *metricsFilter.Prefix
@@ -203,7 +204,7 @@ func flattenS3MetricsFilter(metricsFilter *s3.MetricsFilter) map[string]interfac
 		tags := []*s3.Tag{
 			metricsFilter.Tag,
 		}
-		m["tags"] = tagsToMapS3(tags)
+		m["tags"] = keyvaluetags.S3KeyValueTags(tags).IgnoreAws().Map()
 	}
 	return m
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10688.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSS3BucketMetric_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSS3BucketMetric_ -timeout 120m
=== RUN   TestAccAWSS3BucketMetric_basic
=== PAUSE TestAccAWSS3BucketMetric_basic
=== RUN   TestAccAWSS3BucketMetric_WithEmptyFilter
=== PAUSE TestAccAWSS3BucketMetric_WithEmptyFilter
=== RUN   TestAccAWSS3BucketMetric_WithFilterPrefix
=== PAUSE TestAccAWSS3BucketMetric_WithFilterPrefix
=== RUN   TestAccAWSS3BucketMetric_WithFilterPrefixAndMultipleTags
=== PAUSE TestAccAWSS3BucketMetric_WithFilterPrefixAndMultipleTags
=== RUN   TestAccAWSS3BucketMetric_WithFilterPrefixAndSingleTag
=== PAUSE TestAccAWSS3BucketMetric_WithFilterPrefixAndSingleTag
=== RUN   TestAccAWSS3BucketMetric_WithFilterMultipleTags
=== PAUSE TestAccAWSS3BucketMetric_WithFilterMultipleTags
=== RUN   TestAccAWSS3BucketMetric_WithFilterSingleTag
=== PAUSE TestAccAWSS3BucketMetric_WithFilterSingleTag
=== CONT  TestAccAWSS3BucketMetric_basic
=== CONT  TestAccAWSS3BucketMetric_WithFilterPrefixAndSingleTag
=== CONT  TestAccAWSS3BucketMetric_WithFilterSingleTag
=== CONT  TestAccAWSS3BucketMetric_WithFilterMultipleTags
=== CONT  TestAccAWSS3BucketMetric_WithFilterPrefix
=== CONT  TestAccAWSS3BucketMetric_WithEmptyFilter
=== CONT  TestAccAWSS3BucketMetric_WithFilterPrefixAndMultipleTags
--- PASS: TestAccAWSS3BucketMetric_WithEmptyFilter (38.19s)
--- PASS: TestAccAWSS3BucketMetric_basic (40.86s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterPrefixAndMultipleTags (65.30s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterPrefixAndSingleTag (65.90s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterSingleTag (65.91s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterPrefix (65.95s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterMultipleTags (66.20s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	66.254s
```
