### PR TITLE
Wait longer for ACM certificates creation.

### DIFF
--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -226,7 +226,7 @@ func resourceAwsAcmCertificateRead(d *schema.ResourceData, meta interface{}) err
 		CertificateArn: aws.String(d.Id()),
 	}
 
-	return resource.Retry(time.Duration(1)*time.Minute, func() *resource.RetryError {
+	return resource.Retry(time.Duration(5)*time.Minute, func() *resource.RetryError {
 		resp, err := acmconn.DescribeCertificate(params)
 
 		if err != nil {


### PR DESCRIPTION
When an ACM certificate has a lot of SANs (>20), it takes more
than 1 minute for AWS to generate all the DNS challenges. This PR
will make the resource wait for the challenges 5 minutes instead of
1 minute.

Closes #12445