### PR TITLE
resource/aws_ssm_document: Fixes for tfproviderlint R006

### DIFF
--- a/aws/resource_aws_ssm_document.go
+++ b/aws/resource_aws_ssm_document.go
@@ -208,21 +208,8 @@ func resourceAwsSsmDocumentCreate(d *schema.ResourceData, meta interface{}) erro
 		docInput.TargetType = aws.String(v.(string))
 	}
 
-	log.Printf("[DEBUG] Waiting for SSM Document %q to be created", d.Get("name").(string))
-	var resp *ssm.CreateDocumentOutput
-	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
-		var err error
-		resp, err = ssmconn.CreateDocument(docInput)
+	resp, err := ssmconn.CreateDocument(docInput)
 
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
-		return nil
-	})
-
-	if isResourceTimeoutError(err) {
-		resp, err = ssmconn.CreateDocument(docInput)
-	}
 	if err != nil {
 		return fmt.Errorf("Error creating SSM document: %s", err)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/11864

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

`RetryFunc` should only be used when logic has a retryable condition. In the case of working with the AWS Go SDK, it also arbitrarily restricts the automatic retrying logic of API calls to the timeout, which is generally undesired.

Previously:

```
aws/resource_aws_ssm_document.go:213:39: R006: RetryFunc should include RetryableError() handling or be removed
```

Output from acceptance testing:

```
--- PASS: TestAccAWSSSMDocument_basic (26.29s)
--- PASS: TestAccAWSSSMDocument_session (37.24s)
--- PASS: TestAccAWSSSMDocument_automation (41.32s)
--- PASS: TestAccAWSSSMDocument_permission_batching (44.07s)
--- PASS: TestAccAWSSSMDocument_params (46.96s)
--- PASS: TestAccAWSSSMDocument_SchemaVersion_1 (48.76s)
--- PASS: TestAccAWSSSMDocument_DocumentFormat_YAML (51.32s)
--- PASS: TestAccAWSSSMDocument_target_type (51.87s)
--- PASS: TestAccAWSSSMDocument_Tags (58.75s)
--- PASS: TestAccAWSSSMDocument_permission_private (66.11s)
--- PASS: TestAccAWSSSMDocument_permission_public (67.63s)
--- PASS: TestAccAWSSSMDocument_update (76.88s)
--- PASS: TestAccAWSSSMDocument_permission_change (77.82s)
--- PASS: TestAccAWSSSMDocument_package (83.33s)
```