### PR TITLE
service/docdb: Remove deprecated (helper/schema.ResourceData).Partial() and (helper/schema.ResourceData).SetPartial()

### DIFF
--- a/aws/resource_aws_docdb_cluster.go
+++ b/aws/resource_aws_docdb_cluster.go
@@ -617,13 +617,11 @@ func resourceAwsDocDBClusterUpdate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	if d.HasChange("db_cluster_parameter_group_name") {
-		d.SetPartial("db_cluster_parameter_group_name")
 		req.DBClusterParameterGroupName = aws.String(d.Get("db_cluster_parameter_group_name").(string))
 		requestUpdate = true
 	}
 
 	if d.HasChange("enabled_cloudwatch_logs_exports") {
-		d.SetPartial("enabled_cloudwatch_logs_exports")
 		req.CloudwatchLogsExportConfiguration = buildDocDBCloudwatchLogsExportConfiguration(d)
 		requestUpdate = true
 	}
@@ -669,7 +667,6 @@ func resourceAwsDocDBClusterUpdate(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("error updating DocumentDB Cluster (%s) tags: %s", d.Get("arn").(string), err)
 		}
 
-		d.SetPartial("tags")
 	}
 
 	return resourceAwsDocDBClusterRead(d, meta)

--- a/aws/resource_aws_docdb_cluster_instance.go
+++ b/aws/resource_aws_docdb_cluster_instance.go
@@ -342,25 +342,21 @@ func resourceAwsDocDBClusterInstanceUpdate(d *schema.ResourceData, meta interfac
 	}
 
 	if d.HasChange("preferred_maintenance_window") {
-		d.SetPartial("preferred_maintenance_window")
 		req.PreferredMaintenanceWindow = aws.String(d.Get("preferred_maintenance_window").(string))
 		requestUpdate = true
 	}
 
 	if d.HasChange("auto_minor_version_upgrade") {
-		d.SetPartial("auto_minor_version_upgrade")
 		req.AutoMinorVersionUpgrade = aws.Bool(d.Get("auto_minor_version_upgrade").(bool))
 		requestUpdate = true
 	}
 
 	if d.HasChange("promotion_tier") {
-		d.SetPartial("promotion_tier")
 		req.PromotionTier = aws.Int64(int64(d.Get("promotion_tier").(int)))
 		requestUpdate = true
 	}
 
 	if d.HasChange("ca_cert_identifier") {
-		d.SetPartial("ca_cert_identifier")
 		req.CACertificateIdentifier = aws.String(d.Get("ca_cert_identifier").(string))
 		requestUpdate = true
 	}
@@ -410,7 +406,6 @@ func resourceAwsDocDBClusterInstanceUpdate(d *schema.ResourceData, meta interfac
 			return fmt.Errorf("error updating DocumentDB Cluster Instance (%s) tags: %s", d.Get("arn").(string), err)
 		}
 
-		d.SetPartial("tags")
 	}
 
 	return resourceAwsDocDBClusterInstanceRead(d, meta)

--- a/aws/resource_aws_docdb_cluster_parameter_group.go
+++ b/aws/resource_aws_docdb_cluster_parameter_group.go
@@ -182,8 +182,6 @@ func resourceAwsDocDBClusterParameterGroupRead(d *schema.ResourceData, meta inte
 func resourceAwsDocDBClusterParameterGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).docdbconn
 
-	d.Partial(true)
-
 	if d.HasChange("parameter") {
 		o, n := d.GetChange("parameter")
 		if o == nil {
@@ -227,7 +225,6 @@ func resourceAwsDocDBClusterParameterGroupUpdate(d *schema.ResourceData, meta in
 					return fmt.Errorf("Error modifying DocDB Cluster Parameter Group: %s", err)
 				}
 			}
-			d.SetPartial("parameter")
 		}
 	}
 
@@ -237,11 +234,7 @@ func resourceAwsDocDBClusterParameterGroupUpdate(d *schema.ResourceData, meta in
 		if err := keyvaluetags.DocdbUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
 			return fmt.Errorf("error updating DocumentDB Cluster Parameter Group (%s) tags: %s", d.Get("arn").(string), err)
 		}
-
-		d.SetPartial("tags")
 	}
-
-	d.Partial(false)
 
 	return resourceAwsDocDBClusterParameterGroupRead(d, meta)
 }

--- a/aws/resource_aws_docdb_subnet_group.go
+++ b/aws/resource_aws_docdb_subnet_group.go
@@ -175,8 +175,6 @@ func resourceAwsDocDBSubnetGroupUpdate(d *schema.ResourceData, meta interface{})
 		if err := keyvaluetags.DocdbUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
 			return fmt.Errorf("error updating DocumentDB Subnet Group (%s) tags: %s", d.Get("arn").(string), err)
 		}
-
-		d.SetPartial("tags")
 	}
 
 	return resourceAwsDocDBSubnetGroupRead(d, meta)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12083
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12087

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
aws/resource_aws_docdb_cluster.go:620:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_docdb_cluster.go:626:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_docdb_cluster.go:672:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_docdb_cluster_instance.go:345:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_docdb_cluster_instance.go:351:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_docdb_cluster_instance.go:357:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_docdb_cluster_instance.go:363:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_docdb_cluster_instance.go:413:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_docdb_cluster_parameter_group.go:185:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_docdb_cluster_parameter_group.go:230:4: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_docdb_cluster_parameter_group.go:241:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_docdb_cluster_parameter_group.go:244:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_docdb_subnet_group.go:179:3: R008: deprecated (schema.ResourceData).SetPartial
```

Output from acceptance testing:

```
--- PASS: TestAccAWSDocDBCluster_backupsUpdate (260.19s)
--- PASS: TestAccAWSDocDBCluster_basic (130.28s)
--- PASS: TestAccAWSDocDBCluster_encrypted (203.87s)
--- PASS: TestAccAWSDocDBCluster_generatedName (130.17s)
--- PASS: TestAccAWSDocDBCluster_kmsKey (233.75s)
--- PASS: TestAccAWSDocDBCluster_missingUserNameCausesError (4.93s)
--- PASS: TestAccAWSDocDBCluster_namePrefix (129.97s)
--- PASS: TestAccAWSDocDBCluster_Port (369.93s)
--- PASS: TestAccAWSDocDBCluster_takeFinalSnapshot (252.47s)
--- PASS: TestAccAWSDocDBCluster_updateCloudwatchLogsExports (227.06s)
--- PASS: TestAccAWSDocDBCluster_updateTags (235.10s)

--- PASS: TestAccAWSDocDBClusterInstance_az (714.97s)
--- PASS: TestAccAWSDocDBClusterInstance_basic (1416.43s)
--- PASS: TestAccAWSDocDBClusterInstance_disappears (748.64s)
--- PASS: TestAccAWSDocDBClusterInstance_generatedName (753.18s)
--- PASS: TestAccAWSDocDBClusterInstance_kmsKey (821.87s)
--- PASS: TestAccAWSDocDBClusterInstance_namePrefix (764.04s)

--- PASS: TestAccAWSDocDBClusterParameterGroup_basic (43.89s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_Description (31.42s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_disappears (13.72s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_generatedName (27.74s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_namePrefix (48.18s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_Parameter (50.36s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_Tags (65.89s)

--- PASS: TestAccAWSDocDBSubnetGroup_basic (57.22s)
--- PASS: TestAccAWSDocDBSubnetGroup_disappears (31.33s)
--- PASS: TestAccAWSDocDBSubnetGroup_generatedName (44.49s)
--- PASS: TestAccAWSDocDBSubnetGroup_namePrefix (46.41s)
--- PASS: TestAccAWSDocDBSubnetGroup_updateDescription (67.20s)
```
