### PR TITLE
resource/aws_proxy_protocol_policy: Fixes for tfproviderlint R002

### DIFF
--- a/aws/resource_aws_proxy_protocol_policy.go
+++ b/aws/resource_aws_proxy_protocol_policy.go
@@ -70,11 +70,11 @@ func resourceAwsProxyProtocolPolicyCreate(d *schema.ResourceData, meta interface
 
 func resourceAwsProxyProtocolPolicyRead(d *schema.ResourceData, meta interface{}) error {
 	elbconn := meta.(*AWSClient).elbconn
-	elbname := aws.String(d.Get("load_balancer").(string))
+	elbname := d.Get("load_balancer").(string)
 
 	// Retrieve the current ELB policies for updating the state
 	req := &elb.DescribeLoadBalancersInput{
-		LoadBalancerNames: []*string{elbname},
+		LoadBalancerNames: []*string{aws.String(elbname)},
 	}
 	resp, err := elbconn.DescribeLoadBalancers(req)
 	if err != nil {
@@ -94,7 +94,7 @@ func resourceAwsProxyProtocolPolicyRead(d *schema.ResourceData, meta interface{}
 		ports = append(ports, &ipstr)
 	}
 	d.Set("instance_ports", ports)
-	d.Set("load_balancer", *elbname)
+	d.Set("load_balancer", elbname)
 	return nil
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/9952

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Remove pointer value dereferences, which can cause potential panics and are extraneous as `Set()` automatically handles pointer types including when `nil`.

Previously:

```
aws/resource_aws_proxy_protocol_policy.go:97:25: R002: ResourceData.Set() pointer value dereference is extraneous
```

Output from acceptance testing:

```
--- PASS: TestAccAWSProxyProtocolPolicy_basic (40.77s)
```
