### PR TITLE
tests/resource/aws_ssm_activation: Remove broken ExpectError testing from TestAccAWSSSMActivation_expirationDate

### DIFF
--- a/aws/resource_aws_ssm_activation_test.go
+++ b/aws/resource_aws_ssm_activation_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 	"time"
 
@@ -82,10 +81,6 @@ func TestAccAWSSSMActivation_expirationDate(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSSMActivationDestroy,
 		Steps: []resource.TestStep{
-			{
-				Config:      testAccAWSSSMActivationConfig_expirationDate(rName, "2018-03-01"),
-				ExpectError: regexp.MustCompile(`invalid RFC3339 timestamp`),
-			},
 			{
 				Config: testAccAWSSSMActivationConfig_expirationDate(rName, expirationDateS),
 				Check: resource.ComposeTestCheckFunc(


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously from the acceptance testing:

```
--- FAIL: TestAccAWSSSMActivation_expirationDate (1.08s)
    testing.go:647: Step 0, expected error:

        config is invalid: expected "expiration_date" to be a valid RFC3339 date, got "2018-03-01": parsing time "2018-03-01" as "2006-01-02T15:04:05Z07:00": cannot parse "" as "T"

        To match:

        invalid RFC3339 timestamp
```

It appears the error messaging changed with the RFC3339 timestamp validation around January 31, 2020. We typically do not use `ExpectError` testing too often with plan-time value validations, since its usually an unnecessary maintenance burden, so here we remove the extra test step rather than manually update the expected error messaging to match disconnected code.

Output from acceptance testing:

```
--- PASS: TestAccAWSSSMActivation_expirationDate (36.94s)
```
