### PR TITLE
Sorting ACM Certificate SAN names

### DIFF
--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"sort"
 	"strings"
 	"time"
 
@@ -316,6 +317,7 @@ func cleanUpSubjectAlternativeNames(cert *acm.CertificateDetail) []string {
 			vs = append(vs, aws.StringValue(v))
 		}
 	}
+	sort.Strings(vs)
 	return vs
 
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->
AWS API acm.describe_certificate returns the list of SAN names in an unpredictable order. This could cause that TF tries to recreate it even without changing the resource definition.
This change would sort the returned names alphabetically. In HCL the subject_alternative_names list can be also sorted with the sort() function or manually added like that.
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates  #10959

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_acm_certificate: prevent recreating the resource because the order of the SAN names returned form AWS API are upredictable.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
I have not run acceptance tests as I do not have a suitable AWS test account configured at the moment.
