### PR TITLE
add support for Cloudwatch Log Metric Filter import

### DIFF
--- a/aws/resource_aws_cloudwatch_log_metric_filter.go
+++ b/aws/resource_aws_cloudwatch_log_metric_filter.go
@@ -113,7 +113,7 @@ func resourceAwsCloudWatchLogMetricFilterUpdate(d *schema.ResourceData, meta int
 		return fmt.Errorf("Creating/Updating CloudWatch Log Metric Filter failed: %s", err)
 	}
 
-	d.SetId(logGroupName + ":" + name)
+	d.SetId(d.Get("name").(string))
 
 	log.Println("[INFO] CloudWatch Log Metric Filter created/updated")
 
@@ -217,6 +217,6 @@ func resourceAwsCloudWatchLogMetricFilterImport(d *schema.ResourceData, meta int
 	name := idParts[1]
 	d.Set("log_group_name", logGroupName)
 	d.Set("name", name)
-	d.SetId(logGroupName + ":" + name)
+	d.SetId(name)
 	return []*schema.ResourceData{d}, nil
 }

--- a/aws/resource_aws_cloudwatch_log_metric_filter.go
+++ b/aws/resource_aws_cloudwatch_log_metric_filter.go
@@ -20,6 +20,9 @@ func resourceAwsCloudWatchLogMetricFilter() *schema.Resource {
 		Read:   resourceAwsCloudWatchLogMetricFilterRead,
 		Update: resourceAwsCloudWatchLogMetricFilterUpdate,
 		Delete: resourceAwsCloudWatchLogMetricFilterDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsCloudWatchLogMetricFilterImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -85,10 +88,13 @@ func resourceAwsCloudWatchLogMetricFilter() *schema.Resource {
 func resourceAwsCloudWatchLogMetricFilterUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).cloudwatchlogsconn
 
+	name := d.Get("name").(string)
+	logGroupName := d.Get("log_group_name").(string)
+
 	input := cloudwatchlogs.PutMetricFilterInput{
-		FilterName:    aws.String(d.Get("name").(string)),
+		FilterName:    aws.String(name),
 		FilterPattern: aws.String(strings.TrimSpace(d.Get("pattern").(string))),
-		LogGroupName:  aws.String(d.Get("log_group_name").(string)),
+		LogGroupName:  aws.String(logGroupName),
 	}
 
 	transformations := d.Get("metric_transformation").([]interface{})
@@ -107,7 +113,7 @@ func resourceAwsCloudWatchLogMetricFilterUpdate(d *schema.ResourceData, meta int
 		return fmt.Errorf("Creating/Updating CloudWatch Log Metric Filter failed: %s", err)
 	}
 
-	d.SetId(d.Get("name").(string))
+	d.SetId(logGroupName + ":" + name)
 
 	log.Println("[INFO] CloudWatch Log Metric Filter created/updated")
 
@@ -200,4 +206,17 @@ func resourceAwsCloudWatchLogMetricFilterDelete(d *schema.ResourceData, meta int
 	log.Println("[INFO] CloudWatch Log Metric Filter deleted")
 
 	return nil
+}
+
+func resourceAwsCloudWatchLogMetricFilterImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	idParts := strings.Split(d.Id(), ":")
+	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
+		return nil, fmt.Errorf("Unexpected format of ID (%q), expected <log_group_name>:<name>", d.Id())
+	}
+	logGroupName := idParts[0]
+	name := idParts[1]
+	d.Set("log_group_name", logGroupName)
+	d.Set("name", name)
+	d.SetId(logGroupName + ":" + name)
+	return []*schema.ResourceData{d}, nil
 }

--- a/aws/resource_aws_cloudwatch_log_metric_filter_test.go
+++ b/aws/resource_aws_cloudwatch_log_metric_filter_test.go
@@ -14,6 +14,7 @@ import (
 func TestAccAWSCloudWatchLogMetricFilter_basic(t *testing.T) {
 	var mf cloudwatchlogs.MetricFilter
 	rInt := acctest.RandInt()
+	resourceName := "aws_cloudwatch_log_metric_filter.foobar"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -23,15 +24,15 @@ func TestAccAWSCloudWatchLogMetricFilter_basic(t *testing.T) {
 			{
 				Config: testAccAWSCloudWatchLogMetricFilterConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchLogMetricFilterExists("aws_cloudwatch_log_metric_filter.foobar", &mf),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_metric_filter.foobar", "name", fmt.Sprintf("MyAppAccessCount-%d", rInt)),
+					testAccCheckCloudWatchLogMetricFilterExists(resourceName, &mf),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("MyAppAccessCount-%d", rInt)),
 					testAccCheckCloudWatchLogMetricFilterName(&mf, fmt.Sprintf("MyAppAccessCount-%d", rInt)),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_metric_filter.foobar", "pattern", ""),
+					resource.TestCheckResourceAttr(resourceName, "pattern", ""),
 					testAccCheckCloudWatchLogMetricFilterPattern(&mf, ""),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_metric_filter.foobar", "log_group_name", fmt.Sprintf("MyApp/access-%d.log", rInt)),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_metric_filter.foobar", "metric_transformation.0.name", "EventCount"),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_metric_filter.foobar", "metric_transformation.0.namespace", "YourNamespace"),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_metric_filter.foobar", "metric_transformation.0.value", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_group_name", fmt.Sprintf("MyApp/access-%d.log", rInt)),
+					resource.TestCheckResourceAttr(resourceName, "metric_transformation.0.name", "EventCount"),
+					resource.TestCheckResourceAttr(resourceName, "metric_transformation.0.namespace", "YourNamespace"),
+					resource.TestCheckResourceAttr(resourceName, "metric_transformation.0.value", "1"),
 					testAccCheckCloudWatchLogMetricFilterTransformation(&mf, &cloudwatchlogs.MetricTransformation{
 						MetricName:      aws.String("EventCount"),
 						MetricNamespace: aws.String("YourNamespace"),
@@ -40,18 +41,24 @@ func TestAccAWSCloudWatchLogMetricFilter_basic(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCloudwatchLogMetricFilterImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAWSCloudWatchLogMetricFilterConfigModified(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchLogMetricFilterExists("aws_cloudwatch_log_metric_filter.foobar", &mf),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_metric_filter.foobar", "name", fmt.Sprintf("MyAppAccessCount-%d", rInt)),
+					testAccCheckCloudWatchLogMetricFilterExists(resourceName, &mf),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("MyAppAccessCount-%d", rInt)),
 					testAccCheckCloudWatchLogMetricFilterName(&mf, fmt.Sprintf("MyAppAccessCount-%d", rInt)),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_metric_filter.foobar", "pattern", "{ $.errorCode = \"AccessDenied\" }"),
+					resource.TestCheckResourceAttr(resourceName, "pattern", "{ $.errorCode = \"AccessDenied\" }"),
 					testAccCheckCloudWatchLogMetricFilterPattern(&mf, "{ $.errorCode = \"AccessDenied\" }"),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_metric_filter.foobar", "log_group_name", fmt.Sprintf("MyApp/access-%d.log", rInt)),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_metric_filter.foobar", "metric_transformation.0.name", "AccessDeniedCount"),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_metric_filter.foobar", "metric_transformation.0.namespace", "MyNamespace"),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_metric_filter.foobar", "metric_transformation.0.value", "2"),
-					resource.TestCheckResourceAttr("aws_cloudwatch_log_metric_filter.foobar", "metric_transformation.0.default_value", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_group_name", fmt.Sprintf("MyApp/access-%d.log", rInt)),
+					resource.TestCheckResourceAttr(resourceName, "metric_transformation.0.name", "AccessDeniedCount"),
+					resource.TestCheckResourceAttr(resourceName, "metric_transformation.0.namespace", "MyNamespace"),
+					resource.TestCheckResourceAttr(resourceName, "metric_transformation.0.value", "2"),
+					resource.TestCheckResourceAttr(resourceName, "metric_transformation.0.default_value", "1"),
 					testAccCheckCloudWatchLogMetricFilterTransformation(&mf, &cloudwatchlogs.MetricTransformation{
 						MetricName:      aws.String("AccessDeniedCount"),
 						MetricNamespace: aws.String("MyNamespace"),
@@ -134,7 +141,7 @@ func testAccCheckCloudWatchLogMetricFilterExists(n string, mf *cloudwatchlogs.Me
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).cloudwatchlogsconn
-		metricFilter, err := lookupCloudWatchLogMetricFilter(conn, rs.Primary.ID, rs.Primary.Attributes["log_group_name"], nil)
+		metricFilter, err := lookupCloudWatchLogMetricFilter(conn, rs.Primary.Attributes["name"], rs.Primary.Attributes["log_group_name"], nil)
 		if err != nil {
 			return err
 		}
@@ -153,7 +160,7 @@ func testAccCheckAWSCloudWatchLogMetricFilterDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := lookupCloudWatchLogMetricFilter(conn, rs.Primary.ID, rs.Primary.Attributes["log_group_name"], nil)
+		_, err := lookupCloudWatchLogMetricFilter(conn, rs.Primary.Attributes["name"], rs.Primary.Attributes["log_group_name"], nil)
 		if err == nil {
 			return fmt.Errorf("MetricFilter Still Exists: %s", rs.Primary.ID)
 		}
@@ -241,4 +248,15 @@ resource "aws_cloudwatch_log_group" "mama" {
   name = "MyApp/count-log-%d.log"
 }
 `, rInt, rInt)
+}
+
+func testAccAWSCloudwatchLogMetricFilterImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return rs.Primary.Attributes["log_group_name"] + ":" + rs.Primary.Attributes["name"], nil
+	}
 }

--- a/website/docs/r/cloudwatch_log_metric_filter.html.markdown
+++ b/website/docs/r/cloudwatch_log_metric_filter.html.markdown
@@ -53,3 +53,11 @@ The `metric_transformation` block supports the following arguments:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The name of the metric filter.
+
+## Import
+
+CloudWatch Log Metric Filter can be imported using the `log_group_name:name`, e.g.
+
+```
+$ terraform import aws_cloudwatch_log_metric_filter.test /aws/lambda/function:test
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #6042

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_cloudwatch_log_metric_filter: support import
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCloudWatchLogMetricFilter_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudWatchLogMetricFilter_ -timeout 120m
=== RUN   TestAccAWSCloudWatchLogMetricFilter_basic
=== PAUSE TestAccAWSCloudWatchLogMetricFilter_basic
=== CONT  TestAccAWSCloudWatchLogMetricFilter_basic
--- PASS: TestAccAWSCloudWatchLogMetricFilter_basic (97.53s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       99.797s
```
