### PR TITLE
Add validation on CloudFront distribution georestriction type

### DIFF
--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -647,6 +647,11 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 									"restriction_type": {
 										Type:     schema.TypeString,
 										Required: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											cloudfront.GeoRestrictionTypeNone,
+											cloudfront.GeoRestrictionTypeBlacklist,
+											cloudfront.GeoRestrictionTypeWhitelist,
+										}, false),
 									},
 								},
 							},


### PR DESCRIPTION
Invalid values passed to the CloudFront distribution georestriction type were causing a crash of the provider, as reported in #11911. This PR adds validation to the field to enforce the three valid values: `none`, `blacklist`, and `whitelist`.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11911

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_cloudfront_distribution: Prevent panic when invalid georestriction type is passed
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCloudFrontDistribution_'

--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName (4.65s)
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID (4.98s)
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers (605.56s)
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames (605.69s)
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Cookies_WhitelistedNames (607.69s)
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_TrustedSigners (610.06s)
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Headers (614.28s)
--- PASS: TestAccAWSCloudFrontDistribution_disappears (615.17s)
--- PASS: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn (624.46s)
--- PASS: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate (620.51s)
--- PASS: TestAccAWSCloudFrontDistribution_noOptionalItemsConfig (1178.20s)
--- PASS: TestAccAWSCloudFrontDistribution_orderedCacheBehavior (1179.61s)
--- PASS: TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig (1182.44s)
--- PASS: TestAccAWSCloudFrontDistribution_customOrigin (1183.07s)
--- PASS: TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig (1184.60s)
--- PASS: TestAccAWSCloudFrontDistribution_S3Origin (1185.27s)
--- PASS: TestAccAWSCloudFrontDistribution_HTTP11Config (1188.58s)
--- PASS: TestAccAWSCloudFrontDistribution_multiOrigin (1188.74s)
--- PASS: TestAccAWSCloudFrontDistribution_RetainOnDelete (1188.83s)
--- PASS: TestAccAWSCloudFrontDistribution_WaitForDeployment (1185.57s)
--- PASS: TestAccAWSCloudFrontDistribution_S3OriginWithTags (1778.81s)
--- PASS: TestAccAWSCloudFrontDistribution_Enabled (1784.44s)
--- PASS: TestAccAWSCloudFrontDistribution_OriginGroups (1178.88s)
```
