### PR TITLE
resource/aws_iam_policy_attachment: Fixes for tfproviderlint R006

### DIFF
--- a/aws/resource_aws_iam_policy_attachment.go
+++ b/aws/resource_aws_iam_policy_attachment.go
@@ -3,13 +3,10 @@ package aws
 import (
 	"fmt"
 	"log"
-	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
@@ -216,39 +213,6 @@ func attachPolicyToRoles(conn *iam.IAM, roles []*string, arn string) error {
 		if err != nil {
 			return err
 		}
-
-		var attachmentErr = resource.Retry(2*time.Minute, func() *resource.RetryError {
-
-			input := iam.ListRolePoliciesInput{
-				RoleName: r,
-			}
-
-			attachedPolicies, err := conn.ListRolePolicies(&input)
-			if err != nil {
-				return resource.NonRetryableError(err)
-			}
-
-			if len(attachedPolicies.PolicyNames) > 0 {
-				var foundPolicy bool
-				for _, policyName := range attachedPolicies.PolicyNames {
-					if strings.HasSuffix(arn, *policyName) {
-						foundPolicy = true
-						break
-					}
-				}
-
-				if !foundPolicy {
-					return resource.NonRetryableError(err)
-				}
-			}
-
-			return nil
-		})
-
-		if attachmentErr != nil {
-			return attachmentErr
-		}
-
 	}
 	return nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/11864

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

`RetryFunc` should only be used when logic has a retryable condition. In the case of working with the AWS Go SDK, it also arbitrarily restricts the automatic retrying logic of API calls to the timeout, which is generally undesired.

This particular case looks like the original intent was to verify via read-after-write that the appropriate write was persisted, however the logic errantly returned `return resource.NonRetryableError()` with `nil` when the role policy was not found, ending the `RetryFunc` without an actual error and never retrying on any condition.

Previously:

```
aws/resource_aws_iam_policy_attachment.go:220:53: R006: RetryFunc should include RetryableError() handling or be removed
```

Output from acceptance testing:

```
--- PASS: TestAccAWSIAMPolicyAttachment_Groups_RenamedGroup (22.54s)
--- PASS: TestAccAWSIAMPolicyAttachment_Users_RenamedUser (23.00s)
--- PASS: TestAccAWSIAMPolicyAttachment_Roles_RenamedRole (24.95s)
--- PASS: TestAccAWSIAMPolicyAttachment_basic (39.85s)
--- PASS: TestAccAWSIAMPolicyAttachment_paginatedEntities (242.04s)
```