### PR TITLE
Securityhub is no longer in preview - update docs

### DIFF
--- a/website/docs/r/securityhub_account.markdown
+++ b/website/docs/r/securityhub_account.markdown
@@ -12,8 +12,6 @@ Enables Security Hub for this AWS account.
 
 ~> **NOTE:** Destroying this resource will disable Security Hub for this AWS account.
 
-~> **NOTE:** This AWS service is in Preview and may change before General Availability release. Backwards compatibility is not guaranteed between Terraform AWS Provider releases.
-
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/securityhub_product_subscription.markdown
+++ b/website/docs/r/securityhub_product_subscription.markdown
@@ -10,8 +10,6 @@ description: |-
 
 Subscribes to a Security Hub product.
 
-~> **NOTE:** This AWS service is in Preview and may change before General Availability release. Backwards compatibility is not guaranteed between Terraform AWS Provider releases.
-
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/securityhub_standards_subscription.markdown
+++ b/website/docs/r/securityhub_standards_subscription.markdown
@@ -10,8 +10,6 @@ description: |-
 
 Subscribes to a Security Hub standard.
 
-~> **NOTE:** This AWS service is in Preview and may change before General Availability release. Backwards compatibility is not guaranteed between Terraform AWS Provider releases.
-
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

The security hub is no longer in preview so updating the note in it's docs.
https://aws.amazon.com/about-aws/whats-new/2019/06/aws-security-hub-now-generally-available/

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:
N/A
