### PR TITLE
add support for Kms grant import

### DIFF
--- a/aws/resource_aws_kms_grant.go
+++ b/aws/resource_aws_kms_grant.go
@@ -24,6 +24,19 @@ func resourceAwsKmsGrant() *schema.Resource {
 		Read:   resourceAwsKmsGrantRead,
 		Delete: resourceAwsKmsGrantDelete,
 		Exists: resourceAwsKmsGrantExists,
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				keyId, grantId, err := decodeKmsGrantId(d.Id())
+				if err != nil {
+					return nil, err
+				}
+				d.Set("key_id", keyId)
+				d.Set("grant_id", grantId)
+				d.SetId(fmt.Sprintf("%s:%s", keyId, grantId))
+
+				return []*schema.ResourceData{d}, nil
+			},
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -533,16 +546,16 @@ func flattenKmsGrantConstraints(constraint *kms.GrantConstraints) *schema.Set {
 
 func decodeKmsGrantId(id string) (string, string, error) {
 	if strings.HasPrefix(id, "arn:aws") {
-		arn_parts := strings.Split(id, "/")
-		if len(arn_parts) != 2 {
+		arnParts := strings.Split(id, "/")
+		if len(arnParts) != 2 {
 			return "", "", fmt.Errorf("unexpected format of ARN (%q), expected KeyID:GrantID", id)
 		}
-		arn_prefix := arn_parts[0]
-		parts := strings.Split(arn_parts[1], ":")
+		arnPrefix := arnParts[0]
+		parts := strings.Split(arnParts[1], ":")
 		if len(parts) != 2 {
 			return "", "", fmt.Errorf("unexpected format of ID (%q), expected KeyID:GrantID", id)
 		}
-		return fmt.Sprintf("%s/%s", arn_prefix, parts[0]), parts[1], nil
+		return fmt.Sprintf("%s/%s", arnPrefix, parts[0]), parts[1], nil
 	} else {
 		parts := strings.Split(id, ":")
 		if len(parts) != 2 {

--- a/aws/resource_aws_kms_grant_test.go
+++ b/aws/resource_aws_kms_grant_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -11,7 +10,8 @@ import (
 )
 
 func TestAccAWSKmsGrant_Basic(t *testing.T) {
-	timestamp := time.Now().Format(time.RFC1123)
+	resourceName := "aws_kms_grant.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -19,23 +19,30 @@ func TestAccAWSKmsGrant_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSKmsGrantDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSKmsGrant_Basic("basic", timestamp, "\"Encrypt\", \"Decrypt\""),
+				Config: testAccAWSKmsGrant_Basic(rName, "\"Encrypt\", \"Decrypt\""),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsGrantExists("aws_kms_grant.basic"),
-					resource.TestCheckResourceAttr("aws_kms_grant.basic", "name", "basic"),
-					resource.TestCheckResourceAttr("aws_kms_grant.basic", "operations.#", "2"),
-					resource.TestCheckResourceAttr("aws_kms_grant.basic", "operations.2238845196", "Encrypt"),
-					resource.TestCheckResourceAttr("aws_kms_grant.basic", "operations.1237510779", "Decrypt"),
-					resource.TestCheckResourceAttrSet("aws_kms_grant.basic", "grantee_principal"),
-					resource.TestCheckResourceAttrSet("aws_kms_grant.basic", "key_id"),
+					testAccCheckAWSKmsGrantExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "operations.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "operations.2238845196", "Encrypt"),
+					resource.TestCheckResourceAttr(resourceName, "operations.1237510779", "Decrypt"),
+					resource.TestCheckResourceAttrSet(resourceName, "grantee_principal"),
+					resource.TestCheckResourceAttrSet(resourceName, "key_id"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"grant_token", "retire_on_delete"},
 			},
 		},
 	})
 }
 
 func TestAccAWSKmsGrant_withConstraints(t *testing.T) {
-	timestamp := time.Now().Format(time.RFC1123)
+	resourceName := "aws_kms_grant.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -43,27 +50,33 @@ func TestAccAWSKmsGrant_withConstraints(t *testing.T) {
 		CheckDestroy: testAccCheckAWSKmsGrantDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSKmsGrant_withConstraints("withConstraintsEq", timestamp, "encryption_context_equals", `foo = "bar"
+				Config: testAccAWSKmsGrant_withConstraints(rName, "encryption_context_equals", `foo = "bar"
                         baz = "kaz"`),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsGrantExists("aws_kms_grant.withConstraintsEq"),
-					resource.TestCheckResourceAttr("aws_kms_grant.withConstraintsEq", "name", "withConstraintsEq"),
-					resource.TestCheckResourceAttr("aws_kms_grant.withConstraintsEq", "constraints.#", "1"),
-					resource.TestCheckResourceAttr("aws_kms_grant.withConstraintsEq", "constraints.449762259.encryption_context_equals.%", "2"),
-					resource.TestCheckResourceAttr("aws_kms_grant.withConstraintsEq", "constraints.449762259.encryption_context_equals.baz", "kaz"),
-					resource.TestCheckResourceAttr("aws_kms_grant.withConstraintsEq", "constraints.449762259.encryption_context_equals.foo", "bar"),
+					testAccCheckAWSKmsGrantExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "constraints.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "constraints.449762259.encryption_context_equals.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "constraints.449762259.encryption_context_equals.baz", "kaz"),
+					resource.TestCheckResourceAttr(resourceName, "constraints.449762259.encryption_context_equals.foo", "bar"),
 				),
 			},
 			{
-				Config: testAccAWSKmsGrant_withConstraints("withConstraintsSub", timestamp, "encryption_context_subset", `foo = "bar"
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"grant_token", "retire_on_delete"},
+			},
+			{
+				Config: testAccAWSKmsGrant_withConstraints(rName, "encryption_context_subset", `foo = "bar"
 			            baz = "kaz"`),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsGrantExists("aws_kms_grant.withConstraintsSub"),
-					resource.TestCheckResourceAttr("aws_kms_grant.withConstraintsSub", "name", "withConstraintsSub"),
-					resource.TestCheckResourceAttr("aws_kms_grant.withConstraintsSub", "constraints.#", "1"),
-					resource.TestCheckResourceAttr("aws_kms_grant.withConstraintsSub", "constraints.2645649985.encryption_context_subset.%", "2"),
-					resource.TestCheckResourceAttr("aws_kms_grant.withConstraintsSub", "constraints.2645649985.encryption_context_subset.baz", "kaz"),
-					resource.TestCheckResourceAttr("aws_kms_grant.withConstraintsSub", "constraints.2645649985.encryption_context_subset.foo", "bar"),
+					testAccCheckAWSKmsGrantExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "constraints.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "constraints.2645649985.encryption_context_subset.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "constraints.2645649985.encryption_context_subset.baz", "kaz"),
+					resource.TestCheckResourceAttr(resourceName, "constraints.2645649985.encryption_context_subset.foo", "bar"),
 				),
 			},
 		},
@@ -71,7 +84,8 @@ func TestAccAWSKmsGrant_withConstraints(t *testing.T) {
 }
 
 func TestAccAWSKmsGrant_withRetiringPrincipal(t *testing.T) {
-	timestamp := time.Now().Format(time.RFC1123)
+	resourceName := "aws_kms_grant.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -79,18 +93,25 @@ func TestAccAWSKmsGrant_withRetiringPrincipal(t *testing.T) {
 		CheckDestroy: testAccCheckAWSKmsGrantDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSKmsGrant_withRetiringPrincipal("withRetiringPrincipal", timestamp),
+				Config: testAccAWSKmsGrant_withRetiringPrincipal(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsGrantExists("aws_kms_grant.withRetiringPrincipal"),
-					resource.TestCheckResourceAttrSet("aws_kms_grant.withRetiringPrincipal", "retiring_principal"),
+					testAccCheckAWSKmsGrantExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "retiring_principal"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"grant_token", "retire_on_delete"},
 			},
 		},
 	})
 }
 
 func TestAccAWSKmsGrant_bare(t *testing.T) {
-	timestamp := time.Now().Format(time.RFC1123)
+	resourceName := "aws_kms_grant.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -98,20 +119,27 @@ func TestAccAWSKmsGrant_bare(t *testing.T) {
 		CheckDestroy: testAccCheckAWSKmsGrantDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSKmsGrant_bare("bare", timestamp),
+				Config: testAccAWSKmsGrant_bare(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsGrantExists("aws_kms_grant.bare"),
-					resource.TestCheckNoResourceAttr("aws_kms_grant.bare", "name"),
-					resource.TestCheckNoResourceAttr("aws_kms_grant.bare", "constraints.#"),
-					resource.TestCheckNoResourceAttr("aws_kms_grant.bare", "retiring_principal"),
+					testAccCheckAWSKmsGrantExists(resourceName),
+					resource.TestCheckNoResourceAttr(resourceName, "name"),
+					resource.TestCheckNoResourceAttr(resourceName, "constraints.#"),
+					resource.TestCheckNoResourceAttr(resourceName, "retiring_principal"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"grant_token", "retire_on_delete"},
 			},
 		},
 	})
 }
 
 func TestAccAWSKmsGrant_ARN(t *testing.T) {
-	timestamp := time.Now().Format(time.RFC1123)
+	resourceName := "aws_kms_grant.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -119,16 +147,22 @@ func TestAccAWSKmsGrant_ARN(t *testing.T) {
 		CheckDestroy: testAccCheckAWSKmsGrantDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSKmsGrant_ARN("arn", timestamp, "\"Encrypt\", \"Decrypt\""),
+				Config: testAccAWSKmsGrant_ARN(rName, "\"Encrypt\", \"Decrypt\""),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsGrantExists("aws_kms_grant.arn"),
-					resource.TestCheckResourceAttr("aws_kms_grant.arn", "name", "arn"),
-					resource.TestCheckResourceAttr("aws_kms_grant.arn", "operations.#", "2"),
-					resource.TestCheckResourceAttr("aws_kms_grant.arn", "operations.2238845196", "Encrypt"),
-					resource.TestCheckResourceAttr("aws_kms_grant.arn", "operations.1237510779", "Decrypt"),
-					resource.TestCheckResourceAttrSet("aws_kms_grant.arn", "grantee_principal"),
-					resource.TestCheckResourceAttrSet("aws_kms_grant.arn", "key_id"),
+					testAccCheckAWSKmsGrantExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "operations.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "operations.2238845196", "Encrypt"),
+					resource.TestCheckResourceAttr(resourceName, "operations.1237510779", "Decrypt"),
+					resource.TestCheckResourceAttrSet(resourceName, "grantee_principal"),
+					resource.TestCheckResourceAttrSet(resourceName, "key_id"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"grant_token", "retire_on_delete"},
 			},
 		},
 	})
@@ -160,109 +194,14 @@ func testAccCheckAWSKmsGrantExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testAccAWSKmsGrant_Basic(rName string, timestamp string, operations string) string {
+func testAccAWSKmsGrantConfigBase(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_kms_key" "tf-acc-test-key" {
-    description = "Terraform acc test key %s"
+resource "aws_kms_key" "test" {
+    description = "Terraform acc test key %[1]s"
     deletion_window_in_days = 7
 }
 
-%s
-
-resource "aws_iam_role" "tf-acc-test-role" {
-  name               = "%s"
-  path               = "/service-role/"
-  assume_role_policy = "${data.aws_iam_policy_document.assumerole-policy-template.json}"
-}
-
-resource "aws_kms_grant" "%[4]s" {
-	name = "%[4]s"
-	key_id = "${aws_kms_key.tf-acc-test-key.key_id}"
-	grantee_principal = "${aws_iam_role.tf-acc-test-role.arn}"
-	operations = [ %[5]s ]
-}
-`, timestamp, staticAssumeRolePolicyString, acctest.RandomWithPrefix("tf-acc-test-kms-grant-role"), rName, operations)
-}
-
-func testAccAWSKmsGrant_withConstraints(rName string, timestamp string, constraintName string, encryptionContext string) string {
-	return fmt.Sprintf(`
-resource "aws_kms_key" "tf-acc-test-key" {
-    description = "Terraform acc test key %s"
-    deletion_window_in_days = 7
-}
-
-%s
-
-resource "aws_iam_role" "tf-acc-test-role" {
-  name               = "%s"
-  path               = "/service-role/"
-  assume_role_policy = "${data.aws_iam_policy_document.assumerole-policy-template.json}"
-}
-
-resource "aws_kms_grant" "%[4]s" {
-	name = "%[4]s"
-	key_id = "${aws_kms_key.tf-acc-test-key.key_id}"
-	grantee_principal = "${aws_iam_role.tf-acc-test-role.arn}"
-	operations = [ "RetireGrant", "DescribeKey" ]
-	constraints {
-		%[5]s = {
-			%[6]s
-		}
-	}
-}
-`, timestamp, staticAssumeRolePolicyString, acctest.RandomWithPrefix("tf-acc-test-kms-grant-role"), rName, constraintName, encryptionContext)
-}
-
-func testAccAWSKmsGrant_withRetiringPrincipal(rName string, timestamp string) string {
-	return fmt.Sprintf(`
-resource "aws_kms_key" "tf-acc-test-key" {
-  description             = "Terraform acc test key %s"
-  deletion_window_in_days = 7
-}
-
-%s
-
-resource "aws_iam_role" "tf-acc-test-role" {
-  name               = "%s"
-  path               = "/service-role/"
-  assume_role_policy = "${data.aws_iam_policy_document.assumerole-policy-template.json}"
-}
-
-resource "aws_kms_grant" "%[4]s" {
-  name               = "%[4]s"
-  key_id             = "${aws_kms_key.tf-acc-test-key.key_id}"
-  grantee_principal  = "${aws_iam_role.tf-acc-test-role.arn}"
-  operations         = ["ReEncryptTo", "CreateGrant"]
-  retiring_principal = "${aws_iam_role.tf-acc-test-role.arn}"
-}
-`, timestamp, staticAssumeRolePolicyString, acctest.RandomWithPrefix("tf-acc-test-kms-grant-role"), rName)
-}
-
-func testAccAWSKmsGrant_bare(rName string, timestamp string) string {
-	return fmt.Sprintf(`
-resource "aws_kms_key" "tf-acc-test-key" {
-  description             = "Terraform acc test key %s"
-  deletion_window_in_days = 7
-}
-
-%s
-
-resource "aws_iam_role" "tf-acc-test-role" {
-  name               = "%s"
-  path               = "/service-role/"
-  assume_role_policy = "${data.aws_iam_policy_document.assumerole-policy-template.json}"
-}
-
-resource "aws_kms_grant" "%s" {
-  key_id            = "${aws_kms_key.tf-acc-test-key.key_id}"
-  grantee_principal = "${aws_iam_role.tf-acc-test-role.arn}"
-  operations        = ["ReEncryptTo", "CreateGrant"]
-}
-`, timestamp, staticAssumeRolePolicyString, acctest.RandomWithPrefix("tf-acc-test-kms-grant-role"), rName)
-}
-
-const staticAssumeRolePolicyString = `
-data "aws_iam_policy_document" "assumerole-policy-template" {
+data "aws_iam_policy_document" "test" {
   statement {
     effect  = "Allow"
     actions = [ "sts:AssumeRole" ]
@@ -272,28 +211,71 @@ data "aws_iam_policy_document" "assumerole-policy-template" {
     }
   }
 }
-`
 
-func testAccAWSKmsGrant_ARN(rName string, timestamp string, operations string) string {
-	return fmt.Sprintf(`
-resource "aws_kms_key" "tf-acc-test-key" {
-    description = "Terraform acc test key %s"
-    deletion_window_in_days = 7
-}
-
-%s
-
-resource "aws_iam_role" "tf-acc-test-role" {
-  name               = "%s"
+resource "aws_iam_role" "test" {
+  name               = %[1]q
   path               = "/service-role/"
-  assume_role_policy = "${data.aws_iam_policy_document.assumerole-policy-template.json}"
+  assume_role_policy = "${data.aws_iam_policy_document.test.json}"
+}
+`, rName)
 }
 
-resource "aws_kms_grant" "%[4]s" {
-	name = "%[4]s"
-	key_id = "${aws_kms_key.tf-acc-test-key.arn}"
-	grantee_principal = "${aws_iam_role.tf-acc-test-role.arn}"
-	operations = [ %[5]s ]
+func testAccAWSKmsGrant_Basic(rName string, operations string) string {
+	return testAccAWSKmsGrantConfigBase(rName) + fmt.Sprintf(`
+resource "aws_kms_grant" "test" {
+	name = %[1]q
+	key_id = "${aws_kms_key.test.key_id}"
+	grantee_principal = "${aws_iam_role.test.arn}"
+	operations = [ %[2]s ]
 }
-`, timestamp, staticAssumeRolePolicyString, acctest.RandomWithPrefix("tf-acc-test-kms-grant-role"), rName, operations)
+`, rName, operations)
+}
+
+func testAccAWSKmsGrant_withConstraints(rName string, constraintName string, encryptionContext string) string {
+	return testAccAWSKmsGrantConfigBase(rName) + fmt.Sprintf(`
+resource "aws_kms_grant" "test" {
+	name = "%[1]s"
+	key_id = "${aws_kms_key.test.key_id}"
+	grantee_principal = "${aws_iam_role.test.arn}"
+	operations = [ "RetireGrant", "DescribeKey" ]
+	constraints {
+		%[2]s = {
+			%[3]s
+		}
+	}
+}
+`, rName, constraintName, encryptionContext)
+}
+
+func testAccAWSKmsGrant_withRetiringPrincipal(rName string) string {
+	return testAccAWSKmsGrantConfigBase(rName) + fmt.Sprintf(`
+resource "aws_kms_grant" "test" {
+  name               = "%[1]s"
+  key_id             = "${aws_kms_key.test.key_id}"
+  grantee_principal  = "${aws_iam_role.test.arn}"
+  operations         = ["ReEncryptTo", "CreateGrant"]
+  retiring_principal = "${aws_iam_role.test.arn}"
+}
+`, rName)
+}
+
+func testAccAWSKmsGrant_bare(rName string) string {
+	return testAccAWSKmsGrantConfigBase(rName) + fmt.Sprintf(`
+resource "aws_kms_grant" "test" {
+  key_id            = "${aws_kms_key.test.key_id}"
+  grantee_principal = "${aws_iam_role.test.arn}"
+  operations        = ["ReEncryptTo", "CreateGrant"]
+}
+`)
+}
+
+func testAccAWSKmsGrant_ARN(rName string, operations string) string {
+	return testAccAWSKmsGrantConfigBase(rName) + fmt.Sprintf(`
+resource "aws_kms_grant" "test" {
+	name = "%[1]s"
+	key_id = "${aws_kms_key.test.arn}"
+	grantee_principal = "${aws_iam_role.test.arn}"
+	operations = [ %[2]s ]
+}
+`, rName, operations)
 }

--- a/aws/resource_aws_kms_grant_test.go
+++ b/aws/resource_aws_kms_grant_test.go
@@ -150,7 +150,7 @@ func TestAccAWSKmsGrant_ARN(t *testing.T) {
 				Config: testAccAWSKmsGrant_ARN(rName, "\"Encrypt\", \"Decrypt\""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSKmsGrantExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "name", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "operations.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "operations.2238845196", "Encrypt"),
 					resource.TestCheckResourceAttr(resourceName, "operations.1237510779", "Decrypt"),

--- a/website/docs/r/kms_grant.html.markdown
+++ b/website/docs/r/kms_grant.html.markdown
@@ -77,8 +77,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-KMS Grants can be imported using the `id`, e.g.
+KMS Grants can be imported using the Key ID and Grant ID separated by a colon (`:`), e.g.
 
 ```
-$ terraform import aws_kms_grant.test 1234abcd-12ab-34cd-56ef-1234567890ab
+$ terraform import aws_kms_grant.test 1234abcd-12ab-34cd-56ef-1234567890ab: abcde1237f76e4ba7987489ac329fbfba6ad343d6f7075dbd1ef191f0120514
 ```

--- a/website/docs/r/kms_grant.html.markdown
+++ b/website/docs/r/kms_grant.html.markdown
@@ -74,3 +74,11 @@ In addition to all arguments above, the following attributes are exported:
 
 * `grant_id` - The unique identifier for the grant.
 * `grant_token` - The grant token for the created grant. For more information, see [Grant Tokens](http://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token).
+
+## Import
+
+KMS Grants can be imported using the `id`, e.g.
+
+```
+$ terraform import aws_kms_grant.test 1234abcd-12ab-34cd-56ef-1234567890ab
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11976

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_kms_grant: add import support
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSKmsGrant_'
--- PASS: TestAccAWSKmsGrant_ARN (99.06s)
--- PASS: TestAccAWSKmsGrant_bare (90.76s)
--- PASS: TestAccAWSKmsGrant_withRetiringPrincipal (98.01s)
--- PASS: TestAccAWSKmsGrant_withConstraints (138.86s)
--- PASS: TestAccAWSKmsGrant_Basic (91.78s)
```
