### PR TITLE
service/elb: Remove deprecated (helper/schema.ResourceData).Partial() and (helper/schema.ResourceData).SetPartial()

### DIFF
--- a/aws/resource_aws_elb.go
+++ b/aws/resource_aws_elb.go
@@ -327,15 +327,6 @@ func resourceAwsElbCreate(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(elbName)
 	log.Printf("[INFO] ELB ID: %s", d.Id())
 
-	// Enable partial mode and record what we set
-	d.Partial(true)
-	d.SetPartial("name")
-	d.SetPartial("internal")
-	d.SetPartial("availability_zones")
-	d.SetPartial("listener")
-	d.SetPartial("security_groups")
-	d.SetPartial("subnets")
-
 	if err := d.Set("tags", keyvaluetags.ElbKeyValueTags(tags).IgnoreAws().Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
@@ -476,8 +467,6 @@ func flattenAwsELbResource(d *schema.ResourceData, ec2conn *ec2.EC2, elbconn *el
 func resourceAwsElbUpdate(d *schema.ResourceData, meta interface{}) error {
 	elbconn := meta.(*AWSClient).elbconn
 
-	d.Partial(true)
-
 	if d.HasChange("listener") {
 		o, n := d.GetChange("listener")
 		os := o.(*schema.Set)
@@ -541,8 +530,6 @@ func resourceAwsElbUpdate(d *schema.ResourceData, meta interface{}) error {
 				return fmt.Errorf("Failure adding new or updated ELB listeners: %s", err)
 			}
 		}
-
-		d.SetPartial("listener")
 	}
 
 	// If we currently have instances, or did have instances,
@@ -577,8 +564,6 @@ func resourceAwsElbUpdate(d *schema.ResourceData, meta interface{}) error {
 				return fmt.Errorf("Failure deregistering instances from ELB: %s", err)
 			}
 		}
-
-		d.SetPartial("instances")
 	}
 
 	if d.HasChange("cross_zone_load_balancing") || d.HasChange("idle_timeout") || d.HasChange("access_logs") {
@@ -615,10 +600,6 @@ func resourceAwsElbUpdate(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return fmt.Errorf("Failure configuring ELB attributes: %s", err)
 		}
-
-		d.SetPartial("cross_zone_load_balancing")
-		d.SetPartial("idle_timeout")
-		d.SetPartial("connection_draining_timeout")
 	}
 
 	// We have to do these changes separately from everything else since
@@ -643,8 +624,6 @@ func resourceAwsElbUpdate(d *schema.ResourceData, meta interface{}) error {
 			if err != nil {
 				return fmt.Errorf("Failure configuring ELB attributes: %s", err)
 			}
-
-			d.SetPartial("connection_draining_timeout")
 		}
 
 		// Then we always set connection draining even if there is no change.
@@ -663,8 +642,6 @@ func resourceAwsElbUpdate(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return fmt.Errorf("Failure configuring ELB attributes: %s", err)
 		}
-
-		d.SetPartial("connection_draining")
 	}
 
 	if d.HasChange("health_check") {
@@ -685,7 +662,6 @@ func resourceAwsElbUpdate(d *schema.ResourceData, meta interface{}) error {
 			if err != nil {
 				return fmt.Errorf("Failure configuring health check for ELB: %s", err)
 			}
-			d.SetPartial("health_check")
 		}
 	}
 
@@ -701,8 +677,6 @@ func resourceAwsElbUpdate(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return fmt.Errorf("Failure applying security groups to ELB: %s", err)
 		}
-
-		d.SetPartial("security_groups")
 	}
 
 	if d.HasChange("availability_zones") {
@@ -738,8 +712,6 @@ func resourceAwsElbUpdate(d *schema.ResourceData, meta interface{}) error {
 				return fmt.Errorf("Failure disabling ELB availability zones: %s", err)
 			}
 		}
-
-		d.SetPartial("availability_zones")
 	}
 
 	if d.HasChange("subnets") {
@@ -790,8 +762,6 @@ func resourceAwsElbUpdate(d *schema.ResourceData, meta interface{}) error {
 				return fmt.Errorf("Failure adding ELB subnets: %s", err)
 			}
 		}
-
-		d.SetPartial("subnets")
 	}
 
 	if d.HasChange("tags") {
@@ -801,13 +771,6 @@ func resourceAwsElbUpdate(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("error updating ELB(%s) tags: %s", d.Id(), err)
 		}
 	}
-
-	//if err := setTagsELB(elbconn, d); err != nil {
-	//	return err
-	//}
-	//
-	//d.SetPartial("tags")
-	d.Partial(false)
 
 	return resourceAwsElbRead(d, meta)
 }

--- a/aws/resource_aws_proxy_protocol_policy.go
+++ b/aws/resource_aws_proxy_protocol_policy.go
@@ -59,10 +59,7 @@ func resourceAwsProxyProtocolPolicyCreate(d *schema.ResourceData, meta interface
 			*input.PolicyName, err)
 	}
 
-	// Assign the policy name for use later
-	d.Partial(true)
 	d.SetId(fmt.Sprintf("%s:%s", *elbname, *input.PolicyName))
-	d.SetPartial("load_balancer")
 	log.Printf("[INFO] ELB PolicyName: %s", *input.PolicyName)
 
 	return resourceAwsProxyProtocolPolicyUpdate(d, meta)
@@ -119,7 +116,6 @@ func resourceAwsProxyProtocolPolicyUpdate(d *schema.ResourceData, meta interface
 	backends := flattenBackendPolicies(resp.LoadBalancerDescriptions[0].BackendServerDescriptions)
 	policyName := resourceAwsProxyProtocolPolicyParseId(d.Id())
 
-	d.Partial(true)
 	if d.HasChange("instance_ports") {
 		o, n := d.GetChange("instance_ports")
 		os := o.(*schema.Set)
@@ -147,8 +143,6 @@ func resourceAwsProxyProtocolPolicyUpdate(d *schema.ResourceData, meta interface
 				return fmt.Errorf("Error setting policy for backend: %s", err)
 			}
 		}
-
-		d.SetPartial("instance_ports")
 	}
 
 	return resourceAwsProxyProtocolPolicyRead(d, meta)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12083
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12087

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
aws/resource_aws_elb.go:331:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_elb.go:332:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_elb.go:333:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_elb.go:334:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_elb.go:335:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_elb.go:336:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_elb.go:337:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_elb.go:479:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_elb.go:545:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_elb.go:581:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_elb.go:619:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_elb.go:620:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_elb.go:621:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_elb.go:647:4: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_elb.go:667:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_elb.go:688:4: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_elb.go:705:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_elb.go:742:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_elb.go:794:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_elb.go:810:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_proxy_protocol_policy.go:122:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_proxy_protocol_policy.go:151:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_proxy_protocol_policy.go:63:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_proxy_protocol_policy.go:65:2: R008: deprecated (schema.ResourceData).SetPartial
```

Output from acceptance testing:

```
--- PASS: TestAccAWSELB_AccessLogs_disabled (275.08s)
--- PASS: TestAccAWSELB_AccessLogs_enabled (88.33s)
--- PASS: TestAccAWSELB_availabilityZones (67.63s)
--- PASS: TestAccAWSELB_basic (40.56s)
--- PASS: TestAccAWSELB_ConnectionDraining (222.97s)
--- PASS: TestAccAWSELB_disappears (132.48s)
--- PASS: TestAccAWSELB_fullCharacterRange (33.99s)
--- PASS: TestAccAWSELB_generatedName (26.07s)
--- PASS: TestAccAWSELB_generatesNameForZeroValue (84.50s)
--- PASS: TestAccAWSELB_HealthCheck (219.59s)
--- PASS: TestAccAWSELB_InstanceAttaching (173.37s)
--- PASS: TestAccAWSELB_listener (101.85s)
--- PASS: TestAccAWSELB_Listener_SSLCertificateID_IAMServerCertificate (42.66s)
--- PASS: TestAccAWSELB_namePrefix (59.05s)
--- PASS: TestAccAWSELB_SecurityGroups (171.23s)
--- PASS: TestAccAWSELB_swap_subnets (276.60s)
--- PASS: TestAccAWSELB_tags (95.49s)
--- PASS: TestAccAWSELB_Timeout (141.20s)

--- PASS: TestAccAWSProxyProtocolPolicy_basic (40.72s)
```