### PR TITLE
resource/aws_cognito_user_pool: Support Software Token MFA Configuration

### DIFF
--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -400,6 +399,7 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 			"sms_configuration": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -422,6 +422,21 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 				Computed:      true,
 				ValidateFunc:  validateCognitoUserPoolSmsVerificationMessage,
 				ConflictsWith: []string{"verification_message_template.0.sms_message"},
+			},
+
+			"software_token_mfa_configuration": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MinItems: 1,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+					},
+				},
 			},
 
 			"tags": tagsSchema(),
@@ -597,10 +612,6 @@ func resourceAwsCognitoUserPoolCreate(d *schema.ResourceData, meta interface{}) 
 		}
 	}
 
-	if v, ok := d.GetOk("mfa_configuration"); ok {
-		params.MfaConfiguration = aws.String(v.(string))
-	}
-
 	if v, ok := d.GetOk("password_policy"); ok {
 		configs := v.([]interface{})
 		config, ok := configs[0].(map[string]interface{})
@@ -617,17 +628,16 @@ func resourceAwsCognitoUserPoolCreate(d *schema.ResourceData, meta interface{}) 
 		params.Schema = expandCognitoUserPoolSchema(configs)
 	}
 
+	// For backwards compatibility, include this outside of MFA configuration
+	// since its configuration is allowed by the API even without SMS MFA.
 	if v, ok := d.GetOk("sms_authentication_message"); ok {
 		params.SmsAuthenticationMessage = aws.String(v.(string))
 	}
 
+	// Include the SMS configuration outside of MFA configuration since it
+	// can be used for user verification.
 	if v, ok := d.GetOk("sms_configuration"); ok {
-		configs := v.([]interface{})
-		config, ok := configs[0].(map[string]interface{})
-
-		if ok && config != nil {
-			params.SmsConfiguration = expandCognitoUserPoolSmsConfiguration(config)
-		}
+		params.SmsConfiguration = expandCognitoSmsConfiguration(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("username_attributes"); ok {
@@ -692,6 +702,51 @@ func resourceAwsCognitoUserPoolCreate(d *schema.ResourceData, meta interface{}) 
 
 	d.SetId(*resp.UserPool.Id)
 
+	if v := d.Get("mfa_configuration").(string); v != cognitoidentityprovider.UserPoolMfaTypeOff {
+		input := &cognitoidentityprovider.SetUserPoolMfaConfigInput{
+			MfaConfiguration:              aws.String(v),
+			SoftwareTokenMfaConfiguration: expandCognitoSoftwareTokenMfaConfiguration(d.Get("software_token_mfa_configuration").([]interface{})),
+			UserPoolId:                    aws.String(d.Id()),
+		}
+
+		if v := d.Get("sms_configuration").([]interface{}); len(v) > 0 && v[0] != nil {
+			input.SmsMfaConfiguration = &cognitoidentityprovider.SmsMfaConfigType{
+				SmsConfiguration: expandCognitoSmsConfiguration(v),
+			}
+
+			if v, ok := d.GetOk("sms_authentication_message"); ok {
+				input.SmsMfaConfiguration.SmsAuthenticationMessage = aws.String(v.(string))
+			}
+		}
+
+		// IAM Roles and Policies can take some time to propagate
+		err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+			_, err := conn.SetUserPoolMfaConfig(input)
+
+			if isAWSErr(err, cognitoidentityprovider.ErrCodeInvalidSmsRoleTrustRelationshipException, "Role does not have a trust relationship allowing Cognito to assume the role") {
+				return resource.RetryableError(err)
+			}
+
+			if isAWSErr(err, cognitoidentityprovider.ErrCodeInvalidSmsRoleAccessPolicyException, "Role does not have permission to publish with SNS") {
+				return resource.RetryableError(err)
+			}
+
+			if err != nil {
+				return resource.NonRetryableError(err)
+			}
+
+			return nil
+		})
+
+		if isResourceTimeoutError(err) {
+			_, err = conn.SetUserPoolMfaConfig(input)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error setting Cognito User Pool (%s) MFA Configuration: %w", d.Id(), err)
+		}
+	}
+
 	return resourceAwsCognitoUserPoolRead(d, meta)
 }
 
@@ -702,17 +757,16 @@ func resourceAwsCognitoUserPoolRead(d *schema.ResourceData, meta interface{}) er
 		UserPoolId: aws.String(d.Id()),
 	}
 
-	log.Printf("[DEBUG] Reading Cognito User Pool: %s", params)
-
 	resp, err := conn.DescribeUserPool(params)
 
+	if isAWSErr(err, cognitoidentityprovider.ErrCodeResourceNotFoundException, "") {
+		log.Printf("[WARN] Cognito User Pool (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == cognitoidentityprovider.ErrCodeResourceNotFoundException {
-			log.Printf("[WARN] Cognito User Pool %s is already gone", d.Id())
-			d.SetId("")
-			return nil
-		}
-		return err
+		return fmt.Errorf("error describing Cognito User Pool (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("admin_create_user_config", flattenCognitoUserPoolAdminCreateUserConfig(resp.UserPool.AdminCreateUserConfig)); err != nil {
@@ -740,9 +794,6 @@ func resourceAwsCognitoUserPoolRead(d *schema.ResourceData, meta interface{}) er
 	}
 	if err := d.Set("lambda_config", flattenCognitoUserPoolLambdaConfig(resp.UserPool.LambdaConfig)); err != nil {
 		return fmt.Errorf("Failed setting lambda_config: %s", err)
-	}
-	if resp.UserPool.MfaConfiguration != nil {
-		d.Set("mfa_configuration", resp.UserPool.MfaConfiguration)
 	}
 	if resp.UserPool.SmsVerificationMessage != nil {
 		d.Set("sms_verification_message", resp.UserPool.SmsVerificationMessage)
@@ -775,7 +826,7 @@ func resourceAwsCognitoUserPoolRead(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Failed setting schema: %s", err)
 	}
 
-	if err := d.Set("sms_configuration", flattenCognitoUserPoolSmsConfiguration(resp.UserPool.SmsConfiguration)); err != nil {
+	if err := d.Set("sms_configuration", flattenCognitoSmsConfiguration(resp.UserPool.SmsConfiguration)); err != nil {
 		return fmt.Errorf("Failed setting sms_configuration: %s", err)
 	}
 
@@ -798,177 +849,270 @@ func resourceAwsCognitoUserPoolRead(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 
+	input := &cognitoidentityprovider.GetUserPoolMfaConfigInput{
+		UserPoolId: aws.String(d.Id()),
+	}
+
+	output, err := conn.GetUserPoolMfaConfig(input)
+
+	if isAWSErr(err, cognitoidentityprovider.ErrCodeResourceNotFoundException, "") {
+		log.Printf("[WARN] Cognito User Pool (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error getting Cognito User Pool (%s) MFA Configuration: %w", d.Id(), err)
+	}
+
+	d.Set("mfa_configuration", output.MfaConfiguration)
+
+	if err := d.Set("software_token_mfa_configuration", flattenCognitoSoftwareTokenMfaConfiguration(output.SoftwareTokenMfaConfiguration)); err != nil {
+		return fmt.Errorf("error setting software_token_mfa_configuration: %s", err)
+	}
+
 	return nil
 }
 
 func resourceAwsCognitoUserPoolUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).cognitoidpconn
 
-	params := &cognitoidentityprovider.UpdateUserPoolInput{
-		UserPoolId: aws.String(d.Id()),
-	}
-
-	if v, ok := d.GetOk("admin_create_user_config"); ok {
-		configs := v.([]interface{})
-		config, ok := configs[0].(map[string]interface{})
-
-		if ok && config != nil {
-			params.AdminCreateUserConfig = expandCognitoUserPoolAdminCreateUserConfig(config)
+	// Multi-Factor Authentication updates
+	if d.HasChanges(
+		"mfa_configuration",
+		"sms_authentication_message",
+		"sms_configuration",
+		"software_token_mfa_configuration",
+	) {
+		mfaConfiguration := d.Get("mfa_configuration").(string)
+		input := &cognitoidentityprovider.SetUserPoolMfaConfigInput{
+			MfaConfiguration:              aws.String(mfaConfiguration),
+			SoftwareTokenMfaConfiguration: expandCognitoSoftwareTokenMfaConfiguration(d.Get("software_token_mfa_configuration").([]interface{})),
+			UserPoolId:                    aws.String(d.Id()),
 		}
-	}
 
-	if v, ok := d.GetOk("auto_verified_attributes"); ok {
-		params.AutoVerifiedAttributes = expandStringList(v.(*schema.Set).List())
-	}
-
-	if v, ok := d.GetOk("device_configuration"); ok {
-		configs := v.([]interface{})
-		config, ok := configs[0].(map[string]interface{})
-
-		if ok && config != nil {
-			params.DeviceConfiguration = expandCognitoUserPoolDeviceConfiguration(config)
-		}
-	}
-
-	if v, ok := d.GetOk("email_configuration"); ok {
-
-		configs := v.([]interface{})
-		config, ok := configs[0].(map[string]interface{})
-
-		if ok && config != nil {
-			log.Printf("[DEBUG] Set Values to update from configs")
-			emailConfigurationType := &cognitoidentityprovider.EmailConfigurationType{}
-
-			if v, ok := config["reply_to_email_address"]; ok && v.(string) != "" {
-				emailConfigurationType.ReplyToEmailAddress = aws.String(v.(string))
+		// Since SMS configuration applies to both verification and MFA, only include if MFA is enabled.
+		// Otherwise, the API will return the following error:
+		// InvalidParameterException: Invalid MFA configuration given, can't turn off MFA and configure an MFA together.
+		if v := d.Get("sms_configuration").([]interface{}); len(v) > 0 && v[0] != nil && mfaConfiguration != cognitoidentityprovider.UserPoolMfaTypeOff {
+			input.SmsMfaConfiguration = &cognitoidentityprovider.SmsMfaConfigType{
+				SmsConfiguration: expandCognitoSmsConfiguration(v),
 			}
 
-			if v, ok := config["source_arn"]; ok && v.(string) != "" {
-				emailConfigurationType.SourceArn = aws.String(v.(string))
+			if v, ok := d.GetOk("sms_authentication_message"); ok {
+				input.SmsMfaConfiguration.SmsAuthenticationMessage = aws.String(v.(string))
+			}
+		}
+
+		// IAM Roles and Policies can take some time to propagate
+		err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+			_, err := conn.SetUserPoolMfaConfig(input)
+
+			if isAWSErr(err, cognitoidentityprovider.ErrCodeInvalidSmsRoleTrustRelationshipException, "Role does not have a trust relationship allowing Cognito to assume the role") {
+				return resource.RetryableError(err)
 			}
 
-			if v, ok := config["email_sending_account"]; ok && v.(string) != "" {
-				emailConfigurationType.EmailSendingAccount = aws.String(v.(string))
+			if isAWSErr(err, cognitoidentityprovider.ErrCodeInvalidSmsRoleAccessPolicyException, "Role does not have permission to publish with SNS") {
+				return resource.RetryableError(err)
 			}
 
-			params.EmailConfiguration = emailConfigurationType
-		}
-	}
-
-	if v, ok := d.GetOk("email_verification_subject"); ok {
-		params.EmailVerificationSubject = aws.String(v.(string))
-	}
-
-	if v, ok := d.GetOk("email_verification_message"); ok {
-		params.EmailVerificationMessage = aws.String(v.(string))
-	}
-
-	if v, ok := d.GetOk("lambda_config"); ok {
-		configs := v.([]interface{})
-		config, ok := configs[0].(map[string]interface{})
-
-		if ok && config != nil {
-			params.LambdaConfig = expandCognitoUserPoolLambdaConfig(config)
-		}
-	}
-
-	if v, ok := d.GetOk("mfa_configuration"); ok {
-		params.MfaConfiguration = aws.String(v.(string))
-	}
-
-	if v, ok := d.GetOk("password_policy"); ok {
-		configs := v.([]interface{})
-		config, ok := configs[0].(map[string]interface{})
-
-		if ok && config != nil {
-			policies := &cognitoidentityprovider.UserPoolPolicyType{}
-			policies.PasswordPolicy = expandCognitoUserPoolPasswordPolicy(config)
-			params.Policies = policies
-		}
-	}
-
-	if v, ok := d.GetOk("sms_authentication_message"); ok {
-		params.SmsAuthenticationMessage = aws.String(v.(string))
-	}
-
-	if v, ok := d.GetOk("sms_configuration"); ok {
-		configs := v.([]interface{})
-		config, ok := configs[0].(map[string]interface{})
-
-		if ok && config != nil {
-			params.SmsConfiguration = expandCognitoUserPoolSmsConfiguration(config)
-		}
-	}
-
-	if v, ok := d.GetOk("user_pool_add_ons"); ok {
-		configs := v.([]interface{})
-		config, ok := configs[0].(map[string]interface{})
-
-		if ok && config != nil {
-			userPoolAddons := &cognitoidentityprovider.UserPoolAddOnsType{}
-
-			if v, ok := config["advanced_security_mode"]; ok && v.(string) != "" {
-				userPoolAddons.AdvancedSecurityMode = aws.String(v.(string))
+			if err != nil {
+				return resource.NonRetryableError(err)
 			}
-			params.UserPoolAddOns = userPoolAddons
+
+			return nil
+		})
+
+		if isResourceTimeoutError(err) {
+			_, err = conn.SetUserPoolMfaConfig(input)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error setting Cognito User Pool (%s) MFA Configuration: %w", d.Id(), err)
 		}
 	}
 
-	if v, ok := d.GetOk("verification_message_template"); ok {
-		configs := v.([]interface{})
-		config, ok := configs[0].(map[string]interface{})
-
-		if d.HasChange("email_verification_message") {
-			config["email_message"] = d.Get("email_verification_message")
-		}
-		if d.HasChange("email_verification_subject") {
-			config["email_subject"] = d.Get("email_verification_subject")
-		}
-		if d.HasChange("sms_verification_message") {
-			config["sms_message"] = d.Get("sms_verification_message")
-		}
-
-		if ok && config != nil {
-			params.VerificationMessageTemplate = expandCognitoUserPoolVerificationMessageTemplate(config)
-		}
-	}
-
-	if v, ok := d.GetOk("sms_verification_message"); ok {
-		params.SmsVerificationMessage = aws.String(v.(string))
-	}
-
-	if v, ok := d.GetOk("tags"); ok {
-		params.UserPoolTags = keyvaluetags.New(v.(map[string]interface{})).IgnoreAws().CognitoidentityproviderTags()
-	}
-
-	log.Printf("[DEBUG] Updating Cognito User Pool: %s", params)
-
-	// IAM roles & policies can take some time to propagate and be attached
-	// to the User Pool.
-	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
-		var err error
-		_, err = conn.UpdateUserPool(params)
-		if isAWSErr(err, cognitoidentityprovider.ErrCodeInvalidSmsRoleTrustRelationshipException, "Role does not have a trust relationship allowing Cognito to assume the role") {
-			log.Printf("[DEBUG] Received %s, retrying UpdateUserPool", err)
-			return resource.RetryableError(err)
-		}
-		if isAWSErr(err, cognitoidentityprovider.ErrCodeInvalidSmsRoleAccessPolicyException, "Role does not have permission to publish with SNS") {
-			log.Printf("[DEBUG] Received %s, retrying UpdateUserPool", err)
-			return resource.RetryableError(err)
-		}
-		if isAWSErr(err, cognitoidentityprovider.ErrCodeInvalidParameterException, "Please use TemporaryPasswordValidityDays in PasswordPolicy instead of UnusedAccountValidityDays") {
-			log.Printf("[DEBUG] Received %s, retrying UpdateUserPool without UnusedAccountValidityDays", err)
-			params.AdminCreateUserConfig.UnusedAccountValidityDays = nil
-			return resource.RetryableError(err)
+	// Non Multi-Factor Authentication updates
+	// NOTES:
+	//  * Include SMS configuration changes since settings are shared between verification and MFA.
+	//  * For backwards compatibility, include SMS authentication message changes without SMS MFA since the API allows it.
+	if d.HasChanges(
+		"admin_create_user_config",
+		"auto_verified_attributes",
+		"device_configuration",
+		"email_configuration",
+		"email_verification_message",
+		"email_verification_subject",
+		"lambda_config",
+		"password_policy",
+		"sms_authentication_message",
+		"sms_configuration",
+		"sms_verification_message",
+		"tags",
+		"user_pool_add_ons",
+		"verification_message_template",
+	) {
+		params := &cognitoidentityprovider.UpdateUserPoolInput{
+			UserPoolId: aws.String(d.Id()),
 		}
 
-		return resource.NonRetryableError(err)
-	})
-	if isResourceTimeoutError(err) {
-		_, err = conn.UpdateUserPool(params)
-	}
-	if err != nil {
-		return fmt.Errorf("Error updating Cognito User pool: %s", err)
+		if v, ok := d.GetOk("admin_create_user_config"); ok {
+			configs := v.([]interface{})
+			config, ok := configs[0].(map[string]interface{})
+
+			if ok && config != nil {
+				params.AdminCreateUserConfig = expandCognitoUserPoolAdminCreateUserConfig(config)
+			}
+		}
+
+		if v, ok := d.GetOk("auto_verified_attributes"); ok {
+			params.AutoVerifiedAttributes = expandStringList(v.(*schema.Set).List())
+		}
+
+		if v, ok := d.GetOk("device_configuration"); ok {
+			configs := v.([]interface{})
+			config, ok := configs[0].(map[string]interface{})
+
+			if ok && config != nil {
+				params.DeviceConfiguration = expandCognitoUserPoolDeviceConfiguration(config)
+			}
+		}
+
+		if v, ok := d.GetOk("email_configuration"); ok {
+
+			configs := v.([]interface{})
+			config, ok := configs[0].(map[string]interface{})
+
+			if ok && config != nil {
+				log.Printf("[DEBUG] Set Values to update from configs")
+				emailConfigurationType := &cognitoidentityprovider.EmailConfigurationType{}
+
+				if v, ok := config["reply_to_email_address"]; ok && v.(string) != "" {
+					emailConfigurationType.ReplyToEmailAddress = aws.String(v.(string))
+				}
+
+				if v, ok := config["source_arn"]; ok && v.(string) != "" {
+					emailConfigurationType.SourceArn = aws.String(v.(string))
+				}
+
+				if v, ok := config["email_sending_account"]; ok && v.(string) != "" {
+					emailConfigurationType.EmailSendingAccount = aws.String(v.(string))
+				}
+
+				params.EmailConfiguration = emailConfigurationType
+			}
+		}
+
+		if v, ok := d.GetOk("email_verification_subject"); ok {
+			params.EmailVerificationSubject = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("email_verification_message"); ok {
+			params.EmailVerificationMessage = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("lambda_config"); ok {
+			configs := v.([]interface{})
+			config, ok := configs[0].(map[string]interface{})
+
+			if ok && config != nil {
+				params.LambdaConfig = expandCognitoUserPoolLambdaConfig(config)
+			}
+		}
+
+		if v, ok := d.GetOk("mfa_configuration"); ok {
+			params.MfaConfiguration = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("password_policy"); ok {
+			configs := v.([]interface{})
+			config, ok := configs[0].(map[string]interface{})
+
+			if ok && config != nil {
+				policies := &cognitoidentityprovider.UserPoolPolicyType{}
+				policies.PasswordPolicy = expandCognitoUserPoolPasswordPolicy(config)
+				params.Policies = policies
+			}
+		}
+
+		if v, ok := d.GetOk("sms_authentication_message"); ok {
+			params.SmsAuthenticationMessage = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("sms_configuration"); ok {
+			params.SmsConfiguration = expandCognitoSmsConfiguration(v.([]interface{}))
+		}
+
+		if v, ok := d.GetOk("user_pool_add_ons"); ok {
+			configs := v.([]interface{})
+			config, ok := configs[0].(map[string]interface{})
+
+			if ok && config != nil {
+				userPoolAddons := &cognitoidentityprovider.UserPoolAddOnsType{}
+
+				if v, ok := config["advanced_security_mode"]; ok && v.(string) != "" {
+					userPoolAddons.AdvancedSecurityMode = aws.String(v.(string))
+				}
+				params.UserPoolAddOns = userPoolAddons
+			}
+		}
+
+		if v, ok := d.GetOk("verification_message_template"); ok {
+			configs := v.([]interface{})
+			config, ok := configs[0].(map[string]interface{})
+
+			if d.HasChange("email_verification_message") {
+				config["email_message"] = d.Get("email_verification_message")
+			}
+			if d.HasChange("email_verification_subject") {
+				config["email_subject"] = d.Get("email_verification_subject")
+			}
+			if d.HasChange("sms_verification_message") {
+				config["sms_message"] = d.Get("sms_verification_message")
+			}
+
+			if ok && config != nil {
+				params.VerificationMessageTemplate = expandCognitoUserPoolVerificationMessageTemplate(config)
+			}
+		}
+
+		if v, ok := d.GetOk("sms_verification_message"); ok {
+			params.SmsVerificationMessage = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("tags"); ok {
+			params.UserPoolTags = keyvaluetags.New(v.(map[string]interface{})).IgnoreAws().CognitoidentityproviderTags()
+		}
+
+		log.Printf("[DEBUG] Updating Cognito User Pool: %s", params)
+
+		// IAM roles & policies can take some time to propagate and be attached
+		// to the User Pool.
+		err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+			var err error
+			_, err = conn.UpdateUserPool(params)
+			if isAWSErr(err, cognitoidentityprovider.ErrCodeInvalidSmsRoleTrustRelationshipException, "Role does not have a trust relationship allowing Cognito to assume the role") {
+				log.Printf("[DEBUG] Received %s, retrying UpdateUserPool", err)
+				return resource.RetryableError(err)
+			}
+			if isAWSErr(err, cognitoidentityprovider.ErrCodeInvalidSmsRoleAccessPolicyException, "Role does not have permission to publish with SNS") {
+				log.Printf("[DEBUG] Received %s, retrying UpdateUserPool", err)
+				return resource.RetryableError(err)
+			}
+			if isAWSErr(err, cognitoidentityprovider.ErrCodeInvalidParameterException, "Please use TemporaryPasswordValidityDays in PasswordPolicy instead of UnusedAccountValidityDays") {
+				log.Printf("[DEBUG] Received %s, retrying UpdateUserPool without UnusedAccountValidityDays", err)
+				params.AdminCreateUserConfig.UnusedAccountValidityDays = nil
+				return resource.RetryableError(err)
+			}
+
+			return resource.NonRetryableError(err)
+		})
+		if isResourceTimeoutError(err) {
+			_, err = conn.UpdateUserPool(params)
+		}
+		if err != nil {
+			return fmt.Errorf("Error updating Cognito User pool: %s", err)
+		}
 	}
 
 	return resourceAwsCognitoUserPoolRead(d, meta)
@@ -990,4 +1134,72 @@ func resourceAwsCognitoUserPoolDelete(d *schema.ResourceData, meta interface{}) 
 	}
 
 	return nil
+}
+
+func expandCognitoSmsConfiguration(tfList []interface{}) *cognitoidentityprovider.SmsConfigurationType {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	tfMap := tfList[0].(map[string]interface{})
+
+	apiObject := &cognitoidentityprovider.SmsConfigurationType{}
+
+	if v, ok := tfMap["external_id"].(string); ok && v != "" {
+		apiObject.ExternalId = aws.String(v)
+	}
+
+	if v, ok := tfMap["sns_caller_arn"].(string); ok && v != "" {
+		apiObject.SnsCallerArn = aws.String(v)
+	}
+
+	return apiObject
+}
+
+func expandCognitoSoftwareTokenMfaConfiguration(tfList []interface{}) *cognitoidentityprovider.SoftwareTokenMfaConfigType {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	tfMap := tfList[0].(map[string]interface{})
+
+	apiObject := &cognitoidentityprovider.SoftwareTokenMfaConfigType{}
+
+	if v, ok := tfMap["enabled"].(bool); ok {
+		apiObject.Enabled = aws.Bool(v)
+	}
+
+	return apiObject
+}
+
+func flattenCognitoSmsConfiguration(apiObject *cognitoidentityprovider.SmsConfigurationType) []interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.ExternalId; v != nil {
+		tfMap["external_id"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.SnsCallerArn; v != nil {
+		tfMap["sns_caller_arn"] = aws.StringValue(v)
+	}
+
+	return []interface{}{tfMap}
+}
+
+func flattenCognitoSoftwareTokenMfaConfiguration(apiObject *cognitoidentityprovider.SoftwareTokenMfaConfigType) []interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.Enabled; v != nil {
+		tfMap["enabled"] = aws.BoolValue(v)
+	}
+
+	return []interface{}{tfMap}
 }

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -71,7 +71,7 @@ func testSweepCognitoUserPools(region string) error {
 }
 
 func TestAccAWSCognitoUserPool_basic(t *testing.T) {
-	name := acctest.RandString(5)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cognito_user_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -80,15 +80,17 @@ func TestAccAWSCognitoUserPool_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolConfig_basic(name),
+				Config: testAccAWSCognitoUserPoolConfig_Name(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolExists(resourceName),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "cognito-idp", regexp.MustCompile(`userpool/.+`)),
-					resource.TestMatchResourceAttr(resourceName, "endpoint",
-						regexp.MustCompile(`^cognito-idp\.[^.]+\.amazonaws.com/[\w-]+_[0-9a-zA-Z]+$`)),
-					resource.TestCheckResourceAttr(resourceName, "name", "terraform-test-pool-"+name),
+					resource.TestMatchResourceAttr(resourceName, "endpoint", regexp.MustCompile(`^cognito-idp\.[^.]+\.amazonaws.com/[\w-]+_[0-9a-zA-Z]+$`)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttrSet(resourceName, "creation_date"),
 					resource.TestCheckResourceAttrSet(resourceName, "last_modified_date"),
+					resource.TestCheckResourceAttr(resourceName, "mfa_configuration", "OFF"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "software_token_mfa_configuration.#", "0"),
 				),
 			},
 			{
@@ -178,7 +180,7 @@ func TestAccAWSCognitoUserPool_withAdminCreateUserConfigurationAndPasswordPolicy
 }
 
 func TestAccAWSCognitoUserPool_withAdvancedSecurityMode(t *testing.T) {
-	name := acctest.RandString(5)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_cognito_user_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -187,7 +189,7 @@ func TestAccAWSCognitoUserPool_withAdvancedSecurityMode(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withAdvancedSecurityMode(name, "OFF"),
+				Config: testAccAWSCognitoUserPoolConfig_AdvancedSecurityMode(rName, "OFF"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "user_pool_add_ons.0.advanced_security_mode", "OFF"),
@@ -199,13 +201,13 @@ func TestAccAWSCognitoUserPool_withAdvancedSecurityMode(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withAdvancedSecurityMode(name, "ENFORCED"),
+				Config: testAccAWSCognitoUserPoolConfig_AdvancedSecurityMode(rName, "ENFORCED"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "user_pool_add_ons.0.advanced_security_mode", "ENFORCED"),
 				),
 			},
 			{
-				Config: testAccAWSCognitoUserPoolConfig_basic(name),
+				Config: testAccAWSCognitoUserPoolConfig_Name(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "user_pool_add_ons.#", "0"),
 				),
@@ -284,12 +286,9 @@ func TestAccAWSCognitoUserPool_withEmailVerificationMessage(t *testing.T) {
 	})
 }
 
-func TestAccAWSCognitoUserPool_withSmsVerificationMessage(t *testing.T) {
-	name := acctest.RandString(5)
-	authenticationMessage := fmt.Sprintf("%s {####}", acctest.RandString(10))
-	updatedAuthenticationMessage := fmt.Sprintf("%s {####}", acctest.RandString(10))
-	verificationMessage := fmt.Sprintf("%s {####}", acctest.RandString(10))
-	upatedVerificationMessage := fmt.Sprintf("%s {####}", acctest.RandString(10))
+func TestAccAWSCognitoUserPool_MfaConfiguration_SmsConfiguration(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	iamRoleResourceName := "aws_iam_role.test"
 	resourceName := "aws_cognito_user_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -298,11 +297,13 @@ func TestAccAWSCognitoUserPool_withSmsVerificationMessage(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withSmsVerificationMessage(name, authenticationMessage, verificationMessage),
+				Config: testAccAWSCognitoUserPoolConfig_MfaConfiguration_SmsConfiguration(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoUserPoolExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "sms_authentication_message", authenticationMessage),
-					resource.TestCheckResourceAttr(resourceName, "sms_verification_message", verificationMessage),
+					resource.TestCheckResourceAttr(resourceName, "mfa_configuration", "ON"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.0.external_id", "test"),
+					resource.TestCheckResourceAttrPair(resourceName, "sms_configuration.0.sns_caller_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "software_token_mfa_configuration.#", "0"),
 				),
 			},
 			{
@@ -311,10 +312,376 @@ func TestAccAWSCognitoUserPool_withSmsVerificationMessage(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withSmsVerificationMessage(name, updatedAuthenticationMessage, upatedVerificationMessage),
+				Config: testAccAWSCognitoUserPoolConfig_MfaConfiguration(rName, cognitoidentityprovider.UserPoolMfaTypeOff),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "sms_authentication_message", updatedAuthenticationMessage),
-					resource.TestCheckResourceAttr(resourceName, "sms_verification_message", upatedVerificationMessage),
+					resource.TestCheckResourceAttr(resourceName, "mfa_configuration", "OFF"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "software_token_mfa_configuration.#", "0"),
+				),
+			},
+			{
+				Config: testAccAWSCognitoUserPoolConfig_MfaConfiguration_SmsConfiguration(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "mfa_configuration", "ON"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.0.external_id", "test"),
+					resource.TestCheckResourceAttrPair(resourceName, "sms_configuration.0.sns_caller_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "software_token_mfa_configuration.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCognitoUserPool_MfaConfiguration_SmsConfigurationAndSoftwareTokenMfaConfiguration(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	iamRoleResourceName := "aws_iam_role.test"
+	resourceName := "aws_cognito_user_pool.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoUserPoolConfig_MfaConfiguration_SmsConfigurationAndSoftwareTokenMfaConfigurationEnabled(rName, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "mfa_configuration", "ON"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.0.external_id", "test"),
+					resource.TestCheckResourceAttrPair(resourceName, "sms_configuration.0.sns_caller_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "software_token_mfa_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "software_token_mfa_configuration.0.enabled", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSCognitoUserPoolConfig_MfaConfiguration_SmsConfigurationAndSoftwareTokenMfaConfigurationEnabled(rName, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "mfa_configuration", "ON"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.0.external_id", "test"),
+					resource.TestCheckResourceAttrPair(resourceName, "sms_configuration.0.sns_caller_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "software_token_mfa_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "software_token_mfa_configuration.0.enabled", "true"),
+				),
+			},
+			{
+				Config: testAccAWSCognitoUserPoolConfig_MfaConfiguration(rName, cognitoidentityprovider.UserPoolMfaTypeOff),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "mfa_configuration", "OFF"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "software_token_mfa_configuration.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCognitoUserPool_MfaConfiguration_SmsConfigurationToSoftwareTokenMfaConfiguration(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	iamRoleResourceName := "aws_iam_role.test"
+	resourceName := "aws_cognito_user_pool.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoUserPoolConfig_MfaConfiguration_SmsConfiguration(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "mfa_configuration", "ON"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.0.external_id", "test"),
+					resource.TestCheckResourceAttrPair(resourceName, "sms_configuration.0.sns_caller_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "software_token_mfa_configuration.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSCognitoUserPoolConfig_MfaConfiguration_SoftwareTokenMfaConfigurationEnabled(rName, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "mfa_configuration", "ON"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "software_token_mfa_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "software_token_mfa_configuration.0.enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCognitoUserPool_MfaConfiguration_SoftwareTokenMfaConfiguration(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_cognito_user_pool.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoUserPoolConfig_MfaConfiguration_SoftwareTokenMfaConfigurationEnabled(rName, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "mfa_configuration", "ON"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "software_token_mfa_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "software_token_mfa_configuration.0.enabled", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSCognitoUserPoolConfig_MfaConfiguration(rName, cognitoidentityprovider.UserPoolMfaTypeOff),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "mfa_configuration", "OFF"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "software_token_mfa_configuration.#", "0"),
+				),
+			},
+			{
+				Config: testAccAWSCognitoUserPoolConfig_MfaConfiguration_SoftwareTokenMfaConfigurationEnabled(rName, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "mfa_configuration", "ON"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "software_token_mfa_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "software_token_mfa_configuration.0.enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCognitoUserPool_MfaConfiguration_SoftwareTokenMfaConfigurationToSmsConfiguration(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	iamRoleResourceName := "aws_iam_role.test"
+	resourceName := "aws_cognito_user_pool.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoUserPoolConfig_MfaConfiguration_SoftwareTokenMfaConfigurationEnabled(rName, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "mfa_configuration", "ON"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "software_token_mfa_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "software_token_mfa_configuration.0.enabled", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSCognitoUserPoolConfig_MfaConfiguration_SmsConfiguration(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "mfa_configuration", "ON"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.0.external_id", "test"),
+					resource.TestCheckResourceAttrPair(resourceName, "sms_configuration.0.sns_caller_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "software_token_mfa_configuration.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCognitoUserPool_SmsAuthenticationMessage(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	smsAuthenticationMessage1 := "test authentication message {####}"
+	smsAuthenticationMessage2 := "test authentication message updated {####}"
+	resourceName := "aws_cognito_user_pool.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoUserPoolConfig_SmsAuthenticationMessage(rName, smsAuthenticationMessage1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoUserPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "sms_authentication_message", smsAuthenticationMessage1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSCognitoUserPoolConfig_SmsAuthenticationMessage(rName, smsAuthenticationMessage2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoUserPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "sms_authentication_message", smsAuthenticationMessage2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCognitoUserPool_SmsConfiguration(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	iamRoleResourceName := "aws_iam_role.test"
+	resourceName := "aws_cognito_user_pool.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoUserPoolConfig_SmsConfiguration_ExternalId(rName, "test"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "mfa_configuration", "OFF"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.0.external_id", "test"),
+					resource.TestCheckResourceAttrPair(resourceName, "sms_configuration.0.sns_caller_arn", iamRoleResourceName, "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSCognitoUserPoolConfig_Name(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "mfa_configuration", "OFF"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "1"),
+				),
+			},
+			{
+				Config: testAccAWSCognitoUserPoolConfig_SmsConfiguration_ExternalId(rName, "test"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "mfa_configuration", "OFF"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.0.external_id", "test"),
+					resource.TestCheckResourceAttrPair(resourceName, "sms_configuration.0.sns_caller_arn", iamRoleResourceName, "arn"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCognitoUserPool_SmsConfiguration_ExternalId(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	iamRoleResourceName := "aws_iam_role.test"
+	resourceName := "aws_cognito_user_pool.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoUserPoolConfig_SmsConfiguration_ExternalId(rName, "test"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "mfa_configuration", "OFF"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.0.external_id", "test"),
+					resource.TestCheckResourceAttrPair(resourceName, "sms_configuration.0.sns_caller_arn", iamRoleResourceName, "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSCognitoUserPoolConfig_SmsConfiguration_ExternalId(rName, "test2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "mfa_configuration", "OFF"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.0.external_id", "test2"),
+					resource.TestCheckResourceAttrPair(resourceName, "sms_configuration.0.sns_caller_arn", iamRoleResourceName, "arn"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCognitoUserPool_SmsConfiguration_SnsCallerArn(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	iamRoleResourceName := "aws_iam_role.test"
+	resourceName := "aws_cognito_user_pool.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoUserPoolConfig_SmsConfiguration_ExternalId(rName, "test"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "mfa_configuration", "OFF"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.0.external_id", "test"),
+					resource.TestCheckResourceAttrPair(resourceName, "sms_configuration.0.sns_caller_arn", iamRoleResourceName, "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSCognitoUserPoolConfig_SmsConfiguration_SnsCallerArn2(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "mfa_configuration", "OFF"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sms_configuration.0.external_id", "test"),
+					resource.TestCheckResourceAttrPair(resourceName, "sms_configuration.0.sns_caller_arn", iamRoleResourceName, "arn"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCognitoUserPool_SmsVerificationMessage(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	smsVerificationMessage1 := "test verification message {####}"
+	smsVerificationMessage2 := "test verification message updated {####}"
+	resourceName := "aws_cognito_user_pool.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoUserPoolConfig_SmsVerificationMessage(rName, smsVerificationMessage1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoUserPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "sms_verification_message", smsVerificationMessage1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSCognitoUserPoolConfig_SmsVerificationMessage(rName, smsVerificationMessage2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoUserPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "sms_verification_message", smsVerificationMessage2),
 				),
 			},
 		},
@@ -356,68 +723,6 @@ func TestAccAWSCognitoUserPool_withEmailConfiguration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "email_configuration.0.reply_to_email_address", replyTo),
 					resource.TestCheckResourceAttr(resourceName, "email_configuration.0.email_sending_account", "DEVELOPER"),
 					resource.TestCheckResourceAttr(resourceName, "email_configuration.0.source_arn", sourceARN),
-				),
-			},
-		},
-	})
-}
-
-// Ensure we can create a User Pool, handling IAM role propagation,
-// taking some time.
-func TestAccAWSCognitoUserPool_withSmsConfiguration(t *testing.T) {
-	name := acctest.RandString(5)
-	resourceName := "aws_cognito_user_pool.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSCognitoUserPoolConfig_withSmsConfiguration(name),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "1"),
-					resource.TestCheckResourceAttrSet(resourceName, "sms_configuration.0.external_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "sms_configuration.0.sns_caller_arn"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-// Ensure we can update a User Pool, handling IAM role propagation.
-func TestAccAWSCognitoUserPool_withSmsConfigurationUpdated(t *testing.T) {
-	name := acctest.RandString(5)
-	resourceName := "aws_cognito_user_pool.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSCognitoUserPoolConfig_basic(name),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoUserPoolExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "0"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccAWSCognitoUserPoolConfig_withSmsConfiguration(name),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "sms_configuration.#", "1"),
-					resource.TestCheckResourceAttrSet(resourceName, "sms_configuration.0.external_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "sms_configuration.0.sns_caller_arn"),
 				),
 			},
 		},
@@ -889,12 +1194,51 @@ func testAccPreCheckAWSCognitoIdentityProvider(t *testing.T) {
 	}
 }
 
-func testAccAWSCognitoUserPoolConfig_basic(name string) string {
+func testAccAWSCognitoUserPoolConfigSmsConfigurationBase(rName string, externalID string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Condition = {
+        "StringEquals" = {
+          "sts:ExternalId" = %[2]q
+        }
+      }
+      Effect    = "Allow"
+      Principal = {
+        Service = "cognito-idp.${data.aws_partition.current.dns_suffix}"
+      }
+    }]
+    Version = "2012-10-17"
+  })
+}
+
+resource "aws_iam_role_policy" "test" {
+  role = aws_iam_role.test.id
+
+  policy = jsonencode({
+    Statement = [{
+      Action   = "sns:publish"
+      Effect   = "Allow"
+      Resource = "*"
+    }]
+    Version = "2012-10-17"
+  })
+}
+`, rName, externalID)
+}
+
+func testAccAWSCognitoUserPoolConfig_Name(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
-  name = "terraform-test-pool-%s"
+  name = %[1]q
 }
-`, name)
+`, rName)
 }
 
 func testAccAWSCognitoUserPoolConfig_withAdminCreateUserConfiguration(name string) string {
@@ -954,16 +1298,16 @@ resource "aws_cognito_user_pool" "test" {
 `, name)
 }
 
-func testAccAWSCognitoUserPoolConfig_withAdvancedSecurityMode(name string, mode string) string {
+func testAccAWSCognitoUserPoolConfig_AdvancedSecurityMode(rName string, advancedSecurityMode string) string {
 	return fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
-  name = "terraform-test-pool-%s"
+  name = %[1]q
 
   user_pool_add_ons {
-    advanced_security_mode = "%s"
+    advanced_security_mode = %[2]q
   }
 }
-`, name, mode)
+`, rName, advancedSecurityMode)
 }
 
 func testAccAWSCognitoUserPoolConfig_withDeviceConfiguration(name string) string {
@@ -1006,14 +1350,102 @@ resource "aws_cognito_user_pool" "test" {
 `, name, subject, message)
 }
 
-func testAccAWSCognitoUserPoolConfig_withSmsVerificationMessage(name, authenticationMessage, verificationMessage string) string {
+func testAccAWSCognitoUserPoolConfig_MfaConfiguration(rName string, mfaConfiguration string) string {
 	return fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
-  name                       = "terraform-test-pool-%s"
-  sms_authentication_message = "%s"
-  sms_verification_message   = "%s"
+  mfa_configuration = %[2]q
+  name              = %[1]q
 }
-`, name, authenticationMessage, verificationMessage)
+`, rName, mfaConfiguration)
+}
+
+func testAccAWSCognitoUserPoolConfig_MfaConfiguration_SmsConfiguration(rName string) string {
+	return testAccAWSCognitoUserPoolConfigSmsConfigurationBase(rName, "test") + fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  mfa_configuration = "ON"
+  name              = %[1]q
+
+  sms_configuration {
+    external_id    = "test"
+    sns_caller_arn = aws_iam_role.test.arn
+  }
+}
+`, rName)
+}
+
+func testAccAWSCognitoUserPoolConfig_MfaConfiguration_SmsConfigurationAndSoftwareTokenMfaConfigurationEnabled(rName string, enabled bool) string {
+	return testAccAWSCognitoUserPoolConfigSmsConfigurationBase(rName, "test") + fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  mfa_configuration = "ON"
+  name              = %[1]q
+
+  sms_configuration {
+    external_id    = "test"
+    sns_caller_arn = aws_iam_role.test.arn
+  }
+
+  software_token_mfa_configuration {
+    enabled = %[2]t
+  }
+}
+`, rName, enabled)
+}
+
+func testAccAWSCognitoUserPoolConfig_MfaConfiguration_SoftwareTokenMfaConfigurationEnabled(rName string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  mfa_configuration = "ON"
+  name              = %[1]q
+
+  software_token_mfa_configuration {
+    enabled = %[2]t
+  }
+}
+`, rName, enabled)
+}
+
+func testAccAWSCognitoUserPoolConfig_SmsAuthenticationMessage(rName, smsAuthenticationMessage string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  name                       = %[1]q
+  sms_authentication_message = %[2]q
+}
+`, rName, smsAuthenticationMessage)
+}
+
+func testAccAWSCognitoUserPoolConfig_SmsConfiguration_ExternalId(rName string, externalID string) string {
+	return testAccAWSCognitoUserPoolConfigSmsConfigurationBase(rName, externalID) + fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  name = %[1]q
+
+  sms_configuration {
+    external_id    = %[2]q
+    sns_caller_arn = aws_iam_role.test.arn
+  }
+}
+`, rName, externalID)
+}
+
+func testAccAWSCognitoUserPoolConfig_SmsConfiguration_SnsCallerArn2(rName string) string {
+	return testAccAWSCognitoUserPoolConfigSmsConfigurationBase(rName+"-2", "test") + fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  name = %[1]q
+
+  sms_configuration {
+    external_id    = "test"
+    sns_caller_arn = aws_iam_role.test.arn
+  }
+}
+`, rName)
+}
+
+func testAccAWSCognitoUserPoolConfig_SmsVerificationMessage(rName, smsVerificationMessage string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  name                     = %[1]q
+  sms_verification_message = %[2]q
+}
+`, rName, smsVerificationMessage)
 }
 
 func testAccAWSCognitoUserPoolConfig_Tags1(name, tagKey1, tagValue1 string) string {
@@ -1053,69 +1485,6 @@ resource "aws_cognito_user_pool" "test" {
       email_sending_account = %[4]q
     }
   }`, name, email, arn, account)
-}
-
-func testAccAWSCognitoUserPoolConfig_withSmsConfiguration(name string) string {
-	return fmt.Sprintf(`
-data "aws_caller_identity" "current" {}
-
-resource "aws_iam_role" "test" {
-  name = "test-role-%[1]s"
-  path = "/service-role/"
-
-  assume_role_policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "cognito-idp.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole",
-      "Condition": {
-        "StringEquals": {
-          "sts:ExternalId": "${data.aws_caller_identity.current.account_id}"
-        }
-      }
-    }
-  ]
-}
-POLICY
-}
-
-resource "aws_iam_role_policy" "test" {
-  name = "test-role-policy-%[1]s"
-  role = "${aws_iam_role.test.id}"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "sns:publish"
-      ],
-      "Resource": [
-        "*"
-      ]
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_cognito_user_pool" "test" {
-  name = "terraform-test-pool-%[1]s"
-
-  sms_configuration {
-    external_id    = "${data.aws_caller_identity.current.account_id}"
-    sns_caller_arn = "${aws_iam_role.test.arn}"
-  }
-}
-`, name)
 }
 
 func testAccAWSCognitoUserPoolConfig_withAliasAttributes(name string) string {

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -3479,33 +3479,6 @@ func flattenCognitoUserPoolSchema(configuredAttributes, inputs []*cognitoidentit
 	return values
 }
 
-func expandCognitoUserPoolSmsConfiguration(config map[string]interface{}) *cognitoidentityprovider.SmsConfigurationType {
-	smsConfigurationType := &cognitoidentityprovider.SmsConfigurationType{
-		SnsCallerArn: aws.String(config["sns_caller_arn"].(string)),
-	}
-
-	if v, ok := config["external_id"]; ok && v.(string) != "" {
-		smsConfigurationType.ExternalId = aws.String(v.(string))
-	}
-
-	return smsConfigurationType
-}
-
-func flattenCognitoUserPoolSmsConfiguration(s *cognitoidentityprovider.SmsConfigurationType) []map[string]interface{} {
-	m := map[string]interface{}{}
-
-	if s == nil {
-		return nil
-	}
-
-	if s.ExternalId != nil {
-		m["external_id"] = *s.ExternalId
-	}
-	m["sns_caller_arn"] = *s.SnsCallerArn
-
-	return []map[string]interface{}{m}
-}
-
 func expandCognitoUserPoolVerificationMessageTemplate(config map[string]interface{}) *cognitoidentityprovider.VerificationMessageTemplateType {
 	verificationMessageTemplateType := &cognitoidentityprovider.VerificationMessageTemplateType{}
 

--- a/website/docs/r/cognito_user_pool.markdown
+++ b/website/docs/r/cognito_user_pool.markdown
@@ -20,6 +20,26 @@ resource "aws_cognito_user_pool" "pool" {
 }
 ```
 
+### Enabling SMS and Software Token Multi-Factor Authentication
+
+```hcl
+resource "aws_cognito_user_pool_mfa_config" "example" {
+  # ... other configuration ...
+
+  mfa_configuration          = "ON"
+  sms_authentication_message = "Your code is {####}"
+
+  sms_configuration {
+    external_id    = "example"
+    sns_caller_arn = aws_iam_role.example.arn
+  }
+
+  software_token_mfa_configuration {
+    enabled = true
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -33,12 +53,16 @@ The following arguments are supported:
 * `email_verification_subject` - (Optional) A string representing the email verification subject. Conflicts with `verification_message_template` configuration block `email_subject` argument.
 * `email_verification_message` - (Optional) A string representing the email verification message. Conflicts with `verification_message_template` configuration block `email_message` argument.
 * `lambda_config` (Optional) - A container for the AWS [Lambda triggers](#lambda-configuration) associated with the user pool.
-* `mfa_configuration` - (Optional, Default: OFF) Set to enable multi-factor authentication. Must be one of the following values (ON, OFF, OPTIONAL)
+* `mfa_configuration` - (Optional) Multi-Factor Authentication (MFA) configuration for the User Pool. Defaults of `OFF`. Valid values:
+    * `OFF` - MFA tokens are not required.
+    * `ON` - MFA is required for all users to sign in. Requires at least one of `sms_configuration` or `software_token_mfa_configuration` to be configured.
+    * `OPTIONAL` - MFA will be required only for individual users who have MFA enabled. Requires at least one of `sms_configuration` or `software_token_mfa_configuration` to be configured.
 * `password_policy` (Optional) - A container for information about the [user pool password policy](#password-policy).
 * `schema` (Optional) - A container with the [schema attributes](#schema-attributes) of a user pool. Schema attributes from the [standard attribute set](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-attributes.html#cognito-user-pools-standard-attributes) only need to be specified if they are different from the default configuration. Maximum of 50 attributes.
-* `sms_authentication_message` - (Optional) A string representing the SMS authentication message.
-* `sms_configuration` (Optional) - The [SMS Configuration](#sms-configuration).
+* `sms_authentication_message` - (Optional) A string representing the SMS authentication message. The message must contain the `{####}` placeholder, which will be replaced with the code.
+* `sms_configuration` (Optional) - Configuration block for Short Message Service (SMS) settings. Detailed below. These settings apply to SMS user verification and SMS Multi-Factor Authentication (MFA). Due to Cognito API restrictions, the SMS configuration cannot be removed without recreating the Cognito User Pool. For user data safety, this resource will ignore the removal of this configuration by disabling drift detection. To force resource recreation after this configuration has been applied, see the [`taint` command](/docs/commands/taint.html).
 * `sms_verification_message` - (Optional) A string representing the SMS verification message. Conflicts with `verification_message_template` configuration block `sms_message` argument.
+* `software_token_mfa_configuration` - (Optional) Configuration block for software token Mult-Factor Authentication (MFA) settings. Detailed below.
 * `tags` - (Optional) A mapping of tags to assign to the User Pool.
 * `username_attributes` - (Optional) Specifies whether email addresses or phone numbers can be specified as usernames when a user signs up. Conflicts with `alias_attributes`.
 * `user_pool_add_ons` - (Optional) Configuration block for [user pool add-ons](#user-pool-add-ons) to enable user pool advanced security mode features.
@@ -137,6 +161,12 @@ resource "aws_cognito_user_pool" "example" {
 
   * `external_id` (Required) - The external ID used in IAM role trust relationships. For more information about using external IDs, see [How to Use an External ID When Granting Access to Your AWS Resources to a Third Party](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html).
   * `sns_caller_arn` (Required) - The ARN of the Amazon SNS caller. This is usually the IAM role that you've given Cognito permission to assume.
+
+### Software Token MFA Configuration
+
+The following arguments are required in the `software_token_mfa_configuration` configuration block:
+
+* `enabled` - (Required) Boolean whether to enable software token Multi-Factor (MFA) tokens, such as Time-based One-Time Password (TOTP). To disable software token MFA when `sms_configuration` is not present, the `mfa_configuration` argument must be set to `OFF` and the `software_token_mfa_configuration` configuration block must be fully removed.
 
 #### User Pool Add-ons
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #5420
Reference: https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateUserPool.html
Reference: https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_DescribeUserPool.html
Reference: https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_GetUserPoolMfaConfig.html
Reference: https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_SetUserPoolMfaConfig.html
Reference: https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UpdateUserPool.html
Reference: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpool.html

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

* resource/aws_cognito_user_pool: The addition of Software Token MFA support required the use of new `GetUserPoolMfaConfig` and `SetUserPoolMfaConfig` API calls. Restrictive IAM permissions for Terraform may require updates.

ENHANCEMENTS:

* resource/aws_cognito_user_pool: Add `software_token_mfa_configuration` configuration block (Support Time-based One-Time Password (TOTP) Multi-Factor Authentication)
```

With the introduction of software token MFA configuration, the API introduced new `GetUserPoolMfaConfig` and `SetUserPoolMfaConfig` calls. The parameters within these overlap with the existing `SmsAuthenticationMessage` and `SmsConfiguration` parameters of the existing `(Create|Describe|Update)UserPool` calls with `SoftwareTokenMfaConfiguration` being the only addition.

Typically when we see separate API calls like this, we prefer to model the new functionality as a separate Terraform resource, however in testing the user experience with a separate resource there were some confusing behaviors due to the overlapping API configurations.

To support this within the existing resource, we need to introduce the new API calls and remove the existing parameters in select places to improve the resource behavior. For example, `SetUserPoolMfaConfig` allows `MfaConfiguration` to be set to the `ON` value after User Pool creation. Even with these new API calls, the same previous Cognito API limitations exist where its not possible to remove SMS MFA once its configured. Should the API introduce that functionality, a new `sms_mfa_configuration` configuration block to match the API structure can be introduced then.

CloudFormation models this new functionality within an `EnabledMfas` list property, but has to document similar API caveats, so instead we opt follow the API structure for the new software token MFA configuration as a future-proofing measure should this MFA configuration receive additional settings or additional MFA configurations be introduced that include settings beyond just enabling it.

Output from acceptance testing:

```
--- PASS: TestAccAWSCognitoUserPool_basic (22.24s)
--- PASS: TestAccAWSCognitoUserPool_MfaConfiguration_SmsConfiguration (99.31s)
--- PASS: TestAccAWSCognitoUserPool_MfaConfiguration_SmsConfigurationAndSoftwareTokenMfaConfiguration (61.67s)
--- PASS: TestAccAWSCognitoUserPool_MfaConfiguration_SmsConfigurationToSoftwareTokenMfaConfiguration (49.14s)
--- PASS: TestAccAWSCognitoUserPool_MfaConfiguration_SoftwareTokenMfaConfiguration (45.52s)
--- PASS: TestAccAWSCognitoUserPool_MfaConfiguration_SoftwareTokenMfaConfigurationToSmsConfiguration (46.24s)
--- PASS: TestAccAWSCognitoUserPool_SmsAuthenticationMessage (36.27s)
--- PASS: TestAccAWSCognitoUserPool_SmsConfiguration (66.50s)
--- PASS: TestAccAWSCognitoUserPool_SmsConfiguration_ExternalId (62.26s)
--- PASS: TestAccAWSCognitoUserPool_SmsConfiguration_SnsCallerArn (62.06s)
--- PASS: TestAccAWSCognitoUserPool_SmsVerificationMessage (35.88s)
--- PASS: TestAccAWSCognitoUserPool_update (68.92s)
--- PASS: TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration (42.31s)
--- PASS: TestAccAWSCognitoUserPool_withAdminCreateUserConfigurationAndPasswordPolicy (19.12s)
--- PASS: TestAccAWSCognitoUserPool_withAdvancedSecurityMode (47.71s)
--- PASS: TestAccAWSCognitoUserPool_withAliasAttributes (35.78s)
--- PASS: TestAccAWSCognitoUserPool_withDeviceConfiguration (36.12s)
--- PASS: TestAccAWSCognitoUserPool_withEmailVerificationMessage (36.19s)
--- PASS: TestAccAWSCognitoUserPool_withLambdaConfig (69.83s)
--- PASS: TestAccAWSCognitoUserPool_withPasswordPolicy (35.79s)
--- PASS: TestAccAWSCognitoUserPool_withSchemaAttributes (41.73s)
--- PASS: TestAccAWSCognitoUserPool_withTags (47.30s)
--- PASS: TestAccAWSCognitoUserPool_withVerificationMessageTemplate (35.71s)
```