### PR TITLE
S3 bucket names for sweeper

### DIFF
--- a/aws/data_source_aws_redshift_cluster_test.go
+++ b/aws/data_source_aws_redshift_cluster_test.go
@@ -70,7 +70,7 @@ func TestAccAWSDataSourceRedshiftCluster_logging(t *testing.T) {
 				Config: testAccAWSDataSourceRedshiftClusterConfigWithLogging(rInt),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_redshift_cluster.test", "enable_logging", "true"),
-					resource.TestCheckResourceAttr("data.aws_redshift_cluster.test", "bucket_name", fmt.Sprintf("tf-redshift-logging-%d", rInt)),
+					resource.TestCheckResourceAttr("data.aws_redshift_cluster.test", "bucket_name", fmt.Sprintf("tf-test-redshift-logging-%d", rInt)),
 					resource.TestCheckResourceAttr("data.aws_redshift_cluster.test", "s3_key_prefix", "cluster-logging/"),
 				),
 			},
@@ -151,7 +151,7 @@ func testAccAWSDataSourceRedshiftClusterConfigWithLogging(rInt int) string {
 data "aws_redshift_service_account" "test" {}
 
 resource "aws_s3_bucket" "test" {
-  bucket        = "tf-redshift-logging-%[1]d"
+  bucket        = "tf-test-redshift-logging-%[1]d"
   force_destroy = true
 }
 

--- a/aws/resource_aws_athena_database_test.go
+++ b/aws/resource_aws_athena_database_test.go
@@ -136,7 +136,7 @@ func testAccCheckAWSAthenaDatabaseDestroy(s *terraform.State) error {
 		}
 
 		rInt := acctest.RandInt()
-		bucketName := fmt.Sprintf("tf-athena-db-%d", rInt)
+		bucketName := fmt.Sprintf("tf-test-athena-db-%d", rInt)
 		_, err := s3conn.CreateBucket(&s3.CreateBucketInput{
 			Bucket: aws.String(bucketName),
 		})
@@ -333,7 +333,7 @@ func testAccAthenaDatabaseFindBucketName(s *terraform.State, dbName string) (buc
 func testAccAthenaDatabaseConfig(randInt int, dbName string, forceDestroy bool) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "hoge" {
-  bucket        = "tf-athena-db-%[1]d"
+  bucket        = "tf-test-athena-db-%[1]d"
   force_destroy = true
 }
 
@@ -352,7 +352,7 @@ resource "aws_kms_key" "hoge" {
 }
 
 resource "aws_s3_bucket" "hoge" {
-  bucket        = "tf-athena-db-%[1]d"
+  bucket        = "tf-test-athena-db-%[1]d"
   force_destroy = true
 
   server_side_encryption_configuration {

--- a/aws/resource_aws_athena_named_query_test.go
+++ b/aws/resource_aws_athena_named_query_test.go
@@ -103,7 +103,7 @@ func testAccCheckAWSAthenaNamedQueryExists(name string) resource.TestCheckFunc {
 func testAccAthenaNamedQueryConfig(rInt int, rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
-  bucket        = "tf-athena-db-%s-%d"
+  bucket        = "tf-test-athena-db-%s-%d"
   force_destroy = true
 }
 
@@ -124,7 +124,7 @@ resource "aws_athena_named_query" "test" {
 func testAccAthenaNamedWorkGroupQueryConfig(rInt int, rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
-  bucket        = "tf-athena-db-%s-%d"
+  bucket        = "tf-test-athena-db-%s-%d"
   force_destroy = true
 }
 

--- a/aws/resource_aws_elastic_transcoder_pipeline_test.go
+++ b/aws/resource_aws_elastic_transcoder_pipeline_test.go
@@ -383,17 +383,17 @@ EOF
 }
 
 resource "aws_s3_bucket" "content_bucket" {
-  bucket = "tf-pipeline-content-%d"
+  bucket = "tf-test-pipeline-content-%d"
   acl    = "private"
 }
 
 resource "aws_s3_bucket" "input_bucket" {
-  bucket = "tf-pipeline-input-%d"
+  bucket = "tf-test-pipeline-input-%d"
   acl    = "private"
 }
 
 resource "aws_s3_bucket" "thumb_bucket" {
-  bucket = "tf-pipeline-thumb-%d"
+  bucket = "tf-test-pipeline-thumb-%d"
   acl    = "private"
 }
 `, rInt, rInt, rInt, rInt, rInt)
@@ -438,17 +438,17 @@ EOF
 }
 
 resource "aws_s3_bucket" "content_bucket" {
-  bucket = "tf-pipeline-content-%d"
+  bucket = "tf-test-pipeline-content-%d"
   acl    = "private"
 }
 
 resource "aws_s3_bucket" "input_bucket" {
-  bucket = "tf-pipeline-input-%d"
+  bucket = "tf-test-pipeline-input-%d"
   acl    = "private"
 }
 
 resource "aws_s3_bucket" "thumb_bucket" {
-  bucket = "tf-pipeline-thumb-%d"
+  bucket = "tf-test-pipeline-thumb-%d"
   acl    = "private"
 }
 `, rInt, rInt, rInt, rInt, rInt)
@@ -505,7 +505,7 @@ EOF
 }
 
 resource "aws_s3_bucket" "content_bucket" {
-  bucket = "tf-transcoding-pipe-%d"
+  bucket = "tf-test-transcoding-pipe-%d"
   acl    = "private"
 }
 `, rInt, rInt, rInt)
@@ -516,7 +516,7 @@ func awsElasticTranscoderNotifications(r int) string {
 resource "aws_elastictranscoder_pipeline" "bar" {
   input_bucket  = "${aws_s3_bucket.test_bucket.bucket}"
   output_bucket = "${aws_s3_bucket.test_bucket.bucket}"
-  name          = "tf-transcoder-%d"
+  name          = "tf-test-transcoder-%d"
   role          = "${aws_iam_role.test_role.arn}"
 
   notifications {
@@ -526,7 +526,7 @@ resource "aws_elastictranscoder_pipeline" "bar" {
 }
 
 resource "aws_iam_role" "test_role" {
-  name = "tf-transcoder-%d"
+  name = "tf-test-transcoder-%d"
 
   assume_role_policy = <<EOF
 {
@@ -546,12 +546,12 @@ EOF
 }
 
 resource "aws_s3_bucket" "test_bucket" {
-  bucket = "tf-transcoder-%d"
+  bucket = "tf-test-transcoder-%d"
   acl    = "private"
 }
 
 resource "aws_sns_topic" "topic_example" {
-  name = "tf-transcoder-%d"
+  name = "tf-test-transcoder-%d"
 
   policy = <<EOF
 {
@@ -577,7 +577,7 @@ func awsElasticTranscoderNotifications_update(r int) string {
 resource "aws_elastictranscoder_pipeline" "bar" {
   input_bucket  = "${aws_s3_bucket.test_bucket.bucket}"
   output_bucket = "${aws_s3_bucket.test_bucket.bucket}"
-  name          = "tf-transcoder-%d"
+  name          = "tf-test-transcoder-%d"
   role          = "${aws_iam_role.test_role.arn}"
 
   notifications {
@@ -586,7 +586,7 @@ resource "aws_elastictranscoder_pipeline" "bar" {
 }
 
 resource "aws_iam_role" "test_role" {
-  name = "tf-transcoder-%d"
+  name = "tf-test-transcoder-%d"
 
   assume_role_policy = <<EOF
 {
@@ -606,12 +606,12 @@ EOF
 }
 
 resource "aws_s3_bucket" "test_bucket" {
-  bucket = "tf-transcoder-%d"
+  bucket = "tf-test-transcoder-%d"
   acl    = "private"
 }
 
 resource "aws_sns_topic" "topic_example" {
-  name = "tf-transcoder-%d"
+  name = "tf-test-transcoder-%d"
 
   policy = <<EOF
 {

--- a/aws/resource_aws_globalaccelerator_accelerator_test.go
+++ b/aws/resource_aws_globalaccelerator_accelerator_test.go
@@ -330,7 +330,7 @@ resource "aws_globalaccelerator_accelerator" "example" {
 func testAccGlobalAcceleratorAccelerator_attributes(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "example" {
-  bucket_prefix = "tf-globalaccelerator-accelerator-"
+  bucket_prefix = "tf-test-globalaccelerator-"
 }
 
 resource "aws_globalaccelerator_accelerator" "example" {

--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -580,7 +580,7 @@ func TestAccAWSLB_noSecurityGroup(t *testing.T) {
 
 func TestAccAWSLB_ALB_AccessLogs(t *testing.T) {
 	var conf elbv2.LoadBalancer
-	bucketName := fmt.Sprintf("testaccawslbaccesslogs-%s", acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum))
+	bucketName := fmt.Sprintf("tf-test-access-logs-%s", acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum))
 	lbName := fmt.Sprintf("testaccawslbaccesslog-%s", acctest.RandStringFromCharSet(4, acctest.CharSetAlpha))
 	resourceName := "aws_lb.test"
 
@@ -668,7 +668,7 @@ func TestAccAWSLB_ALB_AccessLogs(t *testing.T) {
 
 func TestAccAWSLB_ALB_AccessLogs_Prefix(t *testing.T) {
 	var conf elbv2.LoadBalancer
-	bucketName := fmt.Sprintf("testaccawslbaccesslogs-%s", acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum))
+	bucketName := fmt.Sprintf("tf-test-access-logs-%s", acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum))
 	lbName := fmt.Sprintf("testaccawslbaccesslog-%s", acctest.RandStringFromCharSet(4, acctest.CharSetAlpha))
 	resourceName := "aws_lb.test"
 
@@ -738,7 +738,7 @@ func TestAccAWSLB_ALB_AccessLogs_Prefix(t *testing.T) {
 
 func TestAccAWSLB_NLB_AccessLogs(t *testing.T) {
 	var conf elbv2.LoadBalancer
-	bucketName := fmt.Sprintf("testaccawslbaccesslogs-%s", acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum))
+	bucketName := fmt.Sprintf("tf-test-access-logs-%s", acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum))
 	lbName := fmt.Sprintf("testaccawslbaccesslog-%s", acctest.RandStringFromCharSet(4, acctest.CharSetAlpha))
 	resourceName := "aws_lb.test"
 
@@ -826,7 +826,7 @@ func TestAccAWSLB_NLB_AccessLogs(t *testing.T) {
 
 func TestAccAWSLB_NLB_AccessLogs_Prefix(t *testing.T) {
 	var conf elbv2.LoadBalancer
-	bucketName := fmt.Sprintf("testaccawslbaccesslogs-%s", acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum))
+	bucketName := fmt.Sprintf("tf-test-access-logs-%s", acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum))
 	lbName := fmt.Sprintf("testaccawslbaccesslog-%s", acctest.RandStringFromCharSet(4, acctest.CharSetAlpha))
 	resourceName := "aws_lb.test"
 

--- a/aws/resource_aws_macie_s3_bucket_association_test.go
+++ b/aws/resource_aws_macie_s3_bucket_association_test.go
@@ -160,7 +160,7 @@ func testAccPreCheckAWSMacie(t *testing.T) {
 func testAccAWSMacieS3BucketAssociationConfig_basic(randInt int) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
-  bucket = "tf-macie-test-bucket-%d"
+  bucket = "tf-test-macie-bucket-%d"
 }
 
 resource "aws_macie_s3_bucket_association" "test" {
@@ -172,7 +172,7 @@ resource "aws_macie_s3_bucket_association" "test" {
 func testAccAWSMacieS3BucketAssociationConfig_basicOneTime(randInt int) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
-  bucket = "tf-macie-test-bucket-%d"
+  bucket = "tf-test-macie-bucket-%d"
 }
 
 resource "aws_macie_s3_bucket_association" "test" {
@@ -188,7 +188,7 @@ resource "aws_macie_s3_bucket_association" "test" {
 func testAccAWSMacieS3BucketAssociationConfig_accountIdAndPrefix(randInt int) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
-  bucket = "tf-macie-test-bucket-%d"
+  bucket = "tf-test-macie-bucket-%d"
 }
 
 data "aws_caller_identity" "current" {}
@@ -204,7 +204,7 @@ resource "aws_macie_s3_bucket_association" "test" {
 func testAccAWSMacieS3BucketAssociationConfig_accountIdAndPrefixOneTime(randInt int) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
-  bucket = "tf-macie-test-bucket-%d"
+  bucket = "tf-test-macie-bucket-%d"
 }
 
 data "aws_caller_identity" "current" {}

--- a/aws/resource_aws_redshift_cluster_test.go
+++ b/aws/resource_aws_redshift_cluster_test.go
@@ -256,7 +256,7 @@ func TestAccAWSRedshiftCluster_loggingEnabled(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_redshift_cluster.default", "logging.0.enable", "true"),
 					resource.TestCheckResourceAttr(
-						"aws_redshift_cluster.default", "logging.0.bucket_name", fmt.Sprintf("tf-redshift-logging-%d", rInt)),
+						"aws_redshift_cluster.default", "logging.0.bucket_name", fmt.Sprintf("tf-test-redshift-logging-%d", rInt)),
 				),
 			},
 			{
@@ -1153,7 +1153,7 @@ func testAccAWSRedshiftClusterConfig_loggingEnabled(rInt int) string {
 data "aws_redshift_service_account" "main" {}
 
 resource "aws_s3_bucket" "bucket" {
-  bucket        = "tf-redshift-logging-%d"
+  bucket        = "tf-test-redshift-logging-%d"
   force_destroy = true
 
   policy = <<EOF
@@ -1167,7 +1167,7 @@ resource "aws_s3_bucket" "bucket" {
 			 "AWS": "${data.aws_redshift_service_account.main.arn}"
 		 },
 		 "Action": "s3:PutObject",
-		 "Resource": "arn:aws:s3:::tf-redshift-logging-%d/*"
+		 "Resource": "arn:aws:s3:::tf-test-redshift-logging-%d/*"
 	 },
 	 {
 		 "Sid": "Stmt137652664067",
@@ -1176,7 +1176,7 @@ resource "aws_s3_bucket" "bucket" {
 			 "AWS": "${data.aws_redshift_service_account.main.arn}"
 		 },
 		 "Action": "s3:GetBucketAcl",
-		 "Resource": "arn:aws:s3:::tf-redshift-logging-%d"
+		 "Resource": "arn:aws:s3:::tf-test-redshift-logging-%d"
 	 }
  ]
 }


### PR DESCRIPTION
A large number of S3 buckets created by acceptance tests do not match the patterns matched by the S3 sweeper. A number of S3 buckets were orphaned in test accounts.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSELB_'

--- PASS: TestAccAWSELB_namePrefix (35.34s)
--- PASS: TestAccAWSELB_AccessLogs_disabled (63.86s)
--- PASS: TestAccAWSELB_availabilityZones (96.10s)
--- PASS: TestAccAWSELB_ConnectionDraining (110.03s)
--- PASS: TestAccAWSELB_generatesNameForZeroValue (112.05s)
--- PASS: TestAccAWSELB_basic (114.50s)
--- PASS: TestAccAWSELB_fullCharacterRange (119.44s)
--- PASS: TestAccAWSELB_HealthCheck (122.76s)
--- PASS: TestAccAWSELB_Timeout (124.96s)
--- PASS: TestAccAWSELB_SecurityGroups (138.53s)
--- PASS: TestAccAWSELB_listener (155.65s)
--- PASS: TestAccAWSELB_tags (166.73s)
--- PASS: TestAccAWSELB_swap_subnets (168.25s)
--- PASS: TestAccAWSELB_AccessLogs_enabled (168.74s)
--- PASS: TestAccAWSELB_InstanceAttaching (206.90s)
--- PASS: TestAccAWSELB_disappears (229.64s)
--- PASS: TestAccAWSELB_generatedName (251.72s)
--- PASS: TestAccAWSELB_Listener_SSLCertificateID_IAMServerCertificate (49.16s)
```

```
$ make testacc TESTARGS='-run=TestAccAWSLB_'

--- PASS: TestAccAWSLB_namePrefix (189.05s)
--- PASS: TestAccAWSLB_noSecurityGroup (193.90s)
--- PASS: TestAccAWSLB_generatedName (204.95s)
--- PASS: TestAccAWSLB_networkLoadbalancer_subnet_change (226.18s)
--- PASS: TestAccAWSLB_NLB_basic (226.46s)
--- PASS: TestAccAWSLB_ALB_basic (229.87s)
--- PASS: TestAccAWSLB_generatesNameForZeroValue (239.36s)
--- FAIL: TestAccAWSLB_updatedSubnets (243.61s)
--- PASS: TestAccAWSLB_networkLoadbalancerEIP (264.85s)
--- PASS: TestAccAWSLB_updatedSecurityGroups (313.28s)
--- PASS: TestAccAWSLB_updatedIpAddressType (324.67s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateDeletionProtection (328.99s)
--- PASS: TestAccAWSLB_networkLoadbalancer_updateCrossZone (331.22s)
--- PASS: TestAccAWSLB_NLB_AccessLogs_Prefix (348.63s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateHttp2 (359.69s)
--- PASS: TestAccAWSLB_tags (406.82s)
--- PASS: TestAccAWSLB_ALB_AccessLogs_Prefix (420.88s)
--- PASS: TestAccAWSLB_ALB_AccessLogs (425.28s)
--- PASS: TestAccAWSLB_NLB_AccessLogs (448.62s)
```

`TestAccAWSLB_updatedSubnets` is a known failure and is addressed by #12040 

```
$ make testacc TESTARGS='-run=TestAccAWSAthena\(Database\|NamedQuery\)_'

--- PASS: TestAccAWSAthenaDatabase_nameCantHaveUppercase (2.90s)
--- PASS: TestAccAWSAthenaNamedQuery_withWorkGroup (45.71s)
--- PASS: TestAccAWSAthenaNamedQuery_basic (45.80s)
--- PASS: TestAccAWSAthenaDatabase_nameStartsWithUnderscore (48.26s)
--- PASS: TestAccAWSAthenaDatabase_basic (48.60s)
--- PASS: TestAccAWSAthenaDatabase_forceDestroyAlwaysSucceeds (50.92s)
--- PASS: TestAccAWSAthenaDatabase_destroyFailsIfTablesExist (60.60s)
--- PASS: TestAccAWSAthenaDatabase_encryption (70.25s)
```

```
$ make testacc TESTARGS='-run=TestAccAWS\(RedshiftCluster\|DataSourceRedshiftCluster\)_'

--- PASS: TestAccAWSRedshiftCluster_basic (443.12s)
--- PASS: TestAccAWSRedshiftCluster_kmsKey (454.33s)
--- PASS: TestAccAWSDataSourceRedshiftCluster_logging (461.15s)
--- PASS: TestAccAWSRedshiftCluster_tags (463.70s)
--- PASS: TestAccAWSDataSourceRedshiftCluster_basic (487.83s)
--- PASS: TestAccAWSRedshiftCluster_loggingEnabled (496.65s)
--- PASS: TestAccAWSRedshiftCluster_snapshotCopy (516.82s)
--- PASS: TestAccAWSDataSourceRedshiftCluster_vpc (540.55s)
--- PASS: TestAccAWSRedshiftCluster_publiclyAccessible (594.38s)
--- PASS: TestAccAWSRedshiftCluster_iamRoles (623.52s)
--- PASS: TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled (720.54s)
--- PASS: TestAccAWSRedshiftCluster_withFinalSnapshot (783.84s)
--- PASS: TestAccAWSRedshiftCluster_forceNewUsername (888.33s)
--- PASS: TestAccAWSRedshiftCluster_changeAvailabilityZone (916.58s)
--- PASS: TestAccAWSRedshiftCluster_updateNodeType (1629.84s)
--- PASS: TestAccAWSRedshiftCluster_changeEncryption1 (2004.01s)
--- PASS: TestAccAWSRedshiftCluster_changeEncryption2 (2109.36s)
--- PASS: TestAccAWSRedshiftCluster_updateNodeCount (2290.79s)
```

```
$ make testacc TESTARGS='-run=TestAccAwsGlobalAcceleratorAccelerator_'

--- PASS: TestAccAwsGlobalAcceleratorAccelerator_attributes (92.26s)
--- PASS: TestAccAwsGlobalAcceleratorAccelerator_basic (93.70s)
--- PASS: TestAccAwsGlobalAcceleratorAccelerator_update (153.01s)
```

```
$ make testacc TESTARGS='-run=TestAccAWSMacieS3BucketAssociation_'

--- PASS: TestAccAWSMacieS3BucketAssociation_basic (50.12s)
--- PASS: TestAccAWSMacieS3BucketAssociation_accountIdAndPrefix (55.79s)
```

```
$ make testacc TESTARGS='-run=TestAccAWSElasticTranscoderPipeline_'

--- PASS: TestAccAWSElasticTranscoderPipeline_withPermissions (23.86s)
--- PASS: TestAccAWSElasticTranscoderPipeline_basic (26.26s)
--- PASS: TestAccAWSElasticTranscoderPipeline_withContentConfig (40.29s)
--- PASS: TestAccAWSElasticTranscoderPipeline_kmsKey (42.45s)
--- PASS: TestAccAWSElasticTranscoderPipeline_notifications (54.35s)
```