### PR TITLE
add support for resource_aws_glub_job notification_property and notify_delay_after

### DIFF
--- a/website/docs/r/glue_job.html.markdown
+++ b/website/docs/r/glue_job.html.markdown
@@ -82,6 +82,7 @@ be removed in future releases, please use `max_capacity` instead.
 * `max_capacity` – (Optional) The maximum number of AWS Glue data processing units (DPUs) that can be allocated when this job runs.
 * `max_retries` – (Optional) The maximum number of times to retry this job if it fails.
 * `name` – (Required) The name you assign to this job. It must be unique in your account.
+* `notification_property` - (Optional) Notification property of the job. Defined below.
 * `role_arn` – (Required) The ARN of the IAM role associated with this job.
 * `tags` - (Optional) Key-value mapping of resource tags
 * `timeout` – (Optional) The job timeout in minutes. The default is 2880 minutes (48 hours).
@@ -98,6 +99,10 @@ be removed in future releases, please use `max_capacity` instead.
 ### execution_property Argument Reference
 
 * `max_concurrent_runs` - (Optional) The maximum number of concurrent runs allowed for a job. The default is 1.
+
+### notification_property Argument Reference
+
+* `notify_delay_after` - (Optional) After a job run starts, the number of minutes to wait before sending a job run delay notification.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11829

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_glue_job: add notification_property & notify_delay_after support
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSGlueJob_'
--- PASS: TestAccAWSGlueJob_Basic (55.50s)
--- PASS: TestAccAWSGlueJob_ExecutionProperty (94.04s)
--- PASS: TestAccAWSGlueJob_DefaultArguments (94.87s)
--- PASS: TestAccAWSGlueJob_SecurityConfiguration (101.95s)
--- PASS: TestAccAWSGlueJob_Command (108.07s)
--- PASS: TestAccAWSGlueJob_MaxRetries (108.99s)
--- PASS: TestAccAWSGlueJob_Timeout (119.64s)
--- PASS: TestAccAWSGlueJob_AllocatedCapacity (125.96s)
--- PASS: TestAccAWSGlueJob_PythonShell (136.50s)
--- PASS: TestAccAWSGlueJob_GlueVersion (151.28s)
--- PASS: TestAccAWSGlueJob_MaxCapacity (151.92s)
--- PASS: TestAccAWSGlueJob_Description (163.76s)
--- PASS: TestAccAWSGlueJob_Tags (167.47s)
--- PASS: TestAccAWSGlueJob_WorkerType (182.65s)
--- PASS: TestAccAWSGlueJob_NotificationProperty (227.99s)
```
