### PR TITLE
service/sfn: Fixes for tfproviderlint R006

### DIFF
--- a/aws/resource_aws_sfn_activity.go
+++ b/aws/resource_aws_sfn_activity.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/sfn"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
@@ -114,20 +113,12 @@ func resourceAwsSfnActivityDelete(d *schema.ResourceData, meta interface{}) erro
 	input := &sfn.DeleteActivityInput{
 		ActivityArn: aws.String(d.Id()),
 	}
-	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
-		_, err := conn.DeleteActivity(input)
 
-		if err == nil {
-			return nil
-		}
+	_, err := conn.DeleteActivity(input)
 
-		return resource.NonRetryableError(err)
-	})
-	if isResourceTimeoutError(err) {
-		_, err = conn.DeleteActivity(input)
-	}
 	if err != nil {
 		return fmt.Errorf("Error deleting SFN Activity: %s", err)
 	}
+
 	return nil
 }

--- a/aws/resource_aws_sfn_state_machine.go
+++ b/aws/resource_aws_sfn_state_machine.go
@@ -178,20 +178,12 @@ func resourceAwsSfnStateMachineDelete(d *schema.ResourceData, meta interface{}) 
 	input := &sfn.DeleteStateMachineInput{
 		StateMachineArn: aws.String(d.Id()),
 	}
-	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
-		_, err := conn.DeleteStateMachine(input)
 
-		if err == nil {
-			return nil
-		}
+	_, err := conn.DeleteStateMachine(input)
 
-		return resource.NonRetryableError(err)
-	})
-	if isResourceTimeoutError(err) {
-		_, err = conn.DeleteStateMachine(input)
-	}
 	if err != nil {
 		return fmt.Errorf("Error deleting SFN state machine: %s", err)
 	}
+
 	return nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/11864

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

`RetryFunc` should only be used when logic has a retryable condition. In the case of working with the AWS Go SDK, it also arbitrarily restricts the automatic retrying logic of API calls to the timeout, which is generally undesired.

Previously:

```
aws/resource_aws_sfn_activity.go:117:39: R006: RetryFunc should include RetryableError() handling or be removed
aws/resource_aws_sfn_state_machine.go:181:39: R006: RetryFunc should include RetryableError() handling or be removed
```

Output from acceptance testing (unrelated failure present on master due to SFN eventual consistency):

```
--- PASS: TestAccAWSSfnActivity_basic (18.37s)
--- PASS: TestAccAWSSfnActivity_Tags (43.33s)

--- FAIL: TestAccAWSSfnStateMachine_createUpdate (55.52s)
    testing.go:640: Step 1 error: Check failed: Check 5/6 error: aws_sfn_state_machine.foo: Attribute 'definition' didn't match ".*\\\"MaxAttempts\\\": 10.*", got "{\n  \"Comment\": \"A Hello World example of the Amazon States Language using an AWS Lambda Function\",\n  \"StartAt\": \"HelloWorld\",\n  \"States\": {\n    \"HelloWorld\": {\n      \"Type\": \"Task\",\n      \"Resource\": \"arn:aws:lambda:us-west-2:187416307283:function:sfn-uzt6w9nxeb\",\n      \"Retry\": [\n        {\n          \"ErrorEquals\": [\"States.ALL\"],\n          \"IntervalSeconds\": 5,\n          \"MaxAttempts\": 5,\n          \"BackoffRate\": 8.0\n        }\n      ],\n      \"End\": true\n    }\n  }\n}\n"
--- PASS: TestAccAWSSfnStateMachine_Tags (73.52s)
```