### PR TITLE
Fixes Elastic Beanstalk sweeper names

### DIFF
--- a/aws/resource_aws_elastic_beanstalk_application_test.go
+++ b/aws/resource_aws_elastic_beanstalk_application_test.go
@@ -15,14 +15,14 @@ import (
 
 // initialize sweeper
 func init() {
-	resource.AddTestSweepers("aws_beanstalk_application", &resource.Sweeper{
-		Name:         "aws_beanstalk_application",
-		Dependencies: []string{"aws_beanstalk_environment"},
-		F:            testSweepBeanstalkApplications,
+	resource.AddTestSweepers("aws_elastic_beanstalk_application", &resource.Sweeper{
+		Name:         "aws_elastic_beanstalk_application",
+		Dependencies: []string{"aws_elastic_beanstalk_environment"},
+		F:            testSweepElasticBeanstalkApplications,
 	})
 }
 
-func testSweepBeanstalkApplications(region string) error {
+func testSweepElasticBeanstalkApplications(region string) error {
 	client, err := sharedClientForRegion(region)
 	if err != nil {
 		return fmt.Errorf("error getting client: %s", err)

--- a/aws/resource_aws_elastic_beanstalk_environment_test.go
+++ b/aws/resource_aws_elastic_beanstalk_environment_test.go
@@ -20,13 +20,13 @@ import (
 
 // initialize sweeper
 func init() {
-	resource.AddTestSweepers("aws_beanstalk_environment", &resource.Sweeper{
-		Name: "aws_beanstalk_environment",
-		F:    testSweepBeanstalkEnvironments,
+	resource.AddTestSweepers("aws_elastic_beanstalk_environment", &resource.Sweeper{
+		Name: "aws_elastic_beanstalk_environment",
+		F:    testSweepElasticBeanstalkEnvironments,
 	})
 }
 
-func testSweepBeanstalkEnvironments(region string) error {
+func testSweepElasticBeanstalkEnvironments(region string) error {
 	client, err := sharedClientForRegion(region)
 	if err != nil {
 		return fmt.Errorf("error getting client: %s", err)

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -25,7 +25,7 @@ func init() {
 		Dependencies: []string{
 			"aws_autoscaling_group",
 			"aws_batch_compute_environment",
-			"aws_beanstalk_environment",
+			"aws_elastic_beanstalk_environment",
 			"aws_cloudhsm_v2_cluster",
 			"aws_db_subnet_group",
 			"aws_directory_service_directory",


### PR DESCRIPTION
The sweepers had inconsistent names, so they were causing missing sweeper warnings in sweeper runs.

```
[WARN] Sweeper (aws_iam_role) has dependency (aws_elastic_beanstalk_application), but that sweeper was not found
[WARN] Sweeper (aws_iam_role) has dependency (aws_elastic_beanstalk_environment), but that sweeper was not found
[WARN] Sweeper (aws_key_pair) has dependency (aws_elastic_beanstalk_environment), but that sweeper was not found
```

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
