### PR TITLE
docs: Fix terraform 0.12 warning

### DIFF
--- a/website/docs/r/default_network_acl.html.markdown
+++ b/website/docs/r/default_network_acl.html.markdown
@@ -164,7 +164,7 @@ As an alternative to the above, you can also specify the following lifecycle con
 
 ```hcl
 lifecycle {
-  ignore_changes = ["subnet_ids"]
+  ignore_changes = [subnet_ids]
 }
 ```
 


### PR DESCRIPTION
> In this context, references are expected literally rather than in quotes.
> Terraform 0.11 and earlier required quotes, but quoted references are now
> deprecated and will be removed in a future version of Terraform. Remove the
> quotes surrounding this reference to silence this warning.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request