### PR TITLE
S3 ACL: The current docs are incorrect and cause errors

### DIFF
--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -320,12 +320,12 @@ resource "aws_s3_bucket" "bucket" {
   grant {
     id         = "${data.aws_canonical_user_id.current_user.id}"
     type       = "CanonicalUser"
-    permission = ["FULL_ACCESS"]
+    permissions = ["FULL_CONTROL"]
   }
 
   grant {
     type       = "Group"
-    permission = ["READ", "WRITE"]
+    permissions = ["READ", "WRITE"]
     uri        = "http://acs.amazonaws.com/groups/s3/LogDelivery"
   }
 }
@@ -485,7 +485,7 @@ The `grant` object supports the following:
 
 * `id` - (optional) Canonical user id to grant for. Used only when `type` is `CanonicalUser`.  
 * `type` - (required) - Type of grantee to apply for. Valid values are `CanonicalUser` and `Group`. `AmazonCustomerByEmail` is not supported.
-* `permissions` - (required) List of permissions to apply for grantee. Valid values are `READ`, `WRITE`, `READ_ACP`, `WRITE_ACP`, `FULL_ACCESS`.
+* `permissions` - (required) List of permissions to apply for grantee. Valid values are `READ`, `WRITE`, `READ_ACP`, `WRITE_ACP`, `FULL_CONTROL`.
 * `uri` - (optional) Uri address to grant for. Used only when `type` is `Group`.
 
 The `access_control_translation` object supports the following:


### PR DESCRIPTION
Simple change to rename:

- permission -> permissions (this is a list)
- FULL_ACCESS -> FULL_CONTROL

This is the correct syntax for these examples

Example of the error to be fixed:

```
Error: aws_s3_bucket.telemetry: "grant.0.permissions": required field is not set
Error: aws_s3_bucket.telemetry: "grant.1.permissions": required field is not set
Error: aws_s3_bucket.telemetry: grant.0: invalid or unknown key: permission
Error: aws_s3_bucket.telemetry: grant.1: invalid or unknown key: permission

Error: aws_s3_bucket.telemetry: expected grant.0.permissions.0 to be one of [FULL_CONTROL READ READ_ACP WRITE WRITE_ACP], got FULL_ACCESS
```

Signed-off-by: Danny <danny@Dannys-MacBook-Pro.local>

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
