### PR TITLE
resource/aws_iam_saml_provider: Fixes for tfproviderlint R002

### DIFF
--- a/aws/resource_aws_iam_saml_provider.go
+++ b/aws/resource_aws_iam_saml_provider.go
@@ -59,7 +59,7 @@ func resourceAwsIamSamlProviderCreate(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
-	d.SetId(*out.SAMLProviderArn)
+	d.SetId(aws.StringValue(out.SAMLProviderArn))
 
 	return resourceAwsIamSamlProviderRead(d, meta)
 }
@@ -80,15 +80,14 @@ func resourceAwsIamSamlProviderRead(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	validUntil := out.ValidUntil.Format(time.RFC1123)
 	d.Set("arn", d.Id())
 	name, err := extractNameFromIAMSamlProviderArn(d.Id(), meta.(*AWSClient).partition)
 	if err != nil {
 		return err
 	}
 	d.Set("name", name)
-	d.Set("valid_until", validUntil)
-	d.Set("saml_metadata_document", *out.SAMLMetadataDocument)
+	d.Set("valid_until", out.ValidUntil.Format(time.RFC1123))
+	d.Set("saml_metadata_document", out.SAMLMetadataDocument)
 
 	return nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/9952

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Remove pointer value dereferences, which can cause potential panics and are extraneous as `Set()` automatically handles pointer types including when `nil`.

Previously:

```
aws/resource_aws_iam_saml_provider.go:91:34: R002: ResourceData.Set() pointer value dereference is extraneous
```

Output from acceptance testing:

```
--- PASS: TestAccAWSIAMSamlProvider_basic (22.26s)
```