### PR TITLE
resource/aws_directory_service_directory: Remove deprecated (helper/schema.ResourceData).Partial() and (helper/schema.ResourceData).SetPartial()

### DIFF
--- a/aws/resource_aws_directory_service_directory.go
+++ b/aws/resource_aws_directory_service_directory.go
@@ -314,8 +314,6 @@ func createActiveDirectoryService(dsconn *directoryservice.DirectoryService, d *
 }
 
 func enableDirectoryServiceSso(dsconn *directoryservice.DirectoryService, d *schema.ResourceData) error {
-	d.SetPartial("enable_sso")
-
 	if v, ok := d.GetOk("enable_sso"); ok && v.(bool) {
 		log.Printf("[DEBUG] Enabling SSO for DS directory %q", d.Id())
 		if _, err := dsconn.EnableSso(&directoryservice.EnableSsoInput{
@@ -388,8 +386,6 @@ func resourceAwsDirectoryServiceDirectoryCreate(d *schema.ResourceData, meta int
 	}
 
 	if v, ok := d.GetOk("alias"); ok {
-		d.SetPartial("alias")
-
 		input := directoryservice.CreateAliasInput{
 			DirectoryId: aws.String(d.Id()),
 			Alias:       aws.String(v.(string)),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12083
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12087

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
aws/resource_aws_directory_service_directory.go:317:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_directory_service_directory.go:391:3: R008: deprecated (schema.ResourceData).SetPartial
```

Output from acceptance testing:

```
--- PASS: TestAccAWSDirectoryServiceDirectory_basic (488.80s)
--- PASS: TestAccAWSDirectoryServiceDirectory_connector (968.66s)
--- PASS: TestAccAWSDirectoryServiceDirectory_microsoft (1688.96s)
--- PASS: TestAccAWSDirectoryServiceDirectory_microsoftStandard (1824.96s)
--- PASS: TestAccAWSDirectoryServiceDirectory_tags (623.46s)
--- PASS: TestAccAWSDirectoryServiceDirectory_withAliasAndSso (584.98s)
```
