### PR TITLE
resource/aws_autoscaling_group: Remove deprecated (helper/schema.ResourceData).Partial() and (helper/schema.ResourceData).SetPartial()

### DIFF
--- a/aws/resource_aws_autoscaling_group.go
+++ b/aws/resource_aws_autoscaling_group.go
@@ -945,18 +945,9 @@ func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	if d.HasChange("tag") {
-		d.SetPartial("tag")
-	}
-
-	if d.HasChange("tags") {
-		d.SetPartial("tags")
-	}
-
 	log.Printf("[DEBUG] AutoScaling Group update configuration: %#v", opts)
 	_, err := conn.UpdateAutoScalingGroup(&opts)
 	if err != nil {
-		d.Partial(true)
 		return fmt.Errorf("Error updating Autoscaling group: %s", err)
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12083
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12087

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
aws/resource_aws_autoscaling_group.go:949:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_autoscaling_group.go:953:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_autoscaling_group.go:959:3: R007: deprecated (schema.ResourceData).Partial
```

Output from acceptance testing:

```
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups (221.26s)
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity (300.96s)
--- PASS: TestAccAWSAutoScalingGroup_autoGeneratedName (82.26s)
--- PASS: TestAccAWSAutoScalingGroup_basic (385.26s)
--- PASS: TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier (78.87s)
--- PASS: TestAccAWSAutoScalingGroup_emptyAvailabilityZones (96.80s)
--- PASS: TestAccAWSAutoScalingGroup_enablingMetrics (193.31s)
--- PASS: TestAccAWSAutoScalingGroup_initialLifecycleHook (360.02s)
--- PASS: TestAccAWSAutoScalingGroup_launchTemplate (73.68s)
--- PASS: TestAccAWSAutoScalingGroup_LaunchTemplate_IAMInstanceProfile (55.71s)
--- PASS: TestAccAWSAutoScalingGroup_launchTemplate_update (170.76s)
--- PASS: TestAccAWSAutoScalingGroup_LoadBalancers (569.35s)
--- PASS: TestAccAWSAutoScalingGroup_MaxInstanceLifetime (111.74s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy (52.49s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandAllocationStrategy (48.81s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandBaseCapacity (145.14s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandPercentageAboveBaseCapacity (80.84s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotAllocationStrategy (45.67s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotInstancePools (106.02s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotMaxPrice (110.26s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_LaunchTemplateName (109.23s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_Version (81.39s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_InstanceType (81.21s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_WeightedCapacity (167.25s)
--- PASS: TestAccAWSAutoScalingGroup_namePrefix (54.31s)
--- PASS: TestAccAWSAutoScalingGroup_serviceLinkedRoleARN (164.35s)
--- PASS: TestAccAWSAutoScalingGroup_suspendingProcesses (178.65s)
--- PASS: TestAccAWSAutoScalingGroup_tags (215.41s)
--- PASS: TestAccAWSAutoScalingGroup_TargetGroupArns (291.79s)
--- PASS: TestAccAWSAutoScalingGroup_terminationPolicies (113.05s)
--- PASS: TestAccAWSAutoScalingGroup_VpcUpdates (79.41s)
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer (372.04s)
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer_ToTargetGroup (353.81s)
--- PASS: TestAccAWSAutoScalingGroup_withMetrics (173.70s)
--- PASS: TestAccAWSAutoScalingGroup_withPlacementGroup (177.06s)
```
