### PR TITLE
AWS QuickSight keyvaluetags

### DIFF
--- a/aws/internal/keyvaluetags/generators/listtags/main.go
+++ b/aws/internal/keyvaluetags/generators/listtags/main.go
@@ -88,6 +88,7 @@ var serviceNames = []string{
 	"organizations",
 	"pinpoint",
 	"qldb",
+	"quicksight",
 	"rds",
 	"resourcegroups",
 	"route53",

--- a/aws/internal/keyvaluetags/generators/servicetags/main.go
+++ b/aws/internal/keyvaluetags/generators/servicetags/main.go
@@ -70,6 +70,7 @@ var sliceServiceNames = []string{
 	"mediastore",
 	"neptune",
 	"organizations",
+	"quicksight",
 	"ram",
 	"rds",
 	"redshift",

--- a/aws/internal/keyvaluetags/generators/updatetags/main.go
+++ b/aws/internal/keyvaluetags/generators/updatetags/main.go
@@ -93,6 +93,7 @@ var serviceNames = []string{
 	"organizations",
 	"pinpoint",
 	"qldb",
+	"quicksight",
 	"ram",
 	"rds",
 	"redshift",

--- a/aws/internal/keyvaluetags/list_tags_gen.go
+++ b/aws/internal/keyvaluetags/list_tags_gen.go
@@ -75,6 +75,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/organizations"
 	"github.com/aws/aws-sdk-go/service/pinpoint"
 	"github.com/aws/aws-sdk-go/service/qldb"
+	"github.com/aws/aws-sdk-go/service/quicksight"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/resourcegroups"
 	"github.com/aws/aws-sdk-go/service/route53"
@@ -1299,6 +1300,23 @@ func QldbListTags(conn *qldb.QLDB, identifier string) (KeyValueTags, error) {
 	}
 
 	return QldbKeyValueTags(output.Tags), nil
+}
+
+// QuicksightListTags lists quicksight service tags.
+// The identifier is typically the Amazon Resource Name (ARN), although
+// it may also be a different identifier depending on the service.
+func QuicksightListTags(conn *quicksight.QuickSight, identifier string) (KeyValueTags, error) {
+	input := &quicksight.ListTagsForResourceInput{
+		ResourceArn: aws.String(identifier),
+	}
+
+	output, err := conn.ListTagsForResource(input)
+
+	if err != nil {
+		return New(nil), err
+	}
+
+	return QuicksightKeyValueTags(output.Tags), nil
 }
 
 // RdsListTags lists rds service tags.

--- a/aws/internal/keyvaluetags/service_generation_customizations.go
+++ b/aws/internal/keyvaluetags/service_generation_customizations.go
@@ -4,6 +4,7 @@ package keyvaluetags
 
 import (
 	"fmt"
+	"github.com/aws/aws-sdk-go/service/quicksight"
 	"reflect"
 
 	"github.com/aws/aws-sdk-go/service/accessanalyzer"
@@ -266,6 +267,8 @@ func ServiceClientType(serviceName string) string {
 		funcType = reflect.TypeOf(pinpoint.New)
 	case "qldb":
 		funcType = reflect.TypeOf(qldb.New)
+	case "quicksight":
+		funcType = reflect.TypeOf(quicksight.New)
 	case "ram":
 		funcType = reflect.TypeOf(ram.New)
 	case "rds":

--- a/aws/internal/keyvaluetags/service_tags_gen.go
+++ b/aws/internal/keyvaluetags/service_tags_gen.go
@@ -55,6 +55,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/mediastore"
 	"github.com/aws/aws-sdk-go/service/neptune"
 	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/aws/aws-sdk-go/service/quicksight"
 	"github.com/aws/aws-sdk-go/service/ram"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/redshift"
@@ -1803,6 +1804,33 @@ func (tags KeyValueTags) OrganizationsTags() []*organizations.Tag {
 
 // OrganizationsKeyValueTags creates KeyValueTags from organizations service tags.
 func OrganizationsKeyValueTags(tags []*organizations.Tag) KeyValueTags {
+	m := make(map[string]*string, len(tags))
+
+	for _, tag := range tags {
+		m[aws.StringValue(tag.Key)] = tag.Value
+	}
+
+	return New(m)
+}
+
+// QuicksightTags returns quicksight service tags.
+func (tags KeyValueTags) QuicksightTags() []*quicksight.Tag {
+	result := make([]*quicksight.Tag, 0, len(tags))
+
+	for k, v := range tags.Map() {
+		tag := &quicksight.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		}
+
+		result = append(result, tag)
+	}
+
+	return result
+}
+
+// QuicksightKeyValueTags creates KeyValueTags from quicksight service tags.
+func QuicksightKeyValueTags(tags []*quicksight.Tag) KeyValueTags {
 	m := make(map[string]*string, len(tags))
 
 	for _, tag := range tags {

--- a/aws/internal/keyvaluetags/service_tags_gen_test.go
+++ b/aws/internal/keyvaluetags/service_tags_gen_test.go
@@ -1,6 +1,7 @@
 package keyvaluetags
 
 import (
+	"github.com/aws/aws-sdk-go/service/quicksight"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -466,6 +467,104 @@ func TestKeyValueTagsAppmeshTags(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			got := testCase.tags.AppmeshTags()
+
+			gotMap := make(map[string]string, len(got))
+			for _, tag := range got {
+				gotMap[aws.StringValue(tag.Key)] = aws.StringValue(tag.Value)
+			}
+
+			wantMap := make(map[string]string, len(testCase.want))
+			for _, tag := range testCase.want {
+				wantMap[aws.StringValue(tag.Key)] = aws.StringValue(tag.Value)
+			}
+
+			testKeyValueTagsVerifyMap(t, gotMap, wantMap)
+		})
+	}
+}
+
+func TestQuicksightKeyValueTags(t *testing.T) {
+	testCases := []struct {
+		name string
+		tags []*quicksight.Tag
+		want map[string]string
+	}{
+		{
+			name: "empty",
+			tags: []*quicksight.Tag{},
+			want: map[string]string{},
+		},
+		{
+			name: "non_empty",
+			tags: []*quicksight.Tag{
+				{
+					Key:   aws.String("key1"),
+					Value: aws.String("value1"),
+				},
+				{
+					Key:   aws.String("key2"),
+					Value: aws.String("value2"),
+				},
+				{
+					Key:   aws.String("key3"),
+					Value: aws.String("value3"),
+				},
+			},
+			want: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := QuicksightKeyValueTags(testCase.tags)
+
+			testKeyValueTagsVerifyMap(t, got.Map(), testCase.want)
+		})
+	}
+}
+
+func TestKeyValueTagsQuicksightTags(t *testing.T) {
+	testCases := []struct {
+		name string
+		tags KeyValueTags
+		want []*quicksight.Tag
+	}{
+		{
+			name: "empty",
+			tags: New(map[string]string{}),
+			want: []*quicksight.Tag{},
+		},
+		{
+			name: "non_empty",
+			tags: New(map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			}),
+			want: []*quicksight.Tag{
+				{
+					Key:   aws.String("key1"),
+					Value: aws.String("value1"),
+				},
+				{
+					Key:   aws.String("key2"),
+					Value: aws.String("value2"),
+				},
+				{
+					Key:   aws.String("key3"),
+					Value: aws.String("value3"),
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := testCase.tags.QuicksightTags()
 
 			gotMap := make(map[string]string, len(got))
 			for _, tag := range got {

--- a/aws/internal/keyvaluetags/update_tags_gen.go
+++ b/aws/internal/keyvaluetags/update_tags_gen.go
@@ -82,6 +82,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/organizations"
 	"github.com/aws/aws-sdk-go/service/pinpoint"
 	"github.com/aws/aws-sdk-go/service/qldb"
+	"github.com/aws/aws-sdk-go/service/quicksight"
 	"github.com/aws/aws-sdk-go/service/ram"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/redshift"
@@ -2831,6 +2832,42 @@ func QldbUpdateTags(conn *qldb.QLDB, identifier string, oldTagsMap interface{}, 
 		input := &qldb.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        updatedTags.IgnoreAws().QldbTags(),
+		}
+
+		_, err := conn.TagResource(input)
+
+		if err != nil {
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
+		}
+	}
+
+	return nil
+}
+
+// QuicksightUpdateTags updates quicksight service tags.
+// The identifier is typically the Amazon Resource Name (ARN), although
+// it may also be a different identifier depending on the service.
+func QuicksightUpdateTags(conn *quicksight.QuickSight, identifier string, oldTagsMap interface{}, newTagsMap interface{}) error {
+	oldTags := New(oldTagsMap)
+	newTags := New(newTagsMap)
+
+	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+		input := &quicksight.UntagResourceInput{
+			ResourceArn: aws.String(identifier),
+			TagKeys:     aws.StringSlice(removedTags.IgnoreAws().Keys()),
+		}
+
+		_, err := conn.UntagResource(input)
+
+		if err != nil {
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
+		}
+	}
+
+	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+		input := &quicksight.TagResourceInput{
+			ResourceArn: aws.String(identifier),
+			Tags:        updatedTags.IgnoreAws().QuicksightTags(),
 		}
 
 		_, err := conn.TagResource(input)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

keyvaluetags for AWS QuickSight resources.

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates to #10990, #11834, #11835

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Support for keyvaluetags for AWS QuickSight
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTARGS='-run=TestKeyValueTagsQuicksightTags'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestKeyValueTagsQuicksightTags -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2.134s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.458s [no tests to run]
=== RUN   TestKeyValueTagsQuicksightTags
=== RUN   TestKeyValueTagsQuicksightTags/empty
=== RUN   TestKeyValueTagsQuicksightTags/non_empty
--- PASS: TestKeyValueTagsQuicksightTags (0.00s)
    --- PASS: TestKeyValueTagsQuicksightTags/empty (0.00s)
    --- PASS: TestKeyValueTagsQuicksightTags/non_empty (0.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	2.672s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/naming	0.696s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/batch/equivalency	0.264s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks/token	0.304s [no tests to run]
?   	github.com/terraform-providers/terraform-provider-aws/awsproviderlint	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes	0.624s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSAT001	1.445s [no tests to run]

make testacc TESTARGS='-run=TestQuicksightKeyValueTags'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestQuicksightKeyValueTags -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2.102s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.545s [no tests to run]
=== RUN   TestQuicksightKeyValueTags
=== RUN   TestQuicksightKeyValueTags/empty
=== RUN   TestQuicksightKeyValueTags/non_empty
--- PASS: TestQuicksightKeyValueTags (0.00s)
    --- PASS: TestQuicksightKeyValueTags/empty (0.00s)
    --- PASS: TestQuicksightKeyValueTags/non_empty (0.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.581s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/naming	0.434s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/batch/equivalency	0.143s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks/token	0.677s [no tests to run]
?   	github.com/terraform-providers/terraform-provider-aws/awsproviderlint	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes	0.594s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSAT001	0.400s [no tests to run]
```
