### PR TITLE
tests/service/storagegateway: Refactor to use aws_ec2_instance_type_offering and aws_ssm_parameter data sources

### DIFF
--- a/aws/resource_aws_storagegateway_gateway_test.go
+++ b/aws/resource_aws_storagegateway_gateway_test.go
@@ -465,58 +465,51 @@ func testAccCheckAWSStorageGatewayGatewayExists(resourceName string, gateway *st
 // and security group, suitable for Storage Gateway EC2 instances of any type
 func testAccAWSStorageGateway_VPCBase(rName string) string {
 	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # Error launching source instance: Unsupported: Your requested instance type (m4.xlarge) is not supported in your requested Availability Zone (us-west-2d).
-  blacklisted_zone_ids = ["usw2-az4"]
-  state                = "available"
-}
-
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = %q
+    Name = %[1]q
   }
 }
 
 resource "aws_subnet" "test" {
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  cidr_block        = "10.0.0.0/24"
-  vpc_id            = "${aws_vpc.test.id}"
+  cidr_block = "10.0.0.0/24"
+  vpc_id     = aws_vpc.test.id
 
   tags = {
-    Name = %q
+    Name = %[1]q
   }
 }
 
 resource "aws_internet_gateway" "test" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 
   tags = {
-    Name = %q
+    Name = %[1]q
   }
 }
 
 resource "aws_route_table" "test" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = "${aws_internet_gateway.test.id}"
+    gateway_id = aws_internet_gateway.test.id
   }
 
   tags = {
-    Name = %q
+    Name = %[1]q
   }
 }
 
 resource "aws_route_table_association" "test" {
-  subnet_id      = "${aws_subnet.test.id}"
-  route_table_id = "${aws_route_table.test.id}"
+  subnet_id      = aws_subnet.test.id
+  route_table_id = aws_route_table.test.id
 }
 
 resource "aws_security_group" "test" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 
   egress {
     from_port   = 0
@@ -533,69 +526,86 @@ resource "aws_security_group" "test" {
   }
 
   tags = {
-    Name = %q
-  }
-}
-`, rName, rName, rName, rName, rName)
-}
-
-// testAccAWSStorageGateway_FileGatewayBase uses the "thinstaller" Storage
-// Gateway AMI for File Gateways
-func testAccAWSStorageGateway_FileGatewayBase(rName string) string {
-	return testAccAWSStorageGateway_VPCBase(rName) + fmt.Sprintf(`
-data "aws_ami" "aws-thinstaller" {
-  most_recent = true
-  owners      = ["amazon"]
-
-  filter {
-    name   = "name"
-    values = ["aws-thinstaller-*"]
-  }
-}
-
-resource "aws_instance" "test" {
-  depends_on = ["aws_internet_gateway.test"]
-
-  ami                         = "${data.aws_ami.aws-thinstaller.id}"
-  associate_public_ip_address = true
-  # https://docs.aws.amazon.com/storagegateway/latest/userguide/Requirements.html
-  instance_type               = "m4.xlarge"
-  vpc_security_group_ids      = ["${aws_security_group.test.id}"]
-  subnet_id                   = "${aws_subnet.test.id}"
-
-  tags = {
-    Name = %q
+    Name = %[1]q
   }
 }
 `, rName)
 }
 
-// testAccAWSStorageGateway_TapeAndVolumeGatewayBase uses the Storage Gateway
-// AMI for either Tape or Volume Gateways
-func testAccAWSStorageGateway_TapeAndVolumeGatewayBase(rName string) string {
+func testAccAWSStorageGateway_FileGatewayBase(rName string) string {
 	return testAccAWSStorageGateway_VPCBase(rName) + fmt.Sprintf(`
-data "aws_ami" "aws-storage-gateway-2" {
-  most_recent = true
-  owners      = ["amazon"]
+# Reference: https://docs.aws.amazon.com/storagegateway/latest/userguide/Requirements.html
+data "aws_ec2_instance_type_offering" "storagegateway" {
+  filter {
+    name   = "instance-type"
+    values = ["m5.xlarge", "m4.xlarge"]
+  }
 
   filter {
-    name   = "name"
-    values = ["aws-storage-gateway-2.*"]
+    name   = "location"
+    values = [aws_subnet.test.availability_zone]
   }
+  
+  location_type            = "availability-zone"
+  preferred_instance_types = ["m5.xlarge", "m4.xlarge"]
+}
+
+# Reference: https://docs.aws.amazon.com/storagegateway/latest/userguide/ec2-gateway-file.html
+data "aws_ssm_parameter" "aws_service_storagegateway_ami_FILE_S3_latest" {
+  name = "/aws/service/storagegateway/ami/FILE_S3/latest"
 }
 
 resource "aws_instance" "test" {
   depends_on = ["aws_internet_gateway.test"]
 
-  ami                         = "${data.aws_ami.aws-storage-gateway-2.id}"
+  ami                         = data.aws_ssm_parameter.aws_service_storagegateway_ami_FILE_S3_latest.value
   associate_public_ip_address = true
-  # https://docs.aws.amazon.com/storagegateway/latest/userguide/Requirements.html
-  instance_type               = "m4.xlarge"
-  vpc_security_group_ids      = ["${aws_security_group.test.id}"]
-  subnet_id                   = "${aws_subnet.test.id}"
+  instance_type               = data.aws_ec2_instance_type_offering.storagegateway.instance_type
+  vpc_security_group_ids      = [aws_security_group.test.id]
+  subnet_id                   = aws_subnet.test.id
 
   tags = {
-    Name = %q
+    Name = %[1]q
+  }
+}
+`, rName)
+}
+
+func testAccAWSStorageGateway_TapeAndVolumeGatewayBase(rName string) string {
+	return testAccAWSStorageGateway_VPCBase(rName) + fmt.Sprintf(`
+# Reference: https://docs.aws.amazon.com/storagegateway/latest/userguide/Requirements.html
+data "aws_ec2_instance_type_offering" "storagegateway" {
+  filter {
+    name   = "instance-type"
+    values = ["m5.xlarge", "m4.xlarge"]
+  }
+
+  filter {
+    name   = "location"
+    values = [aws_subnet.test.availability_zone]
+  }
+  
+  location_type            = "availability-zone"
+  preferred_instance_types = ["m5.xlarge", "m4.xlarge"]
+}
+
+# Reference: https://docs.aws.amazon.com/storagegateway/latest/userguide/ec2-gateway-common.html
+# NOTE: CACHED, STORED, and VTL Gateway Types share the same AMI
+data "aws_ssm_parameter" "aws_service_storagegateway_ami_CACHED_latest" {
+  name = "/aws/service/storagegateway/ami/CACHED/latest"
+}
+
+resource "aws_instance" "test" {
+  depends_on = ["aws_internet_gateway.test"]
+
+  ami                         = data.aws_ssm_parameter.aws_service_storagegateway_ami_CACHED_latest.value
+  associate_public_ip_address = true
+  instance_type               = data.aws_ec2_instance_type_offering.storagegateway.instance_type
+  vpc_security_group_ids      = [aws_security_group.test.id]
+  subnet_id                   = aws_subnet.test.id
+
+  tags = {
+    Name = %[1]q
   }
 }
 `, rName)
@@ -674,62 +684,61 @@ resource "aws_storagegateway_gateway" "test" {
 
 func testAccAWSStorageGatewayGatewayConfig_SmbActiveDirectorySettings(rName string) string {
 	return fmt.Sprintf(`
+# Directory Service Directories must be deployed across multiple EC2 Availability Zones
 data "aws_availability_zones" "available" {
-  # Error launching source instance: Unsupported: Your requested instance type (m4.xlarge) is not supported in your requested Availability Zone (us-west-2d).
-  blacklisted_zone_ids = ["usw2-az4"]
-  state                = "available"
+  state = "available"
 }
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = %q
+    Name = %[1]q
   }
 }
 
 resource "aws_subnet" "test" {
   count = 2
 
-  availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
+  availability_zone = data.aws_availability_zones.available.names[count.index]
   cidr_block        = "10.0.${count.index}.0/24"
-  vpc_id            = "${aws_vpc.test.id}"
+  vpc_id            = aws_vpc.test.id
 
   tags = {
-    Name = %q
+    Name = %[1]q
   }
 }
 
 resource "aws_internet_gateway" "test" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 
   tags = {
-    Name = %q
+    Name = %[1]q
   }
 }
 
 resource "aws_route_table" "test" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = "${aws_internet_gateway.test.id}"
+    gateway_id = aws_internet_gateway.test.id
   }
 
   tags = {
-    Name = %q
+    Name = %[1]q
   }
 }
 
 resource "aws_route_table_association" "test" {
   count = 2
 
-  subnet_id      = "${aws_subnet.test.*.id[count.index]}"
-  route_table_id = "${aws_route_table.test.id}"
+  subnet_id      = aws_subnet.test[count.index].id
+  route_table_id = aws_route_table.test.id
 }
 
 resource "aws_security_group" "test" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 
   egress {
     from_port   = 0
@@ -746,7 +755,7 @@ resource "aws_security_group" "test" {
   }
 
   tags = {
-    Name = %q
+    Name = %[1]q
   }
 }
 
@@ -757,67 +766,76 @@ resource "aws_directory_service_directory" "test" {
 
   vpc_settings {
     subnet_ids = aws_subnet.test[*].id
-    vpc_id     = "${aws_vpc.test.id}"
+    vpc_id     = aws_vpc.test.id
   }
 
   tags = {
-    Name = %q
+    Name = %[1]q
   }
 }
 
 resource "aws_vpc_dhcp_options" "test" {
-  domain_name         = "${aws_directory_service_directory.test.name}"
+  domain_name         = aws_directory_service_directory.test.name
   domain_name_servers = aws_directory_service_directory.test.dns_ip_addresses
 
   tags = {
-    Name = %q
+    Name = %[1]q
   }
 }
 
 resource "aws_vpc_dhcp_options_association" "test" {
-  dhcp_options_id = "${aws_vpc_dhcp_options.test.id}"
-  vpc_id          = "${aws_vpc.test.id}"
+  dhcp_options_id = aws_vpc_dhcp_options.test.id
+  vpc_id          = aws_vpc.test.id
 }
 
-data "aws_ami" "aws-thinstaller" {
-  most_recent = true
-  owners      = ["amazon"]
+# Reference: https://docs.aws.amazon.com/storagegateway/latest/userguide/Requirements.html
+data "aws_ec2_instance_type_offering" "storagegateway" {
+  filter {
+    name   = "instance-type"
+    values = ["m5.xlarge", "m4.xlarge"]
+  }
 
   filter {
-    name   = "name"
-    values = ["aws-thinstaller-*"]
+    name   = "location"
+    values = [aws_subnet.test[0].availability_zone]
   }
+
+  location_type            = "availability-zone"
+  preferred_instance_types = ["m5.xlarge", "m4.xlarge"]
+}
+
+# Reference: https://docs.aws.amazon.com/storagegateway/latest/userguide/ec2-gateway-file.html
+data "aws_ssm_parameter" "aws_service_storagegateway_ami_FILE_S3_latest" {
+  name = "/aws/service/storagegateway/ami/FILE_S3/latest"
 }
 
 resource "aws_instance" "test" {
-  depends_on = ["aws_internet_gateway.test", "aws_vpc_dhcp_options_association.test"]
+  depends_on = [aws_internet_gateway.test, aws_vpc_dhcp_options_association.test]
 
-  ami                         = "${data.aws_ami.aws-thinstaller.id}"
+  ami                         = data.aws_ssm_parameter.aws_service_storagegateway_ami_FILE_S3_latest.value
   associate_public_ip_address = true
-
-  # https://docs.aws.amazon.com/storagegateway/latest/userguide/Requirements.html
-  instance_type          = "m4.xlarge"
-  vpc_security_group_ids = ["${aws_security_group.test.id}"]
-  subnet_id              = "${aws_subnet.test.*.id[0]}"
+  instance_type               = data.aws_ec2_instance_type_offering.storagegateway.instance_type
+  vpc_security_group_ids      = [aws_security_group.test.id]
+  subnet_id                   = aws_subnet.test[0].id
 
   tags = {
-    Name = %q
+    Name = %[1]q
   }
 }
 
 resource "aws_storagegateway_gateway" "test" {
-  gateway_ip_address = "${aws_instance.test.public_ip}"
-  gateway_name       = %q
+  gateway_ip_address = aws_instance.test.public_ip
+  gateway_name       = %[1]q
   gateway_timezone   = "GMT"
   gateway_type       = "FILE_S3"
 
   smb_active_directory_settings {
-    domain_name = "${aws_directory_service_directory.test.name}"
-    password    = "${aws_directory_service_directory.test.password}"
+    domain_name = aws_directory_service_directory.test.name
+    password    = aws_directory_service_directory.test.password
     username    = "Administrator"
   }
 }
-`, rName, rName, rName, rName, rName, rName, rName, rName, rName)
+`, rName)
 }
 
 func testAccAWSStorageGatewayGatewayConfig_SmbGuestPassword(rName, smbGuestPassword string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://docs.aws.amazon.com/storagegateway/latest/userguide/Requirements.html
Reference: https://docs.aws.amazon.com/storagegateway/latest/userguide/ec2-gateway-file.html
Reference: https://docs.aws.amazon.com/storagegateway/latest/userguide/ec2-gateway-common.html

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Rather than manually maintain an EC2 Availability Zone blacklist for a specific instance type, we can now query EC2 to choose from available Instance Types. Also switches the AMI lookups to use the Storage Gateway documented method of AWS managed SSM Parameter values.

Output from acceptance testing:

```
--- PASS: TestAccAWSStorageGatewayGateway_CloudWatchLogs (242.70s)
--- PASS: TestAccAWSStorageGatewayGateway_GatewayName (281.47s)
--- PASS: TestAccAWSStorageGatewayGateway_GatewayTimezone (222.28s)
--- PASS: TestAccAWSStorageGatewayGateway_GatewayType_Cached (238.61s)
--- PASS: TestAccAWSStorageGatewayGateway_GatewayType_FileS3 (240.81s)
--- PASS: TestAccAWSStorageGatewayGateway_GatewayType_Stored (182.66s)
--- PASS: TestAccAWSStorageGatewayGateway_GatewayType_Vtl (227.83s)
--- PASS: TestAccAWSStorageGatewayGateway_SmbActiveDirectorySettings (725.52s)
--- PASS: TestAccAWSStorageGatewayGateway_SmbGuestPassword (238.51s)
--- PASS: TestAccAWSStorageGatewayGateway_tags (239.00s)
```
