### PR TITLE
resource/aws_media_store_container: Prevent ValidationException on creation when no tags are configured

### DIFF
--- a/aws/resource_aws_media_store_container.go
+++ b/aws/resource_aws_media_store_container.go
@@ -48,7 +48,10 @@ func resourceAwsMediaStoreContainerCreate(d *schema.ResourceData, meta interface
 
 	input := &mediastore.CreateContainerInput{
 		ContainerName: aws.String(d.Get("name").(string)),
-		Tags:          keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().MediastoreTags(),
+	}
+
+	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
+		input.Tags = keyvaluetags.New(v).IgnoreAws().MediastoreTags()
 	}
 
 	resp, err := conn.CreateContainer(input)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_media_store_container: Prevent `ValidationException` error on creation when no tags are configured
```

Previously from the acceptance testing (started February 18, 2020):

```
--- FAIL: TestAccAWSMediaStoreContainer_basic (2.83s)
    testing.go:654: Step 0 error: errors during apply:

        Error: ValidationException: 1 validation error detected: Value '[]' at 'tags' failed to satisfy constraint: Member must have length greater than or equal to 1
```

Output from acceptance testing:

```
--- PASS: TestAccAWSMediaStoreContainer_tags (127.62s)
--- PASS: TestAccAWSMediaStoreContainer_basic (141.24s)
```
