### PR TITLE
d/aws_ec2_transit_gateway_vpn_attachment - filter support

### DIFF
--- a/aws/data_source_aws_ec2_transit_gateway_vpn_attachment.go
+++ b/aws/data_source_aws_ec2_transit_gateway_vpn_attachment.go
@@ -53,22 +53,18 @@ func dataSourceAwsEc2TransitGatewayVpnAttachmentRead(d *schema.ResourceData, met
 	if tagsOk {
 		input.Filters = append(input.Filters, ec2TagFiltersFromMap(tags.(map[string]interface{}))...)
 	}
-	// to preserve original functionality
-	if connectionIdOk && transitGatewayIdOk {
-		input.Filters = []*ec2.Filter{
-			{
-				Name:   aws.String("resource-id"),
-				Values: []*string{aws.String(connectionId.(string))},
-			},
-			{
-				Name:   aws.String("resource-type"),
-				Values: []*string{aws.String(ec2.TransitGatewayAttachmentResourceTypeVpn)},
-			},
-			{
-				Name:   aws.String("transit-gateway-id"),
-				Values: []*string{aws.String(transitGatewayId.(string))},
-			},
-		}
+	if connectionIdOk {
+		input.Filters = append(input.Filters, &ec2.Filter{
+			Name:   aws.String("resource-id"),
+			Values: []*string{aws.String(connectionId.(string))},
+		})
+	}
+
+	if transitGatewayIdOk {
+		input.Filters = append(input.Filters, &ec2.Filter{
+			Name:   aws.String("transit-gateway-id"),
+			Values: []*string{aws.String(transitGatewayId.(string))},
+		})
 	}
 
 	log.Printf("[DEBUG] Reading EC2 Transit Gateway VPN Attachments: %s", input)

--- a/aws/data_source_aws_ec2_transit_gateway_vpn_attachment_test.go
+++ b/aws/data_source_aws_ec2_transit_gateway_vpn_attachment_test.go
@@ -60,32 +60,6 @@ func TestAccAWSEc2TransitGatewayVpnAttachmentDataSource_filter(t *testing.T) {
 	})
 }
 
-func TestAccAWSEc2TransitGatewayVpnAttachmentDataSource_filter_tags(t *testing.T) {
-	rBgpAsn := acctest.RandIntRange(64512, 65534)
-	dataSourceName := "data.aws_ec2_transit_gateway_vpn_attachment.test"
-	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
-	vpnConnectionResourceName := "aws_vpn_connection.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-			testAccPreCheckAWSEc2TransitGateway(t)
-		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSEc2TransitGatewayDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSEc2TransitGatewayVpnAttachmentDataSourceConfigFilterTags(rBgpAsn),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "transit_gateway_id", transitGatewayResourceName, "id"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "vpn_connection_id", vpnConnectionResourceName, "id"),
-				),
-			},
-		},
-	})
-}
-
 func testAccAWSEc2TransitGatewayVpnAttachmentDataSourceConfigBase(rBgpAsn int) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_transit_gateway" "test" {
@@ -121,16 +95,6 @@ func testAccAWSEc2TransitGatewayVpnAttachmentDataSourceConfigTransitGatewayIdAnd
 data "aws_ec2_transit_gateway_vpn_attachment" "test" {
   transit_gateway_id = "${aws_ec2_transit_gateway.test.id}"
   vpn_connection_id  = "${aws_vpn_connection.test.id}"
-}
-`)
-}
-
-func testAccAWSEc2TransitGatewayVpnAttachmentDataSourceConfigFilterTags(rBgpAsn int) string {
-	return testAccAWSEc2TransitGatewayVpnAttachmentDataSourceConfigBase(rBgpAsn) + fmt.Sprintf(`
-data "aws_ec2_transit_gateway_vpn_attachment" "test" {
-  tags = {
-    Name  = "${aws_vpn_connection.test.tags["Name"]}"
-  }
 }
 `)
 }

--- a/aws/data_source_aws_ec2_transit_gateway_vpn_attachment_test.go
+++ b/aws/data_source_aws_ec2_transit_gateway_vpn_attachment_test.go
@@ -34,9 +34,65 @@ func TestAccAWSEc2TransitGatewayVpnAttachmentDataSource_TransitGatewayIdAndVpnCo
 	})
 }
 
-func testAccAWSEc2TransitGatewayVpnAttachmentDataSourceConfigTransitGatewayIdAndVpnConnectionId(rBgpAsn int) string {
+func TestAccAWSEc2TransitGatewayVpnAttachmentDataSource_filter(t *testing.T) {
+	rBgpAsn := acctest.RandIntRange(64512, 65534)
+	dataSourceName := "data.aws_ec2_transit_gateway_vpn_attachment.test"
+	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
+	vpnConnectionResourceName := "aws_vpn_connection.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSEc2TransitGateway(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEc2TransitGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEc2TransitGatewayVpnAttachmentDataSourceConfigFilter(rBgpAsn),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "transit_gateway_id", transitGatewayResourceName, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "vpn_connection_id", vpnConnectionResourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEc2TransitGatewayVpnAttachmentDataSource_filter_tags(t *testing.T) {
+	rBgpAsn := acctest.RandIntRange(64512, 65534)
+	dataSourceName := "data.aws_ec2_transit_gateway_vpn_attachment.test"
+	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
+	vpnConnectionResourceName := "aws_vpn_connection.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSEc2TransitGateway(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEc2TransitGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEc2TransitGatewayVpnAttachmentDataSourceConfigFilterTags(rBgpAsn),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "transit_gateway_id", transitGatewayResourceName, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "vpn_connection_id", vpnConnectionResourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSEc2TransitGatewayVpnAttachmentDataSourceConfigBase(rBgpAsn int) string {
 	return fmt.Sprintf(`
-resource "aws_ec2_transit_gateway" "test" {}
+resource "aws_ec2_transit_gateway" "test" {
+  tags = {
+    Name = "tf-acc-test-ec2-vpn-connection-transit-gateway-id"
+  }
+}
 
 resource "aws_customer_gateway" "test" {
   bgp_asn    = %[1]d
@@ -52,11 +108,40 @@ resource "aws_vpn_connection" "test" {
   customer_gateway_id = "${aws_customer_gateway.test.id}"
   transit_gateway_id  = "${aws_ec2_transit_gateway.test.id}"
   type                = "${aws_customer_gateway.test.type}"
+
+  tags = {
+    Name = "tf-acc-test-ec2-vpn-connection-transit-gateway-id"
+  }
+}
+`, rBgpAsn)
 }
 
+func testAccAWSEc2TransitGatewayVpnAttachmentDataSourceConfigTransitGatewayIdAndVpnConnectionId(rBgpAsn int) string {
+	return testAccAWSEc2TransitGatewayVpnAttachmentDataSourceConfigBase(rBgpAsn) + fmt.Sprintf(`
 data "aws_ec2_transit_gateway_vpn_attachment" "test" {
   transit_gateway_id = "${aws_ec2_transit_gateway.test.id}"
   vpn_connection_id  = "${aws_vpn_connection.test.id}"
 }
-`, rBgpAsn)
+`)
+}
+
+func testAccAWSEc2TransitGatewayVpnAttachmentDataSourceConfigFilterTags(rBgpAsn int) string {
+	return testAccAWSEc2TransitGatewayVpnAttachmentDataSourceConfigBase(rBgpAsn) + fmt.Sprintf(`
+data "aws_ec2_transit_gateway_vpn_attachment" "test" {
+  tags = {
+    Name  = "${aws_vpn_connection.test.tags["Name"]}"
+  }
+}
+`)
+}
+
+func testAccAWSEc2TransitGatewayVpnAttachmentDataSourceConfigFilter(rBgpAsn int) string {
+	return testAccAWSEc2TransitGatewayVpnAttachmentDataSourceConfigBase(rBgpAsn) + fmt.Sprintf(`
+data "aws_ec2_transit_gateway_vpn_attachment" "test" {
+  filter {
+    name   = "resource-id"
+    values = ["${aws_vpn_connection.test.id}"]
+  }
+}
+`)
 }

--- a/website/docs/d/ec2_transit_gateway_vpn_attachment.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_vpn_attachment.html.markdown
@@ -21,6 +21,17 @@ data "aws_ec2_transit_gateway_vpn_attachment" "example" {
 }
 ```
 
+Filter usage:
+
+```hcl
+data "aws_ec2_transit_gateway_vpn_attachment" "test" {
+  filter {
+    name   = "resource-id"
+    values = ["some-resource"]
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/website/docs/d/ec2_transit_gateway_vpn_attachment.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_vpn_attachment.html.markdown
@@ -21,7 +21,7 @@ data "aws_ec2_transit_gateway_vpn_attachment" "example" {
 }
 ```
 
-Filter usage:
+### Filter
 
 ```hcl
 data "aws_ec2_transit_gateway_vpn_attachment" "test" {

--- a/website/docs/d/ec2_transit_gateway_vpn_attachment.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_vpn_attachment.html.markdown
@@ -38,9 +38,14 @@ The following arguments are supported:
 
 * `transit_gateway_id` - (Optional) Identifier of the EC2 Transit Gateway.
 * `vpn_connection_id` - (Optional) Identifier of the EC2 VPN Connection.
-* `filter` - (Optional) One or more name/value pairs to use as filters. There are
-several valid keys, for a full reference, check out
-[describe-transit-gateway-attachments in the AWS CLI reference][1].
+* `filter` - (Optional) Configuration block(s) for filtering. Detailed below.
+
+### filter Configuration Block
+
+The following arguments are supported by the `filter` configuration block:
+
+* `name` - (Required) The name of the filter field. Valid values can be found in the [EC2 DescribeTransitGatewayAttachments API Reference](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeTransitGatewayAttachments.html).
+* `values` - (Required) Set of values that are accepted for the given filter field. Results will be selected if any given value matches.
 
 ## Attribute Reference
 
@@ -48,5 +53,3 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - EC2 Transit Gateway VPN Attachment identifier
 * `tags` - Key-value tags for the EC2 Transit Gateway VPN Attachment
-
-[1]: https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-transit-gateway-attachments.html

--- a/website/docs/d/ec2_transit_gateway_vpn_attachment.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_vpn_attachment.html.markdown
@@ -29,7 +29,7 @@ The following arguments are supported:
 * `vpn_connection_id` - (Optional) Identifier of the EC2 VPN Connection.
 * `filter` - (Optional) One or more name/value pairs to use as filters. There are
 several valid keys, for a full reference, check out
-[describe-vpc-endpoint-services in the AWS CLI reference][1].
+[describe-transit-gateway-attachments in the AWS CLI reference][1].
 
 ## Attribute Reference
 
@@ -38,4 +38,4 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - EC2 Transit Gateway VPN Attachment identifier
 * `tags` - Key-value tags for the EC2 Transit Gateway VPN Attachment
 
-[1]: https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-vpc-endpoint-services.html
+[1]: https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-transit-gateway-attachments.html

--- a/website/docs/d/ec2_transit_gateway_vpn_attachment.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_vpn_attachment.html.markdown
@@ -39,6 +39,7 @@ The following arguments are supported:
 * `transit_gateway_id` - (Optional) Identifier of the EC2 Transit Gateway.
 * `vpn_connection_id` - (Optional) Identifier of the EC2 VPN Connection.
 * `filter` - (Optional) Configuration block(s) for filtering. Detailed below.
+* `tags` - (Optional) A mapping of tags, each pair of which must exactly match a pair on the desired Transit Gateway VPN Attachment.
 
 ### filter Configuration Block
 

--- a/website/docs/d/ec2_transit_gateway_vpn_attachment.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_vpn_attachment.html.markdown
@@ -25,8 +25,11 @@ data "aws_ec2_transit_gateway_vpn_attachment" "example" {
 
 The following arguments are supported:
 
-* `transit_gateway_id` - (Required) Identifier of the EC2 Transit Gateway.
-* `vpn_connection_id` - (Required) Identifier of the EC2 VPN Connection.
+* `transit_gateway_id` - (Optional) Identifier of the EC2 Transit Gateway.
+* `vpn_connection_id` - (Optional) Identifier of the EC2 VPN Connection.
+* `filter` - (Optional) One or more name/value pairs to use as filters. There are
+several valid keys, for a full reference, check out
+[describe-vpc-endpoint-services in the AWS CLI reference][1].
 
 ## Attribute Reference
 
@@ -34,3 +37,5 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - EC2 Transit Gateway VPN Attachment identifier
 * `tags` - Key-value tags for the EC2 Transit Gateway VPN Attachment
+
+[1]: https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-vpc-endpoint-services.html


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11994

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data_source_aws_ec2_transit_gateway_vpn_attachment - add filter support
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEc2TransitGatewayVpnAttachmentDataSource_'
--- PASS: TestAccAWSEc2TransitGatewayVpnAttachmentDataSource_TransitGatewayIdAndVpnConnectionId (615.86s)
--- PASS: TestAccAWSEc2TransitGatewayVpnAttachmentDataSource_filter (482.38s)
```
