### PR TITLE
r/aws_spot_fleet_request - add support for tagging + validations

### DIFF
--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -333,11 +333,11 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 			"excess_capacity_termination_policy": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  ec2.ExcessCapacityTerminationPolicyDefault,
+				Default:  "Default",
 				ForceNew: false,
 				ValidateFunc: validation.StringInSlice([]string{
-					ec2.ExcessCapacityTerminationPolicyDefault,
-					ec2.ExcessCapacityTerminationPolicyNoTermination,
+					"Default",
+					"NoTermination",
 				}, false),
 			},
 			"instance_interruption_behaviour": {

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -123,6 +122,13 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 										Optional: true,
 										Computed: true,
 										ForceNew: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											ec2.VolumeTypeStandard,
+											ec2.VolumeTypeIo1,
+											ec2.VolumeTypeGp2,
+											ec2.VolumeTypeSc1,
+											ec2.VolumeTypeSt1,
+										}, false),
 									},
 								},
 							},
@@ -195,6 +201,13 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 										Optional: true,
 										Computed: true,
 										ForceNew: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											ec2.VolumeTypeStandard,
+											ec2.VolumeTypeIo1,
+											ec2.VolumeTypeGp2,
+											ec2.VolumeTypeSc1,
+											ec2.VolumeTypeSt1,
+										}, false),
 									},
 								},
 							},
@@ -211,9 +224,10 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 							Optional: true,
 						},
 						"iam_instance_profile_arn": {
-							Type:     schema.TypeString,
-							ForceNew: true,
-							Optional: true,
+							Type:         schema.TypeString,
+							ForceNew:     true,
+							Optional:     true,
+							ValidateFunc: validateArn,
 						},
 						"ami": {
 							Type:     schema.TypeString,
@@ -301,8 +315,13 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 			"allocation_strategy": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "lowestPrice",
+				Default:  ec2.AllocationStrategyLowestPrice,
 				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					ec2.AllocationStrategyLowestPrice,
+					ec2.AllocationStrategyDiversified,
+					ec2.AllocationStrategyCapacityOptimized,
+				}, false),
 			},
 			"instance_pools_to_use_count": {
 				Type:     schema.TypeInt,
@@ -314,18 +333,23 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 			"excess_capacity_termination_policy": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "Default",
+				Default:  ec2.ExcessCapacityTerminationPolicyDefault,
 				ForceNew: false,
 				ValidateFunc: validation.StringInSlice([]string{
-					"Default",
-					"NoTermination",
+					ec2.ExcessCapacityTerminationPolicyDefault,
+					ec2.ExcessCapacityTerminationPolicyNoTermination,
 				}, false),
 			},
 			"instance_interruption_behaviour": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "terminate",
+				Default:  ec2.InstanceInterruptionBehaviorTerminate,
 				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					ec2.InstanceInterruptionBehaviorTerminate,
+					ec2.InstanceInterruptionBehaviorStop,
+					ec2.InstanceInterruptionBehaviorHibernate,
+				}, false),
 			},
 			"spot_price": {
 				Type:     schema.TypeString,
@@ -357,6 +381,7 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					ec2.FleetTypeMaintain,
 					ec2.FleetTypeRequest,
+					ec2.FleetTypeInstant,
 				}, false),
 			},
 			"spot_request_state": {
@@ -380,9 +405,13 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validateArn,
+				},
+				Set: schema.HashString,
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -661,6 +690,7 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 		ReplaceUnhealthyInstances:        aws.Bool(d.Get("replace_unhealthy_instances").(bool)),
 		InstanceInterruptionBehavior:     aws.String(d.Get("instance_interruption_behaviour").(string)),
 		Type:                             aws.String(d.Get("fleet_type").(string)),
+		TagSpecifications:                ec2TagSpecificationsFromMap(d.Get("tags").(map[string]interface{}), ec2.ResourceTypeSpotFleetRequest),
 	}
 
 	if v, ok := d.GetOk("excess_capacity_termination_policy"); ok {
@@ -856,7 +886,7 @@ func resourceAwsSpotFleetRequestFulfillmentRefreshFunc(id string, conn *ec2.EC2)
 
 			// Query "information" events (e.g. launchSpecUnusable b/c low bid price)
 			out, err := conn.DescribeSpotFleetRequestHistory(&ec2.DescribeSpotFleetRequestHistoryInput{
-				EventType:          aws.String("information"),
+				EventType:          aws.String(ec2.EventTypeInformation),
 				SpotFleetRequestId: aws.String(id),
 				StartTime:          cfg.CreateTime,
 			})
@@ -900,8 +930,7 @@ func resourceAwsSpotFleetRequestRead(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		// If the spot request was not found, return nil so that we can show
 		// that it is gone.
-		ec2err, ok := err.(awserr.Error)
-		if ok && ec2err.Code() == "InvalidSpotFleetRequestId.NotFound" {
+		if isAWSErr(err, "InvalidSpotFleetRequestId.NotFound", "") {
 			d.SetId("")
 			return nil
 		}
@@ -981,6 +1010,9 @@ func resourceAwsSpotFleetRequestRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("instance_interruption_behaviour", config.InstanceInterruptionBehavior)
 	d.Set("fleet_type", config.Type)
 	d.Set("launch_specification", launchSpec)
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(sfr.Tags).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
 
 	return nil
 }
@@ -1201,19 +1233,38 @@ func resourceAwsSpotFleetRequestUpdate(d *schema.ResourceData, meta interface{})
 		SpotFleetRequestId: aws.String(d.Id()),
 	}
 
-	if val, ok := d.GetOk("target_capacity"); ok {
-		req.TargetCapacity = aws.Int64(int64(val.(int)))
+	updateFlag := false
+
+	if d.HasChange("target_capacity") {
+		if val, ok := d.GetOk("target_capacity"); ok {
+			req.TargetCapacity = aws.Int64(int64(val.(int)))
+		}
+
+		updateFlag = true
 	}
 
-	if val, ok := d.GetOk("excess_capacity_termination_policy"); ok {
-		req.ExcessCapacityTerminationPolicy = aws.String(val.(string))
+	if d.HasChange("excess_capacity_termination_policy") {
+		if val, ok := d.GetOk("excess_capacity_termination_policy"); ok {
+			req.ExcessCapacityTerminationPolicy = aws.String(val.(string))
+		}
+
+		updateFlag = true
 	}
 
-	if _, err := conn.ModifySpotFleetRequest(req); err != nil {
-		return fmt.Errorf("error updating spot request (%s): %s", d.Id(), err)
+	if updateFlag {
+		if _, err := conn.ModifySpotFleetRequest(req); err != nil {
+			return fmt.Errorf("error updating spot request (%s): %s", d.Id(), err)
+		}
 	}
 
-	return nil
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+		if err := keyvaluetags.Ec2UpdateTags(conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("error updating tags: %s", err)
+		}
+	}
+
+	return resourceAwsSpotFleetRequestRead(d, meta)
 }
 
 func resourceAwsSpotFleetRequestDelete(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -261,6 +261,11 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							ForceNew: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								ec2.TenancyDefault,
+								ec2.TenancyDedicated,
+								ec2.TenancyHost,
+							}, false),
 						},
 						"spot_price": {
 							Type:     schema.TypeString,

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -497,7 +497,7 @@ func buildSpotFleetLaunchSpecification(d map[string]interface{}, meta interface{
 		tags := keyvaluetags.New(m).IgnoreAws().Ec2Tags()
 
 		spec := &ec2.SpotFleetTagSpecification{
-			ResourceType: aws.String("instance"),
+			ResourceType: aws.String(ec2.ResourceTypeInstance),
 			Tags:         tags,
 		}
 
@@ -796,8 +796,8 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 	log.Printf("[INFO] Spot Fleet Request ID: %s", d.Id())
 	log.Println("[INFO] Waiting for Spot Fleet Request to be active")
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"submitted"},
-		Target:     []string{"active"},
+		Pending:    []string{ec2.BatchStateSubmitted},
+		Target:     []string{ec2.BatchStateActive},
 		Refresh:    resourceAwsSpotFleetRequestStateRefreshFunc(d, meta),
 		Timeout:    10 * time.Minute,
 		MinTimeout: 10 * time.Second,
@@ -812,8 +812,8 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 	if d.Get("wait_for_fulfillment").(bool) {
 		log.Println("[INFO] Waiting for Spot Fleet Request to be fulfilled")
 		spotStateConf := &resource.StateChangeConf{
-			Pending:    []string{"pending_fulfillment"},
-			Target:     []string{"fulfilled"},
+			Pending:    []string{ec2.ActivityStatusPendingFulfillment},
+			Target:     []string{ec2.ActivityStatusFulfilled},
 			Refresh:    resourceAwsSpotFleetRequestFulfillmentRefreshFunc(d.Id(), meta.(*AWSClient).ec2conn),
 			Timeout:    d.Timeout(schema.TimeoutCreate),
 			Delay:      10 * time.Second,

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -939,6 +939,11 @@ func testAccAWSSpotFleetRequestConfigBase(rName string, rInt int) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
 }
 
 resource "aws_key_pair" "debugging" {

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -61,6 +61,7 @@ func TestAccAWSSpotFleetRequest_basic(t *testing.T) {
 	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	resourceName := "aws_spot_fleet_request.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
@@ -70,10 +71,52 @@ func TestAccAWSSpotFleetRequest_basic(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestConfig(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists("aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "excess_capacity_termination_policy", "Default"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "valid_until", validUntil),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "excess_capacity_termination_policy", "Default"),
+					resource.TestCheckResourceAttr(resourceName, "valid_until", validUntil),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSpotFleetRequest_tags(t *testing.T) {
+	var sfr ec2.SpotFleetRequestConfig
+	rName := acctest.RandString(10)
+	rInt := acctest.RandInt()
+	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	resourceName := "aws_spot_fleet_request.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSpotFleetRequestConfigTags1(rName, validUntil, "key1", "value1", rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				Config: testAccAWSSpotFleetRequestConfigTags2(rName, validUntil, "key1", "value1updated", "key2", "value2", rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSSpotFleetRequestConfigTags1(rName, validUntil, "key2", "value2", rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
 			},
 		},
@@ -85,6 +128,7 @@ func TestAccAWSSpotFleetRequest_associatePublicIpAddress(t *testing.T) {
 	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	resourceName := "aws_spot_fleet_request.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
@@ -94,10 +138,10 @@ func TestAccAWSSpotFleetRequest_associatePublicIpAddress(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestConfigAssociatePublicIpAddress(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists("aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.#", "1"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.24370212.associate_public_ip_address", "true"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.24370212.associate_public_ip_address", "true"),
 				),
 			},
 		},
@@ -109,6 +153,7 @@ func TestAccAWSSpotFleetRequest_instanceInterruptionBehavior(t *testing.T) {
 	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	resourceName := "aws_spot_fleet_request.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
@@ -118,9 +163,9 @@ func TestAccAWSSpotFleetRequest_instanceInterruptionBehavior(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestConfig(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists("aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "instance_interruption_behaviour", "stop"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "instance_interruption_behaviour", "stop"),
 				),
 			},
 		},
@@ -132,6 +177,7 @@ func TestAccAWSSpotFleetRequest_fleetType(t *testing.T) {
 	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	resourceName := "aws_spot_fleet_request.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
@@ -141,9 +187,9 @@ func TestAccAWSSpotFleetRequest_fleetType(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestConfigFleetType(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists("aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "fleet_type", "request"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "fleet_type", "request"),
 				),
 			},
 		},
@@ -155,6 +201,7 @@ func TestAccAWSSpotFleetRequest_iamInstanceProfileArn(t *testing.T) {
 	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	resourceName := "aws_spot_fleet_request.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
@@ -164,9 +211,8 @@ func TestAccAWSSpotFleetRequest_iamInstanceProfileArn(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestConfigIamInstanceProfileArn(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "spot_request_state", "active"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
 					testAccCheckAWSSpotFleetRequest_IamInstanceProfileArn(&sfr),
 				),
 			},
@@ -179,6 +225,7 @@ func TestAccAWSSpotFleetRequest_changePriceForcesNewRequest(t *testing.T) {
 	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	resourceName := "aws_spot_fleet_request.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
@@ -188,21 +235,19 @@ func TestAccAWSSpotFleetRequest_changePriceForcesNewRequest(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestConfig(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &before),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "spot_price", "0.005"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.#", "1"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "spot_price", "0.005"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "1"),
 				),
 			},
 			{
 				Config: testAccAWSSpotFleetRequestConfigChangeSpotBidPrice(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &after),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.#", "1"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "spot_price", "0.01"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &after),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spot_price", "0.01"),
 					testAccCheckAWSSpotFleetRequestConfigRecreated(t, &before, &after),
 				),
 			},
@@ -215,6 +260,7 @@ func TestAccAWSSpotFleetRequest_updateTargetCapacity(t *testing.T) {
 	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	resourceName := "aws_spot_fleet_request.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
@@ -224,24 +270,24 @@ func TestAccAWSSpotFleetRequest_updateTargetCapacity(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestConfig(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists("aws_spot_fleet_request.foo", &before),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "target_capacity", "2"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "target_capacity", "2"),
 				),
 			},
 			{
 				Config: testAccAWSSpotFleetRequestConfigTargetCapacity(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists("aws_spot_fleet_request.foo", &after),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "target_capacity", "3"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &after),
+					resource.TestCheckResourceAttr(resourceName, "target_capacity", "3"),
 				),
 			},
 			{
 				Config: testAccAWSSpotFleetRequestConfig(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists("aws_spot_fleet_request.foo", &before),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "target_capacity", "2"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "target_capacity", "2"),
 				),
 			},
 		},
@@ -253,6 +299,7 @@ func TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy(t *testing
 	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	resourceName := "aws_spot_fleet_request.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
@@ -262,16 +309,16 @@ func TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy(t *testing
 			{
 				Config: testAccAWSSpotFleetRequestConfig(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists("aws_spot_fleet_request.foo", &before),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "excess_capacity_termination_policy", "Default"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "excess_capacity_termination_policy", "Default"),
 				),
 			},
 			{
 				Config: testAccAWSSpotFleetRequestConfigExcessCapacityTermination(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists("aws_spot_fleet_request.foo", &after),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "excess_capacity_termination_policy", "NoTermination"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &after),
+					resource.TestCheckResourceAttr(resourceName, "excess_capacity_termination_policy", "NoTermination"),
 				),
 			},
 		},
@@ -283,6 +330,7 @@ func TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion(t *testing.T) {
 	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	resourceName := "aws_spot_fleet_request.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
@@ -292,10 +340,9 @@ func TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestConfig(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.#", "1"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "1"),
 				),
 			},
 		},
@@ -307,6 +354,7 @@ func TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList(t *testing.T) {
 	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	resourceName := "aws_spot_fleet_request.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
@@ -316,12 +364,11 @@ func TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestConfigWithAzs(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.#", "2"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.1991689378.availability_zone", "us-west-2a"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.19404370.availability_zone", "us-west-2b"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.1991689378.availability_zone", "us-west-2a"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.19404370.availability_zone", "us-west-2b"),
 				),
 			},
 		},
@@ -333,6 +380,7 @@ func TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList(t *testing.T) {
 	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	resourceName := "aws_spot_fleet_request.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
@@ -342,10 +390,9 @@ func TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestConfigWithSubnet(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.#", "2"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "2"),
 				),
 			},
 		},
@@ -357,6 +404,7 @@ func TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz(t *testing.T) {
 	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	resourceName := "aws_spot_fleet_request.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
@@ -366,14 +414,13 @@ func TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestConfigMultipleInstanceTypesinSameAz(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.#", "2"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.1991689378.instance_type", "m1.small"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.1991689378.availability_zone", "us-west-2a"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.590403189.instance_type", "m3.large"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.590403189.availability_zone", "us-west-2a"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.1991689378.instance_type", "m1.small"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.1991689378.availability_zone", "us-west-2a"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.590403189.instance_type", "m3.large"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.590403189.availability_zone", "us-west-2a"),
 				),
 			},
 		},
@@ -385,6 +432,7 @@ func TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet(t *testing.T) 
 	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	resourceName := "aws_spot_fleet_request.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
@@ -394,10 +442,9 @@ func TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet(t *testing.T) 
 			{
 				Config: testAccAWSSpotFleetRequestConfigMultipleInstanceTypesinSameSubnet(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.#", "2"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "2"),
 				),
 			},
 		},
@@ -409,6 +456,7 @@ func TestAccAWSSpotFleetRequest_overriddingSpotPrice(t *testing.T) {
 	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	resourceName := "aws_spot_fleet_request.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
@@ -418,15 +466,14 @@ func TestAccAWSSpotFleetRequest_overriddingSpotPrice(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestConfigOverridingSpotPrice(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "spot_price", "0.035"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.#", "2"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.4143232216.spot_price", "0.01"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.4143232216.instance_type", "m3.large"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.1991689378.spot_price", ""), //there will not be a value here since it's not overriding
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.1991689378.instance_type", "m1.small"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "spot_price", "0.035"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.4143232216.spot_price", "0.01"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.4143232216.instance_type", "m3.large"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.1991689378.spot_price", ""), //there will not be a value here since it's not overriding
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.1991689378.instance_type", "m1.small"),
 				),
 			},
 		},
@@ -438,6 +485,7 @@ func TestAccAWSSpotFleetRequest_withoutSpotPrice(t *testing.T) {
 	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	resourceName := "aws_spot_fleet_request.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
@@ -447,10 +495,9 @@ func TestAccAWSSpotFleetRequest_withoutSpotPrice(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestConfigWithoutSpotPrice(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.#", "2"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "2"),
 				),
 			},
 		},
@@ -462,6 +509,7 @@ func TestAccAWSSpotFleetRequest_diversifiedAllocation(t *testing.T) {
 	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	resourceName := "aws_spot_fleet_request.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
@@ -471,11 +519,10 @@ func TestAccAWSSpotFleetRequest_diversifiedAllocation(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestConfigDiversifiedAllocation(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.#", "3"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "allocation_strategy", "diversified"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "allocation_strategy", "diversified"),
 				),
 			},
 		},
@@ -487,6 +534,7 @@ func TestAccAWSSpotFleetRequest_multipleInstancePools(t *testing.T) {
 	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	resourceName := "aws_spot_fleet_request.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
@@ -496,12 +544,11 @@ func TestAccAWSSpotFleetRequest_multipleInstancePools(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestConfigMultipleInstancePools(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.#", "3"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "allocation_strategy", "lowestPrice"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "instance_pools_to_use_count", "2"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "allocation_strategy", "lowestPrice"),
+					resource.TestCheckResourceAttr(resourceName, "instance_pools_to_use_count", "2"),
 				),
 			},
 		},
@@ -513,6 +560,7 @@ func TestAccAWSSpotFleetRequest_withWeightedCapacity(t *testing.T) {
 	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	resourceName := "aws_spot_fleet_request.test"
 
 	fulfillSleep := func() resource.TestCheckFunc {
 		// sleep so that EC2 can fuflill the request. We do this to guard against a
@@ -537,14 +585,13 @@ func TestAccAWSSpotFleetRequest_withWeightedCapacity(t *testing.T) {
 				Config: testAccAWSSpotFleetRequestConfigWithWeightedCapacity(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					fulfillSleep(),
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.#", "2"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.4120185872.weighted_capacity", "3"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.4120185872.instance_type", "r3.large"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.590403189.weighted_capacity", "6"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.590403189.instance_type", "m3.large"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.4120185872.weighted_capacity", "3"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.4120185872.instance_type", "r3.large"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.590403189.weighted_capacity", "6"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.590403189.instance_type", "m3.large"),
 				),
 			},
 		},
@@ -556,6 +603,7 @@ func TestAccAWSSpotFleetRequest_withEBSDisk(t *testing.T) {
 	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	resourceName := "aws_spot_fleet_request.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
@@ -565,10 +613,8 @@ func TestAccAWSSpotFleetRequest_withEBSDisk(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestEBSConfig(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &config),
-					testAccCheckAWSSpotFleetRequest_EBSAttributes(
-						&config),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &config),
+					testAccCheckAWSSpotFleetRequest_EBSAttributes(&config),
 				),
 			},
 		},
@@ -624,6 +670,7 @@ func TestAccAWSSpotFleetRequest_withTags(t *testing.T) {
 	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	resourceName := "aws_spot_fleet_request.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
@@ -633,10 +680,10 @@ func TestAccAWSSpotFleetRequest_withTags(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestTagsConfig(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists("aws_spot_fleet_request.foo", &config),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.24370212.tags.%", "2"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.24370212.tags.First", "TfAccTest"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.24370212.tags.Second", "Terraform"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &config),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.24370212.tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.24370212.tags.First", "TfAccTest"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.24370212.tags.Second", "Terraform"),
 				),
 			},
 		},
@@ -648,6 +695,7 @@ func TestAccAWSSpotFleetRequest_placementTenancyAndGroup(t *testing.T) {
 	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	resourceName := "aws_spot_fleet_request.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
@@ -657,8 +705,8 @@ func TestAccAWSSpotFleetRequest_placementTenancyAndGroup(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestTenancyGroupConfig(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists("aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "spot_request_state", "active"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
 					testAccCheckAWSSpotFleetRequest_PlacementAttributes(&sfr, rName),
 				),
 			},
@@ -671,6 +719,7 @@ func TestAccAWSSpotFleetRequest_WithELBs(t *testing.T) {
 	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	resourceName := "aws_spot_fleet_request.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
@@ -680,11 +729,10 @@ func TestAccAWSSpotFleetRequest_WithELBs(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestConfigWithELBs(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.#", "1"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "load_balancers.#", "1"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "load_balancers.#", "1"),
 				),
 			},
 		},
@@ -696,6 +744,7 @@ func TestAccAWSSpotFleetRequest_WithTargetGroups(t *testing.T) {
 	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	resourceName := "aws_spot_fleet_request.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
@@ -705,11 +754,10 @@ func TestAccAWSSpotFleetRequest_WithTargetGroups(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestConfigWithTargetGroups(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.#", "1"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "target_group_arns.#", "1"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "target_group_arns.#", "1"),
 				),
 			},
 		},
@@ -951,7 +999,7 @@ resource "aws_iam_policy_attachment" "test-attach" {
 
 func testAccAWSSpotFleetRequestConfig(rName string, rInt int, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
-resource "aws_spot_fleet_request" "foo" {
+resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
     spot_price = "0.005"
     target_capacity = 2
@@ -969,9 +1017,56 @@ resource "aws_spot_fleet_request" "foo" {
 `, validUntil)
 }
 
+func testAccAWSSpotFleetRequestConfigTags1(rName, validUntil, tagKey1, tagValue1 string, rInt int) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+resource "aws_spot_fleet_request" "test" {
+    iam_fleet_role = "${aws_iam_role.test-role.arn}"
+    spot_price = "0.005"
+    target_capacity = 2
+    valid_until = %[1]q
+    terminate_instances_with_expiration = true
+    instance_interruption_behaviour = "stop"
+    wait_for_fulfillment = true
+    launch_specification {
+        instance_type = "m1.small"
+        ami = "ami-516b9131"
+        key_name = "${aws_key_pair.debugging.key_name}"
+    }
+    tags = {
+      %[2]q = %[3]q
+    }
+    depends_on = ["aws_iam_policy_attachment.test-attach"]
+}
+`, validUntil, tagKey1, tagValue1)
+}
+
+func testAccAWSSpotFleetRequestConfigTags2(rName, validUntil, tagKey1, tagValue1, tagKey2, tagValue2 string, rInt int) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+resource "aws_spot_fleet_request" "test" {
+    iam_fleet_role = "${aws_iam_role.test-role.arn}"
+    spot_price = "0.005"
+    target_capacity = 2
+    valid_until = %[1]q
+    terminate_instances_with_expiration = true
+    instance_interruption_behaviour = "stop"
+    wait_for_fulfillment = true
+    launch_specification {
+        instance_type = "m1.small"
+        ami = "ami-516b9131"
+        key_name = "${aws_key_pair.debugging.key_name}"
+    }
+    tags = {
+      %[2]q = %[3]q
+      %[4]q = %[5]q
+    }
+    depends_on = ["aws_iam_policy_attachment.test-attach"]
+}
+`, validUntil, tagKey1, tagValue1, tagKey2, tagValue2)
+}
+
 func testAccAWSSpotFleetRequestConfigAssociatePublicIpAddress(rName string, rInt int, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
-resource "aws_spot_fleet_request" "foo" {
+resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
     spot_price = "0.027"
     target_capacity = 2
@@ -991,7 +1086,7 @@ resource "aws_spot_fleet_request" "foo" {
 
 func testAccAWSSpotFleetRequestConfigTargetCapacity(rName string, rInt int, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
-resource "aws_spot_fleet_request" "foo" {
+resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
     spot_price = "0.005"
     target_capacity = 3
@@ -1010,7 +1105,7 @@ resource "aws_spot_fleet_request" "foo" {
 
 func testAccAWSSpotFleetRequestConfigExcessCapacityTermination(rName string, rInt int, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
-resource "aws_spot_fleet_request" "foo" {
+resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
     spot_price = "0.005"
     target_capacity = 2
@@ -1030,7 +1125,7 @@ resource "aws_spot_fleet_request" "foo" {
 
 func testAccAWSSpotFleetRequestConfigFleetType(rName string, rInt int, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
-resource "aws_spot_fleet_request" "foo" {
+resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
     spot_price = "0.005"
     target_capacity = 2
@@ -1091,7 +1186,7 @@ resource "aws_iam_instance_profile" "test-iam-instance-profile1" {
 	role = "${aws_iam_role.test-role1.name}"
 }
 
-resource "aws_spot_fleet_request" "foo" {
+resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
     spot_price = "0.005"
     target_capacity = 2
@@ -1112,7 +1207,7 @@ resource "aws_spot_fleet_request" "foo" {
 
 func testAccAWSSpotFleetRequestConfigChangeSpotBidPrice(rName string, rInt int, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
-resource "aws_spot_fleet_request" "foo" {
+resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
     spot_price = "0.01"
     target_capacity = 2
@@ -1131,7 +1226,7 @@ resource "aws_spot_fleet_request" "foo" {
 
 func testAccAWSSpotFleetRequestConfigWithAzs(rName string, rInt int, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
-resource "aws_spot_fleet_request" "foo" {
+resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
     spot_price = "0.005"
     target_capacity = 2
@@ -1157,32 +1252,32 @@ resource "aws_spot_fleet_request" "foo" {
 
 func testAccAWSSpotFleetRequestConfigWithSubnet(rName string, rInt int, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
     cidr_block = "10.1.0.0/16"
   tags = {
         Name = "terraform-testacc-spot-fleet-request-w-subnet"
     }
 }
 
-resource "aws_subnet" "foo" {
+resource "aws_subnet" "test" {
     cidr_block = "10.1.1.0/24"
-    vpc_id = "${aws_vpc.foo.id}"
+    vpc_id = "${aws_vpc.test.id}"
     availability_zone = "us-west-2a"
   tags = {
-        Name = "tf-acc-spot-fleet-request-w-subnet-foo"
+        Name = "tf-acc-spot-fleet-request-w-subnet-test"
     }
 }
 
 resource "aws_subnet" "bar" {
     cidr_block = "10.1.20.0/24"
-    vpc_id = "${aws_vpc.foo.id}"
+    vpc_id = "${aws_vpc.test.id}"
     availability_zone = "us-west-2b"
   tags = {
         Name = "tf-acc-spot-fleet-request-w-subnet-bar"
     }
 }
 
-resource "aws_spot_fleet_request" "foo" {
+resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
     spot_price = "0.05"
     target_capacity = 4
@@ -1193,7 +1288,7 @@ resource "aws_spot_fleet_request" "foo" {
         instance_type = "m3.large"
         ami = "ami-d0f506b0"
         key_name = "${aws_key_pair.debugging.key_name}"
-        subnet_id = "${aws_subnet.foo.id}"
+        subnet_id = "${aws_subnet.test.id}"
     }
     launch_specification {
         instance_type = "m3.large"
@@ -1208,22 +1303,22 @@ resource "aws_spot_fleet_request" "foo" {
 
 func testAccAWSSpotFleetRequestConfigWithELBs(rName string, rInt int, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
     cidr_block = "10.1.0.0/16"
 }
 
-resource "aws_subnet" "foo" {
+resource "aws_subnet" "test" {
     cidr_block = "10.1.1.0/24"
-    vpc_id = "${aws_vpc.foo.id}"
+    vpc_id = "${aws_vpc.test.id}"
     availability_zone = "us-west-2a"
   tags = {
-        Name = "tf-acc-spot-fleet-request-with-elb-foo"
+        Name = "tf-acc-spot-fleet-request-with-elb-test"
     }
 }
 
 resource "aws_subnet" "bar" {
     cidr_block = "10.1.20.0/24"
-    vpc_id = "${aws_vpc.foo.id}"
+    vpc_id = "${aws_vpc.test.id}"
     availability_zone = "us-west-2b"
   tags = {
         Name = "tf-acc-spot-fleet-request-with-elb-bar"
@@ -1232,7 +1327,7 @@ resource "aws_subnet" "bar" {
 
 resource "aws_elb" "elb" {
   name = "test-elb-%[1]s"
-  subnets = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
+  subnets = ["${aws_subnet.test.id}", "${aws_subnet.bar.id}"]
   internal = true
 
   listener {
@@ -1243,7 +1338,7 @@ resource "aws_elb" "elb" {
   }
 }
 
-resource "aws_spot_fleet_request" "foo" {
+resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
     spot_price = "0.5"
     target_capacity = 2
@@ -1255,7 +1350,7 @@ resource "aws_spot_fleet_request" "foo" {
         instance_type = "m3.large"
         ami = "ami-d0f506b0"
         key_name = "${aws_key_pair.debugging.key_name}"
-        subnet_id = "${aws_subnet.foo.id}"
+        subnet_id = "${aws_subnet.test.id}"
     }
     depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
@@ -1264,22 +1359,22 @@ resource "aws_spot_fleet_request" "foo" {
 
 func testAccAWSSpotFleetRequestConfigWithTargetGroups(rName string, rInt int, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
     cidr_block = "10.1.0.0/16"
 }
 
-resource "aws_subnet" "foo" {
+resource "aws_subnet" "test" {
     cidr_block = "10.1.1.0/24"
-    vpc_id = "${aws_vpc.foo.id}"
+    vpc_id = "${aws_vpc.test.id}"
     availability_zone = "us-west-2a"
   tags = {
-        Name = "tf-acc-spot-fleet-request-with-target-groups-foo"
+        Name = "tf-acc-spot-fleet-request-with-target-groups-test"
     }
 }
 
 resource "aws_subnet" "bar" {
     cidr_block = "10.1.20.0/24"
-    vpc_id = "${aws_vpc.foo.id}"
+    vpc_id = "${aws_vpc.test.id}"
     availability_zone = "us-west-2b"
   tags = {
         Name = "tf-acc-spot-fleet-request-with-target-groups-bar"
@@ -1289,7 +1384,7 @@ resource "aws_subnet" "bar" {
 resource "aws_alb" "alb" {
   name            = "test-elb-%[1]s"
   internal        = true
-  subnets         = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
+  subnets         = ["${aws_subnet.test.id}", "${aws_subnet.bar.id}"]
 }
 
 resource "aws_alb_listener" "listener" {
@@ -1307,10 +1402,10 @@ resource "aws_alb_target_group" "target_group" {
  name     = "${aws_alb.alb.name}"
  port     = 80
  protocol = "HTTP"
- vpc_id   = "${aws_vpc.foo.id}"
+ vpc_id   = "${aws_vpc.test.id}"
 }
 
-resource "aws_spot_fleet_request" "foo" {
+resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
     spot_price = "0.5"
     target_capacity = 2
@@ -1322,7 +1417,7 @@ resource "aws_spot_fleet_request" "foo" {
         instance_type = "m3.large"
         ami = "ami-d0f506b0"
         key_name = "${aws_key_pair.debugging.key_name}"
-        subnet_id = "${aws_subnet.foo.id}"
+        subnet_id = "${aws_subnet.test.id}"
     }
     depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
@@ -1331,7 +1426,7 @@ resource "aws_spot_fleet_request" "foo" {
 
 func testAccAWSSpotFleetRequestConfigMultipleInstanceTypesinSameAz(rName string, rInt int, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
-resource "aws_spot_fleet_request" "foo" {
+resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
     spot_price = "0.025"
     target_capacity = 2
@@ -1357,23 +1452,23 @@ resource "aws_spot_fleet_request" "foo" {
 
 func testAccAWSSpotFleetRequestConfigMultipleInstanceTypesinSameSubnet(rName string, rInt int, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
     cidr_block = "10.1.0.0/16"
   tags = {
         Name = "terraform-testacc-spot-fleet-request-multi-instance-types"
     }
 }
 
-resource "aws_subnet" "foo" {
+resource "aws_subnet" "test" {
     cidr_block = "10.1.1.0/24"
-    vpc_id = "${aws_vpc.foo.id}"
+    vpc_id = "${aws_vpc.test.id}"
     availability_zone = "us-west-2a"
   tags = {
         Name = "tf-acc-spot-fleet-request-multi-instance-types"
     }
 }
 
-resource "aws_spot_fleet_request" "foo" {
+resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
     spot_price = "0.035"
     target_capacity = 4
@@ -1384,13 +1479,13 @@ resource "aws_spot_fleet_request" "foo" {
         instance_type = "m3.large"
         ami = "ami-d0f506b0"
         key_name = "${aws_key_pair.debugging.key_name}"
-        subnet_id = "${aws_subnet.foo.id}"
+        subnet_id = "${aws_subnet.test.id}"
     }
     launch_specification {
         instance_type = "r3.large"
         ami = "ami-d0f506b0"
         key_name = "${aws_key_pair.debugging.key_name}"
-        subnet_id = "${aws_subnet.foo.id}"
+        subnet_id = "${aws_subnet.test.id}"
     }
     depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
@@ -1399,7 +1494,7 @@ resource "aws_spot_fleet_request" "foo" {
 
 func testAccAWSSpotFleetRequestConfigOverridingSpotPrice(rName string, rInt int, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
-resource "aws_spot_fleet_request" "foo" {
+resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
     spot_price = "0.035"
     target_capacity = 2
@@ -1426,7 +1521,7 @@ resource "aws_spot_fleet_request" "foo" {
 
 func testAccAWSSpotFleetRequestConfigWithoutSpotPrice(rName string, rInt int, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
-resource "aws_spot_fleet_request" "foo" {
+resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
     target_capacity = 2
     valid_until = %[1]q
@@ -1451,7 +1546,7 @@ resource "aws_spot_fleet_request" "foo" {
 
 func testAccAWSSpotFleetRequestConfigMultipleInstancePools(rName string, rInt int, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
-resource "aws_spot_fleet_request" "foo" {
+resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
     spot_price = "0.7"
     target_capacity = 30
@@ -1484,7 +1579,7 @@ resource "aws_spot_fleet_request" "foo" {
 
 func testAccAWSSpotFleetRequestConfigDiversifiedAllocation(rName string, rInt int, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
-resource "aws_spot_fleet_request" "foo" {
+resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
     spot_price = "0.7"
     target_capacity = 30
@@ -1517,7 +1612,7 @@ resource "aws_spot_fleet_request" "foo" {
 
 func testAccAWSSpotFleetRequestConfigWithWeightedCapacity(rName string, rInt int, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
-resource "aws_spot_fleet_request" "foo" {
+resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
     spot_price = "0.7"
     target_capacity = 10
@@ -1545,7 +1640,7 @@ resource "aws_spot_fleet_request" "foo" {
 
 func testAccAWSSpotFleetRequestEBSConfig(rName string, rInt int, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
-resource "aws_spot_fleet_request" "foo" {
+resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
     spot_price = "0.005"
     target_capacity = 1
@@ -1685,7 +1780,7 @@ data "aws_ami" "ubuntu_instance_store" {
   }
 }
 
-resource "aws_spot_fleet_request" "foo" {
+resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
     spot_price = "0.03"
     target_capacity = 2
@@ -1705,7 +1800,7 @@ resource "aws_spot_fleet_request" "foo" {
 
 func testAccAWSSpotFleetRequestTagsConfig(rName string, rInt int, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
-resource "aws_spot_fleet_request" "foo" {
+resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
     spot_price = "0.005"
     target_capacity = 1
@@ -1732,7 +1827,7 @@ resource "aws_placement_group" "test" {
 	strategy = "cluster"
 }
 
-resource "aws_spot_fleet_request" "foo" {
+resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
     spot_price = "0.005"
     target_capacity = 2

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -937,6 +937,10 @@ func testAccPreCheckAWSEc2SpotFleetRequest(t *testing.T) {
 
 func testAccAWSSpotFleetRequestConfigBase(rName string, rInt int) string {
 	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_key_pair" "debugging" {
   key_name   = "tmp-key-%[1]s"
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
@@ -1237,13 +1241,13 @@ resource "aws_spot_fleet_request" "test" {
         instance_type = "m1.small"
         ami = "ami-516b9131"
         key_name = "${aws_key_pair.debugging.key_name}"
-        availability_zone = "us-west-2a"
+        availability_zone = "${data.aws_availability_zones.available.names[0]}"
     }
     launch_specification {
         instance_type = "m1.small"
         ami = "ami-516b9131"
         key_name = "${aws_key_pair.debugging.key_name}"
-        availability_zone = "us-west-2b"
+        availability_zone = "${data.aws_availability_zones.available.names[1]}"
     }
     depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
@@ -1262,7 +1266,7 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "test" {
     cidr_block = "10.1.1.0/24"
     vpc_id = "${aws_vpc.test.id}"
-    availability_zone = "us-west-2a"
+    availability_zone = "${data.aws_availability_zones.available.names[0]}"
   tags = {
         Name = "tf-acc-spot-fleet-request-w-subnet-test"
     }
@@ -1271,7 +1275,7 @@ resource "aws_subnet" "test" {
 resource "aws_subnet" "bar" {
     cidr_block = "10.1.20.0/24"
     vpc_id = "${aws_vpc.test.id}"
-    availability_zone = "us-west-2b"
+    availability_zone = "${data.aws_availability_zones.available.names[1]}"
   tags = {
         Name = "tf-acc-spot-fleet-request-w-subnet-bar"
     }
@@ -1310,7 +1314,7 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "test" {
     cidr_block = "10.1.1.0/24"
     vpc_id = "${aws_vpc.test.id}"
-    availability_zone = "us-west-2a"
+    availability_zone = "${data.aws_availability_zones.available.names[0]}"
   tags = {
         Name = "tf-acc-spot-fleet-request-with-elb-test"
     }
@@ -1319,7 +1323,7 @@ resource "aws_subnet" "test" {
 resource "aws_subnet" "bar" {
     cidr_block = "10.1.20.0/24"
     vpc_id = "${aws_vpc.test.id}"
-    availability_zone = "us-west-2b"
+    availability_zone = "${data.aws_availability_zones.available.names[1]}"
   tags = {
         Name = "tf-acc-spot-fleet-request-with-elb-bar"
     }
@@ -1366,7 +1370,7 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "test" {
     cidr_block = "10.1.1.0/24"
     vpc_id = "${aws_vpc.test.id}"
-    availability_zone = "us-west-2a"
+    availability_zone = "${data.aws_availability_zones.available.names[0]}"
   tags = {
         Name = "tf-acc-spot-fleet-request-with-target-groups-test"
     }
@@ -1375,7 +1379,7 @@ resource "aws_subnet" "test" {
 resource "aws_subnet" "bar" {
     cidr_block = "10.1.20.0/24"
     vpc_id = "${aws_vpc.test.id}"
-    availability_zone = "us-west-2b"
+    availability_zone = "${data.aws_availability_zones.available.names[1]}"
   tags = {
         Name = "tf-acc-spot-fleet-request-with-target-groups-bar"
     }
@@ -1437,13 +1441,13 @@ resource "aws_spot_fleet_request" "test" {
         instance_type = "m1.small"
         ami = "ami-516b9131"
         key_name = "${aws_key_pair.debugging.key_name}"
-        availability_zone = "us-west-2a"
+        availability_zone = "${data.aws_availability_zones.available.names[0]}"
     }
     launch_specification {
         instance_type = "m3.large"
         ami = "ami-d06a90b0"
         key_name = "${aws_key_pair.debugging.key_name}"
-        availability_zone = "us-west-2a"
+        availability_zone = "${data.aws_availability_zones.available.names[0]}"
     }
     depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
@@ -1462,7 +1466,7 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "test" {
     cidr_block = "10.1.1.0/24"
     vpc_id = "${aws_vpc.test.id}"
-    availability_zone = "us-west-2a"
+    availability_zone = "${data.aws_availability_zones.available.names[0]}"
   tags = {
         Name = "tf-acc-spot-fleet-request-multi-instance-types"
     }
@@ -1505,13 +1509,13 @@ resource "aws_spot_fleet_request" "test" {
         instance_type = "m1.small"
         ami = "ami-516b9131"
         key_name = "${aws_key_pair.debugging.key_name}"
-        availability_zone = "us-west-2a"
+        availability_zone = "${data.aws_availability_zones.available.names[0]}"
     }
     launch_specification {
         instance_type = "m3.large"
         ami = "ami-d06a90b0"
         key_name = "${aws_key_pair.debugging.key_name}"
-        availability_zone = "us-west-2a"
+        availability_zone = "${data.aws_availability_zones.available.names[0]}"
         spot_price = "0.01"
     }
     depends_on = ["aws_iam_policy_attachment.test-attach"]
@@ -1531,13 +1535,13 @@ resource "aws_spot_fleet_request" "test" {
         instance_type = "m1.small"
         ami = "ami-516b9131"
         key_name = "${aws_key_pair.debugging.key_name}"
-        availability_zone = "us-west-2a"
+        availability_zone = "${data.aws_availability_zones.available.names[0]}"
     }
     launch_specification {
         instance_type = "m3.large"
         ami = "ami-d06a90b0"
         key_name = "${aws_key_pair.debugging.key_name}"
-        availability_zone = "us-west-2a"
+        availability_zone = "${data.aws_availability_zones.available.names[0]}"
     }
     depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
@@ -1558,19 +1562,19 @@ resource "aws_spot_fleet_request" "test" {
         instance_type = "m1.small"
         ami = "ami-d06a90b0"
         key_name = "${aws_key_pair.debugging.key_name}"
-        availability_zone = "us-west-2a"
+        availability_zone = "${data.aws_availability_zones.available.names[0]}"
     }
     launch_specification {
         instance_type = "m3.large"
         ami = "ami-d06a90b0"
         key_name = "${aws_key_pair.debugging.key_name}"
-        availability_zone = "us-west-2a"
+        availability_zone = "${data.aws_availability_zones.available.names[0]}"
     }
     launch_specification {
         instance_type = "r3.large"
         ami = "ami-d06a90b0"
         key_name = "${aws_key_pair.debugging.key_name}"
-        availability_zone = "us-west-2a"
+        availability_zone = "${data.aws_availability_zones.available.names[0]}"
     }
     depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
@@ -1591,19 +1595,19 @@ resource "aws_spot_fleet_request" "test" {
         instance_type = "m1.small"
         ami = "ami-d06a90b0"
         key_name = "${aws_key_pair.debugging.key_name}"
-        availability_zone = "us-west-2a"
+        availability_zone = "${data.aws_availability_zones.available.names[0]}"
     }
     launch_specification {
         instance_type = "m3.large"
         ami = "ami-d06a90b0"
         key_name = "${aws_key_pair.debugging.key_name}"
-        availability_zone = "us-west-2a"
+        availability_zone = "${data.aws_availability_zones.available.names[0]}"
     }
     launch_specification {
         instance_type = "r3.large"
         ami = "ami-d06a90b0"
         key_name = "${aws_key_pair.debugging.key_name}"
-        availability_zone = "us-west-2a"
+        availability_zone = "${data.aws_availability_zones.available.names[0]}"
     }
     depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
@@ -1623,14 +1627,14 @@ resource "aws_spot_fleet_request" "test" {
         instance_type = "m3.large"
         ami = "ami-d06a90b0"
         key_name = "${aws_key_pair.debugging.key_name}"
-        availability_zone = "us-west-2a"
+        availability_zone = "${data.aws_availability_zones.available.names[0]}"
         weighted_capacity = "6"
     }
     launch_specification {
         instance_type = "r3.large"
         ami = "ami-d06a90b0"
         key_name = "${aws_key_pair.debugging.key_name}"
-        availability_zone = "us-west-2a"
+        availability_zone = "${data.aws_availability_zones.available.names[0]}"
         weighted_capacity = "3"
     }
     depends_on = ["aws_iam_policy_attachment.test-attach"]


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12078

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_spot_fleet_request: add support for tagging.
resource_aws_spot_fleet_request: add plan time validation to `volume_type`, `iam_instance_profile_arn`, `allocation_strategy`, `instance_interruption_behaviour`, `target_group_arns`, `placement_tenancy`.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSpotFleetRequest_'
--- PASS: TestAccAWSSpotFleetRequest_basic (344.44s)
--- PASS: TestAccAWSSpotFleetRequest_updateTargetCapacity (986.78s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion (364.98s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList (349.96s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList (295.24s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz (291.23s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet (302.79s)
--- PASS: TestAccAWSSpotFleetRequest_overriddingSpotPrice (281.26s)
--- PASS: TestAccAWSSpotFleetRequest_withoutSpotPrice (341.80s)
--- PASS: TestAccAWSSpotFleetRequest_diversifiedAllocation (372.79s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstancePools (362.38s)
--- PASS: TestAccAWSSpotFleetRequest_withWeightedCapacity (358.54s)
--- PASS: TestAccAWSSpotFleetRequest_withEBSDisk (313.12s)
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDevice_KmsKeyId (213.91s)
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDevice_KmsKeyId (227.32s)
--- PASS: TestAccAWSSpotFleetRequest_withTags (354.02s)
--- PASS: TestAccAWSSpotFleetRequest_placementTenancyAndGroup (106.36s)
--- PASS: TestAccAWSSpotFleetRequest_WithELBs (364.46s)
--- PASS: TestAccAWSSpotFleetRequest_WithTargetGroups (497.25s)
--- PASS: TestAccAWSSpotFleetRequest_associatePublicIpAddress (340.35s)
--- PASS: TestAccAWSSpotFleetRequest_instanceInterruptionBehavior (277.50s)
--- PASS: TestAccAWSSpotFleetRequest_fleetType (272.67s)
--- PASS: TestAccAWSSpotFleetRequest_iamInstanceProfileArn (332.60s)
--- PASS: TestAccAWSSpotFleetRequest_changePriceForcesNewRequest (480.32s)
--- PASS: TestAccAWSSpotFleetRequest_tags (346.79s)
```
