### PR TITLE
add tagging support to ec2 traffic mirror filter + read after create

### DIFF
--- a/aws/resource_aws_ec2_traffic_mirror_filter.go
+++ b/aws/resource_aws_ec2_traffic_mirror_filter.go
@@ -4,16 +4,16 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsEc2TrafficMirrorFilter() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceAwsEc2TrafficMirrorinFilterCreate,
+		Create: resourceAwsEc2TrafficMirrorFilterCreate,
 		Read:   resourceAwsEc2TrafficMirrorFilterRead,
 		Update: resourceAwsEc2TrafficMirrorFilterUpdate,
 		Delete: resourceAwsEc2TrafficMirrorFilterDelete,
@@ -36,17 +36,22 @@ func resourceAwsEc2TrafficMirrorFilter() *schema.Resource {
 					}, false),
 				},
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
 
-func resourceAwsEc2TrafficMirrorinFilterCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsEc2TrafficMirrorFilterCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
 	input := &ec2.CreateTrafficMirrorFilterInput{}
 
 	if description, ok := d.GetOk("description"); ok {
 		input.Description = aws.String(description.(string))
+	}
+
+	if v, ok := d.GetOk("tags"); ok {
+		input.TagSpecifications = ec2TagSpecificationsFromMap(v.(map[string]interface{}), ec2.ResourceTypeTrafficMirrorFilter)
 	}
 
 	out, err := conn.CreateTrafficMirrorFilter(input)
@@ -56,7 +61,20 @@ func resourceAwsEc2TrafficMirrorinFilterCreate(d *schema.ResourceData, meta inte
 
 	d.SetId(*out.TrafficMirrorFilter.TrafficMirrorFilterId)
 
-	return resourceAwsEc2TrafficMirrorFilterUpdate(d, meta)
+	if v, ok := d.GetOk("network_services"); ok {
+		input := &ec2.ModifyTrafficMirrorFilterNetworkServicesInput{
+			TrafficMirrorFilterId: aws.String(d.Id()),
+			AddNetworkServices:    expandStringSet(v.(*schema.Set)),
+		}
+
+		_, err := conn.ModifyTrafficMirrorFilterNetworkServices(input)
+		if err != nil {
+			return fmt.Errorf("error modifying EC2 Traffic Mirror Filter (%s) network services: %w", d.Id(), err)
+		}
+
+	}
+
+	return resourceAwsEc2TrafficMirrorFilterRead(d, meta)
 }
 
 func resourceAwsEc2TrafficMirrorFilterUpdate(d *schema.ResourceData, meta interface{}) error {
@@ -84,6 +102,14 @@ func resourceAwsEc2TrafficMirrorFilterUpdate(d *schema.ResourceData, meta interf
 		}
 	}
 
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.Ec2UpdateTags(conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("error updating EC2 Traffic Mirror Filter (%s) tags: %s", d.Id(), err)
+		}
+	}
+
 	return resourceAwsEc2TrafficMirrorFilterRead(d, meta)
 }
 
@@ -95,6 +121,13 @@ func resourceAwsEc2TrafficMirrorFilterRead(d *schema.ResourceData, meta interfac
 	}
 
 	out, err := conn.DescribeTrafficMirrorFilters(input)
+
+	if isAWSErr(err, "InvalidTrafficMirrorFilterId.NotFound", "") {
+		log.Printf("[WARN] EC2 Traffic Mirror Filter (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
 		return fmt.Errorf("Error describing traffic mirror filter %v: %v", d.Id(), err)
 	}
@@ -105,10 +138,14 @@ func resourceAwsEc2TrafficMirrorFilterRead(d *schema.ResourceData, meta interfac
 		return nil
 	}
 
-	d.SetId(*out.TrafficMirrorFilters[0].TrafficMirrorFilterId)
-	d.Set("description", out.TrafficMirrorFilters[0].Description)
+	trafficMirrorFilter := out.TrafficMirrorFilters[0]
+	d.Set("description", trafficMirrorFilter.Description)
 
-	if err := d.Set("network_services", aws.StringValueSlice(out.TrafficMirrorFilters[0].NetworkServices)); err != nil {
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(trafficMirrorFilter.Tags).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	if err := d.Set("network_services", aws.StringValueSlice(trafficMirrorFilter.NetworkServices)); err != nil {
 		return fmt.Errorf("error setting network_services for filter %v: %s", d.Id(), err)
 	}
 

--- a/aws/resource_aws_ec2_traffic_mirror_filter_test.go
+++ b/aws/resource_aws_ec2_traffic_mirror_filter_test.go
@@ -12,7 +12,8 @@ import (
 )
 
 func TestAccAWSEc2TrafficMirrorFilter_basic(t *testing.T) {
-	resourceName := "aws_ec2_traffic_mirror_filter.filter"
+	var v ec2.TrafficMirrorFilter
+	resourceName := "aws_ec2_traffic_mirror_filter.test"
 	description := "test filter"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -27,16 +28,17 @@ func TestAccAWSEc2TrafficMirrorFilter_basic(t *testing.T) {
 			{
 				Config: testAccTrafficMirrorFilterConfig(description),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEc2TrafficMirrorFilterExists(resourceName),
+					testAccCheckAWSEc2TrafficMirrorFilterExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
 					resource.TestCheckResourceAttr(resourceName, "network_services.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			// Test Disable DNS service
 			{
 				Config: testAccTrafficMirrorFilterConfigWithoutDNS(description),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEc2TrafficMirrorFilterExists(resourceName),
+					testAccCheckAWSEc2TrafficMirrorFilterExists(resourceName, &v),
 					resource.TestCheckNoResourceAttr(resourceName, "network_services"),
 				),
 			},
@@ -44,7 +46,7 @@ func TestAccAWSEc2TrafficMirrorFilter_basic(t *testing.T) {
 			{
 				Config: testAccTrafficMirrorFilterConfig(description),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEc2TrafficMirrorFilterExists(resourceName),
+					testAccCheckAWSEc2TrafficMirrorFilterExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
 					resource.TestCheckResourceAttr(resourceName, "network_services.#", "1"),
 				),
@@ -58,7 +60,78 @@ func TestAccAWSEc2TrafficMirrorFilter_basic(t *testing.T) {
 	})
 }
 
-func testAccCheckAWSEc2TrafficMirrorFilterExists(name string) resource.TestCheckFunc {
+func TestAccAWSEc2TrafficMirrorFilter_tags(t *testing.T) {
+	var v ec2.TrafficMirrorFilter
+	resourceName := "aws_ec2_traffic_mirror_filter.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSEc2TrafficMirrorFilter(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEc2TrafficMirrorFilterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrafficMirrorFilterConfigTags1("key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEc2TrafficMirrorFilterExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccTrafficMirrorFilterConfigTags2("key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEc2TrafficMirrorFilterExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccTrafficMirrorFilterConfigTags1("key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEc2TrafficMirrorFilterExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEc2TrafficMirrorFilter_disappears(t *testing.T) {
+	var v ec2.TrafficMirrorFilter
+	resourceName := "aws_ec2_traffic_mirror_filter.test"
+	description := "test filter"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSEc2TrafficMirrorFilter(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEc2TrafficMirrorFilterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrafficMirrorFilterConfig(description),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEc2TrafficMirrorFilterExists(resourceName, &v),
+					testAccCheckAWSEc2TrafficMirrorFilterDisappears(&v),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSEc2TrafficMirrorFilterExists(name string, traffic *ec2.TrafficMirrorFilter) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -83,13 +156,26 @@ func testAccCheckAWSEc2TrafficMirrorFilterExists(name string) resource.TestCheck
 			return fmt.Errorf("Traffic mirror filter %s not found", rs.Primary.ID)
 		}
 
+		*traffic = *out.TrafficMirrorFilters[0]
+
 		return nil
+	}
+}
+
+func testAccCheckAWSEc2TrafficMirrorFilterDisappears(traffic *ec2.TrafficMirrorFilter) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+		_, err := conn.DeleteTrafficMirrorFilter(&ec2.DeleteTrafficMirrorFilterInput{
+			TrafficMirrorFilterId: traffic.TrafficMirrorFilterId,
+		})
+
+		return err
 	}
 }
 
 func testAccTrafficMirrorFilterConfig(description string) string {
 	return fmt.Sprintf(`
-resource "aws_ec2_traffic_mirror_filter" "filter" {
+resource "aws_ec2_traffic_mirror_filter" "test" {
   description = "%s"
 
   network_services = ["amazon-dns"]
@@ -99,10 +185,31 @@ resource "aws_ec2_traffic_mirror_filter" "filter" {
 
 func testAccTrafficMirrorFilterConfigWithoutDNS(description string) string {
 	return fmt.Sprintf(`
-resource "aws_ec2_traffic_mirror_filter" "filter" {
+resource "aws_ec2_traffic_mirror_filter" "test" {
   description = "%s"
 }
 `, description)
+}
+
+func testAccTrafficMirrorFilterConfigTags1(tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_ec2_traffic_mirror_filter" "test" {
+  tags = {
+    %[1]q = %[2]q
+  }
+}
+`, tagKey1, tagValue1)
+}
+
+func testAccTrafficMirrorFilterConfigTags2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_ec2_traffic_mirror_filter" "test" {
+  tags = {
+    %[1]q = %[2]q
+    %[3]q = %[4]q
+  }
+}
+`, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
 func testAccPreCheckAWSEc2TrafficMirrorFilter(t *testing.T) {

--- a/website/docs/r/ec2_traffic_mirror_filter.html.markdown
+++ b/website/docs/r/ec2_traffic_mirror_filter.html.markdown
@@ -27,7 +27,9 @@ resource "aws_ec2_traffic_mirror_filter" "foo" {
 The following arguments are supported:
 
 * `description` - (Optional, Forces new resource) A description of the filter.
-* `network_services` - (Optional) List of amazon network services that should be mirrored. Valid values: amazon-dns
+* `network_services` - (Optional) List of amazon network services that should be mirrored. Valid values: `amazon-dns`.
+* `tags` - (Optional) Key-value mapping of resource tags.
+
 
 ## Attributes Reference
 


### PR DESCRIPTION
+ add disappearing test case
+ read after create

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10688

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_ec2_traffic_mirror_filter: add tagging support
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEc2TrafficMirrorFilter_'
--- PASS: TestAccAWSEc2TrafficMirrorFilter_basic (143.51s)
--- PASS: TestAccAWSEc2TrafficMirrorFilter_disappears (45.50s)
--- PASS: TestAccAWSEc2TrafficMirrorFilter_tags (128.53s)
```
