### PR TITLE
Support manually providing a private IPv4 address for an internal network load balancer

### DIFF
--- a/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/aws/resource_aws_elastic_beanstalk_environment.go
@@ -970,9 +970,11 @@ func (e beanstalkEnvironmentError) Error() string {
 
 type beanstalkEnvironmentErrors []*beanstalkEnvironmentError
 
-func (e beanstalkEnvironmentErrors) Len() int           { return len(e) }
-func (e beanstalkEnvironmentErrors) Swap(i, j int)      { e[i], e[j] = e[j], e[i] }
-func (e beanstalkEnvironmentErrors) Less(i, j int) bool { return e[i].eventDate.Before(*e[j].eventDate) }
+func (e beanstalkEnvironmentErrors) Len() int      { return len(e) }
+func (e beanstalkEnvironmentErrors) Swap(i, j int) { e[i], e[j] = e[j], e[i] }
+func (e beanstalkEnvironmentErrors) Less(i, j int) bool {
+	return e[i].eventDate.Before(*e[j].eventDate)
+}
 
 func getBeanstalkEnvironmentErrors(conn *elasticbeanstalk.ElasticBeanstalk, environmentId string, t time.Time) (*multierror.Error, error) {
 	environmentErrors, err := conn.DescribeEvents(&elasticbeanstalk.DescribeEventsInput{

--- a/aws/resource_aws_lb.go
+++ b/aws/resource_aws_lb.go
@@ -115,6 +115,11 @@ func resourceAwsLb() *schema.Resource {
 							Optional: true,
 							ForceNew: true,
 						},
+						"private_ipv4_address": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
 					},
 				},
 				Set: func(v interface{}) int {
@@ -123,6 +128,9 @@ func resourceAwsLb() *schema.Resource {
 					buf.WriteString(fmt.Sprintf("%s-", m["subnet_id"].(string)))
 					if m["allocation_id"] != "" {
 						buf.WriteString(fmt.Sprintf("%s-", m["allocation_id"].(string)))
+					}
+					if m["private_ipv4_address"] != "" {
+						buf.WriteString(fmt.Sprintf("%s-", m["private_ipv4_address"].(string)))
 					}
 					return hashcode.String(buf.String())
 				},
@@ -268,6 +276,9 @@ func resourceAwsLbCreate(d *schema.ResourceData, meta interface{}) error {
 
 			if subnetMap["allocation_id"].(string) != "" {
 				elbOpts.SubnetMappings[i].AllocationId = aws.String(subnetMap["allocation_id"].(string))
+			}
+			if subnetMap["private_ipv4_address"].(string) != "" {
+				elbOpts.SubnetMappings[i].PrivateIPv4Address = aws.String(subnetMap["private_ipv4_address"].(string))
 			}
 		}
 	}
@@ -674,6 +685,7 @@ func flattenSubnetMappingsFromAvailabilityZones(availabilityZones []*elbv2.Avail
 
 		for _, loadBalancerAddress := range availabilityZone.LoadBalancerAddresses {
 			m["allocation_id"] = aws.StringValue(loadBalancerAddress.AllocationId)
+			m["private_ipv4_address"] = aws.StringValue(loadBalancerAddress.PrivateIPv4Address)
 		}
 
 		l = append(l, m)

--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -74,6 +74,26 @@ resource "aws_lb" "example" {
 }
 ```
 
+### Manually specifying private IPv4 address
+
+```hcl
+resource "aws_lb" "example" {
+  name               = "example"
+  load_balancer_type = "network"
+  internal           = true
+
+  subnet_mapping {
+    subnet_id            = "${aws_subnet.example1.id}"
+    private_ipv4_address = "${cidrhost(aws_subnet.example1.cidr_block, 10)}"
+  }
+
+  subnet_mapping {
+    subnet_id            = "${aws_subnet.example2.id}"
+    private_ipv4_address = "${cidrhost(aws_subnet.example2.cidr_block, 10)}"
+  }
+}
+```
+
 ## Argument Reference
 
 ~> **NOTE:** Please note that internal LBs can only use `ipv4` as the ip_address_type. You can only change to `dualstack` ip_address_type if the selected subnets are IPv6 enabled.
@@ -113,6 +133,7 @@ Subnet Mapping (`subnet_mapping`) blocks support the following:
 
 * `subnet_id` - (Required) The id of the subnet of which to attach to the load balancer. You can specify only one subnet per Availability Zone.
 * `allocation_id` - (Optional) The allocation ID of the Elastic IP address.
+* `private_ipv4_address` - (Optional) The private IPv4 address to assign to the internal network load balancer.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12329

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_lb: Add optional `private_ipv4_address` argument to the `subnet_mappings` block
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSLB_networkLoadbalancerPrivateIPv4Address'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLB_networkLoadbalancerPrivateIPv4Address -timeout 120m
=== RUN   TestAccAWSLB_networkLoadbalancerPrivateIPv4Address
=== PAUSE TestAccAWSLB_networkLoadbalancerPrivateIPv4Address
=== CONT  TestAccAWSLB_networkLoadbalancerPrivateIPv4Address
--- PASS: TestAccAWSLB_networkLoadbalancerPrivateIPv4Address (235.16s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	235.228s
```
