### PR TITLE
r/aws_apigatewayv2_api: Add CORS configuration and quick start attributes

### DIFF
--- a/aws/resource_aws_apigatewayv2_api.go
+++ b/aws/resource_aws_apigatewayv2_api.go
@@ -40,6 +40,53 @@ func resourceAwsApiGatewayV2Api() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"cors_configuration": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"allow_credentials": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"allow_headers": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      hashStringCaseInsensitive,
+						},
+						"allow_methods": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      hashStringCaseInsensitive,
+						},
+						"allow_origins": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      hashStringCaseInsensitive,
+						},
+						"expose_headers": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      hashStringCaseInsensitive,
+						},
+						"max_age": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"credentials_arn": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
+			},
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -63,12 +110,22 @@ func resourceAwsApiGatewayV2Api() *schema.Resource {
 					apigatewayv2.ProtocolTypeWebsocket,
 				}, false),
 			},
+			"route_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"route_selection_expression": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "$request.method $request.path",
 			},
 			"tags": tagsSchema(),
+			"target": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"version": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -90,11 +147,23 @@ func resourceAwsApiGatewayV2ApiCreate(d *schema.ResourceData, meta interface{}) 
 	if v, ok := d.GetOk("api_key_selection_expression"); ok {
 		req.ApiKeySelectionExpression = aws.String(v.(string))
 	}
+	if v, ok := d.GetOk("cors_configuration"); ok {
+		req.CorsConfiguration = expandApiGateway2CorsConfiguration(v.([]interface{}))
+	}
+	if v, ok := d.GetOk("credentials_arn"); ok {
+		req.CredentialsArn = aws.String(v.(string))
+	}
 	if v, ok := d.GetOk("description"); ok {
 		req.Description = aws.String(v.(string))
 	}
+	if v, ok := d.GetOk("route_key"); ok {
+		req.RouteKey = aws.String(v.(string))
+	}
 	if v, ok := d.GetOk("route_selection_expression"); ok {
 		req.RouteSelectionExpression = aws.String(v.(string))
+	}
+	if v, ok := d.GetOk("target"); ok {
+		req.Target = aws.String(v.(string))
 	}
 	if v, ok := d.GetOk("version"); ok {
 		req.Version = aws.String(v.(string))
@@ -135,6 +204,9 @@ func resourceAwsApiGatewayV2ApiRead(d *schema.ResourceData, meta interface{}) er
 		Resource:  fmt.Sprintf("/apis/%s", d.Id()),
 	}.String()
 	d.Set("arn", apiArn)
+	if err := d.Set("cors_configuration", flattenApiGateway2CorsConfiguration(resp.CorsConfiguration)); err != nil {
+		return fmt.Errorf("error setting cors_configuration: %s", err)
+	}
 	d.Set("description", resp.Description)
 	executionArn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
@@ -158,13 +230,33 @@ func resourceAwsApiGatewayV2ApiRead(d *schema.ResourceData, meta interface{}) er
 func resourceAwsApiGatewayV2ApiUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).apigatewayv2conn
 
-	if d.HasChanges("api_key_selection_expression", "description", "name", "route_selection_expression", "version") {
+	deleteCorsConfiguration := false
+	if d.HasChange("cors_configuration") {
+		v := d.Get("cors_configuration")
+		if len(v.([]interface{})) == 0 {
+			deleteCorsConfiguration = true
+
+			log.Printf("[DEBUG] Deleting CORS configuration for API Gateway v2 API (%s)", d.Id())
+			_, err := conn.DeleteCorsConfiguration(&apigatewayv2.DeleteCorsConfigurationInput{
+				ApiId: aws.String(d.Id()),
+			})
+			if err != nil {
+				return fmt.Errorf("error deleting CORS configuration for API Gateway v2 API (%s): %s", d.Id(), err)
+			}
+		}
+	}
+
+	if d.HasChanges("api_key_selection_expression", "description", "name", "route_selection_expression", "version") ||
+		(d.HasChange("cors_configuration") && !deleteCorsConfiguration) {
 		req := &apigatewayv2.UpdateApiInput{
 			ApiId: aws.String(d.Id()),
 		}
 
 		if d.HasChange("api_key_selection_expression") {
 			req.ApiKeySelectionExpression = aws.String(d.Get("api_key_selection_expression").(string))
+		}
+		if d.HasChange("cors_configuration") {
+			req.CorsConfiguration = expandApiGateway2CorsConfiguration(d.Get("cors_configuration").([]interface{}))
 		}
 		if d.HasChange("description") {
 			req.Description = aws.String(d.Get("description").(string))
@@ -211,4 +303,49 @@ func resourceAwsApiGatewayV2ApiDelete(d *schema.ResourceData, meta interface{}) 
 	}
 
 	return nil
+}
+
+func expandApiGateway2CorsConfiguration(vConfiguration []interface{}) *apigatewayv2.Cors {
+	configuration := &apigatewayv2.Cors{}
+
+	if len(vConfiguration) == 0 || vConfiguration[0] == nil {
+		return configuration
+	}
+	mConfiguration := vConfiguration[0].(map[string]interface{})
+
+	if vAllowCredentials, ok := mConfiguration["allow_credentials"].(bool); ok {
+		configuration.AllowCredentials = aws.Bool(vAllowCredentials)
+	}
+	if vAllowHeaders, ok := mConfiguration["allow_headers"].(*schema.Set); ok {
+		configuration.AllowHeaders = expandStringSet(vAllowHeaders)
+	}
+	if vAllowMethods, ok := mConfiguration["allow_methods"].(*schema.Set); ok {
+		configuration.AllowMethods = expandStringSet(vAllowMethods)
+	}
+	if vAllowOrigins, ok := mConfiguration["allow_origins"].(*schema.Set); ok {
+		configuration.AllowOrigins = expandStringSet(vAllowOrigins)
+	}
+	if vExposeHeaders, ok := mConfiguration["expose_headers"].(*schema.Set); ok {
+		configuration.ExposeHeaders = expandStringSet(vExposeHeaders)
+	}
+	if vMaxAge, ok := mConfiguration["max_age"].(int); ok {
+		configuration.MaxAge = aws.Int64(int64(vMaxAge))
+	}
+
+	return configuration
+}
+
+func flattenApiGateway2CorsConfiguration(configuration *apigatewayv2.Cors) []interface{} {
+	if configuration == nil {
+		return []interface{}{}
+	}
+
+	return []interface{}{map[string]interface{}{
+		"allow_credentials": aws.BoolValue(configuration.AllowCredentials),
+		"allow_headers":     flattenCaseInsensitiveStringSet(configuration.AllowHeaders),
+		"allow_methods":     flattenCaseInsensitiveStringSet(configuration.AllowMethods),
+		"allow_origins":     flattenCaseInsensitiveStringSet(configuration.AllowOrigins),
+		"expose_headers":    flattenCaseInsensitiveStringSet(configuration.ExposeHeaders),
+		"max_age":           int(aws.Int64Value(configuration.MaxAge)),
+	}}
 }

--- a/aws/resource_aws_apigatewayv2_api_test.go
+++ b/aws/resource_aws_apigatewayv2_api_test.go
@@ -82,6 +82,7 @@ func TestAccAWSAPIGatewayV2Api_basicWebSocket(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "api_endpoint"),
 					resource.TestCheckResourceAttr(resourceName, "api_key_selection_expression", "$request.header.x-api-key"),
 					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/apis/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					testAccMatchResourceAttrRegionalARN(resourceName, "execution_arn", "execute-api", regexp.MustCompile(`.+`)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -117,6 +118,7 @@ func TestAccAWSAPIGatewayV2Api_basicHttp(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "api_endpoint"),
 					resource.TestCheckResourceAttr(resourceName, "api_key_selection_expression", "$request.header.x-api-key"),
 					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/apis/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					testAccMatchResourceAttrRegionalARN(resourceName, "execution_arn", "execute-api", regexp.MustCompile(`.+`)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -175,6 +177,7 @@ func TestAccAWSAPIGatewayV2Api_AllAttributesWebSocket(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "api_endpoint"),
 					resource.TestCheckResourceAttr(resourceName, "api_key_selection_expression", "$context.authorizer.usageIdentifierKey"),
 					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/apis/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
 					testAccMatchResourceAttrRegionalARN(resourceName, "execution_arn", "execute-api", regexp.MustCompile(`.+`)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName1),
@@ -189,6 +192,7 @@ func TestAccAWSAPIGatewayV2Api_AllAttributesWebSocket(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayV2ApiExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "api_key_selection_expression", "$request.header.x-api-key"),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "name", rName1),
 					resource.TestCheckResourceAttr(resourceName, "protocol_type", apigatewayv2.ProtocolTypeWebsocket),
@@ -202,6 +206,7 @@ func TestAccAWSAPIGatewayV2Api_AllAttributesWebSocket(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayV2ApiExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "api_key_selection_expression", "$context.authorizer.usageIdentifierKey"),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName2),
 					resource.TestCheckResourceAttr(resourceName, "route_selection_expression", "$request.body.service"),
@@ -214,6 +219,7 @@ func TestAccAWSAPIGatewayV2Api_AllAttributesWebSocket(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayV2ApiExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "api_key_selection_expression", "$context.authorizer.usageIdentifierKey"),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName1),
 					resource.TestCheckResourceAttr(resourceName, "route_selection_expression", "$request.body.service"),
@@ -248,6 +254,7 @@ func TestAccAWSAPIGatewayV2Api_AllAttributesHttp(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "api_endpoint"),
 					resource.TestCheckResourceAttr(resourceName, "api_key_selection_expression", "$request.header.x-api-key"),
 					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/apis/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
 					testAccMatchResourceAttrRegionalARN(resourceName, "execution_arn", "execute-api", regexp.MustCompile(`.+`)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName1),
@@ -262,6 +269,7 @@ func TestAccAWSAPIGatewayV2Api_AllAttributesHttp(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayV2ApiExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "api_key_selection_expression", "$request.header.x-api-key"),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "name", rName1),
 					resource.TestCheckResourceAttr(resourceName, "protocol_type", apigatewayv2.ProtocolTypeHttp),
@@ -275,6 +283,7 @@ func TestAccAWSAPIGatewayV2Api_AllAttributesHttp(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayV2ApiExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "api_key_selection_expression", "$request.header.x-api-key"),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName2),
 					resource.TestCheckResourceAttr(resourceName, "route_selection_expression", "$request.method $request.path"),
@@ -287,6 +296,7 @@ func TestAccAWSAPIGatewayV2Api_AllAttributesHttp(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayV2ApiExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "api_key_selection_expression", "$request.header.x-api-key"),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName1),
 					resource.TestCheckResourceAttr(resourceName, "route_selection_expression", "$request.method $request.path"),
@@ -320,6 +330,7 @@ func TestAccAWSAPIGatewayV2Api_Tags(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "api_endpoint"),
 					resource.TestCheckResourceAttr(resourceName, "api_key_selection_expression", "$request.header.x-api-key"),
 					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/apis/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					testAccMatchResourceAttrRegionalARN(resourceName, "execution_arn", "execute-api", regexp.MustCompile(`.+`)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -341,6 +352,7 @@ func TestAccAWSAPIGatewayV2Api_Tags(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayV2ApiExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "api_key_selection_expression", "$request.header.x-api-key"),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "protocol_type", apigatewayv2.ProtocolTypeWebsocket),
@@ -348,6 +360,141 @@ func TestAccAWSAPIGatewayV2Api_Tags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "version", ""),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayV2Api_CorsConfiguration(t *testing.T) {
+	var v apigatewayv2.GetApiOutput
+	resourceName := "aws_apigatewayv2_api.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayV2ApiDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayV2ApiConfig_corsConfiguration(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2ApiExists(resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "api_endpoint"),
+					resource.TestCheckResourceAttr(resourceName, "api_key_selection_expression", "$request.header.x-api-key"),
+					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/apis/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.0.allow_credentials", "false"),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.0.allow_headers.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.0.allow_headers.2053999599", "Authorization"),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.0.allow_methods.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.0.allow_methods.4248514160", "GET"),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.0.allow_methods.2928708052", "put"),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.0.allow_origins.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.0.allow_origins.89023941", "https://www.example.com"),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.0.expose_headers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.0.max_age", "0"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					testAccMatchResourceAttrRegionalARN(resourceName, "execution_arn", "execute-api", regexp.MustCompile(`.+`)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "protocol_type", apigatewayv2.ProtocolTypeHttp),
+					resource.TestCheckResourceAttr(resourceName, "route_selection_expression", "$request.method $request.path"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "version", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSAPIGatewayV2ApiConfig_corsConfigurationUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2ApiExists(resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "api_endpoint"),
+					resource.TestCheckResourceAttr(resourceName, "api_key_selection_expression", "$request.header.x-api-key"),
+					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/apis/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.0.allow_credentials", "true"),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.0.allow_headers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.0.allow_methods.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.0.allow_methods.163128923", "*"),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.0.allow_origins.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.0.allow_origins.1868318776", "HTTP://WWW.EXAMPLE.ORG"),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.0.allow_origins.3551736600", "https://example.io"),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.0.expose_headers.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.0.expose_headers.115091893", "X-Api-Id"),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.0.max_age", "500"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					testAccMatchResourceAttrRegionalARN(resourceName, "execution_arn", "execute-api", regexp.MustCompile(`.+`)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "protocol_type", apigatewayv2.ProtocolTypeHttp),
+					resource.TestCheckResourceAttr(resourceName, "route_selection_expression", "$request.method $request.path"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "version", ""),
+				),
+			},
+			{
+				Config: testAccAWSAPIGatewayV2ApiConfig_basicHttp(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2ApiExists(resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "api_endpoint"),
+					resource.TestCheckResourceAttr(resourceName, "api_key_selection_expression", "$request.header.x-api-key"),
+					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/apis/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					testAccMatchResourceAttrRegionalARN(resourceName, "execution_arn", "execute-api", regexp.MustCompile(`.+`)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "protocol_type", apigatewayv2.ProtocolTypeHttp),
+					resource.TestCheckResourceAttr(resourceName, "route_selection_expression", "$request.method $request.path"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "version", ""),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayV2Api_QuickCreate(t *testing.T) {
+	var v apigatewayv2.GetApiOutput
+	resourceName := "aws_apigatewayv2_api.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayV2ApiDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayV2ApiConfig_quickCreate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2ApiExists(resourceName, &v),
+					testAccCheckAWSAPIGatewayV2ApiQuickCreateIntegration(resourceName, "HTTP_PROXY", "http://www.example.com/"),
+					testAccCheckAWSAPIGatewayV2ApiQuickCreateRoute(resourceName, "GET /pets"),
+					testAccCheckAWSAPIGatewayV2ApiQuickCreateStage(resourceName, "$default"),
+					resource.TestCheckResourceAttrSet(resourceName, "api_endpoint"),
+					resource.TestCheckResourceAttr(resourceName, "api_key_selection_expression", "$request.header.x-api-key"),
+					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/apis/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					testAccMatchResourceAttrRegionalARN(resourceName, "execution_arn", "execute-api", regexp.MustCompile(`.+`)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "protocol_type", apigatewayv2.ProtocolTypeHttp),
+					resource.TestCheckResourceAttr(resourceName, "route_key", "GET /pets"),
+					resource.TestCheckResourceAttr(resourceName, "route_selection_expression", "$request.method $request.path"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "target", "http://www.example.com/"),
+					resource.TestCheckResourceAttr(resourceName, "version", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"route_key",
+					"target",
+				},
 			},
 		},
 	})
@@ -415,6 +562,105 @@ func testAccCheckAWSAPIGatewayV2ApiExists(n string, v *apigatewayv2.GetApiOutput
 	}
 }
 
+func testAccCheckAWSAPIGatewayV2ApiQuickCreateIntegration(n, expectedType, expectedUri string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No API Gateway v2 API ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).apigatewayv2conn
+
+		resp, err := conn.GetIntegrations(&apigatewayv2.GetIntegrationsInput{
+			ApiId: aws.String(rs.Primary.ID),
+		})
+		if err != nil {
+			return err
+		}
+
+		if got := len(resp.Items); got != 1 {
+			return fmt.Errorf("Incorrect number of integrations: %d", got)
+		}
+
+		if got := aws.StringValue(resp.Items[0].IntegrationType); got != expectedType {
+			return fmt.Errorf("Incorrect integration type. Expected: %s, got: %s", expectedType, got)
+		}
+		if got := aws.StringValue(resp.Items[0].IntegrationUri); got != expectedUri {
+			return fmt.Errorf("Incorrect integration URI. Expected: %s, got: %s", expectedUri, got)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSAPIGatewayV2ApiQuickCreateRoute(n, expectedRouteKey string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No API Gateway v2 API ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).apigatewayv2conn
+
+		resp, err := conn.GetRoutes(&apigatewayv2.GetRoutesInput{
+			ApiId: aws.String(rs.Primary.ID),
+		})
+		if err != nil {
+			return err
+		}
+
+		if got := len(resp.Items); got != 1 {
+			return fmt.Errorf("Incorrect number of routes: %d", got)
+		}
+
+		if got := aws.StringValue(resp.Items[0].RouteKey); got != expectedRouteKey {
+			return fmt.Errorf("Incorrect route key. Expected: %s, got: %s", expectedRouteKey, got)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSAPIGatewayV2ApiQuickCreateStage(n, expectedName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No API Gateway v2 API ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).apigatewayv2conn
+
+		resp, err := conn.GetStages(&apigatewayv2.GetStagesInput{
+			ApiId: aws.String(rs.Primary.ID),
+		})
+		if err != nil {
+			return err
+		}
+
+		if got := len(resp.Items); got != 1 {
+			return fmt.Errorf("Incorrect number of stages: %d", got)
+		}
+
+		if got := aws.StringValue(resp.Items[0].StageName); got != expectedName {
+			return fmt.Errorf("Incorrect stage name. Expected: %s, got: %s", expectedName, got)
+		}
+
+		return nil
+	}
+}
+
 func testAccAWSAPIGatewayV2ApiConfig_basicWebSocket(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_apigatewayv2_api" "test" {
@@ -469,6 +715,49 @@ resource "aws_apigatewayv2_api" "test" {
     Key1 = "Value1"
     Key2 = "Value2"
   }
+}
+`, rName)
+}
+
+func testAccAWSAPIGatewayV2ApiConfig_corsConfiguration(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_apigatewayv2_api" "test" {
+  name          = %[1]q
+  protocol_type = "HTTP"
+
+  cors_configuration {
+    allow_headers = ["Authorization"]
+    allow_methods = ["GET", "put"]
+    allow_origins = ["https://www.example.com"]
+  }
+}
+`, rName)
+}
+
+func testAccAWSAPIGatewayV2ApiConfig_corsConfigurationUpdated(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_apigatewayv2_api" "test" {
+  name          = %[1]q
+  protocol_type = "HTTP"
+
+  cors_configuration {
+    allow_credentials = true
+    allow_methods     = ["*"]
+    allow_origins     = ["HTTP://WWW.EXAMPLE.ORG", "https://example.io"]
+    expose_headers    = ["X-Api-Id"]
+    max_age           = 500
+  }
+}
+`, rName)
+}
+
+func testAccAWSAPIGatewayV2ApiConfig_quickCreate(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_apigatewayv2_api" "test" {
+  name          = %[1]q
+  protocol_type = "HTTP"
+  target        = "http://www.example.com/"
+  route_key     = "GET /pets"
 }
 `, rName)
 }

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -46,6 +46,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/aws/aws-sdk-go/service/worklink"
 	"github.com/beevik/etree"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/structure"
 	"github.com/mitchellh/copystructure"
@@ -997,6 +998,16 @@ func flattenStringList(list []*string) []interface{} {
 
 func flattenStringSet(list []*string) *schema.Set {
 	return schema.NewSet(schema.HashString, flattenStringList(list))
+}
+
+// hashStringCaseInsensitive hashes strings in a case insensitive manner.
+// If you want a Set of strings and are case inensitive, this is the SchemaSetFunc you want.
+func hashStringCaseInsensitive(v interface{}) int {
+	return hashcode.String(strings.ToLower(v.(string)))
+}
+
+func flattenCaseInsensitiveStringSet(list []*string) *schema.Set {
+	return schema.NewSet(hashStringCaseInsensitive, flattenStringList(list))
 }
 
 //Flattens an array of private ip addresses into a []string, where the elements returned are the IP strings e.g. "192.168.0.0"

--- a/website/docs/r/apigatewayv2_api.html.markdown
+++ b/website/docs/r/apigatewayv2_api.html.markdown
@@ -42,11 +42,26 @@ The following arguments are supported:
 * `api_key_selection_expression` - (Optional) An [API key selection expression](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-apikey-selection-expressions).
 Valid values: `$context.authorizer.usageIdentifierKey`, `$request.header.x-api-key`. Defaults to `$request.header.x-api-key`.
 Applicable for WebSocket APIs.
+* `cors_configuration` - (Optional) The cross-origin resource sharing (CORS) [configuration](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-cors.html). Applicable for HTTP APIs.
+* `credentials_arn` - (Optional) Part of _quick create_. Specifies any credentials required for the integration. Applicable for HTTP APIs.
 * `description` - (Optional) The description of the API.
+* `route_key` - (Optional) Part of _quick create_. Specifies any [route key](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-routes.html). Applicable for HTTP APIs.
 * `route_selection_expression` - (Optional) The [route selection expression](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-route-selection-expressions) for the API.
 Defaults to `$request.method $request.path`.
 * `tags` - (Optional) A mapping of tags to assign to the API.
+* `target` - (Optional) Part of _quick create_. Quick create produces an API with an integration, a default catch-all route, and a default stage which is configured to automatically deploy changes.
+For HTTP integrations, specify a fully qualified URL. For Lambda integrations, specify a function ARN.
+The type of the integration will be `HTTP_PROXY` or `AWS_PROXY`, respectively. Applicable for HTTP APIs.
 * `version` - (Optional) A version identifier for the API.
+
+The `cors_configuration` object supports the following:
+
+* `allow_credentials` - (Optional) Whether credentials are included in the CORS request.
+* `allow_headers` - (Optional) The set of allowed HTTP headers.
+* `allow_methods` - (Optional) The set of allowed HTTP methods.
+* `allow_origins` - (Optional) The set of allowed origins.
+* `expose_headers` - (Optional) The set of exposed HTTP headers.
+* `max_age` - (Optional) The number of seconds that the browser should cache preflight request results.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/terraform-providers/terraform-provider-aws/issues/11148.

Add CORS configuration and _quick start_ attributes.

Follows on from https://github.com/terraform-providers/terraform-provider-aws/pull/8842.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_apigatewayv2_api: Add `cors_configuration`, `credentials_arn`, `route_key` and `target` attributes
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSAPIGatewayV2Api_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSAPIGatewayV2Api_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayV2Api_basicWebSocket
=== PAUSE TestAccAWSAPIGatewayV2Api_basicWebSocket
=== RUN   TestAccAWSAPIGatewayV2Api_basicHttp
=== PAUSE TestAccAWSAPIGatewayV2Api_basicHttp
=== RUN   TestAccAWSAPIGatewayV2Api_disappears
=== PAUSE TestAccAWSAPIGatewayV2Api_disappears
=== RUN   TestAccAWSAPIGatewayV2Api_AllAttributesWebSocket
=== PAUSE TestAccAWSAPIGatewayV2Api_AllAttributesWebSocket
=== RUN   TestAccAWSAPIGatewayV2Api_AllAttributesHttp
=== PAUSE TestAccAWSAPIGatewayV2Api_AllAttributesHttp
=== RUN   TestAccAWSAPIGatewayV2Api_Tags
=== PAUSE TestAccAWSAPIGatewayV2Api_Tags
=== RUN   TestAccAWSAPIGatewayV2Api_CorsConfiguration
=== PAUSE TestAccAWSAPIGatewayV2Api_CorsConfiguration
=== RUN   TestAccAWSAPIGatewayV2Api_QuickCreate
=== PAUSE TestAccAWSAPIGatewayV2Api_QuickCreate
=== CONT  TestAccAWSAPIGatewayV2Api_basicWebSocket
=== CONT  TestAccAWSAPIGatewayV2Api_Tags
=== CONT  TestAccAWSAPIGatewayV2Api_QuickCreate
=== CONT  TestAccAWSAPIGatewayV2Api_CorsConfiguration
=== CONT  TestAccAWSAPIGatewayV2Api_AllAttributesWebSocket
=== CONT  TestAccAWSAPIGatewayV2Api_AllAttributesHttp
=== CONT  TestAccAWSAPIGatewayV2Api_disappears
=== CONT  TestAccAWSAPIGatewayV2Api_basicHttp
--- PASS: TestAccAWSAPIGatewayV2Api_disappears (19.42s)
--- PASS: TestAccAWSAPIGatewayV2Api_QuickCreate (29.86s)
--- PASS: TestAccAWSAPIGatewayV2Api_basicWebSocket (37.34s)
--- PASS: TestAccAWSAPIGatewayV2Api_basicHttp (37.90s)
--- PASS: TestAccAWSAPIGatewayV2Api_Tags (41.38s)
--- PASS: TestAccAWSAPIGatewayV2Api_CorsConfiguration (57.11s)
--- PASS: TestAccAWSAPIGatewayV2Api_AllAttributesWebSocket (71.49s)
--- PASS: TestAccAWSAPIGatewayV2Api_AllAttributesHttp (82.97s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	83.027s
```
