### PR TITLE
r/aws_flow_log - add tagging support

### DIFF
--- a/aws/resource_aws_flow_log.go
+++ b/aws/resource_aws_flow_log.go
@@ -154,7 +154,7 @@ func resourceAwsLogFlowCreate(d *schema.ResourceData, meta interface{}) error {
 		opts.LogFormat = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("tags"); ok && v != "" {
+	if v, ok := d.GetOk("tags"); ok && len(v) > 0 {
 		opts.TagSpecifications = ec2TagSpecificationsFromMap(d.Get("tags").(map[string]interface{}), ec2.ResourceTypeVpcFlowLog)
 	}
 

--- a/aws/resource_aws_flow_log.go
+++ b/aws/resource_aws_flow_log.go
@@ -9,12 +9,14 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsFlowLog() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsLogFlowCreate,
 		Read:   resourceAwsLogFlowRead,
+		Update: resourceAwsLogFlowUpdate,
 		Delete: resourceAwsLogFlowDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -22,9 +24,10 @@ func resourceAwsFlowLog() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"iam_role_arn": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
 			},
 
 			"log_destination": {
@@ -85,6 +88,11 @@ func resourceAwsFlowLog() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					ec2.TrafficTypeAccept,
+					ec2.TrafficTypeAll,
+					ec2.TrafficTypeReject,
+				}, false),
 			},
 
 			"log_format": {
@@ -93,6 +101,7 @@ func resourceAwsFlowLog() *schema.Resource {
 				ForceNew: true,
 				Computed: true,
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -143,6 +152,10 @@ func resourceAwsLogFlowCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 	if v, ok := d.GetOk("log_format"); ok && v != "" {
 		opts.LogFormat = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("tags"); ok && v != "" {
+		opts.TagSpecifications = ec2TagSpecificationsFromMap(d.Get("tags").(map[string]interface{}), ec2.ResourceTypeVpcFlowLog)
 	}
 
 	log.Printf(
@@ -204,7 +217,24 @@ func resourceAwsLogFlowRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set(resourceKey, fl.ResourceId)
 	}
 
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(fl.Tags).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
 	return nil
+}
+
+func resourceAwsLogFlowUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+		if err := keyvaluetags.Ec2UpdateTags(conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("error updating tags: %s", err)
+		}
+	}
+
+	return resourceAwsLogFlowRead(d, meta)
 }
 
 func resourceAwsLogFlowDelete(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_flow_log.go
+++ b/aws/resource_aws_flow_log.go
@@ -154,7 +154,7 @@ func resourceAwsLogFlowCreate(d *schema.ResourceData, meta interface{}) error {
 		opts.LogFormat = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("tags"); ok && len(v) > 0 {
+	if v, ok := d.GetOk("tags"); ok && len(v.(map[string]interface{})) > 0 {
 		opts.TagSpecifications = ec2TagSpecificationsFromMap(d.Get("tags").(map[string]interface{}), ec2.ResourceTypeVpcFlowLog)
 	}
 

--- a/aws/resource_aws_flow_log_test.go
+++ b/aws/resource_aws_flow_log_test.go
@@ -195,6 +195,75 @@ func TestAccAWSFlowLog_LogDestinationType_S3_Invalid(t *testing.T) {
 	})
 }
 
+func TestAccAWSFlowLog_tags(t *testing.T) {
+	var flowLog ec2.FlowLog
+	resourceName := "aws_flow_log.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckFlowLogDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFlowLogConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFlowLogExists(resourceName, &flowLog),
+					testAccCheckAWSFlowLogAttributes(&flowLog),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccFlowLogConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFlowLogExists(resourceName, &flowLog),
+					testAccCheckAWSFlowLogAttributes(&flowLog),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccFlowLogConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFlowLogExists(resourceName, &flowLog),
+					testAccCheckAWSFlowLogAttributes(&flowLog),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSFlowLog_disappears(t *testing.T) {
+	var flowLog ec2.FlowLog
+	resourceName := "aws_flow_log.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckFlowLogDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFlowLogConfig_VPCID(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFlowLogExists(resourceName, &flowLog),
+					testAccCheckFlowLogDisappears(&flowLog),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccCheckFlowLogExists(n string, flowLog *ec2.FlowLog) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -220,6 +289,18 @@ func testAccCheckFlowLogExists(n string, flowLog *ec2.FlowLog) resource.TestChec
 			return nil
 		}
 		return fmt.Errorf("No Flow Logs found for id (%s)", rs.Primary.ID)
+	}
+}
+
+func testAccCheckFlowLogDisappears(flowLog *ec2.FlowLog) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+		input := &ec2.DeleteFlowLogsInput{
+			FlowLogIds: []*string{flowLog.FlowLogId},
+		}
+		_, err := conn.DeleteFlowLogs(input)
+
+		return err
 	}
 }
 
@@ -490,4 +571,105 @@ resource "aws_flow_log" "test" {
   log_format     = "$${version} $${vpc-id} $${subnet-id}"
 }
 `, rName, rName, rName, rName)
+}
+
+func testAccFlowLogConfigTags1(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "ec2.amazonaws.com"
+        ]
+      },
+      "Action": [
+        "sts:AssumeRole"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_cloudwatch_log_group" "test" {
+  name = %[1]q
+}
+
+resource "aws_flow_log" "test" {
+  iam_role_arn   = "${aws_iam_role.test.arn}"
+  log_group_name = "${aws_cloudwatch_log_group.test.name}"
+  traffic_type   = "ALL"
+  vpc_id         = "${aws_vpc.test.id}"
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccFlowLogConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "ec2.amazonaws.com"
+        ]
+      },
+      "Action": [
+        "sts:AssumeRole"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_cloudwatch_log_group" "test" {
+  name = %[1]q
+}
+
+resource "aws_flow_log" "test" {
+  iam_role_arn   = "${aws_iam_role.test.arn}"
+  log_group_name = "${aws_cloudwatch_log_group.test.name}"
+  traffic_type   = "ALL"
+  vpc_id         = "${aws_vpc.test.id}"
+
+  tags = {
+    %[2]q = %[3]q
+	%[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }

--- a/aws/resource_aws_flow_log_test.go
+++ b/aws/resource_aws_flow_log_test.go
@@ -616,7 +616,7 @@ resource "aws_flow_log" "test" {
 
   tags = {
     %[2]q = %[3]q
-	%[4]q = %[5]q
+    %[4]q = %[5]q
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)

--- a/aws/resource_aws_flow_log_test.go
+++ b/aws/resource_aws_flow_log_test.go
@@ -329,18 +329,22 @@ func testAccCheckFlowLogDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccFlowLogConfig_LogDestinationType_CloudWatchLogs(rName string) string {
+func testAccFlowLogConfigBase(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = %q
+    Name = %[1]q
   }
 }
+`, rName)
+}
 
+func testAccFlowLogConfig_LogDestinationType_CloudWatchLogs(rName string) string {
+	return testAccFlowLogConfigBase(rName) + fmt.Sprintf(`
 resource "aws_iam_role" "test" {
-  name = %q
+  name = %[1]q
 
   assume_role_policy = <<EOF
 {
@@ -363,7 +367,7 @@ EOF
 }
 
 resource "aws_cloudwatch_log_group" "test" {
-  name = %q
+  name = %[1]q
 }
 
 resource "aws_flow_log" "test" {
@@ -373,21 +377,13 @@ resource "aws_flow_log" "test" {
   traffic_type         = "ALL"
   vpc_id               = "${aws_vpc.test.id}"
 }
-`, rName, rName, rName)
+`, rName)
 }
 
 func testAccFlowLogConfig_LogDestinationType_S3(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_vpc" "test" {
-  cidr_block = "10.0.0.0/16"
-
-  tags = {
-    Name = %q
-  }
-}
-
+	return testAccFlowLogConfigBase(rName) + fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
-  bucket        = %q
+  bucket        = %[1]q
   force_destroy = true
 }
 
@@ -397,49 +393,33 @@ resource "aws_flow_log" "test" {
   traffic_type         = "ALL"
   vpc_id               = "${aws_vpc.test.id}"
 }
-`, rName, rName)
+`, rName)
 }
 
 func testAccFlowLogConfig_LogDestinationType_S3_Invalid(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_vpc" "test" {
-  cidr_block = "10.0.0.0/16"
-
-  tags = {
-    Name = %q
-  }
-}
-
+	return testAccFlowLogConfigBase(rName) + fmt.Sprintf(`
 resource "aws_flow_log" "test" {
   log_destination      = "arn:aws:s3:::does-not-exist"
   log_destination_type = "s3"
   traffic_type         = "ALL"
   vpc_id               = "${aws_vpc.test.id}"
 }
-`, rName)
+`)
 }
 
 func testAccFlowLogConfig_SubnetID(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_vpc" "test" {
-  cidr_block = "10.0.0.0/16"
-
-  tags = {
-    Name = %q
-  }
-}
-
+	return testAccFlowLogConfigBase(rName) + fmt.Sprintf(`
 resource "aws_subnet" "test" {
   cidr_block = "10.0.1.0/24"
   vpc_id     = "${aws_vpc.test.id}"
 
   tags = {
-    Name = %q
+    Name = %[1]q
   }
 }
 
 resource "aws_iam_role" "test" {
-  name = %q
+  name = %[1]q
 
   assume_role_policy = <<EOF
 {
@@ -462,7 +442,7 @@ EOF
 }
 
 resource "aws_cloudwatch_log_group" "test" {
-  name = %q
+  name = %[1]q
 }
 
 resource "aws_flow_log" "test" {
@@ -471,21 +451,13 @@ resource "aws_flow_log" "test" {
   subnet_id      = "${aws_subnet.test.id}"
   traffic_type   = "ALL"
 }
-`, rName, rName, rName, rName)
+`, rName)
 }
 
 func testAccFlowLogConfig_VPCID(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_vpc" "test" {
-  cidr_block = "10.0.0.0/16"
-
-  tags = {
-    Name = %q
-  }
-}
-
+	return testAccFlowLogConfigBase(rName) + fmt.Sprintf(`
 resource "aws_iam_role" "test" {
-  name = %q
+  name = %[1]q
 
   assume_role_policy = <<EOF
 {
@@ -508,7 +480,7 @@ EOF
 }
 
 resource "aws_cloudwatch_log_group" "test" {
-  name = %q
+  name = %[1]q
 }
 
 resource "aws_flow_log" "test" {
@@ -517,20 +489,12 @@ resource "aws_flow_log" "test" {
   traffic_type   = "ALL"
   vpc_id         = "${aws_vpc.test.id}"
 }
-`, rName, rName, rName)
+`, rName)
 }
 func testAccFlowLogConfig_LogFormat(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_vpc" "test" {
-  cidr_block = "10.0.0.0/16"
-
-  tags = {
-    Name = %q
-  }
-}
-
+	return testAccFlowLogConfigBase(rName) + fmt.Sprintf(`
 resource "aws_iam_role" "test" {
-  name = %q
+  name = %[1]q
 
   assume_role_policy = <<EOF
 {
@@ -553,10 +517,10 @@ EOF
 }
 
 resource "aws_cloudwatch_log_group" "test" {
-  name = %q
+  name = %[1]q
 }
 resource "aws_s3_bucket" "test" {
-	bucket        = %q
+	bucket        = %[1]q
 	force_destroy = true
   }
   
@@ -570,19 +534,11 @@ resource "aws_flow_log" "test" {
   vpc_id         = "${aws_vpc.test.id}"
   log_format     = "$${version} $${vpc-id} $${subnet-id}"
 }
-`, rName, rName, rName, rName)
+`, rName)
 }
 
 func testAccFlowLogConfigTags1(rName, tagKey1, tagValue1 string) string {
-	return fmt.Sprintf(`
-resource "aws_vpc" "test" {
-  cidr_block = "10.0.0.0/16"
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
+	return testAccFlowLogConfigBase(rName) + fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name = %[1]q
 
@@ -624,15 +580,7 @@ resource "aws_flow_log" "test" {
 }
 
 func testAccFlowLogConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return fmt.Sprintf(`
-resource "aws_vpc" "test" {
-  cidr_block = "10.0.0.0/16"
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
+	return testAccFlowLogConfigBase(rName) + fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name = %[1]q
 

--- a/website/docs/r/flow_log.html.markdown
+++ b/website/docs/r/flow_log.html.markdown
@@ -102,6 +102,7 @@ The following arguments are supported:
 * `subnet_id` - (Optional) Subnet ID to attach to
 * `vpc_id` - (Optional) VPC ID to attach to
 * `log_format` - (Optional) The fields to include in the flow log record, in the order in which they should appear.
+* `tags` - (Optional) Key-value mapping of resource tags
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12245

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_flow_log: add tagging support
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSFlowLog_'
--- PASS: TestAccAWSFlowLog_VPCID (205.42s)
--- PASS: TestAccAWSFlowLog_LogFormat (274.04s)
--- PASS: TestAccAWSFlowLog_SubnetID (205.10s)
--- PASS: TestAccAWSFlowLog_LogDestinationType_CloudWatchLogs (154.09s)
--- PASS: TestAccAWSFlowLog_LogDestinationType_S3 (144.37s)
--- PASS: TestAccAWSFlowLog_LogDestinationType_S3_Invalid (73.61s)
--- PASS: TestAccAWSFlowLog_tags (344.29s)
--- PASS: TestAccAWSFlowLog_disappears (149.67s)
```
