### PR TITLE
restore "required" field in security group rule example

### DIFF
--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -28,11 +28,11 @@ Basic usage
 
 ```hcl
 resource "aws_security_group_rule" "example" {
-  type        = "ingress"
-  from_port   = 0
-  to_port     = 65535
-  protocol    = "tcp"
-  cidr_blocks = aws_vpc.example.cidr_block
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "tcp"
+  cidr_blocks       = aws_vpc.example.cidr_block
   security_group_id = "sg-123456"
 }
 ```

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -33,6 +33,7 @@ resource "aws_security_group_rule" "example" {
   to_port     = 65535
   protocol    = "tcp"
   cidr_blocks = aws_vpc.example.cidr_block
+  security_group_id = "sg-123456"
 }
 ```
 


### PR DESCRIPTION
Was removed erroneously in https://github.com/terraform-providers/terraform-provider-aws/pull/12209

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
