### PR TITLE
add outpost_arn field to data_source_aws_subnet

### DIFF
--- a/aws/data_source_aws_subnet.go
+++ b/aws/data_source_aws_subnet.go
@@ -91,6 +91,11 @@ func dataSourceAwsSubnet() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"outpost_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -184,6 +189,7 @@ func dataSourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("arn", subnet.SubnetArn)
 	d.Set("owner_id", subnet.OwnerId)
+	d.Set("outpost_arn", subnet.OutpostArn)
 
 	return nil
 }

--- a/aws/data_source_aws_subnet_test.go
+++ b/aws/data_source_aws_subnet_test.go
@@ -13,8 +13,6 @@ func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
 	rInt := acctest.RandIntRange(0, 256)
 	cidr := fmt.Sprintf("172.%d.123.0/24", rInt)
 	tag := "tf-acc-subnet-data-source"
-	arnregex := regexp.MustCompile(`^arn:[^:]+:ec2:[^:]+:\d{12}:subnet/subnet-.+`)
-	//outpostArnRegex := regexp.MustCompile(`(^arn:[^:]+:outposts:[^:]+:\d{12}:outpost:\d|^$)`)
 
 	snResourceName := "aws_subnet.test"
 	vpcResourceName := "aws_vpc.test"
@@ -47,8 +45,7 @@ func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
 						ds1ResourceName, "cidr_block", cidr),
 					resource.TestCheckResourceAttr(
 						ds1ResourceName, "tags.Name", tag),
-					resource.TestMatchResourceAttr(
-						ds1ResourceName, "arn", arnregex),
+					testAccMatchResourceAttrRegionalARN(ds1ResourceName, "arn", "ec2", regexp.MustCompile(`subnet/subnet-.+`)),
 					resource.TestCheckResourceAttr(
 						ds1ResourceName, "outpost_arn", ""),
 
@@ -66,8 +63,7 @@ func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
 						ds2ResourceName, "cidr_block", cidr),
 					resource.TestCheckResourceAttr(
 						ds2ResourceName, "tags.Name", tag),
-					resource.TestMatchResourceAttr(
-						ds2ResourceName, "arn", arnregex),
+					testAccMatchResourceAttrRegionalARN(ds2ResourceName, "arn", "ec2", regexp.MustCompile(`subnet/subnet-.+`)),
 					resource.TestCheckResourceAttr(
 						ds2ResourceName, "outpost_arn", ""),
 
@@ -85,8 +81,7 @@ func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
 						ds3ResourceName, "cidr_block", cidr),
 					resource.TestCheckResourceAttr(
 						ds3ResourceName, "tags.Name", tag),
-					resource.TestMatchResourceAttr(
-						ds3ResourceName, "arn", arnregex),
+					testAccMatchResourceAttrRegionalARN(ds3ResourceName, "arn", "ec2", regexp.MustCompile(`subnet/subnet-.+`)),
 					resource.TestCheckResourceAttr(
 						ds3ResourceName, "outpost_arn", ""),
 
@@ -104,8 +99,7 @@ func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
 						ds4ResourceName, "cidr_block", cidr),
 					resource.TestCheckResourceAttr(
 						ds4ResourceName, "tags.Name", tag),
-					resource.TestMatchResourceAttr(
-						ds4ResourceName, "arn", arnregex),
+					testAccMatchResourceAttrRegionalARN(ds4ResourceName, "arn", "ec2", regexp.MustCompile(`subnet/subnet-.+`)),
 					resource.TestCheckResourceAttr(
 						ds4ResourceName, "outpost_arn", ""),
 
@@ -123,8 +117,7 @@ func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
 						ds5ResourceName, "cidr_block", cidr),
 					resource.TestCheckResourceAttr(
 						ds5ResourceName, "tags.Name", tag),
-					resource.TestMatchResourceAttr(
-						ds5ResourceName, "arn", arnregex),
+					testAccMatchResourceAttrRegionalARN(ds5ResourceName, "arn", "ec2", regexp.MustCompile(`subnet/subnet-.+`)),
 					resource.TestCheckResourceAttr(
 						ds5ResourceName, "outpost_arn", ""),
 
@@ -142,8 +135,7 @@ func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
 						ds6ResourceName, "cidr_block", cidr),
 					resource.TestCheckResourceAttr(
 						ds6ResourceName, "tags.Name", tag),
-					resource.TestMatchResourceAttr(
-						ds6ResourceName, "arn", arnregex),
+					testAccMatchResourceAttrRegionalARN(ds6ResourceName, "arn", "ec2", regexp.MustCompile(`subnet/subnet-.+`)),
 					resource.TestCheckResourceAttr(
 						ds6ResourceName, "outpost_arn", ""),
 				),

--- a/aws/data_source_aws_subnet_test.go
+++ b/aws/data_source_aws_subnet_test.go
@@ -14,6 +14,7 @@ func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
 	cidr := fmt.Sprintf("172.%d.123.0/24", rInt)
 	tag := "tf-acc-subnet-data-source"
 	arnregex := regexp.MustCompile(`^arn:[^:]+:ec2:[^:]+:\d{12}:subnet/subnet-.+`)
+	//outpostArnRegex := regexp.MustCompile(`(^arn:[^:]+:outposts:[^:]+:\d{12}:outpost:\d|^$)`)
 
 	snResourceName := "aws_subnet.test"
 	vpcResourceName := "aws_vpc.test"
@@ -48,6 +49,8 @@ func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
 						ds1ResourceName, "tags.Name", tag),
 					resource.TestMatchResourceAttr(
 						ds1ResourceName, "arn", arnregex),
+					resource.TestCheckResourceAttr(
+						ds1ResourceName, "outpost_arn", ""),
 
 					resource.TestCheckResourceAttrPair(
 						ds2ResourceName, "id", snResourceName, "id"),
@@ -65,6 +68,8 @@ func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
 						ds2ResourceName, "tags.Name", tag),
 					resource.TestMatchResourceAttr(
 						ds2ResourceName, "arn", arnregex),
+					resource.TestCheckResourceAttr(
+						ds2ResourceName, "outpost_arn", ""),
 
 					resource.TestCheckResourceAttrPair(
 						ds3ResourceName, "id", snResourceName, "id"),
@@ -82,6 +87,8 @@ func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
 						ds3ResourceName, "tags.Name", tag),
 					resource.TestMatchResourceAttr(
 						ds3ResourceName, "arn", arnregex),
+					resource.TestCheckResourceAttr(
+						ds3ResourceName, "outpost_arn", ""),
 
 					resource.TestCheckResourceAttrPair(
 						ds4ResourceName, "id", snResourceName, "id"),
@@ -99,6 +106,8 @@ func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
 						ds4ResourceName, "tags.Name", tag),
 					resource.TestMatchResourceAttr(
 						ds4ResourceName, "arn", arnregex),
+					resource.TestCheckResourceAttr(
+						ds4ResourceName, "outpost_arn", ""),
 
 					resource.TestCheckResourceAttrPair(
 						ds5ResourceName, "id", snResourceName, "id"),
@@ -116,6 +125,8 @@ func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
 						ds5ResourceName, "tags.Name", tag),
 					resource.TestMatchResourceAttr(
 						ds5ResourceName, "arn", arnregex),
+					resource.TestCheckResourceAttr(
+						ds5ResourceName, "outpost_arn", ""),
 
 					resource.TestCheckResourceAttrPair(
 						ds6ResourceName, "id", snResourceName, "id"),
@@ -133,6 +144,8 @@ func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
 						ds6ResourceName, "tags.Name", tag),
 					resource.TestMatchResourceAttr(
 						ds6ResourceName, "arn", arnregex),
+					resource.TestCheckResourceAttr(
+						ds6ResourceName, "outpost_arn", ""),
 				),
 			},
 		},

--- a/website/docs/d/subnet.html.markdown
+++ b/website/docs/d/subnet.html.markdown
@@ -98,3 +98,4 @@ In addition the following attributes are exported:
 
 * `arn` - The ARN of the subnet.
 * `owner_id` - The ID of the AWS account that owns the subnet.
+* `outpost_arn` - The Amazon Resource Name (ARN) of the Outpost.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12302

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add AWS Outposts support to subnet data source resource
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsSubnet'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsSubnet -timeout 120m
=== RUN   TestAccDataSourceAwsSubnetIDs
=== PAUSE TestAccDataSourceAwsSubnetIDs
=== RUN   TestAccDataSourceAwsSubnetIDs_filter
=== PAUSE TestAccDataSourceAwsSubnetIDs_filter
=== RUN   TestAccDataSourceAwsSubnet_basic
=== PAUSE TestAccDataSourceAwsSubnet_basic
=== RUN   TestAccDataSourceAwsSubnet_ipv6ByIpv6Filter
=== PAUSE TestAccDataSourceAwsSubnet_ipv6ByIpv6Filter
=== RUN   TestAccDataSourceAwsSubnet_ipv6ByIpv6CidrBlock
=== PAUSE TestAccDataSourceAwsSubnet_ipv6ByIpv6CidrBlock
=== CONT  TestAccDataSourceAwsSubnetIDs
=== CONT  TestAccDataSourceAwsSubnet_ipv6ByIpv6Filter
=== CONT  TestAccDataSourceAwsSubnet_ipv6ByIpv6CidrBlock
=== CONT  TestAccDataSourceAwsSubnet_basic
=== CONT  TestAccDataSourceAwsSubnetIDs_filter
--- PASS: TestAccDataSourceAwsSubnetIDs_filter (40.05s)
--- PASS: TestAccDataSourceAwsSubnet_basic (41.76s)
--- PASS: TestAccDataSourceAwsSubnetIDs (57.04s)
--- PASS: TestAccDataSourceAwsSubnet_ipv6ByIpv6Filter (67.35s)
--- PASS: TestAccDataSourceAwsSubnet_ipv6ByIpv6CidrBlock (67.79s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       67.851s
```