### PR TITLE
aws_msk_cluster: support Logging Info

### DIFF
--- a/website/docs/r/msk_cluster.html.markdown
+++ b/website/docs/r/msk_cluster.html.markdown
@@ -48,20 +48,69 @@ resource "aws_kms_key" "kms" {
   description = "example"
 }
 
+resource "aws_cloudwatch_log_group" "test" {
+  name = "msk_broker_logs"
+}
+
+resource "aws_s3_bucket" "bucket" {
+  bucket = "msk-broker-logs-bucket"
+  acl    = "private"
+}
+
+resource "aws_iam_role" "firehose_role" {
+  name = "firehose_test_role"
+
+  assume_role_policy = <<EOF
+{
+"Version": "2012-10-17",
+"Statement": [
+  {
+    "Action": "sts:AssumeRole",
+    "Principal": {
+      "Service": "firehose.amazonaws.com"
+    },
+    "Effect": "Allow",
+    "Sid": ""
+  }
+  ]
+}
+EOF
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
+  name        = "terraform-kinesis-firehose-msk-broker-logs-stream"
+  destination = "s3"
+
+  s3_configuration {
+    role_arn   = "${aws_iam_role.firehose_role.arn}"
+    bucket_arn = "${aws_s3_bucket.bucket.arn}"
+  }
+
+  tags = {
+    LogDeliveryEnabled = "placeholder"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      tags["LogDeliveryEnabled"],
+    ]
+  }
+}
+
 resource "aws_msk_cluster" "example" {
   cluster_name           = "example"
   kafka_version          = "2.1.0"
   number_of_broker_nodes = 3
 
   broker_node_group_info {
-    instance_type  = "kafka.m5.large"
+    instance_type   = "kafka.m5.large"
     ebs_volume_size = 1000
     client_subnets = [
       "${aws_subnet.subnet_az1.id}",
       "${aws_subnet.subnet_az2.id}",
       "${aws_subnet.subnet_az3.id}",
     ]
-    security_groups = [ "${aws_security_group.sg.id}" ]
+    security_groups = ["${aws_security_group.sg.id}"]
   }
 
   encryption_info {
@@ -75,6 +124,24 @@ resource "aws_msk_cluster" "example" {
       }
       node_exporter {
         enabled_in_broker = true
+      }
+    }
+  }
+
+  logging_info {
+    broker_logs {
+      cloudwatch_logs {
+        enabled   = true
+        log_group = "${aws_cloudwatch_log_group.test.name}"
+      }
+      firehose {
+        enabled         = true
+        delivery_stream = "${aws_kinesis_firehose_delivery_stream.test_stream.name}"
+      }
+      s3 {
+        enabled = true
+        bucket  = "${aws_s3_bucket.bucket.id}"
+        prefix  = "logs/msk-"
       }
     }
   }
@@ -112,6 +179,7 @@ The following arguments are supported:
 * `encryption_info` - (Optional) Configuration block for specifying encryption. See below.
 * `enhanced_monitoring` - (Optional) Specify the desired enhanced MSK CloudWatch monitoring level.  See [Monitoring Amazon MSK with Amazon CloudWatch](https://docs.aws.amazon.com/msk/latest/developerguide/monitoring.html)
 * `open_monitoring` - (Optional) Configuration block for JMX and Node monitoring for the MSK cluster. See below.
+* `logging_info` - (Optional) Configuration block for streaming broker logs to Cloudwatch/S3/Kinesis Firehose. See below.
 * `tags` - (Optional) A mapping of tags to assign to the resource
 
 ### broker_node_group_info Argument Reference
@@ -161,6 +229,26 @@ The following arguments are supported:
 #### open_monitoring prometheus node_exporter Argument Reference
 
 * `enabled_in_broker` - (Required) Indicates whether you want to enable or disable the Node Exporter.
+
+#### logging_info Argument Reference
+
+* `broker_logs` - (Required) Configuration block for Broker Logs settings for logging info. See below.
+
+#### logging_info broker_logs cloudwatch_logs Argument Reference
+
+* `enabled` - (Optional) Indicates whether you want to enable or disable streaming broker logs to Cloudwatch Logs. 
+* `log_group` - (Optional) Name of the Cloudwatch Log Group to deliver logs to.
+
+#### logging_info broker_logs firehose Argument Reference
+
+* `enabled` - (Optional) Indicates whether you want to enable or disable streaming broker logs to Kinesis Data Firehose.
+* `delivery_stream` - (Optional) Name of the Kinesis Data Firehose delivery stream to deliver logs to.
+
+#### logging_info broker_logs s3 Argument Reference
+
+* `enabled` - (Optional) Indicates whether you want to enable or disable streaming broker logs to S3.
+* `bucket` - (Optional) Name of the S3 bucket to deliver logs to. 
+* `prefix` - (Optional) Prefix to append to the folder name. 
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12186

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_msk_cluster: support `logging_info` configuration [GH-12186]
```

Output from acceptance testing:
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSMskCluster_LoggingInfo'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSMskCluster_LoggingInfo -timeout 120m
=== RUN   TestAccAWSMskCluster_LoggingInfo
=== PAUSE TestAccAWSMskCluster_LoggingInfo
=== CONT  TestAccAWSMskCluster_LoggingInfo
--- PASS: TestAccAWSMskCluster_LoggingInfo (1486.13s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1487.802s
```
