### PR TITLE
Fix Doc: InvalidParameterValue: 'MaxAgeRule' and 'MaxCountRule' canno…

### DIFF
--- a/website/docs/r/elastic_beanstalk_application.html.markdown
+++ b/website/docs/r/elastic_beanstalk_application.html.markdown
@@ -41,8 +41,8 @@ The following arguments are supported:
 Application version lifecycle (`appversion_lifecycle`) supports the following settings.  Only one of either `max_count` or `max_age_in_days` can be provided:
 
 * `service_role` - (Required) The ARN of an IAM service role under which the application version is deleted.  Elastic Beanstalk must have permission to assume this role.
-* `max_count` - (Optional) The maximum number of application versions to retain.
-* `max_age_in_days` - (Optional) The number of days to retain an application version.
+* `max_count` - (Optional) The maximum number of application versions to retain ('max_age_in_days' and 'max_count' cannot be enabled simultaneously.).
+* `max_age_in_days` - (Optional) The number of days to retain an application version ('max_age_in_days' and 'max_count' cannot be enabled simultaneously.).
 * `delete_source_from_s3` - (Optional) Set to `true` to delete a version's source bundle from S3 when the application version is deleted.
 
 ## Attributes Reference


### PR DESCRIPTION
…t be enabled simultaneously.

AWS doesn't allow setting both `max_age_in_days` and `max_count` at the same time. So, updating the docs accordingly

here's the stack trace that it shows
```
Error: InvalidParameterValue: 'MaxAgeRule' and 'MaxCountRule' cannot be enabled simultaneously.
	status code: 400, request id: 682c0eb9-8c08-485e-9aaf-37c08106ccf7
```

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
