### PR TITLE
docs: add capacitystatus filter to aws_pricing_product

### DIFF
--- a/website/docs/d/pricing_product.html.markdown
+++ b/website/docs/d/pricing_product.html.markdown
@@ -46,6 +46,11 @@ data "aws_pricing_product" "example" {
     field = "tenancy"
     value = "Shared"
   }
+
+  filters {
+    field = "capacitystatus"
+    value = "Used"
+  }
 }
 ```
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


The given example fails when executed:

```
Error: Pricing product query not precise enough. Returned more than one element: <json>
```

Running `jq '.[].product.attributes.capacitystatus'` over the JSON response reveals the (3) values:

```
"AllocatedCapacityReservation"
"UnusedCapacityReservation"
"Used"
```

The "Used" status is the price when an instance is actual in use and is what most users will be interested in.