### PR TITLE
Updates hashibot config to identify `apigatewayv2` service name

### DIFF
--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -99,6 +99,7 @@ behavior "regexp_issue_labeler_v2" "service_labels" {
     ],
     "service/apigatewayv2" = [
       "aws_api_gateway_v2_",
+      "aws_apigatewayv2_",
     ],
     "service/applicationautoscaling" = [
       "aws_appautoscaling_",
@@ -584,7 +585,9 @@ behavior "pull_request_path_labeler" "service_labels" {
     ]
     "service/apigatewayv2" = [
       "**/*_api_gateway_v2_*",
+      "**/*_apigatewayv2_*",
       "**/api_gateway_v2_*"
+      "**/apigatewayv2_*"
     ]
     "service/applicationautoscaling" = [
       "**/*_appautoscaling_*",

--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -586,7 +586,7 @@ behavior "pull_request_path_labeler" "service_labels" {
     "service/apigatewayv2" = [
       "**/*_api_gateway_v2_*",
       "**/*_apigatewayv2_*",
-      "**/api_gateway_v2_*"
+      "**/api_gateway_v2_*",
       "**/apigatewayv2_*"
     ]
     "service/applicationautoscaling" = [


### PR DESCRIPTION
Update hashibot config to include `apigatewayv2`

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #7004

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

N/A
