### PR TITLE
Do not overwrite if GitHub token is already specified

### DIFF
--- a/aws/resource_aws_codepipeline.go
+++ b/aws/resource_aws_codepipeline.go
@@ -279,12 +279,11 @@ func expandAwsCodePipelineActions(s []interface{}) []*codepipeline.ActionDeclara
 		data := config.(map[string]interface{})
 
 		conf := expandAwsCodePipelineStageActionConfiguration(data["configuration"].(map[string]interface{}))
-		if data["provider"].(string) == "GitHub" {
+		if data["provider"].(string) == "GitHub" && conf["OAuthToken"] = "" {
 			githubToken := os.Getenv("GITHUB_TOKEN")
 			if githubToken != "" {
 				conf["OAuthToken"] = aws.String(githubToken)
 			}
-
 		}
 
 		action := codepipeline.ActionDeclaration{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000
https://github.com/terraform-providers/terraform-provider-aws/issues/2796#issuecomment-591204535
This ticket implement the first proposal of @isen-ng

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
If user specify their GITHUB token in OAuthToken field, ignore value from GITHUB_TOKEN
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
