### PR TITLE
Fix for SES configuration sets state and error handling

### DIFF
--- a/aws/resource_aws_ses_configuration_set.go
+++ b/aws/resource_aws_ses_configuration_set.go
@@ -50,7 +50,7 @@ func resourceAwsSesConfigurationSetCreate(d *schema.ResourceData, meta interface
 }
 
 func resourceAwsSesConfigurationSetRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*AWSClient).sesConn
+	conn := meta.(*AWSClient).sesconn
 
 	configSetInput := &ses.DescribeConfigurationSetInput{
 		ConfigurationSetName: aws.String(d.Id()),

--- a/aws/resource_aws_ses_configuration_set.go
+++ b/aws/resource_aws_ses_configuration_set.go
@@ -5,7 +5,6 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ses"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
@@ -91,13 +90,13 @@ func findConfigurationSet(name string, meta interface{}) (bool, error) {
 	response, err := conn.DescribeConfigurationSet(configSetInput)
 
 	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok && aerr.Code() == "ConfigurationSetDoesNotExist" {
+		if isAWSErr(err, ses.ErrCodeConfigurationSetDoesNotExistException, "") {
 			return configurationSetExists, nil
 		}
 		return false, err
 	}
 
-	if *response.ConfigurationSet.Name == name {
+	if aws.StringValue(response.ConfigurationSet.Name) == name {
 		configurationSetExists = true
 	}
 

--- a/aws/resource_aws_ses_configuration_set.go
+++ b/aws/resource_aws_ses_configuration_set.go
@@ -97,9 +97,7 @@ func findConfigurationSet(name string, meta interface{}) (bool, error) {
 		return false, err
 	}
 
-	respString := *response.ConfigurationSet.Name
-
-	if respString == name {
+	if *response.ConfigurationSet.Name == name {
 		configurationSetExists = true
 	}
 

--- a/aws/resource_aws_ses_configuration_set_test.go
+++ b/aws/resource_aws_ses_configuration_set_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ses"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -68,6 +69,8 @@ func testSweepSesConfigurationSets(region string) error {
 }
 
 func TestAccAWSSESConfigurationSet_basic(t *testing.T) {
+	var escRandomInteger = acctest.RandInt()
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -77,7 +80,7 @@ func TestAccAWSSESConfigurationSet_basic(t *testing.T) {
 		CheckDestroy: testAccCheckSESConfigurationSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSESConfigurationSetConfig,
+				Config: testAccAWSSESConfigurationSetConfig(escRandomInteger),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsSESConfigurationSetExists("aws_ses_configuration_set.test"),
 				),
@@ -89,36 +92,6 @@ func TestAccAWSSESConfigurationSet_basic(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccCheckSESConfigurationSetDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*AWSClient).sesconn
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_ses_configuration_set" {
-			continue
-		}
-
-		response, err := conn.ListConfigurationSets(&ses.ListConfigurationSetsInput{})
-		if err != nil {
-			return err
-		}
-
-		found := false
-		for _, element := range response.ConfigurationSets {
-			if *element.Name == fmt.Sprintf("some-configuration-set-%d", escRandomInteger) {
-				found = true
-			}
-		}
-
-		if found {
-			return fmt.Errorf("The configuration set still exists")
-		}
-
-	}
-
-	return nil
-
 }
 
 func testAccCheckAwsSESConfigurationSetExists(n string) resource.TestCheckFunc {
@@ -134,16 +107,19 @@ func testAccCheckAwsSESConfigurationSetExists(n string) resource.TestCheckFunc {
 
 		conn := testAccProvider.Meta().(*AWSClient).sesconn
 
-		response, err := conn.ListConfigurationSets(&ses.ListConfigurationSetsInput{})
+		response, err := conn.DescribeConfigurationSet(&ses.DescribeConfigurationSetInput{
+			ConfigurationSetName: aws.String(rs.Primary.ID),
+		})
+
 		if err != nil {
 			return err
 		}
 
 		found := false
-		for _, element := range response.ConfigurationSets {
-			if *element.Name == fmt.Sprintf("some-configuration-set-%d", escRandomInteger) {
-				found = true
-			}
+		respString := *response.ConfigurationSet.Name
+
+		if respString == rs.Primary.ID {
+			found = true
 		}
 
 		if !found {
@@ -154,9 +130,34 @@ func testAccCheckAwsSESConfigurationSetExists(n string) resource.TestCheckFunc {
 	}
 }
 
-var escRandomInteger = acctest.RandInt()
-var testAccAWSSESConfigurationSetConfig = fmt.Sprintf(`
+func testAccCheckSESConfigurationSetDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).sesConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_ses_configuration_set" {
+			continue
+		}
+
+		_, err := conn.DescribeConfigurationSet(&ses.DescribeConfigurationSetInput{
+			ConfigurationSetName: aws.String(rs.Primary.ID),
+		})
+
+		if err == nil {
+			if aerr, ok := err.(awserr.Error); ok && aerr.Code() == "ConfigurationSetDoesNotExist" {
+				return fmt.Errorf("The configuration set still exists")
+			}
+			return fmt.Errorf("An error occurred: %s", err)
+		}
+	}
+
+	return nil
+
+}
+
+func testAccAWSSESConfigurationSetConfig(escRandomInteger int) string {
+	return fmt.Sprintf(`
 resource "aws_ses_configuration_set" "test" {
     name = "some-configuration-set-%d"
 }
 `, escRandomInteger)
+}

--- a/aws/resource_aws_ses_configuration_set_test.go
+++ b/aws/resource_aws_ses_configuration_set_test.go
@@ -116,9 +116,8 @@ func testAccCheckAwsSESConfigurationSetExists(n string) resource.TestCheckFunc {
 		}
 
 		found := false
-		respString := *response.ConfigurationSet.Name
 
-		if respString == rs.Primary.ID {
+		if *response.ConfigurationSet.Name == rs.Primary.ID {
 			found = true
 		}
 

--- a/aws/resource_aws_ses_configuration_set_test.go
+++ b/aws/resource_aws_ses_configuration_set_test.go
@@ -123,7 +123,7 @@ func testAccCheckAwsSESConfigurationSetExists(n string) resource.TestCheckFunc {
 }
 
 func testAccCheckSESConfigurationSetDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*AWSClient).sesConn
+	conn := testAccProvider.Meta().(*AWSClient).sesconn
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_ses_configuration_set" {

--- a/go.sum
+++ b/go.sum
@@ -39,14 +39,8 @@ github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aws/aws-sdk-go v1.15.78/go.mod h1:E3/ieXAlvM0XWO57iftYVDLLvQ824smPP3ATZkfNZeM=
 github.com/aws/aws-sdk-go v1.25.3/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
-<<<<<<< HEAD
 github.com/aws/aws-sdk-go v1.31.2 h1:REYLkyG1EGES8SJS0QsUwvWix9oQwUbJ8HLgMxUHpKo=
 github.com/aws/aws-sdk-go v1.31.2/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
-=======
-github.com/aws/aws-sdk-go v1.28.9 h1:grIuBQc+p3dTRXerh5+2OxSuWFi0iXuxbFdTSg0jaW0=
-github.com/aws/aws-sdk-go v1.28.9/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
-github.com/aws/aws-sdk-go v1.29.1 h1:U2vZ5WprhGAMjzb4bKVzl2QecUtZFW2BXVqa5bnd+OY=
->>>>>>> 062343253... Fix for SES configuration sets state and error handling
 github.com/beevik/etree v1.1.0 h1:T0xke/WvNtMoCqgzPhkX2r4rjY3GDZFi+FjpRZY2Jbs=
 github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,14 @@ github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aws/aws-sdk-go v1.15.78/go.mod h1:E3/ieXAlvM0XWO57iftYVDLLvQ824smPP3ATZkfNZeM=
 github.com/aws/aws-sdk-go v1.25.3/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+<<<<<<< HEAD
 github.com/aws/aws-sdk-go v1.31.2 h1:REYLkyG1EGES8SJS0QsUwvWix9oQwUbJ8HLgMxUHpKo=
 github.com/aws/aws-sdk-go v1.31.2/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
+=======
+github.com/aws/aws-sdk-go v1.28.9 h1:grIuBQc+p3dTRXerh5+2OxSuWFi0iXuxbFdTSg0jaW0=
+github.com/aws/aws-sdk-go v1.28.9/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.29.1 h1:U2vZ5WprhGAMjzb4bKVzl2QecUtZFW2BXVqa5bnd+OY=
+>>>>>>> 062343253... Fix for SES configuration sets state and error handling
 github.com/beevik/etree v1.1.0 h1:T0xke/WvNtMoCqgzPhkX2r4rjY3GDZFi+FjpRZY2Jbs=
 github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=


### PR DESCRIPTION
Relates to: https://github.com/terraform-providers/terraform-provider-aws/issues/8940

In some cases, when the checking the state for SES Configuration Sets the AWS API call can quietly fail and this results in the resource assuming that none exist and clearing out the state accordingly. In reality, things like authentication errors aren't being handled - in my case, my build environment's role was missing ses:ListConfigurationSets permissions and the resource assumed that no configuration sets existed or found the state/resource to be inconsistent. 

I've refactored this to use DescribeConfigurationSets instead of ListConfigurationSets and iterating through the results to find the specific resource - I couldn't see a need to use the ListConfigurationSets action. This will also throw underlying errors like auth exceptions. 

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8940

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSSESConfigurationSet' -R            
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSESConfigurationSet -timeout 120m
=== RUN   TestAccAWSSESConfigurationSet_basic
=== PAUSE TestAccAWSSESConfigurationSet_basic
=== CONT  TestAccAWSSESConfigurationSet_basic
--- PASS: TestAccAWSSESConfigurationSet_basic (66.84s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       66.866s


...
```
