### PR TITLE
r/aws_ami: add plan time validations + add arn attribute

### DIFF
--- a/aws/data_source_aws_ami.go
+++ b/aws/data_source_aws_ami.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -21,6 +22,10 @@ func dataSourceAwsAmi() *schema.Resource {
 		Read: dataSourceAwsAmiRead,
 
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"filter": dataSourceFiltersSchema(),
 			"executable_users": {
 				Type:     schema.TypeList,
@@ -184,7 +189,6 @@ func dataSourceAwsAmi() *schema.Resource {
 // dataSourceAwsAmiDescriptionRead performs the AMI lookup.
 func dataSourceAwsAmiRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
-	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
 	params := &ec2.DescribeImagesInput{
 		Owners: expandStringList(d.Get("owners").([]interface{})),
@@ -210,13 +214,13 @@ func dataSourceAwsAmiRead(d *schema.ResourceData, meta interface{}) error {
 			// Check for a very rare case where the response would include no
 			// image name. No name means nothing to attempt a match against,
 			// therefore we are skipping such image.
-			if image.Name == nil || *image.Name == "" {
+			if image.Name == nil || aws.StringValue(image.Name) == "" {
 				log.Printf("[WARN] Unable to find AMI name to match against "+
 					"for image ID %q owned by %q, nothing to do.",
-					*image.ImageId, *image.OwnerId)
+					aws.StringValue(image.ImageId), aws.StringValue(image.OwnerId))
 				continue
 			}
-			if r.MatchString(*image.Name) {
+			if r.MatchString(aws.StringValue(image.Name)) {
 				filteredImages = append(filteredImages, image)
 			}
 		}
@@ -240,13 +244,15 @@ func dataSourceAwsAmiRead(d *schema.ResourceData, meta interface{}) error {
 		})
 	}
 
-	return amiDescriptionAttributes(d, filteredImages[0], ignoreTagsConfig)
+	return amiDescriptionAttributes(d, filteredImages[0], meta)
 }
 
 // populate the numerous fields that the image description returns.
-func amiDescriptionAttributes(d *schema.ResourceData, image *ec2.Image, ignoreTagsConfig *keyvaluetags.IgnoreConfig) error {
+func amiDescriptionAttributes(d *schema.ResourceData, image *ec2.Image, meta interface{}) error {
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
 	// Simple attributes first
-	d.SetId(*image.ImageId)
+	d.SetId(aws.StringValue(image.ImageId))
 	d.Set("architecture", image.Architecture)
 	d.Set("creation_date", image.CreationDate)
 	if image.Description != nil {
@@ -294,6 +300,16 @@ func amiDescriptionAttributes(d *schema.ResourceData, image *ec2.Image, ignoreTa
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(image.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
+
+	imageArn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Region:    meta.(*AWSClient).region,
+		Resource:  fmt.Sprintf("image/%s", d.Id()),
+		Service:   "ec2",
+	}.String()
+
+	d.Set("arn", imageArn)
+
 	return nil
 }
 
@@ -348,11 +364,12 @@ func amiRootSnapshotId(image *ec2.Image) string {
 		return ""
 	}
 	for _, bdm := range image.BlockDeviceMappings {
-		if bdm.DeviceName == nil || *bdm.DeviceName != *image.RootDeviceName {
+		if bdm.DeviceName == nil ||
+			aws.StringValue(bdm.DeviceName) != aws.StringValue(image.RootDeviceName) {
 			continue
 		}
 		if bdm.Ebs != nil && bdm.Ebs.SnapshotId != nil {
-			return *bdm.Ebs.SnapshotId
+			return aws.StringValue(bdm.Ebs.SnapshotId)
 		}
 	}
 	return ""

--- a/aws/data_source_aws_ami_test.go
+++ b/aws/data_source_aws_ami_test.go
@@ -26,6 +26,7 @@ func TestAccAWSAmiDataSource_natInstance(t *testing.T) {
 					// deep inspection is not included, simply the count is checked.
 					// Tags and product codes may need more testing, but I'm having a hard time finding images with
 					// these attributes set.
+					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "ec2", regexp.MustCompile(`image/ami-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "architecture", "x86_64"),
 					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.#", "1"),
 					resource.TestMatchResourceAttr(resourceName, "creation_date", regexp.MustCompile("^20[0-9]{2}-")),

--- a/aws/resource_aws_ami.go
+++ b/aws/resource_aws_ami.go
@@ -215,10 +215,10 @@ func resourceAwsAmi() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
-				Default:  "paravirtual",
+				Default:  ec2.VirtualizationTypeParavirtual,
 				ValidateFunc: validation.StringInSlice([]string{
-					"paravirtual",
-					"hvm",
+					ec2.VirtualizationTypeParavirtual,
+					ec2.VirtualizationTypeHvm,
 				}, false),
 			},
 			"arn": {
@@ -332,8 +332,7 @@ func resourceAwsAmiRead(d *schema.ResourceData, meta interface{}) error {
 				if d.IsNewResource() {
 					return resource.RetryableError(err)
 				}
-
-				log.Printf("[DEBUG] %s no longer exists, so we'll drop it from the state", id)
+				log.Printf("[WARN] AMI (%s) not found, removing from state", d.Id())
 				d.SetId("")
 				return nil
 			}
@@ -350,6 +349,7 @@ func resourceAwsAmiRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if len(res.Images) != 1 {
+		log.Printf("[WARN] AMI (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
@@ -371,6 +371,7 @@ func resourceAwsAmiRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if state == ec2.ImageStateDeregistered {
+		log.Printf("[WARN] AMI (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}

--- a/aws/resource_aws_ami.go
+++ b/aws/resource_aws_ami.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ec2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
@@ -220,6 +221,10 @@ func resourceAwsAmi() *schema.Resource {
 					"hvm",
 				}, false),
 			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -385,6 +390,15 @@ func resourceAwsAmiRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("sriov_net_support", image.SriovNetSupport)
 	d.Set("virtualization_type", image.VirtualizationType)
 	d.Set("ena_support", image.EnaSupport)
+
+	imageArn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Region:    meta.(*AWSClient).region,
+		Resource:  fmt.Sprintf("image/%s", d.Id()),
+		Service:   "ec2",
+	}.String()
+
+	d.Set("arn", imageArn)
 
 	var ebsBlockDevs []map[string]interface{}
 	var ephemeralBlockDevs []map[string]interface{}

--- a/aws/resource_aws_ami.go
+++ b/aws/resource_aws_ami.go
@@ -9,12 +9,12 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
@@ -56,7 +56,12 @@ func resourceAwsAmi() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
-				Default:  "x86_64",
+				Default:  ec2.ArchitectureTypeX8664,
+				ValidateFunc: validation.StringInSlice([]string{
+					ec2.ArchitectureTypeX8664,
+					ec2.ArchitectureValuesI386,
+					ec2.ArchitectureValuesArm64,
+				}, false),
 			},
 			"description": {
 				Type:     schema.TypeString,
@@ -116,7 +121,14 @@ func resourceAwsAmi() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							ForceNew: true,
-							Default:  "standard",
+							Default:  ec2.VolumeTypeStandard,
+							ValidateFunc: validation.StringInSlice([]string{
+								ec2.VolumeTypeStandard,
+								ec2.VolumeTypeIo1,
+								ec2.VolumeTypeGp2,
+								ec2.VolumeTypeSc1,
+								ec2.VolumeTypeSt1,
+							}, false),
 						},
 					},
 				},
@@ -203,6 +215,10 @@ func resourceAwsAmi() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				Default:  "paravirtual",
+				ValidateFunc: validation.StringInSlice([]string{
+					"paravirtual",
+					"hvm",
+				}, false),
 			},
 		},
 	}
@@ -336,7 +352,7 @@ func resourceAwsAmiRead(d *schema.ResourceData, meta interface{}) error {
 	image := res.Images[0]
 	state := *image.State
 
-	if state == "pending" {
+	if state == ec2.ImageStatePending {
 		// This could happen if a user manually adds an image we didn't create
 		// to the state. We'll wait for the image to become available
 		// before we continue. We should never take this branch in normal
@@ -349,12 +365,12 @@ func resourceAwsAmiRead(d *schema.ResourceData, meta interface{}) error {
 		state = *image.State
 	}
 
-	if state == "deregistered" {
+	if state == ec2.ImageStateDeregistered {
 		d.SetId("")
 		return nil
 	}
 
-	if state != "available" {
+	if state != ec2.ImageStateAvailable {
 		return fmt.Errorf("AMI has become %s", state)
 	}
 
@@ -488,7 +504,7 @@ func AMIStateRefreshFunc(client *ec2.EC2, id string) resource.StateRefreshFunc {
 
 		resp, err := client.DescribeImages(&ec2.DescribeImagesInput{ImageIds: []*string{aws.String(id)}})
 		if err != nil {
-			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidAMIID.NotFound" {
+			if isAWSErr(err, "InvalidAMIID.NotFound", "") {
 				return emptyResp, "destroyed", nil
 			} else if resp != nil && len(resp.Images) == 0 {
 				return emptyResp, "destroyed", nil
@@ -510,7 +526,7 @@ func resourceAwsAmiWaitForDestroy(timeout time.Duration, id string, client *ec2.
 	log.Printf("Waiting for AMI %s to be deleted...", id)
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"available", "pending", "failed"},
+		Pending:    []string{ec2.ImageStateAvailable, ec2.ImageStatePending, ec2.ImageStateFailed},
 		Target:     []string{"destroyed"},
 		Refresh:    AMIStateRefreshFunc(client, id),
 		Timeout:    timeout,
@@ -530,8 +546,8 @@ func resourceAwsAmiWaitForAvailable(timeout time.Duration, id string, client *ec
 	log.Printf("Waiting for AMI %s to become available...", id)
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"pending"},
-		Target:     []string{"available"},
+		Pending:    []string{ec2.ImageStatePending},
+		Target:     []string{ec2.ImageStateAvailable},
 		Refresh:    AMIStateRefreshFunc(client, id),
 		Timeout:    timeout,
 		Delay:      AWSAMIRetryDelay,

--- a/aws/resource_aws_ami_copy.go
+++ b/aws/resource_aws_ami_copy.go
@@ -182,6 +182,10 @@ func resourceAwsAmiCopy() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 
 		// The remaining operations are shared with the generic aws_ami resource,

--- a/aws/resource_aws_ami_from_instance.go
+++ b/aws/resource_aws_ami_from_instance.go
@@ -169,6 +169,10 @@ func resourceAwsAmiFromInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 
 		// The remaining operations are shared with the generic aws_ami resource,

--- a/aws/resource_aws_ami_from_instance_test.go
+++ b/aws/resource_aws_ami_from_instance_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -25,6 +26,7 @@ func TestAccAWSAMIFromInstance_basic(t *testing.T) {
 				Config: testAccAWSAMIFromInstanceConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAMIFromInstanceExists(resourceName, &image),
+					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "ec2", regexp.MustCompile(`image/ami-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "description", "Testing Terraform aws_ami_from_instance resource"),
 				),
 			},

--- a/aws/resource_aws_ami_test.go
+++ b/aws/resource_aws_ami_test.go
@@ -30,6 +30,7 @@ func TestAccAWSAMI_basic(t *testing.T) {
 					testAccCheckAmiExists(resourceName, &ami),
 					resource.TestCheckResourceAttr(resourceName, "ena_support", "true"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "ec2", regexp.MustCompile(`image/ami-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "root_device_name", "/dev/sda1"),
 					resource.TestCheckResourceAttr(resourceName, "virtualization_type", "hvm"),
 					resource.TestMatchResourceAttr(resourceName, "root_snapshot_id", regexp.MustCompile("^snap-")),
@@ -394,7 +395,7 @@ resource "aws_ami" "test" {
   name                = %[1]q
   root_device_name    = "/dev/sda1"
   virtualization_type = "hvm"
-  description         = %[1]q
+  description         = %[2]q
 
   ebs_block_device {
     device_name = "/dev/sda1"

--- a/aws/resource_aws_ami_test.go
+++ b/aws/resource_aws_ami_test.go
@@ -101,7 +101,7 @@ func TestAccAWSAMI_disappears(t *testing.T) {
 				Config: testAccAmiConfigBasic(rName, 8),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAmiExists(resourceName, &ami),
-					testAccCheckAmiDisappears(&ami),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsAmi(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -225,20 +225,6 @@ func testAccCheckAmiDestroy(s *terraform.State) error {
 		}
 	}
 	return nil
-}
-
-func testAccCheckAmiDisappears(image *ec2.Image) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).ec2conn
-
-		input := &ec2.DeregisterImageInput{
-			ImageId: image.ImageId,
-		}
-
-		_, err := conn.DeregisterImage(input)
-
-		return err
-	}
 }
 
 func testAccCheckAmiExists(n string, ami *ec2.Image) resource.TestCheckFunc {

--- a/aws/resource_aws_launch_configuration_test.go
+++ b/aws/resource_aws_launch_configuration_test.go
@@ -170,7 +170,7 @@ func TestAccAWSLaunchConfiguration_RootBlockDevice_AmiDisappears(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLaunchConfigurationExists(resourceName, &conf),
 					testAccCheckAmiExists(amiCopyResourceName, &ami),
-					testAccCheckResourceDisappears(testAccProvider, resourceAwsAmi(), resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsAmi(), amiCopyResourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/aws/resource_aws_launch_configuration_test.go
+++ b/aws/resource_aws_launch_configuration_test.go
@@ -170,7 +170,7 @@ func TestAccAWSLaunchConfiguration_RootBlockDevice_AmiDisappears(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLaunchConfigurationExists(resourceName, &conf),
 					testAccCheckAmiExists(amiCopyResourceName, &ami),
-					testAccCheckAmiDisappears(&ami),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsAmi(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/website/docs/d/ami.html.markdown
+++ b/website/docs/d/ami.html.markdown
@@ -70,6 +70,7 @@ are exported:
 ~> **NOTE:** Some values are not always set and may not be available for
 interpolation.
 
+* `arn` - The ARN of the AMI.
 * `architecture` - The OS architecture of the AMI (ie: `i386` or `x86_64`).
 * `block_device_mappings` - The block device mappings of the AMI.
   * `block_device_mappings.#.device_name` - The physical name of the device.

--- a/website/docs/d/ami.html.markdown
+++ b/website/docs/d/ami.html.markdown
@@ -3,7 +3,7 @@ subcategory: "EC2"
 layout: "aws"
 page_title: "AWS: aws_ami"
 description: |-
-  Get information on a Amazon Machine Image (AMI).
+  Get information on an Amazon Machine Image (AMI).
 ---
 
 # Data Source: aws_ami

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -222,7 +222,7 @@ for more information about connecting to alternate AWS endpoints or AWS compatib
   API, or metadata API.  When set to `true` and not determined previously,
   returns an empty account ID when manually constructing ARN attributes with
   the following:
-  - [`aws_ami` data source](/docs/providers/aws/d/aws_ami.html)  
+  - [`aws_ami` data source](/docs/providers/aws/d/ami.html)  
   - [`aws_ami` resource](/docs/providers/aws/r/ami.html)
   - [`aws_ami_copy` resource](/docs/providers/aws/r/ami_copy.html)
   - [`aws_ami_from_instance` resource](/docs/providers/aws/r/ami_from_instance.html)  

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -222,6 +222,7 @@ for more information about connecting to alternate AWS endpoints or AWS compatib
   API, or metadata API.  When set to `true` and not determined previously,
   returns an empty account ID when manually constructing ARN attributes with
   the following:
+  - [`aws_ami` data source](/docs/providers/aws/d/aws_ami.html)  
   - [`aws_ami` resource](/docs/providers/aws/r/ami.html)
   - [`aws_ami_copy` resource](/docs/providers/aws/r/ami_copy.html)
   - [`aws_ami_from_instance` resource](/docs/providers/aws/r/ami_from_instance.html)  

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -222,6 +222,9 @@ for more information about connecting to alternate AWS endpoints or AWS compatib
   API, or metadata API.  When set to `true` and not determined previously,
   returns an empty account ID when manually constructing ARN attributes with
   the following:
+  - [`aws_ami` resource](/docs/providers/aws/r/ami.html)
+  - [`aws_ami_copy` resource](/docs/providers/aws/r/ami_copy.html)
+  - [`aws_ami_from_instance` resource](/docs/providers/aws/r/ami_from_instance.html)  
   - [`aws_api_gateway_deployment` resource](/docs/providers/aws/r/api_gateway_deployment.html)
   - [`aws_api_gateway_rest_api` resource](/docs/providers/aws/r/api_gateway_rest_api.html)
   - [`aws_api_gateway_stage` resource](/docs/providers/aws/r/api_gateway_stage.html)

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -222,10 +222,6 @@ for more information about connecting to alternate AWS endpoints or AWS compatib
   API, or metadata API.  When set to `true` and not determined previously,
   returns an empty account ID when manually constructing ARN attributes with
   the following:
-  - [`aws_ami` data source](/docs/providers/aws/d/ami.html)  
-  - [`aws_ami` resource](/docs/providers/aws/r/ami.html)
-  - [`aws_ami_copy` resource](/docs/providers/aws/r/ami_copy.html)
-  - [`aws_ami_from_instance` resource](/docs/providers/aws/r/ami_from_instance.html)  
   - [`aws_api_gateway_deployment` resource](/docs/providers/aws/r/api_gateway_deployment.html)
   - [`aws_api_gateway_rest_api` resource](/docs/providers/aws/r/api_gateway_rest_api.html)
   - [`aws_api_gateway_stage` resource](/docs/providers/aws/r/api_gateway_stage.html)

--- a/website/docs/r/ami.html.markdown
+++ b/website/docs/r/ami.html.markdown
@@ -108,6 +108,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - The ARN of the AMI.
 * `id` - The ID of the created AMI.
 * `root_snapshot_id` - The Snapshot ID for the root volume (for EBS-backed AMIs)
 

--- a/website/docs/r/ami_copy.html.markdown
+++ b/website/docs/r/ami_copy.html.markdown
@@ -62,6 +62,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - The ARN of the AMI.
 * `id` - The ID of the created AMI.
 
 This resource also exports a full set of attributes corresponding to the arguments of the

--- a/website/docs/r/ami_from_instance.html.markdown
+++ b/website/docs/r/ami_from_instance.html.markdown
@@ -59,6 +59,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - The ARN of the AMI.
 * `id` - The ID of the created AMI.
 
 This resource also exports a full set of attributes corresponding to the arguments of the


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13624, #13527


Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_ami: add plan time validations to `architecture`, `volume_type` and `virtualization_type`
resource_aws_ami: add `arn` attribute
resource_aws_ami_copy: add `arn` attribute
resource_aws_ami_from_instance: add `arn` attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSAMI_'
--- PASS: TestAccAWSAMI_basic (92.43s)
--- PASS: TestAccAWSAMI_tags (155.92s)
--- PASS: TestAccAWSAMI_snapshotSize (91.46s)
--- PASS: TestAccAWSAMI_description (171.45s)
```

```
$ make testacc TESTARGS='-run=TestAccAWSAMICopy_'
--- PASS: TestAccAWSAMICopy_EnaSupport (398.66s)
--- PASS: TestAccAWSAMICopy_tags (475.28s)
--- PASS: TestAccAWSAMICopy_Description (430.44s)
--- PASS: TestAccAWSAMICopy_basic (422.77s)
```

```
$ make testacc TESTARGS='-run=TestAccAWSAMIFromInstance_'
--- PASS: TestAccAWSAMIFromInstance_basic (454.10s)
--- PASS: TestAccAWSAMIFromInstance_tags (294.29s)
```

$ make testacc TESTARGS='-run=TestAccAWSAmiDataSource_natInstance'
--- PASS: TestAccAWSAmiDataSource_natInstance (49.88s)
```