### PR TITLE
r/aws_cognito_user_pool_client - change lists to sets to prevent change when values are not sorted

### DIFF
--- a/aws/resource_aws_cognito_user_pool_client.go
+++ b/aws/resource_aws_cognito_user_pool_client.go
@@ -122,7 +122,7 @@ func resourceAwsCognitoUserPoolClient() *schema.Resource {
 			// TODO: analytics_configuration
 
 			"callback_urls": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				MaxItems: 100,
 				Elem: &schema.Schema{
@@ -137,7 +137,7 @@ func resourceAwsCognitoUserPoolClient() *schema.Resource {
 			},
 
 			"logout_urls": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				MaxItems: 100,
 				Elem: &schema.Schema{
@@ -147,7 +147,7 @@ func resourceAwsCognitoUserPoolClient() *schema.Resource {
 			},
 
 			"supported_identity_providers": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -170,15 +170,15 @@ func resourceAwsCognitoUserPoolClientCreate(d *schema.ResourceData, meta interfa
 	}
 
 	if v, ok := d.GetOk("explicit_auth_flows"); ok {
-		params.ExplicitAuthFlows = expandStringList(v.(*schema.Set).List())
+		params.ExplicitAuthFlows = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("read_attributes"); ok {
-		params.ReadAttributes = expandStringList(v.(*schema.Set).List())
+		params.ReadAttributes = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("write_attributes"); ok {
-		params.WriteAttributes = expandStringList(v.(*schema.Set).List())
+		params.WriteAttributes = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("refresh_token_validity"); ok {
@@ -186,7 +186,7 @@ func resourceAwsCognitoUserPoolClientCreate(d *schema.ResourceData, meta interfa
 	}
 
 	if v, ok := d.GetOk("allowed_oauth_flows"); ok {
-		params.AllowedOAuthFlows = expandStringList(v.(*schema.Set).List())
+		params.AllowedOAuthFlows = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("allowed_oauth_flows_user_pool_client"); ok {
@@ -194,11 +194,11 @@ func resourceAwsCognitoUserPoolClientCreate(d *schema.ResourceData, meta interfa
 	}
 
 	if v, ok := d.GetOk("allowed_oauth_scopes"); ok {
-		params.AllowedOAuthScopes = expandStringList(v.(*schema.Set).List())
+		params.AllowedOAuthScopes = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("callback_urls"); ok {
-		params.CallbackURLs = expandStringList(v.([]interface{}))
+		params.CallbackURLs = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("default_redirect_uri"); ok {
@@ -206,11 +206,11 @@ func resourceAwsCognitoUserPoolClientCreate(d *schema.ResourceData, meta interfa
 	}
 
 	if v, ok := d.GetOk("logout_urls"); ok {
-		params.LogoutURLs = expandStringList(v.([]interface{}))
+		params.LogoutURLs = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("supported_identity_providers"); ok {
-		params.SupportedIdentityProviders = expandStringList(v.([]interface{}))
+		params.SupportedIdentityProviders = expandStringSet(v.(*schema.Set))
 	}
 
 	log.Printf("[DEBUG] Creating Cognito User Pool Client: %s", params)
@@ -250,18 +250,18 @@ func resourceAwsCognitoUserPoolClientRead(d *schema.ResourceData, meta interface
 	d.SetId(*resp.UserPoolClient.ClientId)
 	d.Set("user_pool_id", resp.UserPoolClient.UserPoolId)
 	d.Set("name", resp.UserPoolClient.ClientName)
-	d.Set("explicit_auth_flows", flattenStringList(resp.UserPoolClient.ExplicitAuthFlows))
-	d.Set("read_attributes", flattenStringList(resp.UserPoolClient.ReadAttributes))
-	d.Set("write_attributes", flattenStringList(resp.UserPoolClient.WriteAttributes))
+	d.Set("explicit_auth_flows", flattenStringSet(resp.UserPoolClient.ExplicitAuthFlows))
+	d.Set("read_attributes", flattenStringSet(resp.UserPoolClient.ReadAttributes))
+	d.Set("write_attributes", flattenStringSet(resp.UserPoolClient.WriteAttributes))
 	d.Set("refresh_token_validity", resp.UserPoolClient.RefreshTokenValidity)
 	d.Set("client_secret", resp.UserPoolClient.ClientSecret)
-	d.Set("allowed_oauth_flows", flattenStringList(resp.UserPoolClient.AllowedOAuthFlows))
+	d.Set("allowed_oauth_flows", flattenStringSet(resp.UserPoolClient.AllowedOAuthFlows))
 	d.Set("allowed_oauth_flows_user_pool_client", resp.UserPoolClient.AllowedOAuthFlowsUserPoolClient)
-	d.Set("allowed_oauth_scopes", flattenStringList(resp.UserPoolClient.AllowedOAuthScopes))
-	d.Set("callback_urls", flattenStringList(resp.UserPoolClient.CallbackURLs))
+	d.Set("allowed_oauth_scopes", flattenStringSet(resp.UserPoolClient.AllowedOAuthScopes))
+	d.Set("callback_urls", flattenStringSet(resp.UserPoolClient.CallbackURLs))
 	d.Set("default_redirect_uri", resp.UserPoolClient.DefaultRedirectURI)
-	d.Set("logout_urls", flattenStringList(resp.UserPoolClient.LogoutURLs))
-	d.Set("supported_identity_providers", flattenStringList(resp.UserPoolClient.SupportedIdentityProviders))
+	d.Set("logout_urls", flattenStringSet(resp.UserPoolClient.LogoutURLs))
+	d.Set("supported_identity_providers", flattenStringSet(resp.UserPoolClient.SupportedIdentityProviders))
 
 	return nil
 }
@@ -279,15 +279,15 @@ func resourceAwsCognitoUserPoolClientUpdate(d *schema.ResourceData, meta interfa
 	}
 
 	if v, ok := d.GetOk("explicit_auth_flows"); ok {
-		params.ExplicitAuthFlows = expandStringList(v.(*schema.Set).List())
+		params.ExplicitAuthFlows = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("read_attributes"); ok {
-		params.ReadAttributes = expandStringList(v.(*schema.Set).List())
+		params.ReadAttributes = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("write_attributes"); ok {
-		params.WriteAttributes = expandStringList(v.(*schema.Set).List())
+		params.WriteAttributes = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("refresh_token_validity"); ok {
@@ -295,7 +295,7 @@ func resourceAwsCognitoUserPoolClientUpdate(d *schema.ResourceData, meta interfa
 	}
 
 	if v, ok := d.GetOk("allowed_oauth_flows"); ok {
-		params.AllowedOAuthFlows = expandStringList(v.(*schema.Set).List())
+		params.AllowedOAuthFlows = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("allowed_oauth_flows_user_pool_client"); ok {
@@ -303,11 +303,11 @@ func resourceAwsCognitoUserPoolClientUpdate(d *schema.ResourceData, meta interfa
 	}
 
 	if v, ok := d.GetOk("allowed_oauth_scopes"); ok {
-		params.AllowedOAuthScopes = expandStringList(v.(*schema.Set).List())
+		params.AllowedOAuthScopes = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("callback_urls"); ok {
-		params.CallbackURLs = expandStringList(v.([]interface{}))
+		params.CallbackURLs = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("default_redirect_uri"); ok {
@@ -315,11 +315,11 @@ func resourceAwsCognitoUserPoolClientUpdate(d *schema.ResourceData, meta interfa
 	}
 
 	if v, ok := d.GetOk("logout_urls"); ok {
-		params.LogoutURLs = expandStringList(v.([]interface{}))
+		params.LogoutURLs = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("supported_identity_providers"); ok {
-		params.SupportedIdentityProviders = expandStringList(v.([]interface{}))
+		params.SupportedIdentityProviders = expandStringSet(v.(*schema.Set))
 	}
 
 	log.Printf("[DEBUG] Updating Cognito User Pool Client: %s", params)

--- a/aws/resource_aws_cognito_user_pool_client_test.go
+++ b/aws/resource_aws_cognito_user_pool_client_test.go
@@ -144,11 +144,11 @@ func TestAccAWSCognitoUserPoolClient_allFields(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_scopes.380129571", "aws.cognito.signin.user.admin"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_scopes.4080487570", "profile"),
 					resource.TestCheckResourceAttr(resourceName, "callback_urls.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "callback_urls.0", "https://www.example.com/callback"),
-					resource.TestCheckResourceAttr(resourceName, "callback_urls.1", "https://www.example.com/redirect"),
+					resource.TestCheckResourceAttr(resourceName, "callback_urls.3974471891", "https://www.example.com/callback"),
+					resource.TestCheckResourceAttr(resourceName, "callback_urls.2465081732", "https://www.example.com/redirect"),
 					resource.TestCheckResourceAttr(resourceName, "default_redirect_uri", "https://www.example.com/redirect"),
 					resource.TestCheckResourceAttr(resourceName, "logout_urls.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "logout_urls.0", "https://www.example.com/login"),
+					resource.TestCheckResourceAttr(resourceName, "logout_urls.2102268273", "https://www.example.com/login"),
 				),
 			},
 			{
@@ -201,11 +201,11 @@ func TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_scopes.380129571", "aws.cognito.signin.user.admin"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_scopes.4080487570", "profile"),
 					resource.TestCheckResourceAttr(resourceName, "callback_urls.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "callback_urls.0", "https://www.example.com/callback"),
-					resource.TestCheckResourceAttr(resourceName, "callback_urls.1", "https://www.example.com/redirect"),
+					resource.TestCheckResourceAttr(resourceName, "callback_urls.3974471891", "https://www.example.com/callback"),
+					resource.TestCheckResourceAttr(resourceName, "callback_urls.2465081732", "https://www.example.com/redirect"),
 					resource.TestCheckResourceAttr(resourceName, "default_redirect_uri", "https://www.example.com/redirect"),
 					resource.TestCheckResourceAttr(resourceName, "logout_urls.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "logout_urls.0", "https://www.example.com/login"),
+					resource.TestCheckResourceAttr(resourceName, "logout_urls.2102268273", "https://www.example.com/login"),
 				),
 			},
 			{
@@ -364,7 +364,7 @@ resource "aws_cognito_user_pool_client" "client" {
   allowed_oauth_flows_user_pool_client = "true"
   allowed_oauth_scopes                 = ["phone", "email", "openid", "profile", "aws.cognito.signin.user.admin"]
 
-  callback_urls        = ["https://www.example.com/callback", "https://www.example.com/redirect"]
+  callback_urls        = ["https://www.example.com/redirect", "https://www.example.com/callback"]
   default_redirect_uri = "https://www.example.com/redirect"
   logout_urls          = ["https://www.example.com/login"]
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #4550

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_cognito_user_pool_client - change lists to sets to prevent change when values are not sorted
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCognitoUserPoolClient_'
--- PASS: TestAccAWSCognitoUserPoolClient_basic (52.43s)
--- PASS: TestAccAWSCognitoUserPoolClient_RefreshTokenValidity (80.58s)
--- PASS: TestAccAWSCognitoUserPoolClient_Name (80.72s)
--- PASS: TestAccAWSCognitoUserPoolClient_allFields (52.45s)
--- PASS: TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField (79.74s)
```
