### PR TITLE
resource/aws_eks_cluster: Add encryption_config configuration block

### DIFF
--- a/aws/resource_aws_eks_cluster.go
+++ b/aws/resource_aws_eks_cluster.go
@@ -61,6 +61,43 @@ func resourceAwsEksCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"encryption_config": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"provider": {
+							Type:     schema.TypeList,
+							MaxItems: 1,
+							Required: true,
+							ForceNew: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key_arn": {
+										Type:     schema.TypeString,
+										Required: true,
+										ForceNew: true,
+									},
+								},
+							},
+						},
+						"resources": {
+							Type:     schema.TypeSet,
+							MinItems: 1,
+							Required: true,
+							ForceNew: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+								ValidateFunc: validation.StringInSlice([]string{
+									"secrets",
+								}, false),
+							},
+						},
+					},
+				},
+			},
 			"endpoint": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -179,6 +216,7 @@ func resourceAwsEksClusterCreate(d *schema.ResourceData, meta interface{}) error
 	name := d.Get("name").(string)
 
 	input := &eks.CreateClusterInput{
+		EncryptionConfig:   expandEksEncryptionConfig(d.Get("encryption_config").([]interface{})),
 		Name:               aws.String(name),
 		RoleArn:            aws.String(d.Get("role_arn").(string)),
 		ResourcesVpcConfig: expandEksVpcConfigRequest(d.Get("vpc_config").([]interface{})),
@@ -275,6 +313,11 @@ func resourceAwsEksClusterRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("created_at", aws.TimeValue(cluster.CreatedAt).String())
+
+	if err := d.Set("encryption_config", flattenEksEncryptionConfig(cluster.EncryptionConfig)); err != nil {
+		return fmt.Errorf("error setting encryption_config: %s", err)
+	}
+
 	d.Set("endpoint", cluster.Endpoint)
 
 	if err := d.Set("identity", flattenEksIdentity(cluster.Identity)); err != nil {
@@ -429,6 +472,50 @@ func deleteEksCluster(conn *eks.EKS, clusterName string) error {
 	return nil
 }
 
+func expandEksEncryptionConfig(tfList []interface{}) []*eks.EncryptionConfig {
+	if tfList == nil || len(tfList) == 0 {
+		return nil
+	}
+
+	var apiObjects []*eks.EncryptionConfig
+
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]interface{})
+
+		if !ok {
+			continue
+		}
+
+		apiObject := &eks.EncryptionConfig{
+			Provider: expandEksProvider(tfMap["provider"].([]interface{})),
+		}
+
+		if v, ok := tfMap["resources"].(*schema.Set); ok && v.Len() > 0 {
+			apiObject.Resources = expandStringSet(v)
+		}
+
+		apiObjects = append(apiObjects, apiObject)
+	}
+
+	return apiObjects
+}
+
+func expandEksProvider(tfList []interface{}) *eks.Provider {
+	tfMap, ok := tfList[0].(map[string]interface{})
+
+	if !ok {
+		return nil
+	}
+
+	apiObject := &eks.Provider{}
+
+	if v, ok := tfMap["key_arn"].(string); ok && v != "" {
+		apiObject.KeyArn = aws.String(v)
+	}
+
+	return apiObject
+}
+
 func expandEksVpcConfigRequest(l []interface{}) *eks.VpcConfigRequest {
 	if len(l) == 0 {
 		return nil
@@ -524,6 +611,37 @@ func flattenEksOidc(oidc *eks.OIDC) []map[string]interface{} {
 	}
 
 	return []map[string]interface{}{m}
+}
+
+func flattenEksEncryptionConfig(apiObjects []*eks.EncryptionConfig) []interface{} {
+	if apiObjects == nil || len(apiObjects) == 0 {
+		return nil
+	}
+
+	var tfList []interface{}
+
+	for _, apiObject := range apiObjects {
+		tfMap := map[string]interface{}{
+			"provider":  flattenEksProvider(apiObject.Provider),
+			"resources": aws.StringValueSlice(apiObject.Resources),
+		}
+
+		tfList = append(tfList, tfMap)
+	}
+
+	return tfList
+}
+
+func flattenEksProvider(apiObject *eks.Provider) []interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{
+		"key_arn": aws.StringValue(apiObject.KeyArn),
+	}
+
+	return []interface{}{tfMap}
 }
 
 func flattenEksVpcConfigResponse(vpcConfig *eks.VpcConfigResponse) []map[string]interface{} {

--- a/aws/resource_aws_eks_cluster.go
+++ b/aws/resource_aws_eks_cluster.go
@@ -473,7 +473,7 @@ func deleteEksCluster(conn *eks.EKS, clusterName string) error {
 }
 
 func expandEksEncryptionConfig(tfList []interface{}) []*eks.EncryptionConfig {
-	if tfList == nil || len(tfList) == 0 {
+	if len(tfList) == 0 {
 		return nil
 	}
 
@@ -614,7 +614,7 @@ func flattenEksOidc(oidc *eks.OIDC) []map[string]interface{} {
 }
 
 func flattenEksEncryptionConfig(apiObjects []*eks.EncryptionConfig) []interface{} {
-	if apiObjects == nil || len(apiObjects) == 0 {
+	if len(apiObjects) == 0 {
 		return nil
 	}
 

--- a/aws/resource_aws_eks_cluster_test.go
+++ b/aws/resource_aws_eks_cluster_test.go
@@ -111,6 +111,36 @@ func TestAccAWSEksCluster_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSEksCluster_EncryptionConfig(t *testing.T) {
+	var cluster eks.Cluster
+	kmsKeyResourceName := "aws_kms_key.test"
+	resourceName := "aws_eks_cluster.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEksClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEksClusterConfig_EncryptionConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksClusterExists(resourceName, &cluster),
+					resource.TestCheckResourceAttr(resourceName, "encryption_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_config.0.provider.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "encryption_config.0.provider.0.key_arn", kmsKeyResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_config.0.resources.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSEksCluster_Version(t *testing.T) {
 	var cluster1, cluster2 eks.Cluster
 
@@ -633,6 +663,34 @@ resource "aws_eks_cluster" "test" {
   depends_on = ["aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy", "aws_iam_role_policy_attachment.test-AmazonEKSServicePolicy"]
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}
+
+func testAccAWSEksClusterConfig_EncryptionConfig(rName string) string {
+	return testAccAWSEksClusterConfig_Base(rName) + fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  description             = %[1]q
+  deletion_window_in_days = 7
+}
+
+resource "aws_eks_cluster" "test" {
+  name     = %[1]q
+  role_arn = aws_iam_role.test.arn
+
+  encryption_config {
+    resources = ["secrets"]
+
+    provider {
+      key_arn = aws_kms_key.test.arn
+    }
+  }
+
+  vpc_config {
+    subnet_ids = aws_subnet.test[*].id
+  }
+
+  depends_on = ["aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy", "aws_iam_role_policy_attachment.test-AmazonEKSServicePolicy"]
+}
+`, rName)
 }
 
 func testAccAWSEksClusterConfig_VpcConfig_SecurityGroupIds(rName string) string {

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -153,8 +153,22 @@ The following arguments are supported:
 * `role_arn` - (Required) The Amazon Resource Name (ARN) of the IAM role that provides permissions for the Kubernetes control plane to make calls to AWS API operations on your behalf. Ensure the resource configuration includes explicit dependencies on the IAM Role permissions by adding [`depends_on`](/docs/configuration/resources.html#depends_on-explicit-resource-dependencies) if using the [`aws_iam_role_policy` resource](/docs/providers/aws/r/iam_role_policy.html) or [`aws_iam_role_policy_attachment` resource](/docs/providers/aws/r/iam_role_policy_attachment.html), otherwise EKS cannot delete EKS managed EC2 infrastructure such as Security Groups on EKS Cluster deletion.
 * `vpc_config` - (Required) Nested argument for the VPC associated with your cluster. Amazon EKS VPC resources have specific requirements to work properly with Kubernetes. For more information, see [Cluster VPC Considerations](https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html) and [Cluster Security Group Considerations](https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html) in the Amazon EKS User Guide. Configuration detailed below.
 * `enabled_cluster_log_types` - (Optional) A list of the desired control plane logging to enable. For more information, see [Amazon EKS Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html)
+* `encryption_config` - (Optional) Configuration block with encryption configuration for the cluster. Only available on Kubernetes 1.13 and above clusters created after March 6, 2020. Detailed below.
 * `tags` - (Optional) Key-value mapping of resource tags.
 * `version` – (Optional) Desired Kubernetes master version. If you do not specify a value, the latest available version at resource creation is used and no upgrades will occur except those automatically triggered by EKS. The value must be configured and increased to upgrade the version when desired. Downgrades are not supported by EKS.
+
+### encryption_config
+
+The following arguments are supported in the `encryption_config` configuration block:
+
+* `provider` - (Required) Configuration block with provider for encryption. Detailed below.
+* `resources` - (Required) List of strings with resources to be encrypted. Valid values: `secrets`
+
+#### provider
+
+The following arguments are supported in the `provider` configuration block:
+
+* `key_arn` - (Required) Amazon Resource Name (ARN) of the Key Management Service (KMS) customer master key (CMK). The CMK must be symmetric, created in the same region as the cluster, and if the CMK was created in a different account, the user must have access to the CMK. For more information, see [Allowing Users in Other Accounts to Use a CMK in the AWS Key Management Service Developer Guide](https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-modifying-external-accounts.html).
 
 ### vpc_config
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_eks_cluster: Add `encryption_config` configuration block
```

Output from acceptance testing:

```
--- PASS: TestAccAWSEksCluster_VpcConfig_SecurityGroupIds (1190.44s)
--- PASS: TestAccAWSEksCluster_basic (1199.87s)
--- PASS: TestAccAWSEksCluster_EncryptionConfig (1283.39s)
--- PASS: TestAccAWSEksCluster_Tags (1317.91s)
--- PASS: TestAccAWSEksCluster_Logging (1328.91s)
--- PASS: TestAccAWSEksCluster_VpcConfig_PublicAccessCidrs (1530.21s)
--- PASS: TestAccAWSEksCluster_VpcConfig_EndpointPublicAccess (1932.53s)
--- PASS: TestAccAWSEksCluster_VpcConfig_EndpointPrivateAccess (2388.84s)
--- PASS: TestAccAWSEksCluster_Version (2559.12s)
```
