### PR TITLE
docs/provider: Fix and enable markdownlint rules MD003, MD018, MD019, MD026, MD030, MD033, and MD046

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -7,7 +7,6 @@ default: true
 # https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md
 
 MD001: false
-MD003: false
 MD004: false
 MD006: false
 MD007: false
@@ -16,15 +15,9 @@ MD010: false
 MD012: false
 MD013: false
 MD014: false
-MD018: false
-MD019: false
 MD022: false
 MD024: false
-MD026: false
-MD030: false
-MD033: false
 MD034: false
 MD038: false
 MD040: false
-MD046: false
 MD047: false

--- a/website/docs/guides/custom-service-endpoints.html.md
+++ b/website/docs/guides/custom-service-endpoints.html.md
@@ -45,6 +45,7 @@ If multiple, different Terraform AWS Provider configurations are required, see t
 
 The Terraform AWS Provider allows the following endpoints to be customized:
 
+<!-- markdownlint-disable MD033 -->
 <div style="column-width: 14em;">
 
 - `accessanalyzer`
@@ -184,6 +185,7 @@ The Terraform AWS Provider allows the following endpoints to be customized:
 - `xray`
 
 </div>
+<!-- markdownlint-enable MD033 -->
 
 ## Connecting to Local AWS Compatible Solutions
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -39,7 +39,7 @@ explained below:
 - Shared credentials file
 - EC2 Role
 
-### Static credentials ###
+### Static credentials
 
 !> **Warning:** Hard-coding credentials into any Terraform configuration is not
 recommended, and risks secret leakage should this file ever be committed to a

--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -335,7 +335,6 @@ been launched, creating unintended behavior. If you need hooks to run on all
 instances, add them with `initial_lifecycle_hook` here, but take
 care to not duplicate these hooks in `aws_autoscaling_lifecycle_hook`.
 
-<a id="timeouts"></a>
 ## Timeouts
 
 `autoscaling_group` provides the following

--- a/website/docs/r/cloudformation_stack.html.markdown
+++ b/website/docs/r/cloudformation_stack.html.markdown
@@ -84,8 +84,6 @@ Cloudformation Stacks can be imported using the `name`, e.g.
 $ terraform import aws_cloudformation_stack.stack networking-stack
 ```
 
-
-<a id="timeouts"></a>
 ## Timeouts
 
 `aws_cloudformation_stack` provides the following

--- a/website/docs/r/default_network_acl.html.markdown
+++ b/website/docs/r/default_network_acl.html.markdown
@@ -91,7 +91,7 @@ resource "aws_default_network_acl" "default" {
 }
 ```
 
-## Example config to deny all traffic to any Subnet in the Default Network ACL:
+## Example config to deny all traffic to any Subnet in the Default Network ACL
 
 This config denies all traffic in the Default ACL. This can be useful if you
 want a locked down default to force all resources in the VPC to assign a

--- a/website/docs/r/default_route_table.html.markdown
+++ b/website/docs/r/default_route_table.html.markdown
@@ -40,7 +40,7 @@ in conjunction with any Route resources. Doing so will cause
 a conflict of rule settings and will overwrite routes.
 
 
-## Example usage with tags:
+## Example usage with tags
 
 ```hcl
 resource "aws_default_route_table" "r" {

--- a/website/docs/r/dms_replication_instance.html.markdown
+++ b/website/docs/r/dms_replication_instance.html.markdown
@@ -125,7 +125,6 @@ In addition to all arguments above, the following attributes are exported:
 * `replication_instance_private_ips` -  A list of the private IP addresses of the replication instance.
 * `replication_instance_public_ips` - A list of the public IP addresses of the replication instance.
 
-<a id="timeouts"></a>
 ## Timeouts
 
 `aws_dms_replication_instance` provides the following

--- a/website/docs/r/ecs_task_definition.html.markdown
+++ b/website/docs/r/ecs_task_definition.html.markdown
@@ -131,7 +131,7 @@ For more information, see [Specifying a Docker volume in your Task Definition De
 * `driver_opts` - (Optional) A map of Docker driver specific options.
 * `labels` - (Optional) A map of custom metadata to add to your Docker volume.
 
-##### Example Usage:
+##### Example Usage
 
 ```hcl
 resource "aws_ecs_task_definition" "service" {
@@ -163,7 +163,7 @@ For more information, see [Specifying an EFS volume in your Task Definition Deve
 * `file_system_id` - (Required) The ID of the EFS File System.
 * `root_directory` - (Optional) The path to mount on the host
 
-##### Example Usage:
+##### Example Usage
 
 ```hcl
 resource "aws_ecs_task_definition" "service" {

--- a/website/docs/r/elastic_beanstalk_application_version.html.markdown
+++ b/website/docs/r/elastic_beanstalk_application_version.html.markdown
@@ -18,12 +18,7 @@ Environment.
 ~> **NOTE on Application Version Resource:**  When using the Application Version resource with multiple 
 [Elastic Beanstalk Environments](elastic_beanstalk_environment.html) it is possible that an error may be returned
 when attempting to delete an Application Version while it is still in use by a different environment.
-To work around this you can:
-<ol>
-<li>Create each environment in a separate AWS account</li>
-<li>Create your `aws_elastic_beanstalk_application_version` resources with a unique names in your 
-Elastic Beanstalk Application. For example &lt;revision&gt;-&lt;environment&gt;.</li>
-</ol>
+To work around this you can either create each environment in a separate AWS account or create your `aws_elastic_beanstalk_application_version` resources with a unique names in your Elastic Beanstalk Application. For example &lt;revision&gt;-&lt;environment&gt;.
 
 ## Example Usage
 

--- a/website/docs/r/internet_gateway.html.markdown
+++ b/website/docs/r/internet_gateway.html.markdown
@@ -31,15 +31,17 @@ The following arguments are supported:
 
 -> **Note:** It's recommended to denote that the AWS Instance or Elastic IP depends on the Internet Gateway. For example:
 
+```hcl
+resource "aws_internet_gateway" "gw" {
+  vpc_id = "${aws_vpc.main.id}"
+}
 
-    resource "aws_internet_gateway" "gw" {
-      vpc_id = "${aws_vpc.main.id}"
-    }
+resource "aws_instance" "foo" {
+  # ... other arguments ...
 
-    resource "aws_instance" "foo" {
-      depends_on = ["aws_internet_gateway.gw"]
-    }
-
+  depends_on = ["aws_internet_gateway.gw"]
+}
+```
 
 ## Attributes Reference
 

--- a/website/docs/r/nat_gateway.html.markdown
+++ b/website/docs/r/nat_gateway.html.markdown
@@ -42,16 +42,17 @@ The following arguments are supported:
 
 -> **Note:** It's recommended to denote that the NAT Gateway depends on the Internet Gateway for the VPC in which the NAT Gateway's subnet is located. For example:
 
-    resource "aws_internet_gateway" "gw" {
-      vpc_id = "${aws_vpc.main.id}"
-    }
+```hcl
+resource "aws_internet_gateway" "gw" {
+  vpc_id = "${aws_vpc.main.id}"
+}
 
-    resource "aws_nat_gateway" "gw" {
-      //other arguments
+resource "aws_nat_gateway" "gw" {
+  # ... other arguments ...
 
-      depends_on = ["aws_internet_gateway.gw"]
-    }
-
+  depends_on = ["aws_internet_gateway.gw"]
+}
+```
 
 ## Attributes Reference
 

--- a/website/docs/r/organizations_account.html.markdown
+++ b/website/docs/r/organizations_account.html.markdown
@@ -14,7 +14,7 @@ Provides a resource to create a member account in the current organization.
 
 !> **WARNING:** Deleting this Terraform resource will only remove an AWS account from an organization. Terraform will not close the account. The member account must be prepared to be a standalone account beforehand. See the [AWS Organizations documentation](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_accounts_remove.html) for more information.
 
-## Example Usage:
+## Example Usage
 
 ```hcl
 resource "aws_organizations_account" "account" {

--- a/website/docs/r/organizations_organization.html.markdown
+++ b/website/docs/r/organizations_organization.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides a resource to create an organization.
 
-## Example Usage:
+## Example Usage
 
 ```hcl
 resource "aws_organizations_organization" "org" {

--- a/website/docs/r/route.html.markdown
+++ b/website/docs/r/route.html.markdown
@@ -16,7 +16,7 @@ defined in-line. At this time you cannot use a Route Table with in-line routes
 in conjunction with any Route resources. Doing so will cause
 a conflict of rule settings and will overwrite rules.
 
-## Example usage:
+## Example Usage
 
 ```hcl
 resource "aws_route" "r" {
@@ -27,7 +27,7 @@ resource "aws_route" "r" {
 }
 ```
 
-##Example IPv6 Usage:
+## Example IPv6 Usage
 
 ```hcl
 resource "aws_vpc" "vpc" {

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -29,7 +29,7 @@ this resource will delete any propagating gateways not explicitly listed in
 `propagating_vgws`. Omit this argument when defining route propagation using
 the separate resource.
 
-## Example usage with tags:
+## Example Usage
 
 ```hcl
 resource "aws_route_table" "r" {

--- a/website/docs/r/sagemaker_notebook_instance.html.markdown
+++ b/website/docs/r/sagemaker_notebook_instance.html.markdown
@@ -36,7 +36,7 @@ The following arguments are supported:
 * `subnet_id` - (Optional) The VPC subnet ID.
 * `security_groups` - (Optional) The associated security groups.
 * `kms_key_id` - (Optional) The AWS Key Management Service (AWS KMS) key that Amazon SageMaker uses to encrypt the model artifacts at rest using Amazon S3 server-side encryption.
-*  `lifecycle_config_name` - (Optional) The name of a lifecycle configuration to associate with the notebook instance.
+* `lifecycle_config_name` - (Optional) The name of a lifecycle configuration to associate with the notebook instance.
 * `direct_internet_access` - (Optional) Set to `Disabled` to disable internet access to notebook. Requires `security_groups` and `subnet_id` to be set. Supported values: `Enabled` (Default) or `Disabled`. If set to `Disabled`, the notebook instance will be able to access resources only in your VPC, and will not be able to connect to Amazon SageMaker training and endpoint services unless your configure a NAT Gateway in your VPC.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/sns_topic.html.markdown
+++ b/website/docs/r/sns_topic.html.markdown
@@ -45,7 +45,7 @@ EOF
 }
 ```
 
-##  Example with Server-side encryption (SSE)
+## Example with Server-side encryption (SSE)
 
 ```hcl
 resource "aws_sns_topic" "user_updates" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md
Reference: https://www.terraform.io/docs/providers/aws/guides/custom-service-endpoints.html#available-endpoint-customizations
Reference: https://registry.terraform.io/providers/hashicorp/aws/2.48.0/docs/resources/elastic_beanstalk_application_version

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

These are the lowest hanging fruit. Previously:

```
website/docs/guides/custom-service-endpoints.html.md:48 MD033/no-inline-html Inline HTML [Element: div]
website/docs/index.html.markdown:42 MD003/heading-style/header-style Heading style [Expected: atx; Actual: atx_closed]
website/docs/r/autoscaling_group.html.markdown:338 MD033/no-inline-html Inline HTML [Element: a]
website/docs/r/cloudformation_stack.html.markdown:88 MD033/no-inline-html Inline HTML [Element: a]
website/docs/r/default_network_acl.html.markdown:94 MD026/no-trailing-punctuation Trailing punctuation in heading [Punctuation: ':']
website/docs/r/default_route_table.html.markdown:43 MD026/no-trailing-punctuation Trailing punctuation in heading [Punctuation: ':']
website/docs/r/dms_replication_instance.html.markdown:128 MD033/no-inline-html Inline HTML [Element: a]
website/docs/r/ecs_task_definition.html.markdown:134 MD026/no-trailing-punctuation Trailing punctuation in heading [Punctuation: ':']
website/docs/r/ecs_task_definition.html.markdown:166 MD026/no-trailing-punctuation Trailing punctuation in heading [Punctuation: ':']
website/docs/r/elastic_beanstalk_application_version.html.markdown:22 MD033/no-inline-html Inline HTML [Element: ol]
website/docs/r/elastic_beanstalk_application_version.html.markdown:23 MD033/no-inline-html Inline HTML [Element: li]
website/docs/r/elastic_beanstalk_application_version.html.markdown:24 MD033/no-inline-html Inline HTML [Element: li]
website/docs/r/internet_gateway.html.markdown:35 MD046/code-block-style Code block style [Expected: fenced; Actual: indented]
website/docs/r/nat_gateway.html.markdown:45 MD046/code-block-style Code block style [Expected: fenced; Actual: indented]
website/docs/r/organizations_account.html.markdown:17 MD026/no-trailing-punctuation Trailing punctuation in heading [Punctuation: ':']
website/docs/r/organizations_organization.html.markdown:13 MD026/no-trailing-punctuation Trailing punctuation in heading [Punctuation: ':']
website/docs/r/route.html.markdown:19 MD026/no-trailing-punctuation Trailing punctuation in heading [Punctuation: ':']
website/docs/r/route.html.markdown:30 MD018/no-missing-space-atx No space after hash on atx style heading [Context: "##Example IPv6 Usage:"]
website/docs/r/route.html.markdown:30 MD026/no-trailing-punctuation Trailing punctuation in heading [Punctuation: ':']
website/docs/r/route_table.html.markdown:32 MD026/no-trailing-punctuation Trailing punctuation in heading [Punctuation: ':']
website/docs/r/sagemaker_notebook_instance.html.markdown:39 MD030/list-marker-space Spaces after list markers [Expected: 1; Actual: 2]
website/docs/r/sns_topic.html.markdown:48 MD019/no-multiple-space-atx Multiple spaces after hash on atx style heading [Context: "##  Example with Server-side e..."]
```

Output from acceptance testing: N/A (documentation updates)