### PR TITLE
r/aws_network_interface - read after create + add support for ipv6

### DIFF
--- a/aws/resource_aws_network_interface.go
+++ b/aws/resource_aws_network_interface.go
@@ -253,7 +253,7 @@ func resourceAwsNetworkInterfaceRead(d *schema.ResourceData, meta interface{}) e
 
 	d.Set("source_dest_check", eni.SourceDestCheck)
 	d.Set("subnet_id", eni.SubnetId)
-	d.Set("ipv6_address_count", len(eni.Ipv6Addresses)-1)
+	d.Set("ipv6_address_count", len(eni.Ipv6Addresses))
 	d.Set("ipv6_addresses", flattenEc2NetworkInterfaceIpv6Address(eni.Ipv6Addresses))
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(eni.TagSet).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {

--- a/aws/resource_aws_network_interface.go
+++ b/aws/resource_aws_network_interface.go
@@ -12,8 +12,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/hashcode"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 

--- a/aws/resource_aws_network_interface.go
+++ b/aws/resource_aws_network_interface.go
@@ -137,14 +137,12 @@ func resourceAwsNetworkInterfaceCreate(d *schema.ResourceData, meta interface{})
 		TagSpecifications: ec2TagSpecificationsFromMap(d.Get("tags").(map[string]interface{}), ec2.ResourceTypeNetworkInterface),
 	}
 
-	security_groups := d.Get("security_groups").(*schema.Set).List()
-	if len(security_groups) != 0 {
-		request.Groups = expandStringList(security_groups)
+	if v, ok := d.GetOk("security_groups"); ok && len(v.(*schema.Set).List()) > 0 {
+		request.Groups = expandStringList(v.(*schema.Set).List())
 	}
 
-	private_ips := d.Get("private_ips").(*schema.Set).List()
-	if len(private_ips) != 0 {
-		request.PrivateIpAddresses = expandPrivateIPAddresses(private_ips)
+	if v, ok := d.GetOk("private_ips"); ok && len(v.(*schema.Set).List()) > 0 {
+		request.PrivateIpAddresses = expandPrivateIPAddresses(v.(*schema.Set).List())
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -159,9 +157,8 @@ func resourceAwsNetworkInterfaceCreate(d *schema.ResourceData, meta interface{})
 		request.Ipv6AddressCount = aws.Int64(int64(v.(int)))
 	}
 
-	ipv6Addresses := d.Get("ipv6_addresses").(*schema.Set).List()
-	if len(ipv6Addresses) != 0 {
-		request.Ipv6Addresses = expandIP6Addresses(ipv6Addresses)
+	if v, ok := d.GetOk("ipv6_addresses"); ok && len(v.(*schema.Set).List()) > 0 {
+		request.Ipv6Addresses = expandIP6Addresses(v.(*schema.Set).List())
 	}
 
 	log.Printf("[DEBUG] Creating network interface")
@@ -422,7 +419,7 @@ func resourceAwsNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{})
 
 	// ModifyNetworkInterfaceAttribute needs to be called after creating an ENI
 	// since CreateNetworkInterface doesn't take SourceDeskCheck parameter.
-	if d.HasChange("source_dest_check") || d.IsNewResource() {
+	if d.HasChange("source_dest_check") {
 		request := &ec2.ModifyNetworkInterfaceAttributeInput{
 			NetworkInterfaceId: aws.String(d.Id()),
 			SourceDestCheck:    &ec2.AttributeBooleanValue{Value: aws.Bool(d.Get("source_dest_check").(bool))},
@@ -434,7 +431,7 @@ func resourceAwsNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{})
 		}
 	}
 
-	if d.HasChange("private_ips_count") && !d.IsNewResource() {
+	if d.HasChange("private_ips_count") {
 		o, n := d.GetChange("private_ips_count")
 		private_ips := d.Get("private_ips").(*schema.Set).List()
 		private_ips_filtered := private_ips[:0]

--- a/aws/resource_aws_network_interface.go
+++ b/aws/resource_aws_network_interface.go
@@ -141,7 +141,7 @@ func resourceAwsNetworkInterfaceCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	if v, ok := d.GetOk("security_groups"); ok && v.(*schema.Set).Len() > 0 {
-		request.Groups = expandStringList(v.(*schema.Set).List())
+		request.Groups = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("private_ips"); ok && v.(*schema.Set).Len() > 0 {
@@ -368,7 +368,7 @@ func resourceAwsNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{})
 		if unassignIps.Len() != 0 {
 			input := &ec2.UnassignPrivateIpAddressesInput{
 				NetworkInterfaceId: aws.String(d.Id()),
-				PrivateIpAddresses: expandStringList(unassignIps.List()),
+				PrivateIpAddresses: expandStringSet(unassignIps),
 			}
 			_, err := conn.UnassignPrivateIpAddresses(input)
 			if err != nil {
@@ -381,7 +381,7 @@ func resourceAwsNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{})
 		if assignIps.Len() != 0 {
 			input := &ec2.AssignPrivateIpAddressesInput{
 				NetworkInterfaceId: aws.String(d.Id()),
-				PrivateIpAddresses: expandStringList(assignIps.List()),
+				PrivateIpAddresses: expandStringSet(assignIps),
 			}
 			_, err := conn.AssignPrivateIpAddresses(input)
 			if err != nil {
@@ -407,7 +407,7 @@ func resourceAwsNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{})
 		if unassignIps.Len() != 0 {
 			input := &ec2.UnassignIpv6AddressesInput{
 				NetworkInterfaceId: aws.String(d.Id()),
-				Ipv6Addresses:      expandStringList(unassignIps.List()),
+				Ipv6Addresses:      expandStringSet(unassignIps),
 			}
 			_, err := conn.UnassignIpv6Addresses(input)
 			if err != nil {
@@ -420,7 +420,7 @@ func resourceAwsNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{})
 		if assignIps.Len() != 0 {
 			input := &ec2.AssignIpv6AddressesInput{
 				NetworkInterfaceId: aws.String(d.Id()),
-				Ipv6Addresses:      expandStringList(assignIps.List()),
+				Ipv6Addresses:      expandStringSet(assignIps),
 			}
 			_, err := conn.AssignIpv6Addresses(input)
 			if err != nil {

--- a/aws/resource_aws_network_interface.go
+++ b/aws/resource_aws_network_interface.go
@@ -41,10 +41,9 @@ func resourceAwsNetworkInterface() *schema.Resource {
 			},
 
 			"private_ip": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.IsIPv4Address,
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 
 			"private_dns_name": {
@@ -56,10 +55,7 @@ func resourceAwsNetworkInterface() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,
-				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: validation.IsIPv4Address,
-				},
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
 			"private_ips_count": {

--- a/aws/resource_aws_network_interface.go
+++ b/aws/resource_aws_network_interface.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/hashcode"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
@@ -40,9 +41,10 @@ func resourceAwsNetworkInterface() *schema.Resource {
 			},
 
 			"private_ip": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IsIPv4Address,
 			},
 
 			"private_dns_name": {
@@ -54,8 +56,11 @@ func resourceAwsNetworkInterface() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.IsIPv4Address,
+				},
+				Set: schema.HashString,
 			},
 
 			"private_ips_count": {
@@ -119,10 +124,13 @@ func resourceAwsNetworkInterface() *schema.Resource {
 				ConflictsWith: []string{"ipv6_addresses"},
 			},
 			"ipv6_addresses": {
-				Type:          schema.TypeSet,
-				Optional:      true,
-				Computed:      true,
-				Elem:          &schema.Schema{Type: schema.TypeString},
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.IsIPv6Address,
+				},
 				Set:           schema.HashString,
 				ConflictsWith: []string{"ipv6_address_count"},
 			},

--- a/aws/resource_aws_network_interface_sg_attachment_test.go
+++ b/aws/resource_aws_network_interface_sg_attachment_test.go
@@ -56,7 +56,7 @@ func TestAccAWSNetworkInterfaceSGAttachment_disappears(t *testing.T) {
 				Config: testAccAwsNetworkInterfaceSGAttachmentConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSNetworkInterfaceSGAttachmentExists(resourceName, &networkInterface),
-					testAccCheckResourceDisappears(testAccProvider, resourceAwsNetworkInterface(), resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsNetworkInterfaceSGAttachment(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/aws/resource_aws_network_interface_sg_attachment_test.go
+++ b/aws/resource_aws_network_interface_sg_attachment_test.go
@@ -56,7 +56,7 @@ func TestAccAWSNetworkInterfaceSGAttachment_disappears(t *testing.T) {
 				Config: testAccAwsNetworkInterfaceSGAttachmentConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSNetworkInterfaceSGAttachmentExists(resourceName, &networkInterface),
-					testAccCheckAWSENIDisappears(&networkInterface),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsNetworkInterface(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/aws/resource_aws_network_interface_test.go
+++ b/aws/resource_aws_network_interface_test.go
@@ -625,14 +625,6 @@ func testAccCheckAWSENIMakeExternalAttachment(n string, conf *ec2.NetworkInterfa
 
 func testAccAWSENIConfig() string {
 	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
- 
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
 resource "aws_vpc" "test" {
   cidr_block           = "172.16.0.0/16"
   enable_dns_hostnames = true
@@ -897,14 +889,6 @@ resource "aws_network_interface" "test" {
 
 func testAccAWSENIConfigWithAttachment() string {
 	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
- 
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
 resource "aws_vpc" "test" {
   cidr_block           = "172.16.0.0/16"
   enable_dns_hostnames = true
@@ -975,15 +959,6 @@ resource "aws_network_interface" "test" {
 
 func testAccAWSENIConfigExternalAttachment() string {
 	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
- 
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_vpc" "test" {
   cidr_block           = "172.16.0.0/16"
   enable_dns_hostnames = true

--- a/aws/resource_aws_network_interface_test.go
+++ b/aws/resource_aws_network_interface_test.go
@@ -688,7 +688,7 @@ resource "aws_vpc" "test" {
   enable_dns_hostnames = true
 
   tags = {
-    Name = "terraform-testacc-network-interface"
+    Name = "tf-acc-network-interface"
   }
 }
 
@@ -721,6 +721,10 @@ resource "aws_security_group" "test" {
     protocol    = "tcp"
     cidr_blocks = ["10.0.0.0/16"]
   }
+
+  tags = {
+    Name = "tf-acc-network-interface"
+  }
 }
 
 resource "aws_network_interface" "test" {
@@ -739,7 +743,7 @@ resource "aws_vpc" "test" {
   enable_dns_hostnames             = true
 
   tags = {
-  	Name = "terraform-testacc-network-interface-ipv6"
+  	Name = "tf-acc-network-interface-ipv6"
   }
 }
 
@@ -760,7 +764,7 @@ resource "aws_security_group" "test" {
   name        = "tf-acc-network-interface-ipv6"
 
   tags = {
-    Name = "test-interface-ipv6"
+    Name = "tf-acc-network-interface-ipv6"
   }
 }
 
@@ -772,7 +776,7 @@ resource "aws_network_interface" "test" {
   description     = "Managed by Terraform"
 
   tags = {
-    Name = "test-interface-ipv6"
+    Name = "tf-acc-network-interface-ipv6"
   }
 }
 `
@@ -785,7 +789,7 @@ resource "aws_vpc" "test" {
   enable_dns_hostnames             = true
 
   tags = {
-  	Name = "terraform-testacc-network-interface-ipv6"
+  	Name = "tf-acc-network-interface-ipv6"
   }
 }
 
@@ -806,7 +810,7 @@ resource "aws_security_group" "test" {
   name        = "tf-acc-network-interface-ipv6"
 
   tags = {
-    Name = "test-interface-ipv6"
+    Name = "tf-acc-network-interface-ipv6"
   }
 }
 
@@ -818,7 +822,7 @@ resource "aws_network_interface" "test" {
   description         = "Managed by Terraform"
 
   tags = {
-    Name = "test-interface-ipv6"
+    Name = "tf-acc-network-interface-ipv6"
   }
 }
 `, ipCount)
@@ -871,9 +875,6 @@ resource "aws_network_interface" "test" {
   private_ips     = ["172.16.10.100"]
   security_groups = [aws_security_group.test.id]
   description     = "Updated ENI Description"
-  tags = {
-    Name = "test_interface"
-  }
 }
 `)
 }

--- a/aws/resource_aws_network_interface_test.go
+++ b/aws/resource_aws_network_interface_test.go
@@ -118,6 +118,7 @@ func TestAccAWSENI_ipv6(t *testing.T) {
 					testAccCheckAWSENIAttributes(&conf),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", "1"),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_addresses.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "outpost_arn", ""),
 				),
 			},
 			{

--- a/aws/resource_aws_network_interface_test.go
+++ b/aws/resource_aws_network_interface_test.go
@@ -734,7 +734,7 @@ resource "aws_vpc" "test" {
   enable_dns_hostnames = true
 
   tags = {
-    Name = "terraform-testacc-network-interface-update-desc"
+    Name = "terraform-testacc-network-interface"
   }
 }
 
@@ -752,14 +752,14 @@ resource "aws_subnet" "test" {
   cidr_block        = "172.16.10.0/24"
   availability_zone = data.aws_availability_zones.available.names[0]
   tags = {
-    Name = "tf-acc-network-interface-update-desc"
+    Name = "tf-acc-network-interface"
   }
 }
 
 resource "aws_security_group" "test" {
   vpc_id      = aws_vpc.test.id
   description = "test"
-  name        = "terraform-testacc-network-interface-update-desc"
+  name        = "tf-acc-network-interface"
 
   egress {
     from_port   = 0

--- a/aws/resource_aws_network_interface_test.go
+++ b/aws/resource_aws_network_interface_test.go
@@ -740,11 +740,11 @@ resource "aws_network_interface" "test" {
 func testAccAWSENIIPV6CountConfig(ipCount int, rName string) string {
 	return testAccAWSENIIPV6ConfigBase(rName) + fmt.Sprintf(`
 resource "aws_network_interface" "test" {
-  subnet_id           = aws_subnet.test.id
-  private_ips         = ["172.16.10.100"]
-  ipv6_address_count  = %[1]d
-  security_groups     = [aws_security_group.test.id]
-  description         = "Managed by Terraform"
+  subnet_id          = aws_subnet.test.id
+  private_ips        = ["172.16.10.100"]
+  ipv6_address_count = %[1]d
+  security_groups    = [aws_security_group.test.id]
+  description        = "Managed by Terraform"
 }
 `, ipCount)
 }
@@ -798,7 +798,7 @@ resource "aws_vpc" "test" {
   enable_dns_hostnames = true
 
   tags = {
-  	Name = "terraform-testacc-network-interface-w-source-dest-check"
+    Name = "terraform-testacc-network-interface-w-source-dest-check"
   }
 }
 
@@ -806,6 +806,7 @@ resource "aws_subnet" "test" {
   vpc_id            = aws_vpc.test.id
   cidr_block        = "172.16.10.0/24"
   availability_zone = data.aws_availability_zones.available.names[0]
+
   tags = {
     Name = "tf-acc-network-interface-w-source-dest-check"
   }

--- a/aws/resource_aws_network_interface_test.go
+++ b/aws/resource_aws_network_interface_test.go
@@ -827,18 +827,19 @@ resource "aws_network_interface" "test" {
 func testAccAWSENIConfigWithNoPrivateIPs() string {
 	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
-	cidr_block           = "172.16.0.0/16"
-	enable_dns_hostnames = true
+  cidr_block           = "172.16.0.0/16"
+  enable_dns_hostnames = true
 
-	tags = {
-	  Name = "terraform-testacc-network-interface-w-no-private-ips"
-	}
+  tags = {
+    Name = "terraform-testacc-network-interface-w-no-private-ips"
+  }
 }
 
 resource "aws_subnet" "test" {
   vpc_id            = aws_vpc.test.id
   cidr_block        = "172.16.10.0/24"
   availability_zone = data.aws_availability_zones.available.names[0]
+
   tags = {
     Name = "tf-acc-network-interface-w-no-private-ips"
   }
@@ -857,6 +858,7 @@ func testAccAWSENIConfigWithAttachment() string {
 resource "aws_vpc" "test" {
   cidr_block           = "172.16.0.0/16"
   enable_dns_hostnames = true
+
   tags = {
     Name = "terraform-testacc-network-interface-w-attachment"
   }
@@ -866,6 +868,7 @@ resource "aws_subnet" "test1" {
   vpc_id            = aws_vpc.test.id
   cidr_block        = "172.16.10.0/24"
   availability_zone = data.aws_availability_zones.available.names[0]
+
   tags = {
     Name = "tf-acc-network-interface-w-attachment-test"
   }
@@ -875,6 +878,7 @@ resource "aws_subnet" "test2" {
   vpc_id            = aws_vpc.test.id
   cidr_block        = "172.16.11.0/24"
   availability_zone = data.aws_availability_zones.available.names[0]
+
   tags = {
     Name = "tf-acc-network-interface-w-attachment-test"
   }
@@ -892,6 +896,7 @@ resource "aws_instance" "test" {
   subnet_id                   = aws_subnet.test2.id
   associate_public_ip_address = false
   private_ip                  = "172.16.11.50"
+
   tags = {
     Name = "test-tf-eni-test"
   }
@@ -906,6 +911,7 @@ resource "aws_network_interface" "test" {
     instance     = aws_instance.test.id
     device_index = 1
   }
+
   tags = {
     Name = "test_interface"
   }
@@ -919,6 +925,7 @@ func testAccAWSENIConfigExternalAttachment() string {
 resource "aws_vpc" "test" {
   cidr_block           = "172.16.0.0/16"
   enable_dns_hostnames = true
+
   tags = {
     Name = "terraform-testacc-network-interface-external-attachment"
   }
@@ -928,6 +935,7 @@ resource "aws_subnet" "test1" {
   vpc_id            = aws_vpc.test.id
   cidr_block        = "172.16.10.0/24"
   availability_zone = data.aws_availability_zones.available.names[0]
+
   tags = {
     Name = "tf-acc-network-interface-external-attachment-test"
   }
@@ -937,6 +945,7 @@ resource "aws_subnet" "test2" {
   vpc_id            = aws_vpc.test.id
   cidr_block        = "172.16.11.0/24"
   availability_zone = data.aws_availability_zones.available.names[0]
+
   tags = {
     Name = "tf-acc-network-interface-external-attachment-test"
   }
@@ -954,6 +963,7 @@ resource "aws_instance" "test" {
   subnet_id                   = aws_subnet.test2.id
   associate_public_ip_address = false
   private_ip                  = "172.16.11.50"
+
   tags = {
     Name = "tf-eni-test"
   }
@@ -963,6 +973,7 @@ resource "aws_network_interface" "test" {
   subnet_id       = aws_subnet.test1.id
   private_ips     = ["172.16.10.100"]
   security_groups = [aws_security_group.test.id]
+  
   tags = {
     Name = "test_interface"
   }

--- a/aws/resource_aws_network_interface_test.go
+++ b/aws/resource_aws_network_interface_test.go
@@ -301,7 +301,7 @@ func TestAccAWSENI_ignoreExternalAttachment(t *testing.T) {
 					testAccCheckAWSENIExists(resourceName, &conf),
 					testAccCheckAWSENIAttributes(&conf),
 					testAccCheckAWSENIAvailabilityZone("data.aws_availability_zones.available", "names.0", &conf),
-					testAccCheckAWSENIMakeExternalAttachment("aws_instance.foo", &conf),
+					testAccCheckAWSENIMakeExternalAttachment("aws_instance.test", &conf),
 				),
 			},
 			{
@@ -873,7 +873,7 @@ data "aws_availability_zones" "available" {
   }
 }
 
-resource "aws_subnet" "test" {
+resource "aws_subnet" "test1" {
   vpc_id            = aws_vpc.test.id
   cidr_block        = "172.16.10.0/24"
   availability_zone = data.aws_availability_zones.available.names[0]
@@ -882,7 +882,7 @@ resource "aws_subnet" "test" {
   }
 }
 
-resource "aws_subnet" "test" {
+resource "aws_subnet" "test2" {
   vpc_id            = aws_vpc.test.id
   cidr_block        = "172.16.11.0/24"
   availability_zone = data.aws_availability_zones.available.names[0]
@@ -900,7 +900,7 @@ resource "aws_security_group" "test" {
 resource "aws_instance" "test" {
   ami                         = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type               = "t2.micro"
-  subnet_id                   = aws_subnet.test.id
+  subnet_id                   = aws_subnet.test2.id
   associate_public_ip_address = false
   private_ip                  = "172.16.11.50"
   tags = {
@@ -909,7 +909,7 @@ resource "aws_instance" "test" {
 }
 
 resource "aws_network_interface" "test" {
-  subnet_id       = aws_subnet.test.id
+  subnet_id       = aws_subnet.test1.id
   private_ips     = ["172.16.10.100"]
   security_groups = [aws_security_group.test.id]
 
@@ -943,7 +943,7 @@ data "aws_availability_zones" "available" {
   }
 }
 
-resource "aws_subnet" "test" {
+resource "aws_subnet" "test1" {
   vpc_id            = aws_vpc.test.id
   cidr_block        = "172.16.10.0/24"
   availability_zone = data.aws_availability_zones.available.names[0]
@@ -952,7 +952,7 @@ resource "aws_subnet" "test" {
   }
 }
 
-resource "aws_subnet" "test" {
+resource "aws_subnet" "test2" {
   vpc_id            = aws_vpc.test.id
   cidr_block        = "172.16.11.0/24"
   availability_zone = data.aws_availability_zones.available.names[0]
@@ -970,7 +970,7 @@ resource "aws_security_group" "test" {
 resource "aws_instance" "test" {
   ami                         = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type               = "t2.micro"
-  subnet_id                   = aws_subnet.test.id
+  subnet_id                   = aws_subnet.test2.id
   associate_public_ip_address = false
   private_ip                  = "172.16.11.50"
   tags = {
@@ -979,7 +979,7 @@ resource "aws_instance" "test" {
 }
 
 resource "aws_network_interface" "test" {
-  subnet_id       = aws_subnet.test.id
+  subnet_id       = aws_subnet.test1.id
   private_ips     = ["172.16.10.100"]
   security_groups = [aws_security_group.test.id]
   tags = {

--- a/aws/resource_aws_network_interface_test.go
+++ b/aws/resource_aws_network_interface_test.go
@@ -611,15 +611,15 @@ func testAccCheckAWSENIMakeExternalAttachment(n string, conf *ec2.NetworkInterfa
 		if !ok || rs.Primary.ID == "" {
 			return fmt.Errorf("Not found: %s", n)
 		}
-		attach_request := &ec2.AttachNetworkInterfaceInput{
+		input := &ec2.AttachNetworkInterfaceInput{
 			DeviceIndex:        aws.Int64(1),
 			InstanceId:         aws.String(rs.Primary.ID),
 			NetworkInterfaceId: conf.NetworkInterfaceId,
 		}
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
-		_, attach_err := conn.AttachNetworkInterface(attach_request)
-		if attach_err != nil {
-			return fmt.Errorf("Error attaching ENI: %s", attach_err)
+		_, err := conn.AttachNetworkInterface(input)
+		if err != nil {
+			return fmt.Errorf("Error attaching ENI: %s", err)
 		}
 		return nil
 	}
@@ -679,7 +679,7 @@ resource "aws_vpc" "test" {
   enable_dns_hostnames             = true
 
   tags = {
-  	Name = %[1]q
+    Name = %[1]q
   }
 }
 

--- a/aws/resource_aws_network_interface_test.go
+++ b/aws/resource_aws_network_interface_test.go
@@ -588,10 +588,10 @@ func testAccCheckAWSENIDestroy(s *terraform.State) error {
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
-		describe_network_interfaces_request := &ec2.DescribeNetworkInterfacesInput{
+		input := &ec2.DescribeNetworkInterfacesInput{
 			NetworkInterfaceIds: []*string{aws.String(rs.Primary.ID)},
 		}
-		_, err := conn.DescribeNetworkInterfaces(describe_network_interfaces_request)
+		_, err := conn.DescribeNetworkInterfaces(input)
 
 		if err != nil {
 			if isAWSErr(err, "InvalidNetworkInterfaceID.NotFound", "") {
@@ -973,7 +973,7 @@ resource "aws_network_interface" "test" {
   subnet_id       = aws_subnet.test1.id
   private_ips     = ["172.16.10.100"]
   security_groups = [aws_security_group.test.id]
-  
+
   tags = {
     Name = "test_interface"
   }

--- a/aws/resource_aws_network_interface_test.go
+++ b/aws/resource_aws_network_interface_test.go
@@ -116,11 +116,8 @@ func TestAccAWSENI_ipv6(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSENIExists(resourceName, &conf),
 					testAccCheckAWSENIAttributes(&conf),
-					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count.#", "1"),
-					resource.TestCheckResourceAttrSet(resourceName, "ipv6_addresses"),
-					resource.TestCheckResourceAttrSet(resourceName, "mac_address"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", "test_interface"),
-					resource.TestCheckResourceAttr(resourceName, "description", "Managed by Terraform"),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_addresses.#", "1"),
 				),
 			},
 			{

--- a/aws/resource_aws_network_interface_test.go
+++ b/aws/resource_aws_network_interface_test.go
@@ -118,13 +118,30 @@ func TestAccAWSENI_ipv6(t *testing.T) {
 					testAccCheckAWSENIAttributes(&conf),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", "1"),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_addresses.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "outpost_arn", ""),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSENIIPV6MultipleConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSENIExists(resourceName, &conf),
+					testAccCheckAWSENIAttributes(&conf),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", "2"),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_addresses.#", "2"),
+				),
+			},
+			{
+				Config: testAccAWSENIIPV6Config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSENIExists(resourceName, &conf),
+					testAccCheckAWSENIAttributes(&conf),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_addresses.#", "1"),
+				),
 			},
 		},
 	})
@@ -293,7 +310,6 @@ func TestAccAWSENI_attached(t *testing.T) {
 					testAccCheckAWSENIAttributesWithAttachment(&conf),
 					testAccCheckAWSENIAvailabilityZone("data.aws_availability_zones.available", "names.0", &conf),
 					resource.TestCheckResourceAttr(resourceName, "private_ips.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", "test_interface"),
 				),
 			},
 			{
@@ -724,6 +740,16 @@ resource "aws_network_interface" "test" {
   subnet_id       = aws_subnet.test.id
   private_ips     = ["172.16.10.100"]
   ipv6_addresses  = [cidrhost(aws_subnet.test.ipv6_cidr_block, 4)]
+  security_groups = [aws_security_group.test.id]
+  description     = "Managed by Terraform"
+}
+`
+
+const testAccAWSENIIPV6MultipleConfig = testAccAWSENIIPV6ConfigBase + `
+resource "aws_network_interface" "test" {
+  subnet_id       = aws_subnet.test.id
+  private_ips     = ["172.16.10.100"]
+  ipv6_addresses  = [cidrhost(aws_subnet.test.ipv6_cidr_block, 4), cidrhost(aws_subnet.test.ipv6_cidr_block, 8)]
   security_groups = [aws_security_group.test.id]
   description     = "Managed by Terraform"
 }

--- a/aws/resource_aws_network_interface_test.go
+++ b/aws/resource_aws_network_interface_test.go
@@ -234,7 +234,7 @@ func TestAccAWSENI_disappears(t *testing.T) {
 				Config: testAccAWSENIConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSENIExists(resourceName, &networkInterface),
-					testAccCheckAWSENIDisappears(&networkInterface),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsNetworkInterface(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -629,19 +629,6 @@ func testAccCheckAWSENIDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAWSENIDisappears(networkInterface *ec2.NetworkInterface) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).ec2conn
-
-		input := &ec2.DeleteNetworkInterfaceInput{
-			NetworkInterfaceId: networkInterface.NetworkInterfaceId,
-		}
-		_, err := conn.DeleteNetworkInterface(input)
-
-		return err
-	}
-}
-
 func testAccCheckAWSENIMakeExternalAttachment(n string, conf *ec2.NetworkInterface) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -666,6 +653,11 @@ func testAccAWSENIConfig() string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
+ 
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
 }
 resource "aws_vpc" "test" {
   cidr_block           = "172.16.0.0/16"
@@ -723,6 +715,11 @@ resource "aws_network_interface" "test" {
 const testAccAWSENIIPV6ConfigBase = `
 data "aws_availability_zones" "available" {
   state = "available"
+ 
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
 }
 
 resource "aws_vpc" "test" {
@@ -999,6 +996,11 @@ func testAccAWSENIConfigExternalAttachment() string {
 	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
+ 
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
 }
 resource "aws_vpc" "test" {
   cidr_block           = "172.16.0.0/16"

--- a/aws/resource_aws_network_interface_test.go
+++ b/aws/resource_aws_network_interface_test.go
@@ -924,6 +924,11 @@ func testAccAWSENIConfigWithAttachment() string {
 	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
+ 
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
 }
 resource "aws_vpc" "test" {
   cidr_block           = "172.16.0.0/16"
@@ -1003,6 +1008,7 @@ data "aws_availability_zones" "available" {
     values = ["opt-in-not-required"]
   }
 }
+
 resource "aws_vpc" "test" {
   cidr_block           = "172.16.0.0/16"
   enable_dns_hostnames = true

--- a/aws/resource_aws_network_interface_test.go
+++ b/aws/resource_aws_network_interface_test.go
@@ -189,7 +189,6 @@ func TestAccAWSENI_ipv6_count(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", "1"),
-					resource.TestCheckResourceAttr(resourceName, "ipv6_addresses.#", "1"),
 				),
 			},
 			{
@@ -202,39 +201,21 @@ func TestAccAWSENI_ipv6_count(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", "2"),
-					resource.TestCheckResourceAttr(resourceName, "ipv6_addresses.#", "2"),
 				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSENIIPV6CountConfig(0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", "0"),
-					resource.TestCheckResourceAttr(resourceName, "ipv6_addresses.#", "0"),
 				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSENIIPV6CountConfig(1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSENIExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", "1"),
-					resource.TestCheckResourceAttr(resourceName, "ipv6_addresses.#", "1"),
 				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})

--- a/aws/resource_aws_network_interface_test.go
+++ b/aws/resource_aws_network_interface_test.go
@@ -853,8 +853,9 @@ resource "aws_network_interface" "test" {
 }
 
 func testAccAWSENIConfigWithAttachment() string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() +
-		testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
+	return composeConfig(testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
+		testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block           = "172.16.0.0/16"
   enable_dns_hostnames = true
@@ -892,7 +893,7 @@ resource "aws_security_group" "test" {
 
 resource "aws_instance" "test" {
   ami                         = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type               = "t2.micro"
+  instance_type               = data.aws_ec2_instance_type_offering.available.instance_type
   subnet_id                   = aws_subnet.test2.id
   associate_public_ip_address = false
   private_ip                  = "172.16.11.50"
@@ -916,12 +917,13 @@ resource "aws_network_interface" "test" {
     Name = "test_interface"
   }
 }
-`)
+`))
 }
 
 func testAccAWSENIConfigExternalAttachment() string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() +
-		testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
+	return composeConfig(testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
+		testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block           = "172.16.0.0/16"
   enable_dns_hostnames = true
@@ -959,7 +961,7 @@ resource "aws_security_group" "test" {
 
 resource "aws_instance" "test" {
   ami                         = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type               = "t2.micro"
+  instance_type               = data.aws_ec2_instance_type_offering.available.instance_type
   subnet_id                   = aws_subnet.test2.id
   associate_public_ip_address = false
   private_ip                  = "172.16.11.50"
@@ -978,7 +980,7 @@ resource "aws_network_interface" "test" {
     Name = "test_interface"
   }
 }
-`)
+`))
 }
 
 func testAccAWSENIConfigPrivateIpsCount(privateIpsCount int) string {

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -1122,6 +1122,18 @@ func expandPrivateIPAddresses(ips []interface{}) []*ec2.PrivateIpAddressSpecific
 	return dtos
 }
 
+func expandIP6Addresses(ips []interface{}) []*ec2.InstanceIpv6Address {
+	dtos := make([]*ec2.InstanceIpv6Address, 0, len(ips))
+	for _, v := range ips {
+		ipv6Address := &ec2.InstanceIpv6Address{
+			Ipv6Address: aws.String(v.(string)),
+		}
+
+		dtos = append(dtos, ipv6Address)
+	}
+	return dtos
+}
+
 //Flattens network interface attachment into a map[string]interface
 func flattenAttachment(a *ec2.NetworkInterfaceAttachment) map[string]interface{} {
 	att := make(map[string]interface{})

--- a/website/docs/r/network_interface.markdown
+++ b/website/docs/r/network_interface.markdown
@@ -34,7 +34,7 @@ The following arguments are supported:
 * `private_ips` - (Optional) List of private IPs to assign to the ENI.
 * `private_ips_count` - (Optional) Number of secondary private IPs to assign to the ENI. The total number of private IPs will be 1 + private_ips_count, as a primary private IP will be assiged to an ENI by default.
 * `ipv6_addresses` - (Optional) One or more specific IPv6 addresses from the IPv6 CIDR block range of your subnet. You can't use this option if you're specifying `ipv6_address_count`.
-* `ipv6_address_count` - (Optional) The number of IPv6 addresses to assign to a network interface. You can't use this option if specifying specific `ipv6_addresses`. If your subnet has the AssignIpv6AddressOnCreation attribute set to `true`, you can specify `0` to override this setting. 
+* `ipv6_address_count` - (Optional) The number of IPv6 addresses to assign to a network interface. You can't use this option if specifying specific `ipv6_addresses`. If your subnet has the AssignIpv6AddressOnCreation attribute set to `true`, you can specify `0` to override this setting.
 * `security_groups` - (Optional) List of security group IDs to assign to the ENI.
 * `attachment` - (Optional) Block to define the attachment of the ENI. Documented below.
 * `source_dest_check` - (Optional) Whether to enable source destination checking for the ENI. Default true.

--- a/website/docs/r/network_interface.markdown
+++ b/website/docs/r/network_interface.markdown
@@ -33,6 +33,8 @@ The following arguments are supported:
 * `description` - (Optional) A description for the network interface.
 * `private_ips` - (Optional) List of private IPs to assign to the ENI.
 * `private_ips_count` - (Optional) Number of secondary private IPs to assign to the ENI. The total number of private IPs will be 1 + private_ips_count, as a primary private IP will be assiged to an ENI by default.
+* `ipv6_addresses` - (Optional) One or more specific IPv6 addresses from the IPv6 CIDR block range of your subnet. You can't use this option if you're specifying `ipv6_address_count`.
+* `ipv6_address_count` - (Optional) The number of IPv6 addresses to assign to a network interface. You can't use this option if specifying specific `ipv6_addresses`. If your subnet has the AssignIpv6AddressOnCreation attribute set to `true`, you can specify `0` to override this setting. 
 * `security_groups` - (Optional) List of security group IDs to assign to the ENI.
 * `attachment` - (Optional) Block to define the attachment of the ENI. Documented below.
 * `source_dest_check` - (Optional) Whether to enable source destination checking for the ENI. Default true.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12260
Closes #1707
Closes #8408
Relates #1060

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_network_interface: add support for adding IPV6 addresses
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSENI_'
--- PASS: TestAccAWSENI_ipv6 (239.85s)
--- PASS: TestAccAWSENI_tags (241.01s)
--- PASS: TestAccAWSENI_ipv6_count (301.36s)
--- PASS: TestAccAWSENI_sourceDestCheck (235.46s)
--- PASS: TestAccAWSENI_computedIPs (117.03s)
--- PASS: TestAccAWSENI_PrivateIpsCount (253.85s)
--- PASS: TestAccAWSENI_basic (122.11s)
--- PASS: TestAccAWSENI_disappears (100.06s)
--- PASS: TestAccAWSENI_updatedDescription (194.35s)
--- PASS: TestAccAWSENI_attached (214.29s)
--- PASS: TestAccAWSENI_ignoreExternalAttachment (173.77s)
```
