### PR TITLE
Adds default S3 bucket name to S3 sweeper

### DIFF
--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -62,7 +62,7 @@ func testSweepS3Buckets(region string) error {
 		name := aws.StringValue(bucket.Name)
 
 		sweepable := false
-		prefixes := []string{"mybucket.", "mylogs.", "tf-acc", "tf-object-test", "tf-test", "tf-emr-bootstrap"}
+		prefixes := []string{"mybucket.", "mylogs.", "tf-acc", "tf-object-test", "tf-test", "tf-emr-bootstrap", "terraform-remote-s3-test"}
 
 		for _, prefix := range prefixes {
 			if strings.HasPrefix(name, prefix) {

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -60,17 +60,21 @@ func testSweepS3Buckets(region string) error {
 	for _, bucket := range output.Buckets {
 		name := aws.StringValue(bucket.Name)
 
-		hasPrefix := false
+		sweepable := false
 		prefixes := []string{"mybucket.", "mylogs.", "tf-acc", "tf-object-test", "tf-test", "tf-emr-bootstrap"}
 
 		for _, prefix := range prefixes {
 			if strings.HasPrefix(name, prefix) {
-				hasPrefix = true
+				sweepable = true
 				break
 			}
 		}
 
-		if !hasPrefix {
+		if matched, _ := regexp.MatchString(`^terraform-\d+$`, name); matched == true {
+			sweepable = true
+		}
+
+		if !sweepable {
 			log.Printf("[INFO] Skipping S3 Bucket: %s", name)
 			continue
 		}

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -57,6 +57,7 @@ func testSweepS3Buckets(region string) error {
 		return nil
 	}
 
+	defaultNameRegexp := regexp.MustCompile(`^terraform-\d+$`)
 	for _, bucket := range output.Buckets {
 		name := aws.StringValue(bucket.Name)
 
@@ -70,7 +71,7 @@ func testSweepS3Buckets(region string) error {
 			}
 		}
 
-		if matched, _ := regexp.MatchString(`^terraform-\d+$`, name); matched == true {
+		if defaultNameRegexp.MatchString(name) {
 			sweepable = true
 		}
 


### PR DESCRIPTION
The S3 sweeper does not pick up S3 buckets using the default name.

Before change:
```
$ make sweep SWEEPARGS='-sweep-run=aws_s3_bucket'

2020/02/12 14:29:58 [INFO] Skipping S3 Bucket: terraform-20190927111526867500000001
2020/02/12 14:29:58 [INFO] Skipping S3 Bucket: terraform-20200128073442164300000001
2020/02/12 14:29:58 [INFO] Skipping S3 Bucket: terraform-20200206050939898800000002
2020/02/12 14:29:58 [INFO] Skipping S3 Bucket: terraform-20200206051011101200000002
2020/02/12 14:29:58 [INFO] Skipping S3 Bucket: terraform-20200206051057098900000002
2020/02/12 14:29:58 [INFO] Skipping S3 Bucket: terraform-20200207042821830100000002
2020/02/12 14:29:58 [INFO] Skipping S3 Bucket: terraform-20200207042828980600000002
2020/02/12 14:29:58 [INFO] Skipping S3 Bucket: terraform-20200208040318319300000001
2020/02/12 14:29:58 [INFO] Skipping S3 Bucket: terraform-20200208040428441100000002
2020/02/12 14:29:58 [INFO] Skipping S3 Bucket: terraform-20200209040558378700000002
2020/02/12 14:29:58 [INFO] Skipping S3 Bucket: terraform-20200209040640058500000002
2020/02/12 14:29:58 [INFO] Skipping S3 Bucket: terraform-20200210041310786600000002
2020/02/12 14:29:58 [INFO] Skipping S3 Bucket: terraform-20200210041329008600000002
2020/02/12 14:29:58 [INFO] Skipping S3 Bucket: terraform-20200211035252600700000002
2020/02/12 14:29:58 [INFO] Skipping S3 Bucket: terraform-20200211035300319700000002
2020/02/12 14:29:58 [INFO] Skipping S3 Bucket: terraform-20200212040211570600000002
```

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
