### PR TITLE
Support case insensitive usernames for Cognito user pools

### DIFF
--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -455,6 +455,21 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 				ConflictsWith: []string{"alias_attributes"},
 			},
 
+			"username_configuration": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"case_sensitive": {
+							Type:     schema.TypeBool,
+							Required: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
+
 			"user_pool_add_ons": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -642,6 +657,15 @@ func resourceAwsCognitoUserPoolCreate(d *schema.ResourceData, meta interface{}) 
 
 	if v, ok := d.GetOk("username_attributes"); ok {
 		params.UsernameAttributes = expandStringList(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("username_configuration"); ok {
+		configs := v.([]interface{})
+		config, ok := configs[0].(map[string]interface{})
+
+		if ok && config != nil {
+			params.UsernameConfiguration = expandCognitoUserPoolUsernameConfiguration(config)
+		}
 	}
 
 	if v, ok := d.GetOk("user_pool_add_ons"); ok {
@@ -832,6 +856,10 @@ func resourceAwsCognitoUserPoolRead(d *schema.ResourceData, meta interface{}) er
 
 	if resp.UserPool.UsernameAttributes != nil {
 		d.Set("username_attributes", flattenStringList(resp.UserPool.UsernameAttributes))
+	}
+
+	if err := d.Set("username_configuration", flattenCognitoUserPoolUsernameConfiguration(resp.UserPool.UsernameConfiguration)); err != nil {
+		return fmt.Errorf("Failed setting username_configuration: %s", err)
 	}
 
 	if err := d.Set("user_pool_add_ons", flattenCognitoUserPoolUserPoolAddOns(resp.UserPool.UserPoolAddOns)); err != nil {

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -851,6 +851,40 @@ func TestAccAWSCognitoUserPool_withPasswordPolicy(t *testing.T) {
 	})
 }
 
+func TestAccAWSCognitoUserPool_withUsernameConfiguration(t *testing.T) {
+	name := acctest.RandString(5)
+	resourceName := "aws_cognito_user_pool.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoUserPoolConfig_withUsernameConfiguration(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoUserPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "username_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "username_configuration.0.case_sensitive", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSCognitoUserPoolConfig_withUsernameConfigurationUpdated(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoUserPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "username_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "username_configuration.0.case_sensitive", "false"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSCognitoUserPool_withLambdaConfig(t *testing.T) {
 	name := acctest.RandString(5)
 	resourceName := "aws_cognito_user_pool.test"
@@ -1558,6 +1592,30 @@ resource "aws_cognito_user_pool" "test" {
     require_symbols                  = false
     require_uppercase                = true
     temporary_password_validity_days = 14
+  }
+}
+`, name)
+}
+
+func testAccAWSCognitoUserPoolConfig_withUsernameConfiguration(name string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  name = "terraform-test-pool-%s"
+
+  username_configuration {
+    case_sensitive = true
+  }
+}
+`, name)
+}
+
+func testAccAWSCognitoUserPoolConfig_withUsernameConfigurationUpdated(name string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  name = "terraform-test-pool-%s"
+
+  username_configuration {
+    case_sensitive = false
   }
 }
 `, name)

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -3479,6 +3479,26 @@ func flattenCognitoUserPoolSchema(configuredAttributes, inputs []*cognitoidentit
 	return values
 }
 
+func expandCognitoUserPoolUsernameConfiguration(config map[string]interface{}) *cognitoidentityprovider.UsernameConfigurationType {
+	usernameConfigurationType := &cognitoidentityprovider.UsernameConfigurationType{
+		CaseSensitive: aws.Bool(config["case_sensitive"].(bool)),
+	}
+
+	return usernameConfigurationType
+}
+
+func flattenCognitoUserPoolUsernameConfiguration(u *cognitoidentityprovider.UsernameConfigurationType) []map[string]interface{} {
+	m := map[string]interface{}{}
+
+	if u == nil {
+		return nil
+	}
+
+	m["case_sensitive"] = *u.CaseSensitive
+
+	return []map[string]interface{}{m}
+}
+
 func expandCognitoUserPoolVerificationMessageTemplate(config map[string]interface{}) *cognitoidentityprovider.VerificationMessageTemplateType {
 	verificationMessageTemplateType := &cognitoidentityprovider.VerificationMessageTemplateType{}
 

--- a/website/docs/r/cognito_user_pool.markdown
+++ b/website/docs/r/cognito_user_pool.markdown
@@ -163,15 +163,15 @@ resource "aws_cognito_user_pool" "example" {
   * `external_id` (Required) - The external ID used in IAM role trust relationships. For more information about using external IDs, see [How to Use an External ID When Granting Access to Your AWS Resources to a Third Party](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html).
   * `sns_caller_arn` (Required) - The ARN of the Amazon SNS caller. This is usually the IAM role that you've given Cognito permission to assume.
 
-#### Username Configuration
-
-  * `case_sensitive` (Required) - Specifies whether username case sensitivity will be applied for all users in the user pool through Cognito APIs.
-
 ### Software Token MFA Configuration
 
 The following arguments are required in the `software_token_mfa_configuration` configuration block:
 
 * `enabled` - (Required) Boolean whether to enable software token Multi-Factor (MFA) tokens, such as Time-based One-Time Password (TOTP). To disable software token MFA when `sms_configuration` is not present, the `mfa_configuration` argument must be set to `OFF` and the `software_token_mfa_configuration` configuration block must be fully removed.
+
+#### Username Configuration
+
+  * `case_sensitive` (Required) - Specifies whether username case sensitivity will be applied for all users in the user pool through Cognito APIs.
 
 #### User Pool Add-ons
 

--- a/website/docs/r/cognito_user_pool.markdown
+++ b/website/docs/r/cognito_user_pool.markdown
@@ -65,6 +65,7 @@ The following arguments are supported:
 * `software_token_mfa_configuration` - (Optional) Configuration block for software token Mult-Factor Authentication (MFA) settings. Detailed below.
 * `tags` - (Optional) A mapping of tags to assign to the User Pool.
 * `username_attributes` - (Optional) Specifies whether email addresses or phone numbers can be specified as usernames when a user signs up. Conflicts with `alias_attributes`.
+* `username_configuration` - (Optional) The [Username Configuration](#username-configuration).
 * `user_pool_add_ons` - (Optional) Configuration block for [user pool add-ons](#user-pool-add-ons) to enable user pool advanced security mode features.
 * `verification_message_template` (Optional) - The [verification message templates](#verification-message-template) configuration.
 
@@ -161,6 +162,10 @@ resource "aws_cognito_user_pool" "example" {
 
   * `external_id` (Required) - The external ID used in IAM role trust relationships. For more information about using external IDs, see [How to Use an External ID When Granting Access to Your AWS Resources to a Third Party](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html).
   * `sns_caller_arn` (Required) - The ARN of the Amazon SNS caller. This is usually the IAM role that you've given Cognito permission to assume.
+
+#### Username Configuration
+
+  * `case_sensitive` (Required) - Specifies whether username case sensitivity will be applied for all users in the user pool through Cognito APIs.
 
 ### Software Token MFA Configuration
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12094

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_cognito_user_pool: Add `username_configuration` configuration block and nested `case_sensitive` argument
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCognitoUserPool_withUsernameConfiguration'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCognitoUserPool_withUsernameConfiguration -timeout 120m
=== RUN   TestAccAWSCognitoUserPool_withUsernameConfiguration
=== PAUSE TestAccAWSCognitoUserPool_withUsernameConfiguration
=== CONT  TestAccAWSCognitoUserPool_withUsernameConfiguration
--- PASS: TestAccAWSCognitoUserPool_withUsernameConfiguration (48.78s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	48.837s
```
