### PR TITLE
resource/aws_redshift_security_group: Fixes for tfproviderlint R002

### DIFF
--- a/aws/resource_aws_redshift_security_group.go
+++ b/aws/resource_aws_redshift_security_group.go
@@ -135,21 +135,21 @@ func resourceAwsRedshiftSecurityGroupRead(d *schema.ResourceData, meta interface
 	}
 
 	for _, v := range sg.IPRanges {
-		rule := map[string]interface{}{"cidr": *v.CIDRIP}
+		rule := map[string]interface{}{"cidr": aws.StringValue(v.CIDRIP)}
 		rules.Add(rule)
 	}
 
 	for _, g := range sg.EC2SecurityGroups {
 		rule := map[string]interface{}{
-			"security_group_name":     *g.EC2SecurityGroupName,
-			"security_group_owner_id": *g.EC2SecurityGroupOwnerId,
+			"security_group_name":     aws.StringValue(g.EC2SecurityGroupName),
+			"security_group_owner_id": aws.StringValue(g.EC2SecurityGroupOwnerId),
 		}
 		rules.Add(rule)
 	}
 
 	d.Set("ingress", rules)
-	d.Set("name", *sg.ClusterSecurityGroupName)
-	d.Set("description", *sg.Description)
+	d.Set("name", sg.ClusterSecurityGroupName)
+	d.Set("description", sg.Description)
 
 	return nil
 }

--- a/aws/resource_aws_redshift_security_group_test.go
+++ b/aws/resource_aws_redshift_security_group_test.go
@@ -24,7 +24,7 @@ func TestAccAWSRedshiftSecurityGroup_basic(t *testing.T) {
 	resourceName := "aws_redshift_security_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRedshiftSecurityGroupDestroy,
 		Steps: []resource.TestStep{
@@ -53,7 +53,7 @@ func TestAccAWSRedshiftSecurityGroup_ingressCidr(t *testing.T) {
 	resourceName := "aws_redshift_security_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRedshiftSecurityGroupDestroy,
 		Steps: []resource.TestStep{
@@ -90,7 +90,7 @@ func TestAccAWSRedshiftSecurityGroup_updateIngressCidr(t *testing.T) {
 	resourceName := "aws_redshift_security_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRedshiftSecurityGroupDestroy,
 		Steps: []resource.TestStep{
@@ -137,7 +137,7 @@ func TestAccAWSRedshiftSecurityGroup_ingressSecurityGroup(t *testing.T) {
 	resourceName := "aws_redshift_security_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRedshiftSecurityGroupDestroy,
 		Steps: []resource.TestStep{
@@ -172,7 +172,7 @@ func TestAccAWSRedshiftSecurityGroup_updateIngressSecurityGroup(t *testing.T) {
 	resourceName := "aws_redshift_security_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRedshiftSecurityGroupDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/9952

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Remove pointer value dereferences, which can cause potential panics and are extraneous as `Set()` automatically handles pointer types including when `nil`. Also adds missing EC2-Classic PreCheck to acceptance testing.

Previously:

```
aws/resource_aws_redshift_security_group.go:151:16: R002: ResourceData.Set() pointer value dereference is extraneous
aws/resource_aws_redshift_security_group.go:152:23: R002: ResourceData.Set() pointer value dereference is extraneous
```

Output from acceptance testing:

```
--- PASS: TestAccAWSRedshiftSecurityGroup_basic (11.89s)
--- PASS: TestAccAWSRedshiftSecurityGroup_ingressCidr (12.79s)
--- PASS: TestAccAWSRedshiftSecurityGroup_ingressSecurityGroup (13.09s)
--- PASS: TestAccAWSRedshiftSecurityGroup_updateIngressCidr (25.35s)
--- PASS: TestAccAWSRedshiftSecurityGroup_updateIngressSecurityGroup (28.94s)
```