### PR TITLE
EBS Snapshots Create Volume Permission: Fail if the account is snapshot owner

### DIFF
--- a/aws/resource_aws_snapshot_create_volume_permission.go
+++ b/aws/resource_aws_snapshot_create_volume_permission.go
@@ -49,9 +49,19 @@ func resourceAwsSnapshotCreateVolumePermissionCreate(d *schema.ResourceData, met
 	snapshot_id := d.Get("snapshot_id").(string)
 	account_id := d.Get("account_id").(string)
 
-	_, err := conn.ModifySnapshotAttribute(&ec2.ModifySnapshotAttributeInput{
+	accountIsOwner, err := isAccountSnapshotOwner(conn, snapshot_id, account_id)
+	if err != nil {
+		return fmt.Errorf("Error adding snapshot %s: %s", ec2.SnapshotAttributeNameCreateVolumePermission, err)
+	}
+
+	if accountIsOwner {
+		return fmt.Errorf("Error adding snapshot %s: specified account %s is the snapshot owner",
+			ec2.SnapshotAttributeNameCreateVolumePermission, account_id)
+	}
+
+	_, err = conn.ModifySnapshotAttribute(&ec2.ModifySnapshotAttributeInput{
 		SnapshotId: aws.String(snapshot_id),
-		Attribute:  aws.String("createVolumePermission"),
+		Attribute:  aws.String(ec2.SnapshotAttributeNameCreateVolumePermission),
 		CreateVolumePermission: &ec2.CreateVolumePermissionModifications{
 			Add: []*ec2.CreateVolumePermission{
 				{UserId: aws.String(account_id)},
@@ -59,7 +69,7 @@ func resourceAwsSnapshotCreateVolumePermissionCreate(d *schema.ResourceData, met
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("Error adding snapshot createVolumePermission: %s", err)
+		return fmt.Errorf("Error adding snapshot %s: %s", ec2.SnapshotAttributeNameCreateVolumePermission, err)
 	}
 
 	d.SetId(fmt.Sprintf("%s-%s", snapshot_id, account_id))
@@ -75,8 +85,8 @@ func resourceAwsSnapshotCreateVolumePermissionCreate(d *schema.ResourceData, met
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
 		return fmt.Errorf(
-			"Error waiting for snapshot createVolumePermission (%s) to be added: %s",
-			d.Id(), err)
+			"Error waiting for snapshot %s (%s) to be added: %s",
+			ec2.SnapshotAttributeNameCreateVolumePermission, d.Id(), err)
 	}
 
 	return nil
@@ -96,7 +106,7 @@ func resourceAwsSnapshotCreateVolumePermissionDelete(d *schema.ResourceData, met
 
 	_, err = conn.ModifySnapshotAttribute(&ec2.ModifySnapshotAttributeInput{
 		SnapshotId: aws.String(snapshotID),
-		Attribute:  aws.String("createVolumePermission"),
+		Attribute:  aws.String(ec2.SnapshotAttributeNameCreateVolumePermission),
 		CreateVolumePermission: &ec2.CreateVolumePermissionModifications{
 			Remove: []*ec2.CreateVolumePermission{
 				{UserId: aws.String(accountID)},
@@ -104,7 +114,7 @@ func resourceAwsSnapshotCreateVolumePermissionDelete(d *schema.ResourceData, met
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("Error removing snapshot createVolumePermission: %s", err)
+		return fmt.Errorf("Error removing snapshot %s: %s", ec2.SnapshotAttributeNameCreateVolumePermission, err)
 	}
 
 	// Wait for the account to disappear from the permission list
@@ -118,11 +128,27 @@ func resourceAwsSnapshotCreateVolumePermissionDelete(d *schema.ResourceData, met
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
 		return fmt.Errorf(
-			"Error waiting for snapshot createVolumePermission (%s) to be removed: %s",
-			d.Id(), err)
+			"Error waiting for snapshot %s (%s) to be removed: %s",
+			ec2.SnapshotAttributeNameCreateVolumePermission, d.Id(), err)
 	}
 
 	return nil
+}
+
+func isAccountSnapshotOwner(conn *ec2.EC2, snapshot_id string, account_id string) (bool, error) {
+	output, err := conn.DescribeSnapshots(&ec2.DescribeSnapshotsInput{
+		SnapshotIds: aws.StringSlice([]string{snapshot_id}),
+	})
+	if err != nil {
+		return false, fmt.Errorf("Error describing snapshot %s: %s", snapshot_id, err)
+	}
+
+	if len(output.Snapshots) != 1 {
+		return false, fmt.Errorf("Error locating snapshot %s: found %d snapshots, expected 1",
+			snapshot_id, len(output.Snapshots))
+	}
+
+	return *output.Snapshots[0].OwnerId == account_id, nil
 }
 
 func hasCreateVolumePermission(conn *ec2.EC2, snapshot_id string, account_id string) (bool, error) {
@@ -141,10 +167,10 @@ func resourceAwsSnapshotCreateVolumePermissionStateRefreshFunc(conn *ec2.EC2, sn
 	return func() (interface{}, string, error) {
 		attrs, err := conn.DescribeSnapshotAttribute(&ec2.DescribeSnapshotAttributeInput{
 			SnapshotId: aws.String(snapshot_id),
-			Attribute:  aws.String("createVolumePermission"),
+			Attribute:  aws.String(ec2.SnapshotAttributeNameCreateVolumePermission),
 		})
 		if err != nil {
-			return nil, "", fmt.Errorf("Error refreshing snapshot createVolumePermission state: %s", err)
+			return nil, "", fmt.Errorf("Error refreshing snapshot %s state: %s", ec2.SnapshotAttributeNameCreateVolumePermission, err)
 		}
 
 		for _, vp := range attrs.CreateVolumePermissions {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12102

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_snapshot_create_volume_permission: Check if the account is snapshot owner
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSSnapshotCreateVolumePermission_Basic'                                                        okta:sandbox
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSnapshotCreateVolumePermission_Basic -timeout 120m
=== RUN   TestAccAWSSnapshotCreateVolumePermission_Basic
=== PAUSE TestAccAWSSnapshotCreateVolumePermission_Basic
=== CONT  TestAccAWSSnapshotCreateVolumePermission_Basic
--- PASS: TestAccAWSSnapshotCreateVolumePermission_Basic (121.88s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	124.033s
```
