### PR TITLE
Avoid Amazon's SSM security holes

### DIFF
--- a/website/docs/r/ssm_activation.html.markdown
+++ b/website/docs/r/ssm_activation.html.markdown
@@ -30,7 +30,7 @@ EOF
 
 resource "aws_iam_role_policy_attachment" "test_attach" {
   role       = "${aws_iam_role.test_role.name}"
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
 resource "aws_ssm_activation" "foo" {


### PR DESCRIPTION
The `AmazonEC2RoleforSSM` policy is horribly insecure and should not be encouraged:

https://www.daemonology.net/blog/2016-10-09-EC2s-most-dangerous-feature.html

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
