### PR TITLE
resource/aws_redshift_snapshot_copy_grant: Fixes for tfproviderlint R006

### DIFF
--- a/aws/resource_aws_redshift_snapshot_copy_grant.go
+++ b/aws/resource_aws_redshift_snapshot_copy_grant.go
@@ -267,27 +267,13 @@ func findAwsRedshiftSnapshotCopyGrant(conn *redshift.Redshift, grantName string,
 		input.SnapshotCopyGrantName = aws.String(grantName)
 	}
 
-	var out *redshift.DescribeSnapshotCopyGrantsOutput
-	var err error
-	var grant *redshift.SnapshotCopyGrant
+	out, err := conn.DescribeSnapshotCopyGrants(&input)
 
-	err = resource.Retry(3*time.Minute, func() *resource.RetryError {
-		out, err = conn.DescribeSnapshotCopyGrants(&input)
-
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
-
-		return nil
-	})
-	if isResourceTimeoutError(err) {
-		out, err = conn.DescribeSnapshotCopyGrants(&input)
-	}
 	if err != nil {
 		return nil, err
 	}
 
-	grant = getAwsRedshiftSnapshotCopyGrant(out.SnapshotCopyGrants, grantName)
+	grant := getAwsRedshiftSnapshotCopyGrant(out.SnapshotCopyGrants, grantName)
 	if grant != nil {
 		return grant, nil
 	} else if out.Marker != nil {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/11864

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

`RetryFunc` should only be used when logic has a retryable condition. In the case of working with the AWS Go SDK, it also arbitrarily restricts the automatic retrying logic of API calls to the timeout, which is generally undesired.

Previously:

```
aws/resource_aws_redshift_snapshot_copy_grant.go:274:38: R006: RetryFunc should include RetryableError() handling or be removed
```

Output from acceptance testing:

```
--- PASS: TestAccAWSRedshiftSnapshotCopyGrant_Basic (15.81s)
--- PASS: TestAccAWSRedshiftSnapshotCopyGrant_Update (38.59s)
```
