### PR TITLE
Moved VPC SGs from ModifyDB to RestoreDB API Call

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -1008,8 +1008,11 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 		}
 
 		if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
-			modifyDbInstanceInput.VpcSecurityGroupIds = expandStringSet(attr)
-			requiresModifyDbInstance = true
+			var s []*string
+			for _, v := range attr.List() {
+				s = append(s, aws.String(v.(string)))
+			}
+			opts.VpcSecurityGroupIds = s
 		}
 
 		if attr, ok := d.GetOk("performance_insights_enabled"); ok {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9303

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_db_instance: Fixes bug when restoring DB from a snapshot is not possible in a shared subnet
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds -timeout 120m
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds
=== RUN   TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds_Tags
=== PAUSE TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds_Tags
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds
=== CONT  TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds_Tags
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds_Tags (1120.94s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds (1122.80s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       1124.177s
```
