### PR TITLE
r/launch_template - add plan time validations

### DIFF
--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -248,6 +248,11 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 						"type": {
 							Type:     schema.TypeString,
 							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"eia1.medium",
+								"eia1.large",
+								"eia1.xlarge",
+							}, false),
 						},
 					},
 				},
@@ -311,6 +316,11 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 									"instance_interruption_behavior": {
 										Type:     schema.TypeString,
 										Optional: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											ec2.InstanceInterruptionBehaviorHibernate,
+											ec2.InstanceInterruptionBehaviorStop,
+											ec2.InstanceInterruptionBehaviorTerminate,
+										}, false),
 									},
 									"max_price": {
 										Type:     schema.TypeString,

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -90,7 +90,7 @@ func TestAccAWSLaunchTemplate_basic(t *testing.T) {
 					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "default_version", "1"),
 					resource.TestCheckResourceAttr(resourceName, "latest_version", "1"),
-					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`launch-template/.+`)),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`launch-template/lt-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "ebs_optimized", ""),
 					resource.TestCheckResourceAttr(resourceName, "elastic_inference_accelerator.#", "0"),
 				),

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -223,7 +223,7 @@ Attach an Elastic Inference Accelerator to the instance. Additional information 
 
 The `elastic_inference_accelerator` configuration block supports the following:
 
-* `type` - (Required) Accelerator type.
+* `type` - (Required) Accelerator type. can be `eia1.medium`, `eia1.large` or `eia1.xlarge`.
 
 ### Instance Profile
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13624

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_launch_template: add validation to `elastic_inference_accelerator.type`, `spot_options.instance_interruption_behavior`, `spot_options.spot_instance_type`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSLaunchTemplate_'
--- PASS: TestAccAWSLaunchTemplate_disappears (32.51s)
--- PASS: TestAccAWSLaunchTemplate_basic (59.70s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS (96.27s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination (121.31s)
--- PASS: TestAccAWSLaunchTemplate_EbsOptimized (166.54s)
--- PASS: TestAccAWSLaunchTemplate_ElasticInferenceAccelerator (75.12s)
--- PASS: TestAccAWSLaunchTemplate_data (45.16s)
--- PASS: TestAccAWSLaunchTemplate_description (76.37s)
--- PASS: TestAccAWSLaunchTemplate_update (124.42s)
--- PASS: TestAccAWSLaunchTemplate_tags (77.28s)
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_preference (45.90s)
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_target (57.08s)
--- PASS: TestAccAWSLaunchTemplate_cpuOptions (53.25s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_nonBurstable (45.43s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t2 (49.17s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t3 (57.87s)
--- PASS: TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock (50.67s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface (120.22s)
--- PASS: TestAccAWSLaunchTemplate_associatePublicIPAddress (261.63s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses (58.27s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount (58.95s)
--- PASS: TestAccAWSLaunchTemplate_instanceMarketOptions (168.38s)
--- PASS: TestAccAWSLaunchTemplate_licenseSpecification (63.49s)
```
