### PR TITLE
rd/efs_access_point - add new resource

### DIFF
--- a/aws/data_source_aws_efs_access_point.go
+++ b/aws/data_source_aws_efs_access_point.go
@@ -1,0 +1,146 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/efs"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+func dataSourceAwsEfsAccessPoint() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsEfsAccessPointRead,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"file_system_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"file_system_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"owner_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"posix_user": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"gid": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"uid": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"secondary_gids": {
+							Type:     schema.TypeSet,
+							Elem:     &schema.Schema{Type: schema.TypeInt},
+							Set:      schema.HashInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"root_directory": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"path": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creation_info": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"owner_gid": {
+										Type:     schema.TypeInt,
+										Required: true,
+										ForceNew: true,
+									},
+									"owner_uid": {
+										Type:     schema.TypeInt,
+										Required: true,
+										ForceNew: true,
+									},
+									"permissions": {
+										Type:     schema.TypeString,
+										Required: true,
+										ForceNew: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func dataSourceAwsEfsAccessPointRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).efsconn
+	resp, err := conn.DescribeAccessPoints(&efs.DescribeAccessPointsInput{
+		AccessPointId: aws.String(d.Id()),
+	})
+	if err != nil {
+		return fmt.Errorf("Error reading EFS access point %s: %s", d.Id(), err)
+	}
+	if len(resp.AccessPoints) != 1 {
+		return fmt.Errorf("Search returned %d results, please revise so only one is returned", len(resp.AccessPoints))
+	}
+
+	ap := resp.AccessPoints[0]
+
+	log.Printf("[DEBUG] Found EFS access point: %#v", ap)
+
+	d.SetId(*ap.AccessPointId)
+
+	fsARN := arn.ARN{
+		AccountID: meta.(*AWSClient).accountid,
+		Partition: meta.(*AWSClient).partition,
+		Region:    meta.(*AWSClient).region,
+		Resource:  fmt.Sprintf("file-system/%s", aws.StringValue(ap.FileSystemId)),
+		Service:   "elasticfilesystem",
+	}.String()
+
+	d.Set("file_system_arn", fsARN)
+	d.Set("file_system_id", ap.FileSystemId)
+	d.Set("arn", ap.AccessPointArn)
+	d.Set("owner_id", ap.OwnerId)
+
+	if err := d.Set("posix_user", flattenEfsAccessPointPosixUser(ap.PosixUser)); err != nil {
+		return fmt.Errorf("error setting posix user: %s", err)
+	}
+
+	if err := d.Set("root_directory", flattenEfsAccessPointRootDirectory(ap.RootDirectory)); err != nil {
+		return fmt.Errorf("error setting root directory: %s", err)
+	}
+
+	if err := d.Set("tags", keyvaluetags.EfsKeyValueTags(ap.Tags).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}

--- a/aws/data_source_aws_efs_access_point.go
+++ b/aws/data_source_aws_efs_access_point.go
@@ -20,14 +20,17 @@ func dataSourceAwsEfsAccessPoint() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"access_point_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
 			"file_system_arn": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"file_system_id": {
 				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Computed: true,
 			},
 			"arn": {
 				Type:     schema.TypeString,
@@ -102,7 +105,7 @@ func dataSourceAwsEfsAccessPoint() *schema.Resource {
 func dataSourceAwsEfsAccessPointRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).efsconn
 	resp, err := conn.DescribeAccessPoints(&efs.DescribeAccessPointsInput{
-		AccessPointId: aws.String(d.Id()),
+		AccessPointId: aws.String(d.Get("access_point_id").(string)),
 	})
 	if err != nil {
 		return fmt.Errorf("Error reading EFS access point %s: %s", d.Id(), err)

--- a/aws/data_source_aws_efs_access_point.go
+++ b/aws/data_source_aws_efs_access_point.go
@@ -78,18 +78,15 @@ func dataSourceAwsEfsAccessPoint() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"owner_gid": {
 										Type:     schema.TypeInt,
-										Required: true,
-										ForceNew: true,
+										Computed: true,
 									},
 									"owner_uid": {
 										Type:     schema.TypeInt,
-										Required: true,
-										ForceNew: true,
+										Computed: true,
 									},
 									"permissions": {
 										Type:     schema.TypeString,
-										Required: true,
-										ForceNew: true,
+										Computed: true,
 									},
 								},
 							},

--- a/aws/data_source_aws_efs_access_point.go
+++ b/aws/data_source_aws_efs_access_point.go
@@ -97,6 +97,8 @@ func dataSourceAwsEfsAccessPoint() *schema.Resource {
 
 func dataSourceAwsEfsAccessPointRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).efsconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
 	resp, err := conn.DescribeAccessPoints(&efs.DescribeAccessPointsInput{
 		AccessPointId: aws.String(d.Get("access_point_id").(string)),
 	})
@@ -134,7 +136,7 @@ func dataSourceAwsEfsAccessPointRead(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("error setting root directory: %s", err)
 	}
 
-	if err := d.Set("tags", keyvaluetags.EfsKeyValueTags(ap.Tags).IgnoreAws().Map()); err != nil {
+	if err := d.Set("tags", keyvaluetags.EfsKeyValueTags(ap.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 

--- a/aws/data_source_aws_efs_access_point.go
+++ b/aws/data_source_aws_efs_access_point.go
@@ -15,10 +15,6 @@ func dataSourceAwsEfsAccessPoint() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceAwsEfsAccessPointRead,
 
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
-
 		Schema: map[string]*schema.Schema{
 			"access_point_id": {
 				Type:     schema.TypeString,

--- a/aws/data_source_aws_efs_access_point_test.go
+++ b/aws/data_source_aws_efs_access_point_test.go
@@ -1,0 +1,49 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceAWSEFSAccessPoint_basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceName := "data.aws_efs_file_system.test"
+	resourceName := "aws_efs_access_point.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckEfsAccessPointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAWSEFSAccessPointConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "owner_id", resourceName, "owner_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags", resourceName, "tags"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "posix_user", resourceName, "posix_user"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "root_directory", resourceName, "root_directory"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAWSEFSAccessPointConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_efs_file_system" "test" {
+  creation_token = "%s"
+}
+
+resource "aws_efs_access_point" "test" {
+  file_system_id = "${aws_efs_file_system.test.id}"
+}
+
+"data" "aws_efs_access_point" "test" {
+  access_point_id = "${aws_efs_access_point.test.id}"
+}
+`, rName)
+}

--- a/aws/data_source_aws_efs_access_point_test.go
+++ b/aws/data_source_aws_efs_access_point_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAccDataSourceAWSEFSAccessPoint_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	dataSourceName := "data.aws_efs_file_system.test"
+	dataSourceName := "data.aws_efs_access_point.test"
 	resourceName := "aws_efs_access_point.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -42,7 +42,7 @@ resource "aws_efs_access_point" "test" {
   file_system_id = "${aws_efs_file_system.test.id}"
 }
 
-"data" "aws_efs_access_point" "test" {
+data "aws_efs_access_point" "test" {
   access_point_id = "${aws_efs_access_point.test.id}"
 }
 `, rName)

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -230,6 +230,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_ecs_service":                               dataSourceAwsEcsService(),
 			"aws_ecs_task_definition":                       dataSourceAwsEcsTaskDefinition(),
 			"aws_customer_gateway":                          dataSourceAwsCustomerGateway(),
+			"aws_efs_access_point":                          dataSourceAwsEfsAccessPoint(),
 			"aws_efs_file_system":                           dataSourceAwsEfsFileSystem(),
 			"aws_efs_mount_target":                          dataSourceAwsEfsMountTarget(),
 			"aws_eip":                                       dataSourceAwsEip(),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -550,6 +550,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_ecs_cluster":                                         resourceAwsEcsCluster(),
 			"aws_ecs_service":                                         resourceAwsEcsService(),
 			"aws_ecs_task_definition":                                 resourceAwsEcsTaskDefinition(),
+			"aws_efs_access_point":                                    resourceAwsEfsAccessPoint(),
 			"aws_efs_file_system":                                     resourceAwsEfsFileSystem(),
 			"aws_efs_mount_target":                                    resourceAwsEfsMountTarget(),
 			"aws_egress_only_internet_gateway":                        resourceAwsEgressOnlyInternetGateway(),

--- a/aws/resource_aws_efs_access_point.go
+++ b/aws/resource_aws_efs_access_point.go
@@ -1,0 +1,295 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/efs"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+func resourceAwsEfsAccessPoint() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsEfsAccessPointCreate,
+		Read:   resourceAwsEfsAccessPointRead,
+		Update: resourceAwsEfsAccessPointUpdate,
+		Delete: resourceAwsEfsAccessPointDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"file_system_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"file_system_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"owner_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"posix_user": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"gid": {
+							Type:     schema.TypeInt,
+							Required: true,
+							ForceNew: true,
+						},
+						"uid": {
+							Type:     schema.TypeInt,
+							Required: true,
+							ForceNew: true,
+						},
+						"secondary_gids": {
+							Type:     schema.TypeSet,
+							Elem:     &schema.Schema{Type: schema.TypeInt},
+							Set:      schema.HashInt,
+							Optional: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
+			//"root_directory": {
+			//	Type:     schema.TypeList,
+			//	Optional: true,
+			//	MaxItems: 1,
+			//},
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsEfsAccessPointCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).efsconn
+
+	fsId := d.Get("file_system_id").(string)
+
+	input := efs.CreateAccessPointInput{
+		FileSystemId: aws.String(fsId),
+		Tags:         keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().EfsTags(),
+	}
+
+	if v, ok := d.GetOk("posix_user"); ok {
+		input.PosixUser = expandEfsAccessPointPosixUser(v.([]interface{}))
+	}
+
+	log.Printf("[DEBUG] Creating EFS Access Point: %#v", input)
+
+	ap, err := conn.CreateAccessPoint(&input)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(*ap.AccessPointId)
+	log.Printf("[INFO] EFS access point ID: %s", d.Id())
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{efs.LifeCycleStateCreating},
+		Target:  []string{efs.LifeCycleStateAvailable},
+		Refresh: func() (interface{}, string, error) {
+			resp, err := conn.DescribeAccessPoints(&efs.DescribeAccessPointsInput{
+				AccessPointId: aws.String(d.Id()),
+			})
+			if err != nil {
+				return nil, "error", err
+			}
+
+			if hasEmptyAccessPoints(resp) {
+				return nil, "error", fmt.Errorf("EFS access point %q could not be found.", d.Id())
+			}
+
+			mt := resp.AccessPoints[0]
+
+			log.Printf("[DEBUG] Current status of %q: %q", *mt.AccessPointId, *mt.LifeCycleState)
+			return mt, *mt.LifeCycleState, nil
+		},
+		Timeout:    10 * time.Minute,
+		Delay:      2 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for EFS access point (%s) to create: %s", d.Id(), err)
+	}
+
+	log.Printf("[DEBUG] EFS access point created: %s", *ap.AccessPointId)
+
+	return resourceAwsEfsAccessPointRead(d, meta)
+}
+
+func resourceAwsEfsAccessPointUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).efsconn
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.EfsUpdateTags(conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("error updating EFS file system (%s) tags: %s", d.Id(), err)
+		}
+	}
+
+	return resourceAwsEfsAccessPointRead(d, meta)
+}
+
+func resourceAwsEfsAccessPointRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).efsconn
+	resp, err := conn.DescribeAccessPoints(&efs.DescribeAccessPointsInput{
+		AccessPointId: aws.String(d.Id()),
+	})
+	if err != nil {
+		if isAWSErr(err, efs.ErrCodeAccessPointNotFound, "") {
+			log.Printf("[WARN] EFS access point %q could not be found.", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error reading EFS access point %s: %s", d.Id(), err)
+	}
+
+	if hasEmptyAccessPoints(resp) {
+		return fmt.Errorf("EFS access point %q could not be found.", d.Id())
+	}
+
+	ap := resp.AccessPoints[0]
+
+	log.Printf("[DEBUG] Found EFS access point: %#v", ap)
+
+	d.SetId(*ap.AccessPointId)
+
+	fsARN := arn.ARN{
+		AccountID: meta.(*AWSClient).accountid,
+		Partition: meta.(*AWSClient).partition,
+		Region:    meta.(*AWSClient).region,
+		Resource:  fmt.Sprintf("file-system/%s", aws.StringValue(ap.FileSystemId)),
+		Service:   "elasticfilesystem",
+	}.String()
+
+	d.Set("file_system_arn", fsARN)
+	d.Set("file_system_id", ap.FileSystemId)
+	d.Set("arn", ap.AccessPointArn)
+	d.Set("owner_id", ap.OwnerId)
+
+	if err := d.Set("posix_user", flattenEfsAccessPointPosixUser(ap.PosixUser)); err != nil {
+		return fmt.Errorf("error setting posix user: %s", err)
+	}
+
+	if err := d.Set("tags", keyvaluetags.EfsKeyValueTags(ap.Tags).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsEfsAccessPointDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).efsconn
+
+	log.Printf("[DEBUG] Deleting EFS access point %q", d.Id())
+	_, err := conn.DeleteAccessPoint(&efs.DeleteAccessPointInput{
+		AccessPointId: aws.String(d.Id()),
+	})
+	if err != nil {
+		return err
+	}
+
+	err = waitForDeleteEfsAccessPoint(conn, d.Id(), 10*time.Minute)
+	if err != nil {
+		return fmt.Errorf("Error waiting for EFS access point (%q) to delete: %s", d.Id(), err.Error())
+	}
+
+	log.Printf("[DEBUG] EFS access point %q deleted.", d.Id())
+
+	return nil
+}
+
+func waitForDeleteEfsAccessPoint(conn *efs.EFS, id string, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{efs.LifeCycleStateAvailable, efs.LifeCycleStateDeleting, efs.LifeCycleStateDeleted},
+		Target:  []string{},
+		Refresh: func() (interface{}, string, error) {
+			resp, err := conn.DescribeAccessPoints(&efs.DescribeAccessPointsInput{
+				AccessPointId: aws.String(id),
+			})
+			if err != nil {
+				if isAWSErr(err, efs.ErrCodeAccessPointNotFound, "") {
+					return nil, "", nil
+				}
+
+				return nil, "error", err
+			}
+
+			if hasEmptyAccessPoints(resp) {
+				return nil, "", nil
+			}
+
+			mt := resp.AccessPoints[0]
+
+			log.Printf("[DEBUG] Current status of %q: %q", *mt.AccessPointId, *mt.LifeCycleState)
+			return mt, *mt.LifeCycleState, nil
+		},
+		Timeout:    timeout,
+		Delay:      2 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+	_, err := stateConf.WaitForState()
+	return err
+}
+
+func hasEmptyAccessPoints(aps *efs.DescribeAccessPointsOutput) bool {
+	if aps != nil && len(aps.AccessPoints) > 0 {
+		return false
+	}
+	return true
+}
+
+func expandEfsAccessPointPosixUser(pUser []interface{}) *efs.PosixUser {
+	if len(pUser) < 1 || pUser[0] == nil {
+		return nil
+	}
+
+	m := pUser[0].(map[string]interface{})
+
+	posixUser := &efs.PosixUser{
+
+		Gid: aws.Int64(int64(m["gid"].(int))),
+		Uid: aws.Int64(int64(m["uid"].(int))),
+	}
+
+	if v, ok := m["secondary_gids"]; ok && len(v.(*schema.Set).List()) > 0 {
+		posixUser.SecondaryGids = expandInt64Set(v.(*schema.Set))
+	}
+
+	return posixUser
+}
+func flattenEfsAccessPointPosixUser(posixUser *efs.PosixUser) []interface{} {
+	if posixUser == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"gid":            aws.Int64Value(posixUser.Gid),
+		"uid":            aws.Int64Value(posixUser.Uid),
+		"secondary_gids": aws.Int64ValueSlice(posixUser.SecondaryGids),
+	}
+
+	return []interface{}{m}
+}

--- a/aws/resource_aws_efs_access_point.go
+++ b/aws/resource_aws_efs_access_point.go
@@ -74,18 +74,21 @@ func resourceAwsEfsAccessPoint() *schema.Resource {
 				Optional: true,
 				MaxItems: 1,
 				ForceNew: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"path": {
 							Type:     schema.TypeString,
 							Optional: true,
 							ForceNew: true,
+							Computed: true,
 						},
 						"creation_info": {
 							Type:     schema.TypeList,
 							Optional: true,
 							ForceNew: true,
 							MaxItems: 1,
+							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"owner_gid": {

--- a/aws/resource_aws_efs_access_point.go
+++ b/aws/resource_aws_efs_access_point.go
@@ -98,8 +98,8 @@ func resourceAwsEfsAccessPoint() *schema.Resource {
 										Required: true,
 										ForceNew: true,
 									},
-									"permisions": {
-										Type:     schema.TypeInt,
+									"permissions": {
+										Type:     schema.TypeString,
 										Required: true,
 										ForceNew: true,
 									},
@@ -392,8 +392,8 @@ func flattenEfsAccessPointRootDirectoryCreationInfo(cInfo *efs.CreationInfo) []i
 	}
 
 	m := map[string]interface{}{
-		"gid":         aws.Int64Value(cInfo.OwnerGid),
-		"uid":         aws.Int64Value(cInfo.OwnerUid),
+		"owner_gid":   aws.Int64Value(cInfo.OwnerGid),
+		"owner_uid":   aws.Int64Value(cInfo.OwnerUid),
 		"permissions": aws.StringValue(cInfo.Permissions),
 	}
 

--- a/aws/resource_aws_efs_access_point.go
+++ b/aws/resource_aws_efs_access_point.go
@@ -162,8 +162,8 @@ func resourceAwsEfsAccessPointCreate(d *schema.ResourceData, meta interface{}) e
 
 			mt := resp.AccessPoints[0]
 
-			log.Printf("[DEBUG] Current status of %q: %q", *mt.AccessPointId, *mt.LifeCycleState)
-			return mt, *mt.LifeCycleState, nil
+			log.Printf("[DEBUG] Current status of %q: %q", aws.StringValue(mt.AccessPointId), aws.StringValue(mt.LifeCycleState))
+			return mt, aws.StringValue(mt.LifeCycleState), nil
 		},
 		Timeout:    10 * time.Minute,
 		Delay:      2 * time.Second,

--- a/aws/resource_aws_efs_access_point.go
+++ b/aws/resource_aws_efs_access_point.go
@@ -289,8 +289,8 @@ func waitForDeleteEfsAccessPoint(conn *efs.EFS, id string, timeout time.Duration
 
 			mt := resp.AccessPoints[0]
 
-			log.Printf("[DEBUG] Current status of %q: %q", *mt.AccessPointId, *mt.LifeCycleState)
-			return mt, *mt.LifeCycleState, nil
+			log.Printf("[DEBUG] Current status of %q: %q", aws.StringValue(mt.AccessPointId), aws.StringValue(mt.LifeCycleState))
+			return mt, aws.StringValue(mt.LifeCycleState), nil
 		},
 		Timeout:    timeout,
 		Delay:      2 * time.Second,

--- a/aws/resource_aws_efs_access_point.go
+++ b/aws/resource_aws_efs_access_point.go
@@ -139,7 +139,7 @@ func resourceAwsEfsAccessPointCreate(d *schema.ResourceData, meta interface{}) e
 
 	ap, err := conn.CreateAccessPoint(&input)
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating EFS Access Point for File System (%s): %w", fsId, err)
 	}
 
 	d.SetId(*ap.AccessPointId)

--- a/aws/resource_aws_efs_access_point.go
+++ b/aws/resource_aws_efs_access_point.go
@@ -319,8 +319,8 @@ func expandEfsAccessPointPosixUser(pUser []interface{}) *efs.PosixUser {
 		Uid: aws.Int64(int64(m["uid"].(int))),
 	}
 
-	if v, ok := m["secondary_gids"]; ok && len(v.(*schema.Set).List()) > 0 {
-		posixUser.SecondaryGids = expandInt64Set(v.(*schema.Set))
+	if v, ok := m["secondary_gids"].(*schema.Set); ok && len(v.List()) > 0 {
+		posixUser.SecondaryGids = expandInt64Set(v)
 	}
 
 	return posixUser

--- a/aws/resource_aws_efs_access_point.go
+++ b/aws/resource_aws_efs_access_point.go
@@ -196,6 +196,8 @@ func resourceAwsEfsAccessPointUpdate(d *schema.ResourceData, meta interface{}) e
 
 func resourceAwsEfsAccessPointRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).efsconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
 	resp, err := conn.DescribeAccessPoints(&efs.DescribeAccessPointsInput{
 		AccessPointId: aws.String(d.Id()),
 	})
@@ -239,7 +241,7 @@ func resourceAwsEfsAccessPointRead(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("error setting root directory: %s", err)
 	}
 
-	if err := d.Set("tags", keyvaluetags.EfsKeyValueTags(ap.Tags).IgnoreAws().Map()); err != nil {
+	if err := d.Set("tags", keyvaluetags.EfsKeyValueTags(ap.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 

--- a/aws/resource_aws_efs_access_point.go
+++ b/aws/resource_aws_efs_access_point.go
@@ -254,7 +254,7 @@ func resourceAwsEfsAccessPointDelete(d *schema.ResourceData, meta interface{}) e
 		AccessPointId: aws.String(d.Id()),
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("error deleting EFS Access Point (%s): %w", d.Id(), err)
 	}
 
 	err = waitForDeleteEfsAccessPoint(conn, d.Id(), 10*time.Minute)

--- a/aws/resource_aws_efs_access_point_test.go
+++ b/aws/resource_aws_efs_access_point_test.go
@@ -1,0 +1,421 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/efs"
+
+	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_efs_access_point", &resource.Sweeper{
+		Name: "aws_efs_access_point",
+		F:    testSweepEfsAccessPoints,
+	})
+}
+
+func testSweepEfsAccessPoints(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).efsconn
+
+	var errors error
+	input := &efs.DescribeFileSystemsInput{}
+	err = conn.DescribeFileSystemsPages(input, func(page *efs.DescribeFileSystemsOutput, lastPage bool) bool {
+		for _, filesystem := range page.FileSystems {
+			id := aws.StringValue(filesystem.FileSystemId)
+			log.Printf("[INFO] Deleting access points for EFS File System: %s", id)
+
+			var errors error
+			input := &efs.DescribeAccessPointsInput{
+				FileSystemId: filesystem.FileSystemId,
+			}
+			for {
+				out, err := conn.DescribeAccessPoints(input)
+				if err != nil {
+					errors = multierror.Append(errors, fmt.Errorf("error retrieving EFS access points on File System %q: %w", id, err))
+					continue
+				}
+
+				if out == nil || len(out.AccessPoints) == 0 {
+					log.Printf("[INFO] No EFS access points to sweep on File System %q", id)
+					continue
+				}
+
+				for _, AccessPoint := range out.AccessPoints {
+					id := aws.StringValue(AccessPoint.AccessPointId)
+
+					log.Printf("[INFO] Deleting EFS access point: %s", id)
+					_, err := conn.DeleteAccessPoint(&efs.DeleteAccessPointInput{
+						AccessPointId: AccessPoint.AccessPointId,
+					})
+					if err != nil {
+						errors = multierror.Append(errors, fmt.Errorf("error deleting EFS access point %q: %w", id, err))
+						continue
+					}
+
+					err = waitForDeleteEfsAccessPoint(conn, id, 10*time.Minute)
+					if err != nil {
+						errors = multierror.Append(errors, fmt.Errorf("error waiting for EFS access point %q to delete: %w", id, err))
+						continue
+					}
+				}
+
+				if out.NextToken == nil {
+					break
+				}
+				input.NextToken = out.NextToken
+			}
+		}
+		return true
+	})
+	if err != nil {
+		errors = multierror.Append(errors, fmt.Errorf("error retrieving EFS File Systems: %w", err))
+	}
+
+	return errors
+}
+
+func TestAccAWSEFSAccessPoint_basic(t *testing.T) {
+	var ap efs.AccessPointDescription
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_efs_access_point.test"
+	fsResourceName := "aws_efs_file_system.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckEfsAccessPointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEFSAccessPointConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEfsAccessPointExists(resourceName, &ap),
+					resource.TestCheckResourceAttrPair(resourceName, "file_system_arn", fsResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "file_system_id", fsResourceName, "id"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "elasticfilesystem", regexp.MustCompile(`access-point/fsap-.+`)),
+					resource.TestCheckResourceAttrSet(resourceName, "owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "posix_user.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSEFSAccessPoint_posix_user(t *testing.T) {
+	var ap efs.AccessPointDescription
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_efs_access_point.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckEfsAccessPointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEFSAccessPointConfigPosixUser(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEfsAccessPointExists(resourceName, &ap),
+					resource.TestCheckResourceAttr(resourceName, "posix_user.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "posix_user.0.gid", "1001"),
+					resource.TestCheckResourceAttr(resourceName, "posix_user.0.uid", "1001"),
+					resource.TestCheckResourceAttr(resourceName, "posix_user.0.secondary_gids.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSEFSAccessPoint_posix_user_secondary_gids(t *testing.T) {
+	var ap efs.AccessPointDescription
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_efs_access_point.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckEfsAccessPointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEFSAccessPointConfigPosixUserSecondaryGids(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEfsAccessPointExists(resourceName, &ap),
+					resource.TestCheckResourceAttr(resourceName, "posix_user.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "posix_user.0.gid", "1001"),
+					resource.TestCheckResourceAttr(resourceName, "posix_user.0.uid", "1001"),
+					resource.TestCheckResourceAttr(resourceName, "posix_user.0.secondary_gids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "posix_user.0.secondary_gids.0", "1002"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSEFSAccessPoint_tags(t *testing.T) {
+	var ap efs.AccessPointDescription
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_efs_access_point.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckEfsAccessPointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEFSAccessPointConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEfsAccessPointExists(resourceName, &ap),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSEFSAccessPointConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEfsAccessPointExists(resourceName, &ap),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSEFSAccessPointConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEfsAccessPointExists(resourceName, &ap),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEFSAccessPoint_disappears(t *testing.T) {
+	var ap efs.AccessPointDescription
+	resourceName := "aws_efs_access_point.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpnGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEFSAccessPointConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEfsAccessPointExists(resourceName, &ap),
+					testAccAWSEFSAccessPointDisappears(&ap),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckEfsAccessPointDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).efsconn
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_efs_access_point" {
+			continue
+		}
+
+		resp, err := conn.DescribeAccessPoints(&efs.DescribeAccessPointsInput{
+			AccessPointId: aws.String(rs.Primary.ID),
+		})
+		if err != nil {
+			if isAWSErr(err, efs.ErrCodeAccessPointNotFound, "") {
+				return nil
+			}
+			return fmt.Errorf("Error describing EFS access point in tests: %s", err)
+		}
+		if len(resp.AccessPoints) > 0 {
+			return fmt.Errorf("EFS access point %q still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckEfsAccessPointExists(resourceID string, mount *efs.AccessPointDescription) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceID]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceID)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		fs, ok := s.RootModule().Resources[resourceID]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceID)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).efsconn
+		mt, err := conn.DescribeAccessPoints(&efs.DescribeAccessPointsInput{
+			AccessPointId: aws.String(fs.Primary.ID),
+		})
+		if err != nil {
+			return err
+		}
+
+		if *mt.AccessPoints[0].AccessPointId != fs.Primary.ID {
+			return fmt.Errorf("access point ID mismatch: %q != %q",
+				*mt.AccessPoints[0].AccessPointId, fs.Primary.ID)
+		}
+
+		*mount = *mt.AccessPoints[0]
+
+		return nil
+	}
+}
+
+func testAccAWSEFSAccessPointDisappears(mount *efs.AccessPointDescription) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).efsconn
+
+		_, err := conn.DeleteAccessPoint(&efs.DeleteAccessPointInput{
+			AccessPointId: mount.AccessPointId,
+		})
+
+		if err != nil {
+			if isAWSErr(err, efs.ErrCodeAccessPointNotFound, "") {
+				return nil
+			}
+			return err
+		}
+
+		return resource.Retry(3*time.Minute, func() *resource.RetryError {
+			resp, err := conn.DescribeAccessPoints(&efs.DescribeAccessPointsInput{
+				AccessPointId: mount.AccessPointId,
+			})
+			if err != nil {
+				if isAWSErr(err, efs.ErrCodeAccessPointNotFound, "") {
+					return nil
+				}
+				return resource.NonRetryableError(
+					fmt.Errorf("Error reading EFS access point: %s", err))
+			}
+			if resp.AccessPoints == nil || len(resp.AccessPoints) < 1 {
+				return nil
+			}
+			if *resp.AccessPoints[0].LifeCycleState == efs.LifeCycleStateDeleted {
+				return nil
+			}
+			return resource.RetryableError(fmt.Errorf(
+				"Waiting for EFS access point: %s", *mount.AccessPointId))
+		})
+	}
+
+}
+
+func testAccAWSEFSAccessPointConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_efs_file_system" "test" {
+  creation_token = "%s"
+}
+
+resource "aws_efs_access_point" "test" {
+  file_system_id = "${aws_efs_file_system.test.id}"
+}
+`, rName)
+}
+
+func testAccAWSEFSAccessPointConfigPosixUser(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_efs_file_system" "test" {
+  creation_token = "%s"
+}
+
+resource "aws_efs_access_point" "test" {
+  file_system_id = "${aws_efs_file_system.test.id}"
+  posix_user {
+    gid = 1001
+    uid = 1001
+  }
+}
+`, rName)
+}
+
+func testAccAWSEFSAccessPointConfigPosixUserSecondaryGids(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_efs_file_system" "test" {
+  creation_token = "%s"
+}
+
+resource "aws_efs_access_point" "test" {
+  file_system_id = "${aws_efs_file_system.test.id}"
+  posix_user {
+    gid            = 1001
+    uid            = 1001
+    secondary_gids = [1002]
+  }
+}
+`, rName)
+}
+
+func testAccAWSEFSAccessPointConfigTags1(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_efs_file_system" "test" {
+  creation_token = %[1]q
+}
+
+resource "aws_efs_access_point" "test" {
+  file_system_id = "${aws_efs_file_system.test.id}"
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccAWSEFSAccessPointConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_efs_file_system" "test" {
+  creation_token = %[1]q
+}
+
+resource "aws_efs_access_point" "test" {
+  file_system_id = "${aws_efs_file_system.test.id}"
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}

--- a/aws/resource_aws_efs_access_point_test.go
+++ b/aws/resource_aws_efs_access_point_test.go
@@ -108,7 +108,8 @@ func TestAccAWSEFSAccessPoint_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "posix_user.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "root_directory.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "root_directory.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "root_directory.0.path", "/"),
 				),
 			},
 			{

--- a/aws/resource_aws_efs_access_point_test.go
+++ b/aws/resource_aws_efs_access_point_test.go
@@ -315,7 +315,7 @@ func testAccCheckEfsAccessPointDestroy(s *terraform.State) error {
 		})
 		if err != nil {
 			if isAWSErr(err, efs.ErrCodeAccessPointNotFound, "") {
-				return nil
+				continue
 			}
 			return fmt.Errorf("Error describing EFS access point in tests: %s", err)
 		}

--- a/aws/resource_aws_efs_access_point_test.go
+++ b/aws/resource_aws_efs_access_point_test.go
@@ -289,7 +289,7 @@ func TestAccAWSEFSAccessPoint_disappears(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckVpnGatewayDestroy,
+		CheckDestroy: testAccCheckEfsAccessPointDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSEFSAccessPointConfig(rName),

--- a/aws/resource_aws_efs_access_point_test.go
+++ b/aws/resource_aws_efs_access_point_test.go
@@ -295,7 +295,7 @@ func TestAccAWSEFSAccessPoint_disappears(t *testing.T) {
 				Config: testAccAWSEFSAccessPointConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEfsAccessPointExists(resourceName, &ap),
-					testAccAWSEFSAccessPointDisappears(&ap),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsEfsAccessPoint(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/aws/resource_aws_efs_file_system_test.go
+++ b/aws/resource_aws_efs_file_system_test.go
@@ -22,6 +22,7 @@ func init() {
 		F:    testSweepEfsFileSystems,
 		Dependencies: []string{
 			"aws_efs_mount_target",
+			"aws_efs_access_point",
 		},
 	})
 }

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -971,6 +971,16 @@ func expandStringList(configured []interface{}) []*string {
 	return vs
 }
 
+// Takes the result of flatmap.Expand for an array of int64
+// and returns a []*int64
+func expandInt64List(configured []interface{}) []*int64 {
+	vs := make([]*int64, 0, len(configured))
+	for _, v := range configured {
+		vs = append(vs, aws.Int64(int64(v.(int))))
+	}
+	return vs
+}
+
 // Expands a map of string to interface to a map of string to *float
 func expandFloat64Map(m map[string]interface{}) map[string]*float64 {
 	float64Map := make(map[string]*float64, len(m))
@@ -983,6 +993,11 @@ func expandFloat64Map(m map[string]interface{}) map[string]*float64 {
 // Takes the result of schema.Set of strings and returns a []*string
 func expandStringSet(configured *schema.Set) []*string {
 	return expandStringList(configured.List())
+}
+
+// Takes the result of schema.Set of strings and returns a []*int64
+func expandInt64Set(configured *schema.Set) []*int64 {
+	return expandInt64List(configured.List())
 }
 
 // Takes list of pointers to strings. Expand to an array

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1376,6 +1376,9 @@
                             <a href="#">Resources</a>
                             <ul class="nav nav-auto-expand">
                                 <li>
+                                    <a href="/docs/providers/aws/r/efs_access_point.html">aws_efs_access_point</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/aws/r/efs_file_system.html">aws_efs_file_system</a>
                                 </li>
                                 <li>

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1365,6 +1365,9 @@
                             <a href="#">Data Sources</a>
                             <ul class="nav nav-auto-expand">
                                 <li>
+                                    <a href="/docs/providers/aws/d/efs_access_point.html">aws_efs_access_point</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/aws/d/efs_file_system.html">aws_efs_file_system</a>
                                 </li>
                                 <li>

--- a/website/docs/d/efs_access_point.html.markdown
+++ b/website/docs/d/efs_access_point.html.markdown
@@ -1,0 +1,45 @@
+---
+subcategory: "EFS"
+layout: "aws"
+page_title: "AWS: aws_efs_access_point"
+description: |-
+  Provides an Elastic File System (EFS) Access Point data source.
+---
+
+# Data Source: aws_efs_access_point
+
+Provides information about an Elastic File System (EFS) Access Point.
+
+## Example Usage
+
+```hcl
+resource "aws_efs_file_system" "test" {
+  creation_token = "some-token"
+}
+
+resource "aws_efs_access_point" "test" {
+  file_system_id = "${aws_efs_file_system.test.id}"
+}
+
+data "aws_efs_access_point" "test" {
+  access_point_id = "${aws_efs_access_point.test.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `access_point_id` - (Required) The ID that identifies the file system.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the access point.
+* `arn` - Amazon Resource Name of the file system.
+* `file_system_arn` - Amazon Resource Name of the file system.
+* `file_system_id` - The ID of the file system for which the access point is intended.
+* `posix_user` - The operating system user and group applied to all file system requests made using the access point.
+* `root_directory`- Specifies the directory on the Amazon EFS file system that the access point provides access to.
+* `tags` - Key-value mapping of resource tags.

--- a/website/docs/d/efs_access_point.html.markdown
+++ b/website/docs/d/efs_access_point.html.markdown
@@ -13,16 +13,8 @@ Provides information about an Elastic File System (EFS) Access Point.
 ## Example Usage
 
 ```hcl
-resource "aws_efs_file_system" "test" {
-  creation_token = "some-token"
-}
-
-resource "aws_efs_access_point" "test" {
-  file_system_id = "${aws_efs_file_system.test.id}"
-}
-
 data "aws_efs_access_point" "test" {
-  access_point_id = "${aws_efs_access_point.test.id}"
+  access_point_id = "fsap-12345678"
 }
 ```
 

--- a/website/docs/d/efs_access_point.html.markdown
+++ b/website/docs/d/efs_access_point.html.markdown
@@ -40,6 +40,14 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - Amazon Resource Name of the file system.
 * `file_system_arn` - Amazon Resource Name of the file system.
 * `file_system_id` - The ID of the file system for which the access point is intended.
-* `posix_user` - The operating system user and group applied to all file system requests made using the access point.
-* `root_directory`- Specifies the directory on the Amazon EFS file system that the access point provides access to.
+* `posix_user` - Single element list containing operating system user and group applied to all file system requests made using the access point.
+    * `gid` - Group ID
+    * `secondary_gids` - Secondary group IDs
+    * `uid` - User Id
+* `root_directory`- Single element list containing information on the directory on the Amazon EFS file system that the access point provides access to.
+    * `creation_info` - Single element list containing information on the creation permissions of the directory
+        * `owner_gid` - POSIX owner group ID
+        * `owner_uid` - POSIX owner user ID
+        * `permissions` - POSIX permissions mode
+    * `path` - Path exposed as the root directory
 * `tags` - Key-value mapping of resource tags.

--- a/website/docs/d/efs_file_system.html.markdown
+++ b/website/docs/d/efs_file_system.html.markdown
@@ -3,12 +3,12 @@ subcategory: "EFS"
 layout: "aws"
 page_title: "AWS: aws_efs_file_system"
 description: |-
-  Provides an Elastic File System (EFS) data source.
+  Provides an Elastic File System (EFS) File System data source.
 ---
 
 # Data Source: aws_efs_file_system
 
-Provides information about an Elastic File System (EFS).
+Provides information about an Elastic File System (EFS) File System.
 
 ## Example Usage
 

--- a/website/docs/r/efs_access_point.html.markdown
+++ b/website/docs/r/efs_access_point.html.markdown
@@ -25,11 +25,7 @@ The following arguments are supported:
 
 * `file_system_id` - (Required) The ID of the file system for which the access point is intended.
 * `posix_user` - (Optional) The operating system user and group applied to all file system requests made using the access point. See [Posix User](#posix-user) below.
-* `root_directory`- (Optional) Specifies the directory on the Amazon EFS file system that the access point
-                    // provides access to. The access point exposes the specified file system path
-                    // as the root directory of your file system to applications using the access
-                    // point. NFS clients using the access point can only access data in the access
-                    // point's RootDirectory and it's subdirectories.
+* `root_directory`- (Optional) Specifies the directory on the Amazon EFS file system that the access point provides access to. See [Root Directory](#root-directory) below.
 * `tags` - (Optional) Key-value mapping of resource tags.
 
 ### Posix User
@@ -39,6 +35,26 @@ The `posix_user` block supports the following:
 * `gid` - (Required) The POSIX group ID used for all file system operations using this access point.
 * `uid` - (Required) he POSIX user ID used for all file system operations using this access point.
 * `secondary_gids` - (Optional) Secondary POSIX group IDs used for all file system operations using this access point.
+
+### Root Directory
+
+The access point exposes the specified file system path as the root directory of your file system to applications using the access point.
+NFS clients using the access point can only access data in the access point's RootDirectory and it's subdirectories.
+
+The `root_directory` block supports the following:
+
+* `path` - (Optional) Specifies the path on the EFS file system to expose as the root directory to NFS clients using the access point to access the EFS file system. A path can have up to four subdirectories. If the specified path does not exist, you are required to provide `creation_info`. 
+* `creation_info` - (Optional) Specifies the POSIX IDs and permissions to apply to the access point's Root Directory. See [Creation Info](#creation-info) below.
+
+### Creation Info
+
+If the `path` specified does not exist, EFS creates the root directory using the `creation_info` settings when a client connects to an access point.
+
+The `creation_info` block supports the following:
+
+* `owner_gid` - (Required) Specifies the POSIX group ID to apply to the `root_directory`.
+* `owner_uid` - (Required) Specifies the POSIX user ID to apply to the `root_directory`.
+* `permissions` - (Required) Specifies the POSIX permissions to apply to the RootDirectory, in the format of an octal number representing the file's mode bits.
 
 ## Attributes Reference
 

--- a/website/docs/r/efs_access_point.html.markdown
+++ b/website/docs/r/efs_access_point.html.markdown
@@ -1,0 +1,57 @@
+---
+subcategory: "EFS"
+layout: "aws"
+page_title: "AWS: aws_efs_access_point"
+description: |-
+  Provides an Elastic File System (EFS) access point.
+---
+
+# Resource: aws_efs_access_point
+
+Provides an Elastic File System (EFS) access point.
+
+## Example Usage
+
+```hcl
+resource "aws_efs_access_point" "test" {
+  file_system_id = "${aws_efs_file_system.foo.id}"
+  subnet_id      = "${aws_subnet.alpha.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `file_system_id` - (Required) The ID of the file system for which the access point is intended.
+* `posix_user` - (Optional) The operating system user and group applied to all file system requests made using the access point. See [Posix User](#posix-user) below.
+* `root_directory`- (Optional) Specifies the directory on the Amazon EFS file system that the access point
+                    // provides access to. The access point exposes the specified file system path
+                    // as the root directory of your file system to applications using the access
+                    // point. NFS clients using the access point can only access data in the access
+                    // point's RootDirectory and it's subdirectories.
+* `tags` - (Optional) Key-value mapping of resource tags.
+
+### Posix User
+
+The `posix_user` block supports the following:
+
+* `gid` - (Required) The POSIX group ID used for all file system operations using this access point.
+* `uid` - (Required) he POSIX user ID used for all file system operations using this access point.
+* `secondary_gids` - (Optional) Secondary POSIX group IDs used for all file system operations using this access point.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the access point.
+* `arn` - Amazon Resource Name of the access point.
+* `file_system_arn` - Amazon Resource Name of the file system.
+
+## Import
+
+The EFS access points can be imported using the `id`, e.g.
+
+```
+$ terraform import aws_efs_access_point.test fsap-52a643fb
+```

--- a/website/docs/r/efs_access_point.html.markdown
+++ b/website/docs/r/efs_access_point.html.markdown
@@ -15,7 +15,6 @@ Provides an Elastic File System (EFS) access point.
 ```hcl
 resource "aws_efs_access_point" "test" {
   file_system_id = "${aws_efs_file_system.foo.id}"
-  subnet_id      = "${aws_subnet.alpha.id}"
 }
 ```
 

--- a/website/docs/r/efs_file_system.html.markdown
+++ b/website/docs/r/efs_file_system.html.markdown
@@ -3,12 +3,12 @@ subcategory: "EFS"
 layout: "aws"
 page_title: "AWS: aws_efs_file_system"
 description: |-
-  Provides an Elastic File System (EFS) resource.
+  Provides an Elastic File System (EFS) File System resource.
 ---
 
 # Resource: aws_efs_file_system
 
-Provides an Elastic File System (EFS) resource.
+Provides an Elastic File System (EFS) File System resource.
 
 ## Example Usage
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12118

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_efs_access_point: add new resource.
data_source_aws_efs_access_point: add data source.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEFSAccessPoint_'
--- PASS: TestAccAWSEFSAccessPoint_basic (71.24s)
--- PASS: TestAccAWSEFSAccessPoint_root_directory_creation_info (68.25s)
--- PASS: TestAccAWSEFSAccessPoint_root_directory (66.77s)
--- PASS: TestAccAWSEFSAccessPoint_posix_user (68.50s)
--- PASS: TestAccAWSEFSAccessPoint_posix_user_secondary_gids (67.81s)
--- PASS: TestAccAWSEFSAccessPoint_tags (128.30s)
--- PASS: TestAccAWSEFSAccessPoint_disappears (62.09s)
```

```
$ make testacc TESTARGS='-run=TestAccDataSourceAWSEFSAccessPoint_basic '
--- PASS: TestAccDataSourceAWSEFSAccessPoint_basic (78.50s)
```
