### PR TITLE
Replace local version of schema validators with identical versions from terraform-plugin-sdk helper/validation package

### DIFF
--- a/aws/resource_aws_dax_cluster.go
+++ b/aws/resource_aws_dax_cluster.go
@@ -48,8 +48,8 @@ func resourceAwsDaxCluster() *schema.Resource {
 					validation.StringLenBetween(1, 20),
 					validation.StringMatch(regexp.MustCompile(`^[0-9a-z-]+$`), "must contain only lowercase alphanumeric characters and hyphens"),
 					validation.StringMatch(regexp.MustCompile(`^[a-z]`), "must begin with a lowercase letter"),
-					validateStringNotMatch(regexp.MustCompile(`--`), "cannot contain two consecutive hyphens"),
-					validateStringNotMatch(regexp.MustCompile(`-$`), "cannot end with a hyphen"),
+					validation.StringDoesNotMatch(regexp.MustCompile(`--`), "cannot contain two consecutive hyphens"),
+					validation.StringDoesNotMatch(regexp.MustCompile(`-$`), "cannot end with a hyphen"),
 				),
 			},
 			"iam_role_arn": {

--- a/aws/resource_aws_elasticache_cluster.go
+++ b/aws/resource_aws_elasticache_cluster.go
@@ -105,8 +105,8 @@ func resourceAwsElasticacheCluster() *schema.Resource {
 					validation.StringLenBetween(1, 50),
 					validation.StringMatch(regexp.MustCompile(`^[0-9a-z-]+$`), "must contain only lowercase alphanumeric characters and hyphens"),
 					validation.StringMatch(regexp.MustCompile(`^[a-z]`), "must begin with a lowercase letter"),
-					validateStringNotMatch(regexp.MustCompile(`--`), "cannot contain two consecutive hyphens"),
-					validateStringNotMatch(regexp.MustCompile(`-$`), "cannot end with a hyphen"),
+					validation.StringDoesNotMatch(regexp.MustCompile(`--`), "cannot contain two consecutive hyphens"),
+					validation.StringDoesNotMatch(regexp.MustCompile(`-$`), "cannot end with a hyphen"),
 				),
 			},
 			"configuration_endpoint": {

--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elasticache"
-
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -166,8 +165,8 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 					validation.StringLenBetween(1, 40),
 					validation.StringMatch(regexp.MustCompile(`^[0-9a-zA-Z-]+$`), "must contain only alphanumeric characters and hyphens"),
 					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z]`), "must begin with a letter"),
-					validateStringNotMatch(regexp.MustCompile(`--`), "cannot contain two consecutive hyphens"),
-					validateStringNotMatch(regexp.MustCompile(`-$`), "cannot end with a hyphen"),
+					validation.StringDoesNotMatch(regexp.MustCompile(`--`), "cannot contain two consecutive hyphens"),
+					validation.StringDoesNotMatch(regexp.MustCompile(`-$`), "cannot end with a hyphen"),
 				),
 				StateFunc: func(val interface{}) string {
 					return strings.ToLower(val.(string))

--- a/aws/resource_aws_sagemaker_endpoint_configuration.go
+++ b/aws/resource_aws_sagemaker_endpoint_configuration.go
@@ -4,12 +4,11 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sagemaker"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
@@ -72,7 +71,7 @@ func resourceAwsSagemakerEndpointConfiguration() *schema.Resource {
 							Type:         schema.TypeFloat,
 							Optional:     true,
 							ForceNew:     true,
-							ValidateFunc: FloatAtLeast(0),
+							ValidateFunc: validation.FloatAtLeast(0),
 							Default:      1,
 						},
 

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -32,48 +32,6 @@ var awsAccountIDRegexp = regexp.MustCompile(awsAccountIDRegexpPattern)
 var awsPartitionRegexp = regexp.MustCompile(awsPartitionRegexpPattern)
 var awsRegionRegexp = regexp.MustCompile(awsRegionRegexpPattern)
 
-// FloatAtLeast returns a SchemaValidateFunc which tests if the provided value
-// is of type float and is at least min (inclusive)
-func FloatAtLeast(min float64) schema.SchemaValidateFunc {
-	return func(i interface{}, k string) (s []string, es []error) {
-		v, ok := i.(float64)
-		if !ok {
-			es = append(es, fmt.Errorf("expected type of %s to be float", k))
-			return
-		}
-
-		if v < min {
-			es = append(es, fmt.Errorf("expected %s to be at least (%f), got %f", k, min, v))
-			return
-		}
-
-		return
-	}
-}
-
-// validateStringNotMatch returns a SchemaValidateFunc which tests if the provided value
-// does not match a given regexp. Optionally an error message can be provided to
-// return something friendlier than "must match some globby regexp".
-// This function is an inverse copy of validation.StringMatch and will be
-// migrated to the Terraform Provider SDK.
-func validateStringNotMatch(r *regexp.Regexp, message string) schema.SchemaValidateFunc {
-	return func(i interface{}, k string) ([]string, []error) {
-		v, ok := i.(string)
-		if !ok {
-			return nil, []error{fmt.Errorf("expected type of %s to be string", k)}
-		}
-
-		if ok := r.MatchString(v); ok {
-			if message != "" {
-				return nil, []error{fmt.Errorf("invalid value for %s (%s)", k, message)}
-
-			}
-			return nil, []error{fmt.Errorf("expected value of %s to not match regular expression %q", k, r)}
-		}
-		return nil, nil
-	}
-}
-
 // validateTypeStringNullableBoolean provides custom error messaging for TypeString booleans
 // Some arguments require three values: true, false, and "" (unspecified).
 // This ValidateFunc returns a custom message since the message with


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/11034.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSSagemakerEndpointConfiguration_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSSagemakerEndpointConfiguration_Basic -timeout 120m
=== RUN   TestAccAWSSagemakerEndpointConfiguration_Basic
=== PAUSE TestAccAWSSagemakerEndpointConfiguration_Basic
=== CONT  TestAccAWSSagemakerEndpointConfiguration_Basic
--- PASS: TestAccAWSSagemakerEndpointConfiguration_Basic (44.59s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	44.629s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSDAXCluster_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSDAXCluster_basic -timeout 120m
=== RUN   TestAccAWSDAXCluster_basic
=== PAUSE TestAccAWSDAXCluster_basic
=== CONT  TestAccAWSDAXCluster_basic
--- PASS: TestAccAWSDAXCluster_basic (707.82s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	707.860s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSElasticacheCluster_Engine_Memcached'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSElasticacheCluster_Engine_Memcached -timeout 120m
=== RUN   TestAccAWSElasticacheCluster_Engine_Memcached
=== PAUSE TestAccAWSElasticacheCluster_Engine_Memcached
=== CONT  TestAccAWSElasticacheCluster_Engine_Memcached
--- PASS: TestAccAWSElasticacheCluster_Engine_Memcached (503.92s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	503.965s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSElasticacheReplicationGroup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSElasticacheReplicationGroup_basic -timeout 120m
=== RUN   TestAccAWSElasticacheReplicationGroup_basic
=== PAUSE TestAccAWSElasticacheReplicationGroup_basic
=== CONT  TestAccAWSElasticacheReplicationGroup_basic
--- PASS: TestAccAWSElasticacheReplicationGroup_basic (714.18s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	714.222s
```
