### PR TITLE
service/sagemaker: Remove deprecated (helper/schema.ResourceData).Partial() and (helper/schema.ResourceData).SetPartial()

### DIFF
--- a/aws/resource_aws_sagemaker_endpoint.go
+++ b/aws/resource_aws_sagemaker_endpoint.go
@@ -132,8 +132,6 @@ func resourceAwsSagemakerEndpointRead(d *schema.ResourceData, meta interface{}) 
 func resourceAwsSagemakerEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).sagemakerconn
 
-	d.Partial(true)
-
 	if d.HasChange("tags") {
 		o, n := d.GetChange("tags")
 
@@ -141,7 +139,6 @@ func resourceAwsSagemakerEndpointUpdate(d *schema.ResourceData, meta interface{}
 			return fmt.Errorf("error updating Sagemaker Endpoint (%s) tags: %s", d.Id(), err)
 		}
 	}
-	d.SetPartial("tags")
 
 	if d.HasChange("endpoint_config_name") {
 		modifyOpts := &sagemaker.UpdateEndpointInput{
@@ -153,7 +150,6 @@ func resourceAwsSagemakerEndpointUpdate(d *schema.ResourceData, meta interface{}
 		if _, err := conn.UpdateEndpoint(modifyOpts); err != nil {
 			return fmt.Errorf("error updating SageMaker Endpoint (%s): %s", d.Id(), err)
 		}
-		d.SetPartial("endpoint_config_name")
 
 		describeInput := &sagemaker.DescribeEndpointInput{
 			EndpointName: aws.String(d.Id()),
@@ -164,8 +160,6 @@ func resourceAwsSagemakerEndpointUpdate(d *schema.ResourceData, meta interface{}
 			return fmt.Errorf("error waiting for SageMaker Endpoint (%s) to be in service: %s", d.Id(), err)
 		}
 	}
-
-	d.Partial(false)
 
 	return resourceAwsSagemakerEndpointRead(d, meta)
 }

--- a/aws/resource_aws_sagemaker_model.go
+++ b/aws/resource_aws_sagemaker_model.go
@@ -281,8 +281,6 @@ func flattenSageMakerVpcConfigResponse(vpcConfig *sagemaker.VpcConfig) []map[str
 func resourceAwsSagemakerModelUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).sagemakerconn
 
-	d.Partial(true)
-
 	if d.HasChange("tags") {
 		o, n := d.GetChange("tags")
 
@@ -290,8 +288,6 @@ func resourceAwsSagemakerModelUpdate(d *schema.ResourceData, meta interface{}) e
 			return fmt.Errorf("error updating Sagemaker Model (%s) tags: %s", d.Id(), err)
 		}
 	}
-
-	d.Partial(false)
 
 	return resourceAwsSagemakerModelRead(d, meta)
 }

--- a/aws/resource_aws_sagemaker_notebook_instance.go
+++ b/aws/resource_aws_sagemaker_notebook_instance.go
@@ -214,8 +214,6 @@ func resourceAwsSagemakerNotebookInstanceRead(d *schema.ResourceData, meta inter
 func resourceAwsSagemakerNotebookInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).sagemakerconn
 
-	d.Partial(true)
-
 	if d.HasChange("tags") {
 		o, n := d.GetChange("tags")
 
@@ -223,7 +221,6 @@ func resourceAwsSagemakerNotebookInstanceUpdate(d *schema.ResourceData, meta int
 			return fmt.Errorf("error updating Sagemaker Notebook Instance (%s) tags: %s", d.Id(), err)
 		}
 	}
-	d.SetPartial("tags")
 
 	hasChanged := false
 	// Update
@@ -324,8 +321,6 @@ func resourceAwsSagemakerNotebookInstanceUpdate(d *schema.ResourceData, meta int
 			}
 		}
 	}
-
-	d.Partial(false)
 
 	return resourceAwsSagemakerNotebookInstanceRead(d, meta)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12083
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12087

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
aws/resource_aws_sagemaker_endpoint.go:135:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_sagemaker_endpoint.go:144:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_sagemaker_endpoint.go:156:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_sagemaker_endpoint.go:168:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_sagemaker_model.go:284:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_sagemaker_model.go:294:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_sagemaker_notebook_instance.go:217:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_sagemaker_notebook_instance.go:226:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_sagemaker_notebook_instance.go:328:2: R007: deprecated (schema.ResourceData).Partial
```

Output from acceptance testing:

```
--- PASS: TestAccAWSSagemakerEndpoint_basic (485.91s)
--- PASS: TestAccAWSSagemakerEndpoint_EndpointConfigName (852.16s)
--- PASS: TestAccAWSSagemakerEndpoint_Tags (525.67s)

--- PASS: TestAccAWSSagemakerModel_basic (47.36s)
--- PASS: TestAccAWSSagemakerModel_containers (35.84s)
--- PASS: TestAccAWSSagemakerModel_networkIsolation (59.84s)
--- PASS: TestAccAWSSagemakerModel_primaryContainerEnvironment (33.08s)
--- PASS: TestAccAWSSagemakerModel_primaryContainerHostname (30.86s)
--- PASS: TestAccAWSSagemakerModel_primaryContainerModelDataUrl (57.54s)
--- PASS: TestAccAWSSagemakerModel_tags (42.35s)
--- PASS: TestAccAWSSagemakerModel_vpcConfig (62.13s)

--- PASS: TestAccAWSSagemakerNotebookInstance_basic (359.34s)
--- PASS: TestAccAWSSagemakerNotebookInstance_direct_internet_access (714.40s)
--- PASS: TestAccAWSSagemakerNotebookInstance_disappears (396.62s)
--- PASS: TestAccAWSSagemakerNotebookInstance_LifecycleConfigName (296.66s)
--- PASS: TestAccAWSSagemakerNotebookInstance_tags (411.90s)
--- PASS: TestAccAWSSagemakerNotebookInstance_update (625.72s)
```
