### PR TITLE
service/redshift: Remove deprecated (helper/schema.ResourceData).Partial() and (helper/schema.ResourceData).SetPartial()

### DIFF
--- a/aws/resource_aws_redshift_cluster.go
+++ b/aws/resource_aws_redshift_cluster.go
@@ -641,7 +641,6 @@ func resourceAwsRedshiftClusterRead(d *schema.ResourceData, meta interface{}) er
 
 func resourceAwsRedshiftClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).redshiftconn
-	d.Partial(true)
 
 	if d.HasChange("tags") {
 		o, n := d.GetChange("tags")
@@ -649,8 +648,6 @@ func resourceAwsRedshiftClusterUpdate(d *schema.ResourceData, meta interface{}) 
 		if err := keyvaluetags.RedshiftUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
 			return fmt.Errorf("error updating Redshift Cluster (%s) tags: %s", d.Get("arn").(string), err)
 		}
-
-		d.SetPartial("tags")
 	}
 
 	requestUpdate := false
@@ -770,8 +767,6 @@ func resourceAwsRedshiftClusterUpdate(d *schema.ResourceData, meta interface{}) 
 		if err != nil {
 			return fmt.Errorf("Error modifying Redshift Cluster IAM Roles (%s): %s", d.Id(), err)
 		}
-
-		d.SetPartial("iam_roles")
 	}
 
 	if requestUpdate || d.HasChange("iam_roles") {
@@ -824,8 +819,6 @@ func resourceAwsRedshiftClusterUpdate(d *schema.ResourceData, meta interface{}) 
 			}
 		}
 	}
-
-	d.Partial(false)
 
 	return resourceAwsRedshiftClusterRead(d, meta)
 }

--- a/aws/resource_aws_redshift_event_subscription.go
+++ b/aws/resource_aws_redshift_event_subscription.go
@@ -188,8 +188,6 @@ func resourceAwsRedshiftEventSubscriptionRetrieve(name string, conn *redshift.Re
 func resourceAwsRedshiftEventSubscriptionUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).redshiftconn
 
-	d.Partial(true)
-
 	req := &redshift.ModifyEventSubscriptionInput{
 		SubscriptionName: aws.String(d.Id()),
 		SnsTopicArn:      aws.String(d.Get("sns_topic_arn").(string)),
@@ -212,11 +210,7 @@ func resourceAwsRedshiftEventSubscriptionUpdate(d *schema.ResourceData, meta int
 		if err := keyvaluetags.RedshiftUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
 			return fmt.Errorf("error updating Redshift Event Subscription (%s) tags: %s", d.Get("arn").(string), err)
 		}
-
-		d.SetPartial("tags")
 	}
-
-	d.Partial(false)
 
 	return nil
 }

--- a/aws/resource_aws_redshift_parameter_group.go
+++ b/aws/resource_aws_redshift_parameter_group.go
@@ -165,8 +165,6 @@ func resourceAwsRedshiftParameterGroupRead(d *schema.ResourceData, meta interfac
 func resourceAwsRedshiftParameterGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).redshiftconn
 
-	d.Partial(true)
-
 	if d.HasChange("parameter") {
 		o, n := d.GetChange("parameter")
 		if o == nil {
@@ -197,7 +195,6 @@ func resourceAwsRedshiftParameterGroupUpdate(d *schema.ResourceData, meta interf
 				return fmt.Errorf("Error modifying Redshift Parameter Group: %s", err)
 			}
 		}
-		d.SetPartial("parameter")
 	}
 
 	if d.HasChange("tags") {
@@ -206,11 +203,8 @@ func resourceAwsRedshiftParameterGroupUpdate(d *schema.ResourceData, meta interf
 		if err := keyvaluetags.RedshiftUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
 			return fmt.Errorf("error updating Redshift Parameter Group (%s) tags: %s", d.Get("arn").(string), err)
 		}
-
-		d.SetPartial("tags")
 	}
 
-	d.Partial(false)
 	return resourceAwsRedshiftParameterGroupRead(d, meta)
 }
 

--- a/aws/resource_aws_redshift_snapshot_copy_grant.go
+++ b/aws/resource_aws_redshift_snapshot_copy_grant.go
@@ -115,19 +115,13 @@ func resourceAwsRedshiftSnapshotCopyGrantRead(d *schema.ResourceData, meta inter
 func resourceAwsRedshiftSnapshotCopyGrantUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).redshiftconn
 
-	d.Partial(true)
-
 	if d.HasChange("tags") {
 		o, n := d.GetChange("tags")
 
 		if err := keyvaluetags.RedshiftUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
 			return fmt.Errorf("error updating Redshift Snapshot Copy Grant (%s) tags: %s", d.Get("arn").(string), err)
 		}
-
-		d.SetPartial("tags")
 	}
-
-	d.Partial(false)
 
 	return resourceAwsRedshiftSnapshotCopyGrantRead(d, meta)
 }

--- a/aws/resource_aws_redshift_snapshot_schedule.go
+++ b/aws/resource_aws_redshift_snapshot_schedule.go
@@ -139,7 +139,6 @@ func resourceAwsRedshiftSnapshotScheduleRead(d *schema.ResourceData, meta interf
 
 func resourceAwsRedshiftSnapshotScheduleUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).redshiftconn
-	d.Partial(true)
 
 	if d.HasChange("tags") {
 		o, n := d.GetChange("tags")
@@ -147,8 +146,6 @@ func resourceAwsRedshiftSnapshotScheduleUpdate(d *schema.ResourceData, meta inte
 		if err := keyvaluetags.RedshiftUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
 			return fmt.Errorf("error updating Redshift Snapshot Schedule (%s) tags: %s", d.Get("arn").(string), err)
 		}
-
-		d.SetPartial("tags")
 	}
 
 	if d.HasChange("definitions") {
@@ -165,7 +162,6 @@ func resourceAwsRedshiftSnapshotScheduleUpdate(d *schema.ResourceData, meta inte
 		if err != nil {
 			return fmt.Errorf("Error modifying Redshift Snapshot Schedule %s: %s", d.Id(), err)
 		}
-		d.SetPartial("definitions")
 	}
 
 	return resourceAwsRedshiftSnapshotScheduleRead(d, meta)

--- a/aws/resource_aws_redshift_subnet_group.go
+++ b/aws/resource_aws_redshift_subnet_group.go
@@ -124,7 +124,6 @@ func resourceAwsRedshiftSubnetGroupRead(d *schema.ResourceData, meta interface{}
 
 func resourceAwsRedshiftSubnetGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).redshiftconn
-	d.Partial(true)
 
 	if d.HasChange("tags") {
 		o, n := d.GetChange("tags")
@@ -132,8 +131,6 @@ func resourceAwsRedshiftSubnetGroupUpdate(d *schema.ResourceData, meta interface
 		if err := keyvaluetags.RedshiftUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
 			return fmt.Errorf("error updating Redshift Subnet Group (%s) tags: %s", d.Get("arn").(string), err)
 		}
-
-		d.SetPartial("tags")
 	}
 
 	if d.HasChange("subnet_ids") || d.HasChange("description") {
@@ -158,8 +155,6 @@ func resourceAwsRedshiftSubnetGroupUpdate(d *schema.ResourceData, meta interface
 			return err
 		}
 	}
-
-	d.Partial(false)
 
 	return resourceAwsRedshiftSubnetGroupRead(d, meta)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12083
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12087

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
aws/resource_aws_redshift_cluster.go:644:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_redshift_cluster.go:653:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_redshift_cluster.go:774:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_redshift_cluster.go:828:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_redshift_event_subscription.go:191:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_redshift_event_subscription.go:216:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_redshift_event_subscription.go:219:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_redshift_parameter_group.go:168:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_redshift_parameter_group.go:200:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_redshift_parameter_group.go:210:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_redshift_parameter_group.go:213:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_redshift_snapshot_copy_grant.go:118:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_redshift_snapshot_copy_grant.go:127:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_redshift_snapshot_copy_grant.go:130:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_redshift_snapshot_schedule.go:142:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_redshift_snapshot_schedule.go:151:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_redshift_snapshot_schedule.go:168:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_redshift_subnet_group.go:127:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_redshift_subnet_group.go:136:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_redshift_subnet_group.go:162:2: R007: deprecated (schema.ResourceData).Partial
```

Output from acceptance testing (failure present on master):

```
--- PASS: TestAccAWSRedshiftCluster_basic (374.33s)
--- PASS: TestAccAWSRedshiftCluster_changeAvailabilityZone (664.68s)
--- PASS: TestAccAWSRedshiftCluster_changeEncryption1 (2088.45s)
--- PASS: TestAccAWSRedshiftCluster_changeEncryption2 (1868.48s)
--- PASS: TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled (959.29s)
--- PASS: TestAccAWSRedshiftCluster_forceNewUsername (1672.20s)
--- PASS: TestAccAWSRedshiftCluster_iamRoles (824.30s)
--- PASS: TestAccAWSRedshiftCluster_kmsKey (1387.64s)
--- PASS: TestAccAWSRedshiftCluster_loggingEnabled (1178.50s)
--- PASS: TestAccAWSRedshiftCluster_publiclyAccessible (1435.60s)
--- PASS: TestAccAWSRedshiftCluster_snapshotCopy (434.54s)
--- PASS: TestAccAWSRedshiftCluster_tags (476.81s)
--- PASS: TestAccAWSRedshiftCluster_updateNodeCount (3699.47s)
--- PASS: TestAccAWSRedshiftCluster_updateNodeType (1911.25s)
--- PASS: TestAccAWSRedshiftCluster_withFinalSnapshot (1449.68s)

--- PASS: TestAccAWSRedshiftEventSubscription_basicUpdate (41.61s)
--- PASS: TestAccAWSRedshiftEventSubscription_categoryUpdate (51.13s)
--- PASS: TestAccAWSRedshiftEventSubscription_tagsUpdate (145.74s)
--- PASS: TestAccAWSRedshiftEventSubscription_withPrefix (44.47s)
--- PASS: TestAccAWSRedshiftEventSubscription_withSourceIds (84.82s)

--- PASS: TestAccAWSRedshiftParameterGroup_basic (44.40s)
--- PASS: TestAccAWSRedshiftParameterGroup_withoutParameters (76.56s)
--- PASS: TestAccAWSRedshiftParameterGroup_withParameters (27.47s)
--- PASS: TestAccAWSRedshiftParameterGroup_withTags (101.82s)

--- PASS: TestAccAWSRedshiftSnapshotCopyGrant_Basic (34.09s)
--- PASS: TestAccAWSRedshiftSnapshotCopyGrant_Update (74.12s)

--- FAIL: TestAccAWSRedshiftSnapshotSchedule_withForceDestroy (314.27s)
--- PASS: TestAccAWSRedshiftSnapshotSchedule_basic (55.17s)
--- PASS: TestAccAWSRedshiftSnapshotSchedule_withDescription (48.15s)
--- PASS: TestAccAWSRedshiftSnapshotSchedule_withIdentifierPrefix (44.69s)
--- PASS: TestAccAWSRedshiftSnapshotSchedule_withMultipleDefinition (37.15s)
--- PASS: TestAccAWSRedshiftSnapshotSchedule_withTags (97.33s)

--- PASS: TestAccAWSRedshiftSubnetGroup_basic (41.15s)
--- PASS: TestAccAWSRedshiftSubnetGroup_tags (64.37s)
--- PASS: TestAccAWSRedshiftSubnetGroup_updateDescription (67.68s)
--- PASS: TestAccAWSRedshiftSubnetGroup_updateSubnetIds (59.10s)
```
