### PR TITLE
resource/aws_s3_bucket: Do not fail updating acceleration status

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -373,14 +373,6 @@ func testAccEC2VPCOnlyPreCheck(t *testing.T) {
 	}
 }
 
-func testAccPartitionHasServicePreCheck(serviceId string, t *testing.T) {
-	if partition, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), testAccGetRegion()); ok {
-		if _, ok := partition.Services()[serviceId]; !ok {
-			t.Skip(fmt.Sprintf("skipping tests; partition %s does not support %s service", partition.ID(), serviceId))
-		}
-	}
-}
-
 // testAccRegionHasServicePreCheck skips a test if the AWS Go SDK endpoint value in a region is missing
 // NOTE: Most acceptance testing should prefer behavioral checks against an API (e.g. making an API call and
 //       using response errors) to determine if a test should be skipped since AWS Go SDK endpoint information

--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -1738,7 +1738,7 @@ func resourceAwsS3BucketAccelerationUpdate(s3conn *s3.S3, d *schema.ResourceData
 	_, err := retryOnAwsCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
 		return s3conn.PutBucketAccelerateConfiguration(i)
 	})
-	if err != nil {
+	if err != nil && !isAWSErr(err, "MethodNotAllowed", "") && !isAWSErr(err, "UnsupportedArgument", "") {
 		return fmt.Errorf("Error putting S3 acceleration: %s", err)
 	}
 

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -482,7 +482,6 @@ func TestAccAWSS3Bucket_acceleration(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPartitionHasServicePreCheck("cloudfront", t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSS3BucketDestroy,


### PR DESCRIPTION
in regions that don't support the endpoint such as Osaka. Without this change, creating S3 buckets with `acceleration_status` set to either `Enabled` or `Suspended` will return an error.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11556 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_s3_bucket: Do not fail to create buckets if the region does not support acceleration.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ export AWS_DEFAULT_REGION=ap-northeast-1
$ make testacc TESTARGS='-run=TestAccAWSS3Bucket_acceleration'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSS3Bucket_acceleration -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSS3Bucket_acceleration
=== PAUSE TestAccAWSS3Bucket_acceleration
=== CONT  TestAccAWSS3Bucket_acceleration
--- PASS: TestAccAWSS3Bucket_acceleration (135.82s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	137.466s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.429s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.279s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/batch/equivalency	0.170s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks/token	0.298s [no tests to run]
?   	github.com/terraform-providers/terraform-provider-aws/awsproviderlint	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes	0.623s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSAT001	0.313s [no tests to run]
```
