### PR TITLE
resource/aws_codedeploy_deployment_group: Fixes for tfproviderlint R006

### DIFF
--- a/aws/resource_aws_codedeploy_deployment_group.go
+++ b/aws/resource_aws_codedeploy_deployment_group.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"log"
-	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -553,7 +552,20 @@ func resourceAwsCodeDeployDeploymentGroupCreate(d *schema.ResourceData, meta int
 	var err error
 	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
 		resp, err = conn.CreateDeploymentGroup(&input)
-		return handleCreateError(err)
+
+		if isAWSErr(err, codedeploy.ErrCodeInvalidRoleException, "") {
+			return resource.RetryableError(err)
+		}
+
+		if isAWSErr(err, codedeploy.ErrCodeInvalidTriggerConfigException, "Topic ARN") {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
 	})
 
 	if isResourceTimeoutError(err) {
@@ -733,7 +745,20 @@ func resourceAwsCodeDeployDeploymentGroupUpdate(d *schema.ResourceData, meta int
 	var err error
 	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
 		_, err = conn.UpdateDeploymentGroup(&input)
-		return handleUpdateError(err)
+
+		if isAWSErr(err, codedeploy.ErrCodeInvalidRoleException, "") {
+			return resource.RetryableError(err)
+		}
+
+		if isAWSErr(err, codedeploy.ErrCodeInvalidTriggerConfigException, "Topic ARN") {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
 	})
 
 	if isResourceTimeoutError(err) {
@@ -756,44 +781,6 @@ func resourceAwsCodeDeployDeploymentGroupDelete(d *schema.ResourceData, meta int
 	})
 
 	return err
-}
-
-func handleCreateError(err error) *resource.RetryError {
-	return handleCodeDeployApiError(err, "create")
-}
-
-func handleUpdateError(err error) *resource.RetryError {
-	return handleCodeDeployApiError(err, "update")
-}
-
-func handleCodeDeployApiError(err error, operation string) *resource.RetryError {
-	if err == nil {
-		return nil
-	}
-
-	retry := false
-	codedeployErr, ok := err.(awserr.Error)
-	if !ok {
-		return resource.NonRetryableError(err)
-	}
-
-	if codedeployErr.Code() == "InvalidRoleException" {
-		retry = true
-	}
-
-	if codedeployErr.Code() == "InvalidTriggerConfigException" {
-		r := regexp.MustCompile("^Topic ARN .+ is not valid$")
-		if r.MatchString(codedeployErr.Message()) {
-			retry = true
-		}
-	}
-
-	if retry {
-		log.Printf("[DEBUG] Trying to %s DeploymentGroup again: %q", operation, codedeployErr.Message())
-		return resource.RetryableError(err)
-	}
-
-	return resource.NonRetryableError(err)
 }
 
 // buildOnPremTagFilters converts raw schema lists into a list of

--- a/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -2242,52 +2241,6 @@ func testAccCheckAWSCodeDeployDeploymentGroupExists(name string, group *codedepl
 		*group = *resp.DeploymentGroupInfo
 
 		return nil
-	}
-}
-
-func TestAWSCodeDeployDeploymentGroup_handleCodeDeployApiError(t *testing.T) {
-	notAnAwsError := errors.New("Not an awserr")
-	invalidRoleException := awserr.New("InvalidRoleException", "Invalid role exception", nil)
-	invalidTriggerConfigExceptionNoMatch := awserr.New("InvalidTriggerConfigException", "Some other error message", nil)
-	invalidTriggerConfigExceptionMatch := awserr.New("InvalidTriggerConfigException", "Topic ARN INVALID_ARN is not valid", nil)
-	fakeAwsError := awserr.New("FakeAwsException", "Not a real AWS error", nil)
-
-	testCases := []struct {
-		Input    error
-		Expected *resource.RetryError
-	}{
-		{
-			Input:    nil,
-			Expected: nil,
-		},
-		{
-			Input:    notAnAwsError,
-			Expected: resource.NonRetryableError(notAnAwsError),
-		},
-		{
-			Input:    invalidRoleException,
-			Expected: resource.RetryableError(invalidRoleException),
-		},
-		{
-			Input:    invalidTriggerConfigExceptionNoMatch,
-			Expected: resource.NonRetryableError(invalidTriggerConfigExceptionNoMatch),
-		},
-		{
-			Input:    invalidTriggerConfigExceptionMatch,
-			Expected: resource.RetryableError(invalidTriggerConfigExceptionMatch),
-		},
-		{
-			Input:    fakeAwsError,
-			Expected: resource.NonRetryableError(fakeAwsError),
-		},
-	}
-
-	for _, tc := range testCases {
-		actual := handleCodeDeployApiError(tc.Input, "test")
-		if !reflect.DeepEqual(actual, tc.Expected) {
-			t.Fatalf(`handleCodeDeployApiError output is not correct. Expected: %v, Actual: %v.`,
-				tc.Expected, actual)
-		}
 	}
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/11864

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

`RetryFunc` should only be used when logic has a retryable condition. In the case of working with the AWS Go SDK, it also arbitrarily restricts the automatic retrying logic of API calls to the timeout, which is generally undesired.

This particular case is a false positive, but does indicate this resource is not following the current practice of inlining the error handling in this retry function. Another option here would be to have the retryable error checking as a boolean returning function, in which the `RetryFunc` triggers `return resource.RetryableError(err)`.

Previously:

```
aws/resource_aws_codedeploy_deployment_group.go:554:38: R006: RetryFunc should include RetryableError() handling or be removed
aws/resource_aws_codedeploy_deployment_group.go:734:38: R006: RetryFunc should include RetryableError() handling or be removed
```

Output from acceptance testing:

```
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create (34.18s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete (43.48s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable (51.83s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_update (70.71s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create (36.35s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete (49.34s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable (59.52s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_update (45.27s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_basic (63.68s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_basic_tagSet (53.52s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeployment_complete (50.69s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_create (166.59s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete (59.43s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update (48.95s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update_with_asg (173.58s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_create (51.83s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_default (47.18s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_delete (60.90s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_update (74.54s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_disappears (44.40s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_ECS_BlueGreen (318.29s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_create (30.55s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_update (68.76s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_create (44.55s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete (40.08s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_create (28.30s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_delete (37.85s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_update (42.57s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_update (56.71s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_onPremiseTag (31.77s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic (43.51s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple (59.76s)
```