### PR TITLE
AWS AppSync integration with AWS X-Ray

### DIFF
--- a/aws/resource_aws_appsync_graphql_api.go
+++ b/aws/resource_aws_appsync_graphql_api.go
@@ -199,6 +199,10 @@ func resourceAwsAppsyncGraphqlApi() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"tags": tagsSchema(),
+			"xray_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -229,6 +233,10 @@ func resourceAwsAppsyncGraphqlApiCreate(d *schema.ResourceData, meta interface{}
 
 	if v, ok := d.GetOk("tags"); ok {
 		input.Tags = keyvaluetags.New(v.(map[string]interface{})).IgnoreAws().AppsyncTags()
+	}
+
+	if v, ok := d.GetOk("xray_enabled"); ok {
+		input.XrayEnabled = aws.Bool(v.(bool))
 	}
 
 	resp, err := conn.CreateGraphqlApi(input)
@@ -292,6 +300,10 @@ func resourceAwsAppsyncGraphqlApiRead(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 
+	if err := d.Set("xray_enabled", aws.BoolValue(resp.GraphqlApi.XrayEnabled)); err != nil {
+		return fmt.Errorf("error setting xray_enabled: %s", err)
+	}
+
 	return nil
 }
 
@@ -326,6 +338,10 @@ func resourceAwsAppsyncGraphqlApiUpdate(d *schema.ResourceData, meta interface{}
 
 	if v, ok := d.GetOk("additional_authentication_provider"); ok {
 		input.AdditionalAuthenticationProviders = expandAppsyncGraphqlApiAdditionalAuthProviders(v.([]interface{}), meta.(*AWSClient).region)
+	}
+
+	if v, ok := d.GetOk("xray_enabled"); ok {
+		input.XrayEnabled = aws.Bool(v.(bool))
 	}
 
 	_, err := conn.UpdateGraphqlApi(input)

--- a/website/docs/r/appsync_graphql_api.html.markdown
+++ b/website/docs/r/appsync_graphql_api.html.markdown
@@ -138,6 +138,7 @@ The following arguments are supported:
 * `schema` - (Optional) The schema definition, in GraphQL schema language format. Terraform cannot perform drift detection of this configuration.
 * `additional_authentication_provider` - (Optional) One or more additional authentication providers for the GraphqlApi. Defined below.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+* `xray_enabled` - (Optional) Whether tracing with X-ray is enabled. Defaults to false.
 
 ### log_config
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/11969

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_appsync_graphql_api: Add `xray_enabled` argument
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAppsyncGraphqlApi_XrayEnabled'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAppsyncGraphqlApi_XrayEnabled -timeout 120m
=== RUN   TestAccAWSAppsyncGraphqlApi_XrayEnabled
=== PAUSE TestAccAWSAppsyncGraphqlApi_XrayEnabled
=== CONT  TestAccAWSAppsyncGraphqlApi_XrayEnabled
--- PASS: TestAccAWSAppsyncGraphqlApi_XrayEnabled (64.65s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	64.686s
```
