### PR TITLE
internal/naming: New package for shared naming logic

### DIFF
--- a/aws/import_aws_security_group.go
+++ b/aws/import_aws_security_group.go
@@ -3,8 +3,10 @@ package aws
 import (
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/naming"
 )
 
 // Security group import fans out to multiple resources due to the
@@ -24,6 +26,11 @@ func resourceAwsSecurityGroupImportState(
 		return nil, fmt.Errorf("security group not found")
 	}
 	sg := sgRaw.(*ec2.SecurityGroup)
+
+	// Perform nil check to avoid ImportStateVerify difference when unconfigured
+	if namePrefix := naming.NamePrefixFromName(aws.StringValue(sg.GroupName)); namePrefix != nil {
+		d.Set("name_prefix", namePrefix)
+	}
 
 	// Start building our results
 	results := make([]*schema.ResourceData, 1,

--- a/aws/internal/naming/naming.go
+++ b/aws/internal/naming/naming.go
@@ -1,0 +1,96 @@
+package naming
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+var resourceUniqueIDSuffixRegexpPattern = fmt.Sprintf("\\d{%d}$", resource.UniqueIDSuffixLength)
+var resourceUniqueIDSuffixRegexp = regexp.MustCompile(resourceUniqueIDSuffixRegexpPattern)
+
+var resourceUniqueIDRegexpPattern = resourcePrefixedUniqueIDRegexpPattern(resource.UniqueIdPrefix)
+var resourceUniqueIDRegexp = regexp.MustCompile(resourceUniqueIDRegexpPattern)
+
+// Generate returns in order the name if non-empty, a prefix generated name if non-empty, or fully generated name prefixed with terraform-
+func Generate(name string, namePrefix string) string {
+	if name != "" {
+		return name
+	}
+
+	if namePrefix != "" {
+		return resource.PrefixedUniqueId(namePrefix)
+	}
+
+	return resource.UniqueId()
+}
+
+// HasResourceUniqueIdPrefix returns true if the string has the built-in unique ID prefix
+func HasResourceUniqueIdPrefix(s string) bool {
+	return strings.HasPrefix(s, resource.UniqueIdPrefix)
+}
+
+// HasResourceUniqueIdSuffix returns true if the string has the built-in unique ID suffix
+func HasResourceUniqueIdSuffix(s string) bool {
+	return resourceUniqueIDSuffixRegexp.MatchString(s)
+}
+
+// NamePrefixFromName returns a name prefix if the string matches prefix criteria
+//
+// The input to this function must be strictly the "name" and not any
+// additional information such as a full Amazon Resource Name (ARN). The output
+// is suitable for custom resource Importer State functions after nil checking
+// to ensure differences are not reported with ImportStateVerify testing, e.g.
+//
+// if namePrefix := naming.NamePrefixFromName(d.Id()); namePrefix != nil {
+//   d.Set("name_prefix", namePrefix)
+// }
+func NamePrefixFromName(name string) *string {
+	if !HasResourceUniqueIdSuffix(name) {
+		return nil
+	}
+
+	// If the name begins with terraform-, then the name may have been fully
+	// generated (e.g. omitting both name and name_prefix arguments)
+	if HasResourceUniqueIdPrefix(name) {
+		return nil
+	}
+
+	namePrefixIndex := len(name) - resource.UniqueIDSuffixLength
+
+	if namePrefixIndex <= 0 {
+		return nil
+	}
+
+	namePrefix := name[:namePrefixIndex]
+
+	return &namePrefix
+}
+
+// TestCheckResourceAttrNameFromPrefix verifies that the state attribute value matches name generated from given prefix
+func TestCheckResourceAttrNameFromPrefix(resourceName string, attributeName string, prefix string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		nameRegexpPattern := resourcePrefixedUniqueIDRegexpPattern(prefix)
+		attributeMatch, err := regexp.Compile(nameRegexpPattern)
+
+		if err != nil {
+			return fmt.Errorf("Unable to compile name regexp (%s): %s", nameRegexpPattern, err)
+		}
+
+		return resource.TestMatchResourceAttr(resourceName, attributeName, attributeMatch)(s)
+	}
+}
+
+// TestCheckResourceAttrNameGenerated verifies that the state attribute value matches name automatically generated without prefix
+func TestCheckResourceAttrNameGenerated(resourceName string, attributeName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		return resource.TestMatchResourceAttr(resourceName, attributeName, resourceUniqueIDRegexp)(s)
+	}
+}
+
+func resourcePrefixedUniqueIDRegexpPattern(prefix string) string {
+	return fmt.Sprintf("^%s%s", prefix, resourceUniqueIDSuffixRegexpPattern)
+}

--- a/aws/internal/naming/naming_test.go
+++ b/aws/internal/naming/naming_test.go
@@ -1,0 +1,180 @@
+package naming
+
+import (
+	"regexp"
+	"testing"
+)
+
+func strPtr(str string) *string {
+	return &str
+}
+
+func TestGenerate(t *testing.T) {
+	testCases := []struct {
+		TestName              string
+		Name                  string
+		NamePrefix            string
+		ExpectedRegexpPattern string
+	}{
+		{
+			TestName:              "name",
+			Name:                  "test",
+			NamePrefix:            "",
+			ExpectedRegexpPattern: "^test$",
+		},
+		{
+			TestName:              "name prefix",
+			Name:                  "",
+			NamePrefix:            "test",
+			ExpectedRegexpPattern: resourcePrefixedUniqueIDRegexpPattern("test"),
+		},
+		{
+			TestName:              "fully generated",
+			Name:                  "",
+			NamePrefix:            "",
+			ExpectedRegexpPattern: resourceUniqueIDRegexpPattern,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			got := Generate(testCase.Name, testCase.NamePrefix)
+
+			expectedRegexp, err := regexp.Compile(testCase.ExpectedRegexpPattern)
+
+			if err != nil {
+				t.Errorf("unable to compile regular expression pattern %s: %s", testCase.ExpectedRegexpPattern, err)
+			}
+
+			if !expectedRegexp.MatchString(got) {
+				t.Errorf("got %s, expected to match regular expression pattern %s", got, testCase.ExpectedRegexpPattern)
+			}
+		})
+	}
+}
+
+func TestHasResourceUniqueIdPrefix(t *testing.T) {
+	testCases := []struct {
+		TestName string
+		Input    string
+		Expected bool
+	}{
+		{
+			TestName: "empty",
+			Input:    "",
+			Expected: false,
+		},
+		{
+			TestName: "incorrect prefix",
+			Input:    "test-20060102150405000000000001",
+			Expected: false,
+		},
+		{
+			TestName: "correct prefix",
+			Input:    "terraform-20060102150405000000000001",
+			Expected: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			got := HasResourceUniqueIdPrefix(testCase.Input)
+
+			if got != testCase.Expected {
+				t.Errorf("got %t, expected %t", got, testCase.Expected)
+			}
+		})
+	}
+}
+
+func TestHasResourceUniqueIdSuffix(t *testing.T) {
+	testCases := []struct {
+		TestName string
+		Input    string
+		Expected bool
+	}{
+		{
+			TestName: "empty",
+			Input:    "",
+			Expected: false,
+		},
+		{
+			TestName: "incorrect suffix",
+			Input:    "test-123",
+			Expected: false,
+		},
+		{
+			TestName: "correct suffix, incorrect prefix",
+			Input:    "test-20060102150405000000000001",
+			Expected: true,
+		},
+		{
+			TestName: "correct suffix, correct prefix",
+			Input:    "terraform-20060102150405000000000001",
+			Expected: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			got := HasResourceUniqueIdSuffix(testCase.Input)
+
+			if got != testCase.Expected {
+				t.Errorf("got %t, expected %t", got, testCase.Expected)
+			}
+		})
+	}
+}
+
+func TestNamePrefixFromName(t *testing.T) {
+	testCases := []struct {
+		TestName string
+		Input    string
+		Expected *string
+	}{
+		{
+			TestName: "empty",
+			Input:    "",
+			Expected: nil,
+		},
+		{
+			TestName: "correct prefix, incorrect suffix",
+			Input:    "test-123",
+			Expected: nil,
+		},
+		{
+			TestName: "correct prefix without hyphen, correct suffix",
+			Input:    "test20060102150405000000000001",
+			Expected: strPtr("test"),
+		},
+		{
+			TestName: "correct prefix with hyphen, correct suffix",
+			Input:    "test-20060102150405000000000001",
+			Expected: strPtr("test-"),
+		},
+		{
+			TestName: "incorrect prefix, correct suffix",
+			Input:    "terraform-20060102150405000000000001",
+			Expected: nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			expected := testCase.Expected
+			got := NamePrefixFromName(testCase.Input)
+
+			if expected == nil && got != nil {
+				t.Errorf("got %s, expected nil", *got)
+			}
+
+			if expected != nil && got == nil {
+				t.Errorf("got nil, expected %s", *expected)
+			}
+
+			if expected != nil && got != nil && *expected != *got {
+				t.Errorf("got %s, expected %s", *got, *expected)
+			}
+		})
+	}
+}

--- a/aws/resource_aws_security_group.go
+++ b/aws/resource_aws_security_group.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/naming"
 )
 
 func resourceAwsSecurityGroup() *schema.Resource {
@@ -244,14 +245,7 @@ func resourceAwsSecurityGroupCreate(d *schema.ResourceData, meta interface{}) er
 		securityGroupOpts.Description = aws.String(v.(string))
 	}
 
-	var groupName string
-	if v, ok := d.GetOk("name"); ok {
-		groupName = v.(string)
-	} else if v, ok := d.GetOk("name_prefix"); ok {
-		groupName = resource.PrefixedUniqueId(v.(string))
-	} else {
-		groupName = resource.UniqueId()
-	}
+	groupName := naming.Generate(d.Get("name").(string), d.Get("name_prefix").(string))
 	securityGroupOpts.GroupName = aws.String(groupName)
 
 	var err error

--- a/aws/resource_aws_security_group_test.go
+++ b/aws/resource_aws_security_group_test.go
@@ -7,7 +7,6 @@ import (
 	"reflect"
 	"regexp"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -18,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/naming"
 )
 
 // add sweeper to delete known test sgs
@@ -1090,19 +1090,22 @@ func TestAccAWSSecurityGroup_namePrefix(t *testing.T) {
 	resourceName := "aws_security_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:        func() { testAccPreCheck(t) },
-		IDRefreshName:   resourceName,
-		IDRefreshIgnore: []string{"name_prefix"},
-		Providers:       testAccProviders,
-		CheckDestroy:    testAccCheckAWSSecurityGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSecurityGroupPrefixNameConfig,
+				Config: testAccAWSSecurityGroupPrefixNameConfig("tf-acc-test-prefix-"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityGroupExists(resourceName, &group),
-					testAccCheckAWSSecurityGroupGeneratedNamePrefix(
-						resourceName, "baz-"),
+					naming.TestCheckResourceAttrNameFromPrefix(resourceName, "name", "tf-acc-test-prefix-"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"revoke_rules_on_delete"},
 			},
 		},
 	})
@@ -1459,27 +1462,22 @@ func TestAccAWSSecurityGroup_generatedName(t *testing.T) {
 	resourceName := "aws_security_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: resourceName,
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSSecurityGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSecurityGroupConfig_generatedName,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityGroupExists(resourceName, &group),
-					resource.TestCheckResourceAttr(
-						resourceName, "description", "Managed by Terraform"),
-					func(s *terraform.State) error {
-						if group.GroupName == nil {
-							return fmt.Errorf("bad: No SG name")
-						}
-						if !strings.HasPrefix(*group.GroupName, "terraform-") {
-							return fmt.Errorf("No terraform- prefix: %s", *group.GroupName)
-						}
-						return nil
-					},
+					naming.TestCheckResourceAttrNameGenerated(resourceName, "name"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"revoke_rules_on_delete"},
 			},
 		},
 	})
@@ -2098,24 +2096,6 @@ func testAccCheckAWSSecurityGroupDestroy(s *terraform.State) error {
 	}
 
 	return nil
-}
-
-func testAccCheckAWSSecurityGroupGeneratedNamePrefix(
-	resource, prefix string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		r, ok := s.RootModule().Resources[resource]
-		if !ok {
-			return fmt.Errorf("Resource not found")
-		}
-		name, ok := r.Primary.Attributes["name"]
-		if !ok {
-			return fmt.Errorf("Name attr not found: %#v", r.Primary.Attributes)
-		}
-		if !strings.HasPrefix(name, prefix) {
-			return fmt.Errorf("Name: %q, does not have prefix: %q", name, prefix)
-		}
-		return nil
-	}
 }
 
 func testAccCheckAWSSecurityGroupExists(n string, group *ec2.SecurityGroup) resource.TestCheckFunc {
@@ -3283,16 +3263,22 @@ resource "aws_security_group" "test" {
 }
 `
 
-const testAccAWSSecurityGroupPrefixNameConfig = `
-provider "aws" {
-  region = "us-east-1"
+func testAccAWSSecurityGroupPrefixNameConfig(namePrefix string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "tf-acc-test-security-group-name-prefix"
+  }
 }
 
 resource "aws_security_group" "test" {
-   name_prefix = "baz-"
-   description = "Used in the terraform acceptance tests"
+  name_prefix = %[1]q
+  vpc_id      = aws_vpc.test.id
 }
-`
+`, namePrefix)
+}
 
 func testAccAWSSecurityGroupConfig_drift() string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #3206
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/9574

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_security_group: Support import of `name_prefix` argument
```

Certain Terraform AWS Provider resources support the ability to choose between a fully configured name, a name generated with a prefix, and a fully generated name. These resources currently implement disperate and repeated logic to accomplish this. These resources do not currently support automatically importing the attribute as its not provided by the API during refresh.

This new package centralizes handling for this name generation logic and also introduces functions to ease import implementation and acceptance testing. This package may move to the Terraform Plugin SDK in the future.

The `aws_security_group` resource is the first one migrated to the new package to show a full implementation. Verification of the `name_prefix` attribute import is shown by the lack of adding that attribute to the `ImportStateVerifyIgnore` list.

Adding this enhancement to resources is now documented in the Contributing Guide.

Output from acceptance testing:

```
--- PASS: TestAccAWSSecurityGroup_allowAll (61.31s)
--- PASS: TestAccAWSSecurityGroup_basic (50.77s)
--- PASS: TestAccAWSSecurityGroup_change (26.56s)
--- PASS: TestAccAWSSecurityGroup_CIDRandGroups (52.67s)
--- PASS: TestAccAWSSecurityGroup_defaultEgressClassic (20.46s)
--- PASS: TestAccAWSSecurityGroup_defaultEgressVPC (23.00s)
--- PASS: TestAccAWSSecurityGroup_drift (22.12s)
--- PASS: TestAccAWSSecurityGroup_driftComplex (39.64s)
--- PASS: TestAccAWSSecurityGroup_egressConfigMode (73.28s)
--- PASS: TestAccAWSSecurityGroup_egressWithPrefixList (55.76s)
--- PASS: TestAccAWSSecurityGroup_failWithDiffMismatch (42.09s)
--- PASS: TestAccAWSSecurityGroup_forceRevokeRulesFalse (743.11s)
--- PASS: TestAccAWSSecurityGroup_forceRevokeRulesTrue (676.63s)
--- PASS: TestAccAWSSecurityGroup_generatedName (43.71s)
--- PASS: TestAccAWSSecurityGroup_ingressConfigMode (89.61s)
--- PASS: TestAccAWSSecurityGroup_ingressWithCidrAndSGsClassic (33.17s)
--- PASS: TestAccAWSSecurityGroup_ingressWithCidrAndSGsVPC (52.83s)
--- PASS: TestAccAWSSecurityGroup_ingressWithPrefixList (63.06s)
--- PASS: TestAccAWSSecurityGroup_invalidCIDRBlock (2.22s)
--- PASS: TestAccAWSSecurityGroup_IPRangeAndSecurityGroupWithSameRules (32.23s)
--- PASS: TestAccAWSSecurityGroup_IPRangesWithSameRules (59.30s)
--- PASS: TestAccAWSSecurityGroup_ipv4andipv6Egress (30.32s)
--- PASS: TestAccAWSSecurityGroup_ipv6 (31.90s)
--- PASS: TestAccAWSSecurityGroup_multiIngress (37.08s)
--- PASS: TestAccAWSSecurityGroup_namePrefix (36.60s)
--- PASS: TestAccAWSSecurityGroup_ruleDescription (88.50s)
--- PASS: TestAccAWSSecurityGroup_ruleGathering (60.56s)
--- PASS: TestAccAWSSecurityGroup_ruleLimitCidrBlockExceededAppend (30.73s)
--- PASS: TestAccAWSSecurityGroup_ruleLimitExceededAllNew (35.05s)
--- PASS: TestAccAWSSecurityGroup_ruleLimitExceededAppend (31.55s)
--- PASS: TestAccAWSSecurityGroup_ruleLimitExceededPrepend (33.96s)
--- PASS: TestAccAWSSecurityGroup_rulesDropOnError (84.24s)
--- PASS: TestAccAWSSecurityGroup_self (60.71s)
--- PASS: TestAccAWSSecurityGroup_sourceSecurityGroup (28.02s)
--- PASS: TestAccAWSSecurityGroup_tags (45.35s)
--- PASS: TestAccAWSSecurityGroup_vpc (64.14s)
--- PASS: TestAccAWSSecurityGroup_vpcNegOneIngress (39.37s)
--- PASS: TestAccAWSSecurityGroup_vpcProtoNumIngress (132.87s)
```