### PR TITLE
[WIP] Update 'aws_route' to handle changes in IPv6 route entries

### DIFF
--- a/aws/resource_aws_route.go
+++ b/aws/resource_aws_route.go
@@ -385,9 +385,15 @@ func resourceAwsRouteUpdate(d *schema.ResourceData, meta interface{}) error {
 	switch setTarget {
 	case "gateway_id":
 		replaceOpts = &ec2.ReplaceRouteInput{
-			RouteTableId:         aws.String(d.Get("route_table_id").(string)),
-			DestinationCidrBlock: aws.String(d.Get("destination_cidr_block").(string)),
-			GatewayId:            aws.String(d.Get("gateway_id").(string)),
+			RouteTableId: aws.String(d.Get("route_table_id").(string)),
+			GatewayId:    aws.String(d.Get("gateway_id").(string)),
+		}
+		if v, ok := d.GetOk("destination_cidr_block"); ok {
+			replaceOpts.DestinationCidrBlock = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("destination_ipv6_cidr_block"); ok {
+			replaceOpts.DestinationIpv6CidrBlock = aws.String(v.(string))
 		}
 	case "egress_only_gateway_id":
 		replaceOpts = &ec2.ReplaceRouteInput{
@@ -403,27 +409,51 @@ func resourceAwsRouteUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	case "instance_id":
 		replaceOpts = &ec2.ReplaceRouteInput{
-			RouteTableId:         aws.String(d.Get("route_table_id").(string)),
-			DestinationCidrBlock: aws.String(d.Get("destination_cidr_block").(string)),
-			InstanceId:           aws.String(d.Get("instance_id").(string)),
+			RouteTableId: aws.String(d.Get("route_table_id").(string)),
+			InstanceId:   aws.String(d.Get("instance_id").(string)),
+		}
+		if v, ok := d.GetOk("destination_cidr_block"); ok {
+			replaceOpts.DestinationCidrBlock = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("destination_ipv6_cidr_block"); ok {
+			replaceOpts.DestinationIpv6CidrBlock = aws.String(v.(string))
 		}
 	case "network_interface_id":
 		replaceOpts = &ec2.ReplaceRouteInput{
-			RouteTableId:         aws.String(d.Get("route_table_id").(string)),
-			DestinationCidrBlock: aws.String(d.Get("destination_cidr_block").(string)),
-			NetworkInterfaceId:   aws.String(d.Get("network_interface_id").(string)),
+			RouteTableId:       aws.String(d.Get("route_table_id").(string)),
+			NetworkInterfaceId: aws.String(d.Get("network_interface_id").(string)),
+		}
+		if v, ok := d.GetOk("destination_cidr_block"); ok {
+			replaceOpts.DestinationCidrBlock = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("destination_ipv6_cidr_block"); ok {
+			replaceOpts.DestinationIpv6CidrBlock = aws.String(v.(string))
 		}
 	case "transit_gateway_id":
 		replaceOpts = &ec2.ReplaceRouteInput{
-			RouteTableId:         aws.String(d.Get("route_table_id").(string)),
-			DestinationCidrBlock: aws.String(d.Get("destination_cidr_block").(string)),
-			TransitGatewayId:     aws.String(d.Get("transit_gateway_id").(string)),
+			RouteTableId:     aws.String(d.Get("route_table_id").(string)),
+			TransitGatewayId: aws.String(d.Get("transit_gateway_id").(string)),
+		}
+		if v, ok := d.GetOk("destination_cidr_block"); ok {
+			replaceOpts.DestinationCidrBlock = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("destination_ipv6_cidr_block"); ok {
+			replaceOpts.DestinationIpv6CidrBlock = aws.String(v.(string))
 		}
 	case "vpc_peering_connection_id":
 		replaceOpts = &ec2.ReplaceRouteInput{
 			RouteTableId:           aws.String(d.Get("route_table_id").(string)),
-			DestinationCidrBlock:   aws.String(d.Get("destination_cidr_block").(string)),
 			VpcPeeringConnectionId: aws.String(d.Get("vpc_peering_connection_id").(string)),
+		}
+		if v, ok := d.GetOk("destination_cidr_block"); ok {
+			replaceOpts.DestinationCidrBlock = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("destination_ipv6_cidr_block"); ok {
+			replaceOpts.DestinationIpv6CidrBlock = aws.String(v.(string))
 		}
 	default:
 		return fmt.Errorf("An invalid target type specified: %s", setTarget)


### PR DESCRIPTION
Allow the `aws_route` resource to update targets for all IPv6 destinations it can create route entries for. Currently, `aws_route` assumes all route targets for update are IPv4 except for a couple targets.

For example, given the following Terraform code

```
resource "aws_route" "default_ipv6_route" {
  route_table_id = aws_route_table.routes.id

  destination_ipv6_cidr_block = "::/0"
  network_interface_id        = aws_instance.router.primary_network_interface_id
}
```

this `aws_route` could be created, but if the network interface ever changed the provider would attempt to make the following POST to AWS 

```
Action=ReplaceRoute&DestinationCidrBlock=&Network
InterfaceId=eni-<eni>&RouteTableId=rtb-<rtb>&Version=2016-11-15
```

and return the following error message:

```
MissingParameter: The request must contain the parameter destinationCidrBlock or destinationIpv6CidrBlock
```


<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Output from acceptance testing:

**Currently no acceptance testing**, but I'm willing to tackle that once I wrap my head around it.

**NOTE**: I have only tested with a target of `network_interface`, as that's the use case I ran into.
