### PR TITLE
Increase go test timeout as 30s seems to be too low for dockerized environments

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -19,7 +19,7 @@ sweep:
 	go test $(TEST) -v -sweep=$(SWEEP) $(SWEEPARGS) -timeout 60m
 
 test: fmtcheck
-	go test $(TEST) -timeout=30s -parallel=4
+	go test $(TEST) -timeout=120s -parallel=4
 
 testacc: fmtcheck
 	TF_ACC=1 go test $(TEST) -v -count $(TEST_COUNT) -parallel 20 $(TESTARGS) -timeout 120m


### PR DESCRIPTION
closes #11989