### PR TITLE
resource/aws_cognito_user_pool: Allow admin_create_user_config configuration block unused_account_validity_days to be omitted

### DIFF
--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -67,6 +67,7 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 						"unused_account_validity_days": {
 							Type:          schema.TypeInt,
 							Optional:      true,
+							Computed:      true,
 							Deprecated:    "Use password_policy.temporary_password_validity_days instead",
 							ValidateFunc:  validation.IntBetween(0, 90),
 							ConflictsWith: []string{"password_policy.0.temporary_password_validity_days"},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11858
Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/10890

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_cognito_user_pool: Allow deprecated `admin_create_user_config` configuration block `unused_account_validity_days` argument to be omitted
```

There was previously no test configuration covering both admin_create_user_config and password_policy being defined. The upstream API has deprecated a field in the former, however if the configuration block was defined, the attribute would errantly show a difference on the deprecated field.

Previous output from acceptance testing (before code fix):

```
--- FAIL: TestAccAWSCognitoUserPool_withAdminCreateUserConfigurationAndPasswordPolicy (13.28s)
    testing.go:640: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        UPDATE: aws_cognito_user_pool.test
          admin_create_user_config.#:                              "1" => "1"
          admin_create_user_config.0.allow_admin_create_user_only: "true" => "true"
          admin_create_user_config.0.invite_message_template.#:    "0" => "0"
          admin_create_user_config.0.unused_account_validity_days: "7" => ""
... omitted for clarity ...
```

Output from acceptance testing:

```
--- PASS: TestAccAWSCognitoUserPool_withAdminCreateUserConfigurationAndPasswordPolicy (18.41s)
--- PASS: TestAccAWSCognitoUserPool_basic (18.46s)
--- PASS: TestAccAWSCognitoUserPool_withAliasAttributes (27.92s)
--- PASS: TestAccAWSCognitoUserPool_withPasswordPolicy (29.64s)
--- PASS: TestAccAWSCognitoUserPool_withVerificationMessageTemplate (29.68s)
--- PASS: TestAccAWSCognitoUserPool_withDeviceConfiguration (30.52s)
--- PASS: TestAccAWSCognitoUserPool_withEmailVerificationMessage (31.38s)
--- PASS: TestAccAWSCognitoUserPool_withSmsVerificationMessage (32.67s)
--- PASS: TestAccAWSCognitoUserPool_withSchemaAttributes (33.39s)
--- PASS: TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration (37.94s)
--- PASS: TestAccAWSCognitoUserPool_withAdvancedSecurityMode (39.71s)
--- PASS: TestAccAWSCognitoUserPool_withTags (44.33s)
--- PASS: TestAccAWSCognitoUserPool_withSmsConfiguration (50.12s)
--- PASS: TestAccAWSCognitoUserPool_withSmsConfigurationUpdated (51.37s)
--- PASS: TestAccAWSCognitoUserPool_update (66.06s)
--- PASS: TestAccAWSCognitoUserPool_withLambdaConfig (75.15s)
```
