### PR TITLE
Fix CloudFormation StackSet acceptance tests and sweepers in GovCloud

### DIFF
--- a/aws/resource_aws_cloudformation_stack_set.go
+++ b/aws/resource_aws_cloudformation_stack_set.go
@@ -133,11 +133,11 @@ func resourceAwsCloudFormationStackSetCreate(d *schema.ResourceData, meta interf
 		input.TemplateURL = aws.String(v.(string))
 	}
 
-	log.Printf("[DEBUG] Creating CloudFormation Stack Set: %s", input)
+	log.Printf("[DEBUG] Creating CloudFormation StackSet: %s", input)
 	_, err := conn.CreateStackSet(input)
 
 	if err != nil {
-		return fmt.Errorf("error creating CloudFormation Stack Set: %s", err)
+		return fmt.Errorf("error creating CloudFormation StackSet: %s", err)
 	}
 
 	d.SetId(name)
@@ -152,21 +152,21 @@ func resourceAwsCloudFormationStackSetRead(d *schema.ResourceData, meta interfac
 		StackSetName: aws.String(d.Id()),
 	}
 
-	log.Printf("[DEBUG] Reading CloudFormation Stack Set: %s", d.Id())
+	log.Printf("[DEBUG] Reading CloudFormation StackSet: %s", d.Id())
 	output, err := conn.DescribeStackSet(input)
 
 	if isAWSErr(err, cloudformation.ErrCodeStackSetNotFoundException, "") {
-		log.Printf("[WARN] CloudFormation Stack Set (%s) not found, removing from state", d.Id())
+		log.Printf("[WARN] CloudFormation StackSet (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
 	if err != nil {
-		return fmt.Errorf("error reading CloudFormation Stack Set (%s): %s", d.Id(), err)
+		return fmt.Errorf("error reading CloudFormation StackSet (%s): %s", d.Id(), err)
 	}
 
 	if output == nil || output.StackSet == nil {
-		return fmt.Errorf("error reading CloudFormation Stack Set (%s): empty response", d.Id())
+		return fmt.Errorf("error reading CloudFormation StackSet (%s): empty response", d.Id())
 	}
 
 	stackSet := output.StackSet
@@ -232,15 +232,15 @@ func resourceAwsCloudFormationStackSetUpdate(d *schema.ResourceData, meta interf
 		input.TemplateURL = aws.String(v.(string))
 	}
 
-	log.Printf("[DEBUG] Updating CloudFormation Stack Set: %s", input)
+	log.Printf("[DEBUG] Updating CloudFormation StackSet: %s", input)
 	output, err := conn.UpdateStackSet(input)
 
 	if err != nil {
-		return fmt.Errorf("error updating CloudFormation Stack Set (%s): %s", d.Id(), err)
+		return fmt.Errorf("error updating CloudFormation StackSet (%s): %s", d.Id(), err)
 	}
 
 	if err := waitForCloudFormationStackSetOperation(conn, d.Id(), aws.StringValue(output.OperationId), d.Timeout(schema.TimeoutUpdate)); err != nil {
-		return fmt.Errorf("error waiting for CloudFormation Stack Set (%s) update: %s", d.Id(), err)
+		return fmt.Errorf("error waiting for CloudFormation StackSet (%s) update: %s", d.Id(), err)
 	}
 
 	return resourceAwsCloudFormationStackSetRead(d, meta)
@@ -253,7 +253,7 @@ func resourceAwsCloudFormationStackSetDelete(d *schema.ResourceData, meta interf
 		StackSetName: aws.String(d.Id()),
 	}
 
-	log.Printf("[DEBUG] Deleting CloudFormation Stack Set: %s", d.Id())
+	log.Printf("[DEBUG] Deleting CloudFormation StackSet: %s", d.Id())
 	_, err := conn.DeleteStackSet(input)
 
 	if isAWSErr(err, cloudformation.ErrCodeStackSetNotFoundException, "") {
@@ -261,7 +261,7 @@ func resourceAwsCloudFormationStackSetDelete(d *schema.ResourceData, meta interf
 	}
 
 	if err != nil {
-		return fmt.Errorf("error deleting CloudFormation Stack Set (%s): %s", d.Id(), err)
+		return fmt.Errorf("error deleting CloudFormation StackSet (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_cloudformation_stack_set_instance.go
+++ b/aws/resource_aws_cloudformation_stack_set_instance.go
@@ -94,17 +94,17 @@ func resourceAwsCloudFormationStackSetInstanceCreate(d *schema.ResourceData, met
 		input.ParameterOverrides = expandCloudFormationParameters(v.(map[string]interface{}))
 	}
 
-	log.Printf("[DEBUG] Creating CloudFormation Stack Set Instance: %s", input)
+	log.Printf("[DEBUG] Creating CloudFormation StackSet Instance: %s", input)
 	output, err := conn.CreateStackInstances(input)
 
 	if err != nil {
-		return fmt.Errorf("error creating CloudFormation Stack Set Instance: %s", err)
+		return fmt.Errorf("error creating CloudFormation StackSet Instance: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s,%s,%s", stackSetName, accountID, region))
 
 	if err := waitForCloudFormationStackSetOperation(conn, stackSetName, aws.StringValue(output.OperationId), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return fmt.Errorf("error waiting for CloudFormation Stack Set Instance (%s) creation: %s", d.Id(), err)
+		return fmt.Errorf("error waiting for CloudFormation StackSet Instance (%s) creation: %s", d.Id(), err)
 	}
 
 	return resourceAwsCloudFormationStackSetInstanceRead(d, meta)
@@ -125,27 +125,27 @@ func resourceAwsCloudFormationStackSetInstanceRead(d *schema.ResourceData, meta 
 		StackSetName:         aws.String(stackSetName),
 	}
 
-	log.Printf("[DEBUG] Reading CloudFormation Stack Set Instance: %s", d.Id())
+	log.Printf("[DEBUG] Reading CloudFormation StackSet Instance: %s", d.Id())
 	output, err := conn.DescribeStackInstance(input)
 
 	if isAWSErr(err, cloudformation.ErrCodeStackInstanceNotFoundException, "") {
-		log.Printf("[WARN] CloudFormation Stack Set Instance (%s) not found, removing from state", d.Id())
+		log.Printf("[WARN] CloudFormation StackSet Instance (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
 	if isAWSErr(err, cloudformation.ErrCodeStackSetNotFoundException, "") {
-		log.Printf("[WARN] CloudFormation Stack Set (%s) not found, removing from state", d.Id())
+		log.Printf("[WARN] CloudFormation StackSet (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
 	if err != nil {
-		return fmt.Errorf("error reading CloudFormation Stack Set Instance (%s): %s", d.Id(), err)
+		return fmt.Errorf("error reading CloudFormation StackSet Instance (%s): %s", d.Id(), err)
 	}
 
 	if output == nil || output.StackInstance == nil {
-		return fmt.Errorf("error reading CloudFormation Stack Set Instance (%s): empty response", d.Id())
+		return fmt.Errorf("error reading CloudFormation StackSet Instance (%s): empty response", d.Id())
 	}
 
 	stackInstance := output.StackInstance
@@ -185,15 +185,15 @@ func resourceAwsCloudFormationStackSetInstanceUpdate(d *schema.ResourceData, met
 			input.ParameterOverrides = expandCloudFormationParameters(v.(map[string]interface{}))
 		}
 
-		log.Printf("[DEBUG] Updating CloudFormation Stack Set Instance: %s", input)
+		log.Printf("[DEBUG] Updating CloudFormation StackSet Instance: %s", input)
 		output, err := conn.UpdateStackInstances(input)
 
 		if err != nil {
-			return fmt.Errorf("error updating CloudFormation Stack Set Instance (%s): %s", d.Id(), err)
+			return fmt.Errorf("error updating CloudFormation StackSet Instance (%s): %s", d.Id(), err)
 		}
 
 		if err := waitForCloudFormationStackSetOperation(conn, stackSetName, aws.StringValue(output.OperationId), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return fmt.Errorf("error waiting for CloudFormation Stack Set Instance (%s) update: %s", d.Id(), err)
+			return fmt.Errorf("error waiting for CloudFormation StackSet Instance (%s) update: %s", d.Id(), err)
 		}
 	}
 
@@ -217,7 +217,7 @@ func resourceAwsCloudFormationStackSetInstanceDelete(d *schema.ResourceData, met
 		StackSetName: aws.String(stackSetName),
 	}
 
-	log.Printf("[DEBUG] Deleting CloudFormation Stack Set Instance: %s", d.Id())
+	log.Printf("[DEBUG] Deleting CloudFormation StackSet Instance: %s", d.Id())
 	output, err := conn.DeleteStackInstances(input)
 
 	if isAWSErr(err, cloudformation.ErrCodeStackInstanceNotFoundException, "") {
@@ -229,11 +229,11 @@ func resourceAwsCloudFormationStackSetInstanceDelete(d *schema.ResourceData, met
 	}
 
 	if err != nil {
-		return fmt.Errorf("error deleting CloudFormation Stack Set Instance (%s): %s", d.Id(), err)
+		return fmt.Errorf("error deleting CloudFormation StackSet Instance (%s): %s", d.Id(), err)
 	}
 
 	if err := waitForCloudFormationStackSetOperation(conn, stackSetName, aws.StringValue(output.OperationId), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return fmt.Errorf("error waiting for CloudFormation Stack Set Instance (%s) deletion: %s", d.Id(), err)
+		return fmt.Errorf("error waiting for CloudFormation StackSet Instance (%s) deletion: %s", d.Id(), err)
 	}
 
 	return nil
@@ -341,7 +341,7 @@ func waitForCloudFormationStackSetOperation(conn *cloudformation.CloudFormation,
 		Delay:   5 * time.Second,
 	}
 
-	log.Printf("[DEBUG] Waiting for CloudFormation Stack Set (%s) operation: %s", stackSetName, operationID)
+	log.Printf("[DEBUG] Waiting for CloudFormation StackSet (%s) operation: %s", stackSetName, operationID)
 	_, err := stateConf.WaitForState()
 
 	return err

--- a/aws/resource_aws_cloudformation_stack_set_instance_test.go
+++ b/aws/resource_aws_cloudformation_stack_set_instance_test.go
@@ -32,12 +32,12 @@ func testSweepCloudformationStackSetInstances(region string) error {
 	stackSets, err := listCloudFormationStackSets(conn)
 
 	if testSweepSkipSweepError(err) || isAWSErr(err, "ValidationError", "AWS CloudFormation StackSets is not supported") {
-		log.Printf("[WARN] Skipping CloudFormation Stack Set Instance sweep for %s: %s", region, err)
+		log.Printf("[WARN] Skipping CloudFormation StackSet Instance sweep for %s: %s", region, err)
 		return nil
 	}
 
 	if err != nil {
-		return fmt.Errorf("error listing CloudFormation Stack Sets: %w", err)
+		return fmt.Errorf("error listing CloudFormation StackSets: %w", err)
 	}
 
 	var sweeperErrs *multierror.Error
@@ -47,7 +47,7 @@ func testSweepCloudformationStackSetInstances(region string) error {
 		instances, err := listCloudFormationStackSetInstances(conn, stackSetName)
 
 		if err != nil {
-			sweeperErr := fmt.Errorf("error listing CloudFormation Stack Set (%s) Instances: %w", stackSetName, err)
+			sweeperErr := fmt.Errorf("error listing CloudFormation StackSet (%s) Instances: %w", stackSetName, err)
 			log.Printf("[ERROR] %s", sweeperErr)
 			sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
 			continue
@@ -66,7 +66,7 @@ func testSweepCloudformationStackSetInstances(region string) error {
 				StackSetName: aws.String(stackSetName),
 			}
 
-			log.Printf("[INFO] Deleting CloudFormation Stack Set Instance: %s", id)
+			log.Printf("[INFO] Deleting CloudFormation StackSet Instance: %s", id)
 			output, err := conn.DeleteStackInstances(input)
 
 			if isAWSErr(err, cloudformation.ErrCodeStackInstanceNotFoundException, "") {
@@ -78,14 +78,14 @@ func testSweepCloudformationStackSetInstances(region string) error {
 			}
 
 			if err != nil {
-				sweeperErr := fmt.Errorf("error deleting CloudFormation Stack Set Instance (%s): %w", id, err)
+				sweeperErr := fmt.Errorf("error deleting CloudFormation StackSet Instance (%s): %w", id, err)
 				log.Printf("[ERROR] %s", sweeperErr)
 				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
 				continue
 			}
 
 			if err := waitForCloudFormationStackSetOperation(conn, stackSetName, aws.StringValue(output.OperationId), 30*time.Minute); err != nil {
-				sweeperErr := fmt.Errorf("error waiting for CloudFormation Stack Set Instance (%s) deletion: %w", id, err)
+				sweeperErr := fmt.Errorf("error waiting for CloudFormation StackSet Instance (%s) deletion: %w", id, err)
 				log.Printf("[ERROR] %s", sweeperErr)
 				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
 				continue
@@ -239,7 +239,7 @@ func TestAccAWSCloudFormationStackSetInstance_ParameterOverrides(t *testing.T) {
 
 // TestAccAWSCloudFrontDistribution_RetainStack verifies retain_stack = true
 // This acceptance test performs the following steps:
-//  * Trigger a Terraform destroy of the resource, which should only remove the instance from the stack set
+//  * Trigger a Terraform destroy of the resource, which should only remove the instance from the StackSet
 //  * Check it still exists outside Terraform
 //  * Destroy for real outside Terraform
 func TestAccAWSCloudFormationStackSetInstance_RetainStack(t *testing.T) {
@@ -325,7 +325,7 @@ func testAccCheckCloudFormationStackSetInstanceExists(resourceName string, stack
 		}
 
 		if output == nil || output.StackInstance == nil {
-			return fmt.Errorf("CloudFormation Stack Set Instance (%s) not found", rs.Primary.ID)
+			return fmt.Errorf("CloudFormation StackSet Instance (%s) not found", rs.Primary.ID)
 		}
 
 		*stackInstance = *output.StackInstance
@@ -393,7 +393,7 @@ func testAccCheckAWSCloudFormationStackSetInstanceDestroy(s *terraform.State) er
 		}
 
 		if output != nil && output.StackInstance != nil {
-			return fmt.Errorf("CloudFormation Stack Set Instance (%s) still exists", rs.Primary.ID)
+			return fmt.Errorf("CloudFormation StackSet Instance (%s) still exists", rs.Primary.ID)
 		}
 	}
 
@@ -424,7 +424,7 @@ func testAccCheckCloudFormationStackSetInstanceDisappears(stackInstance *cloudfo
 func testAccCheckCloudFormationStackSetInstanceNotRecreated(i, j *cloudformation.StackInstance) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if aws.StringValue(i.StackId) != aws.StringValue(j.StackId) {
-			return fmt.Errorf("CloudFormation Stack Set Instance (%s,%s,%s) recreated", aws.StringValue(i.StackSetId), aws.StringValue(i.Account), aws.StringValue(i.Region))
+			return fmt.Errorf("CloudFormation StackSet Instance (%s,%s,%s) recreated", aws.StringValue(i.StackSetId), aws.StringValue(i.Account), aws.StringValue(i.Region))
 		}
 
 		return nil

--- a/aws/resource_aws_cloudformation_stack_set_instance_test.go
+++ b/aws/resource_aws_cloudformation_stack_set_instance_test.go
@@ -104,7 +104,7 @@ func TestAccAWSCloudFormationStackSetInstance_basic(t *testing.T) {
 	resourceName := "aws_cloudformation_stack_set_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFormationStackSet(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudFormationStackSetInstanceDestroy,
 		Steps: []resource.TestStep{
@@ -138,7 +138,7 @@ func TestAccAWSCloudFormationStackSetInstance_disappears(t *testing.T) {
 	resourceName := "aws_cloudformation_stack_set_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFormationStackSet(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudFormationStackSetInstanceDestroy,
 		Steps: []resource.TestStep{
@@ -162,7 +162,7 @@ func TestAccAWSCloudFormationStackSetInstance_disappears_StackSet(t *testing.T) 
 	resourceName := "aws_cloudformation_stack_set_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFormationStackSet(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudFormationStackSetInstanceDestroy,
 		Steps: []resource.TestStep{
@@ -186,7 +186,7 @@ func TestAccAWSCloudFormationStackSetInstance_ParameterOverrides(t *testing.T) {
 	resourceName := "aws_cloudformation_stack_set_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFormationStackSet(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudFormationStackSetInstanceDestroy,
 		Steps: []resource.TestStep{
@@ -249,7 +249,7 @@ func TestAccAWSCloudFormationStackSetInstance_RetainStack(t *testing.T) {
 	resourceName := "aws_cloudformation_stack_set_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFormationStackSet(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudFormationStackSetInstanceDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_cloudformation_stack_set_instance_test.go
+++ b/aws/resource_aws_cloudformation_stack_set_instance_test.go
@@ -25,19 +25,19 @@ func testSweepCloudformationStackSetInstances(region string) error {
 	client, err := sharedClientForRegion(region)
 
 	if err != nil {
-		return fmt.Errorf("error getting client: %s", err)
+		return fmt.Errorf("error getting client: %w", err)
 	}
 
 	conn := client.(*AWSClient).cfconn
 	stackSets, err := listCloudFormationStackSets(conn)
 
-	if testSweepSkipSweepError(err) {
+	if testSweepSkipSweepError(err) || isAWSErr(err, "ValidationError", "AWS CloudFormation StackSets is not supported") {
 		log.Printf("[WARN] Skipping CloudFormation Stack Set Instance sweep for %s: %s", region, err)
 		return nil
 	}
 
 	if err != nil {
-		return fmt.Errorf("error listing CloudFormation Stack Sets: %s", err)
+		return fmt.Errorf("error listing CloudFormation Stack Sets: %w", err)
 	}
 
 	var sweeperErrs *multierror.Error
@@ -78,14 +78,14 @@ func testSweepCloudformationStackSetInstances(region string) error {
 			}
 
 			if err != nil {
-				sweeperErr := fmt.Errorf("error deleting CloudFormation Stack Set Instance (%s): %s", id, err)
+				sweeperErr := fmt.Errorf("error deleting CloudFormation Stack Set Instance (%s): %w", id, err)
 				log.Printf("[ERROR] %s", sweeperErr)
 				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
 				continue
 			}
 
 			if err := waitForCloudFormationStackSetOperation(conn, stackSetName, aws.StringValue(output.OperationId), 30*time.Minute); err != nil {
-				sweeperErr := fmt.Errorf("error waiting for CloudFormation Stack Set Instance (%s) deletion: %s", id, err)
+				sweeperErr := fmt.Errorf("error waiting for CloudFormation Stack Set Instance (%s) deletion: %w", id, err)
 				log.Printf("[ERROR] %s", sweeperErr)
 				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
 				continue

--- a/aws/resource_aws_cloudformation_stack_set_test.go
+++ b/aws/resource_aws_cloudformation_stack_set_test.go
@@ -76,7 +76,7 @@ func TestAccAWSCloudFormationStackSet_basic(t *testing.T) {
 	resourceName := "aws_cloudformation_stack_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFormationStackSet(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudFormationStackSetDestroy,
 		Steps: []resource.TestStep{
@@ -115,7 +115,7 @@ func TestAccAWSCloudFormationStackSet_disappears(t *testing.T) {
 	resourceName := "aws_cloudformation_stack_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFormationStackSet(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudFormationStackSetDestroy,
 		Steps: []resource.TestStep{
@@ -139,7 +139,7 @@ func TestAccAWSCloudFormationStackSet_AdministrationRoleArn(t *testing.T) {
 	resourceName := "aws_cloudformation_stack_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFormationStackSet(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudFormationStackSetDestroy,
 		Steps: []resource.TestStep{
@@ -176,7 +176,7 @@ func TestAccAWSCloudFormationStackSet_Description(t *testing.T) {
 	resourceName := "aws_cloudformation_stack_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFormationStackSet(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudFormationStackSetDestroy,
 		Steps: []resource.TestStep{
@@ -213,7 +213,7 @@ func TestAccAWSCloudFormationStackSet_ExecutionRoleName(t *testing.T) {
 	resourceName := "aws_cloudformation_stack_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFormationStackSet(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudFormationStackSetDestroy,
 		Steps: []resource.TestStep{
@@ -251,7 +251,7 @@ func TestAccAWSCloudFormationStackSet_Name(t *testing.T) {
 	resourceName := "aws_cloudformation_stack_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFormationStackSet(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudFormationStackSetDestroy,
 		Steps: []resource.TestStep{
@@ -304,7 +304,7 @@ func TestAccAWSCloudFormationStackSet_Parameters(t *testing.T) {
 	resourceName := "aws_cloudformation_stack_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFormationStackSet(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudFormationStackSetDestroy,
 		Steps: []resource.TestStep{
@@ -363,7 +363,7 @@ func TestAccAWSCloudFormationStackSet_Parameters_Default(t *testing.T) {
 	resourceName := "aws_cloudformation_stack_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFormationStackSet(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudFormationStackSetDestroy,
 		Steps: []resource.TestStep{
@@ -414,7 +414,7 @@ func TestAccAWSCloudFormationStackSet_Parameters_NoEcho(t *testing.T) {
 	resourceName := "aws_cloudformation_stack_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFormationStackSet(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudFormationStackSetDestroy,
 		Steps: []resource.TestStep{
@@ -453,7 +453,7 @@ func TestAccAWSCloudFormationStackSet_Tags(t *testing.T) {
 	resourceName := "aws_cloudformation_stack_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFormationStackSet(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudFormationStackSetDestroy,
 		Steps: []resource.TestStep{
@@ -508,7 +508,7 @@ func TestAccAWSCloudFormationStackSet_TemplateBody(t *testing.T) {
 	resourceName := "aws_cloudformation_stack_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFormationStackSet(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudFormationStackSetDestroy,
 		Steps: []resource.TestStep{
@@ -545,7 +545,7 @@ func TestAccAWSCloudFormationStackSet_TemplateUrl(t *testing.T) {
 	resourceName := "aws_cloudformation_stack_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFormationStackSet(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudFormationStackSetDestroy,
 		Steps: []resource.TestStep{
@@ -669,6 +669,21 @@ func testAccCheckCloudFormationStackSetRecreated(i, j *cloudformation.StackSet) 
 		}
 
 		return nil
+	}
+}
+
+func testAccPreCheckAWSCloudFormationStackSet(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).cfconn
+
+	input := &cloudformation.ListStackSetsInput{}
+	_, err := conn.ListStackSets(input)
+
+	if testAccPreCheckSkipError(err) || isAWSErr(err, "ValidationError", "AWS CloudFormation StackSets is not supported") {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
 }
 

--- a/aws/resource_aws_cloudformation_stack_set_test.go
+++ b/aws/resource_aws_cloudformation_stack_set_test.go
@@ -35,12 +35,12 @@ func testSweepCloudformationStackSets(region string) error {
 	stackSets, err := listCloudFormationStackSets(conn)
 
 	if testSweepSkipSweepError(err) || isAWSErr(err, "ValidationError", "AWS CloudFormation StackSets is not supported") {
-		log.Printf("[WARN] Skipping CloudFormation Stack Set sweep for %s: %s", region, err)
+		log.Printf("[WARN] Skipping CloudFormation StackSet sweep for %s: %s", region, err)
 		return nil
 	}
 
 	if err != nil {
-		return fmt.Errorf("error listing CloudFormation Stack Sets: %w", err)
+		return fmt.Errorf("error listing CloudFormation StackSets: %w", err)
 	}
 
 	var sweeperErrs *multierror.Error
@@ -51,7 +51,7 @@ func testSweepCloudformationStackSets(region string) error {
 		}
 		name := aws.StringValue(stackSet.StackSetName)
 
-		log.Printf("[INFO] Deleting CloudFormation Stack Set: %s", name)
+		log.Printf("[INFO] Deleting CloudFormation StackSet: %s", name)
 		_, err := conn.DeleteStackSet(input)
 
 		if isAWSErr(err, cloudformation.ErrCodeStackSetNotFoundException, "") {
@@ -59,7 +59,7 @@ func testSweepCloudformationStackSets(region string) error {
 		}
 
 		if err != nil {
-			sweeperErr := fmt.Errorf("error deleting CloudFormation Stack Set (%s): %w", name, err)
+			sweeperErr := fmt.Errorf("error deleting CloudFormation StackSet (%s): %w", name, err)
 			log.Printf("[ERROR] %s", sweeperErr)
 			sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
 			continue
@@ -599,7 +599,7 @@ func testAccCheckCloudFormationStackSetExists(resourceName string, stackSet *clo
 		}
 
 		if output == nil || output.StackSet == nil {
-			return fmt.Errorf("CloudFormation Stack Set (%s) not found", rs.Primary.ID)
+			return fmt.Errorf("CloudFormation StackSet (%s) not found", rs.Primary.ID)
 		}
 
 		*stackSet = *output.StackSet
@@ -631,7 +631,7 @@ func testAccCheckAWSCloudFormationStackSetDestroy(s *terraform.State) error {
 		}
 
 		if output != nil && output.StackSet != nil {
-			return fmt.Errorf("CloudFormation Stack Set (%s) still exists", rs.Primary.ID)
+			return fmt.Errorf("CloudFormation StackSet (%s) still exists", rs.Primary.ID)
 		}
 	}
 
@@ -655,7 +655,7 @@ func testAccCheckCloudFormationStackSetDisappears(stackSet *cloudformation.Stack
 func testAccCheckCloudFormationStackSetNotRecreated(i, j *cloudformation.StackSet) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if aws.StringValue(i.StackSetId) != aws.StringValue(j.StackSetId) {
-			return fmt.Errorf("CloudFormation Stack Set (%s) recreated", aws.StringValue(i.StackSetName))
+			return fmt.Errorf("CloudFormation StackSet (%s) recreated", aws.StringValue(i.StackSetName))
 		}
 
 		return nil
@@ -665,7 +665,7 @@ func testAccCheckCloudFormationStackSetNotRecreated(i, j *cloudformation.StackSe
 func testAccCheckCloudFormationStackSetRecreated(i, j *cloudformation.StackSet) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if aws.StringValue(i.StackSetId) == aws.StringValue(j.StackSetId) {
-			return fmt.Errorf("CloudFormation Stack Set (%s) not recreated", aws.StringValue(i.StackSetName))
+			return fmt.Errorf("CloudFormation StackSet (%s) not recreated", aws.StringValue(i.StackSetName))
 		}
 
 		return nil

--- a/aws/resource_aws_cloudformation_stack_set_test.go
+++ b/aws/resource_aws_cloudformation_stack_set_test.go
@@ -28,19 +28,19 @@ func testSweepCloudformationStackSets(region string) error {
 	client, err := sharedClientForRegion(region)
 
 	if err != nil {
-		return fmt.Errorf("error getting client: %s", err)
+		return fmt.Errorf("error getting client: %w", err)
 	}
 
 	conn := client.(*AWSClient).cfconn
 	stackSets, err := listCloudFormationStackSets(conn)
 
-	if testSweepSkipSweepError(err) {
+	if testSweepSkipSweepError(err) || isAWSErr(err, "ValidationError", "AWS CloudFormation StackSets is not supported") {
 		log.Printf("[WARN] Skipping CloudFormation Stack Set sweep for %s: %s", region, err)
 		return nil
 	}
 
 	if err != nil {
-		return fmt.Errorf("error listing CloudFormation Stack Sets: %s", err)
+		return fmt.Errorf("error listing CloudFormation Stack Sets: %w", err)
 	}
 
 	var sweeperErrs *multierror.Error

--- a/website/docs/r/cloudformation_stack_set.html.markdown
+++ b/website/docs/r/cloudformation_stack_set.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CloudFormation"
 layout: "aws"
 page_title: "AWS: aws_cloudformation_stack_set"
 description: |-
-  Manages a CloudFormation Stack Set.
+  Manages a CloudFormation StackSet.
 ---
 
 # Resource: aws_cloudformation_stack_set
 
-Manages a CloudFormation Stack Set. Stack Sets allow CloudFormation templates to be easily deployed across multiple accounts and regions via Stack Set Instances ([`aws_cloudformation_stack_set_instance` resource](/docs/providers/aws/r/cloudformation_stack_set_instance.html)). Additional information about Stack Sets can be found in the [AWS CloudFormation User Guide](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/what-is-cfnstacksets.html).
+Manages a CloudFormation StackSet. StackSets allow CloudFormation templates to be easily deployed across multiple accounts and regions via StackSet Instances ([`aws_cloudformation_stack_set_instance` resource](/docs/providers/aws/r/cloudformation_stack_set_instance.html)). Additional information about StackSets can be found in the [AWS CloudFormation User Guide](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/what-is-cfnstacksets.html).
 
 ~> **NOTE:** All template parameters, including those with a `Default`, must be configured or ignored with the `lifecycle` configuration block `ignore_changes` argument.
 
@@ -86,12 +86,12 @@ resource "aws_iam_role_policy" "AWSCloudFormationStackSetAdministrationRole_Exec
 The following arguments are supported:
 
 * `administration_role_arn` - (Required) Amazon Resource Number (ARN) of the IAM Role in the administrator account.
-* `name` - (Required) Name of the Stack Set. The name must be unique in the region where you create your Stack Set. The name can contain only alphanumeric characters (case-sensitive) and hyphens. It must start with an alphabetic character and cannot be longer than 128 characters.
+* `name` - (Required) Name of the StackSet. The name must be unique in the region where you create your StackSet. The name can contain only alphanumeric characters (case-sensitive) and hyphens. It must start with an alphabetic character and cannot be longer than 128 characters.
 * `capabilities` - (Optional) A list of capabilities. Valid values: `CAPABILITY_IAM`, `CAPABILITY_NAMED_IAM`, `CAPABILITY_AUTO_EXPAND`.
-* `description` - (Optional) Description of the Stack Set.
-* `execution_role_name` - (Optional) Name of the IAM Role in all target accounts for Stack Set operations. Defaults to `AWSCloudFormationStackSetExecutionRole`.
-* `parameters` - (Optional) Key-value map of input parameters for the Stack Set template. All template parameters, including those with a `Default`, must be configured or ignored with `lifecycle` configuration block `ignore_changes` argument. All `NoEcho` template parameters must be ignored with the `lifecycle` configuration block `ignore_changes` argument.
-* `tags` - (Optional) Key-value map of tags to associate with this Stack Set and the Stacks created from it. AWS CloudFormation also propagates these tags to supported resources that are created in the Stacks. A maximum number of 50 tags can be specified.
+* `description` - (Optional) Description of the StackSet.
+* `execution_role_name` - (Optional) Name of the IAM Role in all target accounts for StackSet operations. Defaults to `AWSCloudFormationStackSetExecutionRole`.
+* `parameters` - (Optional) Key-value map of input parameters for the StackSet template. All template parameters, including those with a `Default`, must be configured or ignored with `lifecycle` configuration block `ignore_changes` argument. All `NoEcho` template parameters must be ignored with the `lifecycle` configuration block `ignore_changes` argument.
+* `tags` - (Optional) Key-value map of tags to associate with this StackSet and the Stacks created from it. AWS CloudFormation also propagates these tags to supported resources that are created in the Stacks. A maximum number of 50 tags can be specified.
 * `template_body` - (Optional) String containing the CloudFormation template body. Maximum size: 51,200 bytes. Conflicts with `template_url`.
 * `template_url` - (Optional) String containing the location of a file containing the CloudFormation template body. The URL must point to a template that is located in an Amazon S3 bucket. Maximum location file size: 460,800 bytes. Conflicts with `template_body`.
 
@@ -99,19 +99,19 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `arn` - Amazon Resource Name (ARN) of the Stack Set.
-* `id` - Name of the Stack Set.
-* `stack_set_id` - Unique identifier of the Stack Set.
+* `arn` - Amazon Resource Name (ARN) of the StackSet.
+* `id` - Name of the StackSet.
+* `stack_set_id` - Unique identifier of the StackSet.
 
 ## Timeouts
 
 `aws_cloudformation_stack_set` provides the following [Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
 
-* `update` - (Default `30m`) How long to wait for a Stack Set to be updated.
+* `update` - (Default `30m`) How long to wait for a StackSet to be updated.
 
 ## Import
 
-CloudFormation Stack Sets can be imported using the `name`, e.g.
+CloudFormation StackSets can be imported using the `name`, e.g.
 
 ```
 $ terraform import aws_cloudformation_stack.example example

--- a/website/docs/r/cloudformation_stack_set_instance.html.markdown
+++ b/website/docs/r/cloudformation_stack_set_instance.html.markdown
@@ -3,14 +3,14 @@ subcategory: "CloudFormation"
 layout: "aws"
 page_title: "AWS: aws_cloudformation_stack_set_instance"
 description: |-
-  Manages a CloudFormation Stack Set Instance.
+  Manages a CloudFormation StackSet Instance.
 ---
 
 # Resource: aws_cloudformation_stack_set_instance
 
-Manages a CloudFormation Stack Set Instance. Instances are managed in the account and region of the Stack Set after the target account permissions have been configured. Additional information about Stack Sets can be found in the [AWS CloudFormation User Guide](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/what-is-cfnstacksets.html).
+Manages a CloudFormation StackSet Instance. Instances are managed in the account and region of the StackSet after the target account permissions have been configured. Additional information about StackSets can be found in the [AWS CloudFormation User Guide](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/what-is-cfnstacksets.html).
 
-~> **NOTE:** All target accounts must have an IAM Role created that matches the name of the execution role configured in the Stack Set (the `execution_role_name` argument in the `aws_cloudformation_stack_set` resource) in a trust relationship with the administrative account or administration IAM Role. The execution role must have appropriate permissions to manage resources defined in the template along with those required for Stack Sets to operate. See the [AWS CloudFormation User Guide](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-prereqs.html) for more details.
+~> **NOTE:** All target accounts must have an IAM Role created that matches the name of the execution role configured in the StackSet (the `execution_role_name` argument in the `aws_cloudformation_stack_set` resource) in a trust relationship with the administrative account or administration IAM Role. The execution role must have appropriate permissions to manage resources defined in the template along with those required for StackSets to operate. See the [AWS CloudFormation User Guide](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-prereqs.html) for more details.
 
 ~> **NOTE:** To retain the Stack during Terraform resource destroy, ensure `retain_stack = true` has been successfully applied into the Terraform state first. This must be completed _before_ an apply that would destroy the resource.
 
@@ -45,7 +45,7 @@ resource "aws_iam_role" "AWSCloudFormationStackSetExecutionRole" {
 }
 
 # Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-prereqs.html
-# Additional IAM permissions necessary depend on the resources defined in the Stack Set template
+# Additional IAM permissions necessary depend on the resources defined in the StackSet template
 data "aws_iam_policy_document" "AWSCloudFormationStackSetExecutionRole_MinimumExecutionPolicy" {
   statement {
     actions = [
@@ -70,17 +70,17 @@ resource "aws_iam_role_policy" "AWSCloudFormationStackSetExecutionRole_MinimumEx
 
 The following arguments are supported:
 
-* `stack_set_name` - (Required) Name of the Stack Set.
-* `account_id` - (Optional) Target AWS Account ID to create a Stack based on the Stack Set. Defaults to current account.
-* `parameter_overrides` - (Optional) Key-value map of input parameters to override from the Stack Set for this Instance.
-* `region` - (Optional) Target AWS Region to create a Stack based on the Stack Set. Defaults to current region.
-* `retain_stack` - (Optional) During Terraform resource destroy, remove Instance from Stack Set while keeping the Stack and its associated resources. Must be enabled in Terraform state _before_ destroy operation to take effect. You cannot reassociate a retained Stack or add an existing, saved Stack to a new Stack Set. Defaults to `false`.
+* `stack_set_name` - (Required) Name of the StackSet.
+* `account_id` - (Optional) Target AWS Account ID to create a Stack based on the StackSet. Defaults to current account.
+* `parameter_overrides` - (Optional) Key-value map of input parameters to override from the StackSet for this Instance.
+* `region` - (Optional) Target AWS Region to create a Stack based on the StackSet. Defaults to current region.
+* `retain_stack` - (Optional) During Terraform resource destroy, remove Instance from StackSet while keeping the Stack and its associated resources. Must be enabled in Terraform state _before_ destroy operation to take effect. You cannot reassociate a retained Stack or add an existing, saved Stack to a new StackSet. Defaults to `false`.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Stack Set name, target AWS account ID, and target AWS region separated by commas (`,`)
+* `id` - StackSet name, target AWS account ID, and target AWS region separated by commas (`,`)
 * `stack_id` - Stack identifier
 
 ## Timeouts
@@ -93,7 +93,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-CloudFormation Stack Set Instances can be imported using the Stack Set name, target AWS account ID, and target AWS region separated by commas (`,`) e.g.
+CloudFormation StackSet Instances can be imported using the StackSet name, target AWS account ID, and target AWS region separated by commas (`,`) e.g.
 
 ```
 $ terraform import aws_cloudformation_stack_set_instance.example example,123456789012,us-east-1


### PR DESCRIPTION
CloudFormation StackSets are not supported in GovCloud, but the acceptance tests and sweepers try to run

Before:

```
go test ./... -v -sweep=us-gov-west-1 -sweep-run=aws_cloudformation_stack_set -timeout 60m

[DEBUG] Sweeper (aws_cloudformation_stack_set) has dependency (aws_cloudformation_stack_set_instance), running..
[DEBUG] Running Sweeper (aws_cloudformation_stack_set_instance) in region (us-gov-west-1)
[ERROR] Error running Sweeper (aws_cloudformation_stack_set_instance) in region (us-gov-west-1): error listing CloudFormation Stack Sets: ValidationError: AWS CloudFormation StackSets is not supported in us-gov-west-1
	status code: 400, request id: dbce6ec4-bd46-435d-98bc-2b1a6d23dd87
```

```
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSCloudFormationStackSet -timeout 120m

--- FAIL: TestAccAWSCloudFormationStackSet_disappears (7.92s)
--- FAIL: TestAccAWSCloudFormationStackSet_basic (8.01s)
--- FAIL: TestAccAWSCloudFormationStackSet_ExecutionRoleName (8.02s)
--- FAIL: TestAccAWSCloudFormationStackSet_TemplateBody (8.06s)
--- FAIL: TestAccAWSCloudFormationStackSet_Tags (8.06s)
--- FAIL: TestAccAWSCloudFormationStackSet_Description (8.07s)
--- FAIL: TestAccAWSCloudFormationStackSet_Parameters (8.09s)
--- FAIL: TestAccAWSCloudFormationStackSet_AdministrationRoleArn (8.13s)
--- FAIL: TestAccAWSCloudFormationStackSet_Name (8.14s)
--- FAIL: TestAccAWSCloudFormationStackSet_TemplateUrl (12.02s)
--- FAIL: TestAccAWSCloudFormationStackSetInstance_RetainStack (15.72s)
--- FAIL: TestAccAWSCloudFormationStackSetInstance_disappears (16.28s)
--- FAIL: TestAccAWSCloudFormationStackSetInstance_basic (19.82s)
--- FAIL: TestAccAWSCloudFormationStackSetInstance_ParameterOverrides (20.29s)
--- FAIL: TestAccAWSCloudFormationStackSetInstance_disappears_StackSet (29.76s)
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	32.058s
```

After:
```
go test ./aws -v -sweep=us-gov-west-1 -sweep-run=aws_cloudformation_stack_set -timeout 60m

[DEBUG] Sweeper (aws_cloudformation_stack_set) has dependency (aws_cloudformation_stack_set_instance), running..
[DEBUG] Running Sweeper (aws_cloudformation_stack_set_instance) in region (us-gov-west-1)
[WARN] Skipping CloudFormation Stack Set Instance sweep for us-gov-west-1: ValidationError: AWS CloudFormation StackSets is not supported in us-gov-west-1
[WARN] Skipping CloudFormation Stack Set sweep for us-gov-west-1: ValidationError: AWS CloudFormation StackSets is not supported in us-gov-west-1
Sweeper Tests ran successfully:
	- aws_cloudformation_stack_set_instance
	- aws_cloudformation_stack_set
```

In GovCloud
```
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudFormationStackSet -timeout 120m

--- SKIP: TestAccAWSCloudFormationStackSet_Name (2.28s)
--- SKIP: TestAccAWSCloudFormationStackSetInstance_disappears (2.29s)
--- SKIP: TestAccAWSCloudFormationStackSet_TemplateUrl (2.29s)
--- SKIP: TestAccAWSCloudFormationStackSet_Tags (2.30s)
--- SKIP: TestAccAWSCloudFormationStackSetInstance_basic (2.31s)
--- SKIP: TestAccAWSCloudFormationStackSetInstance_RetainStack (2.31s)
--- SKIP: TestAccAWSCloudFormationStackSet_Parameters (2.31s)
--- SKIP: TestAccAWSCloudFormationStackSet_Description (2.31s)
--- SKIP: TestAccAWSCloudFormationStackSet_AdministrationRoleArn (2.31s)
--- SKIP: TestAccAWSCloudFormationStackSet_ExecutionRoleName (2.32s)
--- SKIP: TestAccAWSCloudFormationStackSetInstance_disappears_StackSet (2.32s)
--- SKIP: TestAccAWSCloudFormationStackSet_TemplateBody (2.32s)
--- SKIP: TestAccAWSCloudFormationStackSet_basic (2.32s)
--- SKIP: TestAccAWSCloudFormationStackSetInstance_ParameterOverrides (2.32s)
--- SKIP: TestAccAWSCloudFormationStackSet_disappears (2.32s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	4.437s
```

In Commercial Partition
```
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudFormationStackSet -timeout 120m

--- SKIP: TestAccAWSCloudFormationStackSet_Parameters_Default (0.00s)
    resource_aws_cloudformation_stack_set_test.go:357: this resource does not currently ignore unconfigured CloudFormation template parameters with the Default property
--- SKIP: TestAccAWSCloudFormationStackSet_Parameters_NoEcho (0.00s)
    resource_aws_cloudformation_stack_set_test.go:408: this resource does not currently ignore CloudFormation template parameters with the NoEcho property
--- PASS: TestAccAWSCloudFormationStackSet_disappears (33.22s)
--- PASS: TestAccAWSCloudFormationStackSet_TemplateUrl (57.79s)
--- PASS: TestAccAWSCloudFormationStackSet_Name (76.54s)
--- PASS: TestAccAWSCloudFormationStackSet_AdministrationRoleArn (81.17s)
--- PASS: TestAccAWSCloudFormationStackSet_TemplateBody (81.72s)
--- PASS: TestAccAWSCloudFormationStackSet_Description (83.54s)
--- PASS: TestAccAWSCloudFormationStackSet_basic (85.20s)
--- PASS: TestAccAWSCloudFormationStackSet_Parameters (97.05s)
--- PASS: TestAccAWSCloudFormationStackSet_ExecutionRoleName (107.17s)
--- PASS: TestAccAWSCloudFormationStackSet_Tags (125.27s)

--- FAIL: TestAccAWSCloudFormationStackSetInstance_disappears (52.50s)
--- FAIL: TestAccAWSCloudFormationStackSetInstance_disappears_StackSet (53.23s)
--- FAIL: TestAccAWSCloudFormationStackSetInstance_ParameterOverrides (59.96s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_basic (162.97s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_RetainStack (180.54s)
```

`TestAccAWSCloudFormationStackSetInstance_disappears`, `TestAccAWSCloudFormationStackSetInstance_disappears_StackSet`, and `TestAccAWSCloudFormationStackSetInstance_ParameterOverrides` are known intermittent failures.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
