### PR TITLE
tests/data-source/aws_internet_gateway: Remove hardcoded provider region and ExpectNonEmptyPlan

### DIFF
--- a/aws/data_source_aws_internet_gateway_test.go
+++ b/aws/data_source_aws_internet_gateway_test.go
@@ -32,17 +32,12 @@ func TestAccDataSourceAwsInternetGateway_typical(t *testing.T) {
 					resource.TestCheckResourceAttrPair(ds3ResourceName, "owner_id", igwResourceName, "owner_id"),
 					resource.TestCheckResourceAttrPair(ds3ResourceName, "attachments.0.vpc_id", vpcResourceName, "id"),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
 }
 
 const testAccDataSourceAwsInternetGatewayConfig = `
-provider "aws" {
-  region = "eu-central-1"
-}
-
 resource "aws_vpc" "test" {
   cidr_block = "172.16.0.0/16"
 
@@ -71,10 +66,8 @@ data "aws_internet_gateway" "by_tags" {
 
 data "aws_internet_gateway" "by_filter" {
   filter {
-    name = "attachment.vpc-id"
-    values = ["${aws_vpc.test.id}"]
+    name = "internet-gateway-id"
+    values = ["${aws_internet_gateway.test.id}"]
   }
-
-  depends_on = ["aws_internet_gateway.test"]
 }
 `


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/8983

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously in the acceptance testing:

```
--- FAIL: TestAccDataSourceAwsInternetGateway_typical (11.00s)
    testing.go:654: Step 0 error: errors during apply:

        Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
```

Since this hardcoded region is not part of our normal sweeping regions, it went unchecked and hit the 5 VPC limit. Running the sweeper in that region cleaned up dangling VPC resources.

Output from acceptance testing:

```
--- PASS: TestAccDataSourceAwsInternetGateway_typical (43.46s)
```
