### PR TITLE
New resource r/aws_wafv2_regex_pattern_set

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -151,7 +150,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/xray"
 	awsbase "github.com/hashicorp/aws-sdk-go-base"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/logging"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
@@ -722,7 +720,7 @@ func (c *Config) Client() (interface{}, error) {
 			r.Retryable = aws.Bool(true)
 		}
 
-		if r.Operation.Name == "CreateIPSet" {
+		if r.Operation.Name == "CreateIPSet" || r.Operation.Name == "CreateRegexPatternSet" {
 			// WAFv2 supports tag on create which can result in the below error codes according to the documentation
 			if isAWSErr(r.Error, wafv2.ErrCodeWAFTagOperationException, "Retry your request") {
 				r.Retryable = aws.Bool(true)
@@ -782,40 +780,4 @@ func GetSupportedEC2Platforms(conn *ec2.EC2) ([]string, error) {
 	}
 
 	return platforms, nil
-}
-
-type wafv2CallFunc func() (interface{}, error)
-
-// Calls a WAFv2 action and retries on a retryable error
-func callWafv2WithRetry(f wafv2CallFunc) (interface{}, error) {
-	var out interface{}
-	err := resource.Retry(15*time.Minute, func() *resource.RetryError {
-		var err error
-		out, err = f()
-		if err != nil {
-			if isAWSErr(err, wafv2.ErrCodeWAFInternalErrorException, "AWS WAF couldn’t perform the operation because of a system problem") {
-				return resource.RetryableError(err)
-			}
-			if isAWSErr(err, wafv2.ErrCodeWAFTagOperationException, "An error occurred during the tagging operation") {
-				return resource.RetryableError(err)
-			}
-			if isAWSErr(err, wafv2.ErrCodeWAFTagOperationInternalErrorException, "AWS WAF couldn’t perform your tagging operation because of an internal error") {
-				return resource.RetryableError(err)
-			}
-			if isAWSErr(err, wafv2.ErrCodeWAFAssociatedItemException, "AWS WAF couldn’t perform the operation because your resource is being used by another resource or it’s associated with another resource") {
-				return resource.RetryableError(err)
-			}
-			return resource.NonRetryableError(err)
-		}
-		return nil
-	})
-
-	if isResourceTimeoutError(err) {
-		_, err = f()
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	return out, nil
 }

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -886,6 +886,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_wafregional_web_acl":                                 resourceAwsWafRegionalWebAcl(),
 			"aws_wafregional_web_acl_association":                     resourceAwsWafRegionalWebAclAssociation(),
 			"aws_wafv2_ip_set":                                        resourceAwsWafv2IPSet(),
+			"aws_wafv2_regex_pattern_set":                             resourceAwsWafv2RegexPatternSet(),
 			"aws_worklink_fleet":                                      resourceAwsWorkLinkFleet(),
 			"aws_worklink_website_certificate_authority_association":  resourceAwsWorkLinkWebsiteCertificateAuthorityAssociation(),
 			"aws_workspaces_directory":                                resourceAwsWorkspacesDirectory(),

--- a/aws/resource_aws_wafv2_regex_pattern_set.go
+++ b/aws/resource_aws_wafv2_regex_pattern_set.go
@@ -65,7 +65,7 @@ func resourceAwsWafv2RegexPatternSet() *schema.Resource {
 						"regex_string": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validation.StringLenBetween(1, 512),
+							ValidateFunc: validation.StringLenBetween(1, 200),
 						},
 					},
 				},

--- a/aws/resource_aws_wafv2_regex_pattern_set.go
+++ b/aws/resource_aws_wafv2_regex_pattern_set.go
@@ -58,8 +58,8 @@ func resourceAwsWafv2RegexPatternSet() *schema.Resource {
 			},
 			"regular_expression_list": {
 				Type:     schema.TypeSet,
-				Required: true,
-				MinItems: 1,
+				Optional: true,
+				MaxItems: 10,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"regex_string": {

--- a/aws/resource_aws_wafv2_regex_pattern_set.go
+++ b/aws/resource_aws_wafv2_regex_pattern_set.go
@@ -245,22 +245,11 @@ func resourceAwsWafv2RegexPatternSetUpdate(d *schema.ResourceData, meta interfac
 
 func resourceAwsWafv2RegexPatternSetDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).wafv2conn
-	var resp *wafv2.GetRegexPatternSetOutput
-	params := &wafv2.GetRegexPatternSetInput{
-		Id:    aws.String(d.Id()),
-		Name:  aws.String(d.Get("name").(string)),
-		Scope: aws.String(d.Get("scope").(string)),
-	}
+
 	log.Printf("[INFO] Deleting WAFV2 RegexPatternSet %s", d.Id())
 
 	err := resource.Retry(15*time.Minute, func() *resource.RetryError {
-		var err error
-		resp, err = conn.GetRegexPatternSet(params)
-		if err != nil {
-			return resource.NonRetryableError(fmt.Errorf("Error getting lock token: %s", err))
-		}
-
-		_, err = conn.DeleteRegexPatternSet(&wafv2.DeleteRegexPatternSetInput{
+		_, err := conn.DeleteRegexPatternSet(&wafv2.DeleteRegexPatternSetInput{
 			Id:        aws.String(d.Id()),
 			Name:      aws.String(d.Get("name").(string)),
 			Scope:     aws.String(d.Get("scope").(string)),

--- a/aws/resource_aws_wafv2_regex_pattern_set.go
+++ b/aws/resource_aws_wafv2_regex_pattern_set.go
@@ -165,7 +165,6 @@ func resourceAwsWafv2RegexPatternSetUpdate(d *schema.ResourceData, meta interfac
 		Id:                    aws.String(d.Id()),
 		Name:                  aws.String(d.Get("name").(string)),
 		Scope:                 aws.String(d.Get("scope").(string)),
-		Description:           aws.String(d.Get("description").(string)),
 		LockToken:             aws.String(d.Get("lock_token").(string)),
 		RegularExpressionList: []*wafv2.Regex{},
 	}

--- a/aws/resource_aws_wafv2_regex_pattern_set.go
+++ b/aws/resource_aws_wafv2_regex_pattern_set.go
@@ -126,7 +126,7 @@ func resourceAwsWafv2RegexPatternSetRead(d *schema.ResourceData, meta interface{
 
 	resp, err := conn.GetRegexPatternSet(params)
 	if err != nil {
-		if isAWSErr(err, wafv2.ErrCodeWAFNonexistentItemException, "AWS WAF couldn’t perform the operation because your resource doesn’t exist") {
+		if isAWSErr(err, wafv2.ErrCodeWAFNonexistentItemException, "") {
 			log.Printf("[WARN] WAFv2 RegexPatternSet (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
@@ -207,7 +207,7 @@ func resourceAwsWafv2RegexPatternSetDelete(d *schema.ResourceData, meta interfac
 		_, err := conn.DeleteRegexPatternSet(params)
 
 		if err != nil {
-			if isAWSErr(err, wafv2.ErrCodeWAFAssociatedItemException, "AWS WAF couldn’t perform the operation because your resource is being used by another resource or it’s associated with another resource") {
+			if isAWSErr(err, wafv2.ErrCodeWAFAssociatedItemException, "") {
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)

--- a/aws/resource_aws_wafv2_regex_pattern_set.go
+++ b/aws/resource_aws_wafv2_regex_pattern_set.go
@@ -1,0 +1,336 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/wafv2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+func resourceAwsWafv2RegexPatternSet() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsWafv2RegexPatternSetCreate,
+		Read:   resourceAwsWafv2RegexPatternSetRead,
+		Update: resourceAwsWafv2RegexPatternSetUpdate,
+		Delete: resourceAwsWafv2RegexPatternSetDelete,
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				idParts := strings.Split(d.Id(), "/")
+				if len(idParts) != 3 || idParts[0] == "" || idParts[1] == "" || idParts[2] == "" {
+					return nil, fmt.Errorf("Unexpected format of ID (%q), expected ID/NAME/SCOPE", d.Id())
+				}
+				id := idParts[0]
+				name := idParts[1]
+				scope := idParts[2]
+				d.SetId(id)
+				d.Set("name", name)
+				d.Set("scope", scope)
+				return []*schema.ResourceData{d}, nil
+			},
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 256),
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 128),
+			},
+			"regular_expression_list": {
+				Type:     schema.TypeSet,
+				Required: true,
+				MinItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"regex_string": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringLenBetween(1, 512),
+						},
+					},
+				},
+			},
+			"scope": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					wafv2.ScopeCloudfront,
+					wafv2.ScopeRegional,
+				}, false),
+			},
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsWafv2RegexPatternSetCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafv2conn
+	var resp *wafv2.CreateRegexPatternSetOutput
+
+	params := &wafv2.CreateRegexPatternSetInput{
+		Name:  aws.String(d.Get("name").(string)),
+		Scope: aws.String(d.Get("scope").(string)),
+	}
+
+	if d.HasChange("description") {
+		params.Description = aws.String(d.Get("description").(string))
+	}
+
+	if v, ok := d.GetOk("regular_expression_list"); ok && v.(*schema.Set).Len() > 0 {
+		params.RegularExpressionList = expandWafv2RegexPatternSet(d.Get("regular_expression_list").(*schema.Set).List())
+	}
+
+	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
+		params.Tags = keyvaluetags.New(v).IgnoreAws().Wafv2Tags()
+	}
+
+	err := resource.Retry(15*time.Minute, func() *resource.RetryError {
+		var err error
+		resp, err = conn.CreateRegexPatternSet(params)
+		if err != nil {
+			if isAWSErr(err, wafv2.ErrCodeWAFInternalErrorException, "AWS WAF couldn’t perform the operation because of a system problem") {
+				return resource.RetryableError(err)
+			}
+			if isAWSErr(err, wafv2.ErrCodeWAFTagOperationException, "An error occurred during the tagging operation") {
+				return resource.RetryableError(err)
+			}
+			if isAWSErr(err, wafv2.ErrCodeWAFTagOperationInternalErrorException, "AWS WAF couldn’t perform your tagging operation because of an internal error") {
+				return resource.RetryableError(err)
+			}
+			if isAWSErr(err, wafv2.ErrCodeWAFOptimisticLockException, "AWS WAF couldn’t save your changes because you tried to update or delete a resource that has changed since you last retrieved it") {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.CreateRegexPatternSet(params)
+	}
+	if err != nil {
+		return err
+	}
+	d.SetId(*resp.Summary.Id)
+
+	return resourceAwsWafv2RegexPatternSetRead(d, meta)
+}
+
+func resourceAwsWafv2RegexPatternSetRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafv2conn
+
+	params := &wafv2.GetRegexPatternSetInput{
+		Id:    aws.String(d.Id()),
+		Name:  aws.String(d.Get("name").(string)),
+		Scope: aws.String(d.Get("scope").(string)),
+	}
+
+	resp, err := conn.GetRegexPatternSet(params)
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == wafv2.ErrCodeWAFNonexistentItemException {
+			log.Printf("[WARN] WAFV2 RegexPatternSet (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		return err
+	}
+
+	d.Set("name", resp.RegexPatternSet.Name)
+	d.Set("description", resp.RegexPatternSet.Description)
+	d.Set("arn", resp.RegexPatternSet.ARN)
+
+	if err := d.Set("regular_expression_list", flattenWafv2RegexPatternSet(resp.RegexPatternSet.RegularExpressionList)); err != nil {
+		return fmt.Errorf("Error setting regular_expression_list: %s", err)
+	}
+
+	tags, err := keyvaluetags.Wafv2ListTags(conn, *resp.RegexPatternSet.ARN)
+	if err != nil {
+		return fmt.Errorf("error listing tags for WAFV2 RegexPatternSet (%s): %s", *resp.RegexPatternSet.ARN, err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}
+
+func flattenWafv2RegexPatternSet(r []*wafv2.Regex) interface{} {
+	regexPatterns := make([]interface{}, len(r))
+
+	for i, regexPattern := range r {
+		d := map[string]interface{}{
+			"regex_string": *regexPattern.RegexString,
+		}
+		regexPatterns[i] = d
+	}
+
+	return regexPatterns
+}
+
+func resourceAwsWafv2RegexPatternSetUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafv2conn
+	var resp *wafv2.GetRegexPatternSetOutput
+	params := &wafv2.GetRegexPatternSetInput{
+		Id:    aws.String(d.Id()),
+		Name:  aws.String(d.Get("name").(string)),
+		Scope: aws.String(d.Get("scope").(string)),
+	}
+	log.Printf("[INFO] Updating WAFV2 RegexPatternSet %s", d.Id())
+
+	err := resource.Retry(15*time.Minute, func() *resource.RetryError {
+		var err error
+		resp, err = conn.GetRegexPatternSet(params)
+		if err != nil {
+			return resource.NonRetryableError(fmt.Errorf("Error getting lock token: %s", err))
+		}
+
+		u := &wafv2.UpdateRegexPatternSetInput{
+			Id:          aws.String(d.Id()),
+			Name:        aws.String(d.Get("name").(string)),
+			Scope:       aws.String(d.Get("scope").(string)),
+			Description: aws.String(d.Get("description").(string)),
+			LockToken:   resp.LockToken,
+		}
+
+		if v, ok := d.GetOk("regular_expression_list"); ok && v.(*schema.Set).Len() > 0 {
+			u.RegularExpressionList = expandWafv2RegexPatternSet(d.Get("regular_expression_list").(*schema.Set).List())
+		}
+
+		if d.HasChange("description") {
+			u.Description = aws.String(d.Get("description").(string))
+		}
+
+		_, err = conn.UpdateRegexPatternSet(u)
+
+		if err != nil {
+			if isAWSErr(err, wafv2.ErrCodeWAFInternalErrorException, "AWS WAF couldn’t perform the operation because of a system problem") {
+				return resource.RetryableError(err)
+			}
+			if isAWSErr(err, wafv2.ErrCodeWAFOptimisticLockException, "AWS WAF couldn’t save your changes because you tried to update or delete a resource that has changed since you last retrieved it") {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+
+	if isResourceTimeoutError(err) {
+		_, err = conn.DeleteRegexPatternSet(&wafv2.DeleteRegexPatternSetInput{
+			Id:        aws.String(d.Id()),
+			Name:      aws.String(d.Get("name").(string)),
+			Scope:     aws.String(d.Get("scope").(string)),
+			LockToken: resp.LockToken,
+		})
+	}
+
+	if err != nil {
+		return fmt.Errorf("Error updating WAFV2 RegexPatternSet: %s", err)
+	}
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+		if err := keyvaluetags.Wafv2UpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating tags: %s", err)
+		}
+	}
+
+	return resourceAwsWafv2RegexPatternSetRead(d, meta)
+}
+
+func resourceAwsWafv2RegexPatternSetDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafv2conn
+	var resp *wafv2.GetRegexPatternSetOutput
+	params := &wafv2.GetRegexPatternSetInput{
+		Id:    aws.String(d.Id()),
+		Name:  aws.String(d.Get("name").(string)),
+		Scope: aws.String(d.Get("scope").(string)),
+	}
+	log.Printf("[INFO] Deleting WAFV2 RegexPatternSet %s", d.Id())
+
+	err := resource.Retry(15*time.Minute, func() *resource.RetryError {
+		var err error
+		resp, err = conn.GetRegexPatternSet(params)
+		if err != nil {
+			return resource.NonRetryableError(fmt.Errorf("Error getting lock token: %s", err))
+		}
+
+		_, err = conn.DeleteRegexPatternSet(&wafv2.DeleteRegexPatternSetInput{
+			Id:        aws.String(d.Id()),
+			Name:      aws.String(d.Get("name").(string)),
+			Scope:     aws.String(d.Get("scope").(string)),
+			LockToken: resp.LockToken,
+		})
+
+		if err != nil {
+			if isAWSErr(err, wafv2.ErrCodeWAFInternalErrorException, "AWS WAF couldn’t perform the operation because of a system problem") {
+				return resource.RetryableError(err)
+			}
+			if isAWSErr(err, wafv2.ErrCodeWAFOptimisticLockException, "AWS WAF couldn’t save your changes because you tried to update or delete a resource that has changed since you last retrieved it") {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+
+	if isResourceTimeoutError(err) {
+		_, err = conn.DeleteRegexPatternSet(&wafv2.DeleteRegexPatternSetInput{
+			Id:        aws.String(d.Id()),
+			Name:      aws.String(d.Get("name").(string)),
+			Scope:     aws.String(d.Get("scope").(string)),
+			LockToken: resp.LockToken,
+		})
+	}
+
+	if err != nil {
+		return fmt.Errorf("Error deleting WAFV2 RegexPatternSet: %s", err)
+	}
+
+	return nil
+}
+
+func expandWafv2RegexPatternSet(l []interface{}) []*wafv2.Regex {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	regexPatterns := make([]*wafv2.Regex, 0)
+	for _, regexPattern := range l {
+		if regexPattern == nil {
+			continue
+		}
+
+		regexPatterns = append(regexPatterns, expandWafv2Regex(regexPattern.(map[string]interface{})))
+	}
+
+	return regexPatterns
+}
+
+func expandWafv2Regex(m map[string]interface{}) *wafv2.Regex {
+	if m == nil {
+		return nil
+	}
+
+	return &wafv2.Regex{
+		RegexString: aws.String(m["regex_string"].(string)),
+	}
+}

--- a/aws/resource_aws_wafv2_regex_pattern_set.go
+++ b/aws/resource_aws_wafv2_regex_pattern_set.go
@@ -260,6 +260,9 @@ func resourceAwsWafv2RegexPatternSetDelete(d *schema.ResourceData, meta interfac
 			if isAWSErr(err, wafv2.ErrCodeWAFInternalErrorException, "AWS WAF couldn’t perform the operation because of a system problem") {
 				return resource.RetryableError(err)
 			}
+			if isAWSErr(err, wafv2.ErrCodeWAFAssociatedItemException, "AWS WAF couldn’t perform the operation because your resource is being used by another resource or it’s associated with another resource") {
+				return resource.RetryableError(err)
+			}
 			return resource.NonRetryableError(err)
 		}
 		return nil

--- a/aws/resource_aws_wafv2_regex_pattern_set_test.go
+++ b/aws/resource_aws_wafv2_regex_pattern_set_test.go
@@ -77,7 +77,7 @@ func TestAccAwsWafv2RegexPatternSet_Disappears(t *testing.T) {
 				Config: testAccAwsWafv2RegexPatternSetConfig_Minimal(regexPatternSetName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafv2RegexPatternSetExists(resourceName, &v),
-					testAccCheckAWSWafv2RegexPatternSetDisappears(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsWafv2RegexPatternSet(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -226,29 +226,6 @@ func testAccCheckAWSWafv2RegexPatternSetDestroy(s *terraform.State) error {
 	}
 
 	return nil
-}
-
-func testAccCheckAWSWafv2RegexPatternSetDisappears(n string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no WAFv2 RegexPatternSet ID is set")
-		}
-
-		conn := testAccProvider.Meta().(*AWSClient).wafv2conn
-		_, err := conn.DeleteRegexPatternSet(&wafv2.DeleteRegexPatternSetInput{
-			Id:        aws.String(rs.Primary.ID),
-			Name:      aws.String(rs.Primary.Attributes["name"]),
-			Scope:     aws.String(rs.Primary.Attributes["scope"]),
-			LockToken: aws.String(rs.Primary.Attributes["lock_token"]),
-		})
-
-		return err
-	}
 }
 
 func testAccCheckAWSWafv2RegexPatternSetExists(n string, v *wafv2.RegexPatternSet) resource.TestCheckFunc {

--- a/aws/resource_aws_wafv2_regex_pattern_set_test.go
+++ b/aws/resource_aws_wafv2_regex_pattern_set_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestAccAwsWafv2RegexPatternSet_Basic(t *testing.T) {
 	var v wafv2.RegexPatternSet
-	regexPatternSetName := fmt.Sprintf("regex-pattern-set-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafv2_regex_pattern_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -23,33 +23,32 @@ func TestAccAwsWafv2RegexPatternSet_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSWafv2RegexPatternSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsWafv2RegexPatternSetConfig(regexPatternSetName),
+				Config: testAccAwsWafv2RegexPatternSetConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafv2RegexPatternSetExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/regexpatternset/.+$`)),
-					resource.TestCheckResourceAttr(resourceName, "name", regexPatternSetName),
-					resource.TestCheckResourceAttr(resourceName, "description", regexPatternSetName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", rName),
 					resource.TestCheckResourceAttr(resourceName, "scope", wafv2.ScopeRegional),
 					resource.TestCheckResourceAttr(resourceName, "regular_expression.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "regular_expression.1641128102.regex_string", "one"),
 					resource.TestCheckResourceAttr(resourceName, "regular_expression.265355341.regex_string", "two"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Tag1", "Value1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Tag2", "Value2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
-				Config: testAccAwsWafv2RegexPatternSetConfig_Update(regexPatternSetName),
+				Config: testAccAwsWafv2RegexPatternSetConfig_Update(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafv2RegexPatternSetExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/regexpatternset/.+$`)),
-					resource.TestCheckResourceAttr(resourceName, "name", regexPatternSetName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "description", "Updated"),
 					resource.TestCheckResourceAttr(resourceName, "scope", wafv2.ScopeRegional),
 					resource.TestCheckResourceAttr(resourceName, "regular_expression.#", "3"),
 					resource.TestCheckResourceAttr(resourceName, "regular_expression.1641128102.regex_string", "one"),
 					resource.TestCheckResourceAttr(resourceName, "regular_expression.265355341.regex_string", "two"),
 					resource.TestCheckResourceAttr(resourceName, "regular_expression.2339296779.regex_string", "three"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
@@ -64,7 +63,7 @@ func TestAccAwsWafv2RegexPatternSet_Basic(t *testing.T) {
 
 func TestAccAwsWafv2RegexPatternSet_Disappears(t *testing.T) {
 	var v wafv2.RegexPatternSet
-	regexPatternSetName := fmt.Sprintf("regex-pattern-set-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafv2_regex_pattern_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -73,7 +72,7 @@ func TestAccAwsWafv2RegexPatternSet_Disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAWSWafv2RegexPatternSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsWafv2RegexPatternSetConfig_Minimal(regexPatternSetName),
+				Config: testAccAwsWafv2RegexPatternSetConfig_Minimal(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafv2RegexPatternSetExists(resourceName, &v),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsWafv2RegexPatternSet(), resourceName),
@@ -86,7 +85,7 @@ func TestAccAwsWafv2RegexPatternSet_Disappears(t *testing.T) {
 
 func TestAccAwsWafv2RegexPatternSet_Minimal(t *testing.T) {
 	var v wafv2.RegexPatternSet
-	regexPatternSetName := fmt.Sprintf("regex-pattern-set-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafv2_regex_pattern_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -95,11 +94,11 @@ func TestAccAwsWafv2RegexPatternSet_Minimal(t *testing.T) {
 		CheckDestroy: testAccCheckAWSWafv2RegexPatternSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsWafv2RegexPatternSetConfig_Minimal(regexPatternSetName),
+				Config: testAccAwsWafv2RegexPatternSetConfig_Minimal(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafv2RegexPatternSetExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/regexpatternset/.+$`)),
-					resource.TestCheckResourceAttr(resourceName, "name", regexPatternSetName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "scope", wafv2.ScopeRegional),
 					resource.TestCheckResourceAttr(resourceName, "regular_expression.#", "0"),
@@ -111,8 +110,8 @@ func TestAccAwsWafv2RegexPatternSet_Minimal(t *testing.T) {
 
 func TestAccAwsWafv2RegexPatternSet_ChangeNameForceNew(t *testing.T) {
 	var before, after wafv2.RegexPatternSet
-	regexPatternSetName := fmt.Sprintf("regex-pattern-set-%s", acctest.RandString(5))
-	regexPatternSetNewName := fmt.Sprintf("regex-pattern-set-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rNewName := fmt.Sprintf("regex-pattern-set-%s", acctest.RandString(5))
 	resourceName := "aws_wafv2_regex_pattern_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -121,23 +120,23 @@ func TestAccAwsWafv2RegexPatternSet_ChangeNameForceNew(t *testing.T) {
 		CheckDestroy: testAccCheckAWSWafv2RegexPatternSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsWafv2RegexPatternSetConfig(regexPatternSetName),
+				Config: testAccAwsWafv2RegexPatternSetConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafv2RegexPatternSetExists(resourceName, &before),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/regexpatternset/.+$`)),
-					resource.TestCheckResourceAttr(resourceName, "name", regexPatternSetName),
-					resource.TestCheckResourceAttr(resourceName, "description", regexPatternSetName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", rName),
 					resource.TestCheckResourceAttr(resourceName, "scope", wafv2.ScopeRegional),
 					resource.TestCheckResourceAttr(resourceName, "regular_expression.#", "2"),
 				),
 			},
 			{
-				Config: testAccAwsWafv2RegexPatternSetConfig(regexPatternSetNewName),
+				Config: testAccAwsWafv2RegexPatternSetConfig(rNewName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafv2RegexPatternSetExists(resourceName, &after),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/regexpatternset/.+$`)),
-					resource.TestCheckResourceAttr(resourceName, "name", regexPatternSetNewName),
-					resource.TestCheckResourceAttr(resourceName, "description", regexPatternSetNewName),
+					resource.TestCheckResourceAttr(resourceName, "name", rNewName),
+					resource.TestCheckResourceAttr(resourceName, "description", rNewName),
 					resource.TestCheckResourceAttr(resourceName, "scope", wafv2.ScopeRegional),
 					resource.TestCheckResourceAttr(resourceName, "regular_expression.#", "2"),
 				),
@@ -148,7 +147,7 @@ func TestAccAwsWafv2RegexPatternSet_ChangeNameForceNew(t *testing.T) {
 
 func TestAccAwsWafv2RegexPatternSet_Tags(t *testing.T) {
 	var v wafv2.RegexPatternSet
-	regexPatternSetName := fmt.Sprintf("regex-pattern-set-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafv2_regex_pattern_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -157,7 +156,7 @@ func TestAccAwsWafv2RegexPatternSet_Tags(t *testing.T) {
 		CheckDestroy: testAccCheckAWSWafv2RegexPatternSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsWafv2RegexPatternSetConfig_OneTag(regexPatternSetName, "Tag1", "Value1"),
+				Config: testAccAwsWafv2RegexPatternSetConfig_OneTag(rName, "Tag1", "Value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafv2RegexPatternSetExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/regexpatternset/.+$`)),
@@ -172,7 +171,7 @@ func TestAccAwsWafv2RegexPatternSet_Tags(t *testing.T) {
 				ImportStateIdFunc: testAccAWSWafv2RegexPatternSetImportStateIdFunc(resourceName),
 			},
 			{
-				Config: testAccAwsWafv2RegexPatternSetConfig_TwoTags(regexPatternSetName, "Tag1", "Value1Updated", "Tag2", "Value2"),
+				Config: testAccAwsWafv2RegexPatternSetConfig_TwoTags(rName, "Tag1", "Value1Updated", "Tag2", "Value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafv2RegexPatternSetExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/regexpatternset/.+$`)),
@@ -182,7 +181,7 @@ func TestAccAwsWafv2RegexPatternSet_Tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAwsWafv2RegexPatternSetConfig_OneTag(regexPatternSetName, "Tag2", "Value2"),
+				Config: testAccAwsWafv2RegexPatternSetConfig_OneTag(rName, "Tag2", "Value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafv2RegexPatternSetExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/regexpatternset/.+$`)),
@@ -274,11 +273,6 @@ resource "aws_wafv2_regex_pattern_set" "test" {
 
   regular_expression {
     regex_string = "two"
-  }
-
-  tags = {
-    Tag1 = "Value1"
-    Tag2 = "Value2"
   }
 }
 `, name, name)

--- a/aws/resource_aws_wafv2_regex_pattern_set_test.go
+++ b/aws/resource_aws_wafv2_regex_pattern_set_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAwsWafv2RegexPatternSet_basic(t *testing.T) {
+func TestAccAwsWafv2RegexPatternSet_Basic(t *testing.T) {
 	var v wafv2.RegexPatternSet
 	regexPatternSetName := fmt.Sprintf("regex-pattern-set-%s", acctest.RandString(5))
 	resourceName := "aws_wafv2_regex_pattern_set.test"
@@ -40,7 +40,7 @@ func TestAccAwsWafv2RegexPatternSet_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAwsWafv2RegexPatternSetConfigUpdate(regexPatternSetName),
+				Config: testAccAwsWafv2RegexPatternSetConfig_Update(regexPatternSetName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafv2RegexPatternSetExists("aws_wafv2_regex_pattern_set.test", &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/regexpatternset/.+$`)),
@@ -63,7 +63,7 @@ func TestAccAwsWafv2RegexPatternSet_basic(t *testing.T) {
 	})
 }
 
-func TestAccAwsWafv2RegexPatternSet_minimal(t *testing.T) {
+func TestAccAwsWafv2RegexPatternSet_Minimal(t *testing.T) {
 	var v wafv2.RegexPatternSet
 	regexPatternSetName := fmt.Sprintf("regex-pattern-set-%s", acctest.RandString(5))
 	resourceName := "aws_wafv2_regex_pattern_set.test"
@@ -74,7 +74,7 @@ func TestAccAwsWafv2RegexPatternSet_minimal(t *testing.T) {
 		CheckDestroy: testAccCheckAWSWafv2RegexPatternSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsWafv2RegexPatternSetConfigMinimal(regexPatternSetName),
+				Config: testAccAwsWafv2RegexPatternSetConfig_Minimal(regexPatternSetName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafv2RegexPatternSetExists("aws_wafv2_regex_pattern_set.test", &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/regexpatternset/.+$`)),
@@ -88,7 +88,7 @@ func TestAccAwsWafv2RegexPatternSet_minimal(t *testing.T) {
 	})
 }
 
-func TestAccAwsWafv2RegexPatternSet_changeNameForceNew(t *testing.T) {
+func TestAccAwsWafv2RegexPatternSet_ChangeNameForceNew(t *testing.T) {
 	var before, after wafv2.RegexPatternSet
 	regexPatternSetName := fmt.Sprintf("regex-pattern-set-%s", acctest.RandString(5))
 	regexPatternSetNewName := fmt.Sprintf("regex-pattern-set-%s", acctest.RandString(5))
@@ -125,7 +125,7 @@ func TestAccAwsWafv2RegexPatternSet_changeNameForceNew(t *testing.T) {
 	})
 }
 
-func TestAccAwsWafv2RegexPatternSet_tags(t *testing.T) {
+func TestAccAwsWafv2RegexPatternSet_Tags(t *testing.T) {
 	var v wafv2.RegexPatternSet
 	regexPatternSetName := fmt.Sprintf("regex-pattern-set-%s", acctest.RandString(5))
 	resourceName := "aws_wafv2_regex_pattern_set.test"
@@ -136,7 +136,7 @@ func TestAccAwsWafv2RegexPatternSet_tags(t *testing.T) {
 		CheckDestroy: testAccCheckAWSWafv2RegexPatternSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsWafv2RegexPatternSetConfigOneTag(regexPatternSetName, "Tag1", "Value1"),
+				Config: testAccAwsWafv2RegexPatternSetConfig_OneTag(regexPatternSetName, "Tag1", "Value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafv2RegexPatternSetExists("aws_wafv2_regex_pattern_set.test", &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/regexpatternset/.+$`)),
@@ -151,7 +151,7 @@ func TestAccAwsWafv2RegexPatternSet_tags(t *testing.T) {
 				ImportStateIdFunc: testAccAWSWafv2RegexPatternSetImportStateIdFunc(resourceName),
 			},
 			{
-				Config: testAccAwsWafv2RegexPatternSetConfigTwoTags(regexPatternSetName, "Tag1", "Value1Updated", "Tag2", "Value2"),
+				Config: testAccAwsWafv2RegexPatternSetConfig_TwoTags(regexPatternSetName, "Tag1", "Value1Updated", "Tag2", "Value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafv2RegexPatternSetExists("aws_wafv2_regex_pattern_set.test", &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/regexpatternset/.+$`)),
@@ -161,7 +161,7 @@ func TestAccAwsWafv2RegexPatternSet_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAwsWafv2RegexPatternSetConfigOneTag(regexPatternSetName, "Tag2", "Value2"),
+				Config: testAccAwsWafv2RegexPatternSetConfig_OneTag(regexPatternSetName, "Tag2", "Value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafv2RegexPatternSetExists("aws_wafv2_regex_pattern_set.test", &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/regexpatternset/.+$`)),
@@ -260,7 +260,7 @@ resource "aws_wafv2_regex_pattern_set" "test" {
 `, name, name)
 }
 
-func testAccAwsWafv2RegexPatternSetConfigUpdate(name string) string {
+func testAccAwsWafv2RegexPatternSetConfig_Update(name string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_regex_pattern_set" "test" {
   name        = "%s"
@@ -282,20 +282,16 @@ resource "aws_wafv2_regex_pattern_set" "test" {
 `, name)
 }
 
-func testAccAwsWafv2RegexPatternSetConfigMinimal(name string) string {
+func testAccAwsWafv2RegexPatternSetConfig_Minimal(name string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_regex_pattern_set" "test" {
   name  = "%s"
   scope = "REGIONAL"
-
-  regular_expression_list {
-    regex_string = "one"
-  }
 }
 `, name)
 }
 
-func testAccAwsWafv2RegexPatternSetConfigOneTag(name, tagKey, tagValue string) string {
+func testAccAwsWafv2RegexPatternSetConfig_OneTag(name, tagKey, tagValue string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_regex_pattern_set" "test" {
   name        = "%s"
@@ -317,7 +313,7 @@ resource "aws_wafv2_regex_pattern_set" "test" {
 `, name, name, tagKey, tagValue)
 }
 
-func testAccAwsWafv2RegexPatternSetConfigTwoTags(name, tag1Key, tag1Value, tag2Key, tag2Value string) string {
+func testAccAwsWafv2RegexPatternSetConfig_TwoTags(name, tag1Key, tag1Value, tag2Key, tag2Value string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_regex_pattern_set" "test" {
   name        = "%s"

--- a/aws/resource_aws_wafv2_regex_pattern_set_test.go
+++ b/aws/resource_aws_wafv2_regex_pattern_set_test.go
@@ -240,9 +240,9 @@ func testAccCheckAWSWafv2RegexPatternSetExists(n string, v *wafv2.RegexPatternSe
 func testAccAwsWafv2RegexPatternSetConfig(name string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_regex_pattern_set" "test" {
-  name = "%s"
+  name        = "%s"
   description = "%s"
-  scope = "REGIONAL"
+  scope       = "REGIONAL"
 
   regular_expression_list {
     regex_string = "one"
@@ -263,9 +263,9 @@ resource "aws_wafv2_regex_pattern_set" "test" {
 func testAccAwsWafv2RegexPatternSetConfigUpdate(name string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_regex_pattern_set" "test" {
-  name = "%s"
+  name        = "%s"
   description = "Updated"
-  scope = "REGIONAL"
+  scope       = "REGIONAL"
 
   regular_expression_list {
     regex_string = "one"
@@ -285,7 +285,7 @@ resource "aws_wafv2_regex_pattern_set" "test" {
 func testAccAwsWafv2RegexPatternSetConfigMinimal(name string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_regex_pattern_set" "test" {
-  name = "%s"
+  name  = "%s"
   scope = "REGIONAL"
 
   regular_expression_list {
@@ -298,9 +298,9 @@ resource "aws_wafv2_regex_pattern_set" "test" {
 func testAccAwsWafv2RegexPatternSetConfigOneTag(name, tagKey, tagValue string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_regex_pattern_set" "test" {
-  name = "%s"
+  name        = "%s"
   description = "%s"
-  scope = "REGIONAL"
+  scope       = "REGIONAL"
 
   regular_expression_list {
     regex_string = "one"
@@ -311,7 +311,7 @@ resource "aws_wafv2_regex_pattern_set" "test" {
   }
 
   tags = {
-    %q = %q
+    "%s" = "%s"
   }
 }
 `, name, name, tagKey, tagValue)
@@ -320,17 +320,17 @@ resource "aws_wafv2_regex_pattern_set" "test" {
 func testAccAwsWafv2RegexPatternSetConfigTwoTags(name, tag1Key, tag1Value, tag2Key, tag2Value string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_regex_pattern_set" "test" {
-  name = "%s"
+  name        = "%s"
   description = "%s"
-  scope = "REGIONAL"
+  scope       = "REGIONAL"
 
   regular_expression_list {
     regex_string = "one"
   }
 
   tags = {
-    %q = %q
-    %q = %q
+    "%s" = "%s"
+    "%s" = "%s"
   }
 }
 `, name, name, tag1Key, tag1Value, tag2Key, tag2Value)

--- a/aws/resource_aws_wafv2_regex_pattern_set_test.go
+++ b/aws/resource_aws_wafv2_regex_pattern_set_test.go
@@ -26,7 +26,7 @@ func TestAccAwsWafv2RegexPatternSet_Basic(t *testing.T) {
 			{
 				Config: testAccAwsWafv2RegexPatternSetConfig(regexPatternSetName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafv2RegexPatternSetExists("aws_wafv2_regex_pattern_set.test", &v),
+					testAccCheckAWSWafv2RegexPatternSetExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/regexpatternset/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "name", regexPatternSetName),
 					resource.TestCheckResourceAttr(resourceName, "description", regexPatternSetName),
@@ -42,7 +42,7 @@ func TestAccAwsWafv2RegexPatternSet_Basic(t *testing.T) {
 			{
 				Config: testAccAwsWafv2RegexPatternSetConfig_Update(regexPatternSetName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafv2RegexPatternSetExists("aws_wafv2_regex_pattern_set.test", &v),
+					testAccCheckAWSWafv2RegexPatternSetExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/regexpatternset/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "name", regexPatternSetName),
 					resource.TestCheckResourceAttr(resourceName, "description", "Updated"),
@@ -63,6 +63,28 @@ func TestAccAwsWafv2RegexPatternSet_Basic(t *testing.T) {
 	})
 }
 
+func TestAccAwsWafv2RegexPatternSet_Disappears(t *testing.T) {
+	var v wafv2.RegexPatternSet
+	regexPatternSetName := fmt.Sprintf("regex-pattern-set-%s", acctest.RandString(5))
+	resourceName := "aws_wafv2_regex_pattern_set.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafv2RegexPatternSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsWafv2RegexPatternSetConfig_Minimal(regexPatternSetName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafv2RegexPatternSetExists(resourceName, &v),
+					testAccCheckAWSWafv2RegexPatternSetDisappears(resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccAwsWafv2RegexPatternSet_Minimal(t *testing.T) {
 	var v wafv2.RegexPatternSet
 	regexPatternSetName := fmt.Sprintf("regex-pattern-set-%s", acctest.RandString(5))
@@ -76,12 +98,12 @@ func TestAccAwsWafv2RegexPatternSet_Minimal(t *testing.T) {
 			{
 				Config: testAccAwsWafv2RegexPatternSetConfig_Minimal(regexPatternSetName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafv2RegexPatternSetExists("aws_wafv2_regex_pattern_set.test", &v),
+					testAccCheckAWSWafv2RegexPatternSetExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/regexpatternset/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "name", regexPatternSetName),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "scope", wafv2.ScopeRegional),
-					resource.TestCheckResourceAttr(resourceName, "regular_expression_list.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "regular_expression_list.#", "0"),
 				),
 			},
 		},
@@ -102,7 +124,7 @@ func TestAccAwsWafv2RegexPatternSet_ChangeNameForceNew(t *testing.T) {
 			{
 				Config: testAccAwsWafv2RegexPatternSetConfig(regexPatternSetName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafv2RegexPatternSetExists("aws_wafv2_regex_pattern_set.test", &before),
+					testAccCheckAWSWafv2RegexPatternSetExists(resourceName, &before),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/regexpatternset/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "name", regexPatternSetName),
 					resource.TestCheckResourceAttr(resourceName, "description", regexPatternSetName),
@@ -113,7 +135,7 @@ func TestAccAwsWafv2RegexPatternSet_ChangeNameForceNew(t *testing.T) {
 			{
 				Config: testAccAwsWafv2RegexPatternSetConfig(regexPatternSetNewName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafv2RegexPatternSetExists("aws_wafv2_regex_pattern_set.test", &after),
+					testAccCheckAWSWafv2RegexPatternSetExists(resourceName, &after),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/regexpatternset/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "name", regexPatternSetNewName),
 					resource.TestCheckResourceAttr(resourceName, "description", regexPatternSetNewName),
@@ -138,7 +160,7 @@ func TestAccAwsWafv2RegexPatternSet_Tags(t *testing.T) {
 			{
 				Config: testAccAwsWafv2RegexPatternSetConfig_OneTag(regexPatternSetName, "Tag1", "Value1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafv2RegexPatternSetExists("aws_wafv2_regex_pattern_set.test", &v),
+					testAccCheckAWSWafv2RegexPatternSetExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/regexpatternset/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Tag1", "Value1"),
@@ -153,7 +175,7 @@ func TestAccAwsWafv2RegexPatternSet_Tags(t *testing.T) {
 			{
 				Config: testAccAwsWafv2RegexPatternSetConfig_TwoTags(regexPatternSetName, "Tag1", "Value1Updated", "Tag2", "Value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafv2RegexPatternSetExists("aws_wafv2_regex_pattern_set.test", &v),
+					testAccCheckAWSWafv2RegexPatternSetExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/regexpatternset/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Tag1", "Value1Updated"),
@@ -163,7 +185,7 @@ func TestAccAwsWafv2RegexPatternSet_Tags(t *testing.T) {
 			{
 				Config: testAccAwsWafv2RegexPatternSetConfig_OneTag(regexPatternSetName, "Tag2", "Value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafv2RegexPatternSetExists("aws_wafv2_regex_pattern_set.test", &v),
+					testAccCheckAWSWafv2RegexPatternSetExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "wafv2", regexp.MustCompile(`regional/regexpatternset/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Tag2", "Value2"),
@@ -189,7 +211,7 @@ func testAccCheckAWSWafv2RegexPatternSetDestroy(s *terraform.State) error {
 
 		if err == nil {
 			if *resp.RegexPatternSet.Id == rs.Primary.ID {
-				return fmt.Errorf("WAFV2 RegexPatternSet %s still exists", rs.Primary.ID)
+				return fmt.Errorf("WAFv2 RegexPatternSet %s still exists", rs.Primary.ID)
 			}
 		}
 
@@ -206,6 +228,29 @@ func testAccCheckAWSWafv2RegexPatternSetDestroy(s *terraform.State) error {
 	return nil
 }
 
+func testAccCheckAWSWafv2RegexPatternSetDisappears(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no WAFv2 RegexPatternSet ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).wafv2conn
+		_, err := conn.DeleteRegexPatternSet(&wafv2.DeleteRegexPatternSetInput{
+			Id:        aws.String(rs.Primary.ID),
+			Name:      aws.String(rs.Primary.Attributes["name"]),
+			Scope:     aws.String(rs.Primary.Attributes["scope"]),
+			LockToken: aws.String(rs.Primary.Attributes["lock_token"]),
+		})
+
+		return err
+	}
+}
+
 func testAccCheckAWSWafv2RegexPatternSetExists(n string, v *wafv2.RegexPatternSet) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -214,7 +259,7 @@ func testAccCheckAWSWafv2RegexPatternSetExists(n string, v *wafv2.RegexPatternSe
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No WAFV2 RegexPatternSet ID is set")
+			return fmt.Errorf("No WAFv2 RegexPatternSet ID is set")
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).wafv2conn
@@ -233,7 +278,7 @@ func testAccCheckAWSWafv2RegexPatternSetExists(n string, v *wafv2.RegexPatternSe
 			return nil
 		}
 
-		return fmt.Errorf("WAFV2 RegexPatternSet (%s) not found", rs.Primary.ID)
+		return fmt.Errorf("WAFv2 RegexPatternSet (%s) not found", rs.Primary.ID)
 	}
 }
 

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -3576,6 +3576,19 @@
                     </ul>
                 </li>
                 <li>
+                    <a href="#">WAFv2</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/wafv2_regex_pattern_set.html">aws_wafv2_regex_pattern_set</a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </li>
+                <li>
                     <a href="#">WorkLink</a>
                     <ul class="nav">
                         <li>

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -3571,16 +3571,6 @@
                                 <li>
                                     <a href="/docs/providers/aws/r/wafv2_ip_set.html">aws_wafv2_ip_set</a>
                                 </li>
-                            </ul>
-                        </li>
-                    </ul>
-                </li>
-                <li>
-                    <a href="#">WAFv2</a>
-                    <ul class="nav">
-                        <li>
-                            <a href="#">Resources</a>
-                            <ul class="nav nav-auto-expand">
                                 <li>
                                     <a href="/docs/providers/aws/r/wafv2_regex_pattern_set.html">aws_wafv2_regex_pattern_set</a>
                                 </li>

--- a/website/docs/r/wafv2_regex_pattern_set.html.markdown
+++ b/website/docs/r/wafv2_regex_pattern_set.html.markdown
@@ -18,11 +18,11 @@ resource "aws_wafv2_regex_pattern_set" "example" {
   description = "Example regex pattern set"
   scope       = "REGIONAL"
 
-  regular_expression_list {
+  regular_expression {
     regex_string = "one"
   }
 
-  regular_expression_list {
+  regular_expression {
     regex_string = "two"
   }
 
@@ -40,12 +40,10 @@ The following arguments are supported:
 * `name` - (Required) A friendly name of the regular expression pattern set.
 * `description` - (Optional) A friendly description of the regular expression pattern set.
 * `scope` - (Required) Specifies whether this is for an AWS CloudFront distribution or for a regional application. Valid values are `CLOUDFRONT` or `REGIONAL`. To work with CloudFront, you must also specify the Region US East (N. Virginia).
-* `regular_expression_list` - (Optional) One or more blocks of regular expression patterns that you want AWS WAF to search for, such as `B[a@]dB[o0]t`.
+* `regular_expression` - (Optional) One or more blocks of regular expression patterns that you want AWS WAF to search for, such as `B[a@]dB[o0]t`. See [Visibility Configuration](#regular-expression) below for details.
 * `tags` - (Optional) An array of key:value pairs to associate with the resource.
 
-## Nested blocks
-
-### `regular_expression_list`
+### Regular Expression
 
 * `regex_string` - (Required) The string representing the regular expression, see the AWS WAF [documentation](https://docs.aws.amazon.com/waf/latest/developerguide/waf-regex-pattern-set-creating.html) for more information.
 

--- a/website/docs/r/wafv2_regex_pattern_set.html.markdown
+++ b/website/docs/r/wafv2_regex_pattern_set.html.markdown
@@ -1,0 +1,65 @@
+---
+subcategory: "WAFv2"
+layout: "aws"
+page_title: "AWS: aws_wafv2_regex_pattern_set"
+description: |-
+  Provides an AWS WAFv2 Regex Pattern Set resource.
+---
+
+# Resource: aws_wafv2_regex_pattern_set
+
+Provides an AWS WAFv2 Regex Pattern Set Resource
+
+## Example Usage
+
+```hcl
+resource "aws_wafv2_regex_pattern_set" "example" {
+  name        = "example"
+  description = "Example regex pattern set"
+  scope       = "REGIONAL"
+
+  regular_expression_list {
+    regex_string = "one"
+  }
+
+  regular_expression_list {
+    regex_string = "two"
+  }
+
+  tags = {
+    Tag1 = "Value1"
+    Tag2 = "Value2"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) A friendly name of the regular expression pattern set.
+* `description` - (Optional) A friendly description of the regular expression pattern set.
+* `scope` - (Required) Specifies whether this is for an AWS CloudFront distribution or for a regional application. Valid values are `CLOUDFRONT` or `REGIONAL`. To work with CloudFront, you must also specify the Region US East (N. Virginia).
+* `regular_expression_list` - (Required) One or more blocks of regular expression patterns that you want AWS WAF to search for, such as `B[a@]dB[o0]t`.
+* `tags` - (Optional) An array of key:value pairs to associate with the resource.
+
+## Nested blocks
+
+### `regular_expression_list`
+
+* `regex_string` - (Required) The string representing the regular expression, see the AWS WAF [documentation](https://docs.aws.amazon.com/waf/latest/developerguide/waf-regex-pattern-set-creating.html) for more information.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - A unique identifier for the set.
+* `arn` - The Amazon Resource Name (ARN) that identifies the cluster.
+
+## Import
+
+WAFv2 Regex Pattern Sets can be imported using their ID, Name and Scope e.g.
+
+```
+$ terraform import aws_wafv2_regex_pattern_set.example a1b2c3d4-d5f6-7777-8888-9999aaaabbbbcccc/example/REGIONAL
+```

--- a/website/docs/r/wafv2_regex_pattern_set.html.markdown
+++ b/website/docs/r/wafv2_regex_pattern_set.html.markdown
@@ -39,7 +39,7 @@ The following arguments are supported:
 
 * `name` - (Required) A friendly name of the regular expression pattern set.
 * `description` - (Optional) A friendly description of the regular expression pattern set.
-* `scope` - (Required) Specifies whether this is for an AWS CloudFront distribution or for a regional application. Valid values are `CLOUDFRONT` or `REGIONAL`. To work with CloudFront, you must also specify the Region US East (N. Virginia).
+* `scope` - (Required) Specifies whether this is for an AWS CloudFront distribution or for a regional application. Valid values are `CLOUDFRONT` or `REGIONAL`. To work with CloudFront, you must also specify the region `us-east-1` (N. Virginia) on the AWS provider.
 * `regular_expression` - (Optional) One or more blocks of regular expression patterns that you want AWS WAF to search for, such as `B[a@]dB[o0]t`. See [Regular Expression](#regular-expression) below for details.
 * `tags` - (Optional) An array of key:value pairs to associate with the resource.
 

--- a/website/docs/r/wafv2_regex_pattern_set.html.markdown
+++ b/website/docs/r/wafv2_regex_pattern_set.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 * `name` - (Required) A friendly name of the regular expression pattern set.
 * `description` - (Optional) A friendly description of the regular expression pattern set.
 * `scope` - (Required) Specifies whether this is for an AWS CloudFront distribution or for a regional application. Valid values are `CLOUDFRONT` or `REGIONAL`. To work with CloudFront, you must also specify the Region US East (N. Virginia).
-* `regular_expression_list` - (Required) One or more blocks of regular expression patterns that you want AWS WAF to search for, such as `B[a@]dB[o0]t`.
+* `regular_expression_list` - (Optional) One or more blocks of regular expression patterns that you want AWS WAF to search for, such as `B[a@]dB[o0]t`.
 * `tags` - (Optional) An array of key:value pairs to associate with the resource.
 
 ## Nested blocks

--- a/website/docs/r/wafv2_regex_pattern_set.html.markdown
+++ b/website/docs/r/wafv2_regex_pattern_set.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 * `name` - (Required) A friendly name of the regular expression pattern set.
 * `description` - (Optional) A friendly description of the regular expression pattern set.
 * `scope` - (Required) Specifies whether this is for an AWS CloudFront distribution or for a regional application. Valid values are `CLOUDFRONT` or `REGIONAL`. To work with CloudFront, you must also specify the Region US East (N. Virginia).
-* `regular_expression` - (Optional) One or more blocks of regular expression patterns that you want AWS WAF to search for, such as `B[a@]dB[o0]t`. See [Visibility Configuration](#regular-expression) below for details.
+* `regular_expression` - (Optional) One or more blocks of regular expression patterns that you want AWS WAF to search for, such as `B[a@]dB[o0]t`. See [Regular Expression](#regular-expression) below for details.
 * `tags` - (Optional) An array of key:value pairs to associate with the resource.
 
 ### Regular Expression
@@ -56,7 +56,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-WAFv2 Regex Pattern Sets can be imported using their ID, Name and Scope e.g.
+WAFv2 Regex Pattern Sets can be imported using `ID/name/scope` e.g.
 
 ```
 $ terraform import aws_wafv2_regex_pattern_set.example a1b2c3d4-d5f6-7777-8888-9999aaaabbbbcccc/example/REGIONAL


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #11174
Relates #11046

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* **New Resource**: `aws_wafv2_regex_pattern_set` (#12284)
```

Output from acceptance testing:
```
--- PASS: TestAccAwsWafv2RegexPatternSet_Disappears (17.37s)
--- PASS: TestAccAwsWafv2RegexPatternSet_Minimal (19.88s)
--- PASS: TestAccAwsWafv2RegexPatternSet_Basic (35.35s)
--- PASS: TestAccAwsWafv2RegexPatternSet_ChangeNameForceNew (35.46s)
--- PASS: TestAccAwsWafv2RegexPatternSet_Tags (42.81s)
```
