### PR TITLE
service/route53resolver: Remove deprecated (helper/schema.ResourceData).Partial() and (helper/schema.ResourceData).SetPartial()

### DIFF
--- a/aws/resource_aws_route53_resolver_endpoint.go
+++ b/aws/resource_aws_route53_resolver_endpoint.go
@@ -196,7 +196,6 @@ func resourceAwsRoute53ResolverEndpointRead(d *schema.ResourceData, meta interfa
 func resourceAwsRoute53ResolverEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).route53resolverconn
 
-	d.Partial(true)
 	if d.HasChange("name") {
 		req := &route53resolver.UpdateResolverEndpointInput{
 			ResolverEndpointId: aws.String(d.Id()),
@@ -215,8 +214,6 @@ func resourceAwsRoute53ResolverEndpointUpdate(d *schema.ResourceData, meta inter
 		if err != nil {
 			return err
 		}
-
-		d.SetPartial("name")
 	}
 
 	if d.HasChange("ip_address") {
@@ -260,8 +257,6 @@ func resourceAwsRoute53ResolverEndpointUpdate(d *schema.ResourceData, meta inter
 				return err
 			}
 		}
-
-		d.SetPartial("ip_address")
 	}
 
 	if d.HasChange("tags") {
@@ -269,10 +264,8 @@ func resourceAwsRoute53ResolverEndpointUpdate(d *schema.ResourceData, meta inter
 		if err := keyvaluetags.Route53resolverUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
 			return fmt.Errorf("error updating Route53 Resolver endpoint (%s) tags: %s", d.Get("arn").(string), err)
 		}
-		d.SetPartial("tags")
 	}
 
-	d.Partial(false)
 	return resourceAwsRoute53ResolverEndpointRead(d, meta)
 }
 

--- a/aws/resource_aws_route53_resolver_rule.go
+++ b/aws/resource_aws_route53_resolver_rule.go
@@ -188,7 +188,6 @@ func resourceAwsRoute53ResolverRuleRead(d *schema.ResourceData, meta interface{}
 func resourceAwsRoute53ResolverRuleUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).route53resolverconn
 
-	d.Partial(true)
 	if d.HasChange("name") || d.HasChange("resolver_endpoint_id") || d.HasChange("target_ip") {
 		req := &route53resolver.UpdateResolverRuleInput{
 			ResolverRuleId: aws.String(d.Id()),
@@ -216,10 +215,6 @@ func resourceAwsRoute53ResolverRuleUpdate(d *schema.ResourceData, meta interface
 		if err != nil {
 			return err
 		}
-
-		d.SetPartial("name")
-		d.SetPartial("resolver_endpoint_id")
-		d.SetPartial("target_ip")
 	}
 
 	if d.HasChange("tags") {
@@ -227,10 +222,8 @@ func resourceAwsRoute53ResolverRuleUpdate(d *schema.ResourceData, meta interface
 		if err := keyvaluetags.Route53resolverUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
 			return fmt.Errorf("error updating Route53 Resolver rule (%s) tags: %s", d.Get("arn").(string), err)
 		}
-		d.SetPartial("tags")
 	}
 
-	d.Partial(false)
 	return resourceAwsRoute53ResolverRuleRead(d, meta)
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12083
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12087

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
aws/resource_aws_route53_resolver_endpoint.go:199:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_route53_resolver_endpoint.go:219:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_route53_resolver_endpoint.go:264:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_route53_resolver_endpoint.go:272:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_route53_resolver_endpoint.go:275:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_route53_resolver_rule.go:191:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_route53_resolver_rule.go:220:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_route53_resolver_rule.go:221:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_route53_resolver_rule.go:222:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_route53_resolver_rule.go:230:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_route53_resolver_rule.go:233:2: R007: deprecated (schema.ResourceData).Partial
```

Output from acceptance testing:

```
--- PASS: TestAccAwsRoute53ResolverEndpoint_basicInbound (102.08s)
--- PASS: TestAccAwsRoute53ResolverEndpoint_updateOutbound (446.81s)
--- PASS: TestAccAwsRoute53ResolverRule_basic (39.84s)
--- PASS: TestAccAwsRoute53ResolverRule_forward (316.33s)
--- PASS: TestAccAwsRoute53ResolverRule_forwardEndpointRecreate (448.03s)
--- PASS: TestAccAwsRoute53ResolverRule_tags (66.35s)
--- PASS: TestAccAwsRoute53ResolverRule_updateName (62.64s)
```
