### PR TITLE
Limits directories for sweepers to just `./aws`

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,6 @@
 SWEEP?=us-east-1,us-west-2
 TEST?=./...
+SWEEP_DIR?=./aws
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 PKG_NAME=aws
 WEBSITE_REPO=github.com/hashicorp/terraform-website
@@ -16,7 +17,7 @@ gen:
 
 sweep:
 	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."
-	go test $(TEST) -v -sweep=$(SWEEP) $(SWEEPARGS) -timeout 60m
+	go test $(SWEEP_DIR) -v -sweep=$(SWEEP) $(SWEEPARGS) -timeout 60m
 
 test: fmtcheck
 	go test $(TEST) $(TESTARGS) -timeout=120s -parallel=4


### PR DESCRIPTION
When running `make sweep` it was running all tests in the repository, most of which failed on the `-sweep` flag.

```
$ make sweep SWEEPARGS='-sweep-run=aws_launch_template'
```

Previously

```
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./... -v -sweep=us-east-1,us-west-2 -sweep-run=aws_launch_template -timeout 60m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
...
2020/02/19 14:28:55 Sweeper Tests ran successfully:
	- aws_launch_template
	- aws_autoscaling_group
	- aws_batch_job_queue
	- aws_batch_compute_environment
...
2020/02/19 14:29:02 Sweeper Tests ran successfully:
	- aws_autoscaling_group
	- aws_batch_job_queue
	- aws_batch_compute_environment
	- aws_launch_template
ok  	github.com/terraform-providers/terraform-provider-aws/aws	20.127s
flag provided but not defined: -sweep
Usage of /var/folders/ty/v7j822bx4jqgy6bg9mbnvp1c0000gp/T/go-build072098635/b603/flatmap.test:
...
FAIL	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.033s
flag provided but not defined: -sweep
...
FAIL	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.159s
flag provided but not defined: -sweep
...
FAIL	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/batch/equivalency	0.072s
flag provided but not defined: -sweep
...
FAIL	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks/token	0.086s
?   	github.com/terraform-providers/terraform-provider-aws/awsproviderlint	[no test files]
=== RUN   TestValidateAllChecks
--- PASS: TestValidateAllChecks (0.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes	0.197s
...
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSAT001	3.339s
FAIL
make: *** [sweep] Error 1
```

Now

```
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=us-east-1,us-west-2 -sweep-run=aws_launch_template -timeout 60m
...
2020/02/19 14:30:41 Sweeper Tests ran successfully:
	- aws_autoscaling_group
	- aws_batch_job_queue
	- aws_batch_compute_environment
	- aws_launch_template
...
2020/02/19 14:30:48 Sweeper Tests ran successfully:
	- aws_autoscaling_group
	- aws_batch_job_queue
	- aws_batch_compute_environment
	- aws_launch_template
ok  	github.com/terraform-providers/terraform-provider-aws/aws	18.936s
```

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
