### PR TITLE
r/aws_kinesis_stream Fix kms_key_id field not updating

### DIFF
--- a/aws/resource_aws_kinesis_stream.go
+++ b/aws/resource_aws_kinesis_stream.go
@@ -322,13 +322,14 @@ func updateKinesisShardCount(conn *kinesis.Kinesis, d *schema.ResourceData) erro
 func updateKinesisStreamEncryption(conn *kinesis.Kinesis, d *schema.ResourceData) error {
 	sn := d.Get("name").(string)
 
-	// If this is not a new resource AND there is no change to encryption_type or kms_key_id
-	// return nil
-	if !d.IsNewResource() && (!d.HasChange("encryption_type") || !d.HasChange("kms_key_id")) {
+	// If this is not a new resource and there is no change to encryption_type and kms_key_id
+	if !d.IsNewResource() && !d.HasChange("encryption_type") && !d.HasChange("kms_key_id") {
 		return nil
 	}
 
 	oldType, newType := d.GetChange("encryption_type")
+	oldKey, newKey := d.GetChange("kms_key_id")
+
 	if oldType.(string) != "" && oldType.(string) != "NONE" {
 		// This means that we have an old encryption type - i.e. Encryption is enabled and we want to change it
 		// The quirk about this API is that, when we are disabling the StreamEncryption
@@ -339,8 +340,6 @@ func updateKinesisStreamEncryption(conn *kinesis.Kinesis, d *schema.ResourceData
 		// We get the following error
 		//
 		//        InvalidArgumentException: Encryption type cannot be NONE.
-		oldKey, _ := d.GetChange("kms_key_id")
-		oldType, _ := d.GetChange("encryption_type")
 
 		log.Printf("[INFO] Stopping Stream Encryption for %s", sn)
 		params := &kinesis.StopStreamEncryptionInput{
@@ -351,6 +350,10 @@ func updateKinesisStreamEncryption(conn *kinesis.Kinesis, d *schema.ResourceData
 
 		_, err := conn.StopStreamEncryption(params)
 		if err != nil {
+			return err
+		}
+
+		if err := waitForKinesisToBeActive(conn, d.Timeout(schema.TimeoutUpdate), sn); err != nil {
 			return err
 		}
 	}
@@ -364,29 +367,16 @@ func updateKinesisStreamEncryption(conn *kinesis.Kinesis, d *schema.ResourceData
 		params := &kinesis.StartStreamEncryptionInput{
 			StreamName:     aws.String(sn),
 			EncryptionType: aws.String(newType.(string)),
-			KeyId:          aws.String(d.Get("kms_key_id").(string)),
+			KeyId:          aws.String(newKey.(string)),
 		}
 
 		_, err := conn.StartStreamEncryption(params)
 		if err != nil {
 			return err
 		}
-	}
-
-	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"UPDATING"},
-		Target:     []string{"ACTIVE"},
-		Refresh:    streamStateRefreshFunc(conn, sn),
-		Timeout:    5 * time.Minute,
-		Delay:      10 * time.Second,
-		MinTimeout: 3 * time.Second,
-	}
-
-	_, err := stateConf.WaitForState()
-	if err != nil {
-		return fmt.Errorf(
-			"Error waiting for Stream (%s) to be ACTIVE: %s",
-			sn, err)
+		if err := waitForKinesisToBeActive(conn, d.Timeout(schema.TimeoutUpdate), sn); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Fix a bug where `kms_key_id` does not update in `r/aws_kinesis_stream`, resulting in an always non-empty plan.
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12003 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_kinesis_stream: Fix `kms_key_id` field update not applied
```

Output from acceptance testing:
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSKinesisStream'
--- PASS: TestAccAWSKinesisStream_basic (74.73s)
--- PASS: TestAccAWSKinesisStream_enforceConsumerDeletion (75.18s)
--- PASS: TestAccAWSKinesisStream_encryptionWithoutKmsKeyThrowsError (79.58s)
--- PASS: TestAccAWSKinesisStream_retentionPeriod (150.47s)
--- PASS: TestAccAWSKinesisStream_shardLevelMetrics (156.20s)
--- PASS: TestAccAWSKinesisStream_createMultipleConcurrentStreams (157.79s)
--- PASS: TestAccAWSKinesisStream_shardCount (158.78s)
--- PASS: TestAccAWSKinesisStreamDataSource (171.52s)
--- PASS: TestAccAWSKinesisStream_UpdateKmsKeyId (182.96s)
--- PASS: TestAccAWSKinesisStream_Tags (193.19s)
--- PASS: TestAccAWSKinesisStream_encryption (221.40s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       222.830s
```
