### PR TITLE
add kms support for iscsi cached volume

### DIFF
--- a/aws/resource_aws_storagegateway_cached_iscsi_volume.go
+++ b/aws/resource_aws_storagegateway_cached_iscsi_volume.go
@@ -87,6 +87,15 @@ func resourceAwsStorageGatewayCachedIscsiVolume() *schema.Resource {
 				ForceNew: true,
 			},
 			"tags": tagsSchema(),
+			"kms_encrypted": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"kms_key": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateArn,
+			},
 		},
 	}
 }
@@ -109,6 +118,14 @@ func resourceAwsStorageGatewayCachedIscsiVolumeCreate(d *schema.ResourceData, me
 
 	if v, ok := d.GetOk("source_volume_arn"); ok {
 		input.SourceVolumeARN = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("kms_key"); ok {
+		input.KMSKey = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("kms_encrypted"); ok {
+		input.KMSEncrypted = aws.Bool(v.(bool))
 	}
 
 	log.Printf("[DEBUG] Creating Storage Gateway cached iSCSI volume: %s", input)
@@ -168,6 +185,12 @@ func resourceAwsStorageGatewayCachedIscsiVolumeRead(d *schema.ResourceData, meta
 	d.Set("volume_arn", arn)
 	d.Set("volume_id", aws.StringValue(volume.VolumeId))
 	d.Set("volume_size_in_bytes", int(aws.Int64Value(volume.VolumeSizeInBytes)))
+	d.Set("kms_key", volume.KMSKey)
+	if volume.KMSKey != nil {
+		d.Set("kms_encrypted", true)
+	} else {
+		d.Set("kms_encrypted", false)
+	}
 
 	tags, err := keyvaluetags.StoragegatewayListTags(conn, arn)
 	if err != nil {

--- a/aws/resource_aws_storagegateway_cached_iscsi_volume_test.go
+++ b/aws/resource_aws_storagegateway_cached_iscsi_volume_test.go
@@ -94,6 +94,35 @@ func TestAccAWSStorageGatewayCachedIscsiVolume_Basic(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceName, "volume_id", regexp.MustCompile(`^vol-.+$`)),
 					testAccMatchResourceAttrRegionalARN(resourceName, "volume_arn", "storagegateway", regexp.MustCompile(`gateway/sgw-.+/volume/vol-.`)),
 					resource.TestCheckResourceAttr(resourceName, "volume_size_in_bytes", "5368709120"),
+					resource.TestCheckResourceAttr(resourceName, "kms_encrypted", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSStorageGatewayCachedIscsiVolume_kms(t *testing.T) {
+	var cachedIscsiVolume storagegateway.CachediSCSIVolume
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_cached_iscsi_volume.test"
+	keyResourceName := "aws_kms_key.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewayCachedIscsiVolumeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewayCachedIscsiVolumeConfigKMSEncrypted(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayCachedIscsiVolumeExists(resourceName, &cachedIscsiVolume),
+					resource.TestCheckResourceAttr(resourceName, "kms_encrypted", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key", keyResourceName, "arn"),
 				),
 			},
 			{
@@ -336,6 +365,76 @@ resource "aws_storagegateway_cached_iscsi_volume" "test" {
   volume_size_in_bytes = 5368709120
 }
 `, rName, rName)
+}
+
+func testAccAWSStorageGatewayCachedIscsiVolumeConfigKMSEncrypted(rName string) string {
+	return testAccAWSStorageGatewayGatewayConfig_GatewayType_Cached(rName) + fmt.Sprintf(`
+resource "aws_ebs_volume" "test" {
+  availability_zone = "${aws_instance.test.availability_zone}"
+  size              = 10
+  type              = "gp2"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_volume_attachment" "test" {
+  device_name  = "/dev/xvdc"
+  force_detach = true
+  instance_id  = "${aws_instance.test.id}"
+  volume_id    = "${aws_ebs_volume.test.id}"
+}
+
+data "aws_storagegateway_local_disk" "test" {
+  disk_path   = "${aws_volume_attachment.test.device_name}"
+  gateway_arn = "${aws_storagegateway_gateway.test.arn}"
+}
+
+resource "aws_storagegateway_cache" "test" {
+  # ACCEPTANCE TESTING WORKAROUND:
+  # Data sources are not refreshed before plan after apply in TestStep
+  # Step 0 error: After applying this step, the plan was not empty:
+  #   disk_id:     "0b68f77a-709b-4c79-ad9d-d7728014b291" => "/dev/xvdc" (forces new resource)
+  # We expect this data source value to change due to how Storage Gateway works.
+  lifecycle {
+    ignore_changes = ["disk_id"]
+  }
+
+  disk_id     = "${data.aws_storagegateway_local_disk.test.id}"
+  gateway_arn = "${aws_storagegateway_gateway.test.arn}"
+}
+
+ resource "aws_kms_key" "test" {
+     description = "Terraform acc test %[1]s"
+     policy = <<POLICY
+ {
+   "Version": "2012-10-17",
+   "Id": "kms-tf-1",
+   "Statement": [
+     {
+       "Sid": "Enable IAM User Permissions",
+       "Effect": "Allow",
+       "Principal": {
+         "AWS": "*"
+       },
+       "Action": "kms:*",
+       "Resource": "*"
+     }
+   ]
+ }
+ POLICY
+ }
+
+resource "aws_storagegateway_cached_iscsi_volume" "test" {
+  gateway_arn          = "${aws_storagegateway_cache.test.gateway_arn}"
+  network_interface_id = "${aws_instance.test.private_ip}"
+  target_name          = %[1]q
+  volume_size_in_bytes = 5368709120
+  kms_encrypted        = true
+  kms_key              = "${aws_kms_key.test.arn}"
+}
+`, rName)
 }
 
 func testAccAWSStorageGatewayCachedIscsiVolumeConfigTags1(rName, tagKey1, tagValue1 string) string {

--- a/website/docs/r/storagegateway_cached_iscsi_volume.html.markdown
+++ b/website/docs/r/storagegateway_cached_iscsi_volume.html.markdown
@@ -63,6 +63,8 @@ The following arguments are supported:
 * `volume_size_in_bytes` - (Required) The size of the volume in bytes.
 * `snapshot_id` - (Optional) The snapshot ID of the snapshot to restore as the new cached volume. e.g. `snap-1122aabb`.
 * `source_volume_arn` - (Optional) The ARN for an existing volume. Specifying this ARN makes the new volume into an exact copy of the specified existing volume's latest recovery point. The `volume_size_in_bytes` value for this new volume must be equal to or larger than the size of the existing volume, in bytes.
+* `kms_encrypted` - (Optional) `true` to use Amazon S3 server side encryption with your own AWS KMS key, or `false` to use a key managed by Amazon S3. Optional.
+* `kms_key` - (Optional) The Amazon Resource Name (ARN) of the AWS KMS key used for Amazon S3 server side encryption. This value can only be set when `kms_encrypted` is `true`.
 * `tags` - (Optional) Key-value mapping of resource tags
 
 ## Attribute Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
aws_resource_storagegateway_cached_iscsi_volume: enable setting kms key to encrypt volume
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSStorageGatewayCachedIscsiVolume_'
--- PASS: TestAccAWSStorageGatewayCachedIscsiVolume_kms (336.57s)
--- PASS: TestAccAWSStorageGatewayCachedIscsiVolume_Basic (331.23s)
--- PASS: TestAccAWSStorageGatewayCachedIscsiVolume_Tags (495.63s)
--- PASS: TestAccAWSStorageGatewayCachedIscsiVolume_SnapshotId (349.52s)
```
