### PR TITLE
r/aws_backup_plan - add import support

### DIFF
--- a/aws/resource_aws_backup_plan.go
+++ b/aws/resource_aws_backup_plan.go
@@ -18,6 +18,9 @@ func resourceAwsBackupPlan() *schema.Resource {
 		Read:   resourceAwsBackupPlanRead,
 		Update: resourceAwsBackupPlanUpdate,
 		Delete: resourceAwsBackupPlanDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/aws/resource_aws_backup_plan_test.go
+++ b/aws/resource_aws_backup_plan_test.go
@@ -39,6 +39,11 @@ func TestAccAwsBackupPlan_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "version"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -65,6 +70,11 @@ func TestAccAwsBackupPlan_withTags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "Value1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "Value2a"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAwsBackupPlanConfig_tagsUpdated(rName),
@@ -123,6 +133,11 @@ func TestAccAwsBackupPlan_withRules(t *testing.T) {
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rule2Name, "recovery_point_tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAwsBackupPlanConfig_threeRules(rName),
@@ -189,6 +204,11 @@ func TestAccAwsBackupPlan_withLifecycle(t *testing.T) {
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "lifecycle.0.delete_after", "0"),
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "recovery_point_tags.%", "0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAwsBackupPlanConfig_lifecycleDeleteAfterOnly(rName),
@@ -258,6 +278,11 @@ func TestAccAwsBackupPlan_withRecoveryPointTags(t *testing.T) {
 					testAccCheckAwsBackupPlanRuleAttr(resourceName, &ruleNameMap, rName, "recovery_point_tags.Key2", "Value2a"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAwsBackupPlanConfig_recoveryPointTagsUpdated(rName),

--- a/website/docs/r/backup_plan.html.markdown
+++ b/website/docs/r/backup_plan.html.markdown
@@ -56,3 +56,11 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The id of the backup plan.
 * `arn` - The ARN of the backup plan.
 * `version` - Unique, randomly generated, Unicode, UTF-8 encoded string that serves as the version ID of the backup plan.
+
+## Import
+
+Backup Plan can be imported using the `id`, e.g.
+
+```
+$ terraform import aws_backup_paln.test <id>
+```

--- a/website/docs/r/backup_plan.html.markdown
+++ b/website/docs/r/backup_plan.html.markdown
@@ -62,5 +62,5 @@ In addition to all arguments above, the following attributes are exported:
 Backup Plan can be imported using the `id`, e.g.
 
 ```
-$ terraform import aws_backup_paln.test <id>
+$ terraform import aws_backup_plan.test <id>
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12380

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_backup_plan - add import support
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsBackupPlan_'
--- PASS: TestAccAwsBackupPlan_basic (49.44s)
--- PASS: TestAccAwsBackupPlan_withTags (131.62s)
--- PASS: TestAccAwsBackupPlan_withRules (109.21s)
--- PASS: TestAccAwsBackupPlan_withLifecycle (138.57s)
--- PASS: TestAccAwsBackupPlan_withRecoveryPointTags (109.30s)
--- PASS: TestAccAwsBackupPlan_disappears (40.02s).
```
