### PR TITLE
resource/aws_ses_receipt_rule: Fixes for tfproviderlint R002

### DIFF
--- a/aws/resource_aws_ses_receipt_rule.go
+++ b/aws/resource_aws_ses_receipt_rule.go
@@ -447,10 +447,10 @@ func resourceAwsSesReceiptRuleRead(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 
-	d.Set("enabled", *response.Rule.Enabled)
+	d.Set("enabled", response.Rule.Enabled)
 	d.Set("recipients", flattenStringList(response.Rule.Recipients))
-	d.Set("scan_enabled", *response.Rule.ScanEnabled)
-	d.Set("tls_policy", *response.Rule.TlsPolicy)
+	d.Set("scan_enabled", response.Rule.ScanEnabled)
+	d.Set("tls_policy", response.Rule.TlsPolicy)
 
 	addHeaderActionList := []map[string]interface{}{}
 	bounceActionList := []map[string]interface{}{}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/9952

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Remove pointer value dereferences, which can cause potential panics and are extraneous as `Set()` automatically handles pointer types including when `nil`.

Previously:

```
aws/resource_aws_ses_receipt_rule.go:450:19: R002: ResourceData.Set() pointer value dereference is extraneous
aws/resource_aws_ses_receipt_rule.go:452:24: R002: ResourceData.Set() pointer value dereference is extraneous
aws/resource_aws_ses_receipt_rule.go:453:22: R002: ResourceData.Set() pointer value dereference is extraneous
```

Output from acceptance testing:

```
--- PASS: TestAccAWSSESReceiptRule_actions (18.64s)
--- PASS: TestAccAWSSESReceiptRule_basic (19.07s)
--- PASS: TestAccAWSSESReceiptRule_order (22.13s)
--- PASS: TestAccAWSSESReceiptRule_s3Action (36.32s)
```