### PR TITLE
Add missing makefile phony targets

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -128,5 +128,21 @@ ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
 endif
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
-.PHONY: build gen sweep test testacc fmt fmtcheck lint tools test-compile website website-lint website-test depscheck docscheck
-
+.PHONY: default \
+        build \
+        gen \
+        sweep \
+        test \
+        testacc \
+        fmt \
+        fmtcheck \
+        gencheck \
+        websitefmtcheck \
+        depscheck \
+        docscheck \
+        lint \
+        tools \
+        test-compile \
+        website \
+        website-lint \
+        website-test


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Relates https://github.com/terraform-providers/terraform-provider-aws/pull/11638.

When adding the `gencheck` target I forgot to add it to the [phony target](https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html).
This PR adds a number of missing phony targets.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
n/a
```
