### PR TITLE
Fixing example resource

### DIFF
--- a/website/docs/d/subnet_ids.html.markdown
+++ b/website/docs/d/subnet_ids.html.markdown
@@ -27,7 +27,7 @@ data "aws_subnet" "example" {
 }
 
 output "subnet_cidr_blocks" {
-  value = [for s in data.aws_subnet.for-each-example : s.cidr_block]
+  value = [for s in data.aws_subnet.example : s.cidr_block]
 }
 ```
 


### PR DESCRIPTION
This example returns an error because: `A data resource "aws_subnet" "for-each-example" has not been declared in web.` Updating the example to use a declared resource.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
