### PR TITLE
resource/aws_batch_job_definition: Prevent extraneous differences with container properties missing environment, mount point, ulimits, and volumes configuration

### DIFF
--- a/aws/internal/service/batch/equivalency/container_properties.go
+++ b/aws/internal/service/batch/equivalency/container_properties.go
@@ -19,8 +19,24 @@ func (cp *containerProperties) Reduce() error {
 		return aws.StringValue(cp.Environment[i].Name) < aws.StringValue(cp.Environment[j].Name)
 	})
 
+	if len(cp.Environment) == 0 {
+		cp.Environment = nil
+	}
+
+	if len(cp.MountPoints) == 0 {
+		cp.MountPoints = nil
+	}
+
 	if len(cp.ResourceRequirements) == 0 {
 		cp.ResourceRequirements = nil
+	}
+
+	if len(cp.Ulimits) == 0 {
+		cp.Ulimits = nil
+	}
+
+	if len(cp.Volumes) == 0 {
+		cp.Volumes = nil
 	}
 
 	return nil

--- a/aws/internal/service/batch/equivalency/container_properties.go
+++ b/aws/internal/service/batch/equivalency/container_properties.go
@@ -19,22 +19,27 @@ func (cp *containerProperties) Reduce() error {
 		return aws.StringValue(cp.Environment[i].Name) < aws.StringValue(cp.Environment[j].Name)
 	})
 
+	// Prevent difference of API response that adds an empty array when not configured during the request
 	if len(cp.Environment) == 0 {
 		cp.Environment = nil
 	}
 
+	// Prevent difference of API response that adds an empty array when not configured during the request
 	if len(cp.MountPoints) == 0 {
 		cp.MountPoints = nil
 	}
 
+	// Prevent difference of API response that adds an empty array when not configured during the request
 	if len(cp.ResourceRequirements) == 0 {
 		cp.ResourceRequirements = nil
 	}
 
+	// Prevent difference of API response that adds an empty array when not configured during the request
 	if len(cp.Ulimits) == 0 {
 		cp.Ulimits = nil
 	}
 
+	// Prevent difference of API response that adds an empty array when not configured during the request
 	if len(cp.Volumes) == 0 {
 		cp.Volumes = nil
 	}

--- a/aws/internal/service/batch/equivalency/container_properties_test.go
+++ b/aws/internal/service/batch/equivalency/container_properties_test.go
@@ -181,6 +181,33 @@ func TestEquivalentBatchContainerPropertiesJSON(t *testing.T) {
 `,
 			ExpectEquivalent: true,
 		},
+		{
+			Name: "empty environment, mountPoints, ulimits, and volumes",
+			ApiJson: `
+{
+	"image": "example:image",
+	"vcpus": 8,
+	"memory": 2048,
+	"command": ["start.py", "Ref::S3bucket", "Ref::S3key"],
+	"jobRoleArn": "arn:aws:iam::123456789012:role/example",
+	"volumes": [],
+	"environment": [],
+	"mountPoints": [],
+	"ulimits": [],
+	"resourceRequirements": []
+}
+`,
+			ConfigurationJson: `
+{
+	"command": ["start.py", "Ref::S3bucket", "Ref::S3key"],
+	"image": "example:image",
+	"memory": 2048,
+	"vcpus": 8,
+	"jobRoleArn": "arn:aws:iam::123456789012:role/example"
+}
+`,
+			ExpectEquivalent: true,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/aws/resource_aws_batch_job_definition_test.go
+++ b/aws/resource_aws_batch_job_definition_test.go
@@ -2,10 +2,8 @@ package aws
 
 import (
 	"fmt"
-	"strings"
-	"testing"
-
 	"reflect"
+	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/batch"
@@ -15,6 +13,31 @@ import (
 )
 
 func TestAccAWSBatchJobDefinition_basic(t *testing.T) {
+	var jd batch.JobDefinition
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_batch_job_definition.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBatchJobDefinitionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBatchJobDefinitionConfigName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBatchJobDefinitionExists(resourceName, &jd),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSBatchJobDefinition_ContainerProperties_Advanced(t *testing.T) {
 	var jd batch.JobDefinition
 	compare := batch.JobDefinition{
 		Parameters: map[string]*string{
@@ -50,16 +73,16 @@ func TestAccAWSBatchJobDefinition_basic(t *testing.T) {
 			},
 		},
 	}
-	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccBatchJobDefinitionBaseConfig, ri)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_batch_job_definition.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchJobDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: config,
+				Config: testAccBatchJobDefinitionConfigContainerPropertiesAdvanced(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBatchJobDefinitionExists(resourceName, &jd),
 					testAccCheckBatchJobDefinitionAttributes(&jd, &compare),
@@ -75,26 +98,24 @@ func TestAccAWSBatchJobDefinition_basic(t *testing.T) {
 }
 
 func TestAccAWSBatchJobDefinition_updateForcesNewResource(t *testing.T) {
-	var before batch.JobDefinition
-	var after batch.JobDefinition
-	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccBatchJobDefinitionBaseConfig, ri)
-	updateConfig := fmt.Sprintf(testAccBatchJobDefinitionUpdateConfig, ri)
+	var before, after batch.JobDefinition
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_batch_job_definition.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchJobDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: config,
+				Config: testAccBatchJobDefinitionConfigContainerPropertiesAdvanced(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBatchJobDefinitionExists(resourceName, &before),
 					testAccCheckBatchJobDefinitionAttributes(&before, nil),
 				),
 			},
 			{
-				Config: updateConfig,
+				Config: testAccBatchJobDefinitionConfigContainerPropertiesAdvancedUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBatchJobDefinitionExists(resourceName, &after),
 					testAccCheckJobDefinitionRecreated(t, &before, &after),
@@ -137,9 +158,6 @@ func testAccCheckBatchJobDefinitionExists(n string, jd *batch.JobDefinition) res
 
 func testAccCheckBatchJobDefinitionAttributes(jd *batch.JobDefinition, compare *batch.JobDefinition) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if !strings.HasPrefix(*jd.JobDefinitionName, "tf_acctest_batch_job_definition") {
-			return fmt.Errorf("Bad Job Definition name: %s", *jd.JobDefinitionName)
-		}
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_batch_job_definition" {
 				continue
@@ -190,9 +208,10 @@ func testAccCheckBatchJobDefinitionDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccBatchJobDefinitionBaseConfig = `
+func testAccBatchJobDefinitionConfigContainerPropertiesAdvanced(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_batch_job_definition" "test" {
-	name = "tf_acctest_batch_job_definition_%[1]d"
+	name = %[1]q
 	type = "container"
 	parameters = {
 		param1 = "val1"
@@ -238,11 +257,13 @@ resource "aws_batch_job_definition" "test" {
 }
 CONTAINER_PROPERTIES
 }
-`
+`, rName)
+}
 
-const testAccBatchJobDefinitionUpdateConfig = `
+func testAccBatchJobDefinitionConfigContainerPropertiesAdvancedUpdate(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_batch_job_definition" "test" {
-	name = "tf_acctest_batch_job_definition_%[1]d"
+	name = %[1]q
 	type = "container"
 	container_properties = <<CONTAINER_PROPERTIES
 {
@@ -278,4 +299,20 @@ resource "aws_batch_job_definition" "test" {
 }
 CONTAINER_PROPERTIES
 }
-`
+`, rName)
+}
+
+func testAccBatchJobDefinitionConfigName(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_batch_job_definition" "test" {
+  container_properties = jsonencode({
+    command = ["echo", "test"]
+    image   = "busybox"
+    memory  = 128
+    vcpus   = 1
+  })
+  name = %[1]q
+  type = "container"
+}
+`, rName)
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11998
Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/11488

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_batch_job_definition: Prevent extraneous differences with container properties missing `environment`, `mountPoints`, `ulimits`, and `volumes` configuration
```

Now that this resource is properly refreshing the `container_properties` attribute into the Terraform state, additional cases have been reported where the API canonicalizes the response with empty arrays. Here we account for `environment`, `mountPoints`, `ulimits`, and `volumes`.

Previous output from unit testing (before code update):

```
2020/02/11 12:37:58 [DEBUG] Canonical Batch Container Properties JSON are not equal.
First: {"command":["start.py","Ref::S3bucket","Ref::S3key"],"image":"example:image","jobRoleArn":"arn:aws:iam::123456789012:role/example","memory":2048,"vcpus":8}
Second: {"command":["start.py","Ref::S3bucket","Ref::S3key"],"environment":[],"image":"example:image","jobRoleArn":"arn:aws:iam::123456789012:role/example","memory":2048,"mountPoints":[],"ulimits":[],"vcpus":8,"volumes":[]}
--- FAIL: TestEquivalentBatchContainerPropertiesJSON (0.00s)
    --- FAIL: TestEquivalentBatchContainerPropertiesJSON/empty_environment,_mountPoints,_ulimits,_and_volumes (0.00s)
        container_properties_test.go:226: got false, expected true
```

Previous output from acceptance testing (before code update):

```
--- FAIL: TestAccAWSBatchJobDefinition_basic (13.16s)
    testing.go:640: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        DESTROY/CREATE: aws_batch_job_definition.test
          arn:                  "arn:aws:batch:us-west-2:--OMITTED--:job-definition/tf-acc-test-118932874341187373:1" => "<computed>"
          container_properties: "{\"command\":[\"echo\",\"test\"],\"environment\":[],\"image\":\"busybox\",\"memory\":128,\"mountPoints\":[],\"resourceRequirements\":[],\"ulimits\":[],\"vcpus\":1,\"volumes\":[]}" => "{\"command\":[\"echo\",\"test\"],\"image\":\"busybox\",\"memory\":128,\"vcpus\":1}" (forces new resource)
          id:                   "arn:aws:batch:us-west-2:--OMITTED--:job-definition/tf-acc-test-118932874341187373:1" => "<computed>"
          name:                 "tf-acc-test-118932874341187373" => "tf-acc-test-118932874341187373"
          retry_strategy.#:     "0" => "0"
          revision:             "1" => "<computed>"
          timeout.#:            "0" => "0"
          type:                 "container" => "container"
```

Output from acceptance testing:

```
--- PASS: TestAccAWSBatchJobDefinition_basic (16.80s)
--- PASS: TestAccAWSBatchJobDefinition_ContainerProperties_Advanced (16.84s)
--- PASS: TestAccAWSBatchJobDefinition_updateForcesNewResource (27.13s)
```
