### PR TITLE
resource/aws_storagegateway_smb_file_share: Add support for admin_user_list

### DIFF
--- a/aws/resource_aws_storagegateway_smb_file_share_test.go
+++ b/aws/resource_aws_storagegateway_smb_file_share_test.go
@@ -41,6 +41,7 @@ func TestAccAWSStorageGatewaySmbFileShare_Authentication_ActiveDirectory(t *test
 					resource.TestCheckResourceAttr(resourceName, "requester_pays", "false"),
 					resource.TestMatchResourceAttr(resourceName, "role_arn", regexp.MustCompile(`^arn:`)),
 					resource.TestCheckResourceAttr(resourceName, "valid_user_list.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "admin_user_list.#", "0"),
 				),
 			},
 			{
@@ -81,6 +82,7 @@ func TestAccAWSStorageGatewaySmbFileShare_Authentication_GuestAccess(t *testing.
 					resource.TestCheckResourceAttr(resourceName, "requester_pays", "false"),
 					resource.TestMatchResourceAttr(resourceName, "role_arn", regexp.MustCompile(`^arn:`)),
 					resource.TestCheckResourceAttr(resourceName, "valid_user_list.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "admin_user_list.#", "0"),
 				),
 			},
 			{
@@ -453,6 +455,46 @@ func TestAccAWSStorageGatewaySmbFileShare_ValidUserList(t *testing.T) {
 	})
 }
 
+func TestAccAWSStorageGatewaySmbFileShare_AdminUserList(t *testing.T) {
+	var smbFileShare storagegateway.SMBFileShareInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_smb_file_share.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewaySmbFileShareDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewaySmbFileShareConfig_AdminUserList_Single(rName, "adminuser1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewaySmbFileShareExists(resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "admin_user_list.#", "1"),
+				),
+			},
+			{
+				Config: testAccAWSStorageGatewaySmbFileShareConfig_AdminUserList_Multiple(rName, "adminuser2", "adminuser3"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewaySmbFileShareExists(resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "admin_user_list.#", "2"),
+				),
+			},
+			{
+				Config: testAccAWSStorageGatewaySmbFileShareConfig_AdminUserList_Single(rName, "adminuser4"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewaySmbFileShareExists(resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "admin_user_list.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAWSStorageGatewaySmbFileShareDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).storagegatewayconn
 
@@ -801,6 +843,32 @@ resource "aws_storagegateway_smb_file_share" "test" {
   valid_user_list = [%q, %q]
 }
 `, validUser1, validUser2)
+}
+
+func testAccAWSStorageGatewaySmbFileShareConfig_AdminUserList_Single(rName, adminUser1 string) string {
+	return testAccAWSStorageGateway_SmbFileShare_ActiveDirectoryBase(rName) + fmt.Sprintf(`
+resource "aws_storagegateway_smb_file_share" "test" {
+  # Must be ActiveDirectory
+  authentication    = "ActiveDirectory"
+  gateway_arn     = "${aws_storagegateway_gateway.test.arn}"
+  location_arn    = "${aws_s3_bucket.test.arn}"
+  role_arn        = "${aws_iam_role.test.arn}"
+  admin_user_list = [%q]
+}
+`, adminUser1)
+}
+
+func testAccAWSStorageGatewaySmbFileShareConfig_AdminUserList_Multiple(rName, adminUser1, adminUser2 string) string {
+	return testAccAWSStorageGateway_SmbFileShare_ActiveDirectoryBase(rName) + fmt.Sprintf(`
+resource "aws_storagegateway_smb_file_share" "test" {
+  # Must be ActiveDirectory
+  authentication    = "ActiveDirectory"
+  gateway_arn     = "${aws_storagegateway_gateway.test.arn}"
+  location_arn    = "${aws_s3_bucket.test.arn}"
+  role_arn        = "${aws_iam_role.test.arn}"
+  admin_user_list = [%q, %q]
+}
+`, adminUser1, adminUser2)
 }
 
 func testAccAWSStorageGatewaySmbFileShareConfigTags1(rName, tagKey1, tagValue1 string) string {

--- a/website/docs/r/storagegateway_smb_file_share.html.markdown
+++ b/website/docs/r/storagegateway_smb_file_share.html.markdown
@@ -56,6 +56,7 @@ The following arguments are supported:
 * `read_only` - (Optional) Boolean to indicate write status of file share. File share does not accept writes if `true`. Defaults to `false`.
 * `requester_pays` - (Optional) Boolean who pays the cost of the request and the data download from the Amazon S3 bucket. Set this value to `true` if you want the requester to pay instead of the bucket owner. Defaults to `false`.
 * `valid_user_list` - (Optional) A list of users in the Active Directory that are allowed to access the file share. Only valid if `authentication` is set to `ActiveDirectory`.
+* `admin_user_list` - (Optional) A list of users in the Active Directory that have admin access to the file share. Only valid if `authentication` is set to `ActiveDirectory`.
 * `tags` - (Optional) Key-value mapping of resource tags
 
 ### smb_file_share_defaults


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

This adds support for specifying a Storage Gateway SMB File Share admin user list. There was already support for invalid and valid user lists, but not an admin user list.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Closes #12255

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_storagegateway_smb_file_share: Add support for `admin_user_list` parameter
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSStorageGatewaySmbFileShare_AdminUserList'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSStorageGatewaySmbFileShare_AdminUserList -timeout 120m
=== RUN   TestAccAWSStorageGatewaySmbFileShare_AdminUserList
=== PAUSE TestAccAWSStorageGatewaySmbFileShare_AdminUserList
=== CONT  TestAccAWSStorageGatewaySmbFileShare_AdminUserList
--- PASS: TestAccAWSStorageGatewaySmbFileShare_AdminUserList (841.71s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       843.095s
```
