### PR TITLE
resource/aws_route53_record: Fixes for tfproviderlint R002

### DIFF
--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -584,7 +584,7 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if record.MultiValueAnswer != nil {
-		if err := d.Set("multivalue_answer_routing_policy", *record.MultiValueAnswer); err != nil {
+		if err := d.Set("multivalue_answer_routing_policy", record.MultiValueAnswer); err != nil {
 			return fmt.Errorf("Error setting multivalue answer records for: %s, error: %#v", d.Id(), err)
 		}
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/9952

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Remove pointer value dereferences, which can cause potential panics and are extraneous as `Set()` automatically handles pointer types including when `nil`.

Previously:

```
aws/resource_aws_route53_record.go:587:55: R002: ResourceData.Set() pointer value dereference is extraneous
```

Output from acceptance testing:

```
--- PASS: TestAccAWSRoute53Record_Alias_Elb (211.82s)
--- PASS: TestAccAWSRoute53Record_Alias_S3 (160.72s)
--- PASS: TestAccAWSRoute53Record_Alias_Uppercase (123.68s)
--- PASS: TestAccAWSRoute53Record_Alias_VpcEndpoint (487.77s)
--- PASS: TestAccAWSRoute53Record_AliasChange (248.01s)
--- PASS: TestAccAWSRoute53Record_allowOverwrite (182.93s)
--- PASS: TestAccAWSRoute53Record_basic (207.48s)
--- PASS: TestAccAWSRoute53Record_basic_fqdn (226.89s)
--- PASS: TestAccAWSRoute53Record_caaSupport (147.38s)
--- PASS: TestAccAWSRoute53Record_disappears (131.77s)
--- PASS: TestAccAWSRoute53Record_disappears_MultipleRecords (224.92s)
--- PASS: TestAccAWSRoute53Record_empty (190.97s)
--- PASS: TestAccAWSRoute53Record_failover (212.86s)
--- PASS: TestAccAWSRoute53Record_generatesSuffix (147.38s)
--- PASS: TestAccAWSRoute53Record_geolocation_basic (227.35s)
--- PASS: TestAccAWSRoute53Record_latency_basic (148.07s)
--- PASS: TestAccAWSRoute53Record_longTXTrecord (206.77s)
--- PASS: TestAccAWSRoute53Record_multivalue_answer_basic (230.61s)
--- PASS: TestAccAWSRoute53Record_SetIdentifierChange (257.14s)
--- PASS: TestAccAWSRoute53Record_spfSupport (134.89s)
--- PASS: TestAccAWSRoute53Record_txtSupport (153.41s)
--- PASS: TestAccAWSRoute53Record_TypeChange (174.50s)
--- PASS: TestAccAWSRoute53Record_underscored (126.59s)
--- PASS: TestAccAWSRoute53Record_weighted_alias (258.50s)
--- PASS: TestAccAWSRoute53Record_weighted_basic (253.20s)
--- PASS: TestAccAWSRoute53Record_weighted_to_simple_basic (227.46s)
--- PASS: TestAccAWSRoute53Record_wildcard (283.88s)
```
