### PR TITLE
add outpost support to subnet resource

### DIFF
--- a/aws/data_source_aws_subnet.go
+++ b/aws/data_source_aws_subnet.go
@@ -39,6 +39,12 @@ func dataSourceAwsSubnet() *schema.Resource {
 				Computed: true,
 			},
 
+			"outpost_arn": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
 			"default_for_az": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -163,6 +169,7 @@ func dataSourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("cidr_block", subnet.CidrBlock)
 	d.Set("default_for_az", subnet.DefaultForAz)
 	d.Set("state", subnet.State)
+	d.Set("outpost_arn", subnet.OutpostArn)
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(subnet.Tags).IgnoreAws().Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)

--- a/aws/data_source_aws_subnet.go
+++ b/aws/data_source_aws_subnet.go
@@ -41,7 +41,6 @@ func dataSourceAwsSubnet() *schema.Resource {
 
 			"outpost_arn": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 

--- a/aws/resource_aws_subnet.go
+++ b/aws/resource_aws_subnet.go
@@ -111,11 +111,14 @@ func resourceAwsSubnetCreate(d *schema.ResourceData, meta interface{}) error {
 		AvailabilityZoneId: aws.String(d.Get("availability_zone_id").(string)),
 		CidrBlock:          aws.String(d.Get("cidr_block").(string)),
 		VpcId:              aws.String(d.Get("vpc_id").(string)),
-		OutpostArn:         aws.String(d.Get("outpost_arn").(string)),
 	}
 
 	if v, ok := d.GetOk("ipv6_cidr_block"); ok {
 		createOpts.Ipv6CidrBlock = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("outpost_arn"); ok {
+		createOpts.OutpostArn = aws.String(v.(string))
 	}
 
 	var err error

--- a/aws/resource_aws_subnet.go
+++ b/aws/resource_aws_subnet.go
@@ -72,6 +72,11 @@ func resourceAwsSubnet() *schema.Resource {
 				Default:  false,
 			},
 
+			"outpost_arn": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			"assign_ipv6_address_on_creation": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -106,6 +111,7 @@ func resourceAwsSubnetCreate(d *schema.ResourceData, meta interface{}) error {
 		AvailabilityZoneId: aws.String(d.Get("availability_zone_id").(string)),
 		CidrBlock:          aws.String(d.Get("cidr_block").(string)),
 		VpcId:              aws.String(d.Get("vpc_id").(string)),
+		OutpostArn:         aws.String(d.Get("outpost_arn").(string)),
 	}
 
 	if v, ok := d.GetOk("ipv6_cidr_block"); ok {

--- a/aws/resource_aws_subnet.go
+++ b/aws/resource_aws_subnet.go
@@ -75,6 +75,7 @@ func resourceAwsSubnet() *schema.Resource {
 			"outpost_arn": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 			},
 
 			"assign_ipv6_address_on_creation": {

--- a/aws/resource_aws_subnet.go
+++ b/aws/resource_aws_subnet.go
@@ -73,9 +73,10 @@ func resourceAwsSubnet() *schema.Resource {
 			},
 
 			"outpost_arn": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
 			},
 
 			"assign_ipv6_address_on_creation": {
@@ -245,6 +246,7 @@ func resourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("cidr_block", subnet.CidrBlock)
 	d.Set("map_public_ip_on_launch", subnet.MapPublicIpOnLaunch)
 	d.Set("assign_ipv6_address_on_creation", subnet.AssignIpv6AddressOnCreation)
+	d.Set("outpost_arn", subnet.OutpostArn)
 
 	// Make sure those values are set, if an IPv6 block exists it'll be set in the loop
 	d.Set("ipv6_cidr_block_association_id", "")

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"os"
 	"regexp"
 	"testing"
 	"time"
@@ -312,6 +313,42 @@ func TestAccAWSSubnet_availabilityZoneId(t *testing.T) {
 	})
 }
 
+func TestAccAWSSubnet_outpost(t *testing.T) {
+	var v ec2.Subnet
+	resourceName := "aws_subnet.test"
+
+	outpostArn := os.Getenv("AWS_OUTPOST_ARN")
+	if outpostArn == "" {
+		t.Skip(
+			"Environment variable AWS_OUTPOST_ARN is not set. " +
+				"This environment variable must be set to the ARN of " +
+				"a deployed Outpost to enable this test.")
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckSubnetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSubnetConfigOutpost(outpostArn),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSubnetExists(
+						resourceName, &v),
+					resource.TestCheckResourceAttr(
+						resourceName, "outpost_arn", outpostArn),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAwsSubnetIpv6BeforeUpdate(t *testing.T, subnet *ec2.Subnet) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if subnet.Ipv6CidrBlockAssociationSet == nil {
@@ -532,3 +569,23 @@ resource "aws_subnet" "test" {
   }
 }
 `
+
+func testAccSubnetConfigOutpost(outpostArn string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+  tags = {
+    Name = "terraform-testacc-subnet-outpost"
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block = "10.1.1.0/24"
+  vpc_id = "${aws_vpc.test.id}"
+  outpost_arn = "%s"
+  tags = {
+    Name = "tf-acc-subnet-outpost"
+  }
+}
+`, outpostArn)
+}

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -572,6 +572,11 @@ resource "aws_subnet" "test" {
 
 func testAccSubnetConfigOutpost(outpostArn string) string {
 	return fmt.Sprintf(`
+data "aws_availability_zones" "current" {
+  # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
+  blacklisted_zone_ids = ["usw2-az4"]
+}
+
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
   tags = {
@@ -582,6 +587,7 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "test" {
   cidr_block = "10.1.1.0/24"
   vpc_id = "${aws_vpc.test.id}"
+  availability_zone       = "${data.aws_availability_zones.current.names[0]}"
   outpost_arn = "%s"
   tags = {
     Name = "tf-acc-subnet-outpost"

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -162,6 +162,8 @@ func TestAccAWSSubnet_basic(t *testing.T) {
 						resourceName, "availability_zone"),
 					resource.TestCheckResourceAttrSet(
 						resourceName, "availability_zone_id"),
+					resource.TestCheckResourceAttr(
+						resourceName, "outpost_arn", ""),
 				),
 			},
 			{

--- a/website/docs/d/subnet.html.markdown
+++ b/website/docs/d/subnet.html.markdown
@@ -98,3 +98,4 @@ In addition the following attributes are exported:
 
 * `arn` - The ARN of the subnet.
 * `owner_id` - The ID of the AWS account that owns the subnet.
+* `outpost_arn` - The Amazon Resource Name (ARN) of the Outpost.

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -56,6 +56,7 @@ The following arguments are supported:
 * `map_public_ip_on_launch` -  (Optional) Specify true to indicate
     that instances launched into the subnet should be assigned
     a public IP address. Default is `false`.
+* `outpost_arn` - (Optional) The Amazon Resource Name (ARN) of the Outpost.
 * `assign_ipv6_address_on_creation` - (Optional) Specify true to indicate
     that network interfaces created in the specified subnet should be
     assigned an IPv6 address. Default is `false`


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add Outpost support to subnet resource
Add Outpost support to subnet data source
```

On the matter of acceptance testing:

Still working on getting a test Outpost unit installed. Since most users won't have access to Outpost for acceptance testing in the future, I'd like feedback on how we might test this case. My only verification step has been to ensure passing an outpost_arn to the subnet provider correctly interacts with the AWS API.

```output
aws_subnet.main: Creating...

Error: Error creating subnet: InvalidOutpostArnID.NotFound: The outpostArn ID 'arn:aws:outpost:us-east-1:xxxxxxxx:o-xxxxxxxx' does not exist
        status code: 400, request id: <snip>
```
