### PR TITLE
tests/provider: Remove extraneously hardcoded provider configurations in test configurations

### DIFF
--- a/aws/data_source_aws_elastic_beanstalk_hosted_zone_test.go
+++ b/aws/data_source_aws_elastic_beanstalk_hosted_zone_test.go
@@ -6,9 +6,12 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSDataSourceElasticBeanstalkHostedZone(t *testing.T) {
+func TestAccAWSDataSourceElasticBeanstalkHostedZone_basic(t *testing.T) {
+	dataSourceName := "data.aws_elastic_beanstalk_hosted_zone.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -16,19 +19,30 @@ func TestAccAWSDataSourceElasticBeanstalkHostedZone(t *testing.T) {
 			{
 				Config: testAccCheckAwsElasticBeanstalkHostedZoneDataSource_currentRegion,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_elastic_beanstalk_hosted_zone.current", "id", "Z2PCDNR3VC2G1N"),
+					testAccCheckAwsElasticBeanstalkHostedZone(dataSourceName, testAccGetRegion()),
 				),
 			},
+		},
+	})
+}
+
+func TestAccAWSDataSourceElasticBeanstalkHostedZone_Region(t *testing.T) {
+	dataSourceName := "data.aws_elastic_beanstalk_hosted_zone.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckAwsElasticBeanstalkHostedZoneDataSource_byRegion("ap-southeast-2"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_elastic_beanstalk_hosted_zone.test", "id", "Z2PCDNR3VC2G1N"),
+					testAccCheckAwsElasticBeanstalkHostedZone(dataSourceName, "ap-southeast-2"),
 				),
 			},
 			{
 				Config: testAccCheckAwsElasticBeanstalkHostedZoneDataSource_byRegion("eu-west-1"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_elastic_beanstalk_hosted_zone.test", "id", "Z2NYPWQ7DFZAZH"),
+					testAccCheckAwsElasticBeanstalkHostedZone(dataSourceName, "eu-west-1"),
 				),
 			},
 			{
@@ -39,11 +53,20 @@ func TestAccAWSDataSourceElasticBeanstalkHostedZone(t *testing.T) {
 	})
 }
 
-const testAccCheckAwsElasticBeanstalkHostedZoneDataSource_currentRegion = `
-provider "aws" {
-	region = "ap-southeast-2"
+func testAccCheckAwsElasticBeanstalkHostedZone(resourceName string, region string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		expectedValue, ok := elasticBeanstalkHostedZoneIds[region]
+
+		if !ok {
+			return fmt.Errorf("Unsupported region: %s", region)
+		}
+
+		return resource.TestCheckResourceAttr(resourceName, "id", expectedValue)(s)
+	}
 }
-data "aws_elastic_beanstalk_hosted_zone" "current" {}
+
+const testAccCheckAwsElasticBeanstalkHostedZoneDataSource_currentRegion = `
+data "aws_elastic_beanstalk_hosted_zone" "test" {}
 `
 
 func testAccCheckAwsElasticBeanstalkHostedZoneDataSource_byRegion(r string) string {

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -381,25 +381,6 @@ func testAccPartitionHasServicePreCheck(serviceId string, t *testing.T) {
 	}
 }
 
-// testAccRegionHasServicePreCheck skips a test if the AWS Go SDK endpoint value in a region is missing
-// NOTE: Most acceptance testing should prefer behavioral checks against an API (e.g. making an API call and
-//       using response errors) to determine if a test should be skipped since AWS Go SDK endpoint information
-//       can be incorrect, especially for newer endpoints or for private feature testing. This functionality
-//       is provided for cases where the API behavior may be completely unacceptable, such as permanent
-//       retries by the AWS Go SDK.
-func testAccRegionHasServicePreCheck(serviceId string, t *testing.T) {
-	regionId := testAccGetRegion()
-	if partition, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), regionId); ok {
-		service, ok := partition.Services()[serviceId]
-		if !ok {
-			t.Skip(fmt.Sprintf("skipping tests; partition %s does not support %s service", partition.ID(), serviceId))
-		}
-		if _, ok := service.Regions()[regionId]; !ok {
-			t.Skip(fmt.Sprintf("skipping tests; region %s does not support %s service", regionId, serviceId))
-		}
-	}
-}
-
 func testAccMultipleRegionsPreCheck(t *testing.T) {
 	if partition, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), testAccGetRegion()); ok {
 		if len(partition.Regions()) < 2 {
@@ -422,6 +403,7 @@ func testAccOrganizationsAccountPreCheck(t *testing.T) {
 }
 
 func testAccAlternateAccountProviderConfig() string {
+	//lintignore:AT004
 	return fmt.Sprintf(`
 provider "aws" {
   access_key = %[1]q
@@ -433,6 +415,7 @@ provider "aws" {
 }
 
 func testAccAlternateAccountAlternateRegionProviderConfig() string {
+	//lintignore:AT004
 	return fmt.Sprintf(`
 provider "aws" {
   access_key = %[1]q
@@ -445,6 +428,7 @@ provider "aws" {
 }
 
 func testAccAlternateRegionProviderConfig() string {
+	//lintignore:AT004
 	return fmt.Sprintf(`
 provider "aws" {
   alias  = "alternate"
@@ -454,6 +438,7 @@ provider "aws" {
 }
 
 func testAccProviderConfigIgnoreTagPrefixes1(keyPrefix1 string) string {
+	//lintignore:AT004
 	return fmt.Sprintf(`
 provider "aws" {
   ignore_tag_prefixes = [%[1]q]
@@ -462,6 +447,7 @@ provider "aws" {
 }
 
 func testAccProviderConfigIgnoreTags1(key1 string) string {
+	//lintignore:AT004
 	return fmt.Sprintf(`
 provider "aws" {
   ignore_tags = [%[1]q]
@@ -476,6 +462,7 @@ provider "aws" {
 // Other valid usage is for services only available in us-east-1 such as the
 // Cost and Usage Reporting and Pricing services.
 func testAccUsEast1RegionProviderConfig() string {
+	//lintignore:AT004
 	return fmt.Sprintf(`
 provider "aws" {
   alias  = "us-east-1"
@@ -1112,6 +1099,7 @@ func testAccCheckAWSProviderPartition(providers *[]*schema.Provider, expectedPar
 }
 
 func testAccAWSProviderConfigEndpoints(endpoints string) string {
+	//lintignore:AT004
 	return fmt.Sprintf(`
 provider "aws" {
   skip_credentials_validation = true
@@ -1132,6 +1120,7 @@ data "aws_arn" "test" {
 }
 
 func testAccAWSProviderConfigIgnoreTagPrefixes0() string {
+	//lintignore:AT004
 	return fmt.Sprintf(`
 provider "aws" {
   skip_credentials_validation = true
@@ -1148,6 +1137,7 @@ data "aws_arn" "test" {
 }
 
 func testAccAWSProviderConfigIgnoreTagPrefixes1(tagPrefix1 string) string {
+	//lintignore:AT004
 	return fmt.Sprintf(`
 provider "aws" {
   ignore_tag_prefixes         = [%[1]q]
@@ -1165,6 +1155,7 @@ data "aws_arn" "test" {
 }
 
 func testAccAWSProviderConfigIgnoreTagPrefixes2(tagPrefix1, tagPrefix2 string) string {
+	//lintignore:AT004
 	return fmt.Sprintf(`
 provider "aws" {
   ignore_tag_prefixes         = [%[1]q, %[2]q]
@@ -1182,6 +1173,7 @@ data "aws_arn" "test" {
 }
 
 func testAccAWSProviderConfigIgnoreTags0() string {
+	//lintignore:AT004
 	return fmt.Sprintf(`
 provider "aws" {
   skip_credentials_validation = true
@@ -1198,6 +1190,7 @@ data "aws_arn" "test" {
 }
 
 func testAccAWSProviderConfigIgnoreTags1(tag1 string) string {
+	//lintignore:AT004
 	return fmt.Sprintf(`
 provider "aws" {
   ignore_tags                 = [%[1]q]
@@ -1215,6 +1208,7 @@ data "aws_arn" "test" {
 }
 
 func testAccAWSProviderConfigIgnoreTags2(tag1, tag2 string) string {
+	//lintignore:AT004
 	return fmt.Sprintf(`
 provider "aws" {
   ignore_tags                 = [%[1]q, %[2]q]
@@ -1232,6 +1226,7 @@ data "aws_arn" "test" {
 }
 
 func testAccAWSProviderConfigRegion(region string) string {
+	//lintignore:AT004
 	return fmt.Sprintf(`
 provider "aws" {
   region                      = %[1]q
@@ -1256,6 +1251,7 @@ func testAccAssumeRoleARNPreCheck(t *testing.T) {
 }
 
 func testAccProviderConfigAssumeRolePolicy(policy string) string {
+	//lintignore:AT004
 	return fmt.Sprintf(`
 provider "aws" {
 	assume_role {

--- a/aws/resource_aws_ami_from_instance_test.go
+++ b/aws/resource_aws_ami_from_instance_test.go
@@ -129,16 +129,33 @@ func testAccCheckAWSAMIFromInstanceDestroy(s *terraform.State) error {
 
 func testAccAWSAMIFromInstanceConfigBase() string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
+data "aws_ec2_instance_type_offering" "available" {
+  filter {
+    name   = "instance-type"
+    values = ["t3.micro", "t2.micro"]
+  }
+
+  preferred_instance_types = ["t3.micro", "t2.micro"]
+}
+
+data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn-ami-minimal-hvm-*"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
 }
 
 resource "aws_instance" "test" {
-  // This AMI has one block device mapping, so we expect to have
-  // one snapshot in our created AMI.
-  ami = "ami-408c7f28"
-
-  instance_type = "t1.micro"
+  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
 
   tags = {
     Name = "testAccAWSAMIFromInstanceConfig_TestAMI"

--- a/aws/resource_aws_codecommit_trigger_test.go
+++ b/aws/resource_aws_codecommit_trigger_test.go
@@ -7,22 +7,25 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/codecommit"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func TestAccAWSCodeCommitTrigger_basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_codecommit_trigger.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCodeCommitTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCodeCommitTrigger_basic,
+				Config: testAccCodeCommitTrigger_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCodeCommitTriggerExists("aws_codecommit_trigger.test"),
-					resource.TestCheckResourceAttr(
-						"aws_codecommit_trigger.test", "trigger.#", "1"),
+					testAccCheckCodeCommitTriggerExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "trigger.#", "1"),
 				),
 			},
 		},
@@ -81,24 +84,24 @@ func testAccCheckCodeCommitTriggerExists(name string) resource.TestCheckFunc {
 	}
 }
 
-const testAccCodeCommitTrigger_basic = `
-provider "aws" {
-  region = "us-east-1"
-}
+func testAccCodeCommitTrigger_basic(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_sns_topic" "test" {
-  name = "tf-test-topic"
+  name = %[1]q
 }
+
 resource "aws_codecommit_repository" "test" {
-  repository_name = "tf_test_repository"
-  description = "This is a test description"
+  repository_name = %[1]q
 }
+
 resource "aws_codecommit_trigger" "test" {
-   depends_on = ["aws_codecommit_repository.test"]
-   repository_name = "tf_test_repository"
-    trigger {
-    name = "tf-test-trigger"
-    events = ["all"]
-    destination_arn = "${aws_sns_topic.test.arn}"
+  repository_name = aws_codecommit_repository.test.id
+
+  trigger {
+    name            = %[1]q
+    events          = ["all"]
+    destination_arn = aws_sns_topic.test.arn
   }
  }
-`
+`, rName)
+}

--- a/aws/resource_aws_dynamodb_global_table_test.go
+++ b/aws/resource_aws_dynamodb_global_table_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
@@ -53,13 +54,19 @@ func TestAccAWSDynamoDbGlobalTable_basic(t *testing.T) {
 }
 
 func TestAccAWSDynamoDbGlobalTable_multipleRegions(t *testing.T) {
+	var providers []*schema.Provider
 	resourceName := "aws_dynamodb_global_table.test"
 	tableName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSDynamodbGlobalTable(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsDynamoDbGlobalTableDestroy,
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSDynamodbGlobalTable(t)
+			testAccMultipleRegionsPreCheck(t)
+			testAccAlternateRegionPreCheck(t)
+		},
+		ProviderFactories: testAccProviderFactories(&providers),
+		CheckDestroy:      testAccCheckAwsDynamoDbGlobalTableDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDynamoDbGlobalTableConfig_multipleRegions1(tableName),
@@ -67,12 +74,11 @@ func TestAccAWSDynamoDbGlobalTable_multipleRegions(t *testing.T) {
 					testAccCheckAwsDynamoDbGlobalTableExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", tableName),
 					resource.TestCheckResourceAttr(resourceName, "replica.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "replica.2896117718.region_name", "us-east-1"),
-					resource.TestMatchResourceAttr(resourceName, "arn",
-						regexp.MustCompile("^arn:aws:dynamodb::[0-9]{12}:global-table/[a-z0-9-]+$")),
+					testAccMatchResourceAttrGlobalARN(resourceName, "arn", "dynamodb", regexp.MustCompile("global-table/[a-z0-9-]+$")),
 				),
 			},
 			{
+				Config:            testAccDynamoDbGlobalTableConfig_multipleRegions1(tableName),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -82,17 +88,13 @@ func TestAccAWSDynamoDbGlobalTable_multipleRegions(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsDynamoDbGlobalTableExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "replica.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "replica.2896117718.region_name", "us-east-1"),
-					resource.TestCheckResourceAttr(resourceName, "replica.2276617237.region_name", "us-east-2"),
 				),
 			},
 			{
-				Config: testAccDynamoDbGlobalTableConfig_multipleRegions3(tableName),
+				Config: testAccDynamoDbGlobalTableConfig_multipleRegions1(tableName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsDynamoDbGlobalTableExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "replica.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "replica.2896117718.region_name", "us-east-1"),
-					resource.TestCheckResourceAttr(resourceName, "replica.3965887460.region_name", "us-west-2"),
+					resource.TestCheckResourceAttr(resourceName, "replica.#", "1"),
 				),
 			},
 		},
@@ -183,27 +185,16 @@ resource "aws_dynamodb_global_table" "test" {
 }
 
 func testAccDynamoDbGlobalTableConfig_multipleRegions_dynamodb_tables(tableName string) string {
-	return fmt.Sprintf(`
-provider "aws" {
-  alias  = "us-east-1"
-  region = "us-east-1"
+	return testAccAlternateRegionProviderConfig() + fmt.Sprintf(`
+data "aws_region" "alternate" {
+  provider = "aws.alternate"
 }
 
-provider "aws" {
-  alias  = "us-east-2"
-  region = "us-east-2"
-}
+data "aws_region" "current" {}
 
-provider "aws" {
-  alias  = "us-west-2"
-  region = "us-west-2"
-}
-
-resource "aws_dynamodb_table" "us-east-1" {
-  provider = "aws.us-east-1"
-
+resource "aws_dynamodb_table" "test" {
   hash_key         = "myAttribute"
-  name             = "%s"
+  name             = %[1]q
   stream_enabled   = true
   stream_view_type = "NEW_AND_OLD_IMAGES"
   read_capacity    = 1
@@ -215,11 +206,11 @@ resource "aws_dynamodb_table" "us-east-1" {
   }
 }
 
-resource "aws_dynamodb_table" "us-east-2" {
-  provider = "aws.us-east-2"
+resource "aws_dynamodb_table" "alternate" {
+  provider = "aws.alternate"
 
   hash_key         = "myAttribute"
-  name             = "%s"
+  name             = %[1]q
   stream_enabled   = true
   stream_view_type = "NEW_AND_OLD_IMAGES"
   read_capacity    = 1
@@ -230,82 +221,37 @@ resource "aws_dynamodb_table" "us-east-2" {
     type = "S"
   }
 }
-
-resource "aws_dynamodb_table" "us-west-2" {
-  provider = "aws.us-west-2"
-
-  hash_key         = "myAttribute"
-  name             = "%s"
-  stream_enabled   = true
-  stream_view_type = "NEW_AND_OLD_IMAGES"
-  read_capacity    = 1
-  write_capacity   = 1
-
-  attribute {
-    name = "myAttribute"
-    type = "S"
-  }
-}
-`, tableName, tableName, tableName)
+`, tableName)
 }
 
 func testAccDynamoDbGlobalTableConfig_multipleRegions1(tableName string) string {
-	return fmt.Sprintf(`
-%s
-
+	return testAccDynamoDbGlobalTableConfig_multipleRegions_dynamodb_tables(tableName) + fmt.Sprintf(`
 resource "aws_dynamodb_global_table" "test" {
-  depends_on = ["aws_dynamodb_table.us-east-1"]
-  provider   = "aws.us-east-1"
-
-  name = "%s"
+  name = aws_dynamodb_table.test.name
 
   replica {
-    region_name = "us-east-1"
+    region_name = data.aws_region.current.name
   }
 }
-`, testAccDynamoDbGlobalTableConfig_multipleRegions_dynamodb_tables(tableName), tableName)
+`)
 }
 
 func testAccDynamoDbGlobalTableConfig_multipleRegions2(tableName string) string {
-	return fmt.Sprintf(`
-%s
-
+	return testAccDynamoDbGlobalTableConfig_multipleRegions_dynamodb_tables(tableName) + fmt.Sprintf(`
 resource "aws_dynamodb_global_table" "test" {
-  depends_on = ["aws_dynamodb_table.us-east-1", "aws_dynamodb_table.us-east-2"]
-  provider   = "aws.us-east-1"
+  depends_on = [aws_dynamodb_table.alternate]
 
-  name = "%s"
+  name = aws_dynamodb_table.test.name
 
   replica {
-    region_name = "us-east-1"
+    region_name = data.aws_region.alternate.name
   }
 
   replica {
-    region_name = "us-east-2"
-  }
-}
-`, testAccDynamoDbGlobalTableConfig_multipleRegions_dynamodb_tables(tableName), tableName)
-}
-
-func testAccDynamoDbGlobalTableConfig_multipleRegions3(tableName string) string {
-	return fmt.Sprintf(`
-%s
-
-resource "aws_dynamodb_global_table" "test" {
-  depends_on = ["aws_dynamodb_table.us-east-1", "aws_dynamodb_table.us-west-2"]
-  provider   = "aws.us-east-1"
-
-  name = "%s"
-
-  replica {
-    region_name = "us-east-1"
-  }
-
-  replica {
-    region_name = "us-west-2"
+    region_name = data.aws_region.current.name
   }
 }
-`, testAccDynamoDbGlobalTableConfig_multipleRegions_dynamodb_tables(tableName), tableName)
+`)
 }
 
 func testAccDynamoDbGlobalTableConfig_invalidName(tableName string) string {

--- a/aws/resource_aws_eip_test.go
+++ b/aws/resource_aws_eip_test.go
@@ -275,37 +275,27 @@ func TestAccAWSEIP_associated_user_private_ip(t *testing.T) {
 
 // Regression test for https://github.com/hashicorp/terraform/issues/3429 (now
 // https://github.com/terraform-providers/terraform-provider-aws/issues/42)
-func TestAccAWSEIP_classic_disassociate(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+func TestAccAWSEIP_Instance_Reassociate(t *testing.T) {
+	instanceResourceName := "aws_instance.test"
+	resourceName := "aws_eip.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEIP_classic_disassociate("instance-store"),
+				Config: testAccAWSEIP_Instance(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(
-						"aws_eip.test.0",
-						"instance"),
-					resource.TestCheckResourceAttrSet(
-						"aws_eip.test.1",
-						"instance"),
+					resource.TestCheckResourceAttrPair(resourceName, "instance", instanceResourceName, "id"),
 				),
 			},
 			{
-				Config: testAccAWSEIP_classic_disassociate("ebs"),
+				Config: testAccAWSEIP_Instance(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(
-						"aws_eip.test.0",
-						"instance"),
-					resource.TestCheckResourceAttrSet(
-						"aws_eip.test.1",
-						"instance"),
+					resource.TestCheckResourceAttrPair(resourceName, "instance", instanceResourceName, "id"),
 				),
+				Taint: []string{resourceName},
 			},
 		},
 	})
@@ -995,51 +985,51 @@ resource "aws_eip" "test2" {
 }
 `
 
-func testAccAWSEIP_classic_disassociate(rootDeviceType string) string {
+func testAccAWSEIP_Instance() string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
-variable "server_count" {
-  default = 2
-}
-
-data "aws_ami" "amzn-ami-minimal-pv" {
+data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
   most_recent = true
   owners      = ["amazon"]
 
   filter {
     name = "name"
-    values = ["amzn-ami-minimal-pv-*"]
+    values = ["amzn-ami-minimal-hvm-*"]
   }
+
   filter {
     name = "root-device-type"
-    values = [%q]
+    values = ["ebs"]
   }
 }
 
-data "aws_availability_zones" "available" {
-  state = "available"
+data "aws_ec2_instance_type_offering" "available" {
+  filter {
+    name   = "instance-type"
+    values = ["t3.micro", "t2.micro"]
+  }
+
+  filter {
+    name   = "location"
+    values = [aws_subnet.test.availability_zone]
+  }
+
+  location_type            = "availability-zone"
+  preferred_instance_types = ["t3.micro", "t2.micro"]
 }
 
 resource "aws_eip" "test" {
-  count    = "${var.server_count}"
-  instance = "${element(aws_instance.example.*.id, count.index)}"
+  instance = aws_instance.test.id
   vpc      = true
 }
 
-resource "aws_instance" "example" {
-  count = "${var.server_count}"
-
-  ami                         = "${data.aws_ami.amzn-ami-minimal-pv.id}"
-  instance_type               = "m1.small"
+resource "aws_instance" "test" {
+  ami                         = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   associate_public_ip_address = true
-  subnet_id                   = "${aws_subnet.us-east-1-0-public.id}"
-  availability_zone           = "${aws_subnet.us-east-1-0-public.availability_zone}"
+  instance_type               = data.aws_ec2_instance_type_offering.available.instance_type
+  subnet_id                   = aws_subnet.test.id
 
   tags = {
-    Name = "testAccAWSEIP_classic_disassociate"
+    Name = "testAccAWSEIP_Instance"
   }
 
   lifecycle {
@@ -1047,41 +1037,41 @@ resource "aws_instance" "example" {
   }
 }
 
-resource "aws_vpc" "example" {
+resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-	tags = {
-		Name = "terraform-testacc-eip-classic-disassociate"
-	}
-}
 
-resource "aws_internet_gateway" "example" {
-  vpc_id = "${aws_vpc.example.id}"
-}
-
-resource "aws_subnet" "us-east-1-0-public" {
-  vpc_id = "${aws_vpc.example.id}"
-
-  cidr_block        = "10.0.0.0/24"
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
   tags = {
-    Name = "tf-acc-eip-classic-disassociate"
+    Name = "terraform-testacc-eip-disassociate"
   }
 }
 
-resource "aws_route_table" "us-east-1-public" {
-  vpc_id = "${aws_vpc.example.id}"
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+}
+
+resource "aws_subnet" "test" {
+  cidr_block = "10.0.0.0/24"
+  vpc_id     = aws_vpc.test.id
+
+  tags = {
+    Name = "tf-acc-eip-disassociate"
+  }
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
 
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = "${aws_internet_gateway.example.id}"
+    gateway_id = aws_internet_gateway.test.id
   }
 }
 
-resource "aws_route_table_association" "us-east-1-0-public" {
-  subnet_id      = "${aws_subnet.us-east-1-0-public.id}"
-  route_table_id = "${aws_route_table.us-east-1-public.id}"
+resource "aws_route_table_association" "test" {
+  subnet_id      = aws_subnet.test.id
+  route_table_id = aws_route_table.test.id
 }
-`, rootDeviceType)
+`)
 }
 
 const testAccAWSEIPAssociate_not_associated = `

--- a/aws/resource_aws_pinpoint_adm_channel_test.go
+++ b/aws/resource_aws_pinpoint_adm_channel_test.go
@@ -43,17 +43,13 @@ func testAccAwsPinpointADMChannelConfigurationFromEnv(t *testing.T) *testAccAwsP
 }
 
 func TestAccAWSPinpointADMChannel_basic(t *testing.T) {
-	oldDefaultRegion := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldDefaultRegion)
-
 	var channel pinpoint.ADMChannelResponse
 	resourceName := "aws_pinpoint_adm_channel.channel"
 
 	config := testAccAwsPinpointADMChannelConfigurationFromEnv(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSPinpointADMChannelDestroy,
@@ -113,10 +109,6 @@ func testAccCheckAWSPinpointADMChannelExists(n string, channel *pinpoint.ADMChan
 
 func testAccAWSPinpointADMChannelConfig_basic(conf *testAccAwsPinpointADMChannelConfiguration) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
 resource "aws_pinpoint_app" "test_app" {}
 
 resource "aws_pinpoint_adm_channel" "channel" {

--- a/aws/resource_aws_pinpoint_apns_channel_test.go
+++ b/aws/resource_aws_pinpoint_apns_channel_test.go
@@ -89,17 +89,13 @@ func testAccAwsPinpointAPNSChannelTokenConfigurationFromEnv(t *testing.T) *testA
 }
 
 func TestAccAWSPinpointAPNSChannel_basicCertificate(t *testing.T) {
-	oldDefaultRegion := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldDefaultRegion)
-
 	var channel pinpoint.APNSChannelResponse
 	resourceName := "aws_pinpoint_apns_channel.test_apns_channel"
 
 	configuration := testAccAwsPinpointAPNSChannelCertConfigurationFromEnv(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSPinpointAPNSChannelDestroy,
@@ -127,17 +123,13 @@ func TestAccAWSPinpointAPNSChannel_basicCertificate(t *testing.T) {
 }
 
 func TestAccAWSPinpointAPNSChannel_basicToken(t *testing.T) {
-	oldDefaultRegion := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldDefaultRegion)
-
 	var channel pinpoint.APNSChannelResponse
 	resourceName := "aws_pinpoint_apns_channel.test_apns_channel"
 
 	configuration := testAccAwsPinpointAPNSChannelTokenConfigurationFromEnv(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSPinpointAPNSChannelDestroy,
@@ -195,10 +187,6 @@ func testAccCheckAWSPinpointAPNSChannelExists(n string, channel *pinpoint.APNSCh
 
 func testAccAWSPinpointAPNSChannelConfig_basicCertificate(conf *testAccAwsPinpointAPNSChannelCertConfiguration) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
 resource "aws_pinpoint_app" "test_app" {}
 
 resource "aws_pinpoint_apns_channel" "test_apns_channel" {
@@ -213,10 +201,6 @@ resource "aws_pinpoint_apns_channel" "test_apns_channel" {
 
 func testAccAWSPinpointAPNSChannelConfig_basicToken(conf *testAccAwsPinpointAPNSChannelTokenConfiguration) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
 resource "aws_pinpoint_app" "test_app" {}
 
 resource "aws_pinpoint_apns_channel" "test_apns_channel" {

--- a/aws/resource_aws_pinpoint_apns_sandbox_channel_test.go
+++ b/aws/resource_aws_pinpoint_apns_sandbox_channel_test.go
@@ -89,17 +89,13 @@ func testAccAwsPinpointAPNSSandboxChannelTokenConfigurationFromEnv(t *testing.T)
 }
 
 func TestAccAWSPinpointAPNSSandboxChannel_basicCertificate(t *testing.T) {
-	oldDefaultRegion := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldDefaultRegion)
-
 	var channel pinpoint.APNSSandboxChannelResponse
 	resourceName := "aws_pinpoint_apns_sandbox_channel.test_channel"
 
 	configuration := testAccAwsPinpointAPNSSandboxChannelCertConfigurationFromEnv(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSPinpointAPNSSandboxChannelDestroy,
@@ -127,17 +123,13 @@ func TestAccAWSPinpointAPNSSandboxChannel_basicCertificate(t *testing.T) {
 }
 
 func TestAccAWSPinpointAPNSSandboxChannel_basicToken(t *testing.T) {
-	oldDefaultRegion := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldDefaultRegion)
-
 	var channel pinpoint.APNSSandboxChannelResponse
 	resourceName := "aws_pinpoint_apns_sandbox_channel.test_channel"
 
 	configuration := testAccAwsPinpointAPNSSandboxChannelTokenConfigurationFromEnv(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSPinpointAPNSSandboxChannelDestroy,
@@ -195,10 +187,6 @@ func testAccCheckAWSPinpointAPNSSandboxChannelExists(n string, channel *pinpoint
 
 func testAccAWSPinpointAPNSSandboxChannelConfig_basicCertificate(conf *testAccAwsPinpointAPNSSandboxChannelCertConfiguration) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
 resource "aws_pinpoint_app" "test_app" {}
 
 resource "aws_pinpoint_apns_sandbox_channel" "test_channel" {
@@ -213,10 +201,6 @@ resource "aws_pinpoint_apns_sandbox_channel" "test_channel" {
 
 func testAccAWSPinpointAPNSSandboxChannelConfig_basicToken(conf *testAccAwsPinpointAPNSSandboxChannelTokenConfiguration) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
 resource "aws_pinpoint_app" "test_app" {}
 
 resource "aws_pinpoint_apns_sandbox_channel" "test_channel" {

--- a/aws/resource_aws_pinpoint_apns_voip_channel_test.go
+++ b/aws/resource_aws_pinpoint_apns_voip_channel_test.go
@@ -89,17 +89,13 @@ func testAccAwsPinpointAPNSVoipChannelTokenConfigurationFromEnv(t *testing.T) *t
 }
 
 func TestAccAWSPinpointAPNSVoipChannel_basicCertificate(t *testing.T) {
-	oldDefaultRegion := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldDefaultRegion)
-
 	var channel pinpoint.APNSVoipChannelResponse
 	resourceName := "aws_pinpoint_apns_voip_channel.test_channel"
 
 	configuration := testAccAwsPinpointAPNSVoipChannelCertConfigurationFromEnv(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSPinpointAPNSVoipChannelDestroy,
@@ -127,17 +123,13 @@ func TestAccAWSPinpointAPNSVoipChannel_basicCertificate(t *testing.T) {
 }
 
 func TestAccAWSPinpointAPNSVoipChannel_basicToken(t *testing.T) {
-	oldDefaultRegion := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldDefaultRegion)
-
 	var channel pinpoint.APNSVoipChannelResponse
 	resourceName := "aws_pinpoint_apns_voip_channel.test_channel"
 
 	configuration := testAccAwsPinpointAPNSVoipChannelTokenConfigurationFromEnv(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSPinpointAPNSVoipChannelDestroy,
@@ -195,10 +187,6 @@ func testAccCheckAWSPinpointAPNSVoipChannelExists(n string, channel *pinpoint.AP
 
 func testAccAWSPinpointAPNSVoipChannelConfig_basicCertificate(conf *testAccAwsPinpointAPNSVoipChannelCertConfiguration) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
 resource "aws_pinpoint_app" "test_app" {}
 
 resource "aws_pinpoint_apns_voip_channel" "test_channel" {
@@ -213,10 +201,6 @@ resource "aws_pinpoint_apns_voip_channel" "test_channel" {
 
 func testAccAWSPinpointAPNSVoipChannelConfig_basicToken(conf *testAccAwsPinpointAPNSVoipChannelTokenConfiguration) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
 resource "aws_pinpoint_app" "test_app" {}
 
 resource "aws_pinpoint_apns_voip_channel" "test_channel" {

--- a/aws/resource_aws_pinpoint_apns_voip_sandbox_channel_test.go
+++ b/aws/resource_aws_pinpoint_apns_voip_sandbox_channel_test.go
@@ -89,17 +89,13 @@ func testAccAwsPinpointAPNSVoipSandboxChannelTokenConfigurationFromEnv(t *testin
 }
 
 func TestAccAWSPinpointAPNSVoipSandboxChannel_basicCertificate(t *testing.T) {
-	oldDefaultRegion := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldDefaultRegion)
-
 	var channel pinpoint.APNSVoipSandboxChannelResponse
 	resourceName := "aws_pinpoint_apns_voip_sandbox_channel.test_channel"
 
 	configuration := testAccAwsPinpointAPNSVoipSandboxChannelCertConfigurationFromEnv(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSPinpointAPNSVoipSandboxChannelDestroy,
@@ -127,17 +123,13 @@ func TestAccAWSPinpointAPNSVoipSandboxChannel_basicCertificate(t *testing.T) {
 }
 
 func TestAccAWSPinpointAPNSVoipSandboxChannel_basicToken(t *testing.T) {
-	oldDefaultRegion := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldDefaultRegion)
-
 	var channel pinpoint.APNSVoipSandboxChannelResponse
 	resourceName := "aws_pinpoint_apns_voip_sandbox_channel.test_channel"
 
 	configuration := testAccAwsPinpointAPNSVoipSandboxChannelTokenConfigurationFromEnv(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSPinpointAPNSVoipSandboxChannelDestroy,
@@ -195,10 +187,6 @@ func testAccCheckAWSPinpointAPNSVoipSandboxChannelExists(n string, channel *pinp
 
 func testAccAWSPinpointAPNSVoipSandboxChannelConfig_basicCertificate(conf *testAccAwsPinpointAPNSVoipSandboxChannelCertConfiguration) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
 resource "aws_pinpoint_app" "test_app" {}
 
 resource "aws_pinpoint_apns_voip_sandbox_channel" "test_channel" {
@@ -213,10 +201,6 @@ resource "aws_pinpoint_apns_voip_sandbox_channel" "test_channel" {
 
 func testAccAWSPinpointAPNSVoipSandboxChannelConfig_basicToken(conf *testAccAwsPinpointAPNSVoipSandboxChannelTokenConfiguration) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
 resource "aws_pinpoint_app" "test_app" {}
 
 resource "aws_pinpoint_apns_voip_sandbox_channel" "test_channel" {

--- a/aws/resource_aws_pinpoint_app_test.go
+++ b/aws/resource_aws_pinpoint_app_test.go
@@ -69,7 +69,7 @@ func TestAccAWSPinpointApp_basic(t *testing.T) {
 	resourceName := "aws_pinpoint_app.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccRegionHasServicePreCheck("pinpoint", t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSPinpointAppDestroy,
@@ -95,7 +95,7 @@ func TestAccAWSPinpointApp_CampaignHookLambda(t *testing.T) {
 	resourceName := "aws_pinpoint_app.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccRegionHasServicePreCheck("pinpoint", t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSPinpointAppDestroy,
@@ -123,7 +123,7 @@ func TestAccAWSPinpointApp_Limits(t *testing.T) {
 	resourceName := "aws_pinpoint_app.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccRegionHasServicePreCheck("pinpoint", t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSPinpointAppDestroy,
@@ -151,7 +151,7 @@ func TestAccAWSPinpointApp_QuietTime(t *testing.T) {
 	resourceName := "aws_pinpoint_app.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccRegionHasServicePreCheck("pinpoint", t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSPinpointAppDestroy,
@@ -179,7 +179,7 @@ func TestAccAWSPinpointApp_Tags(t *testing.T) {
 	resourceName := "aws_pinpoint_app.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccRegionHasServicePreCheck("pinpoint", t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsRamResourceShareDestroy,
 		Steps: []resource.TestStep{
@@ -215,6 +215,22 @@ func TestAccAWSPinpointApp_Tags(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccPreCheckAWSPinpointApp(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).pinpointconn
+
+	input := &pinpoint.GetAppsInput{}
+
+	_, err := conn.GetApps(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
 }
 
 func testAccCheckAWSPinpointAppExists(n string, application *pinpoint.ApplicationResponse) resource.TestCheckFunc {

--- a/aws/resource_aws_pinpoint_baidu_channel_test.go
+++ b/aws/resource_aws_pinpoint_baidu_channel_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/pinpoint"
@@ -13,10 +12,6 @@ import (
 )
 
 func TestAccAWSPinpointBaiduChannel_basic(t *testing.T) {
-	oldDefaultRegion := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldDefaultRegion)
-
 	var channel pinpoint.BaiduChannelResponse
 	resourceName := "aws_pinpoint_baidu_channel.channel"
 
@@ -25,7 +20,7 @@ func TestAccAWSPinpointBaiduChannel_basic(t *testing.T) {
 	secretKey := "456"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSPinpointBaiduChannelDestroy,
@@ -46,7 +41,7 @@ func TestAccAWSPinpointBaiduChannel_basic(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"api_key", "secret_key"},
 			},
 			{
-				Config: testAccAWSPinpointBaiduChannelConfig_update(apikeyUpdated, secretKey),
+				Config: testAccAWSPinpointBaiduChannelConfig_basic(apikeyUpdated, secretKey),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSPinpointBaiduChannelExists(resourceName, &channel),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
@@ -89,28 +84,6 @@ func testAccCheckAWSPinpointBaiduChannelExists(n string, channel *pinpoint.Baidu
 
 func testAccAWSPinpointBaiduChannelConfig_basic(apiKey, secretKey string) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
-resource "aws_pinpoint_app" "test_app" {}
-
-resource "aws_pinpoint_baidu_channel" "channel" {
-  application_id = "${aws_pinpoint_app.test_app.application_id}"
-
-  enabled    = "false"
-  api_key    = "%s"
-  secret_key = "%s"
-}
-`, apiKey, secretKey)
-}
-
-func testAccAWSPinpointBaiduChannelConfig_update(apiKey, secretKey string) string {
-	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
 resource "aws_pinpoint_app" "test_app" {}
 
 resource "aws_pinpoint_baidu_channel" "channel" {

--- a/aws/resource_aws_pinpoint_email_channel_test.go
+++ b/aws/resource_aws_pinpoint_email_channel_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/pinpoint"
@@ -13,21 +12,17 @@ import (
 )
 
 func TestAccAWSPinpointEmailChannel_basic(t *testing.T) {
-	oldDefaultRegion := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldDefaultRegion)
-
 	var channel pinpoint.EmailChannelResponse
 	resourceName := "aws_pinpoint_email_channel.test_email_channel"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSPinpointEmailChannelDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSPinpointEmailChannelConfig_basic,
+				Config: testAccAWSPinpointEmailChannelConfig_FromAddress("user@example.com"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSPinpointEmailChannelExists(resourceName, &channel),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
@@ -40,7 +35,7 @@ func TestAccAWSPinpointEmailChannel_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSPinpointEmailChannelConfig_update,
+				Config: testAccAWSPinpointEmailChannelConfig_FromAddress("userupdated@example.com"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSPinpointEmailChannelExists(resourceName, &channel),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
@@ -80,17 +75,14 @@ func testAccCheckAWSPinpointEmailChannelExists(n string, channel *pinpoint.Email
 	}
 }
 
-const testAccAWSPinpointEmailChannelConfig_basic = `
-provider "aws" {
-  region = "us-east-1"
-}
-
+func testAccAWSPinpointEmailChannelConfig_FromAddress(fromAddress string) string {
+	return fmt.Sprintf(`
 resource "aws_pinpoint_app" "test_app" {}
 
 resource "aws_pinpoint_email_channel" "test_email_channel" {
   application_id = "${aws_pinpoint_app.test_app.application_id}"
   enabled        = "false"
-  from_address   = "user@example.com"
+  from_address   = %[1]q
   identity       = "${aws_ses_domain_identity.test_identity.arn}"
   role_arn       = "${aws_iam_role.test_role.arn}"
 }
@@ -136,65 +128,8 @@ resource "aws_iam_role_policy" "test_role_policy" {
 }
 EOF
 }
-`
-
-const testAccAWSPinpointEmailChannelConfig_update = `
-provider "aws" {
-  region = "us-east-1"
+`, fromAddress)
 }
-
-resource "aws_pinpoint_app" "test_app" {}
-
-resource "aws_pinpoint_email_channel" "test_email_channel" {
-  application_id = "${aws_pinpoint_app.test_app.application_id}"
-  enabled        = "false"
-  from_address   = "userupdate@example.com"
-  identity       = "${aws_ses_domain_identity.test_identity.arn}"
-  role_arn       = "${aws_iam_role.test_role.arn}"
-}
-
-resource "aws_ses_domain_identity" "test_identity" {
-  domain = "example.com"
-}
-
-resource "aws_iam_role" "test_role" {
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "pinpoint.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy" "test_role_policy" {
-  name   = "test_policy"
-  role   = "${aws_iam_role.test_role.id}"
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": {
-    "Action": [
-      "mobileanalytics:PutEvents",
-      "mobileanalytics:PutItems"
-    ],
-    "Effect": "Allow",
-    "Resource": [
-      "*"
-    ]
-  }
-}
-EOF
-}
-`
 
 func testAccCheckAWSPinpointEmailChannelDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).pinpointconn

--- a/aws/resource_aws_pinpoint_event_stream_test.go
+++ b/aws/resource_aws_pinpoint_event_stream_test.go
@@ -2,32 +2,29 @@ package aws
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/pinpoint"
-
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/pinpoint"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func TestAccAWSPinpointEventStream_basic(t *testing.T) {
-	oldDefaultRegion := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldDefaultRegion)
-
 	var stream pinpoint.EventStream
 	resourceName := "aws_pinpoint_event_stream.test_event_stream"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rName2 := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSPinpointEventStreamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSPinpointEventStreamConfig_basic,
+				Config: testAccAWSPinpointEventStreamConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSPinpointEventStreamExists(resourceName, &stream),
 				),
@@ -38,7 +35,7 @@ func TestAccAWSPinpointEventStream_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSPinpointEventStreamConfig_update,
+				Config: testAccAWSPinpointEventStreamConfig_basic(rName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSPinpointEventStreamExists(resourceName, &stream),
 				),
@@ -76,11 +73,8 @@ func testAccCheckAWSPinpointEventStreamExists(n string, stream *pinpoint.EventSt
 	}
 }
 
-const testAccAWSPinpointEventStreamConfig_basic = `
-provider "aws" {
-  region = "us-east-1"
-}
-
+func testAccAWSPinpointEventStreamConfig_basic(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_pinpoint_app" "test_app" {}
 
 resource "aws_pinpoint_event_stream" "test_event_stream" {
@@ -90,7 +84,7 @@ resource "aws_pinpoint_event_stream" "test_event_stream" {
 }
 
 resource "aws_kinesis_stream" "test_stream" {
-  name        = "terraform-kinesis-test"
+  name        = %[1]q
   shard_count = 1
 }
 
@@ -102,7 +96,7 @@ resource "aws_iam_role" "test_role" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "pinpoint.us-east-1.amazonaws.com"
+        "Service": "pinpoint.amazonaws.com"
       },
       "Effect": "Allow",
       "Sid": ""
@@ -125,70 +119,14 @@ resource "aws_iam_role_policy" "test_role_policy" {
     ],
     "Effect": "Allow",
     "Resource": [
-      "arn:aws:kinesis:us-east-1:*:*/*"
+      "*"
     ]
   }
 }
 EOF
 }
-`
-
-const testAccAWSPinpointEventStreamConfig_update = `
-provider "aws" {
-  region = "us-east-1"
+`, rName)
 }
-
-resource "aws_pinpoint_app" "test_app" {}
-
-resource "aws_pinpoint_event_stream" "test_event_stream" {
-  application_id         = "${aws_pinpoint_app.test_app.application_id}"
-  destination_stream_arn = "${aws_kinesis_stream.test_stream_updated.arn}"
-  role_arn               = "${aws_iam_role.test_role.arn}"
-}
-
-resource "aws_kinesis_stream" "test_stream_updated" {
-  name        = "terraform-kinesis-test-updated"
-  shard_count = 1
-}
-
-resource "aws_iam_role" "test_role" {
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "pinpoint.us-east-1.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy" "test_role_policy" {
-  name   = "test_policy"
-  role   = "${aws_iam_role.test_role.id}"
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": {
-    "Action": [
-      "kinesis:PutRecords",
-      "kinesis:DescribeStream"
-    ],
-    "Effect": "Allow",
-    "Resource": [
-      "arn:aws:kinesis:us-east-1:*:*/*"
-    ]
-  }
-}
-EOF
-}
-`
 
 func testAccCheckAWSPinpointEventStreamDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).pinpointconn

--- a/aws/resource_aws_pinpoint_gcm_channel_test.go
+++ b/aws/resource_aws_pinpoint_gcm_channel_test.go
@@ -19,10 +19,6 @@ import (
 **/
 
 func TestAccAWSPinpointGCMChannel_basic(t *testing.T) {
-	oldDefaultRegion := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldDefaultRegion)
-
 	var channel pinpoint.GCMChannelResponse
 	resourceName := "aws_pinpoint_gcm_channel.test_gcm_channel"
 
@@ -33,7 +29,7 @@ func TestAccAWSPinpointGCMChannel_basic(t *testing.T) {
 	apiKey := os.Getenv("GCM_API_KEY")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSPinpointGCMChannelDestroy,
@@ -93,10 +89,6 @@ func testAccCheckAWSPinpointGCMChannelExists(n string, channel *pinpoint.GCMChan
 
 func testAccAWSPinpointGCMChannelConfig_basic(apiKey string) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
 resource "aws_pinpoint_app" "test_app" {}
 
 resource "aws_pinpoint_gcm_channel" "test_gcm_channel" {

--- a/aws/resource_aws_pinpoint_sms_channel_test.go
+++ b/aws/resource_aws_pinpoint_sms_channel_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/pinpoint"
@@ -13,15 +12,11 @@ import (
 )
 
 func TestAccAWSPinpointSMSChannel_basic(t *testing.T) {
-	oldDefaultRegion := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldDefaultRegion)
-
 	var channel pinpoint.SMSChannelResponse
 	resourceName := "aws_pinpoint_sms_channel.test_sms_channel"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSPinpointSMSChannelDestroy,
@@ -58,10 +53,6 @@ func TestAccAWSPinpointSMSChannel_basic(t *testing.T) {
 	})
 }
 func TestAccAWSPinpointSMSChannel_full(t *testing.T) {
-	oldDefaultRegion := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldDefaultRegion)
-
 	var channel pinpoint.SMSChannelResponse
 	resourceName := "aws_pinpoint_sms_channel.test_sms_channel"
 	senderId := "1234"
@@ -69,7 +60,7 @@ func TestAccAWSPinpointSMSChannel_full(t *testing.T) {
 	newShortCode := "7890"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSPinpointApp(t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSPinpointSMSChannelDestroy,
@@ -144,10 +135,6 @@ func testAccCheckAWSPinpointSMSChannelExists(n string, channel *pinpoint.SMSChan
 }
 
 const testAccAWSPinpointSMSChannelConfig_basic = `
-provider "aws" {
-  region = "us-east-1"
-}
-
 resource "aws_pinpoint_app" "test_app" {}
 
 resource "aws_pinpoint_sms_channel" "test_sms_channel" {
@@ -156,10 +143,6 @@ resource "aws_pinpoint_sms_channel" "test_sms_channel" {
 
 func testAccAWSPinpointSMSChannelConfig_full(senderId, shortCode string) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
 resource "aws_pinpoint_app" "test_app" {}
 
 resource "aws_pinpoint_sms_channel" "test_sms_channel" {

--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -672,29 +672,32 @@ func TestAccAWSRDSCluster_copyTagsToSnapshot(t *testing.T) {
 func TestAccAWSRDSCluster_EncryptedCrossRegionReplication(t *testing.T) {
 	var primaryCluster rds.DBCluster
 	var replicaCluster rds.DBCluster
-	resourceName := "aws_rds_cluster.test_primary"
-	resourceName2 := "aws_rds_cluster.test_replica"
+	resourceName := "aws_rds_cluster.test"
+	resourceName2 := "aws_rds_cluster.alternate"
+	rInt := acctest.RandInt()
 
 	// record the initialized providers so that we can use them to
 	// check for the cluster in each region
 	var providers []*schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccMultipleRegionsPreCheck(t)
+			testAccAlternateRegionPreCheck(t)
+		},
 		ProviderFactories: testAccProviderFactories(&providers),
 		CheckDestroy:      testAccCheckWithProviders(testAccCheckAWSClusterDestroyWithProvider, &providers),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSClusterConfigEncryptedCrossRegionReplica(acctest.RandInt()),
+				Config: testAccAWSClusterConfigEncryptedCrossRegionReplica(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSClusterExistsWithProvider(resourceName,
-						&primaryCluster, testAccAwsRegionProviderFunc("us-west-2", &providers)),
-					testAccCheckAWSClusterExistsWithProvider(resourceName2,
-						&replicaCluster, testAccAwsRegionProviderFunc("us-east-1", &providers)),
+					testAccCheckAWSClusterExistsWithProvider(resourceName, &primaryCluster, testAccAwsRegionProviderFunc(testAccGetRegion(), &providers)),
+					testAccCheckAWSClusterExistsWithProvider(resourceName2, &replicaCluster, testAccAwsRegionProviderFunc(testAccGetAlternateRegion(), &providers)),
 				),
 			},
 			{
-				Config:            testAccAWSClusterConfigEncryptedCrossRegionReplica(acctest.RandInt()),
+				Config:            testAccAWSClusterConfigEncryptedCrossRegionReplica(rInt),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -2793,30 +2796,16 @@ resource "aws_rds_cluster" "test" {
 }
 
 func testAccAWSClusterConfigEncryptedCrossRegionReplica(n int) string {
-	return fmt.Sprintf(`
-provider "aws" {
-  alias  = "useast1"
-  region = "us-east-1"
+	return testAccAlternateRegionProviderConfig() + fmt.Sprintf(`
+data "aws_availability_zones" "alternate" {
+  provider = "aws.alternate"
 }
 
-provider "aws" {
-  alias  = "uswest2"
-  region = "us-west-2"
-}
+data "aws_caller_identity" "current" {}
 
-data "aws_availability_zones" "us-east-1" {
-  provider = "aws.useast1"
-}
+data "aws_region" "current" {}
 
-resource "aws_rds_cluster_instance" "test_instance" {
-  provider           = "aws.uswest2"
-  identifier         = "tf-aurora-instance-%[1]d"
-  cluster_identifier = "${aws_rds_cluster.test_primary.id}"
-  instance_class     = "db.t2.small"
-}
-
-resource "aws_rds_cluster_parameter_group" "default" {
-  provider    = "aws.uswest2"
+resource "aws_rds_cluster_parameter_group" "test" {
   name        = "tf-aurora-prm-grp-%[1]d"
   family      = "aurora5.6"
   description = "RDS default cluster parameter group"
@@ -2828,10 +2817,9 @@ resource "aws_rds_cluster_parameter_group" "default" {
   }
 }
 
-resource "aws_rds_cluster" "test_primary" {
-  provider                        = "aws.uswest2"
+resource "aws_rds_cluster" "test" {
   cluster_identifier              = "tf-test-primary-%[1]d"
-  db_cluster_parameter_group_name = "${aws_rds_cluster_parameter_group.default.name}"
+  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.test.name
   database_name                   = "mydb"
   master_username                 = "foo"
   master_password                 = "mustbeeightcharaters"
@@ -2839,10 +2827,14 @@ resource "aws_rds_cluster" "test_primary" {
   skip_final_snapshot             = true
 }
 
-data "aws_caller_identity" "current" {}
+resource "aws_rds_cluster_instance" "test" {
+  identifier         = "tf-aurora-instance-%[1]d"
+  cluster_identifier = aws_rds_cluster.test.id
+  instance_class     = "db.t2.small"
+}
 
-resource "aws_kms_key" "kms_key_east" {
-  provider    = "aws.useast1"
+resource "aws_kms_key" "alternate" {
+  provider    = "aws.alternate"
   description = "Terraform acc test %[1]d"
 
   policy = <<POLICY
@@ -2864,8 +2856,8 @@ resource "aws_kms_key" "kms_key_east" {
   POLICY
 }
 
-resource "aws_vpc" "main" {
-  provider   = "aws.useast1"
+resource "aws_vpc" "alternate" {
+  provider   = "aws.alternate"
   cidr_block = "10.0.0.0/16"
 
   tags = {
@@ -2873,11 +2865,11 @@ resource "aws_vpc" "main" {
   }
 }
 
-resource "aws_subnet" "db" {
-  provider          = "aws.useast1"
+resource "aws_subnet" "alternate" {
+  provider          = "aws.alternate"
   count             = 3
-  vpc_id            = "${aws_vpc.main.id}"
-  availability_zone = "${data.aws_availability_zones.us-east-1.names[count.index]}"
+  vpc_id            = aws_vpc.alternate.id
+  availability_zone = data.aws_availability_zones.alternate.names[count.index]
   cidr_block        = "10.0.${count.index}.0/24"
 
   tags = {
@@ -2885,27 +2877,27 @@ resource "aws_subnet" "db" {
   }
 }
 
-resource "aws_db_subnet_group" "replica" {
-  provider   = "aws.useast1"
+resource "aws_db_subnet_group" "alternate" {
+  provider   = "aws.alternate"
   name       = "test_replica-subnet-%[1]d"
-  subnet_ids = ["${aws_subnet.db.*.id[0]}", "${aws_subnet.db.*.id[1]}", "${aws_subnet.db.*.id[2]}"]
+  subnet_ids = aws_subnet.alternate[*].id
 }
 
-resource "aws_rds_cluster" "test_replica" {
-  provider                      = "aws.useast1"
+resource "aws_rds_cluster" "alternate" {
+  provider                      = "aws.alternate"
   cluster_identifier            = "tf-test-replica-%[1]d"
-  db_subnet_group_name          = "${aws_db_subnet_group.replica.name}"
+  db_subnet_group_name          = aws_db_subnet_group.alternate.name
   database_name                 = "mydb"
   master_username               = "foo"
   master_password               = "mustbeeightcharaters"
-  kms_key_id                    = "${aws_kms_key.kms_key_east.arn}"
+  kms_key_id                    = aws_kms_key.alternate.arn
   storage_encrypted             = true
   skip_final_snapshot           = true
-  replication_source_identifier = "arn:aws:rds:us-west-2:${data.aws_caller_identity.current.account_id}:cluster:${aws_rds_cluster.test_primary.cluster_identifier}"
-  source_region                 = "us-west-2"
+  replication_source_identifier = aws_rds_cluster.test.arn
+  source_region                 = data.aws_region.current.name
 
   depends_on = [
-    "aws_rds_cluster_instance.test_instance",
+    aws_rds_cluster_instance.test,
   ]
 }
 `, n)

--- a/aws/resource_aws_route53_zone_association_test.go
+++ b/aws/resource_aws_route53_zone_association_test.go
@@ -111,26 +111,29 @@ func TestAccAWSRoute53ZoneAssociation_disappears_Zone(t *testing.T) {
 
 func TestAccAWSRoute53ZoneAssociation_region(t *testing.T) {
 	var vpc route53.VPC
-	resourceName := "aws_route53_zone_association.foobar"
+	resourceName := "aws_route53_zone_association.test"
 
 	// record the initialized providers so that we can use them to
 	// check for the instances in each region
 	var providers []*schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccMultipleRegionsPreCheck(t)
+			testAccAlternateRegionPreCheck(t)
+		},
 		ProviderFactories: testAccProviderFactories(&providers),
-		CheckDestroy:      testAccCheckWithProviders(testAccCheckRoute53ZoneAssociationDestroyWithProvider, &providers),
+		CheckDestroy:      testAccCheckRoute53ZoneAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53ZoneAssociationRegionConfig,
+				Config: testAccRoute53ZoneAssociationRegionConfig(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53ZoneAssociationExistsWithProvider(resourceName, &vpc,
-						testAccAwsRegionProviderFunc("us-west-2", &providers)),
+					testAccCheckRoute53ZoneAssociationExists(resourceName, &vpc),
 				),
 			},
 			{
-				Config:            testAccRoute53ZoneAssociationRegionConfig,
+				Config:            testAccRoute53ZoneAssociationRegionConfig(),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -140,11 +143,7 @@ func TestAccAWSRoute53ZoneAssociation_region(t *testing.T) {
 }
 
 func testAccCheckRoute53ZoneAssociationDestroy(s *terraform.State) error {
-	return testAccCheckRoute53ZoneAssociationDestroyWithProvider(s, testAccProvider)
-}
-
-func testAccCheckRoute53ZoneAssociationDestroyWithProvider(s *terraform.State, provider *schema.Provider) error {
-	conn := provider.Meta().(*AWSClient).r53conn
+	conn := testAccProvider.Meta().(*AWSClient).r53conn
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_route53_zone_association" {
 			continue
@@ -174,10 +173,6 @@ func testAccCheckRoute53ZoneAssociationDestroyWithProvider(s *terraform.State, p
 }
 
 func testAccCheckRoute53ZoneAssociationExists(n string, vpc *route53.VPC) resource.TestCheckFunc {
-	return testAccCheckRoute53ZoneAssociationExistsWithProvider(n, vpc, func() *schema.Provider { return testAccProvider })
-}
-
-func testAccCheckRoute53ZoneAssociationExistsWithProvider(n string, vpc *route53.VPC, providerF func() *schema.Provider) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -194,8 +189,7 @@ func testAccCheckRoute53ZoneAssociationExistsWithProvider(n string, vpc *route53
 			return err
 		}
 
-		provider := providerF()
-		conn := provider.Meta().(*AWSClient).r53conn
+		conn := testAccProvider.Meta().(*AWSClient).r53conn
 
 		associationVPC, err := route53GetZoneAssociation(conn, zoneID, vpcID)
 
@@ -264,53 +258,53 @@ resource "aws_route53_zone_association" "foobar" {
 }
 `
 
-const testAccRoute53ZoneAssociationRegionConfig = `
-provider "aws" {
-	alias = "west"
-	region = "us-west-2"
+func testAccRoute53ZoneAssociationRegionConfig() string {
+	return testAccAlternateRegionProviderConfig() + `
+data "aws_region" "alternate" {
+  provider = "aws.alternate"
 }
 
-provider "aws" {
-	alias = "east"
-	region = "us-east-1"
+data "aws_region" "current" {}
+
+resource "aws_vpc" "test" {
+  cidr_block           = "10.6.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name = "terraform-testacc-route53-zone-association-region-foo"
+  }
 }
 
-resource "aws_vpc" "foo" {
-	provider = "aws.west"
-	cidr_block = "10.6.0.0/16"
-	enable_dns_hostnames = true
-	enable_dns_support = true
-	tags = {
-		Name = "terraform-testacc-route53-zone-association-region-foo"
-	}
+resource "aws_vpc" "alternate" {
+  provider = "aws.alternate"
+
+  cidr_block           = "10.7.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name = "terraform-testacc-route53-zone-association-region-bar"
+  }
 }
 
-resource "aws_vpc" "bar" {
-	provider = "aws.east"
-	cidr_block = "10.7.0.0/16"
-	enable_dns_hostnames = true
-	enable_dns_support = true
-	tags = {
-		Name = "terraform-testacc-route53-zone-association-region-bar"
-	}
+resource "aws_route53_zone" "test" {
+  name = "foo.com"
+
+  vpc {
+    vpc_id     = aws_vpc.test.id
+    vpc_region = data.aws_region.current.name
+  }
+
+  lifecycle {
+    ignore_changes = [vpc]
+  }
 }
 
-resource "aws_route53_zone" "foo" {
-	provider = "aws.west"
-	name = "foo.com"
-	vpc {
-		vpc_id     = "${aws_vpc.foo.id}"
-		vpc_region = "us-west-2"
-	}
-	lifecycle {
-		ignore_changes = ["vpc"]
-	}
-}
-
-resource "aws_route53_zone_association" "foobar" {
-	provider = "aws.west"
-	zone_id = "${aws_route53_zone.foo.id}"
-	vpc_id  = "${aws_vpc.bar.id}"
-	vpc_region = "us-east-1"
+resource "aws_route53_zone_association" "test" {
+  vpc_id     = aws_vpc.alternate.id
+  vpc_region = data.aws_region.alternate.name
+  zone_id    = aws_route53_zone.test.id
 }
 `
+}

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -456,25 +456,19 @@ func TestAccAWSS3Bucket_generatedName(t *testing.T) {
 }
 
 func TestAccAWSS3Bucket_region(t *testing.T) {
-	resourceName := "aws_s3_bucket.bucket"
-	rInt := acctest.RandInt()
-	bucketName := fmt.Sprintf("tf-test-bucket-%d", rInt)
-	region := "eu-west-1"
-	var providers []*schema.Provider
+	resourceName := "aws_s3_bucket.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-			testAccMultipleRegionsPreCheck(t)
-		},
-		ProviderFactories: testAccProviderFactories(&providers),
-		CheckDestroy:      testAccCheckWithProviders(testAccCheckAWSS3BucketDestroyWithProvider, &providers),
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSS3BucketConfigWithRegion(bucketName, region),
+				Config: testAccAWSS3BucketConfigWithRegion(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketExistsWithProvider(resourceName, testAccAwsRegionProviderFunc(region, &providers)),
-					resource.TestCheckResourceAttr(resourceName, "region", region),
+					testAccCheckAWSS3BucketExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "region", testAccGetRegion()),
 				),
 			},
 		},
@@ -1471,8 +1465,10 @@ func TestAccAWSS3Bucket_LifecycleExpireMarkerOnly(t *testing.T) {
 
 func TestAccAWSS3Bucket_Replication(t *testing.T) {
 	rInt := acctest.RandInt()
+	alternateRegion := testAccGetAlternateRegion()
 	region := testAccGetRegion()
 	partition := testAccGetPartition()
+	iamRoleResourceName := "aws_iam_role.role"
 	resourceName := "aws_s3_bucket.bucket"
 
 	// record the initialized providers so that we can use them to check for the instances in each region
@@ -1482,6 +1478,7 @@ func TestAccAWSS3Bucket_Replication(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccMultipleRegionsPreCheck(t)
+			testAccAlternateRegionPreCheck(t)
 		},
 		ProviderFactories: testAccProviderFactories(&providers),
 		CheckDestroy:      testAccCheckWithProviders(testAccCheckAWSS3BucketDestroyWithProvider, &providers),
@@ -1490,7 +1487,7 @@ func TestAccAWSS3Bucket_Replication(t *testing.T) {
 				Config: testAccAWSS3BucketConfigReplication(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketExistsWithProvider(resourceName, testAccAwsRegionProviderFunc(region, &providers)),
-					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc("eu-west-1", &providers)),
+					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc(alternateRegion, &providers)),
 					resource.TestCheckResourceAttr(resourceName, "replication_configuration.#", "0"),
 				),
 			},
@@ -1507,9 +1504,9 @@ func TestAccAWSS3Bucket_Replication(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketExistsWithProvider(resourceName, testAccAwsRegionProviderFunc(region, &providers)),
 					resource.TestCheckResourceAttr(resourceName, "replication_configuration.#", "1"),
-					resource.TestMatchResourceAttr(resourceName, "replication_configuration.0.role", regexp.MustCompile(fmt.Sprintf("^arn:aws[\\w-]*:iam::[\\d+]+:role/tf-iam-role-replication-%d", rInt))),
+					resource.TestCheckResourceAttrPair(resourceName, "replication_configuration.0.role", iamRoleResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "replication_configuration.0.rules.#", "1"),
-					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc("eu-west-1", &providers)),
+					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc(alternateRegion, &providers)),
 					testAccCheckAWSS3BucketReplicationRules(
 						resourceName,
 						testAccAwsRegionProviderFunc(region, &providers),
@@ -1532,9 +1529,9 @@ func TestAccAWSS3Bucket_Replication(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketExistsWithProvider(resourceName, testAccAwsRegionProviderFunc(region, &providers)),
 					resource.TestCheckResourceAttr(resourceName, "replication_configuration.#", "1"),
-					resource.TestMatchResourceAttr(resourceName, "replication_configuration.0.role", regexp.MustCompile(fmt.Sprintf("^arn:aws[\\w-]*:iam::[\\d+]+:role/tf-iam-role-replication-%d", rInt))),
+					resource.TestCheckResourceAttrPair(resourceName, "replication_configuration.0.role", iamRoleResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "replication_configuration.0.rules.#", "1"),
-					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc("eu-west-1", &providers)),
+					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc(alternateRegion, &providers)),
 					testAccCheckAWSS3BucketReplicationRules(
 						resourceName,
 						testAccAwsRegionProviderFunc(region, &providers),
@@ -1557,7 +1554,7 @@ func TestAccAWSS3Bucket_Replication(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketExistsWithProvider(resourceName, testAccAwsRegionProviderFunc(region, &providers)),
 					resource.TestCheckResourceAttr(resourceName, "replication_configuration.#", "1"),
-					resource.TestMatchResourceAttr(resourceName, "replication_configuration.0.role", regexp.MustCompile(fmt.Sprintf("^arn:aws[\\w-]*:iam::[\\d+]+:role/tf-iam-role-replication-%d", rInt))),
+					resource.TestCheckResourceAttrPair(resourceName, "replication_configuration.0.role", iamRoleResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "replication_configuration.0.rules.#", "1"),
 					testAccCheckAWSS3BucketReplicationRules(
 						resourceName,
@@ -1592,6 +1589,7 @@ func TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlT
 	rInt := acctest.RandInt()
 	region := testAccGetRegion()
 	partition := testAccGetPartition()
+	iamRoleResourceName := "aws_iam_role.role"
 	resourceName := "aws_s3_bucket.bucket"
 
 	// record the initialized providers so that we can use them to check for the instances in each region
@@ -1601,6 +1599,7 @@ func TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlT
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccMultipleRegionsPreCheck(t)
+			testAccAlternateRegionPreCheck(t)
 		},
 		ProviderFactories: testAccProviderFactories(&providers),
 		CheckDestroy:      testAccCheckWithProviders(testAccCheckAWSS3BucketDestroyWithProvider, &providers),
@@ -1610,7 +1609,7 @@ func TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlT
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketExistsWithProvider(resourceName, testAccAwsRegionProviderFunc(region, &providers)),
 					resource.TestCheckResourceAttr(resourceName, "replication_configuration.#", "1"),
-					resource.TestMatchResourceAttr(resourceName, "replication_configuration.0.role", regexp.MustCompile(fmt.Sprintf("^arn:%s:iam::[\\d+]+:role/tf-iam-role-replication-%d", partition, rInt))),
+					resource.TestCheckResourceAttrPair(resourceName, "replication_configuration.0.role", iamRoleResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "replication_configuration.0.rules.#", "1"),
 					testAccCheckAWSS3BucketReplicationRules(
 						resourceName,
@@ -1646,7 +1645,7 @@ func TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlT
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketExistsWithProvider(resourceName, testAccAwsRegionProviderFunc(region, &providers)),
 					resource.TestCheckResourceAttr(resourceName, "replication_configuration.#", "1"),
-					resource.TestMatchResourceAttr(resourceName, "replication_configuration.0.role", regexp.MustCompile(fmt.Sprintf("^arn:%s:iam::[\\d+]+:role/tf-iam-role-replication-%d", partition, rInt))),
+					resource.TestCheckResourceAttrPair(resourceName, "replication_configuration.0.role", iamRoleResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "replication_configuration.0.rules.#", "1"),
 					testAccCheckAWSS3BucketReplicationRules(
 						resourceName,
@@ -1684,6 +1683,7 @@ func TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlT
 // StorageClass issue: https://github.com/hashicorp/terraform/issues/10909
 func TestAccAWSS3Bucket_ReplicationWithoutStorageClass(t *testing.T) {
 	rInt := acctest.RandInt()
+	alternateRegion := testAccGetAlternateRegion()
 	region := testAccGetRegion()
 	resourceName := "aws_s3_bucket.bucket"
 
@@ -1694,6 +1694,7 @@ func TestAccAWSS3Bucket_ReplicationWithoutStorageClass(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccMultipleRegionsPreCheck(t)
+			testAccAlternateRegionPreCheck(t)
 		},
 		ProviderFactories: testAccProviderFactories(&providers),
 		CheckDestroy:      testAccCheckWithProviders(testAccCheckAWSS3BucketDestroyWithProvider, &providers),
@@ -1702,7 +1703,7 @@ func TestAccAWSS3Bucket_ReplicationWithoutStorageClass(t *testing.T) {
 				Config: testAccAWSS3BucketConfigReplicationWithoutStorageClass(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketExistsWithProvider(resourceName, testAccAwsRegionProviderFunc(region, &providers)),
-					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc("eu-west-1", &providers)),
+					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc(alternateRegion, &providers)),
 				),
 			},
 			{
@@ -1727,6 +1728,7 @@ func TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError(t *testing.T)
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccMultipleRegionsPreCheck(t)
+			testAccAlternateRegionPreCheck(t)
 		},
 		ProviderFactories: testAccProviderFactories(&providers),
 		CheckDestroy:      testAccCheckWithProviders(testAccCheckAWSS3BucketDestroyWithProvider, &providers),
@@ -1742,6 +1744,7 @@ func TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError(t *testing.T)
 // Prefix issue: https://github.com/terraform-providers/terraform-provider-aws/issues/6340
 func TestAccAWSS3Bucket_ReplicationWithoutPrefix(t *testing.T) {
 	rInt := acctest.RandInt()
+	alternateRegion := testAccGetAlternateRegion()
 	region := testAccGetRegion()
 	resourceName := "aws_s3_bucket.bucket"
 
@@ -1752,6 +1755,7 @@ func TestAccAWSS3Bucket_ReplicationWithoutPrefix(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccMultipleRegionsPreCheck(t)
+			testAccAlternateRegionPreCheck(t)
 		},
 		ProviderFactories: testAccProviderFactories(&providers),
 		CheckDestroy:      testAccCheckWithProviders(testAccCheckAWSS3BucketDestroyWithProvider, &providers),
@@ -1760,7 +1764,7 @@ func TestAccAWSS3Bucket_ReplicationWithoutPrefix(t *testing.T) {
 				Config: testAccAWSS3BucketConfigReplicationWithoutPrefix(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketExistsWithProvider(resourceName, testAccAwsRegionProviderFunc(region, &providers)),
-					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc("eu-west-1", &providers)),
+					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc(alternateRegion, &providers)),
 				),
 			},
 			{
@@ -1777,8 +1781,10 @@ func TestAccAWSS3Bucket_ReplicationWithoutPrefix(t *testing.T) {
 
 func TestAccAWSS3Bucket_ReplicationSchemaV2(t *testing.T) {
 	rInt := acctest.RandInt()
+	alternateRegion := testAccGetAlternateRegion()
 	region := testAccGetRegion()
 	partition := testAccGetPartition()
+	iamRoleResourceName := "aws_iam_role.role"
 	resourceName := "aws_s3_bucket.bucket"
 
 	// record the initialized providers so that we can use them to check for the instances in each region
@@ -1788,6 +1794,7 @@ func TestAccAWSS3Bucket_ReplicationSchemaV2(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccMultipleRegionsPreCheck(t)
+			testAccAlternateRegionPreCheck(t)
 		},
 		ProviderFactories: testAccProviderFactories(&providers),
 		CheckDestroy:      testAccCheckWithProviders(testAccCheckAWSS3BucketDestroyWithProvider, &providers),
@@ -1797,9 +1804,9 @@ func TestAccAWSS3Bucket_ReplicationSchemaV2(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketExistsWithProvider(resourceName, testAccAwsRegionProviderFunc(region, &providers)),
 					resource.TestCheckResourceAttr(resourceName, "replication_configuration.#", "1"),
-					resource.TestMatchResourceAttr(resourceName, "replication_configuration.0.role", regexp.MustCompile(fmt.Sprintf("^arn:aws[\\w-]*:iam::[\\d+]+:role/tf-iam-role-replication-%d", rInt))),
+					resource.TestCheckResourceAttrPair(resourceName, "replication_configuration.0.role", iamRoleResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "replication_configuration.0.rules.#", "1"),
-					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc("eu-west-1", &providers)),
+					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc(alternateRegion, &providers)),
 					testAccCheckAWSS3BucketReplicationRules(
 						resourceName,
 						testAccAwsRegionProviderFunc(region, &providers),
@@ -1836,9 +1843,9 @@ func TestAccAWSS3Bucket_ReplicationSchemaV2(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketExistsWithProvider(resourceName, testAccAwsRegionProviderFunc(region, &providers)),
 					resource.TestCheckResourceAttr(resourceName, "replication_configuration.#", "1"),
-					resource.TestMatchResourceAttr(resourceName, "replication_configuration.0.role", regexp.MustCompile(fmt.Sprintf("^arn:aws[\\w-]*:iam::[\\d+]+:role/tf-iam-role-replication-%d", rInt))),
+					resource.TestCheckResourceAttrPair(resourceName, "replication_configuration.0.role", iamRoleResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "replication_configuration.0.rules.#", "1"),
-					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc("eu-west-1", &providers)),
+					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc(alternateRegion, &providers)),
 					testAccCheckAWSS3BucketReplicationRules(
 						resourceName,
 						testAccAwsRegionProviderFunc(region, &providers),
@@ -1875,9 +1882,9 @@ func TestAccAWSS3Bucket_ReplicationSchemaV2(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketExistsWithProvider(resourceName, testAccAwsRegionProviderFunc(region, &providers)),
 					resource.TestCheckResourceAttr(resourceName, "replication_configuration.#", "1"),
-					resource.TestMatchResourceAttr(resourceName, "replication_configuration.0.role", regexp.MustCompile(fmt.Sprintf("^arn:aws[\\w-]*:iam::[\\d+]+:role/tf-iam-role-replication-%d", rInt))),
+					resource.TestCheckResourceAttrPair(resourceName, "replication_configuration.0.role", iamRoleResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "replication_configuration.0.rules.#", "1"),
-					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc("eu-west-1", &providers)),
+					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc(alternateRegion, &providers)),
 					testAccCheckAWSS3BucketReplicationRules(
 						resourceName,
 						testAccAwsRegionProviderFunc(region, &providers),
@@ -1918,9 +1925,9 @@ func TestAccAWSS3Bucket_ReplicationSchemaV2(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketExistsWithProvider(resourceName, testAccAwsRegionProviderFunc(region, &providers)),
 					resource.TestCheckResourceAttr(resourceName, "replication_configuration.#", "1"),
-					resource.TestMatchResourceAttr(resourceName, "replication_configuration.0.role", regexp.MustCompile(fmt.Sprintf("^arn:aws[\\w-]*:iam::[\\d+]+:role/tf-iam-role-replication-%d", rInt))),
+					resource.TestCheckResourceAttrPair(resourceName, "replication_configuration.0.role", iamRoleResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "replication_configuration.0.rules.#", "1"),
-					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc("eu-west-1", &providers)),
+					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc(alternateRegion, &providers)),
 					testAccCheckAWSS3BucketReplicationRules(
 						resourceName,
 						testAccAwsRegionProviderFunc(region, &providers),
@@ -2935,19 +2942,15 @@ resource "aws_s3_bucket" "bucket6" {
 `, randInt)
 }
 
-func testAccAWSS3BucketConfigWithRegion(bucketName, region string) string {
+func testAccAWSS3BucketConfigWithRegion(bucketName string) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  alias  = "west"
-  region = "%s"
-}
+data "aws_region" "current" {}
 
-resource "aws_s3_bucket" "bucket" {
-  provider = "aws.west"
-  bucket   = "%s"
-  region   = "%s"
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+  region = data.aws_region.current.name
 }
-`, region, bucketName, region)
+`, bucketName)
 }
 
 func testAccAWSS3BucketWebsiteConfig(randInt int) string {
@@ -3461,19 +3464,12 @@ resource "aws_s3_bucket" "bucket" {
 `, randInt)
 }
 
-const testAccAWSS3BucketConfigReplicationBasic = `
-provider "aws" {
-  alias  = "euwest"
-  region = "eu-west-1"
-}
-
-provider "aws" {
-  alias  = "uswest2"
-  region = "us-west-2"
-}
+func testAccAWSS3BucketConfigReplicationBasic(randInt int) string {
+	return testAccAlternateRegionProviderConfig() + fmt.Sprintf(`
+data "aws_partition" "current" {}
 
 resource "aws_iam_role" "role" {
-  name               = "tf-iam-role-replication-%d"
+  name               = "tf-iam-role-replication-%[1]d"
   assume_role_policy = <<POLICY
 {
   "Version": "2012-10-17",
@@ -3481,7 +3477,7 @@ resource "aws_iam_role" "role" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "s3.amazonaws.com"
+        "Service": "s3.${data.aws_partition.current.dns_suffix}"
       },
       "Effect": "Allow",
       "Sid": ""
@@ -3490,37 +3486,35 @@ resource "aws_iam_role" "role" {
 }
 POLICY
 }
-`
+
+resource "aws_s3_bucket" "destination" {
+  provider = "aws.alternate"
+  bucket   = "tf-test-bucket-destination-%[1]d"
+
+  versioning {
+    enabled = true
+  }
+}
+`, randInt)
+}
 
 func testAccAWSS3BucketConfigReplication(randInt int) string {
-	return fmt.Sprintf(testAccAWSS3BucketConfigReplicationBasic+`
+	return testAccAWSS3BucketConfigReplicationBasic(randInt) + fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-    provider = "aws.uswest2"
-    bucket   = "tf-test-bucket-%d"
+    bucket   = "tf-test-bucket-%[1]d"
     acl      = "private"
 
     versioning {
         enabled = true
     }
 }
-
-resource "aws_s3_bucket" "destination" {
-    provider = "aws.euwest"
-    bucket   = "tf-test-bucket-destination-%d"
-    region   = "eu-west-1"
-
-    versioning {
-        enabled = true
-    }
-}
-`, randInt, randInt, randInt)
+`, randInt)
 }
 
 func testAccAWSS3BucketConfigReplicationWithConfiguration(randInt int, storageClass string) string {
-	return fmt.Sprintf(testAccAWSS3BucketConfigReplicationBasic+`
+	return testAccAWSS3BucketConfigReplicationBasic(randInt) + fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-    provider = "aws.uswest2"
-    bucket   = "tf-test-bucket-%d"
+    bucket   = "tf-test-bucket-%[1]d"
     acl      = "private"
 
     versioning {
@@ -3536,35 +3530,24 @@ resource "aws_s3_bucket" "bucket" {
 
             destination {
                 bucket        = "${aws_s3_bucket.destination.arn}"
-                storage_class = "%s"
+                storage_class = "%[2]s"
             }
         }
     }
 }
-
-resource "aws_s3_bucket" "destination" {
-    provider = "aws.euwest"
-    bucket   = "tf-test-bucket-destination-%d"
-    region   = "eu-west-1"
-
-    versioning {
-        enabled = true
-    }
-}
-`, randInt, randInt, storageClass, randInt)
+`, randInt, storageClass)
 }
 
 func testAccAWSS3BucketConfigReplicationWithSseKmsEncryptedObjects(randInt int) string {
-	return fmt.Sprintf(testAccAWSS3BucketConfigReplicationBasic+`
+	return testAccAWSS3BucketConfigReplicationBasic(randInt) + fmt.Sprintf(`
 resource "aws_kms_key" "replica" {
-  provider                = "aws.euwest"
+  provider                = "aws.alternate"
   description             = "TF Acceptance Test S3 repl KMS key"
   deletion_window_in_days = 7
 }
 
 resource "aws_s3_bucket" "bucket" {
-    provider = "aws.uswest2"
-    bucket   = "tf-test-bucket-%d"
+    bucket   = "tf-test-bucket-%[1]d"
     acl      = "private"
 
     versioning {
@@ -3592,26 +3575,15 @@ resource "aws_s3_bucket" "bucket" {
         }
     }
 }
-
-resource "aws_s3_bucket" "destination" {
-    provider = "aws.euwest"
-    bucket   = "tf-test-bucket-destination-%d"
-    region   = "eu-west-1"
-
-    versioning {
-        enabled = true
-    }
-}
-`, randInt, randInt, randInt)
+`, randInt)
 }
 
 func testAccAWSS3BucketConfigReplicationWithAccessControlTranslation(randInt int) string {
-	return fmt.Sprintf(testAccAWSS3BucketConfigReplicationBasic+`
+	return testAccAWSS3BucketConfigReplicationBasic(randInt) + fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 
 resource "aws_s3_bucket" "bucket" {
-    provider = "aws.uswest2"
-    bucket   = "tf-test-bucket-%d"
+    bucket   = "tf-test-bucket-%[1]d"
     acl      = "private"
 
     versioning {
@@ -3637,32 +3609,21 @@ resource "aws_s3_bucket" "bucket" {
         }
     }
 }
-
-resource "aws_s3_bucket" "destination" {
-    provider = "aws.euwest"
-    bucket   = "tf-test-bucket-destination-%d"
-    region   = "eu-west-1"
-
-    versioning {
-        enabled = true
-    }
-}
-`, randInt, randInt, randInt)
+`, randInt)
 }
 
 func testAccAWSS3BucketConfigReplicationWithSseKmsEncryptedObjectsAndAccessControlTranslation(randInt int) string {
-	return fmt.Sprintf(testAccAWSS3BucketConfigReplicationBasic+`
+	return testAccAWSS3BucketConfigReplicationBasic(randInt) + fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 
 resource "aws_kms_key" "replica" {
-  provider                = "aws.euwest"
+  provider                = "aws.alternate"
   description             = "TF Acceptance Test S3 repl KMS key"
   deletion_window_in_days = 7
 }
 
 resource "aws_s3_bucket" "bucket" {
-    provider = "aws.uswest2"
-    bucket   = "tf-test-bucket-%d"
+    bucket   = "tf-test-bucket-%[1]d"
     acl      = "private"
 
     versioning {
@@ -3695,24 +3656,13 @@ resource "aws_s3_bucket" "bucket" {
         }
     }
 }
-
-resource "aws_s3_bucket" "destination" {
-    provider = "aws.euwest"
-    bucket   = "tf-test-bucket-destination-%d"
-    region   = "eu-west-1"
-
-    versioning {
-        enabled = true
-    }
-}
-`, randInt, randInt, randInt)
+`, randInt)
 }
 
 func testAccAWSS3BucketConfigReplicationWithoutStorageClass(randInt int) string {
-	return fmt.Sprintf(testAccAWSS3BucketConfigReplicationBasic+`
+	return testAccAWSS3BucketConfigReplicationBasic(randInt) + fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-    provider = "aws.uswest2"
-    bucket   = "tf-test-bucket-%d"
+    bucket   = "tf-test-bucket-%[1]d"
     acl      = "private"
 
     versioning {
@@ -3732,24 +3682,13 @@ resource "aws_s3_bucket" "bucket" {
         }
     }
 }
-
-resource "aws_s3_bucket" "destination" {
-    provider = "aws.euwest"
-    bucket   = "tf-test-bucket-destination-%d"
-    region   = "eu-west-1"
-
-    versioning {
-        enabled = true
-    }
-}
-`, randInt, randInt, randInt)
+`, randInt)
 }
 
 func testAccAWSS3BucketConfigReplicationWithoutPrefix(randInt int) string {
-	return fmt.Sprintf(testAccAWSS3BucketConfigReplicationBasic+`
+	return testAccAWSS3BucketConfigReplicationBasic(randInt) + fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-    provider = "aws.uswest2"
-    bucket   = "tf-test-bucket-%d"
+    bucket   = "tf-test-bucket-%[1]d"
     acl      = "private"
 
     versioning {
@@ -3769,24 +3708,13 @@ resource "aws_s3_bucket" "bucket" {
         }
     }
 }
-
-resource "aws_s3_bucket" "destination" {
-    provider = "aws.euwest"
-    bucket   = "tf-test-bucket-destination-%d"
-    region   = "eu-west-1"
-
-    versioning {
-        enabled = true
-    }
-}
-`, randInt, randInt, randInt)
+`, randInt)
 }
 
 func testAccAWSS3BucketConfigReplicationNoVersioning(randInt int) string {
-	return fmt.Sprintf(testAccAWSS3BucketConfigReplicationBasic+`
+	return testAccAWSS3BucketConfigReplicationBasic(randInt) + fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-    provider = "aws.uswest2"
-    bucket   = "tf-test-bucket-%d"
+    bucket   = "tf-test-bucket-%[1]d"
     acl      = "private"
 
     replication_configuration {
@@ -3803,24 +3731,13 @@ resource "aws_s3_bucket" "bucket" {
         }
     }
 }
-
-resource "aws_s3_bucket" "destination" {
-    provider = "aws.euwest"
-    bucket   = "tf-test-bucket-destination-%d"
-    region   = "eu-west-1"
-
-    versioning {
-        enabled = true
-    }
-}
-`, randInt, randInt, randInt)
+`, randInt)
 }
 
 func testAccAWSS3BucketConfigReplicationWithV2ConfigurationNoTags(randInt int) string {
-	return fmt.Sprintf(testAccAWSS3BucketConfigReplicationBasic+`
+	return testAccAWSS3BucketConfigReplicationBasic(randInt) + fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-    provider = "aws.uswest2"
-    bucket   = "tf-test-bucket-%d"
+    bucket   = "tf-test-bucket-%[1]d"
     acl      = "private"
 
     versioning {
@@ -3844,24 +3761,13 @@ resource "aws_s3_bucket" "bucket" {
         }
     }
 }
-
-resource "aws_s3_bucket" "destination" {
-    provider = "aws.euwest"
-    bucket   = "tf-test-bucket-destination-%d"
-    region   = "eu-west-1"
-
-    versioning {
-        enabled = true
-    }
-}
-`, randInt, randInt, randInt)
+`, randInt)
 }
 
 func testAccAWSS3BucketConfigReplicationWithV2ConfigurationOnlyOneTag(randInt int) string {
-	return fmt.Sprintf(testAccAWSS3BucketConfigReplicationBasic+`
+	return testAccAWSS3BucketConfigReplicationBasic(randInt) + fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-    provider = "aws.uswest2"
-    bucket   = "tf-test-bucket-%d"
+    bucket   = "tf-test-bucket-%[1]d"
     acl      = "private"
 
     versioning {
@@ -3889,24 +3795,13 @@ resource "aws_s3_bucket" "bucket" {
         }
     }
 }
-
-resource "aws_s3_bucket" "destination" {
-    provider = "aws.euwest"
-    bucket   = "tf-test-bucket-destination-%d"
-    region   = "eu-west-1"
-
-    versioning {
-        enabled = true
-    }
-}
-`, randInt, randInt, randInt)
+`, randInt)
 }
 
 func testAccAWSS3BucketConfigReplicationWithV2ConfigurationPrefixAndTags(randInt int) string {
-	return fmt.Sprintf(testAccAWSS3BucketConfigReplicationBasic+`
+	return testAccAWSS3BucketConfigReplicationBasic(randInt) + fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-    provider = "aws.uswest2"
-    bucket   = "tf-test-bucket-%d"
+    bucket   = "tf-test-bucket-%[1]d"
     acl      = "private"
 
     versioning {
@@ -3937,24 +3832,13 @@ resource "aws_s3_bucket" "bucket" {
         }
     }
 }
-
-resource "aws_s3_bucket" "destination" {
-    provider = "aws.euwest"
-    bucket   = "tf-test-bucket-destination-%d"
-    region   = "eu-west-1"
-
-    versioning {
-        enabled = true
-    }
-}
-`, randInt, randInt, randInt)
+`, randInt)
 }
 
 func testAccAWSS3BucketConfigReplicationWithV2ConfigurationMultipleTags(randInt int) string {
-	return fmt.Sprintf(testAccAWSS3BucketConfigReplicationBasic+`
+	return testAccAWSS3BucketConfigReplicationBasic(randInt) + fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-    provider = "aws.uswest2"
-    bucket   = "tf-test-bucket-%d"
+    bucket   = "tf-test-bucket-%[1]d"
     acl      = "private"
 
     versioning {
@@ -3982,17 +3866,7 @@ resource "aws_s3_bucket" "bucket" {
         }
     }
 }
-
-resource "aws_s3_bucket" "destination" {
-    provider = "aws.euwest"
-    bucket   = "tf-test-bucket-destination-%d"
-    region   = "eu-west-1"
-
-    versioning {
-        enabled = true
-    }
-}
-`, randInt, randInt, randInt)
+`, randInt)
 }
 
 func testAccAWSS3BucketObjectLockEnabledNoDefaultRetention(randInt int) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/8983
Reference: https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#writing-and-running-cross-region-acceptance-tests

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

This is the first round of tfproviderlint AT004 fixes. Remaining reports will require some additional design work, e.g. potentially creating a separate EC2 Classic provider in the acceptance testing framework.

Previously:

```
aws/data_source_aws_elastic_beanstalk_hosted_zone_test.go:42:75: AT004: provider declaration should be omitted
aws/provider_test.go:425:21: AT004: provider declaration should be omitted
...
aws/provider_test.go:1259:21: AT004: provider declaration should be omitted
aws/resource_aws_ami_from_instance_test.go:131:21: AT004: provider declaration should be omitted
aws/resource_aws_codecommit_trigger_test.go:84:40: AT004: provider declaration should be omitted
aws/resource_aws_dynamodb_global_table_test.go:186:21: AT004: provider declaration should be omitted
aws/resource_aws_eip_test.go:999:21: AT004: provider declaration should be
aws/resource_aws_pinpoint_adm_channel_test.go:115:21: AT004: provider declaration should be omitted
aws/resource_aws_pinpoint_apns_channel_test.go:197:21: AT004: provider declaration should be omitted
aws/resource_aws_pinpoint_apns_channel_test.go:215:21: AT004: provider declaration should be omitted
aws/resource_aws_pinpoint_apns_sandbox_channel_test.go:197:21: AT004: provider declaration should be omitted
aws/resource_aws_pinpoint_apns_sandbox_channel_test.go:215:21: AT004: provider declaration should be omitted
aws/resource_aws_pinpoint_apns_voip_channel_test.go:197:21: AT004: provider declaration should be omitted
aws/resource_aws_pinpoint_apns_voip_channel_test.go:215:21: AT004: provider declaration should be omitted
aws/resource_aws_pinpoint_apns_voip_sandbox_channel_test.go:197:21: AT004: provider declaration should be omitted
aws/resource_aws_pinpoint_apns_voip_sandbox_channel_test.go:215:21: AT004: provider declaration should be omitted
aws/resource_aws_pinpoint_baidu_channel_test.go:109:21: AT004: provider declaration should be omitted
aws/resource_aws_pinpoint_baidu_channel_test.go:91:21: AT004: provider declaration should be omitted
aws/resource_aws_pinpoint_email_channel_test.go:141:53: AT004: provider declaration should be omitted
aws/resource_aws_pinpoint_email_channel_test.go:83:52: AT004: provider declaration should be omitted
aws/resource_aws_pinpoint_event_stream_test.go:136:52: AT004: provider declaration should be omitted
aws/resource_aws_pinpoint_event_stream_test.go:79:51: AT004: provider declaration should be omitted
aws/resource_aws_pinpoint_gcm_channel_test.go:95:21: AT004: provider declaration should be omitted
aws/resource_aws_pinpoint_sms_channel_test.go:146:50: AT004: provider declaration should be omitted
aws/resource_aws_pinpoint_sms_channel_test.go:158:21: AT004: provider declaration should be omitted
aws/resource_aws_rds_cluster_test.go:2796:21: AT004: provider declaration should be omitted
aws/resource_aws_route53_zone_association_test.go:267:51: AT004: provider declaration should be omitted
aws/resource_aws_s3_bucket_test.go:2772:21: AT004: provider declaration should be omitted
aws/resource_aws_s3_bucket_test.go:3268:50: AT004: provider declaration should be omitted
```

Output from acceptance testing:

```
--- PASS: TestAccAWSDataSourceElasticBeanstalkHostedZone_basic (15.30s)
--- PASS: TestAccAWSDataSourceElasticBeanstalkHostedZone_Region (19.40s)

--- PASS: TestAccAWSAMIFromInstance_basic (458.33s)
--- PASS: TestAccAWSAMIFromInstance_tags (459.26s)

--- PASS: TestAccAWSCodeCommitTrigger_basic (16.98s)

--- PASS: TestAccAWSDynamoDbGlobalTable_multipleRegions (107.60s)

--- PASS: TestAccAWSEIP_Instance_Reassociate (120.78s)

--- SKIP: TestAccAWSPinpointADMChannel_basic (0.00s)
    resource_aws_pinpoint_adm_channel_test.go:30: ADM_CLIENT_ID ENV is missing

--- SKIP: TestAccAWSPinpointAPNSChannel_basicCertificate (0.00s)
    resource_aws_pinpoint_apns_channel_test.go:58: Pinpoint certificate credentials envs are missing, skipping test
--- SKIP: TestAccAWSPinpointAPNSChannel_basicToken (0.00s)
    resource_aws_pinpoint_apns_channel_test.go:66: APNS_BUNDLE_ID env is missing, skipping test

--- SKIP: TestAccAWSPinpointAPNSSandboxChannel_basicCertificate (0.00s)
    resource_aws_pinpoint_apns_sandbox_channel_test.go:58: Pinpoint certificate credentials envs are missing, skipping test
--- SKIP: TestAccAWSPinpointAPNSSandboxChannel_basicToken (0.00s)
    resource_aws_pinpoint_apns_sandbox_channel_test.go:66: APNS_SANDBOX_BUNDLE_ID env is missing, skipping test

--- SKIP: TestAccAWSPinpointAPNSVoipChannel_basicCertificate (0.00s)
    resource_aws_pinpoint_apns_voip_channel_test.go:58: Pinpoint certificate credentials envs are missing, skipping test
--- SKIP: TestAccAWSPinpointAPNSVoipChannel_basicToken (0.00s)
    resource_aws_pinpoint_apns_voip_channel_test.go:66: APNS_VOIP_BUNDLE_ID env is missing, skipping test

--- SKIP: TestAccAWSPinpointAPNSVoipSandboxChannel_basicCertificate (0.00s)
    resource_aws_pinpoint_apns_voip_sandbox_channel_test.go:58: Pinpoint certificate credentials envs are missing, skipping test
--- SKIP: TestAccAWSPinpointAPNSVoipSandboxChannel_basicToken (0.00s)
    resource_aws_pinpoint_apns_voip_sandbox_channel_test.go:66: APNS_VOIP_BUNDLE_ID env is missing, skipping test

--- SKIP: TestAccAWSPinpointGCMChannel_basic (0.00s)
    resource_aws_pinpoint_gcm_channel_test.go:26: GCM_API_KEY env missing, skip test

--- PASS: TestAccAWSPinpointApp_basic (18.30s)
--- PASS: TestAccAWSPinpointApp_CampaignHookLambda (51.62s)
--- PASS: TestAccAWSPinpointApp_Limits (16.81s)
--- PASS: TestAccAWSPinpointApp_QuietTime (16.39s)
--- PASS: TestAccAWSPinpointApp_Tags (39.82s)

--- PASS: TestAccAWSPinpointBaiduChannel_basic (27.75s)

--- PASS: TestAccAWSPinpointEmailChannel_basic (31.77s)

--- PASS: TestAccAWSPinpointEventStream_basic (192.97s)

--- PASS: TestAccAWSPinpointSMSChannel_basic (27.71s)
--- PASS: TestAccAWSPinpointSMSChannel_full (29.13s)

--- PASS: TestAccAWSRDSCluster_EncryptedCrossRegionReplication (1593.29s)

--- PASS: TestAccAWSRoute53ZoneAssociation_region (161.54s)

--- PASS: TestAccAWSS3Bucket_region (38.19s)
--- PASS: TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError (28.48s)
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutPrefix (55.65s)
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutStorageClass (56.38s)
--- PASS: TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation (108.97s)
--- PASS: TestAccAWSS3Bucket_ReplicationSchemaV2 (161.13s)
--- PASS: TestAccAWSS3Bucket_Replication (172.15s)
```

In a region where Pinpoint is not supported, all tests continue to skip:

```
--- SKIP: TestAccAWSPinpointApp_basic (27.81s)
    resource_aws_pinpoint_app_test.go:228: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://pinpoint.us-east-2.amazonaws.com/v1/apps: dial tcp: lookup pinpoint.us-east-2.amazonaws.com: no such host
```