### PR TITLE
service/neptune: Remove deprecated (helper/schema.ResourceData).Partial() and (helper/schema.ResourceData).SetPartial()

### DIFF
--- a/aws/resource_aws_neptune_cluster.go
+++ b/aws/resource_aws_neptune_cluster.go
@@ -594,7 +594,6 @@ func resourceAwsNeptuneClusterUpdate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if d.HasChange("neptune_cluster_parameter_group_name") {
-		d.SetPartial("neptune_cluster_parameter_group_name")
 		req.DBClusterParameterGroupName = aws.String(d.Get("neptune_cluster_parameter_group_name").(string))
 		requestUpdate = true
 	}
@@ -681,7 +680,6 @@ func resourceAwsNeptuneClusterUpdate(d *schema.ResourceData, meta interface{}) e
 			return fmt.Errorf("error updating Neptune Cluster (%s) tags: %s", d.Get("arn").(string), err)
 		}
 
-		d.SetPartial("tags")
 	}
 
 	return resourceAwsNeptuneClusterRead(d, meta)

--- a/aws/resource_aws_neptune_cluster_instance.go
+++ b/aws/resource_aws_neptune_cluster_instance.go
@@ -381,25 +381,21 @@ func resourceAwsNeptuneClusterInstanceUpdate(d *schema.ResourceData, meta interf
 	}
 
 	if d.HasChange("preferred_backup_window") {
-		d.SetPartial("preferred_backup_window")
 		req.PreferredBackupWindow = aws.String(d.Get("preferred_backup_window").(string))
 		requestUpdate = true
 	}
 
 	if d.HasChange("preferred_maintenance_window") {
-		d.SetPartial("preferred_maintenance_window")
 		req.PreferredMaintenanceWindow = aws.String(d.Get("preferred_maintenance_window").(string))
 		requestUpdate = true
 	}
 
 	if d.HasChange("auto_minor_version_upgrade") {
-		d.SetPartial("auto_minor_version_upgrade")
 		req.AutoMinorVersionUpgrade = aws.Bool(d.Get("auto_minor_version_upgrade").(bool))
 		requestUpdate = true
 	}
 
 	if d.HasChange("promotion_tier") {
-		d.SetPartial("promotion_tier")
 		req.PromotionTier = aws.Int64(int64(d.Get("promotion_tier").(int)))
 		requestUpdate = true
 	}
@@ -447,8 +443,6 @@ func resourceAwsNeptuneClusterInstanceUpdate(d *schema.ResourceData, meta interf
 		if err := keyvaluetags.NeptuneUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
 			return fmt.Errorf("error updating Neptune Cluster Instance (%s) tags: %s", d.Get("arn").(string), err)
 		}
-
-		d.SetPartial("tags")
 	}
 
 	return resourceAwsNeptuneClusterInstanceRead(d, meta)

--- a/aws/resource_aws_neptune_cluster_parameter_group.go
+++ b/aws/resource_aws_neptune_cluster_parameter_group.go
@@ -182,8 +182,6 @@ func resourceAwsNeptuneClusterParameterGroupRead(d *schema.ResourceData, meta in
 func resourceAwsNeptuneClusterParameterGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).neptuneconn
 
-	d.Partial(true)
-
 	if d.HasChange("parameter") {
 		o, n := d.GetChange("parameter")
 		if o == nil {
@@ -223,7 +221,6 @@ func resourceAwsNeptuneClusterParameterGroupUpdate(d *schema.ResourceData, meta 
 					return fmt.Errorf("Error modifying Neptune Cluster Parameter Group: %s", err)
 				}
 			}
-			d.SetPartial("parameter")
 		}
 	}
 
@@ -233,11 +230,7 @@ func resourceAwsNeptuneClusterParameterGroupUpdate(d *schema.ResourceData, meta 
 		if err := keyvaluetags.NeptuneUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
 			return fmt.Errorf("error updating Neptune Cluster Parameter Group (%s) tags: %s", d.Get("arn").(string), err)
 		}
-
-		d.SetPartial("tags")
 	}
-
-	d.Partial(false)
 
 	return resourceAwsNeptuneClusterParameterGroupRead(d, meta)
 }

--- a/aws/resource_aws_neptune_event_subscription.go
+++ b/aws/resource_aws_neptune_event_subscription.go
@@ -206,7 +206,6 @@ func resourceAwsNeptuneEventSubscriptionRead(d *schema.ResourceData, meta interf
 func resourceAwsNeptuneEventSubscriptionUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).neptuneconn
 
-	d.Partial(true)
 	requestUpdate := false
 
 	req := &neptune.ModifyEventSubscriptionInput{
@@ -262,10 +261,6 @@ func resourceAwsNeptuneEventSubscriptionUpdate(d *schema.ResourceData, meta inte
 		if err != nil {
 			return err
 		}
-		d.SetPartial("event_categories")
-		d.SetPartial("enabled")
-		d.SetPartial("sns_topic_arn")
-		d.SetPartial("source_type")
 	}
 
 	if d.HasChange("tags") {
@@ -274,8 +269,6 @@ func resourceAwsNeptuneEventSubscriptionUpdate(d *schema.ResourceData, meta inte
 		if err := keyvaluetags.NeptuneUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
 			return fmt.Errorf("error updating Neptune Cluster Event Subscription (%s) tags: %s", d.Get("arn").(string), err)
 		}
-
-		d.SetPartial("tags")
 	}
 
 	if d.HasChange("source_ids") {
@@ -317,10 +310,7 @@ func resourceAwsNeptuneEventSubscriptionUpdate(d *schema.ResourceData, meta inte
 				}
 			}
 		}
-		d.SetPartial("source_ids")
 	}
-
-	d.Partial(false)
 
 	return resourceAwsNeptuneEventSubscriptionRead(d, meta)
 }

--- a/aws/resource_aws_neptune_parameter_group.go
+++ b/aws/resource_aws_neptune_parameter_group.go
@@ -97,12 +97,6 @@ func resourceAwsNeptuneParameterGroupCreate(d *schema.ResourceData, meta interfa
 		return fmt.Errorf("Error creating Neptune Parameter Group: %s", err)
 	}
 
-	d.Partial(true)
-	d.SetPartial("name")
-	d.SetPartial("family")
-	d.SetPartial("description")
-	d.Partial(false)
-
 	d.SetId(*resp.DBParameterGroup.DBParameterGroupName)
 	d.Set("arn", resp.DBParameterGroup.DBParameterGroupArn)
 	log.Printf("[INFO] Neptune Parameter Group ID: %s", d.Id())
@@ -177,8 +171,6 @@ func resourceAwsNeptuneParameterGroupRead(d *schema.ResourceData, meta interface
 
 func resourceAwsNeptuneParameterGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).neptuneconn
-
-	d.Partial(true)
 
 	if d.HasChange("parameter") {
 		o, n := d.GetChange("parameter")
@@ -255,8 +247,6 @@ func resourceAwsNeptuneParameterGroupUpdate(d *schema.ResourceData, meta interfa
 				return fmt.Errorf("Error modifying Neptune Parameter Group: %s", err)
 			}
 		}
-
-		d.SetPartial("parameter")
 	}
 
 	if !d.IsNewResource() && d.HasChange("tags") {
@@ -265,11 +255,7 @@ func resourceAwsNeptuneParameterGroupUpdate(d *schema.ResourceData, meta interfa
 		if err := keyvaluetags.NeptuneUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
 			return fmt.Errorf("error updating Neptune Parameter Group (%s) tags: %s", d.Get("arn").(string), err)
 		}
-
-		d.SetPartial("tags")
 	}
-
-	d.Partial(false)
 
 	return resourceAwsNeptuneParameterGroupRead(d, meta)
 }

--- a/aws/resource_aws_neptune_subnet_group.go
+++ b/aws/resource_aws_neptune_subnet_group.go
@@ -191,8 +191,6 @@ func resourceAwsNeptuneSubnetGroupUpdate(d *schema.ResourceData, meta interface{
 		if err := keyvaluetags.NeptuneUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
 			return fmt.Errorf("error updating Neptune Subnet Group (%s) tags: %s", d.Get("arn").(string), err)
 		}
-
-		d.SetPartial("tags")
 	}
 
 	return resourceAwsNeptuneSubnetGroupRead(d, meta)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12083
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12087

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
aws/resource_aws_neptune_cluster.go:597:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_neptune_cluster.go:684:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_neptune_cluster_instance.go:384:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_neptune_cluster_instance.go:390:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_neptune_cluster_instance.go:396:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_neptune_cluster_instance.go:402:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_neptune_cluster_instance.go:451:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_neptune_cluster_parameter_group.go:185:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_neptune_cluster_parameter_group.go:226:4: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_neptune_cluster_parameter_group.go:237:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_neptune_cluster_parameter_group.go:240:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_neptune_event_subscription.go:209:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_neptune_event_subscription.go:265:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_neptune_event_subscription.go:266:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_neptune_event_subscription.go:267:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_neptune_event_subscription.go:268:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_neptune_event_subscription.go:278:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_neptune_event_subscription.go:320:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_neptune_event_subscription.go:323:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_neptune_parameter_group.go:100:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_neptune_parameter_group.go:101:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_neptune_parameter_group.go:102:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_neptune_parameter_group.go:103:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_neptune_parameter_group.go:104:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_neptune_parameter_group.go:181:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_neptune_parameter_group.go:259:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_neptune_parameter_group.go:269:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_neptune_parameter_group.go:272:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_neptune_subnet_group.go:195:3: R008: deprecated (schema.ResourceData).SetPartial
```

Output from acceptance testing:

```
--- PASS: TestAccAWSNeptuneCluster_backupsUpdate (297.92s)
--- PASS: TestAccAWSNeptuneCluster_basic (168.78s)
--- PASS: TestAccAWSNeptuneCluster_deleteProtection (212.60s)
--- PASS: TestAccAWSNeptuneCluster_encrypted (175.61s)
--- PASS: TestAccAWSNeptuneCluster_iamAuth (193.62s)
--- PASS: TestAccAWSNeptuneCluster_kmsKey (195.57s)
--- PASS: TestAccAWSNeptuneCluster_namePrefix (154.44s)
--- PASS: TestAccAWSNeptuneCluster_tags (209.12s)
--- PASS: TestAccAWSNeptuneCluster_takeFinalSnapshot (254.53s)
--- PASS: TestAccAWSNeptuneCluster_updateCloudwatchLogsExports (233.15s)
--- PASS: TestAccAWSNeptuneCluster_updateIamRoles (195.20s)

--- PASS: TestAccAWSNeptuneClusterInstance_basic (1755.23s)
--- PASS: TestAccAWSNeptuneClusterInstance_generatedName (785.56s)
--- PASS: TestAccAWSNeptuneClusterInstance_kmsKey (835.57s)
--- PASS: TestAccAWSNeptuneClusterInstance_namePrefix (807.49s)
--- PASS: TestAccAWSNeptuneClusterInstance_withaz (925.05s)
--- PASS: TestAccAWSNeptuneClusterInstance_withSubnetGroup (783.88s)

--- PASS: TestAccAWSNeptuneClusterParameterGroup_basic (17.40s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_Description (17.46s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_generatedName (17.68s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_namePrefix (20.77s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_Parameter (31.24s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_Tags (64.82s)

--- PASS: TestAccAWSNeptuneEventSubscription_basic (150.00s)
--- PASS: TestAccAWSNeptuneEventSubscription_withCategories (124.64s)
--- PASS: TestAccAWSNeptuneEventSubscription_withPrefix (123.58s)
--- PASS: TestAccAWSNeptuneEventSubscription_withSourceIds (97.81s)

--- PASS: TestAccAWSNeptuneParameterGroup_basic (28.51s)
--- PASS: TestAccAWSNeptuneParameterGroup_Description (22.30s)
--- PASS: TestAccAWSNeptuneParameterGroup_Parameter (114.91s)
--- PASS: TestAccAWSNeptuneParameterGroup_Tags (60.91s)

--- PASS: TestAccAWSNeptuneSubnetGroup_basic (46.02s)
--- PASS: TestAccAWSNeptuneSubnetGroup_generatedName (49.96s)
--- PASS: TestAccAWSNeptuneSubnetGroup_namePrefix (48.39s)
--- PASS: TestAccAWSNeptuneSubnetGroup_updateDescription (76.13s)
```
