### PR TITLE
r/aws_route53_health_check - suppress diff when expanded ipv6 address is the same

### DIFF
--- a/aws/resource_aws_route53_health_check.go
+++ b/aws/resource_aws_route53_health_check.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"net"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -57,6 +58,9 @@ func resourceAwsRoute53HealthCheck() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return net.ParseIP(old).Equal(net.ParseIP(new))
+				},
 			},
 			"fqdn": {
 				Type:     schema.TypeString,
@@ -114,6 +118,11 @@ func resourceAwsRoute53HealthCheck() *schema.Resource {
 			"insufficient_data_health_status": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					route53.InsufficientDataHealthStatusHealthy,
+					route53.InsufficientDataHealthStatusLastKnownStatus,
+					route53.InsufficientDataHealthStatusUnhealthy,
+				}, true),
 			},
 			"reference_name": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_route53_health_check_test.go
+++ b/aws/resource_aws_route53_health_check_test.go
@@ -211,11 +211,8 @@ func TestAccAWSRoute53HealthCheck_Ipv6Config(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccRoute53HealthCheckIpv6ExpandedConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53HealthCheckExists(resourceName, &check),
-					resource.TestCheckResourceAttr(resourceName, "ip_address", "1234:5678:9abc:6811:0:0:0:4"),
-				),
+				Config:   testAccRoute53HealthCheckIpv6ExpandedConfig,
+				PlanOnly: true,
 			},
 		},
 	})

--- a/aws/resource_aws_route53_health_check_test.go
+++ b/aws/resource_aws_route53_health_check_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/route53"
@@ -10,6 +11,7 @@ import (
 )
 
 func TestAccAWSRoute53HealthCheck_basic(t *testing.T) {
+	var check route53.HealthCheck
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -20,7 +22,7 @@ func TestAccAWSRoute53HealthCheck_basic(t *testing.T) {
 			{
 				Config: testAccRoute53HealthCheckConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53HealthCheckExists(resourceName),
+					testAccCheckRoute53HealthCheckExists(resourceName, &check),
 					resource.TestCheckResourceAttr(resourceName, "measure_latency", "true"),
 					resource.TestCheckResourceAttr(resourceName, "port", "80"),
 					resource.TestCheckResourceAttr(resourceName, "invert_healthcheck", "true"),
@@ -35,7 +37,7 @@ func TestAccAWSRoute53HealthCheck_basic(t *testing.T) {
 			{
 				Config: testAccRoute53HealthCheckConfigUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53HealthCheckExists(resourceName),
+					testAccCheckRoute53HealthCheckExists(resourceName, &check),
 					resource.TestCheckResourceAttr(resourceName, "failure_threshold", "5"),
 					resource.TestCheckResourceAttr(resourceName, "invert_healthcheck", "false"),
 				),
@@ -45,6 +47,7 @@ func TestAccAWSRoute53HealthCheck_basic(t *testing.T) {
 }
 
 func TestAccAWSRoute53HealthCheck_tags(t *testing.T) {
+	var check route53.HealthCheck
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -55,7 +58,7 @@ func TestAccAWSRoute53HealthCheck_tags(t *testing.T) {
 			{
 				Config: testAccRoute53HealthCheckConfigTags1("key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53HealthCheckExists(resourceName),
+					testAccCheckRoute53HealthCheckExists(resourceName, &check),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
@@ -68,7 +71,7 @@ func TestAccAWSRoute53HealthCheck_tags(t *testing.T) {
 			{
 				Config: testAccRoute53HealthCheckConfigTags2("key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53HealthCheckExists(resourceName),
+					testAccCheckRoute53HealthCheckExists(resourceName, &check),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
@@ -77,7 +80,7 @@ func TestAccAWSRoute53HealthCheck_tags(t *testing.T) {
 			{
 				Config: testAccRoute53HealthCheckConfigTags1("key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53HealthCheckExists(resourceName),
+					testAccCheckRoute53HealthCheckExists(resourceName, &check),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
@@ -87,6 +90,7 @@ func TestAccAWSRoute53HealthCheck_tags(t *testing.T) {
 }
 
 func TestAccAWSRoute53HealthCheck_withSearchString(t *testing.T) {
+	var check route53.HealthCheck
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -97,7 +101,7 @@ func TestAccAWSRoute53HealthCheck_withSearchString(t *testing.T) {
 			{
 				Config: testAccRoute53HealthCheckConfigWithSearchString,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53HealthCheckExists(resourceName),
+					testAccCheckRoute53HealthCheckExists(resourceName, &check),
 					resource.TestCheckResourceAttr(resourceName, "invert_healthcheck", "false"),
 					resource.TestCheckResourceAttr(resourceName, "search_string", "OK"),
 				),
@@ -110,7 +114,7 @@ func TestAccAWSRoute53HealthCheck_withSearchString(t *testing.T) {
 			{
 				Config: testAccRoute53HealthCheckConfigWithSearchStringUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53HealthCheckExists(resourceName),
+					testAccCheckRoute53HealthCheckExists(resourceName, &check),
 					resource.TestCheckResourceAttr(resourceName, "invert_healthcheck", "true"),
 					resource.TestCheckResourceAttr(resourceName, "search_string", "FAILED"),
 				),
@@ -120,6 +124,7 @@ func TestAccAWSRoute53HealthCheck_withSearchString(t *testing.T) {
 }
 
 func TestAccAWSRoute53HealthCheck_withChildHealthChecks(t *testing.T) {
+	var check route53.HealthCheck
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -129,7 +134,7 @@ func TestAccAWSRoute53HealthCheck_withChildHealthChecks(t *testing.T) {
 			{
 				Config: testAccRoute53HealthCheckConfig_withChildHealthChecks,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53HealthCheckExists(resourceName),
+					testAccCheckRoute53HealthCheckExists(resourceName, &check),
 				),
 			},
 			{
@@ -142,6 +147,7 @@ func TestAccAWSRoute53HealthCheck_withChildHealthChecks(t *testing.T) {
 }
 
 func TestAccAWSRoute53HealthCheck_withHealthCheckRegions(t *testing.T) {
+	var check route53.HealthCheck
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -151,7 +157,7 @@ func TestAccAWSRoute53HealthCheck_withHealthCheckRegions(t *testing.T) {
 			{
 				Config: testAccRoute53HealthCheckConfig_withHealthCheckRegions,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53HealthCheckExists(resourceName),
+					testAccCheckRoute53HealthCheckExists(resourceName, &check),
 					resource.TestCheckResourceAttr(resourceName, "regions.#", "3"),
 				),
 			},
@@ -165,6 +171,7 @@ func TestAccAWSRoute53HealthCheck_withHealthCheckRegions(t *testing.T) {
 }
 
 func TestAccAWSRoute53HealthCheck_IpConfig(t *testing.T) {
+	var check route53.HealthCheck
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -174,7 +181,7 @@ func TestAccAWSRoute53HealthCheck_IpConfig(t *testing.T) {
 			{
 				Config: testAccRoute53HealthCheckIpConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53HealthCheckExists(resourceName),
+					testAccCheckRoute53HealthCheckExists(resourceName, &check),
 					resource.TestCheckResourceAttr(resourceName, "ip_address", "1.2.3.4"),
 				),
 			},
@@ -188,6 +195,7 @@ func TestAccAWSRoute53HealthCheck_IpConfig(t *testing.T) {
 }
 
 func TestAccAWSRoute53HealthCheck_Ipv6Config(t *testing.T) {
+	var check route53.HealthCheck
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -197,7 +205,7 @@ func TestAccAWSRoute53HealthCheck_Ipv6Config(t *testing.T) {
 			{
 				Config: testAccRoute53HealthCheckIpv6Config,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53HealthCheckExists(resourceName),
+					testAccCheckRoute53HealthCheckExists(resourceName, &check),
 					resource.TestCheckResourceAttr(resourceName, "ip_address", "1234:5678:9abc:6811:0:0:0:4"),
 				),
 			},
@@ -206,11 +214,19 @@ func TestAccAWSRoute53HealthCheck_Ipv6Config(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccRoute53HealthCheckIpv6ExpandedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53HealthCheckExists(resourceName, &check),
+					resource.TestCheckResourceAttr(resourceName, "ip_address", "1234:5678:9abc:6811:0:0:0:4"),
+				),
+			},
 		},
 	})
 }
 
 func TestAccAWSRoute53HealthCheck_CloudWatchAlarmCheck(t *testing.T) {
+	var check route53.HealthCheck
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -220,7 +236,7 @@ func TestAccAWSRoute53HealthCheck_CloudWatchAlarmCheck(t *testing.T) {
 			{
 				Config: testAccRoute53HealthCheckCloudWatchAlarm,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53HealthCheckExists(resourceName),
+					testAccCheckRoute53HealthCheckExists(resourceName, &check),
 					resource.TestCheckResourceAttr(resourceName, "cloudwatch_alarm_name", "cloudwatch-healthcheck-alarm"),
 				),
 			},
@@ -234,6 +250,7 @@ func TestAccAWSRoute53HealthCheck_CloudWatchAlarmCheck(t *testing.T) {
 }
 
 func TestAccAWSRoute53HealthCheck_withSNI(t *testing.T) {
+	var check route53.HealthCheck
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -244,7 +261,7 @@ func TestAccAWSRoute53HealthCheck_withSNI(t *testing.T) {
 			{
 				Config: testAccRoute53HealthCheckConfigWithoutSNI,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53HealthCheckExists(resourceName),
+					testAccCheckRoute53HealthCheckExists(resourceName, &check),
 					resource.TestCheckResourceAttr(resourceName, "enable_sni", "true"),
 				),
 			},
@@ -256,16 +273,36 @@ func TestAccAWSRoute53HealthCheck_withSNI(t *testing.T) {
 			{
 				Config: testAccRoute53HealthCheckConfigWithSNIDisabled,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53HealthCheckExists(resourceName),
+					testAccCheckRoute53HealthCheckExists(resourceName, &check),
 					resource.TestCheckResourceAttr(resourceName, "enable_sni", "false"),
 				),
 			},
 			{
 				Config: testAccRoute53HealthCheckConfigWithSNI,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53HealthCheckExists(resourceName),
+					testAccCheckRoute53HealthCheckExists(resourceName, &check),
 					resource.TestCheckResourceAttr(resourceName, "enable_sni", "true"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute53HealthCheck_disappears(t *testing.T) {
+	var check route53.HealthCheck
+	resourceName := "aws_route53_health_check.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53HealthCheckConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53HealthCheckExists(resourceName, &check),
+					testAccCheckRoute53HealthCheckDisappears(&check),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -299,7 +336,7 @@ func testAccCheckRoute53HealthCheckDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckRoute53HealthCheckExists(n string) resource.TestCheckFunc {
+func testAccCheckRoute53HealthCheckExists(n string, hCheck *route53.HealthCheck) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).r53conn
 
@@ -323,11 +360,25 @@ func testAccCheckRoute53HealthCheckExists(n string) resource.TestCheckFunc {
 
 		for _, check := range resp.HealthChecks {
 			if *check.Id == rs.Primary.ID {
+				*hCheck = *check
 				return nil
 			}
 
 		}
 		return fmt.Errorf("Health Check does not exist")
+	}
+}
+
+func testAccCheckRoute53HealthCheckDisappears(hCheck *route53.HealthCheck) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).r53conn
+		input := &route53.DeleteHealthCheckInput{
+			HealthCheckId: hCheck.Id,
+		}
+		log.Printf("[DEBUG] Deleting Route53 Health Check: %#v", input)
+		_, err := conn.DeleteHealthCheck(input)
+
+		return err
 	}
 }
 
@@ -414,6 +465,21 @@ resource "aws_route53_health_check" "test" {
 const testAccRoute53HealthCheckIpv6Config = `
 resource "aws_route53_health_check" "test" {
   ip_address = "1234:5678:9abc:6811::4"
+  port = 80
+  type = "HTTP"
+  resource_path = "/"
+  failure_threshold = "2"
+  request_interval = "30"
+
+  tags = {
+    Name = "tf-test-health-check"
+   }
+}
+`
+
+const testAccRoute53HealthCheckIpv6ExpandedConfig = `
+resource "aws_route53_health_check" "test" {
+  ip_address = "1234:5678:9abc:6811:0:0:0:4"
   port = 80
   type = "HTTP"
   resource_path = "/"

--- a/aws/resource_aws_route53_health_check_test.go
+++ b/aws/resource_aws_route53_health_check_test.go
@@ -36,7 +36,11 @@ func TestAccAWSRoute53HealthCheck_basic(t *testing.T) {
 			},
 			{
 				Config: testAccRoute53HealthCheckConfigUpdate,
-				PlanOnly: true,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53HealthCheckExists(resourceName, &check),
+					resource.TestCheckResourceAttr(resourceName, "failure_threshold", "5"),
+					resource.TestCheckResourceAttr(resourceName, "invert_healthcheck", "false"),
+				),
 			},
 		},
 	})

--- a/aws/resource_aws_route53_health_check_test.go
+++ b/aws/resource_aws_route53_health_check_test.go
@@ -22,6 +22,7 @@ func TestAccAWSRoute53HealthCheck_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53HealthCheckExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "measure_latency", "true"),
+					resource.TestCheckResourceAttr(resourceName, "port", "80"),
 					resource.TestCheckResourceAttr(resourceName, "invert_healthcheck", "true"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
@@ -174,6 +175,30 @@ func TestAccAWSRoute53HealthCheck_IpConfig(t *testing.T) {
 				Config: testAccRoute53HealthCheckIpConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53HealthCheckExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "ip_address", "1.2.3.4"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute53HealthCheck_Ipv6Config(t *testing.T) {
+	resourceName := "aws_route53_health_check.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53HealthCheckIpv6Config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53HealthCheckExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "ip_address", "1234:5678:9abc:6811:0:0:0:4"),
 				),
 			},
 			{
@@ -374,6 +399,21 @@ resource "aws_route53_health_check" "test" {
 const testAccRoute53HealthCheckIpConfig = `
 resource "aws_route53_health_check" "test" {
   ip_address = "1.2.3.4"
+  port = 80
+  type = "HTTP"
+  resource_path = "/"
+  failure_threshold = "2"
+  request_interval = "30"
+
+  tags = {
+    Name = "tf-test-health-check"
+   }
+}
+`
+
+const testAccRoute53HealthCheckIpv6Config = `
+resource "aws_route53_health_check" "test" {
+  ip_address = "1234:5678:9abc:6811::4"
   port = 80
   type = "HTTP"
   resource_path = "/"

--- a/aws/resource_aws_route53_health_check_test.go
+++ b/aws/resource_aws_route53_health_check_test.go
@@ -36,11 +36,7 @@ func TestAccAWSRoute53HealthCheck_basic(t *testing.T) {
 			},
 			{
 				Config: testAccRoute53HealthCheckConfigUpdate,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53HealthCheckExists(resourceName, &check),
-					resource.TestCheckResourceAttr(resourceName, "failure_threshold", "5"),
-					resource.TestCheckResourceAttr(resourceName, "invert_healthcheck", "false"),
-				),
+				PlanOnly: true,
 			},
 		},
 	})


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11069

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_route53_health_check: do not recreate health check when using compressed ipv6 address.
resource_aws_route53_health_check: add plan time validation to `insufficient_data_health_status`.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSRoute53HealthCheck_'
--- PASS: TestAccAWSRoute53HealthCheck_basic (72.75s)
--- PASS: TestAccAWSRoute53HealthCheck_IpConfig (43.30s)
--- PASS: TestAccAWSRoute53HealthCheck_Ipv6Config (44.32s)
--- PASS: TestAccAWSRoute53HealthCheck_CloudWatchAlarmCheck (54.50s)
--- PASS: TestAccAWSRoute53HealthCheck_withSNI (103.25s)
--- PASS: TestAccAWSRoute53HealthCheck_withChildHealthChecks (50.15s)
--- PASS: TestAccAWSRoute53HealthCheck_withHealthCheckRegions (42.71s)
--- PASS: TestAccAWSRoute53HealthCheck_withSearchString (72.53s)
--- PASS: TestAccAWSRoute53HealthCheck_tags (101.66s)
--- PASS: TestAccAWSRoute53HealthCheck_disappears (35.03s)
```
