### PR TITLE
Fix LB update subnets acceptance test

### DIFF
--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -1254,7 +1254,7 @@ resource "aws_lb" "lb_test" {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
+  subnets         = "${aws_subnet.alb_test.*.id}"
 
   idle_timeout               = 30
   enable_deletion_protection = false
@@ -1323,7 +1323,7 @@ resource "aws_lb" "lb_test" {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
+  subnets         = "${aws_subnet.alb_test.*.id}"
 
   idle_timeout               = 30
   enable_deletion_protection = false
@@ -1394,7 +1394,7 @@ resource "aws_lb" "lb_test" {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
+  subnets         = "${aws_subnet.alb_test.*.id}"
 
   idle_timeout               = 30
   enable_deletion_protection = %t
@@ -1630,7 +1630,7 @@ resource "aws_alb" "lb_test" {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
+  subnets         = "${aws_subnet.alb_test.*.id}"
 
   idle_timeout               = 30
   enable_deletion_protection = false
@@ -1699,7 +1699,7 @@ resource "aws_lb" "lb_test" {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}", "${aws_subnet.alb_test.*.id[2]}"]
+  subnets         = "${aws_subnet.alb_test.*.id}"
 
   idle_timeout               = 30
   enable_deletion_protection = false
@@ -1767,7 +1767,7 @@ func testAccAWSLBConfig_generatedName() string {
 resource "aws_lb" "lb_test" {
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
+  subnets         = "${aws_subnet.alb_test.*.id}"
 
   idle_timeout = 30
   enable_deletion_protection = false
@@ -1843,7 +1843,7 @@ resource "aws_lb" "lb_test" {
   name            = ""
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
+  subnets         = "${aws_subnet.alb_test.*.id}"
 
   idle_timeout = 30
   enable_deletion_protection = false
@@ -1924,7 +1924,7 @@ resource "aws_lb" "lb_test" {
   name_prefix     = "tf-lb-"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
+  subnets         = "${aws_subnet.alb_test.*.id}"
 
   idle_timeout = 30
   enable_deletion_protection = false
@@ -1991,7 +1991,7 @@ resource "aws_lb" "lb_test" {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
+  subnets         = "${aws_subnet.alb_test.*.id}"
 
   idle_timeout = 30
   enable_deletion_protection = false
@@ -2069,7 +2069,7 @@ resource "aws_vpc" "test" {
   }
 }
 
-resource "aws_subnet" "test" {
+resource "aws_subnet" "alb_test" {
   count = 2
 
   availability_zone = "${element(data.aws_availability_zones.available.names, count.index)}"
@@ -2111,7 +2111,7 @@ func testAccAWSLBConfigALBAccessLogs(enabled bool, lbName, bucketName, bucketPre
 resource "aws_lb" "test" {
   internal = true
   name     = %[1]q
-  subnets  = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
+  subnets  = "${aws_subnet.alb_test.*.id}"
 
   access_logs {
     bucket  = "${aws_s3_bucket_policy.test.bucket}"
@@ -2127,7 +2127,7 @@ func testAccAWSLBConfigALBAccessLogsNoBlocks(lbName, bucketName string) string {
 resource "aws_lb" "test" {
   internal = true
   name     = %[1]q
-  subnets  = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
+  subnets  = "${aws_subnet.alb_test.*.id}"
 }
 `, lbName)
 }
@@ -2146,7 +2146,7 @@ resource "aws_vpc" "test" {
   }
 }
 
-resource "aws_subnet" "test" {
+resource "aws_subnet" "alb_test" {
   count = 2
 
   availability_zone = "${element(data.aws_availability_zones.available.names, count.index)}"
@@ -2200,7 +2200,7 @@ resource "aws_lb" "test" {
   internal           = true
   load_balancer_type = "network"
   name               = %[1]q
-  subnets            = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
+  subnets            = "${aws_subnet.alb_test.*.id}"
 
   access_logs {
     bucket  = "${aws_s3_bucket_policy.test.bucket}"
@@ -2217,7 +2217,7 @@ resource "aws_lb" "test" {
   internal           = true
   load_balancer_type = "network"
   name               = %[1]q
-  subnets            = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
+  subnets            = "${aws_subnet.alb_test.*.id}"
 }
 `, lbName)
 }
@@ -2227,7 +2227,7 @@ func testAccAWSLBConfig_nosg(lbName string) string {
 resource "aws_lb" "lb_test" {
   name     = "%s"
   internal = true
-  subnets  = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
+  subnets  = "${aws_subnet.alb_test.*.id}"
 
   idle_timeout               = 30
   enable_deletion_protection = false
@@ -2272,7 +2272,7 @@ resource "aws_lb" "lb_test" {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}", "${aws_security_group.alb_test_2.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
+  subnets         = "${aws_subnet.alb_test.*.id}"
 
   idle_timeout               = 30
   enable_deletion_protection = false

--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -1699,7 +1699,7 @@ resource "aws_lb" "lb_test" {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
+  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}", "${aws_subnet.alb_test.*.id[2]}"]
 
   idle_timeout               = 30
   enable_deletion_protection = false


### PR DESCRIPTION
Was previously getting

```
--- FAIL: TestAccAWSLB_updatedSubnets (206.14s)
    testing.go:640: Step 1 error: Check failed: 1 error occurred:
        	* Check 2/3 error: aws_lb.lb_test: Attribute 'subnets.#' expected "3", got "2"
```

because only two subnets were assigned.

Results of acceptance tests after change:

```
$ make testacc TESTARGS='-run=TestAccAWSLB_'

--- PASS: TestAccAWSLB_NLB_basic (205.30s)
--- PASS: TestAccAWSLB_generatedName (207.76s)
--- PASS: TestAccAWSLB_networkLoadbalancer_subnet_change (215.66s)
--- PASS: TestAccAWSLB_namePrefix (237.94s)
--- PASS: TestAccAWSLB_updatedIpAddressType (239.22s)
--- PASS: TestAccAWSLB_ALB_basic (245.85s)
--- PASS: TestAccAWSLB_updatedSecurityGroups (256.26s)
--- PASS: TestAccAWSLB_noSecurityGroup (266.93s)
--- PASS: TestAccAWSLB_generatesNameForZeroValue (280.44s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateHttp2 (288.46s)
--- PASS: TestAccAWSLB_networkLoadbalancerEIP (289.66s)
--- PASS: TestAccAWSLB_tags (294.91s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateDeletionProtection (299.42s)
--- PASS: TestAccAWSLB_ALB_AccessLogs_Prefix (305.55s)
--- PASS: TestAccAWSLB_networkLoadbalancer_updateCrossZone (336.78s)
--- PASS: TestAccAWSLB_updatedSubnets (337.58s)
--- PASS: TestAccAWSLB_ALB_AccessLogs (357.73s)
--- PASS: TestAccAWSLB_NLB_AccessLogs_Prefix (365.96s)
--- PASS: TestAccAWSLB_NLB_AccessLogs (397.89s)
```

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
