### PR TITLE
r/subnet - Fix removing ipv6 cidr block from subnet

### DIFF
--- a/aws/resource_aws_subnet.go
+++ b/aws/resource_aws_subnet.go
@@ -195,7 +195,7 @@ func resourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 
 	if err != nil {
 		if isAWSErr(err, "InvalidSubnetID.NotFound", "") {
-			// Update state to indicate the subnet no longer exists.
+			log.Printf("[WARN] Subnet (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}

--- a/aws/resource_aws_subnet.go
+++ b/aws/resource_aws_subnet.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -547,7 +547,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
   tags = {
-  	Name = %[1]q
+    Name = %[1]q
   }
 }
 
@@ -569,7 +569,7 @@ resource "aws_vpc" "test" {
   assign_generated_ipv6_cidr_block = true
 
   tags = {
-  	Name = "terraform-testacc-subnet-ipv6"
+    Name = "terraform-testacc-subnet-ipv6"
   }
 }
 
@@ -579,7 +579,7 @@ resource "aws_subnet" "test" {
   map_public_ip_on_launch = true
 
   tags = {
-  	Name = "tf-acc-subnet-ipv6"
+    Name = "tf-acc-subnet-ipv6"
   }
 }
 `
@@ -590,7 +590,7 @@ resource "aws_vpc" "test" {
   assign_generated_ipv6_cidr_block = true
 
   tags = {
-  	Name = "terraform-testacc-subnet-ipv6"
+    Name = "terraform-testacc-subnet-ipv6"
   }
 }
 
@@ -602,7 +602,7 @@ resource "aws_subnet" "test" {
   assign_ipv6_address_on_creation = true
 
   tags = {
-  	Name = "tf-acc-subnet-ipv6"
+    Name = "tf-acc-subnet-ipv6"
   }
 }
 `
@@ -613,7 +613,7 @@ resource "aws_vpc" "test" {
   assign_generated_ipv6_cidr_block = true
 
   tags = {
-  	Name = "terraform-testacc-subnet-assign-ipv6-on-creation"
+    Name = "terraform-testacc-subnet-assign-ipv6-on-creation"
   }
 }
 
@@ -625,7 +625,7 @@ resource "aws_subnet" "test" {
   assign_ipv6_address_on_creation = false
 
   tags = {
-  	Name = "tf-acc-subnet-assign-ipv6-on-creation"
+    Name = "tf-acc-subnet-assign-ipv6-on-creation"
   }
 }
 `
@@ -636,7 +636,7 @@ resource "aws_vpc" "test" {
   assign_generated_ipv6_cidr_block = true
 
   tags = {
-  	Name = "terraform-testacc-subnet-ipv6-update-cidr"
+    Name = "terraform-testacc-subnet-ipv6-update-cidr"
   }
 }
 
@@ -648,22 +648,13 @@ resource "aws_subnet" "test" {
   assign_ipv6_address_on_creation = false
 
   tags = {
-  	Name = "tf-acc-subnet-ipv6-update-cidr"
+    Name = "tf-acc-subnet-ipv6-update-cidr"
   }
 }
 `
 
 func testAccSubnetConfigAvailabilityZoneId() string {
 	return composeConfig(testAccAvailableAZsNoOptInConfig(), `
-data "aws_availability_zones" "test" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
@@ -675,7 +666,7 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "test" {
   cidr_block           = "10.1.1.0/24"
   vpc_id               = aws_vpc.test.id
-  availability_zone_id = data.aws_availability_zones.test.zone_ids[0]
+  availability_zone_id = data.aws_availability_zones.available.zone_ids[0]
 
   tags = {
     Name = "tf-acc-subnet"

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -337,7 +337,7 @@ func TestAccAWSSubnet_availabilityZoneId(t *testing.T) {
 		CheckDestroy:  testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubnetConfigAvailabilityZoneId,
+				Config: testAccSubnetConfigAvailabilityZoneId(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "availability_zone"),
@@ -653,7 +653,8 @@ resource "aws_subnet" "test" {
 }
 `
 
-const testAccSubnetConfigAvailabilityZoneId = `
+func testAccSubnetConfigAvailabilityZoneId() string {
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), `
 data "aws_availability_zones" "test" {
   state = "available"
 
@@ -680,7 +681,8 @@ resource "aws_subnet" "test" {
     Name = "tf-acc-subnet"
   }
 }
-`
+`)
+}
 
 func testAccSubnetConfigOutpost() string {
 	return `

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -298,6 +298,8 @@ func TestAccAWSSubnet_enableIpv6(t *testing.T) {
 				Config: testAccSubnetConfigPreIpv6,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "assign_ipv6_address_on_creation", "false"),
 				),
 			},
 			{
@@ -309,6 +311,8 @@ func TestAccAWSSubnet_enableIpv6(t *testing.T) {
 				Config: testAccSubnetConfigIpv6,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
+					resource.TestCheckResourceAttrSet(resourceName, "ipv6_cidr_block"),
+					resource.TestCheckResourceAttr(resourceName, "assign_ipv6_address_on_creation", "true"),
 				),
 			},
 			{
@@ -316,6 +320,7 @@ func TestAccAWSSubnet_enableIpv6(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "assign_ipv6_address_on_creation", "false"),
 				),
 			},
 		},

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -341,7 +341,7 @@ func TestAccAWSSubnet_availabilityZoneId(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "availability_zone"),
-					resource.TestCheckResourceAttrPair(resourceName, "availability_zone_id", "data.aws_availability_zones.available", "zone_ids.0"),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone_id", "data.aws_availability_zones.test", "zone_ids.0"),
 				),
 			},
 			{
@@ -652,7 +652,7 @@ resource "aws_subnet" "test" {
 `
 
 const testAccSubnetConfigAvailabilityZoneId = `
-data "aws_availability_zones" "available" {
+data "aws_availability_zones" "test" {
   state = "available"
 
   filter {
@@ -673,6 +673,7 @@ resource "aws_subnet" "test" {
   cidr_block           = "10.1.1.0/24"
   vpc_id               = aws_vpc.test.id
   availability_zone_id = data.aws_availability_zones.test.zone_ids[0]
+
   tags = {
     Name = "tf-acc-subnet"
   }

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -509,7 +509,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
   tags = {
-  	Name = "terraform-testacc-subnet"
+    Name = "terraform-testacc-subnet"
   }
 }
 

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -544,7 +544,9 @@ resource "aws_subnet" "test" {
 func testAccSubnetTagsConfig2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
-  cidr_block = "10.1.0.0/16"tags = {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
   	Name = %[1]q
   }
 }

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -276,7 +276,6 @@ func TestAccAWSSubnet_ipv6(t *testing.T) {
 				Config: testAccSubnetConfigIpv6UpdateIpv6Cidr,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &after),
-
 					testAccCheckAwsSubnetNotRecreated(t, &before, &after),
 				),
 			},
@@ -520,7 +519,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-subnet"
+  	Name = "terraform-testacc-subnet"
   }
 }
 
@@ -528,7 +527,8 @@ resource "aws_subnet" "test" {
   cidr_block              = "10.1.1.0/24"
   vpc_id                  = aws_vpc.test.id
   map_public_ip_on_launch = true
-}
+
+  }
 `
 
 func testAccSubnetTagsConfig1(rName, tagKey1, tagValue1 string) string {
@@ -555,10 +555,8 @@ resource "aws_subnet" "test" {
 func testAccSubnetTagsConfig2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
-  cidr_block = "10.1.0.0/16"
-
-  tags = {
-    Name = %[1]q
+  cidr_block = "10.1.0.0/16"tags = {
+  	Name = %[1]q
   }
 }
 
@@ -580,7 +578,7 @@ resource "aws_vpc" "test" {
   assign_generated_ipv6_cidr_block = true
 
   tags = {
-    Name = "terraform-testacc-subnet-ipv6"
+  	Name = "terraform-testacc-subnet-ipv6"
   }
 }
 
@@ -590,7 +588,7 @@ resource "aws_subnet" "test" {
   map_public_ip_on_launch = true
 
   tags = {
-    Name = "tf-acc-subnet-ipv6"
+  	Name = "tf-acc-subnet-ipv6"
   }
 }
 `
@@ -601,7 +599,7 @@ resource "aws_vpc" "test" {
   assign_generated_ipv6_cidr_block = true
 
   tags = {
-    Name = "terraform-testacc-subnet-ipv6"
+  	Name = "terraform-testacc-subnet-ipv6"
   }
 }
 
@@ -613,7 +611,7 @@ resource "aws_subnet" "test" {
   assign_ipv6_address_on_creation = true
 
   tags = {
-    Name = "tf-acc-subnet-ipv6"
+  	Name = "tf-acc-subnet-ipv6"
   }
 }
 `
@@ -624,7 +622,7 @@ resource "aws_vpc" "test" {
   assign_generated_ipv6_cidr_block = true
 
   tags = {
-    Name = "terraform-testacc-subnet-assign-ipv6-on-creation"
+  	Name = "terraform-testacc-subnet-assign-ipv6-on-creation"
   }
 }
 
@@ -636,7 +634,7 @@ resource "aws_subnet" "test" {
   assign_ipv6_address_on_creation = false
 
   tags = {
-    Name = "tf-acc-subnet-assign-ipv6-on-creation"
+  	Name = "tf-acc-subnet-assign-ipv6-on-creation"
   }
 }
 `
@@ -647,7 +645,7 @@ resource "aws_vpc" "test" {
   assign_generated_ipv6_cidr_block = true
 
   tags = {
-    Name = "terraform-testacc-subnet-ipv6-update-cidr"
+  	Name = "terraform-testacc-subnet-ipv6-update-cidr"
   }
 }
 
@@ -659,7 +657,7 @@ resource "aws_subnet" "test" {
   assign_ipv6_address_on_creation = false
 
   tags = {
-    Name = "tf-acc-subnet-ipv6-update-cidr"
+  	Name = "tf-acc-subnet-ipv6-update-cidr"
   }
 }
 `

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -517,7 +517,7 @@ resource "aws_subnet" "test" {
   cidr_block              = "10.1.1.0/24"
   vpc_id                  = aws_vpc.test.id
   map_public_ip_on_launch = true
-  }
+}
 `
 
 func testAccSubnetTagsConfig1(rName, tagKey1, tagValue1 string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10815

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_subnet: allow removing IPV6 CIDR Block
resource_aws_subnet: add plan time validation to `cidr_block`, `ipv6_cidr_block`.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSubnet_'
--- PASS: TestAccAWSSubnet_ipv6 (220.53s)
--- PASS: TestAccAWSSubnet_ignoreTags (173.26s)
--- PASS: TestAccAWSSubnet_ipv6 (220.53s)
--- PASS: TestAccAWSSubnet_enableIpv6 (191.56s)
--- PASS: TestAccAWSSubnet_availabilityZoneId (83.43s)
--- PASS: TestAccAWSSubnet_disappears (79.87s)
```
