### PR TITLE
Be clear about type for aws_subnet_ids

### DIFF
--- a/website/docs/d/subnet_ids.html.markdown
+++ b/website/docs/d/subnet_ids.html.markdown
@@ -3,12 +3,12 @@ subcategory: "VPC"
 layout: "aws"
 page_title: "AWS: aws_subnet_ids"
 description: |-
-    Provides a list of subnet Ids for a VPC
+    Provides a set of subnet Ids for a VPC
 ---
 
 # Data Source: aws_subnet_ids
 
-`aws_subnet_ids` provides a list of ids for a vpc_id
+`aws_subnet_ids` provides a set of ids for a vpc_id
 
 This resource can be useful for getting back a set of subnet ids for a vpc.
 
@@ -31,7 +31,7 @@ output "subnet_cidr_blocks" {
 }
 ```
 
-The following example retrieves a list of all subnets in a VPC with a custom
+The following example retrieves a set of all subnets in a VPC with a custom
 tag of `Tier` set to a value of "Private" so that the `aws_instance` resource
 can loop through the subnets, putting instances across availability zones.
 


### PR DESCRIPTION
Some time ago the type aws_subnet_ids.ids was changed to a set. Although the attribute reference had already been updated, the term "list" was still used throughout the page which was confusing. Always referring to this data source as a "set" should clear this confusion.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```Be clear about type for aws_subnet_ids

```

