### PR TITLE
Fix EMR Cluster bootstrap action ordering

### DIFF
--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -492,7 +492,7 @@ func resourceAwsEMRCluster() *schema.Resource {
 				Set: resourceAwsEMRClusterInstanceGroupHash,
 			},
 			"bootstrap_action": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: true,
 				Elem: &schema.Resource{
@@ -860,7 +860,7 @@ func resourceAwsEMRClusterCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if v, ok := d.GetOk("bootstrap_action"); ok {
-		bootstrapActions := v.(*schema.Set).List()
+		bootstrapActions := v.([]interface{})
 		params.BootstrapActions = expandBootstrapActions(bootstrapActions)
 	}
 	if v, ok := d.GetOk("step"); ok {

--- a/aws/resource_aws_emr_cluster_test.go
+++ b/aws/resource_aws_emr_cluster_test.go
@@ -1843,8 +1843,8 @@ resource "aws_s3_bucket" "tester" {
 }
 
 resource "aws_s3_bucket_object" "testobject" {
-  bucket = "${aws_s3_bucket.tester.bucket}"
-  key    = "testscript.sh"
+  bucket  = "${aws_s3_bucket.tester.bucket}"
+  key     = "testscript.sh"
   content = <<EOF
 #!/bin/bash
 echo $@
@@ -1913,8 +1913,8 @@ resource "aws_s3_bucket" "tester" {
 }
 
 resource "aws_s3_bucket_object" "testobject" {
-  bucket = "${aws_s3_bucket.tester.bucket}"
-  key    = "testscript.sh"
+  bucket  = "${aws_s3_bucket.tester.bucket}"
+  key     = "testscript.sh"
   content = <<EOF
 #!/bin/bash
 echo $@
@@ -1981,8 +1981,8 @@ resource "aws_s3_bucket" "tester" {
 }
 
 resource "aws_s3_bucket_object" "testobject" {
-  bucket = "${aws_s3_bucket.tester.bucket}"
-  key    = "testscript.sh"
+  bucket  = "${aws_s3_bucket.tester.bucket}"
+  key     = "testscript.sh"
   content = <<EOF
 #!/bin/bash
 echo $@
@@ -2379,7 +2379,7 @@ data "aws_iam_policy_document" "test" {
         "application-autoscaling.amazonaws.com",
         "elasticmapreduce.amazonaws.com",
       ]
-      type        = "Service"
+      type = "Service"
     }
   }
 }
@@ -2440,7 +2440,7 @@ data "aws_iam_policy_document" "test" {
         "application-autoscaling.amazonaws.com",
         "elasticmapreduce.amazonaws.com",
       ]
-      type        = "Service"
+      type = "Service"
     }
   }
 }

--- a/aws/resource_aws_emr_cluster_test.go
+++ b/aws/resource_aws_emr_cluster_test.go
@@ -1157,7 +1157,20 @@ func TestAccAWSEMRCluster_bootstrap_ordering(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEmrClusterExists(resourceName, &cluster),
 					testAccCheck_bootstrap_order(&cluster, argsInts, argsStrings),
-					resource.TestCheckResourceAttr(resourceName, "bootstrap_action.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "bootstrap_action.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "bootstrap_action.0.name", "runif"),
+					resource.TestCheckResourceAttr(resourceName, "bootstrap_action.0.path", "s3://elasticmapreduce/bootstrap-actions/run-if"),
+					resource.TestCheckResourceAttr(resourceName, "bootstrap_action.0.args.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "bootstrap_action.0.args.0", "instance.isMaster=true"),
+					resource.TestCheckResourceAttr(resourceName, "bootstrap_action.0.args.1", "echo running on master node"),
+					resource.TestCheckResourceAttr(resourceName, "bootstrap_action.1.name", "test"),
+					resource.TestCheckResourceAttr(resourceName, "bootstrap_action.1.path", fmt.Sprintf("s3://%s/testscript.sh", rName)),
+					resource.TestCheckResourceAttr(resourceName, "bootstrap_action.1.args.#", "10"),
+					resource.TestCheckResourceAttr(resourceName, "bootstrap_action.2.name", "runif-2"),
+					resource.TestCheckResourceAttr(resourceName, "bootstrap_action.2.path", "s3://elasticmapreduce/bootstrap-actions/run-if"),
+					resource.TestCheckResourceAttr(resourceName, "bootstrap_action.2.args.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "bootstrap_action.2.args.0", "instance.isMaster=true"),
+					resource.TestCheckResourceAttr(resourceName, "bootstrap_action.2.args.1", "echo also running on master node"),
 				),
 			},
 			{
@@ -1772,6 +1785,12 @@ resource "aws_emr_cluster" "test" {
       "9",
       "10",
     ]
+  }
+
+  bootstrap_action {
+    path = "s3://elasticmapreduce/bootstrap-actions/run-if"
+    name = "runif-2"
+    args = ["instance.isMaster=true", "echo also running on master node"]
   }
 }
 

--- a/website/docs/r/emr_cluster.html.markdown
+++ b/website/docs/r/emr_cluster.html.markdown
@@ -245,7 +245,7 @@ The following arguments are supported:
 * `kerberos_attributes` - (Optional) Kerberos configuration for the cluster. Defined below
 * `ebs_root_volume_size` - (Optional) Size in GiB of the EBS root device volume of the Linux AMI that is used for each EC2 instance. Available in Amazon EMR version 4.x and later.
 * `custom_ami_id` - (Optional) A custom Amazon Linux AMI for the cluster (instead of an EMR-owned AMI). Available in Amazon EMR version 5.7.0 and later.
-* `bootstrap_action` - (Optional) List of bootstrap actions that will be run before Hadoop is started on the cluster nodes. Defined below
+* `bootstrap_action` - (Optional) Ordered list of bootstrap actions that will be run before Hadoop is started on the cluster nodes. Defined below.
 * `configurations` - (Optional) List of configurations supplied for the EMR cluster you are creating
 * `configurations_json` - (Optional) A JSON string for supplying list of configurations for the EMR cluster.
 


### PR DESCRIPTION
EMR Clusters were not preserving the order of bootstrap actions when multiple actions were defined in the resource. This PR fixes that.

This will cause EMR Clusters with incorrectly ordered bootstrap actions to be re-created, as bootstrap actions cannot be changed in place.

This PR builds on test cleanup in #12239.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10118

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:
* resource/aws_emr_cluster: The bug fix in this release will potentially re-create EMR Clusters with multiple bootstrap actions, since bootstrap actions cannot be modified in place.

BUG FIXES:
* resource/aws_emr_cluster: Now properly sets the order when multiple bootstrap actions are defined
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEMRCluster_'

--- PASS: TestAccAWSEMRCluster_basic (452.42s)
--- PASS: TestAccAWSEMRCluster_Kerberos_ClusterDedicatedKdc (478.77s)
--- PASS: TestAccAWSEMRCluster_configurationsJson (492.55s)
--- PASS: TestAccAWSEMRCluster_instance_group_names (504.24s)
--- PASS: TestAccAWSEMRCluster_instance_group_update (532.66s)
--- PASS: TestAccAWSEMRCluster_instance_group_EBSVolumeType_st1 (532.91s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_AutoscalingPolicy (577.57s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_Migration_CoreInstanceType (581.60s)
--- PASS: TestAccAWSEMRCluster_disappears (603.86s)
--- PASS: TestAccAWSEMRCluster_updateAutoScalingPolicy (606.66s)
--- PASS: TestAccAWSEMRCluster_instance_group (613.41s)
--- PASS: TestAccAWSEMRCluster_additionalInfo (625.51s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_Migration_InstanceGroup (650.21s)
--- PASS: TestAccAWSEMRCluster_Ec2Attributes_DefaultManagedSecurityGroups (860.23s)
--- PASS: TestAccAWSEMRCluster_security_config (349.10s)
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_Migration_InstanceGroup (473.50s)
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_BidPrice (979.08s)
--- PASS: TestAccAWSEMRCluster_Step_Basic (467.88s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_Name (1031.79s)
--- PASS: TestAccAWSEMRCluster_Step_Multiple (488.43s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_InstanceType (1095.94s)
--- PASS: TestAccAWSEMRCluster_keepJob (511.47s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_BidPrice (1138.37s)
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_InstanceCount (1170.69s)
--- PASS: TestAccAWSEMRCluster_s3Logging (528.15s)
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_Migration_MasterInstanceType (717.91s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_InstanceCount (1214.58s)
--- PASS: TestAccAWSEMRCluster_terminationProtected (639.52s)
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_Name (804.98s)
--- PASS: TestAccAWSEMRCluster_step_concurrency_level (412.49s)
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_InstanceType (1014.42s)
--- PASS: TestAccAWSEMRCluster_custom_ami_id (503.72s)
--- PASS: TestAccAWSEMRCluster_visibleToAllUsers (901.17s)
--- PASS: TestAccAWSEMRCluster_Step_ConfigMode (964.03s)
--- PASS: TestAccAWSEMRCluster_tags (789.41s)
--- PASS: TestAccAWSEMRCluster_root_volume_size (812.27s)
--- PASS: TestAccAWSEMRCluster_bootstrap_ordering (1236.76s)
```
