### PR TITLE
resource/aws_launch_configuration: Allow missing EC2 Image during root block device lookup

### DIFF
--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -1436,7 +1436,7 @@ func fetchRootDeviceName(ami string, conn *ec2.EC2) (*string, error) {
 
 	// For a bad image, we just return nil so we don't block a refresh
 	if len(res.Images) == 0 {
-		return nil, fmt.Errorf("No images found for AMI %s", ami)
+		return nil, nil
 	}
 
 	image := res.Images[0]


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10182

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_launch_configuration: Fix regression from version 2.22.0 to allow missing EC2 Image during root block device lookup
```

Previous output from new acceptance testing:

```
--- FAIL: TestAccAWSLaunchConfiguration_RootBlockDevice_AmiDisappears (329.50s)
    testing.go:640: Step 0 error: errors during follow-up refresh:

        Error: No images found for AMI ami-03f8153b368160e27
```

Output from acceptance testing:

```
--- PASS: TestAccAWSAMI_basic (60.58s)
--- PASS: TestAccAWSAMI_disappears (55.68s)
--- PASS: TestAccAWSAMI_snapshotSize (61.57s)
--- PASS: TestAccAWSAMI_tags (73.23s)

--- PASS: TestAccAWSInstance_addSecondaryInterface (119.45s)
--- PASS: TestAccAWSInstance_addSecurityGroupNetworkInterface (120.56s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPrivate (75.15s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPublic (74.26s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPrivate (74.07s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPublic (94.78s)
--- PASS: TestAccAWSInstance_associatePublic_overridePrivate (103.83s)
--- PASS: TestAccAWSInstance_associatePublic_overridePublic (74.45s)
--- PASS: TestAccAWSInstance_associatePublicIPAndPrivateIP (77.27s)
--- PASS: TestAccAWSInstance_basic (187.91s)
--- PASS: TestAccAWSInstance_blockDevices (79.58s)
--- PASS: TestAccAWSInstance_changeInstanceType (346.21s)
--- PASS: TestAccAWSInstance_CreditSpecification_Empty_NonBurstable (309.18s)
--- PASS: TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable (95.71s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits (94.60s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint (416.77s)
--- PASS: TestAccAWSInstance_creditSpecification_unknownCpuCredits_t2 (84.38s)
--- PASS: TestAccAWSInstance_creditSpecification_unknownCpuCredits_t3 (277.51s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits (94.46s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint (205.09s)
--- PASS: TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard (75.03s)
--- PASS: TestAccAWSInstance_CreditSpecification_UnspecifiedToEmpty_NonBurstable (66.25s)
--- PASS: TestAccAWSInstance_creditSpecification_updateCpuCredits (129.64s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_standardCpuCredits (96.86s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits (93.24s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited (302.23s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_updateCpuCredits (105.73s)
--- PASS: TestAccAWSInstance_disableApiTermination (134.68s)
--- PASS: TestAccAWSInstance_disappears (99.99s)
--- PASS: TestAccAWSInstance_EbsBlockDevice_KmsKeyArn (86.99s)
--- PASS: TestAccAWSInstance_forceNewAndTagsDrift (249.42s)
--- PASS: TestAccAWSInstance_getPasswordData_falseToTrue (153.39s)
--- PASS: TestAccAWSInstance_getPasswordData_trueToFalse (144.29s)
--- PASS: TestAccAWSInstance_GP2IopsDevice (180.27s)
--- PASS: TestAccAWSInstance_GP2WithIopsValue (63.42s)
--- PASS: TestAccAWSInstance_hibernation (184.12s)
--- PASS: TestAccAWSInstance_inDefaultVpcBySgId (82.35s)
--- PASS: TestAccAWSInstance_inDefaultVpcBySgName (72.00s)
--- PASS: TestAccAWSInstance_inEc2Classic (87.12s)
--- PASS: TestAccAWSInstance_instanceProfileChange (165.02s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCount (73.56s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCountWithIpv4 (83.80s)
--- PASS: TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError (9.88s)
--- PASS: TestAccAWSInstance_keyPairCheck (184.21s)
--- PASS: TestAccAWSInstance_multipleRegions (249.46s)
--- PASS: TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups (80.15s)
--- PASS: TestAccAWSInstance_NetworkInstanceSecurityGroups (76.11s)
--- PASS: TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs (75.10s)
--- PASS: TestAccAWSInstance_noAMIEphemeralDevices (180.15s)
--- PASS: TestAccAWSInstance_placementGroup (65.13s)
--- PASS: TestAccAWSInstance_primaryNetworkInterface (75.72s)
--- PASS: TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck (86.88s)
--- PASS: TestAccAWSInstance_privateIP (74.08s)
--- PASS: TestAccAWSInstance_RootBlockDevice_KmsKeyArn (316.78s)
--- PASS: TestAccAWSInstance_rootBlockDeviceMismatch (186.67s)
--- PASS: TestAccAWSInstance_rootInstanceStore (88.21s)
--- PASS: TestAccAWSInstance_sourceDestCheck (111.85s)
--- PASS: TestAccAWSInstance_tags (237.27s)
--- PASS: TestAccAWSInstance_UserData_EmptyStringToUnspecified (92.43s)
--- PASS: TestAccAWSInstance_UserData_UnspecifiedToEmptyString (108.86s)
--- PASS: TestAccAWSInstance_userDataBase64 (221.53s)
--- PASS: TestAccAWSInstance_volumeTags (100.55s)
--- PASS: TestAccAWSInstance_volumeTagsComputed (104.70s)
--- PASS: TestAccAWSInstance_vpc (73.95s)
--- PASS: TestAccAWSInstance_withIamInstanceProfile (112.28s)

--- PASS: TestAccAWSInstanceDataSource_AzUserData (221.28s)
--- PASS: TestAccAWSInstanceDataSource_basic (301.34s)
--- PASS: TestAccAWSInstanceDataSource_blockDevices (90.86s)
--- PASS: TestAccAWSInstanceDataSource_creditSpecification (101.85s)
--- PASS: TestAccAWSInstanceDataSource_EbsBlockDevice_KmsKeyId (205.68s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_falseToTrue (176.04s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_trueToFalse (172.89s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData (123.47s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData_NoUserData (115.57s)
--- PASS: TestAccAWSInstanceDataSource_gp2IopsDevice (95.30s)
--- PASS: TestAccAWSInstanceDataSource_keyPair (189.29s)
--- PASS: TestAccAWSInstanceDataSource_PlacementGroup (186.27s)
--- PASS: TestAccAWSInstanceDataSource_privateIP (108.66s)
--- PASS: TestAccAWSInstanceDataSource_RootBlockDevice_KmsKeyId (110.15s)
--- PASS: TestAccAWSInstanceDataSource_rootInstanceStore (89.90s)
--- PASS: TestAccAWSInstanceDataSource_SecurityGroups (147.45s)
--- PASS: TestAccAWSInstanceDataSource_tags (135.92s)
--- PASS: TestAccAWSInstanceDataSource_VPC (83.45s)
--- PASS: TestAccAWSInstanceDataSource_VPCSecurityGroups (191.31s)

--- PASS: TestAccAWSInstancesDataSource_basic (207.14s)
--- PASS: TestAccAWSInstancesDataSource_instance_state_names (191.23s)
--- PASS: TestAccAWSInstancesDataSource_tags (201.39s)

--- PASS: TestAccAWSLaunchConfiguration_basic (17.97s)
--- PASS: TestAccAWSLaunchConfiguration_ebs_noDevice (10.28s)
--- PASS: TestAccAWSLaunchConfiguration_encryptedRootBlockDevice (13.95s)
--- PASS: TestAccAWSLaunchConfiguration_RootBlockDevice_AmiDisappears (334.21s)
--- PASS: TestAccAWSLaunchConfiguration_RootBlockDevice_VolumeSize (25.12s)
--- PASS: TestAccAWSLaunchConfiguration_updateEbsBlockDevices (16.63s)
--- PASS: TestAccAWSLaunchConfiguration_userData (16.13s)
--- PASS: TestAccAWSLaunchConfiguration_withBlockDevices (11.22s)
--- PASS: TestAccAWSLaunchConfiguration_withEncryption (13.61s)
--- PASS: TestAccAWSLaunchConfiguration_withIAMProfile (29.79s)
--- PASS: TestAccAWSLaunchConfiguration_withInstanceStoreAMI (13.55s)
--- PASS: TestAccAWSLaunchConfiguration_withSpotPrice (10.84s)
--- PASS: TestAccAWSLaunchConfiguration_withVpcClassicLink (19.56s)

--- PASS: TestAccAWSLaunchConfigurationDataSource_basic (8.90s)
--- PASS: TestAccAWSLaunchConfigurationDataSource_securityGroups (11.48s)
```