### PR TITLE
r/aws_cloud9_environment_ec2: Support tagging

### DIFF
--- a/aws/internal/keyvaluetags/generators/listtags/main.go
+++ b/aws/internal/keyvaluetags/generators/listtags/main.go
@@ -26,6 +26,7 @@ var serviceNames = []string{
 	"appsync",
 	"athena",
 	"backup",
+	"cloud9",
 	"cloudfront",
 	"cloudhsmv2",
 	"cloudtrail",
@@ -270,6 +271,8 @@ func ServiceListTagsInputIdentifierField(serviceName string) string {
 	case "acmpca":
 		return "CertificateAuthorityArn"
 	case "athena":
+		return "ResourceARN"
+	case "cloud9":
 		return "ResourceARN"
 	case "cloudfront":
 		return "Resource"

--- a/aws/internal/keyvaluetags/generators/servicetags/main.go
+++ b/aws/internal/keyvaluetags/generators/servicetags/main.go
@@ -23,6 +23,7 @@ var sliceServiceNames = []string{
 	"appmesh",
 	"athena",
 	/* "autoscaling", // includes extra PropagateAtLaunch, skip for now */
+	"cloud9",
 	"cloudformation",
 	"cloudfront",
 	"cloudhsmv2",

--- a/aws/internal/keyvaluetags/generators/updatetags/main.go
+++ b/aws/internal/keyvaluetags/generators/updatetags/main.go
@@ -28,6 +28,7 @@ var serviceNames = []string{
 	"appsync",
 	"athena",
 	"backup",
+	"cloud9",
 	"cloudfront",
 	"cloudhsmv2",
 	"cloudtrail",
@@ -400,6 +401,8 @@ func ServiceTagInputIdentifierField(serviceName string) string {
 	case "acmpca":
 		return "CertificateAuthorityArn"
 	case "athena":
+		return "ResourceARN"
+	case "cloud9":
 		return "ResourceARN"
 	case "cloudfront":
 		return "Resource"

--- a/aws/internal/keyvaluetags/list_tags_gen.go
+++ b/aws/internal/keyvaluetags/list_tags_gen.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/appsync"
 	"github.com/aws/aws-sdk-go/service/athena"
 	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/aws/aws-sdk-go/service/cloud9"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
 	"github.com/aws/aws-sdk-go/service/cloudhsmv2"
 	"github.com/aws/aws-sdk-go/service/cloudtrail"
@@ -245,6 +246,23 @@ func BackupListTags(conn *backup.Backup, identifier string) (KeyValueTags, error
 	}
 
 	return BackupKeyValueTags(output.Tags), nil
+}
+
+// Cloud9ListTags lists cloud9 service tags.
+// The identifier is typically the Amazon Resource Name (ARN), although
+// it may also be a different identifier depending on the service.
+func Cloud9ListTags(conn *cloud9.Cloud9, identifier string) (KeyValueTags, error) {
+	input := &cloud9.ListTagsForResourceInput{
+		ResourceARN: aws.String(identifier),
+	}
+
+	output, err := conn.ListTagsForResource(input)
+
+	if err != nil {
+		return New(nil), err
+	}
+
+	return Cloud9KeyValueTags(output.Tags), nil
 }
 
 // CloudfrontListTags lists cloudfront service tags.

--- a/aws/internal/keyvaluetags/service_generation_customizations.go
+++ b/aws/internal/keyvaluetags/service_generation_customizations.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/appsync"
 	"github.com/aws/aws-sdk-go/service/athena"
 	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/aws/aws-sdk-go/service/cloud9"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
 	"github.com/aws/aws-sdk-go/service/cloudhsmv2"
 	"github.com/aws/aws-sdk-go/service/cloudtrail"
@@ -134,6 +135,8 @@ func ServiceClientType(serviceName string) string {
 		funcType = reflect.TypeOf(athena.New)
 	case "backup":
 		funcType = reflect.TypeOf(backup.New)
+	case "cloud9":
+		funcType = reflect.TypeOf(cloud9.New)
 	case "cloudfront":
 		funcType = reflect.TypeOf(cloudfront.New)
 	case "cloudhsmv2":

--- a/aws/internal/keyvaluetags/service_tags_gen.go
+++ b/aws/internal/keyvaluetags/service_tags_gen.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/acmpca"
 	"github.com/aws/aws-sdk-go/service/appmesh"
 	"github.com/aws/aws-sdk-go/service/athena"
+	"github.com/aws/aws-sdk-go/service/cloud9"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
 	"github.com/aws/aws-sdk-go/service/cloudhsmv2"
@@ -519,6 +520,33 @@ func (tags KeyValueTags) AthenaTags() []*athena.Tag {
 
 // AthenaKeyValueTags creates KeyValueTags from athena service tags.
 func AthenaKeyValueTags(tags []*athena.Tag) KeyValueTags {
+	m := make(map[string]*string, len(tags))
+
+	for _, tag := range tags {
+		m[aws.StringValue(tag.Key)] = tag.Value
+	}
+
+	return New(m)
+}
+
+// Cloud9Tags returns cloud9 service tags.
+func (tags KeyValueTags) Cloud9Tags() []*cloud9.Tag {
+	result := make([]*cloud9.Tag, 0, len(tags))
+
+	for k, v := range tags.Map() {
+		tag := &cloud9.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		}
+
+		result = append(result, tag)
+	}
+
+	return result
+}
+
+// Cloud9KeyValueTags creates KeyValueTags from cloud9 service tags.
+func Cloud9KeyValueTags(tags []*cloud9.Tag) KeyValueTags {
 	m := make(map[string]*string, len(tags))
 
 	for _, tag := range tags {

--- a/aws/internal/keyvaluetags/update_tags_gen.go
+++ b/aws/internal/keyvaluetags/update_tags_gen.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/appsync"
 	"github.com/aws/aws-sdk-go/service/athena"
 	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/aws/aws-sdk-go/service/cloud9"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
 	"github.com/aws/aws-sdk-go/service/cloudhsmv2"
 	"github.com/aws/aws-sdk-go/service/cloudtrail"
@@ -488,6 +489,42 @@ func BackupUpdateTags(conn *backup.Backup, identifier string, oldTagsMap interfa
 		input := &backup.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        updatedTags.IgnoreAws().BackupTags(),
+		}
+
+		_, err := conn.TagResource(input)
+
+		if err != nil {
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
+		}
+	}
+
+	return nil
+}
+
+// Cloud9UpdateTags updates cloud9 service tags.
+// The identifier is typically the Amazon Resource Name (ARN), although
+// it may also be a different identifier depending on the service.
+func Cloud9UpdateTags(conn *cloud9.Cloud9, identifier string, oldTagsMap interface{}, newTagsMap interface{}) error {
+	oldTags := New(oldTagsMap)
+	newTags := New(newTagsMap)
+
+	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+		input := &cloud9.UntagResourceInput{
+			ResourceARN: aws.String(identifier),
+			TagKeys:     aws.StringSlice(removedTags.IgnoreAws().Keys()),
+		}
+
+		_, err := conn.UntagResource(input)
+
+		if err != nil {
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
+		}
+	}
+
+	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+		input := &cloud9.TagResourceInput{
+			ResourceARN: aws.String(identifier),
+			Tags:        updatedTags.IgnoreAws().Cloud9Tags(),
 		}
 
 		_, err := conn.TagResource(input)

--- a/aws/resource_aws_cloud9_environment_ec2.go
+++ b/aws/resource_aws_cloud9_environment_ec2.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloud9"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsCloud9EnvironmentEc2() *schema.Resource {
@@ -61,6 +62,7 @@ func resourceAwsCloud9EnvironmentEc2() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -72,6 +74,7 @@ func resourceAwsCloud9EnvironmentEc2Create(d *schema.ResourceData, meta interfac
 		InstanceType:       aws.String(d.Get("instance_type").(string)),
 		Name:               aws.String(d.Get("name").(string)),
 		ClientRequestToken: aws.String(resource.UniqueId()),
+		Tags:               keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().Cloud9Tags(),
 	}
 
 	if v, ok := d.GetOk("automatic_stop_time_minutes"); ok {
@@ -166,11 +169,22 @@ func resourceAwsCloud9EnvironmentEc2Read(d *schema.ResourceData, meta interface{
 	}
 	env := out.Environments[0]
 
-	d.Set("arn", env.Arn)
+	arn := aws.StringValue(env.Arn)
+	d.Set("arn", arn)
 	d.Set("description", env.Description)
 	d.Set("name", env.Name)
 	d.Set("owner_arn", env.OwnerArn)
 	d.Set("type", env.Type)
+
+	tags, err := keyvaluetags.Cloud9ListTags(conn, arn)
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for Cloud9 EC2 Environment (%s): %s", arn, err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
 
 	log.Printf("[DEBUG] Received Cloud9 Environment EC2: %s", env)
 
@@ -194,6 +208,15 @@ func resourceAwsCloud9EnvironmentEc2Update(d *schema.ResourceData, meta interfac
 	}
 
 	log.Printf("[DEBUG] Cloud9 Environment EC2 updated: %s", out)
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+		arn := d.Get("arn").(string)
+
+		if err := keyvaluetags.Cloud9UpdateTags(conn, arn, o, n); err != nil {
+			return fmt.Errorf("error updating Cloud9 EC2 Environment (%s) tags: %s", arn, err)
+		}
+	}
 
 	return resourceAwsCloud9EnvironmentEc2Read(d, meta)
 }

--- a/aws/resource_aws_cloud9_environment_ec2_test.go
+++ b/aws/resource_aws_cloud9_environment_ec2_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloud9"
@@ -15,9 +16,8 @@ import (
 func TestAccAWSCloud9EnvironmentEc2_basic(t *testing.T) {
 	var conf cloud9.Environment
 
-	rString := acctest.RandString(8)
-	envName := fmt.Sprintf("tf_acc_env_basic_%s", rString)
-	uEnvName := fmt.Sprintf("tf_acc_env_basic_updated_%s", rString)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rNameUpdated := acctest.RandomWithPrefix("tf-acc-test-updated")
 	resourceName := "aws_cloud9_environment_ec2.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -26,13 +26,14 @@ func TestAccAWSCloud9EnvironmentEc2_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloud9EnvironmentEc2Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloud9EnvironmentEc2Config(envName),
+				Config: testAccAWSCloud9EnvironmentEc2Config(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCloud9EnvironmentEc2Exists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "instance_type", "t2.micro"),
-					resource.TestCheckResourceAttr(resourceName, "name", envName),
-					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(`^arn:[^:]+:cloud9:[^:]+:[^:]+:environment:.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "cloud9", regexp.MustCompile(`environment:.+$`)),
 					resource.TestMatchResourceAttr(resourceName, "owner_arn", regexp.MustCompile(`^arn:`)),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
@@ -42,12 +43,12 @@ func TestAccAWSCloud9EnvironmentEc2_basic(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"instance_type", "subnet_id"},
 			},
 			{
-				Config: testAccAWSCloud9EnvironmentEc2Config(uEnvName),
+				Config: testAccAWSCloud9EnvironmentEc2Config(rNameUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCloud9EnvironmentEc2Exists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "instance_type", "t2.micro"),
-					resource.TestCheckResourceAttr(resourceName, "name", uEnvName),
-					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(`^arn:[^:]+:cloud9:[^:]+:[^:]+:environment:.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "cloud9", regexp.MustCompile(`environment:.+$`)),
 					resource.TestMatchResourceAttr(resourceName, "owner_arn", regexp.MustCompile(`^arn:`)),
 				),
 			},
@@ -58,12 +59,11 @@ func TestAccAWSCloud9EnvironmentEc2_basic(t *testing.T) {
 func TestAccAWSCloud9EnvironmentEc2_allFields(t *testing.T) {
 	var conf cloud9.Environment
 
-	rString := acctest.RandString(8)
-	envName := fmt.Sprintf("tf_acc_env_basic_%s", rString)
-	uEnvName := fmt.Sprintf("tf_acc_env_basic_updated_%s", rString)
-	description := fmt.Sprintf("Tf Acc Test %s", rString)
-	uDescription := fmt.Sprintf("Tf Acc Test Updated %s", rString)
-	userName := fmt.Sprintf("tf_acc_cloud9_env_%s", rString)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rNameUpdated := acctest.RandomWithPrefix("tf-acc-test-updated")
+	description := acctest.RandomWithPrefix("Tf Acc Test")
+	uDescription := acctest.RandomWithPrefix("Tf Acc Test Updated")
+	userName := acctest.RandomWithPrefix("tf_acc_cloud9_env")
 	resourceName := "aws_cloud9_environment_ec2.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -72,12 +72,12 @@ func TestAccAWSCloud9EnvironmentEc2_allFields(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloud9EnvironmentEc2Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloud9EnvironmentEc2AllFieldsConfig(envName, description, userName),
+				Config: testAccAWSCloud9EnvironmentEc2AllFieldsConfig(rName, description, userName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCloud9EnvironmentEc2Exists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "instance_type", "t2.micro"),
-					resource.TestCheckResourceAttr(resourceName, "name", envName),
-					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(`^arn:[^:]+:cloud9:[^:]+:[^:]+:environment:.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "cloud9", regexp.MustCompile(`environment:.+$`)),
 					resource.TestMatchResourceAttr(resourceName, "owner_arn", regexp.MustCompile(`^arn:`)),
 					resource.TestCheckResourceAttr(resourceName, "type", "ec2"),
 				),
@@ -89,15 +89,84 @@ func TestAccAWSCloud9EnvironmentEc2_allFields(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"instance_type", "automatic_stop_time_minutes", "subnet_id"},
 			},
 			{
-				Config: testAccAWSCloud9EnvironmentEc2AllFieldsConfig(uEnvName, uDescription, userName),
+				Config: testAccAWSCloud9EnvironmentEc2AllFieldsConfig(rNameUpdated, uDescription, userName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCloud9EnvironmentEc2Exists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "instance_type", "t2.micro"),
-					resource.TestCheckResourceAttr(resourceName, "name", uEnvName),
-					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(`^arn:[^:]+:cloud9:[^:]+:[^:]+:environment:.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "cloud9", regexp.MustCompile(`environment:.+$`)),
 					resource.TestMatchResourceAttr(resourceName, "owner_arn", regexp.MustCompile(`^arn:`)),
 					resource.TestCheckResourceAttr(resourceName, "type", "ec2"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCloud9EnvironmentEc2_tags(t *testing.T) {
+	var conf cloud9.Environment
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_cloud9_environment_ec2.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloud9(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloud9EnvironmentEc2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloud9EnvironmentEc2ConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCloud9EnvironmentEc2Exists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"instance_type", "subnet_id"},
+			},
+			{
+				Config: testAccAWSCloud9EnvironmentEc2ConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCloud9EnvironmentEc2Exists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSCloud9EnvironmentEc2ConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCloud9EnvironmentEc2Exists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCloud9EnvironmentEc2_disappears(t *testing.T) {
+	var conf cloud9.Environment
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_cloud9_environment_ec2.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloud9(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloud9EnvironmentEc2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloud9EnvironmentEc2Config(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCloud9EnvironmentEc2Exists(resourceName, &conf),
+					testAccCheckAWSCloud9EnvironmentEc2Disappears(&conf),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -133,6 +202,43 @@ func testAccCheckAWSCloud9EnvironmentEc2Exists(n string, res *cloud9.Environment
 		*res = *env
 
 		return nil
+	}
+}
+
+func testAccCheckAWSCloud9EnvironmentEc2Disappears(res *cloud9.Environment) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).cloud9conn
+
+		_, err := conn.DeleteEnvironment(&cloud9.DeleteEnvironmentInput{
+			EnvironmentId: res.Id,
+		})
+
+		if err != nil {
+			return err
+		}
+
+		input := &cloud9.DescribeEnvironmentsInput{
+			EnvironmentIds: []*string{res.Id},
+		}
+		var out *cloud9.DescribeEnvironmentsOutput
+		err = resource.Retry(20*time.Minute, func() *resource.RetryError { // Deleting instances can take a long time
+			out, err = conn.DescribeEnvironments(input)
+			if err != nil {
+				if isAWSErr(err, cloud9.ErrCodeNotFoundException, "") {
+					return nil
+				}
+				if isAWSErr(err, "AccessDeniedException", "is not authorized to access this resource") {
+					return nil
+				}
+				return resource.NonRetryableError(err)
+			}
+			if len(out.Environments) == 0 {
+				return nil
+			}
+			return resource.RetryableError(fmt.Errorf("Cloud9 EC2 Environment %q still exists", &res.Id))
+		})
+
+		return err
 	}
 }
 
@@ -210,6 +316,10 @@ resource "aws_subnet" "test" {
 
 resource "aws_internet_gateway" "test" {
   vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = "tf-acc-test-cloud9-environment-ec2"
+  }
 }
 
 resource "aws_route" "test" {
@@ -249,4 +359,38 @@ resource "aws_iam_user" "test" {
   name = %[3]q
 }
 `, name, description, userName)
+}
+
+func testAccAWSCloud9EnvironmentEc2ConfigTags1(name, tagKey1, tagValue1 string) string {
+	return testAccAWSCloud9EnvironmentEc2ConfigBase() + fmt.Sprintf(`
+resource "aws_cloud9_environment_ec2" "test" {
+  depends_on = [aws_route.test]
+
+  instance_type = "t2.micro"
+  name          = %[1]q
+  subnet_id     = aws_subnet.test.id
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, name, tagKey1, tagValue1)
+}
+
+func testAccAWSCloud9EnvironmentEc2ConfigTags2(name, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return testAccAWSCloud9EnvironmentEc2ConfigBase() + fmt.Sprintf(`
+resource "aws_cloud9_environment_ec2" "test" {
+  depends_on = [aws_route.test]
+
+  instance_type = "t2.micro"
+  name          = %[1]q
+  subnet_id     = aws_subnet.test.id
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+
+  }
+}
+`, name, tagKey1, tagValue1, tagKey2, tagValue2)
 }

--- a/aws/resource_aws_cloud9_environment_ec2_test.go
+++ b/aws/resource_aws_cloud9_environment_ec2_test.go
@@ -235,7 +235,7 @@ func testAccCheckAWSCloud9EnvironmentEc2Disappears(res *cloud9.Environment) reso
 			if len(out.Environments) == 0 {
 				return nil
 			}
-			return resource.RetryableError(fmt.Errorf("Cloud9 EC2 Environment %q still exists", &res.Id))
+			return resource.RetryableError(fmt.Errorf("Cloud9 EC2 Environment %q still exists", aws.StringValue(res.Id)))
 		})
 
 		return err

--- a/website/docs/r/cloud9_environment_ec2.html.markdown
+++ b/website/docs/r/cloud9_environment_ec2.html.markdown
@@ -29,6 +29,7 @@ The following arguments are supported:
 * `description` - (Optional) The description of the environment.
 * `owner_arn` - (Optional) The ARN of the environment owner. This can be ARN of any AWS IAM principal. Defaults to the environment's creator.
 * `subnet_id` - (Optional) The ID of the subnet in Amazon VPC that AWS Cloud9 will use to communicate with the Amazon EC2 instance.
+* `tags` - (Optional) Key-value mapping of resource tags
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12077

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_cloud9_environment_ec2: support tagging
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCloud9EnvironmentEc2'
--- PASS: TestAccAWSCloud9EnvironmentEc2_basic (302.99s)
--- PASS: TestAccAWSCloud9EnvironmentEc2_allFields (400.08s)
--- PASS: TestAccAWSCloud9EnvironmentEc2_tags (354.77s)
--- PASS: TestAccAWSCloud9EnvironmentEc2_disappears (263.08s)
```
