### PR TITLE
Add 1 hour backup interval for DLM

### DIFF
--- a/aws/resource_aws_dlm_lifecycle_policy.go
+++ b/aws/resource_aws_dlm_lifecycle_policy.go
@@ -70,7 +70,7 @@ func resourceAwsDlmLifecyclePolicy() *schema.Resource {
 												"interval": {
 													Type:         schema.TypeInt,
 													Required:     true,
-													ValidateFunc: validation.IntInSlice([]int{2, 3, 4, 6, 8, 12, 24}),
+													ValidateFunc: validation.IntInSlice([]int{1, 2, 3, 4, 6, 8, 12, 24}),
 												},
 												"interval_unit": {
 													Type:     schema.TypeString,

--- a/website/docs/r/dlm_lifecycle_policy.markdown
+++ b/website/docs/r/dlm_lifecycle_policy.markdown
@@ -126,7 +126,7 @@ The following arguments are supported:
 
 #### Create Rule arguments
 
-* `interval` - (Required) How often this lifecycle policy should be evaluated. `2`,`3`,`4`,`6`,`8`,`12` or `24` are valid values.
+* `interval` - (Required) How often this lifecycle policy should be evaluated. `1`, `2`,`3`,`4`,`6`,`8`,`12` or `24` are valid values.
 * `interval_unit` - (Optional) The unit for how often the lifecycle policy should be evaluated. `HOURS` is currently the only allowed value and also the default value.
 * `times` - (Optional) A list of times in 24 hour clock format that sets when the lifecycle policy should be evaluated. Max of 1.
 


### PR DESCRIPTION
DLM now supports 1 hour intervals.

See https://aws.amazon.com/about-aws/whats-new/2020/03/amazon-data-lifecycle-manager-adds-support-for-1-hour-backup-interval/ for more information.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`resource/aws_dlm_lifecycle_policy`: Add validation support for 1 hour schedules in `policy_details` `schedule` `create_rule` `interval` argument (support 1 hour intervals)
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
I haven't ran the acceptance tests because it's just an extra value in a `ValidateFunc.IntInSlice` method.
