### PR TITLE
r/aws_vpc_peering_connection_options: Only modify VPC Peering options that have actually changed

### DIFF
--- a/aws/internal/service/ec2/errors.go
+++ b/aws/internal/service/ec2/errors.go
@@ -13,6 +13,10 @@ const (
 )
 
 const (
+	ErrCodeInvalidVpcPeeringConnectionIDNotFound = "InvalidVpcPeeringConnectionID.NotFound"
+)
+
+const (
 	InvalidVpnGatewayAttachmentNotFound = "InvalidVpnGatewayAttachment.NotFound"
 	InvalidVpnGatewayIDNotFound         = "InvalidVpnGatewayID.NotFound"
 )

--- a/aws/internal/service/ec2/finder/finder.go
+++ b/aws/internal/service/ec2/finder/finder.go
@@ -72,6 +72,25 @@ func SecurityGroupByID(conn *ec2.EC2, id string) (*ec2.SecurityGroup, error) {
 	return result.SecurityGroups[0], nil
 }
 
+// VpcPeeringConnectionByID returns the VPC peering connection corresponding to the specified identifier.
+// Returns nil and potentially an error if no VPC peering connection is found.
+func VpcPeeringConnectionByID(conn *ec2.EC2, id string) (*ec2.VpcPeeringConnection, error) {
+	input := &ec2.DescribeVpcPeeringConnectionsInput{
+		VpcPeeringConnectionIds: aws.StringSlice([]string{id}),
+	}
+
+	output, err := conn.DescribeVpcPeeringConnections(input)
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || len(output.VpcPeeringConnections) == 0 {
+		return nil, nil
+	}
+
+	return output.VpcPeeringConnections[0], nil
+}
+
 // VpnGatewayVpcAttachment returns the attachment between the specified VPN gateway and VPC.
 // Returns nil and potentially an error if no attachment is found.
 func VpnGatewayVpcAttachment(conn *ec2.EC2, vpnGatewayID, vpcID string) (*ec2.VpcAttachment, error) {

--- a/aws/resource_aws_vpc_peering_connection.go
+++ b/aws/resource_aws_vpc_peering_connection.go
@@ -232,7 +232,7 @@ func resourceAwsVPCPeeringUpdate(d *schema.ResourceData, meta interface{}) error
 				req.RequesterPeeringConnectionOptions = expandVpcPeeringConnectionOptions(d.Get("requester").([]interface{}), crossRegionPeering)
 			}
 
-			log.Printf("[DEBUG] Modifying VPC Peering Connection options: %#v", req)
+			log.Printf("[DEBUG] Modifying VPC Peering Connection options: %s", req)
 			if _, err := conn.ModifyVpcPeeringConnectionOptions(req); err != nil {
 				return fmt.Errorf("error modifying VPC Peering Connection (%s) Options: %s", d.Id(), err)
 			}

--- a/aws/resource_aws_vpc_peering_connection.go
+++ b/aws/resource_aws_vpc_peering_connection.go
@@ -265,6 +265,11 @@ func resourceAwsVPCPeeringDelete(d *schema.ResourceData, meta interface{}) error
 		return nil
 	}
 
+	// "InvalidStateTransition: Invalid state transition for pcx-0000000000000000, attempted to transition from failed to deleting"
+	if isAWSErr(err, "InvalidStateTransition", "to deleting") {
+		return nil
+	}
+
 	if err != nil {
 		return fmt.Errorf("Error deleting VPC Peering Connection (%s): %s", d.Id(), err)
 	}

--- a/aws/resource_aws_vpc_peering_connection_options.go
+++ b/aws/resource_aws_vpc_peering_connection_options.go
@@ -3,9 +3,11 @@ package aws
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -40,18 +42,17 @@ func resourceAwsVpcPeeringConnectionOptionsCreate(d *schema.ResourceData, meta i
 func resourceAwsVpcPeeringConnectionOptionsRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	pcRaw, _, err := vpcPeeringConnectionRefreshState(conn, d.Id())()
+	pc, err := vpcPeeringConnection(conn, d.Id())
+
 	if err != nil {
-		return fmt.Errorf("error reading VPC Peering Connection: %s", err)
+		return fmt.Errorf("error reading VPC Peering Connection (%s): %w", d.Id(), err)
 	}
 
-	if pcRaw == nil {
+	if pc == nil {
 		log.Printf("[WARN] VPC Peering Connection (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
-
-	pc := pcRaw.(*ec2.VpcPeeringConnection)
 
 	d.Set("vpc_peering_connection_id", pc.VpcPeeringConnectionId)
 
@@ -68,35 +69,66 @@ func resourceAwsVpcPeeringConnectionOptionsRead(d *schema.ResourceData, meta int
 func resourceAwsVpcPeeringConnectionOptionsUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	pcRaw, _, err := vpcPeeringConnectionRefreshState(conn, d.Id())()
+	pc, err := vpcPeeringConnection(conn, d.Id())
+
 	if err != nil {
-		return fmt.Errorf("error reading VPC Peering Connection (%s): %s", d.Id(), err)
+		return fmt.Errorf("error reading VPC Peering Connection (%s): %w", d.Id(), err)
 	}
 
-	if pcRaw == nil {
-		log.Printf("[WARN] VPC Peering Connection (%s) not found, removing from state", d.Id())
-		d.SetId("")
-		return nil
+	if pc == nil {
+		return fmt.Errorf("VPC Peering Connection (%s) not found", d.Id())
 	}
 
 	if d.HasChanges("accepter", "requester") {
-		pc := pcRaw.(*ec2.VpcPeeringConnection)
 		crossRegionPeering := aws.StringValue(pc.RequesterVpcInfo.Region) != aws.StringValue(pc.AccepterVpcInfo.Region)
 
-		req := &ec2.ModifyVpcPeeringConnectionOptionsInput{
+		input := &ec2.ModifyVpcPeeringConnectionOptionsInput{
 			VpcPeeringConnectionId: aws.String(d.Id()),
 		}
 		if d.HasChange("accepter") {
-			req.AccepterPeeringConnectionOptions = expandVpcPeeringConnectionOptions(d.Get("accepter").([]interface{}), crossRegionPeering)
+			input.AccepterPeeringConnectionOptions = expandVpcPeeringConnectionOptions(d.Get("accepter").([]interface{}), crossRegionPeering)
 		}
 		if d.HasChange("requester") {
-			req.RequesterPeeringConnectionOptions = expandVpcPeeringConnectionOptions(d.Get("requester").([]interface{}), crossRegionPeering)
+			input.RequesterPeeringConnectionOptions = expandVpcPeeringConnectionOptions(d.Get("requester").([]interface{}), crossRegionPeering)
 		}
 
-		log.Printf("[DEBUG] Modifying VPC Peering Connection options: %s", req)
-		if _, err := conn.ModifyVpcPeeringConnectionOptions(req); err != nil {
-			return fmt.Errorf("error modifying VPC Peering Connection (%s) Options: %s", d.Id(), err)
+		log.Printf("[DEBUG] Modifying VPC Peering Connection options: %s", input)
+		_, err = conn.ModifyVpcPeeringConnectionOptions(input)
+
+		if err != nil {
+			return fmt.Errorf("error modifying VPC Peering Connection (%s) Options: %w", d.Id(), err)
 		}
+
+		// Retry reading back the modified options to deal with eventual consistency.
+		// Often this is to do with a delay transitioning from pending-acceptance to active.
+		err = resource.Retry(3*time.Minute, func() *resource.RetryError {
+			pc, err = vpcPeeringConnection(conn, d.Id())
+
+			if err != nil {
+				return resource.NonRetryableError(err)
+			}
+
+			if pc == nil {
+				return nil
+			}
+
+			if d.HasChange("accepter") && pc.AccepterVpcInfo != nil {
+				if aws.BoolValue(pc.AccepterVpcInfo.PeeringOptions.AllowDnsResolutionFromRemoteVpc) != aws.BoolValue(input.AccepterPeeringConnectionOptions.AllowDnsResolutionFromRemoteVpc) ||
+					aws.BoolValue(pc.AccepterVpcInfo.PeeringOptions.AllowEgressFromLocalClassicLinkToRemoteVpc) != aws.BoolValue(input.AccepterPeeringConnectionOptions.AllowEgressFromLocalClassicLinkToRemoteVpc) ||
+					aws.BoolValue(pc.AccepterVpcInfo.PeeringOptions.AllowEgressFromLocalVpcToRemoteClassicLink) != aws.BoolValue(input.AccepterPeeringConnectionOptions.AllowEgressFromLocalVpcToRemoteClassicLink) {
+					return resource.RetryableError(fmt.Errorf("VPC Peering Connection (%s) accepter Options not stable", d.Id()))
+				}
+			}
+			if d.HasChange("requester") && pc.RequesterVpcInfo != nil {
+				if aws.BoolValue(pc.RequesterVpcInfo.PeeringOptions.AllowDnsResolutionFromRemoteVpc) != aws.BoolValue(input.RequesterPeeringConnectionOptions.AllowDnsResolutionFromRemoteVpc) ||
+					aws.BoolValue(pc.RequesterVpcInfo.PeeringOptions.AllowEgressFromLocalClassicLinkToRemoteVpc) != aws.BoolValue(input.RequesterPeeringConnectionOptions.AllowEgressFromLocalClassicLinkToRemoteVpc) ||
+					aws.BoolValue(pc.RequesterVpcInfo.PeeringOptions.AllowEgressFromLocalVpcToRemoteClassicLink) != aws.BoolValue(input.RequesterPeeringConnectionOptions.AllowEgressFromLocalVpcToRemoteClassicLink) {
+					return resource.RetryableError(fmt.Errorf("VPC Peering Connection (%s) requester Options not stable", d.Id()))
+				}
+			}
+
+			return nil
+		})
 	}
 
 	return resourceAwsVpcPeeringConnectionOptionsRead(d, meta)

--- a/aws/resource_aws_vpc_peering_connection_options.go
+++ b/aws/resource_aws_vpc_peering_connection_options.go
@@ -87,13 +87,13 @@ func resourceAwsVpcPeeringConnectionOptionsUpdate(d *schema.ResourceData, meta i
 			VpcPeeringConnectionId: aws.String(d.Id()),
 		}
 		if d.HasChange("accepter") {
-			req.AccepterPeeringConnectionOptions = expandVpcPeeringConnectionOptions(d.Get("accepter").(*schema.Set).List(), crossRegionPeering)
+			req.AccepterPeeringConnectionOptions = expandVpcPeeringConnectionOptions(d.Get("accepter").([]interface{}), crossRegionPeering)
 		}
 		if d.HasChange("requester") {
-			req.RequesterPeeringConnectionOptions = expandVpcPeeringConnectionOptions(d.Get("requester").(*schema.Set).List(), crossRegionPeering)
+			req.RequesterPeeringConnectionOptions = expandVpcPeeringConnectionOptions(d.Get("requester").([]interface{}), crossRegionPeering)
 		}
 
-		log.Printf("[DEBUG] Modifying VPC Peering Connection options: %#v", req)
+		log.Printf("[DEBUG] Modifying VPC Peering Connection options: %s", req)
 		if _, err := conn.ModifyVpcPeeringConnectionOptions(req); err != nil {
 			return fmt.Errorf("error modifying VPC Peering Connection (%s) Options: %s", d.Id(), err)
 		}

--- a/aws/resource_aws_vpc_peering_connection_options_test.go
+++ b/aws/resource_aws_vpc_peering_connection_options_test.go
@@ -190,12 +190,8 @@ func TestAccAWSVpcPeeringConnectionOptions_sameRegionDifferentAccount(t *testing
 						"1",
 					),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "requester.*", map[string]string{
-						"allow_remote_vpc_dns_resolution": "true",
-					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "requester.*", map[string]string{
+						"allow_remote_vpc_dns_resolution":  "true",
 						"allow_classic_link_to_remote_vpc": "false",
-					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "requester.*", map[string]string{
 						"allow_vpc_to_remote_classic_link": "false",
 					}),
 					testAccCheckAWSVpcPeeringConnectionOptions(
@@ -213,13 +209,9 @@ func TestAccAWSVpcPeeringConnectionOptions_sameRegionDifferentAccount(t *testing
 						"accepter.#",
 						"1",
 					),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceNamePeer, "requester.*", map[string]string{
-						"allow_remote_vpc_dns_resolution": "true",
-					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceNamePeer, "requester.*", map[string]string{
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceNamePeer, "accepter.*", map[string]string{
+						"allow_remote_vpc_dns_resolution":  "true",
 						"allow_classic_link_to_remote_vpc": "false",
-					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceNamePeer, "requester.*", map[string]string{
 						"allow_vpc_to_remote_classic_link": "false",
 					}),
 				),

--- a/aws/resource_aws_vpc_peering_connection_options_test.go
+++ b/aws/resource_aws_vpc_peering_connection_options_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func TestAccAWSVpcPeeringConnectionOptions_basic(t *testing.T) {
@@ -26,20 +25,10 @@ func TestAccAWSVpcPeeringConnectionOptions_basic(t *testing.T) {
 				Config: testAccVpcPeeringConnectionOptionsConfig_sameRegion_sameAccount(rName, true, true),
 				Check: resource.ComposeTestCheckFunc(
 					// Requester's view:
-					resource.TestCheckResourceAttr(
-						resourceName,
-						"requester.#",
-						"1",
-					),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "requester.*", map[string]string{
-						"allow_remote_vpc_dns_resolution": "false",
-					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "requester.*", map[string]string{
-						"allow_classic_link_to_remote_vpc": "true",
-					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "requester.*", map[string]string{
-						"allow_vpc_to_remote_classic_link": "true",
-					}),
+					resource.TestCheckResourceAttr(resourceName, "requester.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "requester.0.allow_remote_vpc_dns_resolution", "false"),
+					resource.TestCheckResourceAttr(resourceName, "requester.0.allow_classic_link_to_remote_vpc", "true"),
+					resource.TestCheckResourceAttr(resourceName, "requester.0.allow_vpc_to_remote_classic_link", "true"),
 					testAccCheckAWSVpcPeeringConnectionOptions(
 						pcxResourceName,
 						"requester",
@@ -50,20 +39,10 @@ func TestAccAWSVpcPeeringConnectionOptions_basic(t *testing.T) {
 						},
 					),
 					// Accepter's view:
-					resource.TestCheckResourceAttr(
-						resourceName,
-						"accepter.#",
-						"1",
-					),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "accepter.*", map[string]string{
-						"allow_remote_vpc_dns_resolution": "true",
-					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "accepter.*", map[string]string{
-						"allow_classic_link_to_remote_vpc": "false",
-					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "accepter.*", map[string]string{
-						"allow_vpc_to_remote_classic_link": "false",
-					}),
+					resource.TestCheckResourceAttr(resourceName, "accepter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "accepter.0.allow_remote_vpc_dns_resolution", "true"),
+					resource.TestCheckResourceAttr(resourceName, "accepter.0.allow_classic_link_to_remote_vpc", "false"),
+					resource.TestCheckResourceAttr(resourceName, "accepter.0.allow_vpc_to_remote_classic_link", "false"),
 					testAccCheckAWSVpcPeeringConnectionOptions(
 						pcxResourceName,
 						"accepter",
@@ -140,20 +119,10 @@ func TestAccAWSVpcPeeringConnectionOptions_differentRegionSameAccount(t *testing
 				Config: testAccVpcPeeringConnectionOptionsConfig_differentRegion_sameAccount(rName, true, true),
 				Check: resource.ComposeTestCheckFunc(
 					// Requester's view:
-					resource.TestCheckResourceAttr(
-						resourceName,
-						"requester.#",
-						"1",
-					),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "requester.*", map[string]string{
-						"allow_remote_vpc_dns_resolution": "true",
-					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "requester.*", map[string]string{
-						"allow_classic_link_to_remote_vpc": "false",
-					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "requester.*", map[string]string{
-						"allow_vpc_to_remote_classic_link": "false",
-					}),
+					resource.TestCheckResourceAttr(resourceName, "requester.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "requester.0.allow_remote_vpc_dns_resolution", "true"),
+					resource.TestCheckResourceAttr(resourceName, "requester.0.allow_classic_link_to_remote_vpc", "false"),
+					resource.TestCheckResourceAttr(resourceName, "requester.0.allow_vpc_to_remote_classic_link", "false"),
 					testAccCheckAWSVpcPeeringConnectionOptions(
 						pcxResourceName,
 						"requester",
@@ -164,20 +133,10 @@ func TestAccAWSVpcPeeringConnectionOptions_differentRegionSameAccount(t *testing
 						},
 					),
 					// Accepter's view:
-					resource.TestCheckResourceAttr(
-						resourceNamePeer,
-						"accepter.#",
-						"1",
-					),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceNamePeer, "accepter.*", map[string]string{
-						"allow_remote_vpc_dns_resolution": "true",
-					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceNamePeer, "accepter.*", map[string]string{
-						"allow_classic_link_to_remote_vpc": "false",
-					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceNamePeer, "accepter.*", map[string]string{
-						"allow_vpc_to_remote_classic_link": "false",
-					}),
+					resource.TestCheckResourceAttr(resourceNamePeer, "accepter.#", "1"),
+					resource.TestCheckResourceAttr(resourceNamePeer, "accepter.0.allow_remote_vpc_dns_resolution", "true"),
+					resource.TestCheckResourceAttr(resourceNamePeer, "accepter.0.allow_classic_link_to_remote_vpc", "false"),
+					resource.TestCheckResourceAttr(resourceNamePeer, "accepter.0.allow_vpc_to_remote_classic_link", "false"),
 					testAccCheckAWSVpcPeeringConnectionOptionsWithProvider(
 						pcxResourceNamePeer,
 						"accepter",
@@ -255,20 +214,10 @@ func TestAccAWSVpcPeeringConnectionOptions_sameRegionDifferentAccount(t *testing
 				Config: testAccVpcPeeringConnectionOptionsConfig_sameRegion_differentAccount(rName),
 				Check: resource.ComposeTestCheckFunc(
 					// Requester's view:
-					resource.TestCheckResourceAttr(
-						resourceName,
-						"requester.#",
-						"1",
-					),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "requester.*", map[string]string{
-						"allow_remote_vpc_dns_resolution": "true",
-					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "requester.*", map[string]string{
-						"allow_classic_link_to_remote_vpc": "false",
-					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "requester.*", map[string]string{
-						"allow_vpc_to_remote_classic_link": "false",
-					}),
+					resource.TestCheckResourceAttr(resourceName, "requester.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "requester.0.allow_remote_vpc_dns_resolution", "true"),
+					resource.TestCheckResourceAttr(resourceName, "requester.0.allow_classic_link_to_remote_vpc", "false"),
+					resource.TestCheckResourceAttr(resourceName, "requester.0.allow_vpc_to_remote_classic_link", "false"),
 					testAccCheckAWSVpcPeeringConnectionOptions(
 						pcxResourceName,
 						"requester",
@@ -279,20 +228,10 @@ func TestAccAWSVpcPeeringConnectionOptions_sameRegionDifferentAccount(t *testing
 						},
 					),
 					// Accepter's view:
-					resource.TestCheckResourceAttr(
-						resourceNamePeer,
-						"accepter.#",
-						"1",
-					),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceNamePeer, "accepter.*", map[string]string{
-						"allow_remote_vpc_dns_resolution": "true",
-					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceNamePeer, "accepter.*", map[string]string{
-						"allow_classic_link_to_remote_vpc": "false",
-					}),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceNamePeer, "accepter.*", map[string]string{
-						"allow_vpc_to_remote_classic_link": "false",
-					}),
+					resource.TestCheckResourceAttr(resourceNamePeer, "accepter.#", "1"),
+					resource.TestCheckResourceAttr(resourceNamePeer, "accepter.0.allow_remote_vpc_dns_resolution", "true"),
+					resource.TestCheckResourceAttr(resourceNamePeer, "accepter.0.allow_classic_link_to_remote_vpc", "false"),
+					resource.TestCheckResourceAttr(resourceNamePeer, "accepter.0.allow_vpc_to_remote_classic_link", "false"),
 				),
 			},
 			{

--- a/aws/resource_aws_vpc_peering_connection_options_test.go
+++ b/aws/resource_aws_vpc_peering_connection_options_test.go
@@ -32,8 +32,12 @@ func TestAccAWSVpcPeeringConnectionOptions_basic(t *testing.T) {
 						"1",
 					),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "requester.*", map[string]string{
-						"allow_remote_vpc_dns_resolution":  "false",
+						"allow_remote_vpc_dns_resolution": "false",
+					}),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "requester.*", map[string]string{
 						"allow_classic_link_to_remote_vpc": "true",
+					}),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "requester.*", map[string]string{
 						"allow_vpc_to_remote_classic_link": "true",
 					}),
 					testAccCheckAWSVpcPeeringConnectionOptions(
@@ -52,8 +56,12 @@ func TestAccAWSVpcPeeringConnectionOptions_basic(t *testing.T) {
 						"1",
 					),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "accepter.*", map[string]string{
-						"allow_remote_vpc_dns_resolution":  "true",
+						"allow_remote_vpc_dns_resolution": "true",
+					}),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "accepter.*", map[string]string{
 						"allow_classic_link_to_remote_vpc": "false",
+					}),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "accepter.*", map[string]string{
 						"allow_vpc_to_remote_classic_link": "false",
 					}),
 					testAccCheckAWSVpcPeeringConnectionOptions(
@@ -148,8 +156,12 @@ func TestAccAWSVpcPeeringConnectionOptions_differentRegionSameAccount(t *testing
 						"1",
 					),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "requester.*", map[string]string{
-						"allow_remote_vpc_dns_resolution":  "true",
+						"allow_remote_vpc_dns_resolution": "true",
+					}),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "requester.*", map[string]string{
 						"allow_classic_link_to_remote_vpc": "false",
+					}),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "requester.*", map[string]string{
 						"allow_vpc_to_remote_classic_link": "false",
 					}),
 					testAccCheckAWSVpcPeeringConnectionOptions(
@@ -168,8 +180,12 @@ func TestAccAWSVpcPeeringConnectionOptions_differentRegionSameAccount(t *testing
 						"1",
 					),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceNamePeer, "accepter.*", map[string]string{
-						"allow_remote_vpc_dns_resolution":  "true",
+						"allow_remote_vpc_dns_resolution": "true",
+					}),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceNamePeer, "accepter.*", map[string]string{
 						"allow_classic_link_to_remote_vpc": "false",
+					}),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceNamePeer, "accepter.*", map[string]string{
 						"allow_vpc_to_remote_classic_link": "false",
 					}),
 					testAccCheckAWSVpcPeeringConnectionOptionsWithProvider(
@@ -265,8 +281,12 @@ func TestAccAWSVpcPeeringConnectionOptions_sameRegionDifferentAccount(t *testing
 						"1",
 					),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "requester.*", map[string]string{
-						"allow_remote_vpc_dns_resolution":  "true",
+						"allow_remote_vpc_dns_resolution": "true",
+					}),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "requester.*", map[string]string{
 						"allow_classic_link_to_remote_vpc": "false",
+					}),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "requester.*", map[string]string{
 						"allow_vpc_to_remote_classic_link": "false",
 					}),
 					testAccCheckAWSVpcPeeringConnectionOptions(
@@ -285,8 +305,12 @@ func TestAccAWSVpcPeeringConnectionOptions_sameRegionDifferentAccount(t *testing
 						"1",
 					),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceNamePeer, "accepter.*", map[string]string{
-						"allow_remote_vpc_dns_resolution":  "true",
+						"allow_remote_vpc_dns_resolution": "true",
+					}),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceNamePeer, "accepter.*", map[string]string{
 						"allow_classic_link_to_remote_vpc": "false",
+					}),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceNamePeer, "accepter.*", map[string]string{
 						"allow_vpc_to_remote_classic_link": "false",
 					}),
 				),

--- a/aws/resource_aws_vpc_peering_connection_options_test.go
+++ b/aws/resource_aws_vpc_peering_connection_options_test.go
@@ -295,13 +295,12 @@ func TestAccAWSVpcPeeringConnectionOptions_sameRegionDifferentAccount(t *testing
 					}),
 				),
 			},
-			// Comment out until Plugin SDK correctly handles import testing with multiple providers.
-			// {
-			// 	Config:            testAccVpcPeeringConnectionOptionsConfig_sameRegion_differentAccount(rName),
-			// 	ResourceName:      resourceName,
-			// 	ImportState:       true,
-			// 	ImportStateVerify: true,
-			// },
+			{
+				Config:            testAccVpcPeeringConnectionOptionsConfig_sameRegion_differentAccount(rName),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -421,7 +420,7 @@ resource "aws_vpc_peering_connection_options" "peer" {
 }
 
 func testAccVpcPeeringConnectionOptionsConfig_sameRegion_differentAccount(rName string) string {
-	return testAccAlternateAccountProviderConfig() + fmt.Sprintf(`
+	return composeConfig(testAccAlternateAccountProviderConfig(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block           = "10.0.0.0/16"
   enable_dns_hostnames = true
@@ -491,5 +490,5 @@ resource "aws_vpc_peering_connection_options" "peer" {
     allow_remote_vpc_dns_resolution = true
   }
 }
-`, rName)
+`, rName))
 }

--- a/aws/resource_aws_vpc_peering_connection_options_test.go
+++ b/aws/resource_aws_vpc_peering_connection_options_test.go
@@ -89,11 +89,6 @@ func TestAccAWSVpcPeeringConnectionOptions_basic(t *testing.T) {
 						"requester.#",
 						"1",
 					),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "requester.*", map[string]string{
-						"allow_remote_vpc_dns_resolution":  "false",
-						"allow_classic_link_to_remote_vpc": "true",
-						"allow_vpc_to_remote_classic_link": "false",
-					}),
 					testAccCheckAWSVpcPeeringConnectionOptions(
 						pcxResourceName,
 						"requester",
@@ -109,11 +104,6 @@ func TestAccAWSVpcPeeringConnectionOptions_basic(t *testing.T) {
 						"accepter.#",
 						"1",
 					),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "accepter.*", map[string]string{
-						"allow_remote_vpc_dns_resolution":  "false",
-						"allow_classic_link_to_remote_vpc": "false",
-						"allow_vpc_to_remote_classic_link": "false",
-					}),
 					testAccCheckAWSVpcPeeringConnectionOptions(
 						pcxResourceName,
 						"accepter",
@@ -215,11 +205,6 @@ func TestAccAWSVpcPeeringConnectionOptions_differentRegionSameAccount(t *testing
 						"requester.#",
 						"1",
 					),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "requester.*", map[string]string{
-						"allow_remote_vpc_dns_resolution":  "false",
-						"allow_classic_link_to_remote_vpc": "false",
-						"allow_vpc_to_remote_classic_link": "false",
-					}),
 					testAccCheckAWSVpcPeeringConnectionOptions(
 						pcxResourceName,
 						"requester",
@@ -235,11 +220,6 @@ func TestAccAWSVpcPeeringConnectionOptions_differentRegionSameAccount(t *testing
 						"accepter.#",
 						"1",
 					),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceNamePeer, "accepter.*", map[string]string{
-						"allow_remote_vpc_dns_resolution":  "false",
-						"allow_classic_link_to_remote_vpc": "false",
-						"allow_vpc_to_remote_classic_link": "false",
-					}),
 					testAccCheckAWSVpcPeeringConnectionOptionsWithProvider(
 						pcxResourceNamePeer,
 						"accepter",
@@ -315,12 +295,13 @@ func TestAccAWSVpcPeeringConnectionOptions_sameRegionDifferentAccount(t *testing
 					}),
 				),
 			},
-			{
-				Config:            testAccVpcPeeringConnectionOptionsConfig_sameRegion_differentAccount(rName),
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+			// Comment out until Plugin SDK correctly handles import testing with multiple providers.
+			// {
+			// 	Config:            testAccVpcPeeringConnectionOptionsConfig_sameRegion_differentAccount(rName),
+			// 	ResourceName:      resourceName,
+			// 	ImportState:       true,
+			// 	ImportStateVerify: true,
+			// },
 		},
 	})
 }

--- a/aws/resource_aws_vpc_peering_connection_test.go
+++ b/aws/resource_aws_vpc_peering_connection_test.go
@@ -432,7 +432,7 @@ func testAccCheckAWSVpcPeeringConnectionDestroy(s *terraform.State) error {
 		}
 
 		if pc.Status != nil {
-			if *pc.Status.Code == "deleted" || *pc.Status.Code == "rejected" {
+			if *pc.Status.Code == "deleted" || *pc.Status.Code == "rejected" || *pc.Status.Code == "failed" {
 				return nil
 			}
 			return fmt.Errorf("Found the VPC Peering Connection in an unexpected state: %s", pc)

--- a/aws/resource_aws_vpc_peering_connection_test.go
+++ b/aws/resource_aws_vpc_peering_connection_test.go
@@ -520,6 +520,7 @@ func testAccCheckAWSVpcPeeringConnectionOptionsWithProvider(n, block string, opt
 }
 
 func TestAccAWSVPCPeeringConnection_peerRegionAutoAccept(t *testing.T) {
+	var providers []*schema.Provider
 	rName := fmt.Sprintf("tf-testacc-pcx-%s", acctest.RandStringFromCharSet(17, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -528,10 +529,9 @@ func TestAccAWSVPCPeeringConnection_peerRegionAutoAccept(t *testing.T) {
 			testAccMultipleRegionsPreCheck(t)
 			testAccAlternateRegionPreCheck(t)
 		},
-		IDRefreshIgnore: []string{"auto_accept"},
-
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSVpcPeeringConnectionDestroy,
+		IDRefreshIgnore:   []string{"auto_accept"},
+		ProviderFactories: testAccProviderFactories(&providers),
+		CheckDestroy:      testAccCheckAWSVpcPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccVpcPeeringConfig_region_autoAccept(rName, true),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/12113.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_vpc_peering_connection_options: Only modify options that have changed
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSVpcPeeringConnectionOptions_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 2 -run=TestAccAWSVpcPeeringConnectionOptions_ -timeout 120m
=== RUN   TestAccAWSVpcPeeringConnectionOptions_basic
=== PAUSE TestAccAWSVpcPeeringConnectionOptions_basic
=== RUN   TestAccAWSVpcPeeringConnectionOptions_sameRegionSameAccountUpdates
=== PAUSE TestAccAWSVpcPeeringConnectionOptions_sameRegionSameAccountUpdates
=== RUN   TestAccAWSVpcPeeringConnectionOptions_differentRegionSameAccountBasic
=== PAUSE TestAccAWSVpcPeeringConnectionOptions_differentRegionSameAccountBasic
=== RUN   TestAccAWSVpcPeeringConnectionOptions_differentRegionSameAccountUpdates
=== PAUSE TestAccAWSVpcPeeringConnectionOptions_differentRegionSameAccountUpdates
=== RUN   TestAccAWSVpcPeeringConnectionOptions_sameRegionDifferentAccountBasic
=== PAUSE TestAccAWSVpcPeeringConnectionOptions_sameRegionDifferentAccountBasic
=== RUN   TestAccAWSVpcPeeringConnectionOptions_sameRegionDifferentAccountUpdates
=== PAUSE TestAccAWSVpcPeeringConnectionOptions_sameRegionDifferentAccountUpdates
=== CONT  TestAccAWSVpcPeeringConnectionOptions_basic
=== CONT  TestAccAWSVpcPeeringConnectionOptions_sameRegionDifferentAccountUpdates
--- PASS: TestAccAWSVpcPeeringConnectionOptions_basic (41.32s)
=== CONT  TestAccAWSVpcPeeringConnectionOptions_sameRegionDifferentAccountBasic
--- PASS: TestAccAWSVpcPeeringConnectionOptions_sameRegionDifferentAccountUpdates (73.05s)
=== CONT  TestAccAWSVpcPeeringConnectionOptions_differentRegionSameAccountUpdates
--- PASS: TestAccAWSVpcPeeringConnectionOptions_sameRegionDifferentAccountBasic (45.75s)
=== CONT  TestAccAWSVpcPeeringConnectionOptions_differentRegionSameAccountBasic
--- PASS: TestAccAWSVpcPeeringConnectionOptions_differentRegionSameAccountUpdates (69.23s)
=== CONT  TestAccAWSVpcPeeringConnectionOptions_sameRegionSameAccountUpdates
--- PASS: TestAccAWSVpcPeeringConnectionOptions_differentRegionSameAccountBasic (46.71s)
--- PASS: TestAccAWSVpcPeeringConnectionOptions_sameRegionSameAccountUpdates (64.91s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	169.686s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSVPCPeeringConnection_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 2 -run=TestAccAWSVPCPeeringConnection_ -timeout 120m
=== RUN   TestAccAWSVPCPeeringConnection_basic
=== PAUSE TestAccAWSVPCPeeringConnection_basic
=== RUN   TestAccAWSVPCPeeringConnection_plan
=== PAUSE TestAccAWSVPCPeeringConnection_plan
=== RUN   TestAccAWSVPCPeeringConnection_tags
=== PAUSE TestAccAWSVPCPeeringConnection_tags
=== RUN   TestAccAWSVPCPeeringConnection_options
=== PAUSE TestAccAWSVPCPeeringConnection_options
=== RUN   TestAccAWSVPCPeeringConnection_failedState
=== PAUSE TestAccAWSVPCPeeringConnection_failedState
=== RUN   TestAccAWSVPCPeeringConnection_peerRegionAutoAccept
=== PAUSE TestAccAWSVPCPeeringConnection_peerRegionAutoAccept
=== RUN   TestAccAWSVPCPeeringConnection_region
=== PAUSE TestAccAWSVPCPeeringConnection_region
=== RUN   TestAccAWSVPCPeeringConnection_accept
=== PAUSE TestAccAWSVPCPeeringConnection_accept
=== RUN   TestAccAWSVPCPeeringConnection_optionsNoAutoAccept
=== PAUSE TestAccAWSVPCPeeringConnection_optionsNoAutoAccept
=== CONT  TestAccAWSVPCPeeringConnection_basic
=== CONT  TestAccAWSVPCPeeringConnection_peerRegionAutoAccept
--- PASS: TestAccAWSVPCPeeringConnection_peerRegionAutoAccept (21.17s)
=== CONT  TestAccAWSVPCPeeringConnection_optionsNoAutoAccept
--- PASS: TestAccAWSVPCPeeringConnection_basic (39.62s)
=== CONT  TestAccAWSVPCPeeringConnection_accept
--- PASS: TestAccAWSVPCPeeringConnection_optionsNoAutoAccept (24.94s)
=== CONT  TestAccAWSVPCPeeringConnection_region
--- PASS: TestAccAWSVPCPeeringConnection_region (38.97s)
=== CONT  TestAccAWSVPCPeeringConnection_options
--- PASS: TestAccAWSVPCPeeringConnection_accept (84.16s)
=== CONT  TestAccAWSVPCPeeringConnection_failedState
--- PASS: TestAccAWSVPCPeeringConnection_failedState (21.11s)
=== CONT  TestAccAWSVPCPeeringConnection_tags
--- PASS: TestAccAWSVPCPeeringConnection_options (64.61s)
=== CONT  TestAccAWSVPCPeeringConnection_plan
--- PASS: TestAccAWSVPCPeeringConnection_tags (38.84s)
--- PASS: TestAccAWSVPCPeeringConnection_plan (34.74s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	184.509s
```

Without the fix, updating VPC peering connection options for cross-region peerings would fail:

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSVpcPeeringConnectionOptions_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 1 -run=TestAccAWSVpcPeeringConnectionOptions_ -timeout 120m
=== RUN   TestAccAWSVpcPeeringConnectionOptions_basic
=== PAUSE TestAccAWSVpcPeeringConnectionOptions_basic
=== RUN   TestAccAWSVpcPeeringConnectionOptions_sameRegionSameAccountUpdates
=== PAUSE TestAccAWSVpcPeeringConnectionOptions_sameRegionSameAccountUpdates
=== RUN   TestAccAWSVpcPeeringConnectionOptions_differentRegionSameAccountBasic
=== PAUSE TestAccAWSVpcPeeringConnectionOptions_differentRegionSameAccountBasic
=== RUN   TestAccAWSVpcPeeringConnectionOptions_differentRegionSameAccountUpdates
=== PAUSE TestAccAWSVpcPeeringConnectionOptions_differentRegionSameAccountUpdates
=== RUN   TestAccAWSVpcPeeringConnectionOptions_sameRegionDifferentAccountBasic
=== PAUSE TestAccAWSVpcPeeringConnectionOptions_sameRegionDifferentAccountBasic
=== RUN   TestAccAWSVpcPeeringConnectionOptions_sameRegionDifferentAccountUpdates
=== PAUSE TestAccAWSVpcPeeringConnectionOptions_sameRegionDifferentAccountUpdates
=== CONT  TestAccAWSVpcPeeringConnectionOptions_basic
--- PASS: TestAccAWSVpcPeeringConnectionOptions_basic (41.92s)
=== CONT  TestAccAWSVpcPeeringConnectionOptions_sameRegionDifferentAccountBasic
--- PASS: TestAccAWSVpcPeeringConnectionOptions_sameRegionDifferentAccountBasic (46.27s)
=== CONT  TestAccAWSVpcPeeringConnectionOptions_sameRegionDifferentAccountUpdates
--- PASS: TestAccAWSVpcPeeringConnectionOptions_sameRegionDifferentAccountUpdates (70.79s)
=== CONT  TestAccAWSVpcPeeringConnectionOptions_differentRegionSameAccountBasic
--- PASS: TestAccAWSVpcPeeringConnectionOptions_differentRegionSameAccountBasic (46.41s)
=== CONT  TestAccAWSVpcPeeringConnectionOptions_differentRegionSameAccountUpdates
--- FAIL: TestAccAWSVpcPeeringConnectionOptions_differentRegionSameAccountUpdates (56.62s)
    testing.go:654: Step 2 error: errors during apply:
        
        Error: error modifying VPC Peering Connection (pcx-0db05882d9de2b5fb) Options: InvalidParameterValue: Requester’s VPC Peering connection options cannot be modified for a different region
        	status code: 400, request id: db4628d4-5c79-496f-911b-303cf2e58108
        
          on /tmp/tf-test059046709/main.tf line 63:
          (source code not available)
        
        
        
        Error: error modifying VPC Peering Connection (pcx-0db05882d9de2b5fb) Options: InvalidParameterValue: Accepter’s VPC Peering connection options cannot be modified for a different region
        	status code: 400, request id: ef53e7fb-12a3-480d-a02b-e9fb86e190c6
        
          on /tmp/tf-test059046709/main.tf line 52:
          (source code not available)
        
        
=== CONT  TestAccAWSVpcPeeringConnectionOptions_sameRegionSameAccountUpdates
--- PASS: TestAccAWSVpcPeeringConnectionOptions_sameRegionSameAccountUpdates (65.81s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	327.905s
FAIL
GNUmakefile:25: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```