### PR TITLE
d/aws_iam_role Added Tags as an output.

### DIFF
--- a/aws/data_source_aws_iam_role.go
+++ b/aws/data_source_aws_iam_role.go
@@ -98,10 +98,7 @@ func dataSourceAwsIAMRoleRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("permissions_boundary", output.Role.PermissionsBoundary.PermissionsBoundaryArn)
 	}
 	d.Set("unique_id", output.Role.RoleId)
-
-	if len(output.Role.Tags) > 0 {
-		d.Set("tags", keyvaluetags.IamKeyValueTags(output.Role.Tags).IgnoreAws().Map())
-	}
+	d.Set("tags", keyvaluetags.IamKeyValueTags(output.Role.Tags).IgnoreAws().Map())
 
 	assumRolePolicy, err := url.QueryUnescape(aws.StringValue(output.Role.AssumeRolePolicyDocument))
 	if err != nil {

--- a/aws/data_source_aws_iam_role.go
+++ b/aws/data_source_aws_iam_role.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 	"net/url"
 	"time"
 
@@ -66,6 +67,7 @@ func dataSourceAwsIAMRole() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"tags": tagsSchemaComputed(),
 		},
 	}
 }
@@ -96,6 +98,10 @@ func dataSourceAwsIAMRoleRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("permissions_boundary", output.Role.PermissionsBoundary.PermissionsBoundaryArn)
 	}
 	d.Set("unique_id", output.Role.RoleId)
+
+	if len(output.Role.Tags) > 0 {
+		d.Set("tags", keyvaluetags.IamKeyValueTags(output.Role.Tags).IgnoreAws().Map())
+	}
 
 	assumRolePolicy, err := url.QueryUnescape(aws.StringValue(output.Role.AssumeRolePolicyDocument))
 	if err != nil {

--- a/aws/data_source_aws_iam_role_test.go
+++ b/aws/data_source_aws_iam_role_test.go
@@ -34,6 +34,35 @@ func TestAccAWSDataSourceIAMRole_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSDataSourceIAMRole_tags(t *testing.T) {
+	roleName := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceName := "data.aws_iam_role.test"
+	resourceName := "aws_iam_role.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsIAMRoleConfig_tags(roleName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "assume_role_policy", resourceName, "assume_role_policy"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "create_date", resourceName, "create_date"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "max_session_duration", resourceName, "max_session_duration"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "path", resourceName, "path"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "unique_id", resourceName, "unique_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.tag1", "test-value1"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.tag2", "test-value2"),
+				),
+			},
+		},
+	})
+}
+
 func testAccAwsIAMRoleConfig(roleName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
@@ -56,6 +85,39 @@ resource "aws_iam_role" "test" {
 EOF
 
   path = "/testpath/"
+}
+
+data "aws_iam_role" "test" {
+  name = "${aws_iam_role.test.name}"
+}
+`, roleName)
+}
+
+func testAccAwsIAMRoleConfig_tags(roleName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  name = %q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+
+  tags = {
+    tag1 = "test-value1"
+    tag2 = "test-value2"
+  }
 }
 
 data "aws_iam_role" "test" {

--- a/aws/data_source_aws_iam_role_test.go
+++ b/aws/data_source_aws_iam_role_test.go
@@ -28,6 +28,7 @@ func TestAccAWSDataSourceIAMRole_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "path", resourceName, "path"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "unique_id", resourceName, "unique_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
 				),
 			},
 		},

--- a/website/docs/d/iam_role.html.markdown
+++ b/website/docs/d/iam_role.html.markdown
@@ -35,3 +35,4 @@ data "aws_iam_role" "example" {
 * `path` - The path to the role.
 * `permissions_boundary` - The ARN of the policy that is used to set the permissions boundary for the role.
 * `unique_id` - The stable and unique string identifying the role.
+* `tags` - The tags attached to the role.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data/aws_iam_role Adds tags as an output to the resource.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSDataSourceIAMRole'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSDataSourceIAMRole -timeout 120m
=== RUN   TestAccAWSDataSourceIAMRole_basic
=== PAUSE TestAccAWSDataSourceIAMRole_basic
=== RUN   TestAccAWSDataSourceIAMRole_tags
=== PAUSE TestAccAWSDataSourceIAMRole_tags
=== CONT  TestAccAWSDataSourceIAMRole_basic
=== CONT  TestAccAWSDataSourceIAMRole_tags
--- PASS: TestAccAWSDataSourceIAMRole_basic (31.14s)
--- PASS: TestAccAWSDataSourceIAMRole_tags (31.63s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       31.684s


...
```
