### PR TITLE
d/aws_vpc_endpoint_service - filter support

### DIFF
--- a/aws/data_source_aws_vpc_endpoint_service.go
+++ b/aws/data_source_aws_vpc_endpoint_service.go
@@ -69,6 +69,7 @@ func dataSourceAwsVpcEndpointService() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"filter": dataSourceFiltersSchema(),
 		},
 	}
 }
@@ -76,18 +77,28 @@ func dataSourceAwsVpcEndpointService() *schema.Resource {
 func dataSourceAwsVpcEndpointServiceRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
+	filters, filtersOk := d.GetOk("filter")
+	tags, tagsOk := d.GetOk("tags")
+
 	var serviceName string
+	serviceNameOk := false
 	if v, ok := d.GetOk("service_name"); ok {
 		serviceName = v.(string)
+		serviceNameOk = true
 	} else if v, ok := d.GetOk("service"); ok {
 		serviceName = fmt.Sprintf("com.amazonaws.%s.%s", meta.(*AWSClient).region, v.(string))
-	} else {
-		return fmt.Errorf(
-			"One of ['service', 'service_name'] must be set to query VPC Endpoint Services")
+		serviceNameOk = true
 	}
 
-	req := &ec2.DescribeVpcEndpointServicesInput{
-		ServiceNames: aws.StringSlice([]string{serviceName}),
+	req := &ec2.DescribeVpcEndpointServicesInput{}
+	if filtersOk {
+		req.Filters = buildAwsDataSourceFilters(filters.(*schema.Set))
+	}
+	if serviceNameOk {
+		req.ServiceNames = aws.StringSlice([]string{serviceName})
+	}
+	if tagsOk {
+		req.Filters = append(req.Filters, ec2TagFiltersFromMap(tags.(map[string]interface{}))...)
 	}
 
 	log.Printf("[DEBUG] Reading VPC Endpoint Service: %s", req)

--- a/website/docs/d/vpc_endpoint_service.html.markdown
+++ b/website/docs/d/vpc_endpoint_service.html.markdown
@@ -60,6 +60,7 @@ The given filters must match exactly one VPC endpoint service whose data will be
 * `service` - (Optional) The common name of an AWS service (e.g. `s3`).
 * `service_name` - (Optional) The service name that is specified when creating a VPC endpoint. For AWS services the service name is usually in the form `com.amazonaws.<region>.<service>` (the SageMaker Notebook service is an exception to this rule, the service name is in the form `aws.sagemaker.<region>.notebook`).
 * `filter` - (Optional) Configuration block(s) for filtering. Detailed below.
+* `tags` - (Optional) A mapping of tags, each pair of which must exactly match a pair on the desired VPC Endpoint Service.
 
 ~> **NOTE:** Specifying `service` will not work for non-AWS services or AWS services that don't follow the standard `service_name` pattern of `com.amazonaws.<region>.<service>`.
 

--- a/website/docs/d/vpc_endpoint_service.html.markdown
+++ b/website/docs/d/vpc_endpoint_service.html.markdown
@@ -84,5 +84,3 @@ In addition to all arguments above, the following attributes are exported:
 * `service_type` - The service type, `Gateway` or `Interface`.
 * `tags` - A mapping of tags assigned to the resource.
 * `vpc_endpoint_policy_supported` - Whether or not the service supports endpoint policies - `true` or `false`.
-
-[1]: https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-vpc-endpoint-services.html

--- a/website/docs/d/vpc_endpoint_service.html.markdown
+++ b/website/docs/d/vpc_endpoint_service.html.markdown
@@ -13,7 +13,7 @@ can be specified when creating a VPC endpoint within the region configured in th
 
 ## Example Usage
 
-### AWS Service
+AWS service usage:
 
 ```hcl
 # Declare the data source
@@ -33,7 +33,7 @@ resource "aws_vpc_endpoint" "ep" {
 }
 ```
 
-### Non-AWS Service
+Non-AWS service usage:
 
 ```hcl
 data "aws_vpc_endpoint_service" "custome" {
@@ -41,7 +41,7 @@ data "aws_vpc_endpoint_service" "custome" {
 }
 ```
 
-### Filter:
+Filter usage:
 
 ```hcl
 data "aws_vpc_endpoint_service" "test" {
@@ -58,12 +58,12 @@ The arguments of this data source act as filters for querying the available VPC 
 The given filters must match exactly one VPC endpoint service whose data will be exported as attributes.
 
 * `service` - (Optional) The common name of an AWS service (e.g. `s3`).
-* `service_name` - (Optional) The service name that is specified when creating a VPC endpoint. For AWS services the service name is usually in the form `com.amazonaws.<region>.<service>` (the SageMaker Notebook service is an exception to this rule, the service name is in the form `aws.sagemaker.<region>.notebook`).
+* `service_name` - (Optional) The service name that can be specified when creating a VPC endpoint.
 * `filter` - (Optional) One or more name/value pairs to use as filters. There are
 several valid keys, for a full reference, check out
 [describe-vpc-endpoint-services in the AWS CLI reference][1].
 
-~> **NOTE:** Specifying `service` will not work for non-AWS services or AWS services that don't follow the standard `service_name` pattern of `com.amazonaws.<region>.<service>`.
+~> **NOTE:** One of `service` or `service_name` must be specified.
 
 ## Attributes Reference
 

--- a/website/docs/d/vpc_endpoint_service.html.markdown
+++ b/website/docs/d/vpc_endpoint_service.html.markdown
@@ -58,7 +58,7 @@ The arguments of this data source act as filters for querying the available VPC 
 The given filters must match exactly one VPC endpoint service whose data will be exported as attributes.
 
 * `service` - (Optional) The common name of an AWS service (e.g. `s3`).
-* `service_name` - (Optional) The service name that can be specified when creating a VPC endpoint.
+* `service_name` - (Optional) The service name that is specified when creating a VPC endpoint. For AWS services the service name is usually in the form `com.amazonaws.<region>.<service>` (the SageMaker Notebook service is an exception to this rule, the service name is in the form `aws.sagemaker.<region>.notebook`).
 * `filter` - (Optional) One or more name/value pairs to use as filters. There are
 several valid keys, for a full reference, check out
 [describe-vpc-endpoint-services in the AWS CLI reference][1].

--- a/website/docs/d/vpc_endpoint_service.html.markdown
+++ b/website/docs/d/vpc_endpoint_service.html.markdown
@@ -41,6 +41,17 @@ data "aws_vpc_endpoint_service" "custome" {
 }
 ```
 
+### Filter:
+
+```hcl
+data "aws_vpc_endpoint_service" "test" {
+  filter {
+    name   = "service-name"
+    values = ["some-service"]
+  }
+}
+```
+
 ## Argument Reference
 
 The arguments of this data source act as filters for querying the available VPC endpoint services.
@@ -48,8 +59,11 @@ The given filters must match exactly one VPC endpoint service whose data will be
 
 * `service` - (Optional) The common name of an AWS service (e.g. `s3`).
 * `service_name` - (Optional) The service name that is specified when creating a VPC endpoint. For AWS services the service name is usually in the form `com.amazonaws.<region>.<service>` (the SageMaker Notebook service is an exception to this rule, the service name is in the form `aws.sagemaker.<region>.notebook`).
+* `filter` - (Optional) One or more name/value pairs to use as filters. There are
+several valid keys, for a full reference, check out
+[describe-vpc-endpoint-services in the AWS CLI reference][1].
 
-~> **NOTE:** One of `service` or `service_name` must be specified. Specifying `service` will not work for non-AWS services or AWS services that don't follow the standard `service_name` pattern of `com.amazonaws.<region>.<service>`.
+~> **NOTE:** Specifying `service` will not work for non-AWS services or AWS services that don't follow the standard `service_name` pattern of `com.amazonaws.<region>.<service>`.
 
 ## Attributes Reference
 
@@ -65,3 +79,5 @@ In addition to all arguments above, the following attributes are exported:
 * `service_type` - The service type, `Gateway` or `Interface`.
 * `tags` - A mapping of tags assigned to the resource.
 * `vpc_endpoint_policy_supported` - Whether or not the service supports endpoint policies - `true` or `false`.
+
+[1]: https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-vpc-endpoint-services.html

--- a/website/docs/d/vpc_endpoint_service.html.markdown
+++ b/website/docs/d/vpc_endpoint_service.html.markdown
@@ -59,11 +59,16 @@ The given filters must match exactly one VPC endpoint service whose data will be
 
 * `service` - (Optional) The common name of an AWS service (e.g. `s3`).
 * `service_name` - (Optional) The service name that is specified when creating a VPC endpoint. For AWS services the service name is usually in the form `com.amazonaws.<region>.<service>` (the SageMaker Notebook service is an exception to this rule, the service name is in the form `aws.sagemaker.<region>.notebook`).
-* `filter` - (Optional) One or more name/value pairs to use as filters. There are
-several valid keys, for a full reference, check out
-[describe-vpc-endpoint-services in the AWS CLI reference][1].
+* `filter` - (Optional) Configuration block(s) for filtering. Detailed below.
 
 ~> **NOTE:** Specifying `service` will not work for non-AWS services or AWS services that don't follow the standard `service_name` pattern of `com.amazonaws.<region>.<service>`.
+
+### filter Configuration Block
+
+The following arguments are supported by the `filter` configuration block:
+
+* `name` - (Required) The name of the filter field. Valid values can be found in the [EC2 DescribeVpcEndpointServices API Reference](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeVpcEndpointServices.html).
+* `values` - (Required) Set of values that are accepted for the given filter field. Results will be selected if any given value matches.
 
 ## Attributes Reference
 

--- a/website/docs/d/vpc_endpoint_service.html.markdown
+++ b/website/docs/d/vpc_endpoint_service.html.markdown
@@ -13,7 +13,7 @@ can be specified when creating a VPC endpoint within the region configured in th
 
 ## Example Usage
 
-AWS service usage:
+### AWS Service
 
 ```hcl
 # Declare the data source
@@ -33,7 +33,7 @@ resource "aws_vpc_endpoint" "ep" {
 }
 ```
 
-Non-AWS service usage:
+### Non-AWS Service
 
 ```hcl
 data "aws_vpc_endpoint_service" "custome" {
@@ -41,7 +41,7 @@ data "aws_vpc_endpoint_service" "custome" {
 }
 ```
 
-Filter usage:
+### Filter
 
 ```hcl
 data "aws_vpc_endpoint_service" "test" {
@@ -63,7 +63,7 @@ The given filters must match exactly one VPC endpoint service whose data will be
 several valid keys, for a full reference, check out
 [describe-vpc-endpoint-services in the AWS CLI reference][1].
 
-~> **NOTE:** One of `service` or `service_name` must be specified.
+~> **NOTE:** Specifying `service` will not work for non-AWS services or AWS services that don't follow the standard `service_name` pattern of `com.amazonaws.<region>.<service>`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11168, Relates #11994

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data_source_aws_vpc_endpoint_service - add filter support
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccDataSourceAwsVpcEndpointService_'
--- PASS: TestAccDataSourceAwsVpcEndpointService_gateway (44.38s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_interface (40.23s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_custom (332.81s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_custom_filter_tags (302.40s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_custom_filter (298.24s)
```
