### PR TITLE
resource/aws_cloudformation_stack_set: Add support for SERVICE_MANAGED permission model

### DIFF
--- a/aws/resource_aws_cloudformation_stack_set.go
+++ b/aws/resource_aws_cloudformation_stack_set.go
@@ -31,13 +31,38 @@ func resourceAwsCloudFormationStackSet() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"administration_role_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validateArn,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"auto_deployment"},
+				ValidateFunc:  validateArn,
 			},
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"auto_deployment": {
+				Type:     schema.TypeList,
+				MinItems: 1,
+				MaxItems: 1,
+				Optional: true,
+				ForceNew: true,
+				ConflictsWith: []string{
+					"administration_role_arn",
+					"execution_role_name",
+				},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"retain_stacks_on_account_removal": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+					},
+				},
 			},
 			"capabilities": {
 				Type:     schema.TypeSet,
@@ -57,9 +82,10 @@ func resourceAwsCloudFormationStackSet() *schema.Resource {
 				ValidateFunc: validation.StringLenBetween(0, 1024),
 			},
 			"execution_role_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "AWSCloudFormationStackSetExecutionRole",
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"auto_deployment"},
 			},
 			"name": {
 				Type:     schema.TypeString,
@@ -75,6 +101,15 @@ func resourceAwsCloudFormationStackSet() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"permission_model": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					cloudformation.PermissionModelsServiceManaged,
+					cloudformation.PermissionModelsSelfManaged,
+				}, false),
+				Default: cloudformation.PermissionModelsSelfManaged,
 			},
 			"stack_set_id": {
 				Type:     schema.TypeString,
@@ -103,10 +138,16 @@ func resourceAwsCloudFormationStackSetCreate(d *schema.ResourceData, meta interf
 	name := d.Get("name").(string)
 
 	input := &cloudformation.CreateStackSetInput{
-		AdministrationRoleARN: aws.String(d.Get("administration_role_arn").(string)),
-		ClientRequestToken:    aws.String(resource.UniqueId()),
-		ExecutionRoleName:     aws.String(d.Get("execution_role_name").(string)),
-		StackSetName:          aws.String(name),
+		ClientRequestToken: aws.String(resource.UniqueId()),
+		StackSetName:       aws.String(name),
+	}
+
+	if v, ok := d.GetOk("administration_role_arn"); ok {
+		input.AdministrationRoleARN = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("auto_deployment"); ok {
+		input.AutoDeployment = expandAutoDeployment(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("capabilities"); ok {
@@ -117,8 +158,16 @@ func resourceAwsCloudFormationStackSetCreate(d *schema.ResourceData, meta interf
 		input.Description = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("execution_role_name"); ok {
+		input.ExecutionRoleName = aws.String(v.(string))
+	}
+
 	if v, ok := d.GetOk("parameters"); ok {
 		input.Parameters = expandCloudFormationParameters(v.(map[string]interface{}))
+	}
+
+	if v, ok := d.GetOk("permission_model"); ok {
+		input.PermissionModel = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("tags"); ok {
@@ -174,6 +223,10 @@ func resourceAwsCloudFormationStackSetRead(d *schema.ResourceData, meta interfac
 	d.Set("administration_role_arn", stackSet.AdministrationRoleARN)
 	d.Set("arn", stackSet.StackSetARN)
 
+	if err := d.Set("auto_deployment", flattenStackSetAutoDeploymentResponse(stackSet.AutoDeployment)); err != nil {
+		return fmt.Errorf("error setting auto_deployment: %s", err)
+	}
+
 	if err := d.Set("capabilities", aws.StringValueSlice(stackSet.Capabilities)); err != nil {
 		return fmt.Errorf("error setting capabilities: %s", err)
 	}
@@ -181,6 +234,7 @@ func resourceAwsCloudFormationStackSetRead(d *schema.ResourceData, meta interfac
 	d.Set("description", stackSet.Description)
 	d.Set("execution_role_name", stackSet.ExecutionRoleName)
 	d.Set("name", stackSet.StackSetName)
+	d.Set("permission_model", stackSet.PermissionModel)
 
 	if err := d.Set("parameters", flattenAllCloudFormationParameters(stackSet.Parameters)); err != nil {
 		return fmt.Errorf("error setting parameters: %s", err)
@@ -201,12 +255,18 @@ func resourceAwsCloudFormationStackSetUpdate(d *schema.ResourceData, meta interf
 	conn := meta.(*AWSClient).cfconn
 
 	input := &cloudformation.UpdateStackSetInput{
-		AdministrationRoleARN: aws.String(d.Get("administration_role_arn").(string)),
-		ExecutionRoleName:     aws.String(d.Get("execution_role_name").(string)),
-		OperationId:           aws.String(resource.UniqueId()),
-		StackSetName:          aws.String(d.Id()),
-		Tags:                  []*cloudformation.Tag{},
-		TemplateBody:          aws.String(d.Get("template_body").(string)),
+		OperationId:  aws.String(resource.UniqueId()),
+		StackSetName: aws.String(d.Id()),
+		Tags:         []*cloudformation.Tag{},
+		TemplateBody: aws.String(d.Get("template_body").(string)),
+	}
+
+	if v, ok := d.GetOk("administration_role_arn"); ok {
+		input.AdministrationRoleARN = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("auto_deployment"); ok {
+		input.AutoDeployment = expandAutoDeployment(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("capabilities"); ok {
@@ -217,8 +277,16 @@ func resourceAwsCloudFormationStackSetUpdate(d *schema.ResourceData, meta interf
 		input.Description = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("execution_role_name"); ok {
+		input.ExecutionRoleName = aws.String(v.(string))
+	}
+
 	if v, ok := d.GetOk("parameters"); ok {
 		input.Parameters = expandCloudFormationParameters(v.(map[string]interface{}))
+	}
+
+	if v, ok := d.GetOk("permission_model"); ok {
+		input.PermissionModel = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("tags"); ok {
@@ -290,4 +358,32 @@ func listCloudFormationStackSets(conn *cloudformation.CloudFormation) ([]*cloudf
 	}
 
 	return result, nil
+}
+
+func expandAutoDeployment(l []interface{}) *cloudformation.AutoDeployment {
+	if len(l) == 0 {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	autoDeployment := &cloudformation.AutoDeployment{
+		Enabled:                      aws.Bool(m["enabled"].(bool)),
+		RetainStacksOnAccountRemoval: aws.Bool(m["retain_stacks_on_account_removal"].(bool)),
+	}
+
+	return autoDeployment
+}
+
+func flattenStackSetAutoDeploymentResponse(autoDeployment *cloudformation.AutoDeployment) []map[string]interface{} {
+	if autoDeployment == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"enabled":                          aws.BoolValue(autoDeployment.Enabled),
+		"retain_stacks_on_account_removal": aws.BoolValue(autoDeployment.RetainStacksOnAccountRemoval),
+	}
+
+	return []map[string]interface{}{m}
 }

--- a/aws/resource_aws_cloudformation_stack_set_test.go
+++ b/aws/resource_aws_cloudformation_stack_set_test.go
@@ -91,6 +91,7 @@ func TestAccAWSCloudFormationStackSet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "execution_role_name", "AWSCloudFormationStackSetExecutionRole"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "permission_model", "SELF_MANAGED"),
 					resource.TestMatchResourceAttr(resourceName, "stack_set_id", regexp.MustCompile(fmt.Sprintf("%s:.+", rName))),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "template_body", testAccAWSCloudFormationStackSetTemplateBodyVpc(rName)+"\n"),
@@ -442,6 +443,40 @@ func TestAccAWSCloudFormationStackSet_Parameters_NoEcho(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.Parameter1", "****"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFormationStackSet_PermissionModel_ServiceManaged(t *testing.T) {
+	var stackSet1 cloudformation.StackSet
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_cloudformation_stack_set.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFormationStackSet(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudFormationStackSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFormationStackSetConfigPermissionModel(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet1),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "cloudformation", regexp.MustCompile(`stackset/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "permission_model", "SERVICE_MANAGED"),
+					resource.TestCheckResourceAttr(resourceName, "auto_deployment.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "auto_deployment.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "auto_deployment.0.retain_stacks_on_account_removal", "false"),
+					resource.TestMatchResourceAttr(resourceName, "stack_set_id", regexp.MustCompile(fmt.Sprintf("%s:.+", rName))),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"template_url",
+				},
 			},
 		},
 	})
@@ -1140,4 +1175,23 @@ resource "aws_cloudformation_stack_set" "test" {
   template_url            = "https://${aws_s3_bucket.test.bucket_regional_domain_name}/${aws_s3_bucket_object.test.key}"
 }
 `, rName, testAccAWSCloudFormationStackSetTemplateBodyVpc(rName+"2"))
+}
+
+func testAccAWSCloudFormationStackSetConfigPermissionModel(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudformation_stack_set" "test" {
+  name                    = %[1]q
+
+  permission_model = "SERVICE_MANAGED"
+
+  auto_deployment {
+		enabled                          = true
+		retain_stacks_on_account_removal = false
+  }
+
+  template_body = <<TEMPLATE
+%[2]s
+TEMPLATE
+}
+`, rName, testAccAWSCloudFormationStackSetTemplateBodyVpc(rName))
 }

--- a/website/docs/r/cloudformation_stack_set.html.markdown
+++ b/website/docs/r/cloudformation_stack_set.html.markdown
@@ -85,12 +85,16 @@ resource "aws_iam_role_policy" "AWSCloudFormationStackSetAdministrationRole_Exec
 
 The following arguments are supported:
 
-* `administration_role_arn` - (Required) Amazon Resource Number (ARN) of the IAM Role in the administrator account.
+* `administration_role_arn` - (Optional) Amazon Resource Number (ARN) of the IAM Role in the administrator account. This must be defined when using the `SELF_MANAGED` permission model.
+* `auto_deployment` - (Optional) Nested attribute containing the auto-deployment model for your StackSet. This can only be defined when using the `SERVICE_MANAGED` permission model.
+  * `enabled` - Whether or not auto-deployment is enabled.
+  * `retain_stacks_on_account_removal` - Whether or not to retain stacks when the account is removed.
 * `name` - (Required) Name of the StackSet. The name must be unique in the region where you create your StackSet. The name can contain only alphanumeric characters (case-sensitive) and hyphens. It must start with an alphabetic character and cannot be longer than 128 characters.
 * `capabilities` - (Optional) A list of capabilities. Valid values: `CAPABILITY_IAM`, `CAPABILITY_NAMED_IAM`, `CAPABILITY_AUTO_EXPAND`.
 * `description` - (Optional) Description of the StackSet.
-* `execution_role_name` - (Optional) Name of the IAM Role in all target accounts for StackSet operations. Defaults to `AWSCloudFormationStackSetExecutionRole`.
+* `execution_role_name` - (Optional) Name of the IAM Role in all target accounts for StackSet operations. Defaults to `AWSCloudFormationStackSetExecutionRole` when using the `SELF_MANAGED` permission model. This should not be defined when using the `SERVICE_MANAGED` permission model.
 * `parameters` - (Optional) Key-value map of input parameters for the StackSet template. All template parameters, including those with a `Default`, must be configured or ignored with `lifecycle` configuration block `ignore_changes` argument. All `NoEcho` template parameters must be ignored with the `lifecycle` configuration block `ignore_changes` argument.
+* `permission_model` - (Optional) Describes how the IAM roles required for your StackSet are created. Valid values: `SELF_MANAGED` (default), `SERVICE_MANAGED`.
 * `tags` - (Optional) Key-value map of tags to associate with this StackSet and the Stacks created from it. AWS CloudFormation also propagates these tags to supported resources that are created in the Stacks. A maximum number of 50 tags can be specified.
 * `template_body` - (Optional) String containing the CloudFormation template body. Maximum size: 51,200 bytes. Conflicts with `template_url`.
 * `template_url` - (Optional) String containing the location of a file containing the CloudFormation template body. The URL must point to a template that is located in an Amazon S3 bucket. Maximum location file size: 460,800 bytes. Conflicts with `template_body`.


### PR DESCRIPTION
This updates the `aws_cloudformation_stack_set` resource to support the `SERVICE_MANAGED` permission model. This is necessary if a consumer intends to use CloudFormation StackSets to manage resources across an AWS Organization.

Closes #12422.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
