### PR TITLE
r/sfn_state_machine - iam role eventual consistency + wait for delete + add `arn` attribute

### DIFF
--- a/aws/internal/service/sfn/waiter/status.go
+++ b/aws/internal/service/sfn/waiter/status.go
@@ -1,0 +1,25 @@
+package waiter
+
+import (
+	"github.com/aws/aws-sdk-go/service/sfn"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// StateMachineStatus fetches the Operation and its Status
+func StateMachineStatus(conn *sfn.SFN, stateMachineArn string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		input := &sfn.DescribeStateMachineInput{
+			StateMachineArn: aws.String(stateMachineArn),
+		}
+
+		output, err := conn.DescribeStateMachine(input)
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.Status), nil
+	}
+}

--- a/aws/internal/service/sfn/waiter/status.go
+++ b/aws/internal/service/sfn/waiter/status.go
@@ -19,6 +19,10 @@ func StateMachineStatus(conn *sfn.SFN, stateMachineArn string) resource.StateRef
 			return nil, "", err
 		}
 
+		if output == nil {
+			return nil, "", nil
+		}
+
 		return output, aws.StringValue(output.Status), nil
 	}
 }

--- a/aws/internal/service/sfn/waiter/status.go
+++ b/aws/internal/service/sfn/waiter/status.go
@@ -1,9 +1,8 @@
 package waiter
 
 import (
-	"github.com/aws/aws-sdk-go/service/sfn"
-
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sfn"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 

--- a/aws/internal/service/sfn/waiter/waiter.go
+++ b/aws/internal/service/sfn/waiter/waiter.go
@@ -1,0 +1,31 @@
+package waiter
+
+import (
+	"github.com/aws/aws-sdk-go/service/sfn"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+const (
+	// Maximum amount of time to wait for an Operation to return Success
+	StateMachineDeleteTimeout = 5 * time.Minute
+)
+
+// StateMachineDeleted waits for an Operation to return Success
+func StateMachineDeleted(conn *sfn.SFN, stateMachineArn string) (*sfn.DescribeStateMachineOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{sfn.StateMachineStatusActive, sfn.StateMachineStatusDeleting},
+		Target:  []string{},
+		Refresh: StateMachineStatus(conn, stateMachineArn),
+		Timeout: StateMachineDeleteTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*sfn.DescribeStateMachineOutput); ok {
+		return output, err
+	}
+
+	return nil, err
+}

--- a/aws/internal/service/sfn/waiter/waiter.go
+++ b/aws/internal/service/sfn/waiter/waiter.go
@@ -2,7 +2,7 @@ package waiter
 
 import (
 	"time"
-	
+
 	"github.com/aws/aws-sdk-go/service/sfn"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )

--- a/aws/internal/service/sfn/waiter/waiter.go
+++ b/aws/internal/service/sfn/waiter/waiter.go
@@ -1,9 +1,9 @@
 package waiter
 
 import (
-	"github.com/aws/aws-sdk-go/service/sfn"
 	"time"
-
+	
+	"github.com/aws/aws-sdk-go/service/sfn"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 

--- a/aws/resource_aws_sfn_state_machine.go
+++ b/aws/resource_aws_sfn_state_machine.go
@@ -53,6 +53,10 @@ func resourceAwsSfnStateMachine() *schema.Resource {
 				Computed: true,
 			},
 			"tags": tagsSchema(),
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -122,6 +126,7 @@ func resourceAwsSfnStateMachineRead(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
+	d.Set("arn", sm.StateMachineArn)
 	d.Set("definition", sm.Definition)
 	d.Set("name", sm.Name)
 	d.Set("role_arn", sm.RoleArn)

--- a/aws/resource_aws_sfn_state_machine.go
+++ b/aws/resource_aws_sfn_state_machine.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/sfn"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -69,17 +68,21 @@ func resourceAwsSfnStateMachineCreate(d *schema.ResourceData, meta interface{}) 
 		Tags:       keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().SfnTags(),
 	}
 
-	var activity *sfn.CreateStateMachineOutput
+	var stateMachine *sfn.CreateStateMachineOutput
 
 	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
 		var err error
-		activity, err = conn.CreateStateMachine(params)
+		stateMachine, err = conn.CreateStateMachine(params)
 
 		if err != nil {
 			// Note: the instance may be in a deleting mode, hence the retry
 			// when creating the step function. This can happen when we are
 			// updating the resource (since there is no update API call).
-			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "StateMachineDeleting" {
+			if isAWSErr(err, sfn.ErrCodeStateMachineDeleting, "") {
+				return resource.RetryableError(err)
+			}
+			//This is done to deal with IAM eventual consistency
+			if isAWSErr(err, "AccessDeniedException", "") {
 				return resource.RetryableError(err)
 			}
 
@@ -89,14 +92,14 @@ func resourceAwsSfnStateMachineCreate(d *schema.ResourceData, meta interface{}) 
 		return nil
 	})
 	if isResourceTimeoutError(err) {
-		activity, err = conn.CreateStateMachine(params)
+		stateMachine, err = conn.CreateStateMachine(params)
 	}
 
 	if err != nil {
 		return fmt.Errorf("Error creating Step Function State Machine: %s", err)
 	}
 
-	d.SetId(*activity.StateMachineArn)
+	d.SetId(*stateMachine.StateMachineArn)
 
 	return resourceAwsSfnStateMachineRead(d, meta)
 }
@@ -112,11 +115,9 @@ func resourceAwsSfnStateMachineRead(d *schema.ResourceData, meta interface{}) er
 	})
 	if err != nil {
 
-		if awserr, ok := err.(awserr.Error); ok {
-			if awserr.Code() == "NotFoundException" || awserr.Code() == "StateMachineDoesNotExist" {
-				d.SetId("")
-				return nil
-			}
+		if isAWSErr(err, sfn.ErrCodeStateMachineDoesNotExist, "") {
+			d.SetId("")
+			return nil
 		}
 		return err
 	}
@@ -157,7 +158,7 @@ func resourceAwsSfnStateMachineUpdate(d *schema.ResourceData, meta interface{}) 
 	log.Printf("[DEBUG] Updating Step Function State Machine: %#v", params)
 
 	if err != nil {
-		if isAWSErr(err, "StateMachineDoesNotExist", "State Machine Does Not Exist") {
+		if isAWSErr(err, sfn.ErrCodeStateMachineDoesNotExist, "State Machine Does Not Exist") {
 			return fmt.Errorf("Error updating Step Function State Machine: %s", err)
 		}
 		return err

--- a/aws/resource_aws_sfn_state_machine_test.go
+++ b/aws/resource_aws_sfn_state_machine_test.go
@@ -16,7 +16,7 @@ func TestAccAWSSfnStateMachine_createUpdate(t *testing.T) {
 	var sm sfn.DescribeStateMachineOutput
 	resourceName := "aws_sfn_state_machine.test"
 	roleResourceName := "aws_iam_role.iam_for_sfn"
-	rName := acctest.RandomWithPrefix("tf-acc")
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -57,10 +57,10 @@ func TestAccAWSSfnStateMachine_createUpdate(t *testing.T) {
 	})
 }
 
-func TestAccAWSSfnStateMachine_Tags(t *testing.T) {
+func TestAccAWSSfnStateMachine_tags(t *testing.T) {
 	var sm sfn.DescribeStateMachineOutput
 	resourceName := "aws_sfn_state_machine.test"
-	rName := acctest.RandomWithPrefix("tf-acc")
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -104,7 +104,7 @@ func TestAccAWSSfnStateMachine_Tags(t *testing.T) {
 func TestAccAWSSfnStateMachine_disappears(t *testing.T) {
 	var sm sfn.DescribeStateMachineOutput
 	resourceName := "aws_sfn_state_machine.test"
-	rName := acctest.RandomWithPrefix("tf-acc")
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -164,12 +164,11 @@ func testAccCheckAWSSfnStateMachineDestroy(s *terraform.State) error {
 
 		if err != nil {
 			if isAWSErr(err, sfn.ErrCodeStateMachineDoesNotExist, "") {
-				return nil
+				continue
 			}
-			return err
 		}
 
-		if out != nil && *out.Status != sfn.StateMachineStatusDeleting {
+		if out != nil && aws.StringValue(out.Status) != sfn.StateMachineStatusDeleting {
 			return fmt.Errorf("Expected AWS Step Function State Machine to be destroyed, but was still found")
 		}
 
@@ -182,7 +181,7 @@ func testAccCheckAWSSfnStateMachineDestroy(s *terraform.State) error {
 func testAccAWSSfnStateMachineConfigBase(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "iam_for_lambda" {
-  name = "iam_for_lambda_%s"
+  name = "%[1]s-2"
 
   assume_role_policy = <<EOF
 {

--- a/aws/resource_aws_sfn_state_machine_test.go
+++ b/aws/resource_aws_sfn_state_machine_test.go
@@ -116,7 +116,7 @@ func TestAccAWSSfnStateMachine_disappears(t *testing.T) {
 				Config: testAccAWSSfnStateMachineConfig(rName, 5),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSfnExists(resourceName, &sm),
-					testAccCheckAWSSfnStateMachineDisappears(&sm),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsSfnStateMachine(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/aws/resource_aws_sfn_state_machine_test.go
+++ b/aws/resource_aws_sfn_state_machine_test.go
@@ -113,7 +113,7 @@ func TestAccAWSSfnStateMachine_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSfnStateMachineDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSfnStateMachineConfigBasic(rName),
+				Config: testAccAWSSfnStateMachineConfig(rName, 5),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSfnExists(resourceName, &sm),
 					testAccCheckAWSSfnStateMachineDisappears(&sm),
@@ -192,7 +192,7 @@ func testAccCheckAWSSfnStateMachineDisappears(sm *sfn.DescribeStateMachineOutput
 			return err
 		}
 
-		return resource.Retry(5*time.Minute, func() *resource.RetryError {
+		return resource.Retry(1*time.Minute, func() *resource.RetryError {
 			opts := &sfn.DescribeStateMachineInput{
 				StateMachineArn: sm.StateMachineArn,
 			}
@@ -275,49 +275,6 @@ resource "aws_iam_role" "iam_for_sfn" {
       "Effect": "Allow",
       "Principal": {
         "Service": "states.${data.aws_region.current.name}.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole",
-      "Sid": ""
-    }
-  ]
-}
-EOF
-}
-`, rName)
-}
-
-func testAccAWSSfnStateMachineConfigBasic(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_sfn_state_machine" "test" {
-  name     = %[1]q
-  role_arn = "${aws_iam_role.test.arn}"
-
-  definition = <<EOF
-{
-  "Comment": "A Hello World example of the Amazon States Language using a Pass state",
-  "StartAt": "HelloWorld",
-  "States": {
-    "HelloWorld": {
-      "Type": "Pass",
-      "Result": "Hello World!",
-      "End": true
-    }
-  }
-}
-EOF
-}
-
-resource "aws_iam_role" "test" {
-  name = %[1]q
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "states.amazonaws.com"
       },
       "Action": "sts:AssumeRole",
       "Sid": ""

--- a/website/docs/r/sfn_state_machine.html.markdown
+++ b/website/docs/r/sfn_state_machine.html.markdown
@@ -51,6 +51,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The ARN of the state machine.
 * `creation_date` - The date the state machine was created.
 * `status` - The current status of the state machine. Either "ACTIVE" or "DELETING".
+* `arn` - The ARN of the state machine.
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #7893
Relates #13624

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_sfn_state_machine: add `arn` attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSfnStateMachine_'
--- FAIL: TestAccAWSSfnStateMachine_createUpdate (114.32s)
    testing.go:640: Step 2 error: Check failed: Check 6/7 error: aws_sfn_state_machine.test: Attribute 'definition' didn't match ".*\\\"MaxAttempts\\\": 10.*", got "{\n  \"Comment\": \"A Hello World example of the Amazon States Language using an AWS Lambda Function\",\n  \"StartAt\": \"HelloWorld\",\n  \"States\": {\n    \"HelloWorld\": {\n      \"Type\": \"Task\",\n      \"Resource\": \"arn:aws:lambda:us-west-2:476956259333:function:tf-acc-4347576902814911718\",\n      \"Retry\": [\n        {\n          \"ErrorEquals\": [\"States.ALL\"],\n          \"IntervalSeconds\": 5,\n          \"MaxAttempts\": 5,\n          \"BackoffRate\": 8.0\n        }\n      ],\n      \"End\": true\n    }\n  }\n}\n"


--- PASS: TestAccAWSSfnStateMachine_Tags (147.65s)
--- PASS: TestAccAWSSfnStateMachine_disappears (4732.81s)
```


tests failing due to another eventual consistency issue.