### PR TITLE
 tfproviderlint R009 check: remove Go panic usage from 'structure.go'

### DIFF
--- a/aws/structure.go
+++ b/aws/structure.go
@@ -2094,9 +2094,6 @@ func getStringPtr(m interface{}, key string) *string {
 			s := v.(string)
 			return &s
 		}
-
-	default:
-		panic("unknown type in getStringPtr")
 	}
 
 	return nil
@@ -2113,56 +2110,6 @@ func (s setMap) SetString(key string, value *string) {
 	}
 
 	s[key] = *value
-}
-
-// SetStringMap sets key to value as a map[string]interface{}, stripping any nil
-// values. The value parameter can be a map[string]interface{}, a
-// map[string]*string, or a map[string]string.
-func (s setMap) SetStringMap(key string, value interface{}) {
-	// because these methods are meant to be chained without intermediate
-	// checks for nil, we are likely to get interfaces with dynamic types but
-	// a nil value.
-	if reflect.ValueOf(value).IsNil() {
-		return
-	}
-
-	m := make(map[string]interface{})
-
-	switch value := value.(type) {
-	case map[string]string:
-		for k, v := range value {
-			m[k] = v
-		}
-	case map[string]*string:
-		for k, v := range value {
-			if v == nil {
-				continue
-			}
-			m[k] = *v
-		}
-	case map[string]interface{}:
-		for k, v := range value {
-			if v == nil {
-				continue
-			}
-
-			switch v := v.(type) {
-			case string:
-				m[k] = v
-			case *string:
-				if v != nil {
-					m[k] = *v
-				}
-			default:
-				panic(fmt.Sprintf("unknown type for SetString: %T", v))
-			}
-		}
-	}
-
-	// catch the case where the interface wasn't nil, but we had no non-nil values
-	if len(m) > 0 {
-		s[key] = m
-	}
 }
 
 // Set assigns value to s[key] if value isn't nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/terraform-providers/terraform-provider-aws/issues/12084.

Remove Go `panic()` usage from `structure.go`.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
n/a
```
