### PR TITLE
Rename documentation subcategory for API Gateway v1 to prepare for v2

### DIFF
--- a/website/allowed-subcategories.txt
+++ b/website/allowed-subcategories.txt
@@ -1,7 +1,7 @@
 
 ACM PCA
 ACM
-API Gateway
+API Gateway (REST APIs)
 Access Analyzer
 AppMesh
 AppSync

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -114,7 +114,7 @@
                     </ul>
                 </li>
                 <li>
-                    <a href="#">API Gateway</a>
+                    <a href="#">API Gateway (REST APIs)</a>
                     <ul class="nav">
                         <li>
                             <a href="#">Data Sources</a>

--- a/website/docs/d/api_gateway_api_key.html.markdown
+++ b/website/docs/d/api_gateway_api_key.html.markdown
@@ -1,9 +1,9 @@
 ---
-subcategory: "API Gateway"
+subcategory: "API Gateway (REST APIs)"
 layout: "aws"
 page_title: "AWS: aws_api_gateway_api_key"
 description: |-
-  Get information on an API Gateway API Key
+  Get information on an API Gateway REST API Key
 ---
 
 # Data Source: aws_api_gateway_api_key

--- a/website/docs/d/api_gateway_resource.html.markdown
+++ b/website/docs/d/api_gateway_resource.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "API Gateway"
+subcategory: "API Gateway (REST APIs)"
 layout: "aws"
 page_title: "AWS: aws_api_gateway_resource"
 description: |-

--- a/website/docs/d/api_gateway_rest_api.html.markdown
+++ b/website/docs/d/api_gateway_rest_api.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "API Gateway"
+subcategory: "API Gateway (REST APIs)"
 layout: "aws"
 page_title: "AWS: aws_api_gateway_rest_api"
 description: |-

--- a/website/docs/d/api_gateway_vpc_link.html.markdown
+++ b/website/docs/d/api_gateway_vpc_link.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "API Gateway"
+subcategory: "API Gateway (REST APIs)"
 layout: "aws"
 page_title: "AWS: aws_api_gateway_vpc_link"
 description: |-

--- a/website/docs/r/api_gateway_account.html.markdown
+++ b/website/docs/r/api_gateway_account.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "API Gateway"
+subcategory: "API Gateway (REST APIs)"
 layout: "aws"
 page_title: "AWS: aws_api_gateway_account"
 description: |-

--- a/website/docs/r/api_gateway_api_key.html.markdown
+++ b/website/docs/r/api_gateway_api_key.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "API Gateway"
+subcategory: "API Gateway (REST APIs)"
 layout: "aws"
 page_title: "AWS: aws_api_gateway_api_key"
 description: |-

--- a/website/docs/r/api_gateway_authorizer.html.markdown
+++ b/website/docs/r/api_gateway_authorizer.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "API Gateway"
+subcategory: "API Gateway (REST APIs)"
 layout: "aws"
 page_title: "AWS: aws_api_gateway_authorizer"
 description: |-

--- a/website/docs/r/api_gateway_base_path_mapping.html.markdown
+++ b/website/docs/r/api_gateway_base_path_mapping.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "API Gateway"
+subcategory: "API Gateway (REST APIs)"
 layout: "aws"
 page_title: "AWS: aws_api_gateway_base_path_mapping"
 description: |-

--- a/website/docs/r/api_gateway_client_certificate.html.markdown
+++ b/website/docs/r/api_gateway_client_certificate.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "API Gateway"
+subcategory: "API Gateway (REST APIs)"
 layout: "aws"
 page_title: "AWS: aws_api_gateway_client_certificate"
 description: |-

--- a/website/docs/r/api_gateway_deployment.html.markdown
+++ b/website/docs/r/api_gateway_deployment.html.markdown
@@ -1,14 +1,14 @@
 ---
-subcategory: "API Gateway"
+subcategory: "API Gateway (REST APIs)"
 layout: "aws"
 page_title: "AWS: aws_api_gateway_deployment"
 description: |-
-  Provides an API Gateway Deployment.
+  Provides an API Gateway REST Deployment.
 ---
 
 # Resource: aws_api_gateway_deployment
 
-Provides an API Gateway Deployment.
+Provides an API Gateway REST Deployment.
 
 -> **Note:** Depends on having `aws_api_gateway_integration` inside your rest api (which in turn depends on `aws_api_gateway_method`). To avoid race conditions
 you might need to add an explicit `depends_on = ["aws_api_gateway_integration.name"]`.

--- a/website/docs/r/api_gateway_documentation_part.html.markdown
+++ b/website/docs/r/api_gateway_documentation_part.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "API Gateway"
+subcategory: "API Gateway (REST APIs)"
 layout: "aws"
 page_title: "AWS: aws_api_gateway_documentation_part"
 description: |-

--- a/website/docs/r/api_gateway_documentation_version.html.markdown
+++ b/website/docs/r/api_gateway_documentation_version.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "API Gateway"
+subcategory: "API Gateway (REST APIs)"
 layout: "aws"
 page_title: "AWS: aws_api_gateway_documentation_version"
 description: |-

--- a/website/docs/r/api_gateway_domain_name.html.markdown
+++ b/website/docs/r/api_gateway_domain_name.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "API Gateway"
+subcategory: "API Gateway (REST APIs)"
 layout: "aws"
 page_title: "AWS: aws_api_gateway_domain_name"
 description: |-

--- a/website/docs/r/api_gateway_gateway_response.markdown
+++ b/website/docs/r/api_gateway_gateway_response.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "API Gateway"
+subcategory: "API Gateway (REST APIs)"
 layout: "aws"
 page_title: "AWS: aws_api_gateway_gateway_response"
 description: |-

--- a/website/docs/r/api_gateway_integration.html.markdown
+++ b/website/docs/r/api_gateway_integration.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "API Gateway"
+subcategory: "API Gateway (REST APIs)"
 layout: "aws"
 page_title: "AWS: aws_api_gateway_integration"
 description: |-

--- a/website/docs/r/api_gateway_integration_response.html.markdown
+++ b/website/docs/r/api_gateway_integration_response.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "API Gateway"
+subcategory: "API Gateway (REST APIs)"
 layout: "aws"
 page_title: "AWS: aws_api_gateway_integration_response"
 description: |-

--- a/website/docs/r/api_gateway_method.html.markdown
+++ b/website/docs/r/api_gateway_method.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "API Gateway"
+subcategory: "API Gateway (REST APIs)"
 layout: "aws"
 page_title: "AWS: aws_api_gateway_method"
 description: |-

--- a/website/docs/r/api_gateway_method_response.html.markdown
+++ b/website/docs/r/api_gateway_method_response.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "API Gateway"
+subcategory: "API Gateway (REST APIs)"
 layout: "aws"
 page_title: "AWS: aws_api_gateway_method_response"
 description: |-

--- a/website/docs/r/api_gateway_method_settings.html.markdown
+++ b/website/docs/r/api_gateway_method_settings.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "API Gateway"
+subcategory: "API Gateway (REST APIs)"
 layout: "aws"
 page_title: "AWS: aws_api_gateway_method_settings"
 description: |-

--- a/website/docs/r/api_gateway_model.html.markdown
+++ b/website/docs/r/api_gateway_model.html.markdown
@@ -1,14 +1,14 @@
 ---
-subcategory: "API Gateway"
+subcategory: "API Gateway (REST APIs)"
 layout: "aws"
 page_title: "AWS: aws_api_gateway_model"
 description: |-
-  Provides a Model for a API Gateway.
+  Provides a Model for a REST API Gateway.
 ---
 
 # Resource: aws_api_gateway_model
 
-Provides a Model for a API Gateway.
+Provides a Model for a REST API Gateway.
 
 ## Example Usage
 

--- a/website/docs/r/api_gateway_request_validator.html.markdown
+++ b/website/docs/r/api_gateway_request_validator.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "API Gateway"
+subcategory: "API Gateway (REST APIs)"
 layout: "aws"
 page_title: "AWS: aws_api_gateway_request_validator"
 description: |-

--- a/website/docs/r/api_gateway_resource.html.markdown
+++ b/website/docs/r/api_gateway_resource.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "API Gateway"
+subcategory: "API Gateway (REST APIs)"
 layout: "aws"
 page_title: "AWS: aws_api_gateway_resource"
 description: |-

--- a/website/docs/r/api_gateway_rest_api.html.markdown
+++ b/website/docs/r/api_gateway_rest_api.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "API Gateway"
+subcategory: "API Gateway (REST APIs)"
 layout: "aws"
 page_title: "AWS: aws_api_gateway_rest_api"
 description: |-

--- a/website/docs/r/api_gateway_stage.html.markdown
+++ b/website/docs/r/api_gateway_stage.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "API Gateway"
+subcategory: "API Gateway (REST APIs)"
 layout: "aws"
 page_title: "AWS: aws_api_gateway_stage"
 description: |-

--- a/website/docs/r/api_gateway_usage_plan.html.markdown
+++ b/website/docs/r/api_gateway_usage_plan.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "API Gateway"
+subcategory: "API Gateway (REST APIs)"
 layout: "aws"
 page_title: "AWS: aws_api_gateway_usage_plan"
 description: |-

--- a/website/docs/r/api_gateway_usage_plan_key.html.markdown
+++ b/website/docs/r/api_gateway_usage_plan_key.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "API Gateway"
+subcategory: "API Gateway (REST APIs)"
 layout: "aws"
 page_title: "AWS: aws_api_gateway_usage_plan_key"
 description: |-

--- a/website/docs/r/api_gateway_vpc_link.html.markdown
+++ b/website/docs/r/api_gateway_vpc_link.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "API Gateway"
+subcategory: "API Gateway (REST APIs)"
 layout: "aws"
 page_title: "AWS: aws_api_gateway_vpc_link"
 description: |-


### PR DESCRIPTION
Distinguish API Gateway v1 REST API documentation, since v2 implements WebSocket and HTTP APIs.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7004

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

N/A