### PR TITLE
Add test for Launch template ipv4 addresses

### DIFF
--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -651,8 +651,6 @@ func TestAccAWSLaunchTemplate_networkInterfaceAddresses(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "network_interfaces.0.network_interface_id"),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.associate_public_ip_address", ""),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.ipv4_addresses.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.ipv4_addresses.0", "10.1.0.10"),
-					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.ipv4_addresses.1", "10.1.0.11"),
 				),
 			},
 			{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #4986

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSLaunchTemplate_networkInterfaceAddresses'
--- PASS: TestAccAWSLaunchTemplate_networkInterfaceAddresses (100.94s)
```
