### PR TITLE
resource/aws_rds_cluster_parameter_group and resource/aws_db_parameter_group: Restore ability to change parameter values

### DIFF
--- a/aws/resource_aws_db_parameter_group.go
+++ b/aws/resource_aws_db_parameter_group.go
@@ -277,8 +277,25 @@ func resourceAwsDbParameterGroupUpdate(d *schema.ResourceData, meta interface{})
 			}
 		}
 
+		toRemove := map[string]*rds.Parameter{}
+
+		for _, p := range expandParameters(os.List()) {
+			if p.ParameterName != nil {
+				toRemove[*p.ParameterName] = p
+			}
+		}
+
+		for _, p := range expandParameters(ns.List()) {
+			if p.ParameterName != nil {
+				delete(toRemove, *p.ParameterName)
+			}
+		}
+
 		// Reset parameters that have been removed
-		resetParameters := expandParameters(os.Difference(ns).List())
+		var resetParameters []*rds.Parameter
+		for _, v := range toRemove {
+			resetParameters = append(resetParameters, v)
+		}
 		if len(resetParameters) > 0 {
 			maxParams := 20
 			for resetParameters != nil {


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #11846
Closes #13551

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
* resource/aws_rds_cluster_parameter_group and resource/aws_db_parameter_group: Restore ability to change parameter values ([#11846](https://github.com/terraform-providers/terraform-provider-aws/issues/11846))
```

In #11540, support was added to the rds parameter group resources for resetting parameter values to AWS defaults when parameters are removed from config. A side-effect of these changes, however, was that parameters which remain in the config but whose values have been changed would also be reset to AWS defaults. This commit restores the ability for parameter values to be updated in the config while retaining the ability for parameters being removed from the config to be reset to AWS defaults.

Output from acceptance testing:

```
$  make testacc TEST=./aws TESTARGS='-run=TestAccAWSDBClusterParameterGroup_'
...
--- PASS: TestAccAWSDBClusterParameterGroup_disappears (18.01s)
--- PASS: TestAccAWSDBClusterParameterGroup_namePrefix (23.28s)
--- PASS: TestAccAWSDBClusterParameterGroup_only (23.40s)
--- PASS: TestAccAWSDBClusterParameterGroup_generatedName (23.42s)
--- PASS: TestAccAWSDBClusterParameterGroup_generatedName_Parameter (23.77s)
--- PASS: TestAccAWSDBClusterParameterGroup_namePrefix_Parameter (23.79s)
--- PASS: TestAccAWSDBClusterParameterGroup_withApplyMethod (23.89s)
--- PASS: TestAccAWSDBClusterParameterGroup_basic (86.64s)
```

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDBParameterGroup_'
...
--- PASS: TestAccAWSDBParameterGroup_Disappears (18.18s)
--- PASS: TestAccAWSDBParameterGroup_generatedName (22.40s)
--- PASS: TestAccAWSDBParameterGroup_namePrefix (22.69s)
--- PASS: TestAccAWSDBParameterGroup_Only (23.40s)
--- PASS: TestAccAWSDBParameterGroup_MatchDefault (24.19s)
--- PASS: TestAccAWSDBParameterGroup_withApplyMethod (25.23s)
--- PASS: TestAccAWSDBParameterGroup_limit (45.08s)
--- PASS: TestAccAWSDBParameterGroup_basic (75.38s)
```