### PR TITLE
tests/resource/aws_eks_node_group: Update TestAccAWSEksNodeGroup_ReleaseVersion argument value

### DIFF
--- a/aws/resource_aws_eks_node_group_test.go
+++ b/aws/resource_aws_eks_node_group_test.go
@@ -279,10 +279,10 @@ func TestAccAWSEksNodeGroup_ReleaseVersion(t *testing.T) {
 		CheckDestroy: testAccCheckAWSEksNodeGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEksNodeGroupConfigReleaseVersion(rName, "1.14.7-20190927"),
+				Config: testAccAWSEksNodeGroupConfigReleaseVersion(rName, "1.14.8-20191213"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup1),
-					resource.TestCheckResourceAttr(resourceName, "release_version", "1.14.7-20190927"),
+					resource.TestCheckResourceAttr(resourceName, "release_version", "1.14.8-20191213"),
 				),
 			},
 			{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/awslabs/amazon-eks-ami/issues/423
Reference: https://github.com/aws/containers-roadmap/issues/771

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

There is currently no lookup mechanism for these values other than the website. See referenced issue for hopeful paths forward via a new SSM Parameter or EKS API.

Previous output from acceptance testing (master and latest version testing):

```
--- FAIL: TestAccAWSEksNodeGroup_ReleaseVersion (1225.88s)
    testing.go:654: Step 0 error: errors during apply:

        Error: error creating EKS Node Group (tf-acc-test-9113909416381506697:tf-acc-test-9113909416381506697): InvalidParameterException: Requested Node Group release version 1.14.7-20190927 is invalid. Allowed release version is 1.14.8-20191213

--- FAIL: TestAccAWSEksNodeGroup_ReleaseVersion (1375.87s)
    testing.go:654: Step 0 error: errors during apply:

        Error: error creating EKS Node Group (tf-acc-test-7174874914828901519:tf-acc-test-7174874914828901519): InvalidParameterException: Requested Node Group release version 1.14.9-20200122 is invalid. Allowed release version is 1.14.8-20191213
```

Output from acceptance testing:

```
--- PASS: TestAccAWSEksNodeGroup_ReleaseVersion (1564.18s)
```
