### PR TITLE
New data source - aws_regions

### DIFF
--- a/aws/data_source_aws_regions.go
+++ b/aws/data_source_aws_regions.go
@@ -1,0 +1,86 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"sort"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func dataSourceAwsRegions() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsRegionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"names": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"all_regions": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
+			"opt_in_status": {
+				Type:     schema.TypeString,
+				Optional: true,
+				// There is no OptInStatus constants defined for Regions.
+				// Using those from AvailabilityZone definition.
+				ValidateFunc: validation.StringInSlice([]string{
+					ec2.AvailabilityZoneOptInStatusOptInNotRequired,
+					ec2.AvailabilityZoneOptInStatusOptedIn,
+					ec2.AvailabilityZoneOptInStatusNotOptedIn,
+				}, false),
+			},
+		},
+	}
+}
+
+func dataSourceAwsRegionsRead(d *schema.ResourceData, meta interface{}) error {
+	connection := meta.(*AWSClient).ec2conn
+
+	log.Printf("[DEBUG] Reading regions.")
+
+	request := &ec2.DescribeRegionsInput{}
+
+	if v, ok := d.GetOk("all_regions"); ok {
+		request.AllRegions = aws.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("opt_in_status"); ok {
+		log.Printf("[DEBUG] Adding region filters")
+		request.Filters = []*ec2.Filter{
+			{
+				Name:   aws.String("opt-in-status"),
+				Values: []*string{aws.String(v.(string))},
+			},
+		}
+	}
+
+	log.Printf("[DEBUG] Reading regions for request: %s", request)
+	response, err := connection.DescribeRegions(request)
+	if err != nil {
+		return fmt.Errorf("Error fetching Regions: %s", err)
+	}
+
+	names := []string{}
+	for _, v := range response.Regions {
+		names = append(names, aws.StringValue(v.RegionName))
+	}
+
+	sort.Slice(names, func(i, j int) bool {
+		return names[i] < names[j]
+	})
+
+	d.SetId(time.Now().UTC().String())
+	d.Set("names", names)
+
+	return nil
+}

--- a/aws/data_source_aws_regions.go
+++ b/aws/data_source_aws_regions.go
@@ -54,12 +54,11 @@ func dataSourceAwsRegionsRead(d *schema.ResourceData, meta interface{}) error {
 		names = append(names, aws.StringValue(v.RegionName))
 	}
 
-	sort.Slice(names, func(i, j int) bool {
-		return names[i] < names[j]
-	})
 
 	d.SetId(time.Now().UTC().String())
-	d.Set("names", names)
+	if err := d.Set("names", names); err != nil {
+		return fmt.Errorf("error setting names: %s", err)
+	}
 
 	return nil
 }

--- a/aws/data_source_aws_regions_test.go
+++ b/aws/data_source_aws_regions_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccDataSourceAwsRegionsBasic(t *testing.T) {
+func TestAccDataSourceAwsRegions_Basic(t *testing.T) {
 	resourceName := "data.aws_regions.empty"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -16,7 +16,7 @@ func TestAccDataSourceAwsRegionsBasic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsRegionsConfigEmpty(),
+				Config: testAccDataSourceAwsRegionsConfig_empty(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsRegionsCheck(resourceName),
 					resource.TestCheckNoResourceAttr(resourceName, "all_regions"),
@@ -26,7 +26,7 @@ func TestAccDataSourceAwsRegionsBasic(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceAwsRegionsOptIn(t *testing.T) {
+func TestAccDataSourceAwsRegions_OptIn(t *testing.T) {
 	resourceName := "data.aws_regions.opt_in_status"
 
 	statusOptedIn := "opted-in"
@@ -39,21 +39,21 @@ func TestAccDataSourceAwsRegionsOptIn(t *testing.T) {
 		Steps: []resource.TestStep{
 			// This resource has to be at the very top of the test scenario due to bug in Terrafom Plugin SDK
 			{
-				Config: testAccDataSourceAwsRegionsConfigAllRegionsFiltered(statusOptedIn),
+				Config: testAccDataSourceAwsRegionsConfig_allRegionsFiltered(statusOptedIn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsRegionsCheck(resourceName),
 					resource.TestCheckNoResourceAttr(resourceName, "all_regions"),
 				),
 			},
 			{
-				Config: testAccDataSourceAwsRegionsConfigAllRegionsFiltered(statusOptInNotRequired),
+				Config: testAccDataSourceAwsRegionsConfig_allRegionsFiltered(statusOptInNotRequired),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsRegionsCheck(resourceName),
 					resource.TestCheckNoResourceAttr(resourceName, "all_regions"),
 				),
 			},
 			{
-				Config: testAccDataSourceAwsRegionsConfigAllRegionsFiltered(statusNotOptedIn),
+				Config: testAccDataSourceAwsRegionsConfig_allRegionsFiltered(statusNotOptedIn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsRegionsCheck(resourceName),
 					resource.TestCheckNoResourceAttr(resourceName, "all_regions"),
@@ -63,7 +63,7 @@ func TestAccDataSourceAwsRegionsOptIn(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceAwsRegionsAllRegions(t *testing.T) {
+func TestAccDataSourceAwsRegions_AllRegions(t *testing.T) {
 	resourceAllRegions := "data.aws_regions.all_regions"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -71,7 +71,7 @@ func TestAccDataSourceAwsRegionsAllRegions(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsRegionsConfigAllRegions(),
+				Config: testAccDataSourceAwsRegionsConfig_allRegions(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsRegionsCheck(resourceAllRegions),
 					resource.TestCheckResourceAttr(resourceAllRegions, "all_regions", "true"),
@@ -93,13 +93,13 @@ func testAccDataSourceAwsRegionsCheck(name string) resource.TestCheckFunc {
 	}
 }
 
-func testAccDataSourceAwsRegionsConfigEmpty() string {
+func testAccDataSourceAwsRegionsConfig_empty() string {
 	return `
 data "aws_regions" "empty" {}
 `
 }
 
-func testAccDataSourceAwsRegionsConfigAllRegions() string {
+func testAccDataSourceAwsRegionsConfig_allRegions() string {
 	return `
 data "aws_regions" "all_regions" {
 	all_regions = "true"
@@ -107,7 +107,7 @@ data "aws_regions" "all_regions" {
 `
 }
 
-func testAccDataSourceAwsRegionsConfigAllRegionsFiltered(filter string) string {
+func testAccDataSourceAwsRegionsConfig_allRegionsFiltered(filter string) string {
 	return fmt.Sprintf(`
 data "aws_regions" "opt_in_status" {
 	filter {

--- a/aws/data_source_aws_regions_test.go
+++ b/aws/data_source_aws_regions_test.go
@@ -1,0 +1,125 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccDataSourceAwsRegionsBasic(t *testing.T) {
+	resourceName := "data.aws_regions.empty"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsRegionsConfigEmpty(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsRegionsCheck(resourceName),
+					resource.TestCheckNoResourceAttr(resourceName, "all_regions"),
+					resource.TestCheckNoResourceAttr(resourceName, "opt_in_status"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsRegionsOptIn(t *testing.T) {
+	resourceName := "data.aws_regions.opt_in_status"
+
+	statusOptedIn := "opted-in"
+	statusNotOptedIn := "not-opted-in"
+	statusOptInNotRequired := "opt-in-not-required"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			// This resource has to be at the very top of the test scenario due to bug in Terrafom Plugin SDK
+			{
+				Config:      testAccDataSourceAwsRegionsConfigOptIn("invalid-opt-in-status"),
+				ExpectError: regexp.MustCompile(`expected opt_in_status to be one of .*, got invalid-opt-in-status`),
+			},
+			{
+				Config: testAccDataSourceAwsRegionsConfigOptIn(statusOptedIn),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsRegionsCheck(resourceName),
+					resource.TestCheckNoResourceAttr(resourceName, "all_regions"),
+					resource.TestCheckResourceAttr(resourceName, "opt_in_status", statusOptedIn),
+				),
+			},
+			{
+				Config: testAccDataSourceAwsRegionsConfigOptIn(statusOptInNotRequired),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsRegionsCheck(resourceName),
+					resource.TestCheckNoResourceAttr(resourceName, "all_regions"),
+					resource.TestCheckResourceAttr(resourceName, "opt_in_status", statusOptInNotRequired),
+				),
+			},
+			{
+				Config: testAccDataSourceAwsRegionsConfigOptIn(statusNotOptedIn),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsRegionsCheck(resourceName),
+					resource.TestCheckNoResourceAttr(resourceName, "all_regions"),
+					resource.TestCheckResourceAttr(resourceName, "opt_in_status", statusNotOptedIn),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsRegionsAllRegions(t *testing.T) {
+	resourceAllRegions := "data.aws_regions.all_regions"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsRegionsConfigAllRegions(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsRegionsCheck(resourceAllRegions),
+					resource.TestCheckResourceAttr(resourceAllRegions, "all_regions", "true"),
+					resource.TestCheckNoResourceAttr(resourceAllRegions, "opt_in_status"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsRegionsCheck(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("root module has no resource called %s", name)
+		}
+
+		return nil
+	}
+}
+
+func testAccDataSourceAwsRegionsConfigEmpty() string {
+	return `
+data "aws_regions" "empty" {}
+`
+}
+
+func testAccDataSourceAwsRegionsConfigAllRegions() string {
+	return `
+data "aws_regions" "all_regions" {
+	all_regions = "true"
+}
+`
+}
+
+func testAccDataSourceAwsRegionsConfigOptIn(optInStatus string) string {
+	return fmt.Sprintf(`
+data "aws_regions" "opt_in_status" {
+	opt_in_status = "%s"
+}
+`, optInStatus)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -269,6 +269,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_redshift_cluster":                          dataSourceAwsRedshiftCluster(),
 			"aws_redshift_service_account":                  dataSourceAwsRedshiftServiceAccount(),
 			"aws_region":                                    dataSourceAwsRegion(),
+			"aws_regions":                                   dataSourceAwsRegions(),
 			"aws_route":                                     dataSourceAwsRoute(),
 			"aws_route_table":                               dataSourceAwsRouteTable(),
 			"aws_route_tables":                              dataSourceAwsRouteTables(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -53,6 +53,9 @@
                         <li>
                             <a href="/docs/providers/aws/d/region.html">aws_region</a>
                         </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/regions.html">aws_regions</a>
+                        </li>
                     </ul>
                 </li>
                 <li>

--- a/website/docs/d/regions.html.markdown
+++ b/website/docs/d/regions.html.markdown
@@ -11,7 +11,7 @@ description: |-
 `aws_regions` provides list of all enabled AWS regions.
 
 The data source provides list of AWS regions available.
-Can be used to filter regions by Opt-In status or list only regions enabled for current account.
+Can be used to filter regions i.e. by Opt-In status or list only regions enabled for current account.
 To get details like endpoint and description of each region the data source can be combined with `aws_region`.
 
 ## Example Usage
@@ -19,7 +19,7 @@ To get details like endpoint and description of each region the data source can 
 The following example shows how the resource might be used to obtain
 the list of the AWS regions configured on the provider.
 
-Regions enabled for the user
+To list regions enabled for the user:
 
 ```hcl
 data "aws_regions" "current" {}
@@ -33,13 +33,17 @@ data "aws_regions" "current" {
 }
 ```
 
-To see regions that are `"not-opted-in"` `"all_regions"` need to be set to true 
-or nothing will be displayed.
+To see regions that are filtered by `"not-opted-in"` `"all_regions"` need to be set to true 
+or probably nothing will be displayed.
 
 ```hcl
 data "aws_regions" "current" {
     all_regions = true
-    opt_in_status = "not-opted-in"
+
+    filter {
+      name   = "opt-in-status"
+      values = ["not-opted-in"]
+    }
 }
 ```
 
@@ -51,11 +55,14 @@ exported as attributes.
 
 * `all_regions` - (Optional) If true the source will query all regions regardless of availability.
 
-* `opt_in_status` - (Optional) Filter the list of regions according to op-in-status filter. Can be one of: `"opt-in-not-required"`, `"opted-in"` or `"not-opted-in"`.
+* `filter` - (Optional) One or more key/value pairs to use as filters. Full reference of valid keys 
+can be found [describe-regions in the AWS CLI reference][1].
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `names` - Names of regions that meets the criteria.
+
+[1]: https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-regions.html
 

--- a/website/docs/d/regions.html.markdown
+++ b/website/docs/d/regions.html.markdown
@@ -1,0 +1,61 @@
+---
+subcategory: ""
+layout: "aws"
+page_title: "AWS: aws_regions"
+description: |-
+    Provides list of all enabled AWS regions
+---
+
+# Data Source: aws_region
+
+`aws_regions` provides list of all enabled AWS regions.
+
+The data source provides list of AWS regions available.
+Can be used to filter regions by Opt-In status or list only regions enabled for current account.
+To get details like endpoint and description of each region the data source can be combined with `aws_region`.
+
+## Example Usage
+
+The following example shows how the resource might be used to obtain
+the list of the AWS regions configured on the provider.
+
+Regions enabled for the user
+
+```hcl
+data "aws_regions" "current" {}
+```
+
+All the regions regardless of the availability
+
+```hcl
+data "aws_regions" "current" {
+    all_regions = true
+}
+```
+
+To see regions that are `"not-opted-in"` `"all_regions"` need to be set to true 
+or nothing will be displayed.
+
+```hcl
+data "aws_regions" "current" {
+    all_regions = true
+    opt_in_status = "not-opted-in"
+}
+```
+
+## Argument Reference
+
+The arguments of this data source act as filters for querying the available
+regions. The given filters must match exactly one region whose data will be
+exported as attributes.
+
+* `all_regions` - (Optional) If true the source will query all regions regardless of availability.
+
+* `opt_in_status` - (Optional) Filter the list of regions according to op-in-status filter. Can be one of: `"opt-in-not-required"`, `"opted-in"` or `"not-opted-in"`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `names` - Names of regions that meets the criteria.
+

--- a/website/docs/d/regions.html.markdown
+++ b/website/docs/d/regions.html.markdown
@@ -6,7 +6,7 @@ description: |-
     Provides list of all enabled AWS regions
 ---
 
-# Data Source: aws_region
+# Data Source: aws_regions
 
 `aws_regions` provides list of all enabled AWS regions.
 

--- a/website/docs/d/regions.html.markdown
+++ b/website/docs/d/regions.html.markdown
@@ -3,23 +3,16 @@ subcategory: ""
 layout: "aws"
 page_title: "AWS: aws_regions"
 description: |-
-    Provides list of all enabled AWS regions
+    Provides information about AWS Regions.
 ---
 
 # Data Source: aws_regions
 
-`aws_regions` provides list of all enabled AWS regions.
-
-The data source provides list of AWS regions available.
-Can be used to filter regions i.e. by Opt-In status or list only regions enabled for current account.
-To get details like endpoint and description of each region the data source can be combined with `aws_region`.
+Provides information about AWS Regions. Can be used to filter regions i.e. by Opt-In status or only regions enabled for current account. To get details like endpoint and description of each region the data source can be combined with the [`aws_region` data source](/docs/providers/aws/d/region.html).
 
 ## Example Usage
 
-The following example shows how the resource might be used to obtain
-the list of the AWS regions configured on the provider.
-
-To list regions enabled for the user:
+Enabled AWS Regions:
 
 ```hcl
 data "aws_regions" "current" {}
@@ -29,34 +22,37 @@ All the regions regardless of the availability
 
 ```hcl
 data "aws_regions" "current" {
-    all_regions = true
+  all_regions = true
 }
 ```
 
-To see regions that are filtered by `"not-opted-in"` `"all_regions"` need to be set to true 
-or probably nothing will be displayed.
+To see regions that are filtered by `"not-opted-in"`, the `all_regions` argument needs to be set to `true` or no results will be returned.
 
 ```hcl
 data "aws_regions" "current" {
-    all_regions = true
+  all_regions = true
 
-    filter {
-      name   = "opt-in-status"
-      values = ["not-opted-in"]
-    }
+  filter {
+    name   = "opt-in-status"
+    values = ["not-opted-in"]
+  }
 }
 ```
 
 ## Argument Reference
 
-The arguments of this data source act as filters for querying the available
-regions. The given filters must match exactly one region whose data will be
-exported as attributes.
+The following arguments are supported:
 
 * `all_regions` - (Optional) If true the source will query all regions regardless of availability.
 
-* `filter` - (Optional) One or more key/value pairs to use as filters. Full reference of valid keys 
-can be found [describe-regions in the AWS CLI reference][1].
+* `filter` - (Optional) Configuration block(s) to use as filters. Detailed below.
+
+### filter Configuration Block
+
+The following arguments are supported by the `filter` configuration block:
+
+* `name` - (Required) The name of the filter field. Valid values can be found in the [describe-regions AWS CLI Reference][1].
+* `values` - (Required) Set of values that are accepted for the given filter field. Results will be selected if any given value matches.
 
 ## Attributes Reference
 
@@ -65,4 +61,3 @@ In addition to all arguments above, the following attributes are exported:
 * `names` - Names of regions that meets the criteria.
 
 [1]: https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-regions.html
-


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates: #12270

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* **New Data Source:** `aws_regions`
```

This pull request adds another resource `aws_regions` that can list all available regions by op-in status: `opted-in`, `not-opted-in` and `opt-in-not-required` ([docs](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html))

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccDataSourceAwsRegionsAllRegions (29.20s)
--- PASS: TestAccDataSourceAwsRegionsBasic (29.30s)
--- PASS: TestAccDataSourceAwsRegionsOptIn (63.63s)
```
