### PR TITLE
r/aws_cloudtrail - add support for insight selectors

### DIFF
--- a/aws/resource_aws_cloudtrail.go
+++ b/aws/resource_aws_cloudtrail.go
@@ -139,11 +139,9 @@ func resourceAwsCloudTrail() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"insight_type": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								cloudtrail.InsightTypeApiCallRateInsight,
-							}, false),
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(cloudtrail.InsightType_Values(), false),
 						},
 					},
 				},
@@ -327,7 +325,7 @@ func resourceAwsCloudTrailRead(d *schema.ResourceData, meta interface{}) error {
 	})
 	if err != nil {
 		if !isAWSErr(err, cloudtrail.ErrCodeInsightNotEnabledException, "") {
-			return err
+			return fmt.Errorf("error getting Cloud Trail (%s) Insight Selectors: %w", d.Id(), err)
 		}
 	}
 	if insightSelectors != nil {

--- a/aws/resource_aws_cloudtrail.go
+++ b/aws/resource_aws_cloudtrail.go
@@ -632,7 +632,7 @@ func flattenAwsCloudTrailInsightSelector(configured []*cloudtrail.InsightSelecto
 
 	for _, raw := range configured {
 		item := make(map[string]interface{})
-		item["insight_type"] = *raw.InsightType
+		item["insight_type"] = aws.StringValue(raw.InsightType)
 
 		insightSelectors = append(insightSelectors, item)
 	}

--- a/aws/resource_aws_cloudtrail.go
+++ b/aws/resource_aws_cloudtrail.go
@@ -133,6 +133,21 @@ func resourceAwsCloudTrail() *schema.Resource {
 				Computed: true,
 			},
 			"tags": tagsSchema(),
+			"insight_selector": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"insight_type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								cloudtrail.InsightTypeApiCallRateInsight,
+							}, false),
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -219,6 +234,12 @@ func resourceAwsCloudTrailCreate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
+	if _, ok := d.GetOk("insight_selector"); ok {
+		if err := cloudTrailSetInsightSelectors(conn, d); err != nil {
+			return err
+		}
+	}
+
 	return resourceAwsCloudTrailRead(d, meta)
 }
 
@@ -298,6 +319,21 @@ func resourceAwsCloudTrailRead(d *schema.ResourceData, meta interface{}) error {
 
 	if err := d.Set("event_selector", flattenAwsCloudTrailEventSelector(eventSelectorsOut.EventSelectors)); err != nil {
 		return err
+	}
+
+	// Get InsightSelectors
+	insightSelectors, err := conn.GetInsightSelectors(&cloudtrail.GetInsightSelectorsInput{
+		TrailName: aws.String(d.Id()),
+	})
+	if err != nil {
+		if !isAWSErr(err, cloudtrail.ErrCodeInsightNotEnabledException, "") {
+			return err
+		}
+	}
+	if insightSelectors != nil {
+		if err := d.Set("insight_selector", flattenAwsCloudTrailInsightSelector(insightSelectors.InsightSelectors)); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -383,6 +419,13 @@ func resourceAwsCloudTrailUpdate(d *schema.ResourceData, meta interface{}) error
 	if !d.IsNewResource() && d.HasChange("event_selector") {
 		log.Printf("[DEBUG] Updating event selector on CloudTrail: %s", input)
 		if err := cloudTrailSetEventSelectors(conn, d); err != nil {
+			return err
+		}
+	}
+
+	if !d.IsNewResource() && d.HasChange("insight_selector") {
+		log.Printf("[DEBUG] Updating insight selector on CloudTrail: %s", input)
+		if err := cloudTrailSetInsightSelectors(conn, d); err != nil {
 			return err
 		}
 	}
@@ -547,4 +590,52 @@ func flattenAwsCloudTrailEventSelectorDataResource(configured []*cloudtrail.Data
 	}
 
 	return dataResources
+}
+
+func cloudTrailSetInsightSelectors(conn *cloudtrail.CloudTrail, d *schema.ResourceData) error {
+	input := &cloudtrail.PutInsightSelectorsInput{
+		TrailName: aws.String(d.Id()),
+	}
+
+	insightSelector := expandAwsCloudTrailInsightSelector(d.Get("insight_selector").([]interface{}))
+	input.InsightSelectors = insightSelector
+
+	if err := input.Validate(); err != nil {
+		return fmt.Errorf("Error validate CloudTrail (%s): %s", d.Id(), err)
+	}
+
+	_, err := conn.PutInsightSelectors(input)
+	if err != nil {
+		return fmt.Errorf("Error set insight selector on CloudTrail (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func expandAwsCloudTrailInsightSelector(configured []interface{}) []*cloudtrail.InsightSelector {
+	insightSelectors := make([]*cloudtrail.InsightSelector, 0, len(configured))
+
+	for _, raw := range configured {
+		data := raw.(map[string]interface{})
+
+		is := &cloudtrail.InsightSelector{
+			InsightType: aws.String(data["insight_type"].(string)),
+		}
+		insightSelectors = append(insightSelectors, is)
+	}
+
+	return insightSelectors
+}
+
+func flattenAwsCloudTrailInsightSelector(configured []*cloudtrail.InsightSelector) []map[string]interface{} {
+	insightSelectors := make([]map[string]interface{}, 0, len(configured))
+
+	for _, raw := range configured {
+		item := make(map[string]interface{})
+		item["insight_type"] = *raw.InsightType
+
+		insightSelectors = append(insightSelectors, item)
+	}
+
+	return insightSelectors
 }

--- a/aws/resource_aws_cloudtrail_test.go
+++ b/aws/resource_aws_cloudtrail_test.go
@@ -1574,7 +1574,7 @@ func testAccAWSCloudTrailConfig_insightSelector(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
   name           = %[1]q
-  s3_bucket_name = "${aws_s3_bucket.test.id}"
+  s3_bucket_name = aws_s3_bucket.test.id
 
 
   insight_selector {

--- a/aws/resource_aws_cloudtrail_test.go
+++ b/aws/resource_aws_cloudtrail_test.go
@@ -104,6 +104,7 @@ func TestAccAWSCloudTrail_serial(t *testing.T) {
 			"kmsKey":                     testAccAWSCloudTrail_kmsKey,
 			"tags":                       testAccAWSCloudTrail_tags,
 			"eventSelector":              testAccAWSCloudTrail_event_selector,
+			"insightSelector":            testAccAWSCloudTrail_insight_selector,
 		},
 	}
 
@@ -540,6 +541,31 @@ func testAccAWSCloudTrail_event_selector(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "event_selector.#", "0"),
 				),
+			},
+		},
+	})
+}
+
+func testAccAWSCloudTrail_insight_selector(t *testing.T) {
+	resourceName := "aws_cloudtrail.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudTrailConfig_insightSelector(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "insight_selector.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "insight_selector.0.insight_type", "ApiCallRateInsight"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -1542,4 +1568,50 @@ resource "aws_s3_bucket" "foo" {
 POLICY
 }
 `, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
+}
+
+func testAccAWSCloudTrailConfig_insightSelector(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudtrail" "test" {
+  name           = %[1]q
+  s3_bucket_name = "${aws_s3_bucket.test.id}"
+
+
+  insight_selector {
+    insight_type = "ApiCallRateInsight"
+  }
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket        = %[1]q
+  force_destroy = true
+
+  policy = <<POLICY
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "AWSCloudTrailAclCheck",
+			"Effect": "Allow",
+			"Principal": "*",
+			"Action": "s3:GetBucketAcl",
+			"Resource": "arn:aws:s3:::%[1]s"
+		},
+		{
+			"Sid": "AWSCloudTrailWrite",
+			"Effect": "Allow",
+			"Principal": "*",
+			"Action": "s3:PutObject",
+			"Resource": "arn:aws:s3:::%[1]s/*",
+			"Condition": {
+				"StringEquals": {
+					"s3:x-amz-acl": "bucket-owner-full-control"
+				}
+			}
+		}
+	]
+}
+POLICY
+}
+`, rName)
 }

--- a/aws/resource_aws_cloudtrail_test.go
+++ b/aws/resource_aws_cloudtrail_test.go
@@ -698,7 +698,7 @@ func testAccAWSCloudTrailConfig(cloudTrailRandInt int) string {
 	return fmt.Sprintf(`
 resource "aws_cloudtrail" "foobar" {
   name           = "tf-trail-foobar-%d"
-  s3_bucket_name = "${aws_s3_bucket.foo.id}"
+  s3_bucket_name = aws_s3_bucket.foo.id
 }
 
 resource "aws_s3_bucket" "foo" {

--- a/website/docs/r/cloudtrail.html.markdown
+++ b/website/docs/r/cloudtrail.html.markdown
@@ -158,6 +158,7 @@ The following arguments are supported:
     Defaults to `false`.
 * `kms_key_id` - (Optional) Specifies the KMS key ARN to use to encrypt the logs delivered by CloudTrail.
 * `event_selector` - (Optional) Specifies an event selector for enabling data event logging. Fields documented below. Please note the [CloudTrail limits](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/WhatIsCloudTrail-Limits.html) when configuring these.
+* `insight_selector` - (Optional) Specifies an insight selector for identifying unusual operational activity. Fields documented below.
 * `tags` - (Optional) A map of tags to assign to the trail
 
 ### Event Selector Arguments
@@ -172,6 +173,12 @@ For **data_resource** the following attributes are supported.
 
 * `type` (Required) - The resource type in which you want to log data events. You can specify only the following value: "AWS::S3::Object", "AWS::Lambda::Function"
 * `values` (Required) - A list of ARN for the specified S3 buckets and object prefixes..
+
+### Insight Selector Arguments
+For **insight_selector** the following attributes are supported.
+
+* `insight_type` (Optional) - The type of insights to log on a trail. In this release, only `ApiCallRateInsight` is supported as an insight type.
+
 
 ## Attribute Reference
 

--- a/website/docs/r/cloudtrail.html.markdown
+++ b/website/docs/r/cloudtrail.html.markdown
@@ -175,11 +175,10 @@ For **data_resource** the following attributes are supported.
 * `values` (Required) - A list of ARN for the specified S3 buckets and object prefixes..
 
 ### Insight Selector Arguments
+
 For **insight_selector** the following attributes are supported.
 
 * `insight_type` (Optional) - The type of insights to log on a trail. In this release, only `ApiCallRateInsight` is supported as an insight type.
-
-
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/website/docs/r/cloudtrail.html.markdown
+++ b/website/docs/r/cloudtrail.html.markdown
@@ -179,6 +179,7 @@ For **data_resource** the following attributes are supported.
 For **insight_selector** the following attributes are supported.
 
 * `insight_type` (Optional) - The type of insights to log on a trail. In this release, only `ApiCallRateInsight` is supported as an insight type.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10988

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_cloudtrail - add support for insight selectors
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCloudTrail/Trail/insightSelector|TestAccAWSCloudTrail/Trail/basic'
        --- PASS: TestAccAWSCloudTrail/Trail/insightSelector (112.51s)
        --- PASS: TestAccAWSCloudTrail/Trail/basic (179.40s)
```
