### PR TITLE
d/aws_prefix_lists - add filter

### DIFF
--- a/aws/data_source_aws_prefix_list.go
+++ b/aws/data_source_aws_prefix_list.go
@@ -28,6 +28,7 @@ func dataSourceAwsPrefixList() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"filter": dataSourceFiltersSchema(),
 		},
 	}
 }
@@ -35,8 +36,12 @@ func dataSourceAwsPrefixList() *schema.Resource {
 func dataSourceAwsPrefixListRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	req := &ec2.DescribePrefixListsInput{}
+	filters, filtersOk := d.GetOk("filter")
 
+	req := &ec2.DescribePrefixListsInput{}
+	if filtersOk {
+		req.Filters = buildAwsDataSourceFilters(filters.(*schema.Set))
+	}
 	if prefixListID := d.Get("prefix_list_id"); prefixListID != "" {
 		req.PrefixListIds = aws.StringSlice([]string{prefixListID.(string)})
 	}

--- a/aws/data_source_aws_prefix_list_test.go
+++ b/aws/data_source_aws_prefix_list_test.go
@@ -9,13 +9,29 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccDataSourceAwsPrefixList(t *testing.T) {
+func TestAccDataSourceAwsPrefixList_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceAwsPrefixListConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsPrefixListCheck("data.aws_prefix_list.s3_by_id"),
+					testAccDataSourceAwsPrefixListCheck("data.aws_prefix_list.s3_by_name"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsPrefixList_filter(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsPrefixListConfigFilter,
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsPrefixListCheck("data.aws_prefix_list.s3_by_id"),
 					testAccDataSourceAwsPrefixListCheck("data.aws_prefix_list.s3_by_name"),
@@ -64,5 +80,21 @@ data "aws_prefix_list" "s3_by_id" {
 
 data "aws_prefix_list" "s3_by_name" {
  name = "com.amazonaws.us-west-2.s3"
+}
+`
+
+const testAccDataSourceAwsPrefixListConfigFilter = `
+data "aws_prefix_list" "s3_by_name" {
+  filter {
+    name   = "prefix-list-name"
+    values = ["com.amazonaws.us-west-2.s3"]
+  }
+}
+
+data "aws_prefix_list" "s3_by_id" {
+  filter {
+    name   = "prefix-list-id"
+    values = ["pl-68a54001"]
+  }
 }
 `

--- a/website/docs/d/prefix_list.html.markdown
+++ b/website/docs/d/prefix_list.html.markdown
@@ -62,11 +62,16 @@ prefix lists. The given filters must match exactly one prefix list
 whose data will be exported as attributes.
 
 * `prefix_list_id` - (Optional) The ID of the prefix list to select.
-
 * `name` - (Optional) The name of the prefix list to select.
-* `filter` - (Optional) One or more name/value pairs to use as filters. There are
-several valid keys, for a full reference, check out
-[describe-prefix-lists in the AWS CLI reference][1].
+* `filter` - (Optional) Configuration block(s) for filtering. Detailed below.
+
+### filter Configuration Block
+
+The following arguments are supported by the `filter` configuration block:
+
+* `name` - (Required) The name of the filter field. Valid values can be found in the [EC2 DescribePrefixLists API Reference](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribePrefixLists.html).
+* `values` - (Required) Set of values that are accepted for the given filter field. Results will be selected if any given value matches.
+
 
 ## Attributes Reference
 
@@ -78,5 +83,3 @@ In addition to all arguments above, the following attributes are exported:
 
 * `cidr_blocks` - The list of CIDR blocks for the AWS service associated
 with the prefix list.
-
-[1]: https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-prefix-lists.html

--- a/website/docs/d/prefix_list.html.markdown
+++ b/website/docs/d/prefix_list.html.markdown
@@ -53,6 +53,9 @@ whose data will be exported as attributes.
 * `prefix_list_id` - (Optional) The ID of the prefix list to select.
 
 * `name` - (Optional) The name of the prefix list to select.
+* `filter` - (Optional) One or more name/value pairs to use as filters. There are
+several valid keys, for a full reference, check out
+[describe-prefix-lists in the AWS CLI reference][1].
 
 ## Attributes Reference
 
@@ -64,3 +67,5 @@ In addition to all arguments above, the following attributes are exported:
 
 * `cidr_blocks` - The list of CIDR blocks for the AWS service associated
 with the prefix list.
+
+[1]: https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-prefix-lists.html

--- a/website/docs/d/prefix_list.html.markdown
+++ b/website/docs/d/prefix_list.html.markdown
@@ -72,7 +72,6 @@ The following arguments are supported by the `filter` configuration block:
 * `name` - (Required) The name of the filter field. Valid values can be found in the [EC2 DescribePrefixLists API Reference](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribePrefixLists.html).
 * `values` - (Required) Set of values that are accepted for the given filter field. Results will be selected if any given value matches.
 
-
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/website/docs/d/prefix_list.html.markdown
+++ b/website/docs/d/prefix_list.html.markdown
@@ -44,6 +44,18 @@ resource "aws_network_acl_rule" "private_s3" {
 }
 ```
 
+### Filter
+
+```hcl
+data "aws_prefix_list" "test" {
+  filter {
+    name   = "prefix-list-id"
+    values = ["pl-68a54001"]
+  }
+}
+`
+```
+
 ## Argument Reference
 
 The arguments of this data source act as filters for querying the available

--- a/website/docs/d/prefix_list.html.markdown
+++ b/website/docs/d/prefix_list.html.markdown
@@ -53,7 +53,6 @@ data "aws_prefix_list" "test" {
     values = ["pl-68a54001"]
   }
 }
-`
 ```
 
 ## Argument Reference

--- a/website/docs/d/prefix_list.html.markdown
+++ b/website/docs/d/prefix_list.html.markdown
@@ -77,8 +77,5 @@ The following arguments are supported by the `filter` configuration block:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the selected prefix list.
-
 * `name` - The name of the selected prefix list.
-
-* `cidr_blocks` - The list of CIDR blocks for the AWS service associated
-with the prefix list.
+* `cidr_blocks` - The list of CIDR blocks for the AWS service associated with the prefix list.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11994

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data_source_aws_prefix_lists - add filter support
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccDataSourceAwsPrefixList_'
--- PASS: TestAccDataSourceAwsPrefixList_basic (45.79s)
--- PASS: TestAccDataSourceAwsPrefixList_filter (51.66s)
```
