### PR TITLE
Fix pending states for Neptune Instance

### DIFF
--- a/aws/resource_aws_neptune_cluster_instance.go
+++ b/aws/resource_aws_neptune_cluster_instance.go
@@ -493,6 +493,7 @@ var resourceAwsNeptuneClusterInstanceCreateUpdatePendingStates = []string{
 	"renaming",
 	"starting",
 	"upgrading",
+	"configuring-log-exports",
 }
 
 var resourceAwsNeptuneClusterInstanceDeletePendingStates = []string{


### PR DESCRIPTION

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_neptune_cluster_instance: missing pending state configuring-log-exports 
```

was unable to create neptune cluster instance without failing on the configuration of cloudwatch exports:
```
Error: unexpected state 'configuring-log-exports', wanted target 'available'. last error: %!s(<nil>)

  on ../modules/neptune/v1/main.tf line 19, in resource "aws_neptune_cluster_instance" "this":
  19: resource "aws_neptune_cluster_instance" "this" {
```

```
Output from acceptance testing:

make testacc TESTARGS='-run=TestAccAWSNeptuneCluster_updateCloudwatchLogsExports'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSNeptuneCluster_updateCloudwatchLogsExports -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSNeptuneCluster_updateCloudwatchLogsExports
=== PAUSE TestAccAWSNeptuneCluster_updateCloudwatchLogsExports
=== CONT  TestAccAWSNeptuneCluster_updateCloudwatchLogsExports
--- PASS: TestAccAWSNeptuneCluster_updateCloudwatchLogsExports (174.04s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	175.346s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.139s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.208s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/batch/equivalency	0.139s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks/token	0.209s [no tests to run]
?   	github.com/terraform-providers/terraform-provider-aws/awsproviderlint	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes	0.270s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSAT001	0.514s [no tests to run]
```
