### PR TITLE
resource/aws_lambda_function_event_invoke_config: Retry on additional IAM eventual consistency error with SNS Topic destinations

### DIFF
--- a/aws/resource_aws_lambda_function_event_invoke_config.go
+++ b/aws/resource_aws_lambda_function_event_invoke_config.go
@@ -123,6 +123,11 @@ func resourceAwsLambdaFunctionEventInvokeConfigCreate(d *schema.ResourceData, me
 			return resource.RetryableError(err)
 		}
 
+		// InvalidParameterValueException: The function's execution role does not have permissions to call Publish on arn:...
+		if isAWSErr(err, lambda.ErrCodeInvalidParameterValueException, "does not have permissions") {
+			return resource.RetryableError(err)
+		}
+
 		if err != nil {
 			return resource.NonRetryableError(err)
 		}
@@ -213,6 +218,11 @@ func resourceAwsLambdaFunctionEventInvokeConfigUpdate(d *schema.ResourceData, me
 
 		// InvalidParameterValueException: The destination ARN arn:PARTITION:SERVICE:REGION:ACCOUNT:RESOURCE is invalid.
 		if isAWSErr(err, lambda.ErrCodeInvalidParameterValueException, "destination ARN") {
+			return resource.RetryableError(err)
+		}
+
+		// InvalidParameterValueException: The function's execution role does not have permissions to call Publish on arn:...
+		if isAWSErr(err, lambda.ErrCodeInvalidParameterValueException, "does not have permissions") {
 			return resource.RetryableError(err)
 		}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_lambda_function_event_invoke_config: Retry on additional IAM eventual consistency error with SNS Topic destinations
```

Previous output from acceptance testing (starting January 8, 2020):

```
--- FAIL: TestAccAWSLambdaFunctionEventInvokeConfig_DestinationConfig_OnFailure_Destination (39.34s)
    testing.go:654: Step 2 error: errors during apply:

        Error: error putting Lambda Function Event Invoke Config (tf-acc-test-2587868650326248481): InvalidParameterValueException: The function's execution role does not have permissions to call Publish on arn:aws:sns:us-west-2:*******:tf-acc-test-2587868650326248481

--- FAIL: TestAccAWSLambdaFunctionEventInvokeConfig_DestinationConfig_OnSuccess_Destination (38.93s)
    testing.go:654: Step 2 error: errors during apply:

        Error: error putting Lambda Function Event Invoke Config (tf-acc-test-3054348441165405395): InvalidParameterValueException: The function's execution role does not have permissions to call Publish on arn:aws:sns:us-west-2:*******:tf-acc-test-3054348441165405395
```

Output from acceptance testing:

```
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_Qualifier_Latest (61.87s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_Qualifier_FunctionVersion (90.83s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_disappears_LambdaFunction (93.91s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_disappears_LambdaFunctionEventInvokeConfig (94.80s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_FunctionName_Arn (99.33s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_DestinationConfig_Swap (101.83s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_MaximumEventAgeInSeconds (104.62s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_Qualifier_AliasName (106.73s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_DestinationConfig_OnFailure_Destination (107.43s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_basic (110.48s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_MaximumRetryAttempts (145.50s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_DestinationConfig_Remove (146.86s)
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_DestinationConfig_OnSuccess_Destination (151.83s)
```