### PR TITLE
resource/aws_opsworks_stack: Fixes for tfproviderlint R002

### DIFF
--- a/aws/resource_aws_opsworks_stack.go
+++ b/aws/resource_aws_opsworks_stack.go
@@ -323,9 +323,9 @@ func resourceAwsOpsworksStackRead(d *schema.ResourceData, meta interface{}) erro
 			return dErr
 		}
 		// If the stack was found, set the stack_endpoint
-		if client.Config.Region != nil && *client.Config.Region != "" {
-			log.Printf("[DEBUG] Setting stack_endpoint for (%s) to (%s)", d.Id(), *client.Config.Region)
-			if err := d.Set("stack_endpoint", *client.Config.Region); err != nil {
+		if region := aws.StringValue(client.Config.Region); region != "" {
+			log.Printf("[DEBUG] Setting stack_endpoint for (%s) to (%s)", d.Id(), region)
+			if err := d.Set("stack_endpoint", region); err != nil {
 				log.Printf("[WARN] Error setting stack_endpoint: %s", err)
 			}
 		}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/9952

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Remove pointer value dereferences, which can cause potential panics and are extraneous as `Set()` automatically handles pointer types including when `nil`.

Previously:

```
aws/resource_aws_opsworks_stack.go:328:38: R002: ResourceData.Set() pointer value dereference is extraneous
```

Output from acceptance testing:

```
--- PASS: TestAccAWSOpsworksStack_noVpcBasic (36.09s)
--- PASS: TestAccAWSOpsworksStack_noVpcCreateTags (46.83s)
--- PASS: TestAccAWSOpsworksStack_CustomCookbooks_SetPrivateProperties (40.27s)
--- PASS: TestAccAWSOpsworksStack_vpc (64.43s)
--- PASS: TestAccAWSOpsworksStack_noVpcChangeServiceRoleForceNew (43.03s)
```