### PR TITLE
Make weight in default_capacity_provider_strategy optional.

### DIFF
--- a/website/docs/r/ecs_cluster.html.markdown
+++ b/website/docs/r/ecs_cluster.html.markdown
@@ -40,7 +40,7 @@ The `setting` configuration block supports the following:
 The `default_capacity_provider_strategy` configuration block supports the following:
 
 * `capacity_provider` - (Required) The short name of the capacity provider.
-* `weight` - (Required) The relative percentage of the total number of launched tasks that should use the specified capacity provider.
+* `weight` - (Optional) The relative percentage of the total number of launched tasks that should use the specified capacity provider.
 * `base` - (Optional) The number of tasks, at a minimum, to run on the specified capacity provider. Only one capacity provider in a capacity provider strategy can have a base defined.
 
 ## Attributes Reference


### PR DESCRIPTION
Based on the schema description in #11150, weight is optional (as of provider.aws v2.48.0.)

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Relates #11150

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
Fixed documentation for AWS ecs_cluster resource.
```

