### PR TITLE
add outpost_arn field to data_source_aws_network_interface

### DIFF
--- a/aws/data_source_aws_network_interface.go
+++ b/aws/data_source_aws_network_interface.go
@@ -122,6 +122,10 @@ func dataSourceAwsNetworkInterface() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"outpost_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"vpc_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -179,6 +183,7 @@ func dataSourceAwsNetworkInterfaceRead(d *schema.ResourceData, meta interface{})
 	d.Set("private_ips", flattenNetworkInterfacesPrivateIPAddresses(eni.PrivateIpAddresses))
 	d.Set("requester_id", eni.RequesterId)
 	d.Set("subnet_id", eni.SubnetId)
+	d.Set("outpost_arn", eni.OutpostArn)
 	d.Set("vpc_id", eni.VpcId)
 	d.Set("tags", tagsToMap(eni.TagSet))
 	return nil

--- a/aws/data_source_aws_network_interface_test.go
+++ b/aws/data_source_aws_network_interface_test.go
@@ -25,6 +25,7 @@ func TestAccDataSourceAwsNetworkInterface_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.aws_network_interface.test", "interface_type"),
 					resource.TestCheckResourceAttrPair("data.aws_network_interface.test", "private_dns_name", "aws_network_interface.test", "private_dns_name"),
 					resource.TestCheckResourceAttrPair("data.aws_network_interface.test", "subnet_id", "aws_network_interface.test", "subnet_id"),
+					resource.TestCheckResourceAttr("data.aws_network_interface.test", "outpost_arn", ""),
 					resource.TestCheckResourceAttrSet("data.aws_network_interface.test", "vpc_id"),
 				),
 			},

--- a/aws/resource_aws_network_interface.go
+++ b/aws/resource_aws_network_interface.go
@@ -78,6 +78,11 @@ func resourceAwsNetworkInterface() *schema.Resource {
 				Default:  true,
 			},
 
+			"outpost_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -185,6 +190,7 @@ func resourceAwsNetworkInterfaceRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("private_dns_name", eni.PrivateDnsName)
 	d.Set("mac_address", eni.MacAddress)
 	d.Set("private_ip", eni.PrivateIpAddress)
+	d.Set("outpost_arn", eni.OutpostArn)
 
 	if err := d.Set("private_ips", flattenNetworkInterfacesPrivateIPAddresses(eni.PrivateIpAddresses)); err != nil {
 		return fmt.Errorf("error setting private_ips: %s", err)

--- a/aws/resource_aws_network_interface_test.go
+++ b/aws/resource_aws_network_interface_test.go
@@ -91,6 +91,8 @@ func TestAccAWSENI_basic(t *testing.T) {
 						"aws_network_interface.bar", "tags.Name", "bar_interface"),
 					resource.TestCheckResourceAttr(
 						"aws_network_interface.bar", "description", "Managed by Terraform"),
+					resource.TestCheckResourceAttr(
+						"aws_network_interface.bar", "outpost_arn", ""),
 				),
 			},
 			{

--- a/website/docs/d/network_interface.html.markdown
+++ b/website/docs/d/network_interface.html.markdown
@@ -44,6 +44,7 @@ Additionally, the following attributes are exported:
 * `requester_id` - The ID of the entity that launched the instance on your behalf.
 * `security_groups` - The list of security groups for the network interface.
 * `subnet_id` - The ID of the subnet.
+* `outpost_arn` - The Amazon Resource Name (ARN) of the Outpost.
 * `tags` - Any tags assigned to the network interface.
 * `vpc_id` - The ID of the VPC.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12302

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add outpost_arn to network interface datasource
Add outpost_arn to network interface resource
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsNetworkInterface_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsNetworkInterface_basic -timeout 120m
=== RUN   TestAccDataSourceAwsNetworkInterface_basic
=== PAUSE TestAccDataSourceAwsNetworkInterface_basic
=== CONT  TestAccDataSourceAwsNetworkInterface_basic
--- PASS: TestAccDataSourceAwsNetworkInterface_basic (98.15s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       99.834s

$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSENI_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSENI_basic -timeout 120m
=== RUN   TestAccAWSENI_basic
=== PAUSE TestAccAWSENI_basic
=== CONT  TestAccAWSENI_basic
--- PASS: TestAccAWSENI_basic (108.21s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	109.743s
```
