### PR TITLE
docs/provider: Fix invalid HCL in example configurations

### DIFF
--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -148,19 +148,6 @@ resource "aws_autoscaling_group" "bar" {
   launch_configuration = "${aws_launch_configuration.foobar.name}"
   vpc_zone_identifier  = ["${aws_subnet.example1.id}", "${aws_subnet.example2.id}"]
 
-  tags = [
-    {
-      key                 = "explicit1"
-      value               = "value1"
-      propagate_at_launch = true
-    },
-    {
-      key                 = "explicit2"
-      value               = "value2"
-      propagate_at_launch = true
-    },
-  ]
-
   tags = ["${concat(
     list(
       map("key", "interpolation1", "value", "value3", "propagate_at_launch", true),

--- a/website/docs/r/cognito_user_pool.markdown
+++ b/website/docs/r/cognito_user_pool.markdown
@@ -106,15 +106,19 @@ The following arguments are supported:
 The [standard attributes](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-attributes.html#cognito-user-pools-standard-attributes) have the following defaults. Note that attributes which match the default values are not stored in Terraform state when importing.
 
 ```hcl
-schema {
-  name                     = <name>
-  attribute                = <appropriate type>
-  developer_only_attribute = false
-  mutable                  = true  // false for "sub"
-  required                 = false // true for "sub"
-  string_attribute_constraints { // if it's a string
-    min_length = 0    // 10 for "birthdate"
-    max_length = 2048 // 10 for "birthdate"
+resource "aws_cognito_user_pool" "example" {
+  # ... other configuration ...
+
+  schema {
+    name                     = "<name>"
+    attribute_data_type      = "<appropriate type>"
+    developer_only_attribute = false
+    mutable                  = true  // false for "sub"
+    required                 = false // true for "sub"
+    string_attribute_constraints { // if it's a string
+      min_length = 0    // 10 for "birthdate"
+      max_length = 2048 // 10 for "birthdate"
+    }
   }
 }
 ```

--- a/website/docs/r/default_network_acl.html.markdown
+++ b/website/docs/r/default_network_acl.html.markdown
@@ -45,13 +45,13 @@ resource "aws_vpc" "mainvpc" {
 }
 
 resource "aws_default_network_acl" "default" {
-  default_network_acl_id = "${aws_vpc.mainvpc.default_network_acl_id}"
+  default_network_acl_id = aws_vpc.mainvpc.default_network_acl_id
 
   ingress {
     protocol   = -1
     rule_no    = 100
     action     = "allow"
-    cidr_block = # set a CIDR block here
+    cidr_block = aws_vpc.mainvpc.cidr_block
     from_port  = 0
     to_port    = 0
   }
@@ -78,13 +78,13 @@ resource "aws_vpc" "mainvpc" {
 }
 
 resource "aws_default_network_acl" "default" {
-  default_network_acl_id = "${aws_vpc.mainvpc.default_network_acl_id}"
+  default_network_acl_id = aws_vpc.mainvpc.default_network_acl_id
 
   ingress {
     protocol   = -1
     rule_no    = 100
     action     = "allow"
-    cidr_block = # set a CIDR block here
+    cidr_block = aws_vpc.mainvpc.cidr_block
     from_port  = 0
     to_port    = 0
   }

--- a/website/docs/r/emr_cluster.html.markdown
+++ b/website/docs/r/emr_cluster.html.markdown
@@ -407,10 +407,6 @@ boot an example EMR Cluster. It is not meant to display best practices. Please
 use at your own risk.
 
 ```hcl
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_emr_cluster" "cluster" {
   name          = "emr-test-arn"
   release_label = "emr-4.6.0"
@@ -478,13 +474,10 @@ resource "aws_security_group" "allow_access" {
   vpc_id      = "${aws_vpc.main.id}"
 
   ingress {
-    # these ports should be locked down
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-
-    # we do not recommend opening your cluster to 0.0.0.0/0
-    cidr_blocks = # add your IP address here
+    cidr_blocks = aws_vpc.main.cidr_block
   }
 
   egress {

--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -84,7 +84,7 @@ For more information about CloudWatch Logs for Lambda, see the [Lambda User Guid
 ```hcl
 resource "aws_lambda_function" "test_lambda" {
   function_name = "${var.lambda_function_name}"
-  ...
+  # ... other configuration ...
   depends_on    = ["aws_iam_role_policy_attachment.lambda_logs", "aws_cloudwatch_log_group.example"]
 }
 

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -95,7 +95,7 @@ resource "aws_launch_template" "foo" {
     }
   }
 
-  user_data = "${base64encode(...)}"
+  user_data = filebase64("${path.module}/example.sh")
 }
 ```
 

--- a/website/docs/r/network_acl_rule.html.markdown
+++ b/website/docs/r/network_acl_rule.html.markdown
@@ -20,17 +20,16 @@ a conflict of rule settings and will overwrite rules.
 
 ```hcl
 resource "aws_network_acl" "bar" {
-  vpc_id = "${aws_vpc.foo.id}"
+  vpc_id = aws_vpc.foo.id
 }
 
 resource "aws_network_acl_rule" "bar" {
-  network_acl_id = "${aws_network_acl.bar.id}"
+  network_acl_id = aws_network_acl.bar.id
   rule_number    = 200
   egress         = false
   protocol       = "tcp"
   rule_action    = "allow"
-  # Opening to 0.0.0.0/0 can lead to security vulnerabilities.
-  cidr_block = # add a CIDR block here
+  cidr_block     = aws_vpc.foo.cidr_block
   from_port      = 22
   to_port        = 22
 }

--- a/website/docs/r/sagemaker_notebook_instance_lifecycle_configuration.html.markdown
+++ b/website/docs/r/sagemaker_notebook_instance_lifecycle_configuration.html.markdown
@@ -17,8 +17,8 @@ Usage:
 ```hcl
 resource "aws_sagemaker_notebook_instance_lifecycle_configuration" "lc" {
   name      = "foo"
-  on_create = "${base64encode('echo foo')}"
-  on_start  = "${base64encode('echo bar')}"
+  on_create = base64encode("echo foo")
+  on_start  = base64encode("echo bar")
 }
 ```
 

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -32,45 +32,22 @@ resource "aws_security_group" "allow_tls" {
   vpc_id      = "${aws_vpc.main.id}"
 
   ingress {
-    # TLS (change to whatever ports you need)
+    description = "TLS from VPC"
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
-    # Please restrict your ingress to only necessary IPs and ports.
-    # Opening to 0.0.0.0/0 can lead to security vulnerabilities.
-    cidr_blocks = # add a CIDR block here
+    cidr_blocks = aws_vpc.main.cidr_block
   }
 
   egress {
-    from_port       = 0
-    to_port         = 0
-    protocol        = "-1"
-    cidr_blocks     = ["0.0.0.0/0"]
-    prefix_list_ids = ["pl-12c4e678"]
-  }
-}
-```
-
-Basic usage with tags:
-
-```hcl
-resource "aws_security_group" "allow_tls" {
-  name        = "allow_tls"
-  description = "Allow TLS inbound traffic"
-  vpc_id      = "${aws_vpc.main.id}"
-
-  ingress {
-    # TLS (change to whatever ports you need)
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    # Please restrict your ingress to only necessary IPs and ports.
-    # Opening to 0.0.0.0/0 can lead to security vulnerabilities.
-    cidr_blocks = # add your IP address here
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   tags = {
-    Name = "allow_all"
+    Name = "allow_tls"
   }
 }
 ```

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -27,16 +27,12 @@ a conflict of rule settings and will overwrite rules.
 Basic usage
 
 ```hcl
-resource "aws_security_group_rule" "allow_all" {
+resource "aws_security_group_rule" "example" {
   type            = "ingress"
   from_port       = 0
   to_port         = 65535
   protocol        = "tcp"
-  # Opening to 0.0.0.0/0 can lead to security vulnerabilities.
-  cidr_blocks = # add a CIDR block here
-  prefix_list_ids = ["pl-12c4e678"]
-
-  security_group_id = "sg-123456"
+  cidr_blocks     = aws_vpc.example.cidr_block
 }
 ```
 

--- a/website/docs/r/ssm_document.html.markdown
+++ b/website/docs/r/ssm_document.html.markdown
@@ -118,3 +118,4 @@ resource "aws_ssm_document" "test" {
     ignore_changes = ["attachments_source"]
   }
 }
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

In the near future, we will be able to enforce automatic HCL formatting of the documentation via CI, however there are currently code blocks that have invalid syntax that always will return an error:

```
ERRO[0000] block 4 @ website/docs/r/autoscaling_group.html.markdown#128 failed to process with: failed to parse hcl: website/docs/r/autoscaling_group.html.markdown:36,3-7: Attribute redefined; The argument "tags" was already set at website/docs/r/autoscaling_group.html.markdown:23,3-7. Each argument may be set only once.
ERRO[0000] block 2 @ website/docs/r/cognito_user_pool.markdown#108 failed to process with: failed to parse hcl: website/docs/r/cognito_user_pool.markdown:2,30-31: Invalid expression; Expected the start of an expression, but found an invalid expression token.
ERRO[0000] block 1 @ website/docs/r/default_network_acl.html.markdown#42 failed to process with: failed to parse hcl: website/docs/r/default_network_acl.html.markdown:12,18-13,1: Invalid expression; Expected the start of an expression, but found an invalid expression token.
ERRO[0000] block 2 @ website/docs/r/default_network_acl.html.markdown#75 failed to process with: failed to parse hcl: website/docs/r/default_network_acl.html.markdown:12,18-13,1: Invalid expression; Expected the start of an expression, but found an invalid expression token.
ERRO[0000] block 5 @ website/docs/r/emr_cluster.html.markdown#409 failed to process with: failed to parse hcl: website/docs/r/emr_cluster.html.markdown:78,19-79,1: Invalid expression; Expected the start of an expression, but found an invalid expression token.
ERRO[0000] block 3 @ website/docs/r/lambda_function.html.markdown#84 failed to process with: failed to parse hcl: website/docs/r/lambda_function.html.markdown:3,3-6: Argument or block definition required; An argument or block definition is required here.
ERRO[0000] block 1 @ website/docs/r/launch_template.html.markdown#15 failed to process with: failed to parse hcl: website/docs/r/launch_template.html.markdown:83,31-34: Invalid expression; Expected the start of an expression, but found an invalid expression token.
ERRO[0000] block 1 @ website/docs/r/network_acl_rule.html.markdown#21 failed to process with: failed to parse hcl: website/docs/r/network_acl_rule.html.markdown:12,16-13,1: Invalid expression; Expected the start of an expression, but found an invalid expression token.
ERRO[0000] block 1 @ website/docs/r/sagemaker_notebook_instance_lifecycle_configuration.html.markdown#17 failed to process with: failed to parse hcl: website/docs/r/sagemaker_notebook_instance_lifecycle_configuration.html.markdown:3,31-32: Invalid character; Single quotes are not valid. Use double quotes (") to enclose strings., and 3 other diagnostic(s)
ERRO[0000] block 1 @ website/docs/r/security_group.html.markdown#28 failed to process with: failed to parse hcl: website/docs/r/security_group.html.markdown:13,19-14,1: Invalid expression; Expected the start of an expression, but found an invalid expression token.
ERRO[0000] block 2 @ website/docs/r/security_group.html.markdown#56 failed to process with: failed to parse hcl: website/docs/r/security_group.html.markdown:13,19-14,1: Invalid expression; Expected the start of an expression, but found an invalid expression token.
ERRO[0000] block 1 @ website/docs/r/security_group_rule.html.markdown#29 failed to process with: failed to parse hcl: website/docs/r/security_group_rule.html.markdown:7,17-8,1: Invalid expression; Expected the start of an expression, but found an invalid expression token.
ERRO[0000] block 2 @ website/docs/r/ssm_document.html.markdown#106 failed to find end of block
```

These changes fix those errors in preparation for this additional testing.

Output from acceptance testing: N/A (documentation only)
