### PR TITLE
r/aws_inspector_assessment_template: Support resource tags

### DIFF
--- a/aws/internal/keyvaluetags/inspector_tags.go
+++ b/aws/internal/keyvaluetags/inspector_tags.go
@@ -1,0 +1,44 @@
+// +build !generate
+
+package keyvaluetags
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/inspector"
+)
+
+// Custom Inspector tag service update functions using the same format as generated code.
+
+// InspectorUpdateTags updates WorkSpaces resource tags.
+// The identifier is the resource ARN.
+func InspectorUpdateTags(conn *inspector.Inspector, identifier string, oldTagsMap interface{}, newTagsMap interface{}) error {
+	oldTags := New(oldTagsMap)
+	newTags := New(newTagsMap)
+
+	if len(newTags) > 0 {
+		input := &inspector.SetTagsForResourceInput{
+			ResourceArn: aws.String(identifier),
+			Tags:        newTags.IgnoreAws().InspectorTags(),
+		}
+
+		_, err := conn.SetTagsForResource(input)
+
+		if err != nil {
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
+		}
+	} else if len(oldTags) > 0 {
+		input := &inspector.SetTagsForResourceInput{
+			ResourceArn: aws.String(identifier),
+		}
+
+		_, err := conn.SetTagsForResource(input)
+
+		if err != nil {
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
+		}
+	}
+
+	return nil
+}

--- a/aws/resource_aws_inspector_assessment_template.go
+++ b/aws/resource_aws_inspector_assessment_template.go
@@ -1,19 +1,25 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
+	// "github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/inspector"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAWSInspectorAssessmentTemplate() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsInspectorAssessmentTemplateCreate,
 		Read:   resourceAwsInspectorAssessmentTemplateRead,
+		Update: resourceAwsInspectorAssessmentTemplateUpdate,
 		Delete: resourceAwsInspectorAssessmentTemplateDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -43,6 +49,7 @@ func resourceAWSInspectorAssessmentTemplate() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -50,29 +57,26 @@ func resourceAWSInspectorAssessmentTemplate() *schema.Resource {
 func resourceAwsInspectorAssessmentTemplateCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).inspectorconn
 
-	rules := []*string{}
-	if attr := d.Get("rules_package_arns").(*schema.Set); attr.Len() > 0 {
-		rules = expandStringList(attr.List())
+	req := &inspector.CreateAssessmentTemplateInput{
+		AssessmentTargetArn:    aws.String(d.Get("target_arn").(string)),
+		AssessmentTemplateName: aws.String(d.Get("name").(string)),
+		DurationInSeconds:      aws.Int64(int64(d.Get("duration").(int))),
+		RulesPackageArns:       expandStringSet(d.Get("rules_package_arns").(*schema.Set)),
 	}
 
-	targetArn := d.Get("target_arn").(string)
-	templateName := d.Get("name").(string)
-	duration := int64(d.Get("duration").(int))
-
-	resp, err := conn.CreateAssessmentTemplate(&inspector.CreateAssessmentTemplateInput{
-		AssessmentTargetArn:    aws.String(targetArn),
-		AssessmentTemplateName: aws.String(templateName),
-		DurationInSeconds:      aws.Int64(duration),
-		RulesPackageArns:       rules,
-	})
+	log.Printf("[DEBUG] Creating Inspector assessment template: %s", req)
+	resp, err := conn.CreateAssessmentTemplate(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating Inspector assessment template: %s", err)
 	}
-	log.Printf("[DEBUG] Inspector Assessment Template %s created", *resp.AssessmentTemplateArn)
 
-	d.Set("arn", resp.AssessmentTemplateArn)
+	d.SetId(aws.StringValue(resp.AssessmentTemplateArn))
 
-	d.SetId(*resp.AssessmentTemplateArn)
+	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
+		if err := keyvaluetags.InspectorUpdateTags(conn, d.Id(), nil, v); err != nil {
+			return fmt.Errorf("error adding Inspector assessment template (%s) tags: %s", d.Id(), err)
+		}
+	}
 
 	return resourceAwsInspectorAssessmentTemplateRead(d, meta)
 }
@@ -81,24 +85,55 @@ func resourceAwsInspectorAssessmentTemplateRead(d *schema.ResourceData, meta int
 	conn := meta.(*AWSClient).inspectorconn
 
 	resp, err := conn.DescribeAssessmentTemplates(&inspector.DescribeAssessmentTemplatesInput{
-		AssessmentTemplateArns: []*string{
-			aws.String(d.Id()),
-		},
-	},
-	)
+		AssessmentTemplateArns: aws.StringSlice([]string{d.Id()}),
+	})
 	if err != nil {
-		if inspectorerr, ok := err.(awserr.Error); ok && inspectorerr.Code() == "InvalidInputException" {
-			return nil
-		} else {
-			log.Printf("[ERROR] Error finding Inspector Assessment Template: %s", err)
-			return err
+		return fmt.Errorf("error reading Inspector assessment template (%s): %s", d.Id(), err)
+	}
+
+	if resp.AssessmentTemplates == nil || len(resp.AssessmentTemplates) == 0 {
+		log.Printf("[WARN] Inspector assessment template (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	template := resp.AssessmentTemplates[0]
+
+	arn := aws.StringValue(template.Arn)
+	d.Set("arn", arn)
+	d.Set("duration", template.DurationInSeconds)
+	d.Set("name", template.Name)
+	d.Set("target_arn", template.AssessmentTargetArn)
+
+	if err := d.Set("rules_package_arns", flattenStringSet(template.RulesPackageArns)); err != nil {
+		return fmt.Errorf("error setting rules_package_arns: %s", err)
+	}
+
+	tags, err := keyvaluetags.InspectorListTags(conn, arn)
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for Inspector assessment template (%s): %s", arn, err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsInspectorAssessmentTemplateUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).inspectorconn
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.InspectorUpdateTags(conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("error updating Inspector assessment template (%s) tags: %s", d.Id(), err)
 		}
 	}
 
-	if resp.AssessmentTemplates != nil && len(resp.AssessmentTemplates) > 0 {
-		d.Set("name", resp.AssessmentTemplates[0].Name)
-	}
-	return nil
+	return resourceAwsInspectorAssessmentTemplateRead(d, meta)
 }
 
 func resourceAwsInspectorAssessmentTemplateDelete(d *schema.ResourceData, meta interface{}) error {
@@ -108,13 +143,7 @@ func resourceAwsInspectorAssessmentTemplateDelete(d *schema.ResourceData, meta i
 		AssessmentTemplateArn: aws.String(d.Id()),
 	})
 	if err != nil {
-		if inspectorerr, ok := err.(awserr.Error); ok && inspectorerr.Code() == "AssessmentRunInProgressException" {
-			log.Printf("[ERROR] Assement Run in progress: %s", err)
-			return err
-		} else {
-			log.Printf("[ERROR] Error deleting Assement Template: %s", err)
-			return err
-		}
+		return fmt.Errorf("error deleting Inspector assessment template (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_inspector_assessment_template_test.go
+++ b/aws/resource_aws_inspector_assessment_template_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -13,7 +14,9 @@ import (
 )
 
 func TestAccAWSInspectorTemplate_basic(t *testing.T) {
-	rInt := acctest.RandInt()
+	var v inspector.AssessmentTemplate
+	resourceName := "aws_inspector_assessment_template.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -21,15 +24,93 @@ func TestAccAWSInspectorTemplate_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSInspectorTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSInspectorTemplateAssessment(rInt),
+				Config: testAccAWSInspectorTemplateAssessmentBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSInspectorTemplateExists("aws_inspector_assessment_template.foo"),
+					testAccCheckAWSInspectorTemplateExists(resourceName, &v),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "inspector", regexp.MustCompile(`target/.+/template/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "duration", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "rules_package_arns.#", "data.aws_inspector_rules_packages.available", "arns.#"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttrPair(resourceName, "target_arn", "aws_inspector_assessment_target.test", "arn"),
 				),
 			},
 			{
-				Config: testAccCheckAWSInspectorTemplatetModified(rInt),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSInspectorTemplate_disappears(t *testing.T) {
+	var v inspector.AssessmentTemplate
+	resourceName := "aws_inspector_assessment_template.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSInspectorTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSInspectorTemplateAssessmentBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSInspectorTemplateExists("aws_inspector_assessment_template.foo"),
+					testAccCheckAWSInspectorTemplateExists(resourceName, &v),
+					testAccCheckAWSInspectorTemplateDisappears(&v),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSInspectorTemplate_tags(t *testing.T) {
+	var v inspector.AssessmentTemplate
+	resourceName := "aws_inspector_assessment_template.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSInspectorTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSInspectorTemplateAssessmentTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSInspectorTemplateExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSInspectorTemplateAssessmentTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSInspectorTemplateExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSInspectorTemplateAssessmentTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSInspectorTemplateExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSInspectorTemplateAssessmentBasic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSInspectorTemplateExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 		},
@@ -66,69 +147,109 @@ func testAccCheckAWSInspectorTemplateDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAWSInspectorTemplateExists(name string) resource.TestCheckFunc {
+func testAccCheckAWSInspectorTemplateDisappears(v *inspector.AssessmentTemplate) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		_, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+		conn := testAccProvider.Meta().(*AWSClient).inspectorconn
+
+		_, err := conn.DeleteAssessmentTemplate(&inspector.DeleteAssessmentTemplateInput{
+			AssessmentTemplateArn: v.Arn,
+		})
+		if err != nil {
+			return err
 		}
 
 		return nil
 	}
 }
 
-func testAccAWSInspectorTemplateAssessment(rInt int) string {
+func testAccCheckAWSInspectorTemplateExists(name string, v *inspector.AssessmentTemplate) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Inspector assessment template ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).inspectorconn
+
+		resp, err := conn.DescribeAssessmentTemplates(&inspector.DescribeAssessmentTemplatesInput{
+			AssessmentTemplateArns: aws.StringSlice([]string{rs.Primary.ID}),
+		})
+		if err != nil {
+			return err
+		}
+
+		if resp.AssessmentTemplates == nil || len(resp.AssessmentTemplates) == 0 {
+			return fmt.Errorf("Inspector assessment template not found")
+		}
+
+		*v = *resp.AssessmentTemplates[0]
+
+		return nil
+	}
+}
+
+func testAccAWSInspectorTemplateAssessmentBase(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_inspector_resource_group" "foo" {
+data "aws_inspector_rules_packages" "available" {}
+
+resource "aws_inspector_resource_group" "test" {
   tags = {
-    Name = "tf-acc-test-%d"
+    Name = %[1]q
   }
 }
 
-resource "aws_inspector_assessment_target" "foo" {
-  name               = "tf-acc-test-basic-%d"
-  resource_group_arn = "${aws_inspector_resource_group.foo.arn}"
+resource "aws_inspector_assessment_target" "test" {
+  name               = %[1]q
+  resource_group_arn = "${aws_inspector_resource_group.test.arn}"
+}
+`, rName)
 }
 
-resource "aws_inspector_assessment_template" "foo" {
-  name       = "tf-acc-test-basic-tpl-%d"
-  target_arn = "${aws_inspector_assessment_target.foo.arn}"
+func testAccAWSInspectorTemplateAssessmentBasic(rName string) string {
+	return testAccAWSInspectorTemplateAssessmentBase(rName) + fmt.Sprintf(`
+resource "aws_inspector_assessment_template" "test" {
+  name       = %[1]q
+  target_arn = "${aws_inspector_assessment_target.test.arn}"
   duration   = 3600
 
-  rules_package_arns = [
-    "arn:aws:inspector:us-west-2:758058086616:rulespackage/0-9hgA516p",
-    "arn:aws:inspector:us-west-2:758058086616:rulespackage/0-H5hpSawc",
-    "arn:aws:inspector:us-west-2:758058086616:rulespackage/0-JJOtZiqQ",
-    "arn:aws:inspector:us-west-2:758058086616:rulespackage/0-vg5GGHSD",
-  ]
+  rules_package_arns = "${data.aws_inspector_rules_packages.available.arns}"
 }
-`, rInt, rInt, rInt)
+`, rName)
 }
 
-func testAccCheckAWSInspectorTemplatetModified(rInt int) string {
-	return fmt.Sprintf(`
-resource "aws_inspector_resource_group" "foo" {
+func testAccAWSInspectorTemplateAssessmentTags1(rName, tagKey1, tagValue1 string) string {
+	return testAccAWSInspectorTemplateAssessmentBase(rName) + fmt.Sprintf(`
+resource "aws_inspector_assessment_template" "test" {
+  name       = %[1]q
+  target_arn = "${aws_inspector_assessment_target.test.arn}"
+  duration   = 3600
+
+  rules_package_arns = "${data.aws_inspector_rules_packages.available.arns}"
+
   tags = {
-    Name = "tf-acc-test-%d"
+    %[2]q = %[3]q
   }
 }
-
-resource "aws_inspector_assessment_target" "foo" {
-  name               = "tf-acc-test-basic-%d"
-  resource_group_arn = "${aws_inspector_resource_group.foo.arn}"
+`, rName, tagKey1, tagValue1)
 }
 
-resource "aws_inspector_assessment_template" "foo" {
-  name       = "tf-acc-test-basic-tpl-%d"
-  target_arn = "${aws_inspector_assessment_target.foo.arn}"
+func testAccAWSInspectorTemplateAssessmentTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return testAccAWSInspectorTemplateAssessmentBase(rName) + fmt.Sprintf(`
+resource "aws_inspector_assessment_template" "test" {
+  name       = %[1]q
+  target_arn = "${aws_inspector_assessment_target.test.arn}"
   duration   = 3600
 
-  rules_package_arns = [
-    "arn:aws:inspector:us-west-2:758058086616:rulespackage/0-9hgA516p",
-    "arn:aws:inspector:us-west-2:758058086616:rulespackage/0-H5hpSawc",
-    "arn:aws:inspector:us-west-2:758058086616:rulespackage/0-JJOtZiqQ",
-    "arn:aws:inspector:us-west-2:758058086616:rulespackage/0-vg5GGHSD",
-  ]
+  rules_package_arns = "${data.aws_inspector_rules_packages.available.arns}"
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
 }
-`, rInt, rInt, rInt)
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }

--- a/website/docs/r/inspector_assessment_template.html.markdown
+++ b/website/docs/r/inspector_assessment_template.html.markdown
@@ -13,9 +13,9 @@ Provides a Inspector assessment template
 ## Example Usage
 
 ```hcl
-resource "aws_inspector_assessment_template" "foo" {
-  name       = "bar template"
-  target_arn = "${aws_inspector_assessment_target.foo.arn}"
+resource "aws_inspector_assessment_template" "example" {
+  name       = "example"
+  target_arn = "${aws_inspector_assessment_target.example.arn}"
   duration   = 3600
 
   rules_package_arns = [
@@ -35,9 +35,18 @@ The following arguments are supported:
 * `target_arn` - (Required) The assessment target ARN to attach the template to.
 * `duration` - (Required) The duration of the inspector run.
 * `rules_package_arns` - (Required) The rules to be used during the run.
+* `tags` - (Optional) Key-value mapping of tags for the Inspector assessment template.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The template assessment ARN.
+
+## Import
+
+`aws_inspector_assessment_template` can be imported by using the template assessment ARN, e.g.
+
+```
+$ terraform import aws_inspector_assessment_template.example arn:aws:inspector:us-west-2:123456789012:target/0-9IaAzhGR/template/0-WEcjR8CH
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/11574.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_inspector_assessment_template: Add `tags` attribute
resource/aws_inspector_assessment_template: Add support for resource import
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSInspectorTemplate_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSInspectorTemplate_ -timeout 120m
=== RUN   TestAccAWSInspectorTemplate_basic
=== PAUSE TestAccAWSInspectorTemplate_basic
=== RUN   TestAccAWSInspectorTemplate_disappears
=== PAUSE TestAccAWSInspectorTemplate_disappears
=== RUN   TestAccAWSInspectorTemplate_tags
=== PAUSE TestAccAWSInspectorTemplate_tags
=== CONT  TestAccAWSInspectorTemplate_basic
=== CONT  TestAccAWSInspectorTemplate_tags
=== CONT  TestAccAWSInspectorTemplate_disappears
--- PASS: TestAccAWSInspectorTemplate_disappears (29.29s)
--- PASS: TestAccAWSInspectorTemplate_basic (31.39s)
--- PASS: TestAccAWSInspectorTemplate_tags (85.33s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	85.421s
```
