### PR TITLE
Correctly handle ignored tags for S3 Bucket and Object resources

### DIFF
--- a/aws/internal/keyvaluetags/key_value_tags.go
+++ b/aws/internal/keyvaluetags/key_value_tags.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"reflect"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/hashcode"
@@ -380,6 +381,25 @@ func (tags KeyValueTags) Hash() int {
 	return hash
 }
 
+// String returns the default string representation of the KeyValueTags.
+func (tags KeyValueTags) String() string {
+	var builder strings.Builder
+
+	keys := tags.Keys()
+	sort.Strings(keys)
+
+	builder.WriteString("map[")
+	for i, k := range keys {
+		if i > 0 {
+			builder.WriteString(" ")
+		}
+		fmt.Fprintf(&builder, "%s:%s", k, tags[k].String())
+	}
+	builder.WriteString("]")
+
+	return builder.String()
+}
+
 // UrlEncode returns the KeyValueTags encoded as URL Query parameters.
 func (tags KeyValueTags) UrlEncode() string {
 	values := url.Values{}
@@ -393,23 +413,6 @@ func (tags KeyValueTags) UrlEncode() string {
 	}
 
 	return values.Encode()
-}
-
-func (tags KeyValueTags) String() string {
-	var builder strings.Builder
-
-	builder.WriteString("map[")
-	i := 0
-	for k, v := range tags {
-		if i > 0 {
-			builder.WriteString(" ")
-		}
-		fmt.Fprintf(&builder, "%s:%s", k, *v)
-		i++
-	}
-	builder.WriteString("]")
-
-	return builder.String()
 }
 
 // New creates KeyValueTags from common Terraform Provider SDK types.

--- a/aws/internal/keyvaluetags/key_value_tags.go
+++ b/aws/internal/keyvaluetags/key_value_tags.go
@@ -395,6 +395,23 @@ func (tags KeyValueTags) UrlEncode() string {
 	return values.Encode()
 }
 
+func (tags KeyValueTags) String() string {
+	var builder strings.Builder
+
+	builder.WriteString("map[")
+	i := 0
+	for k, v := range tags {
+		if i > 0 {
+			builder.WriteString(" ")
+		}
+		fmt.Fprintf(&builder, "%s:%s", k, *v)
+		i++
+	}
+	builder.WriteString("]")
+
+	return builder.String()
+}
+
 // New creates KeyValueTags from common Terraform Provider SDK types.
 // Supports map[string]string, map[string]*string, map[string]interface{}, and []interface{}.
 // When passed []interface{}, all elements are treated as keys and assigned nil values.

--- a/aws/internal/keyvaluetags/key_value_tags_test.go
+++ b/aws/internal/keyvaluetags/key_value_tags_test.go
@@ -1859,6 +1859,46 @@ func TestToSnakeCase(t *testing.T) {
 	}
 }
 
+func TestKeyValueTagsString(t *testing.T) {
+	testCases := []struct {
+		name string
+		tags KeyValueTags
+		want string
+	}{
+		{
+			name: "empty",
+			tags: New(map[string]string{}),
+			want: "map[]",
+		},
+		{
+			name: "single",
+			tags: New(map[string]string{
+				"key1": "value1",
+			}),
+			want: "map[key1:value1]",
+		},
+		{
+			name: "multiple",
+			tags: New(map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			}),
+			want: "map[key1:value1 key2:value2 key3:value3]",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := testCase.tags.String()
+
+			if got != testCase.want {
+				t.Errorf("unexpected string value: %q", got)
+			}
+		})
+	}
+}
+
 func testKeyValueTagsVerifyKeys(t *testing.T, got []string, want []string) {
 	for _, g := range got {
 		found := false

--- a/aws/internal/keyvaluetags/key_value_tags_test.go
+++ b/aws/internal/keyvaluetags/key_value_tags_test.go
@@ -1871,20 +1871,29 @@ func TestKeyValueTagsString(t *testing.T) {
 			want: "map[]",
 		},
 		{
+			name: "no value",
+			tags: New(map[string]*string{
+				"key1": nil,
+			}),
+			want: "map[key1:]",
+		},
+		{
 			name: "single",
 			tags: New(map[string]string{
 				"key1": "value1",
 			}),
-			want: "map[key1:value1]",
+			want: "map[key1:TagData{Value: value1}]",
 		},
 		{
 			name: "multiple",
 			tags: New(map[string]string{
 				"key1": "value1",
-				"key2": "value2",
 				"key3": "value3",
+				"key2": "value2",
+				"key5": "value5",
+				"key4": "value4",
 			}),
-			want: "map[key1:value1 key2:value2 key3:value3]",
+			want: "map[key1:TagData{Value: value1} key2:TagData{Value: value2} key3:TagData{Value: value3} key4:TagData{Value: value4} key5:TagData{Value: value5}]",
 		},
 	}
 

--- a/aws/internal/keyvaluetags/s3_tags.go
+++ b/aws/internal/keyvaluetags/s3_tags.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	tfs3 "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/s3"
 )
 
 // Custom S3 tag service update functions using the same format as generated code.
@@ -24,7 +25,7 @@ func S3BucketListTags(conn *s3.S3, identifier string) (KeyValueTags, error) {
 	// S3 API Reference (https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketTagging.html)
 	// lists the special error as NoSuchTagSetError, however the existing logic used NoSuchTagSet
 	// and the AWS Go SDK has neither as a constant.
-	if tfawserr.ErrCodeEquals(err, "NoSuchTagSet") {
+	if tfawserr.ErrCodeEquals(err, tfs3.NoSuchTagSet) {
 		return New(nil), nil
 	}
 

--- a/aws/internal/service/s3/errors.go
+++ b/aws/internal/service/s3/errors.go
@@ -1,0 +1,5 @@
+package s3
+
+const (
+	NoSuchTagSet = "NoSuchTagSet"
+)

--- a/aws/resource_aws_s3_bucket_object_test.go
+++ b/aws/resource_aws_s3_bucket_object_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func init() {
@@ -954,6 +955,53 @@ func TestAccAWSS3BucketObject_ObjectLockRetentionStartWithSet(t *testing.T) {
 	})
 }
 
+func TestAccAWSS3BucketObject_ignoreTags(t *testing.T) {
+	var obj s3.GetObjectOutput
+	resourceName := "aws_s3_bucket_object.object"
+	rInt := acctest.RandInt()
+	key := "test-key"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketObjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {},
+				Config: composeConfig(
+					testAccProviderConfigIgnoreTagsKeyPrefixes1("ignorekey"),
+					testAccAWSS3BucketObjectConfig_withNoTags(rInt, key, "stuff")),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketObjectExists(resourceName, &obj),
+					testAccCheckAWSS3BucketObjectBody(&obj, "stuff"),
+					testAccCheckAWSS3BucketObjectUpdateTags(resourceName, nil, map[string]string{"ignorekey1": "ignorevalue1"}),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				PreConfig: func() {},
+				Config: composeConfig(
+					testAccProviderConfigIgnoreTagsKeyPrefixes1("ignorekey"),
+					testAccAWSS3BucketObjectConfig_withTags(rInt, key, "stuff")),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketObjectExists(resourceName, &obj),
+					testAccCheckAWSS3BucketObjectBody(&obj, "stuff"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "AAA"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "BBB"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key3", "CCC"),
+					testAccCheckAWSS3BucketObjectCheckTags(resourceName, map[string]string{
+						"ignorekey1": "ignorevalue1",
+						"Key1":       "AAA",
+						"Key2":       "BBB",
+						"Key3":       "CCC",
+					}),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSS3BucketObjectVersionIdDiffers(first, second *s3.GetObjectOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if first.VersionId == nil {
@@ -1153,6 +1201,34 @@ func testAccAWSS3BucketObjectCreateTempFile(t *testing.T, data string) string {
 	}
 
 	return filename
+}
+
+func testAccCheckAWSS3BucketObjectUpdateTags(n string, oldTags, newTags map[string]string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs := s.RootModule().Resources[n]
+		conn := testAccProvider.Meta().(*AWSClient).s3conn
+
+		return keyvaluetags.S3ObjectUpdateTags(conn, rs.Primary.Attributes["bucket"], rs.Primary.Attributes["key"], oldTags, newTags)
+	}
+}
+
+func testAccCheckAWSS3BucketObjectCheckTags(n string, expectedTags map[string]string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs := s.RootModule().Resources[n]
+		conn := testAccProvider.Meta().(*AWSClient).s3conn
+
+		got, err := keyvaluetags.S3ObjectListTags(conn, rs.Primary.Attributes["bucket"], rs.Primary.Attributes["key"])
+		if err != nil {
+			return err
+		}
+
+		want := keyvaluetags.New(expectedTags)
+		if !reflect.DeepEqual(want, got) {
+			return fmt.Errorf("Incorrect tags, want: %v got: %v", want, got)
+		}
+
+		return nil
+	}
 }
 
 func testAccAWSS3BucketObjectConfigBasic(bucket, key string) string {

--- a/aws/resource_aws_s3_bucket_object_test.go
+++ b/aws/resource_aws_s3_bucket_object_test.go
@@ -976,6 +976,9 @@ func TestAccAWSS3BucketObject_ignoreTags(t *testing.T) {
 					testAccCheckAWSS3BucketObjectBody(&obj, "stuff"),
 					testAccCheckAWSS3BucketObjectUpdateTags(resourceName, nil, map[string]string{"ignorekey1": "ignorevalue1"}),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					testAccCheckAWSS3BucketObjectCheckTags(resourceName, map[string]string{
+						"ignorekey1": "ignorevalue1",
+					}),
 				),
 			},
 			{

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -380,6 +380,9 @@ func TestAccAWSS3Bucket_ignoreTags(t *testing.T) {
 					testAccCheckAWSS3BucketExists(resourceName),
 					testAccCheckAWSS3BucketUpdateTags(resourceName, nil, map[string]string{"ignorekey1": "ignorevalue1"}),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					testAccCheckAWSS3BucketCheckTags(resourceName, map[string]string{
+						"ignorekey1": "ignorevalue1",
+					}),
 				),
 			},
 			{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/terraform-providers/terraform-provider-aws/pull/11964.
Relates https://github.com/terraform-providers/terraform-provider-aws/pull/11916.
Relates https://github.com/terraform-providers/terraform-provider-aws/issues/10689.
Relates https://github.com/terraform-providers/terraform-provider-aws/pull/7342.

The `aws_s3_bucket_object` scenario was tested using `ignore_tags` functionality and the following acceptance test case:

```go
func TestAccAWSS3BucketObject_ignoreTags(t *testing.T) {
       var obj s3.GetObjectOutput
       resourceName := "aws_s3_bucket_object.object"
       rInt := acctest.RandInt()
       key := "test-key"

       resource.ParallelTest(t, resource.TestCase{
               PreCheck:     func() { testAccPreCheck(t) },
               Providers:    testAccProviders,
               CheckDestroy: testAccCheckAWSS3BucketObjectDestroy,
               Steps: []resource.TestStep{
                       {
                               PreConfig: func() {},
                               Config:    testAccProviderConfigIgnoreTagPrefixes1("ignorekey") + testAccAWSS3BucketObjectConfig_withNoTags(rInt, key, "stuff"),
                               Check: resource.ComposeTestCheckFunc(
                                       testAccCheckAWSS3BucketObjectExists(resourceName, &obj),
                                       testAccCheckAWSS3BucketObjectBody(&obj, "stuff"),
                                       testAccCheckAWSS3BucketObjectUpdateTags(resourceName, nil, map[string]string{"ignorekey1": "ignorevalue1"}),
                                       resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
                               ),
                       },
                       {
                               PreConfig: func() {},
                               Config:    testAccProviderConfigIgnoreTagPrefixes1("ignorekey") + testAccAWSS3BucketObjectConfig_withTags(rInt, key, "stuff"),
                               Check: resource.ComposeTestCheckFunc(
                                       testAccCheckAWSS3BucketObjectExists(resourceName, &obj),
                                       testAccCheckAWSS3BucketObjectBody(&obj, "stuff"),
                                       resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
                                       resource.TestCheckResourceAttr(resourceName, "tags.Key1", "AAA"),
                                       resource.TestCheckResourceAttr(resourceName, "tags.Key2", "BBB"),
                                       resource.TestCheckResourceAttr(resourceName, "tags.Key3", "CCC"),
                                       testAccCheckAWSS3BucketObjecCheckTags(resourceName, map[string]string{
                                               "ignorekey1": "ignorevalue1",
                                               "Key1":       "AAA",
                                               "Key2":       "BBB",
                                               "Key3":       "CCC",
                                       }),
                               ),
                       },
               },
       })
}

func testAccCheckAWSS3BucketObjectUpdateTags(n string, oldTags, newTags map[string]string) resource.TestCheckFunc {
       return func(s *terraform.State) error {
               rs := s.RootModule().Resources[n]
               s3conn := testAccProvider.Meta().(*AWSClient).s3conn

               return keyvaluetags.S3ObjectUpdateTags(s3conn, rs.Primary.Attributes["bucket"], rs.Primary.Attributes["key"], oldTags, newTags)
       }
}

func testAccCheckAWSS3BucketObjecCheckTags(n string, expectedTags map[string]string) resource.TestCheckFunc {
       return func(s *terraform.State) error {
               rs := s.RootModule().Resources[n]
               s3conn := testAccProvider.Meta().(*AWSClient).s3conn

               got, err := keyvaluetags.S3ObjectListTags(s3conn, rs.Primary.Attributes["bucket"], rs.Primary.Attributes["key"])
               if err != nil {
                       return err
               }

               want := keyvaluetags.New(expectedTags)
               if !reflect.DeepEqual(want, got) {
                       return fmt.Errorf("Incorrect tags, want: %v got: %v", want, got)
               }

               return nil
       }
}
```

That case fails without the change:

```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSS3BucketObject_ignoreTags'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSS3BucketObject_ignoreTags -timeout 120m
=== RUN   TestAccAWSS3BucketObject_ignoreTags
=== PAUSE TestAccAWSS3BucketObject_ignoreTags
=== CONT  TestAccAWSS3BucketObject_ignoreTags
--- FAIL: TestAccAWSS3BucketObject_ignoreTags (54.90s)
    testing.go:640: Step 1 error: Check failed: Check 7/7 error: Incorrect tags, want: map[ignorekey1:ignorevalue1 Key1:AAA Key2:BBB Key3:CCC] got: map[Key2:BBB Key1:AAA Key3:CCC]
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	54.957s
FAIL
GNUmakefile:25: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```

and passes after the change:

```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSS3BucketObject_ignoreTags'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSS3BucketObject_ignoreTags -timeout 120m
=== RUN   TestAccAWSS3BucketObject_ignoreTags
=== PAUSE TestAccAWSS3BucketObject_ignoreTags
=== CONT  TestAccAWSS3BucketObject_ignoreTags
--- PASS: TestAccAWSS3BucketObject_ignoreTags (69.11s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	69.152s
```

The `aws_s3_bucket` scenario can be verified with the existing acceptance test cases.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSS3BucketObject_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSS3BucketObject_ -timeout 120m
=== RUN   TestAccAWSS3BucketObject_noNameNoKey
=== PAUSE TestAccAWSS3BucketObject_noNameNoKey
=== RUN   TestAccAWSS3BucketObject_empty
=== PAUSE TestAccAWSS3BucketObject_empty
=== RUN   TestAccAWSS3BucketObject_source
=== PAUSE TestAccAWSS3BucketObject_source
=== RUN   TestAccAWSS3BucketObject_content
=== PAUSE TestAccAWSS3BucketObject_content
=== RUN   TestAccAWSS3BucketObject_etagEncryption
=== PAUSE TestAccAWSS3BucketObject_etagEncryption
=== RUN   TestAccAWSS3BucketObject_contentBase64
=== PAUSE TestAccAWSS3BucketObject_contentBase64
=== RUN   TestAccAWSS3BucketObject_withContentCharacteristics
=== PAUSE TestAccAWSS3BucketObject_withContentCharacteristics
=== RUN   TestAccAWSS3BucketObject_NonVersioned
=== PAUSE TestAccAWSS3BucketObject_NonVersioned
=== RUN   TestAccAWSS3BucketObject_updates
=== PAUSE TestAccAWSS3BucketObject_updates
=== RUN   TestAccAWSS3BucketObject_updateSameFile
=== PAUSE TestAccAWSS3BucketObject_updateSameFile
=== RUN   TestAccAWSS3BucketObject_updatesWithVersioning
=== PAUSE TestAccAWSS3BucketObject_updatesWithVersioning
=== RUN   TestAccAWSS3BucketObject_kms
=== PAUSE TestAccAWSS3BucketObject_kms
=== RUN   TestAccAWSS3BucketObject_sse
=== PAUSE TestAccAWSS3BucketObject_sse
=== RUN   TestAccAWSS3BucketObject_acl
=== PAUSE TestAccAWSS3BucketObject_acl
=== RUN   TestAccAWSS3BucketObject_metadata
=== PAUSE TestAccAWSS3BucketObject_metadata
=== RUN   TestAccAWSS3BucketObject_storageClass
=== PAUSE TestAccAWSS3BucketObject_storageClass
=== RUN   TestAccAWSS3BucketObject_tags
=== PAUSE TestAccAWSS3BucketObject_tags
=== RUN   TestAccAWSS3BucketObject_tagsLeadingSlash
=== PAUSE TestAccAWSS3BucketObject_tagsLeadingSlash
=== RUN   TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithNone
=== PAUSE TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithNone
=== RUN   TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithOn
=== PAUSE TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithOn
=== RUN   TestAccAWSS3BucketObject_ObjectLockRetentionStartWithNone
=== PAUSE TestAccAWSS3BucketObject_ObjectLockRetentionStartWithNone
=== RUN   TestAccAWSS3BucketObject_ObjectLockRetentionStartWithSet
=== PAUSE TestAccAWSS3BucketObject_ObjectLockRetentionStartWithSet
=== CONT  TestAccAWSS3BucketObject_noNameNoKey
=== CONT  TestAccAWSS3BucketObject_sse
=== CONT  TestAccAWSS3BucketObject_ObjectLockRetentionStartWithSet
=== CONT  TestAccAWSS3BucketObject_ObjectLockRetentionStartWithNone
=== CONT  TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithOn
=== CONT  TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithNone
=== CONT  TestAccAWSS3BucketObject_tagsLeadingSlash
=== CONT  TestAccAWSS3BucketObject_tags
=== CONT  TestAccAWSS3BucketObject_kms
=== CONT  TestAccAWSS3BucketObject_updatesWithVersioning
=== CONT  TestAccAWSS3BucketObject_storageClass
=== CONT  TestAccAWSS3BucketObject_metadata
=== CONT  TestAccAWSS3BucketObject_updateSameFile
=== CONT  TestAccAWSS3BucketObject_updates
=== CONT  TestAccAWSS3BucketObject_NonVersioned
=== CONT  TestAccAWSS3BucketObject_acl
=== CONT  TestAccAWSS3BucketObject_withContentCharacteristics
=== CONT  TestAccAWSS3BucketObject_contentBase64
=== CONT  TestAccAWSS3BucketObject_etagEncryption
=== CONT  TestAccAWSS3BucketObject_content
--- SKIP: TestAccAWSS3BucketObject_NonVersioned (2.18s)
    provider_test.go:1254: skipping tests; TF_ACC_ASSUME_ROLE_ARN must be set
=== CONT  TestAccAWSS3BucketObject_source
--- PASS: TestAccAWSS3BucketObject_noNameNoKey (5.52s)
=== CONT  TestAccAWSS3BucketObject_empty
--- PASS: TestAccAWSS3BucketObject_etagEncryption (41.82s)
--- PASS: TestAccAWSS3BucketObject_content (41.93s)
--- PASS: TestAccAWSS3BucketObject_contentBase64 (43.01s)
--- PASS: TestAccAWSS3BucketObject_sse (43.08s)
--- PASS: TestAccAWSS3BucketObject_withContentCharacteristics (43.14s)
--- PASS: TestAccAWSS3BucketObject_source (40.97s)
--- PASS: TestAccAWSS3BucketObject_empty (38.59s)
--- PASS: TestAccAWSS3BucketObject_kms (66.72s)
--- PASS: TestAccAWSS3BucketObject_updatesWithVersioning (69.71s)
--- PASS: TestAccAWSS3BucketObject_updateSameFile (69.89s)
--- PASS: TestAccAWSS3BucketObject_updates (69.97s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithOn (71.51s)
--- PASS: TestAccAWSS3BucketObject_metadata (94.24s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockRetentionStartWithNone (96.23s)
--- PASS: TestAccAWSS3BucketObject_acl (97.62s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithNone (98.68s)
--- PASS: TestAccAWSS3BucketObject_tagsLeadingSlash (122.16s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockRetentionStartWithSet (122.47s)
--- PASS: TestAccAWSS3BucketObject_tags (123.22s)
--- PASS: TestAccAWSS3BucketObject_storageClass (146.78s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	146.860s
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSS3Bucket_tags'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSS3Bucket_tags -timeout 120m
=== RUN   TestAccAWSS3Bucket_tagsWithNoSystemTags
=== PAUSE TestAccAWSS3Bucket_tagsWithNoSystemTags
=== RUN   TestAccAWSS3Bucket_tagsWithSystemTags
=== PAUSE TestAccAWSS3Bucket_tagsWithSystemTags
=== CONT  TestAccAWSS3Bucket_tagsWithSystemTags
=== CONT  TestAccAWSS3Bucket_tagsWithNoSystemTags
--- PASS: TestAccAWSS3Bucket_tagsWithNoSystemTags (130.64s)
--- PASS: TestAccAWSS3Bucket_tagsWithSystemTags (170.73s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	170.777s
$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAWSS3BucketObject_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAWSS3BucketObject_ -timeout 120m
=== RUN   TestAccDataSourceAWSS3BucketObject_basic
=== PAUSE TestAccDataSourceAWSS3BucketObject_basic
=== RUN   TestAccDataSourceAWSS3BucketObject_readableBody
=== PAUSE TestAccDataSourceAWSS3BucketObject_readableBody
=== RUN   TestAccDataSourceAWSS3BucketObject_kmsEncrypted
=== PAUSE TestAccDataSourceAWSS3BucketObject_kmsEncrypted
=== RUN   TestAccDataSourceAWSS3BucketObject_allParams
=== PAUSE TestAccDataSourceAWSS3BucketObject_allParams
=== RUN   TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOff
=== PAUSE TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOff
=== RUN   TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOn
=== PAUSE TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOn
=== RUN   TestAccDataSourceAWSS3BucketObject_LeadingSlash
=== PAUSE TestAccDataSourceAWSS3BucketObject_LeadingSlash
=== RUN   TestAccDataSourceAWSS3BucketObject_MultipleSlashes
=== PAUSE TestAccDataSourceAWSS3BucketObject_MultipleSlashes
=== CONT  TestAccDataSourceAWSS3BucketObject_basic
=== CONT  TestAccDataSourceAWSS3BucketObject_LeadingSlash
=== CONT  TestAccDataSourceAWSS3BucketObject_MultipleSlashes
=== CONT  TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOn
=== CONT  TestAccDataSourceAWSS3BucketObject_allParams
=== CONT  TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOff
=== CONT  TestAccDataSourceAWSS3BucketObject_kmsEncrypted
=== CONT  TestAccDataSourceAWSS3BucketObject_readableBody
--- PASS: TestAccDataSourceAWSS3BucketObject_basic (63.57s)
--- PASS: TestAccDataSourceAWSS3BucketObject_readableBody (63.59s)
--- PASS: TestAccDataSourceAWSS3BucketObject_LeadingSlash (64.84s)
--- PASS: TestAccDataSourceAWSS3BucketObject_MultipleSlashes (65.54s)
--- PASS: TestAccDataSourceAWSS3BucketObject_allParams (65.54s)
--- PASS: TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOff (65.71s)
--- PASS: TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOn (67.10s)
--- PASS: TestAccDataSourceAWSS3BucketObject_kmsEncrypted (86.80s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	86.874s
```
