### PR TITLE
Update ecs_service.html.markdown

### DIFF
--- a/website/docs/r/ecs_service.html.markdown
+++ b/website/docs/r/ecs_service.html.markdown
@@ -103,7 +103,7 @@ The following arguments are supported:
 
 The `capacity_provider_strategy` configuration block supports the following:
 
-* `capacity_provider` - (Required) The short name or full Amazon Resource Name (ARN) of the capacity provider.
+* `capacity_provider` - (Required) The short name of the capacity provider.
 * `weight` - (Required) The relative percentage of the total number of launched tasks that should use the specified capacity provider.
 * `base` - (Optional) The number of tasks, at a minimum, to run on the specified capacity provider. Only one capacity provider in a capacity provider strategy can have a base defined.
 


### PR DESCRIPTION
Confirmed that the service does not recognize the capacity provider when the ecs service is pointed to the arn of the capacity provider. This returns the error message "No Container Instances were found in your capacity provider" and the Cloudwatch metric  "CapacityProviderReservation" is not adjusted. Once the name is used for the capacity provider the service properly launches a task in the provisioning state, "CapacityProviderReservation" is incremented, and an instance is added to the ASG.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
