### PR TITLE
service/ec2: Remove deprecated (helper/schema.ResourceData).Partial() and (helper/schema.ResourceData).SetPartial()

### DIFF
--- a/aws/resource_aws_ami.go
+++ b/aws/resource_aws_ami.go
@@ -411,8 +411,6 @@ func resourceAwsAmiRead(d *schema.ResourceData, meta interface{}) error {
 func resourceAwsAmiUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*AWSClient).ec2conn
 
-	d.Partial(true)
-
 	if d.HasChange("tags") {
 		o, n := d.GetChange("tags")
 
@@ -431,10 +429,7 @@ func resourceAwsAmiUpdate(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return err
 		}
-		d.SetPartial("description")
 	}
-
-	d.Partial(false)
 
 	return resourceAwsAmiRead(d, meta)
 }

--- a/aws/resource_aws_ami_copy.go
+++ b/aws/resource_aws_ami_copy.go
@@ -215,10 +215,7 @@ func resourceAwsAmiCopyCreate(d *schema.ResourceData, meta interface{}) error {
 
 	id := *res.ImageId
 	d.SetId(id)
-	d.Partial(true) // make sure we record the id even if the rest of this gets interrupted
 	d.Set("manage_ebs_snapshots", true)
-	d.SetPartial("manage_ebs_snapshots")
-	d.Partial(false)
 
 	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
 		if err := keyvaluetags.Ec2UpdateTags(client, id, nil, v); err != nil {

--- a/aws/resource_aws_ami_from_instance.go
+++ b/aws/resource_aws_ami_from_instance.go
@@ -197,10 +197,7 @@ func resourceAwsAmiFromInstanceCreate(d *schema.ResourceData, meta interface{}) 
 
 	id := *res.ImageId
 	d.SetId(id)
-	d.Partial(true) // make sure we record the id even if the rest of this gets interrupted
 	d.Set("manage_ebs_snapshots", true)
-	d.SetPartial("manage_ebs_snapshots")
-	d.Partial(false)
 
 	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
 		if err := keyvaluetags.Ec2UpdateTags(client, id, nil, v); err != nil {

--- a/aws/resource_aws_default_network_acl.go
+++ b/aws/resource_aws_default_network_acl.go
@@ -169,7 +169,6 @@ func resourceAwsDefaultNetworkAclCreate(d *schema.ResourceData, meta interface{}
 
 func resourceAwsDefaultNetworkAclUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
-	d.Partial(true)
 
 	if d.HasChange("ingress") {
 		err := updateNetworkAclEntries(d, "ingress", conn)
@@ -241,7 +240,6 @@ func resourceAwsDefaultNetworkAclUpdate(d *schema.ResourceData, meta interface{}
 		}
 	}
 
-	d.Partial(false)
 	// Re-use the exiting Network ACL Resources READ method
 	return resourceAwsNetworkAclRead(d, meta)
 }

--- a/aws/resource_aws_ec2_client_vpn_endpoint.go
+++ b/aws/resource_aws_ec2_client_vpn_endpoint.go
@@ -266,8 +266,6 @@ func resourceAwsEc2ClientVpnEndpointDelete(d *schema.ResourceData, meta interfac
 func resourceAwsEc2ClientVpnEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	d.Partial(true)
-
 	req := &ec2.ModifyClientVpnEndpointInput{
 		ClientVpnEndpointId: aws.String(d.Id()),
 	}
@@ -334,7 +332,6 @@ func resourceAwsEc2ClientVpnEndpointUpdate(d *schema.ResourceData, meta interfac
 		}
 	}
 
-	d.Partial(false)
 	return resourceAwsEc2ClientVpnEndpointRead(d, meta)
 }
 

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -915,16 +915,12 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	d.Partial(true)
-
 	if d.HasChange("tags") && !d.IsNewResource() {
 		o, n := d.GetChange("tags")
 
 		if err := keyvaluetags.Ec2UpdateTags(conn, d.Id(), o, n); err != nil {
 			return fmt.Errorf("error updating tags: %s", err)
 		}
-
-		d.SetPartial("tags")
 	}
 
 	if d.HasChange("volume_tags") && !d.IsNewResource() {
@@ -940,8 +936,6 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 				return fmt.Errorf("error updating volume_tags (%s): %s", volumeId, err)
 			}
 		}
-
-		d.SetPartial("volume_tags")
 	}
 
 	if d.HasChange("iam_instance_profile") && !d.IsNewResource() {
@@ -1213,8 +1207,6 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	// TODO(mitchellh): wait for the attributes we modified to
 	// persist the change...
-
-	d.Partial(false)
 
 	return resourceAwsInstanceRead(d, meta)
 }

--- a/aws/resource_aws_network_acl.go
+++ b/aws/resource_aws_network_acl.go
@@ -251,7 +251,6 @@ func resourceAwsNetworkAclRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceAwsNetworkAclUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
-	d.Partial(true)
 
 	if d.HasChange("ingress") {
 		err := updateNetworkAclEntries(d, "ingress", conn)
@@ -335,7 +334,6 @@ func resourceAwsNetworkAclUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	d.Partial(false)
 	return resourceAwsNetworkAclRead(d, meta)
 }
 

--- a/aws/resource_aws_network_interface.go
+++ b/aws/resource_aws_network_interface.go
@@ -261,7 +261,6 @@ func resourceAwsNetworkInterfaceDetach(oa *schema.Set, meta interface{}, eniId s
 
 func resourceAwsNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
-	d.Partial(true)
 
 	if d.HasChange("attachment") {
 		oa, na := d.GetChange("attachment")
@@ -285,8 +284,6 @@ func resourceAwsNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{})
 				return fmt.Errorf("Error attaching ENI: %s", attach_err)
 			}
 		}
-
-		d.SetPartial("attachment")
 	}
 
 	if d.HasChange("private_ips") {
@@ -326,8 +323,6 @@ func resourceAwsNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{})
 				return fmt.Errorf("Failure to assign Private IPs: %s", err)
 			}
 		}
-
-		d.SetPartial("private_ips")
 	}
 
 	// ModifyNetworkInterfaceAttribute needs to be called after creating an ENI
@@ -342,8 +337,6 @@ func resourceAwsNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{})
 		if err != nil {
 			return fmt.Errorf("Failure updating ENI: %s", err)
 		}
-
-		d.SetPartial("source_dest_check")
 	}
 
 	if d.HasChange("private_ips_count") && !d.IsNewResource() {
@@ -384,8 +377,6 @@ func resourceAwsNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{})
 					return fmt.Errorf("Failure to unassign Private IPs: %s", err)
 				}
 			}
-
-			d.SetPartial("private_ips_count")
 		}
 	}
 
@@ -399,8 +390,6 @@ func resourceAwsNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{})
 		if err != nil {
 			return fmt.Errorf("Failure updating ENI: %s", err)
 		}
-
-		d.SetPartial("security_groups")
 	}
 
 	if d.HasChange("description") {
@@ -413,8 +402,6 @@ func resourceAwsNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{})
 		if err != nil {
 			return fmt.Errorf("Failure updating ENI: %s", err)
 		}
-
-		d.SetPartial("description")
 	}
 
 	if d.HasChange("tags") {
@@ -424,8 +411,6 @@ func resourceAwsNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{})
 			return fmt.Errorf("error updating EC2 Network Interface (%s) tags: %s", d.Id(), err)
 		}
 	}
-
-	d.Partial(false)
 
 	return resourceAwsNetworkInterfaceRead(d, meta)
 }

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -1197,8 +1197,6 @@ func resourceAwsSpotFleetRequestUpdate(d *schema.ResourceData, meta interface{})
 	// http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifySpotFleetRequest.html
 	conn := meta.(*AWSClient).ec2conn
 
-	d.Partial(true)
-
 	req := &ec2.ModifySpotFleetRequestInput{
 		SpotFleetRequestId: aws.String(d.Id()),
 	}

--- a/aws/resource_aws_subnet.go
+++ b/aws/resource_aws_subnet.go
@@ -164,8 +164,6 @@ func resourceAwsSubnetCreate(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return fmt.Errorf("error adding tags: %s", err)
 		}
-
-		d.SetPartial("tags")
 	}
 
 	// You cannot modify multiple subnet attributes in the same request.
@@ -182,8 +180,6 @@ func resourceAwsSubnetCreate(d *schema.ResourceData, meta interface{}) error {
 		if _, err := conn.ModifySubnetAttribute(input); err != nil {
 			return fmt.Errorf("error enabling EC2 Subnet (%s) assign IPv6 address on creation: %s", d.Id(), err)
 		}
-
-		d.SetPartial("assign_ipv6_address_on_creation")
 	}
 
 	if d.Get("map_public_ip_on_launch").(bool) {
@@ -197,11 +193,7 @@ func resourceAwsSubnetCreate(d *schema.ResourceData, meta interface{}) error {
 		if _, err := conn.ModifySubnetAttribute(input); err != nil {
 			return fmt.Errorf("error enabling EC2 Subnet (%s) map public IP on launch: %s", d.Id(), err)
 		}
-
-		d.SetPartial("map_public_ip_on_launch")
 	}
-
-	d.Partial(false)
 
 	return resourceAwsSubnetRead(d, meta)
 }
@@ -262,16 +254,12 @@ func resourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 func resourceAwsSubnetUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	d.Partial(true)
-
 	if d.HasChange("tags") {
 		o, n := d.GetChange("tags")
 
 		if err := keyvaluetags.Ec2UpdateTags(conn, d.Id(), o, n); err != nil {
 			return fmt.Errorf("error updating EC2 Subnet (%s) tags: %s", d.Id(), err)
 		}
-
-		d.SetPartial("tags")
 	}
 
 	if d.HasChange("map_public_ip_on_launch") {
@@ -288,8 +276,6 @@ func resourceAwsSubnetUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		if err != nil {
 			return err
-		} else {
-			d.SetPartial("map_public_ip_on_launch")
 		}
 	}
 
@@ -357,8 +343,6 @@ func resourceAwsSubnetUpdate(d *schema.ResourceData, meta interface{}) error {
 				"Error waiting for IPv6 CIDR (%s) to become associated: %s",
 				d.Id(), err)
 		}
-
-		d.SetPartial("ipv6_cidr_block")
 	}
 
 	if d.HasChange("assign_ipv6_address_on_creation") {
@@ -375,12 +359,8 @@ func resourceAwsSubnetUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		if err != nil {
 			return err
-		} else {
-			d.SetPartial("assign_ipv6_address_on_creation")
 		}
 	}
-
-	d.Partial(false)
 
 	return resourceAwsSubnetRead(d, meta)
 }

--- a/aws/resource_aws_vpc.go
+++ b/aws/resource_aws_vpc.go
@@ -145,10 +145,6 @@ func resourceAwsVpcCreate(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(*vpc.VpcId)
 	log.Printf("[INFO] VPC ID: %s", d.Id())
 
-	// Set partial mode and say that we setup the cidr block
-	d.Partial(true)
-	d.SetPartial("cidr_block")
-
 	// Wait for the VPC to become available
 	log.Printf(
 		"[DEBUG] Waiting for VPC (%s) to become available",
@@ -186,8 +182,6 @@ func resourceAwsVpcCreate(d *schema.ResourceData, meta interface{}) error {
 		if _, err := conn.ModifyVpcAttribute(input); err != nil {
 			return fmt.Errorf("error enabling VPC (%s) DNS hostnames: %s", d.Id(), err)
 		}
-
-		d.SetPartial("enable_dns_hostnames")
 	}
 
 	// By default, only the enableDnsSupport attribute is set to true in a VPC created any other way.
@@ -204,8 +198,6 @@ func resourceAwsVpcCreate(d *schema.ResourceData, meta interface{}) error {
 		if _, err := conn.ModifyVpcAttribute(input); err != nil {
 			return fmt.Errorf("error disabling VPC (%s) DNS support: %s", d.Id(), err)
 		}
-
-		d.SetPartial("enable_dns_support")
 	}
 
 	if d.Get("enable_classiclink").(bool) {
@@ -216,8 +208,6 @@ func resourceAwsVpcCreate(d *schema.ResourceData, meta interface{}) error {
 		if _, err := conn.EnableVpcClassicLink(input); err != nil {
 			return fmt.Errorf("error enabling VPC (%s) ClassicLink: %s", d.Id(), err)
 		}
-
-		d.SetPartial("enable_classiclink")
 	}
 
 	if d.Get("enable_classiclink_dns_support").(bool) {
@@ -228,8 +218,6 @@ func resourceAwsVpcCreate(d *schema.ResourceData, meta interface{}) error {
 		if _, err := conn.EnableVpcClassicLinkDnsSupport(input); err != nil {
 			return fmt.Errorf("error enabling VPC (%s) ClassicLink DNS support: %s", d.Id(), err)
 		}
-
-		d.SetPartial("enable_classiclink_dns_support")
 	}
 
 	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
@@ -255,11 +243,7 @@ func resourceAwsVpcCreate(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return fmt.Errorf("error adding tags: %s", err)
 		}
-
-		d.SetPartial("tags")
 	}
-
-	d.Partial(false)
 
 	return resourceAwsVpcRead(d, meta)
 }
@@ -399,8 +383,6 @@ func resourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 func resourceAwsVpcUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	// Turn on partial mode
-	d.Partial(true)
 	vpcid := d.Id()
 	if d.HasChange("enable_dns_hostnames") {
 		val := d.Get("enable_dns_hostnames").(bool)
@@ -417,8 +399,6 @@ func resourceAwsVpcUpdate(d *schema.ResourceData, meta interface{}) error {
 		if _, err := conn.ModifyVpcAttribute(modifyOpts); err != nil {
 			return err
 		}
-
-		d.SetPartial("enable_dns_hostnames")
 	}
 
 	_, hasEnableDnsSupportOption := d.GetOk("enable_dns_support")
@@ -438,8 +418,6 @@ func resourceAwsVpcUpdate(d *schema.ResourceData, meta interface{}) error {
 		if _, err := conn.ModifyVpcAttribute(modifyOpts); err != nil {
 			return err
 		}
-
-		d.SetPartial("enable_dns_support")
 	}
 
 	if d.HasChange("enable_classiclink") {
@@ -465,8 +443,6 @@ func resourceAwsVpcUpdate(d *schema.ResourceData, meta interface{}) error {
 				return err
 			}
 		}
-
-		d.SetPartial("enable_classiclink")
 	}
 
 	if d.HasChange("enable_classiclink_dns_support") {
@@ -492,8 +468,6 @@ func resourceAwsVpcUpdate(d *schema.ResourceData, meta interface{}) error {
 				return err
 			}
 		}
-
-		d.SetPartial("enable_classiclink_dns_support")
 	}
 
 	if d.HasChange("assign_generated_ipv6_cidr_block") {
@@ -533,8 +507,6 @@ func resourceAwsVpcUpdate(d *schema.ResourceData, meta interface{}) error {
 				return fmt.Errorf("error waiting for EC2 VPC (%s) IPv6 CIDR to become disassociated: %s", d.Id(), err)
 			}
 		}
-
-		d.SetPartial("assign_generated_ipv6_cidr_block")
 	}
 
 	if d.HasChange("instance_tenancy") {
@@ -548,8 +520,6 @@ func resourceAwsVpcUpdate(d *schema.ResourceData, meta interface{}) error {
 		if _, err := conn.ModifyVpcTenancy(modifyOpts); err != nil {
 			return err
 		}
-
-		d.SetPartial("instance_tenancy")
 	}
 
 	if d.HasChange("tags") {
@@ -558,11 +528,8 @@ func resourceAwsVpcUpdate(d *schema.ResourceData, meta interface{}) error {
 		if err := keyvaluetags.Ec2UpdateTags(conn, d.Id(), o, n); err != nil {
 			return fmt.Errorf("error updating tags: %s", err)
 		}
-
-		d.SetPartial("tags")
 	}
 
-	d.Partial(false)
 	return resourceAwsVpcRead(d, meta)
 }
 

--- a/aws/resource_aws_vpc_endpoint_service.go
+++ b/aws/resource_aws_vpc_endpoint_service.go
@@ -178,7 +178,6 @@ func resourceAwsVpcEndpointServiceRead(d *schema.ResourceData, meta interface{})
 func resourceAwsVpcEndpointServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	d.Partial(true)
 	svcId := d.Id()
 
 	modifyCfgReq := &ec2.ModifyVpcEndpointServiceConfigurationInput{
@@ -201,8 +200,6 @@ func resourceAwsVpcEndpointServiceUpdate(d *schema.ResourceData, meta interface{
 		if err := vpcEndpointServiceWaitUntilAvailable(d, conn); err != nil {
 			return err
 		}
-
-		d.SetPartial("network_load_balancer_arns")
 	}
 
 	modifyPermReq := &ec2.ModifyVpcEndpointServicePermissionsInput{
@@ -214,8 +211,6 @@ func resourceAwsVpcEndpointServiceUpdate(d *schema.ResourceData, meta interface{
 		if _, err := conn.ModifyVpcEndpointServicePermissions(modifyPermReq); err != nil {
 			return fmt.Errorf("Error modifying VPC Endpoint Service permissions: %s", err.Error())
 		}
-
-		d.SetPartial("allowed_principals")
 	}
 
 	if d.HasChange("tags") {
@@ -226,7 +221,6 @@ func resourceAwsVpcEndpointServiceUpdate(d *schema.ResourceData, meta interface{
 		}
 	}
 
-	d.Partial(false)
 	return resourceAwsVpcEndpointServiceRead(d, meta)
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12083
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12087

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
aws/resource_aws_ami.go:414:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_ami.go:434:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_ami.go:437:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_ami_copy.go:218:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_ami_copy.go:220:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_ami_copy.go:221:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_ami_from_instance.go:200:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_ami_from_instance.go:202:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_ami_from_instance.go:203:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_default_network_acl.go:172:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_default_network_acl.go:244:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_ec2_client_vpn_endpoint.go:269:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_ec2_client_vpn_endpoint.go:337:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_instance.go:1217:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_instance.go:918:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_instance.go:927:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_instance.go:944:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_network_acl.go:254:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_network_acl.go:338:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_network_interface.go:264:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_network_interface.go:289:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_network_interface.go:330:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_network_interface.go:346:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_network_interface.go:388:4: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_network_interface.go:403:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_network_interface.go:417:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_network_interface.go:428:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_spot_fleet_request.go:1200:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_subnet.go:168:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_subnet.go:186:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_subnet.go:201:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_subnet.go:204:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_subnet.go:265:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_subnet.go:274:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_subnet.go:292:4: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_subnet.go:361:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_subnet.go:379:4: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_subnet.go:383:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_vpc.go:149:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_vpc.go:150:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_vpc.go:190:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_vpc.go:208:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_vpc.go:220:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_vpc.go:232:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_vpc.go:259:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_vpc.go:262:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_vpc.go:403:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_vpc.go:421:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_vpc.go:442:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_vpc.go:469:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_vpc.go:496:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_vpc.go:537:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_vpc.go:552:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_vpc.go:562:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_vpc.go:565:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_vpc_endpoint_service.go:181:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_vpc_endpoint_service.go:205:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_vpc_endpoint_service.go:218:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_vpc_endpoint_service.go:229:2: R007: deprecated (schema.ResourceData).Partial
```

Output from acceptance testing:

```
--- PASS: TestAccAWSAMI_basic (78.71s)
--- PASS: TestAccAWSAMI_disappears (57.61s)
--- PASS: TestAccAWSAMI_snapshotSize (64.52s)
--- PASS: TestAccAWSAMI_tags (93.26s)

--- PASS: TestAccAWSAMICopy_basic (365.47s)
--- PASS: TestAccAWSAMICopy_Description (405.15s)
--- PASS: TestAccAWSAMICopy_EnaSupport (391.75s)
--- PASS: TestAccAWSAMICopy_tags (419.90s)

--- PASS: TestAccAWSAMIFromInstance_basic (369.65s)
--- PASS: TestAccAWSAMIFromInstance_tags (421.26s)

--- PASS: TestAccAWSDefaultNetworkAcl_basic (30.84s)
--- PASS: TestAccAWSDefaultNetworkAcl_basicIpv6Vpc (40.38s)
--- PASS: TestAccAWSDefaultNetworkAcl_deny_ingress (38.32s)
--- PASS: TestAccAWSDefaultNetworkAcl_SubnetReassign (83.61s)
--- PASS: TestAccAWSDefaultNetworkAcl_SubnetRemoval (74.22s)
--- PASS: TestAccAWSDefaultNetworkAcl_withIpv6Ingress (33.89s)

--- PASS: TestAccAwsEc2ClientVpnEndpoint_basic (22.69s)
--- PASS: TestAccAwsEc2ClientVpnEndpoint_disappears (18.67s)
--- PASS: TestAccAwsEc2ClientVpnEndpoint_msAD (1678.33s)
--- PASS: TestAccAwsEc2ClientVpnEndpoint_splitTunnel (36.58s)
--- PASS: TestAccAwsEc2ClientVpnEndpoint_tags (48.82s)
--- PASS: TestAccAwsEc2ClientVpnEndpoint_withDNSServers (36.09s)
--- PASS: TestAccAwsEc2ClientVpnEndpoint_withLogGroup (42.49s)

--- PASS: TestAccAWSENI_attached (243.84s)
--- PASS: TestAccAWSENI_basic (48.62s)
--- PASS: TestAccAWSENI_computedIPs (40.94s)
--- PASS: TestAccAWSENI_disappears (39.87s)
--- PASS: TestAccAWSENI_ignoreExternalAttachment (114.17s)
--- PASS: TestAccAWSENI_PrivateIpsCount (112.43s)
--- PASS: TestAccAWSENI_sourceDestCheck (44.73s)
--- PASS: TestAccAWSENI_updatedDescription (70.49s)

--- PASS: TestAccAWSInstance_addSecondaryInterface (101.85s)
--- PASS: TestAccAWSInstance_addSecurityGroupNetworkInterface (119.12s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPrivate (72.41s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPublic (82.27s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPrivate (89.32s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPublic (80.62s)
--- PASS: TestAccAWSInstance_associatePublic_overridePrivate (91.49s)
--- PASS: TestAccAWSInstance_associatePublic_overridePublic (72.13s)
--- PASS: TestAccAWSInstance_associatePublicIPAndPrivateIP (81.44s)
--- PASS: TestAccAWSInstance_basic (183.70s)
--- PASS: TestAccAWSInstance_blockDevices (109.47s)
--- PASS: TestAccAWSInstance_changeInstanceType (162.79s)
--- PASS: TestAccAWSInstance_CreditSpecification_Empty_NonBurstable (325.46s)
--- PASS: TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable (101.10s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits (103.72s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint (400.62s)
--- PASS: TestAccAWSInstance_creditSpecification_unknownCpuCredits_t2 (92.50s)
--- PASS: TestAccAWSInstance_creditSpecification_unknownCpuCredits_t3 (285.59s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits (103.30s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint (379.85s)
--- PASS: TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard (82.16s)
--- PASS: TestAccAWSInstance_CreditSpecification_UnspecifiedToEmpty_NonBurstable (125.59s)
--- PASS: TestAccAWSInstance_creditSpecification_updateCpuCredits (96.78s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_standardCpuCredits (84.68s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits (62.70s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited (326.84s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_updateCpuCredits (106.79s)
--- PASS: TestAccAWSInstance_disableApiTermination (115.81s)
--- PASS: TestAccAWSInstance_disappears (241.97s)
--- PASS: TestAccAWSInstance_EbsBlockDevice_KmsKeyArn (148.32s)
--- PASS: TestAccAWSInstance_forceNewAndTagsDrift (120.55s)
--- PASS: TestAccAWSInstance_getPasswordData_falseToTrue (223.75s)
--- PASS: TestAccAWSInstance_getPasswordData_trueToFalse (241.06s)
--- PASS: TestAccAWSInstance_GP2IopsDevice (90.09s)
--- PASS: TestAccAWSInstance_GP2WithIopsValue (113.39s)
--- PASS: TestAccAWSInstance_hibernation (169.65s)
--- PASS: TestAccAWSInstance_inDefaultVpcBySgId (77.63s)
--- PASS: TestAccAWSInstance_inDefaultVpcBySgName (79.23s)
--- PASS: TestAccAWSInstance_instanceProfileChange (208.56s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCount (81.76s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCountWithIpv4 (91.39s)
--- PASS: TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError (13.22s)
--- PASS: TestAccAWSInstance_keyPairCheck (67.97s)
--- PASS: TestAccAWSInstance_multipleRegions (260.89s)
--- PASS: TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups (91.04s)
--- PASS: TestAccAWSInstance_NetworkInstanceSecurityGroups (163.04s)
--- PASS: TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs (83.27s)
--- PASS: TestAccAWSInstance_noAMIEphemeralDevices (80.32s)
--- PASS: TestAccAWSInstance_placementGroup (66.52s)
--- PASS: TestAccAWSInstance_primaryNetworkInterface (84.04s)
--- PASS: TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck (74.50s)
--- PASS: TestAccAWSInstance_privateIP (81.69s)
--- PASS: TestAccAWSInstance_RootBlockDevice_KmsKeyArn (173.75s)
--- PASS: TestAccAWSInstance_rootBlockDeviceMismatch (109.59s)
--- PASS: TestAccAWSInstance_rootInstanceStore (150.64s)
--- PASS: TestAccAWSInstance_sourceDestCheck (126.46s)
--- PASS: TestAccAWSInstance_tags (147.76s)
--- PASS: TestAccAWSInstance_UserData_EmptyStringToUnspecified (91.50s)
--- PASS: TestAccAWSInstance_UserData_UnspecifiedToEmptyString (91.89s)
--- PASS: TestAccAWSInstance_userDataBase64 (239.10s)
--- PASS: TestAccAWSInstance_volumeTags (152.07s)
--- PASS: TestAccAWSInstance_volumeTagsComputed (142.92s)
--- PASS: TestAccAWSInstance_volumeTagsComputed (146.73s)
--- PASS: TestAccAWSInstance_vpc (79.83s)
--- PASS: TestAccAWSInstance_withIamInstanceProfile (117.42s)

--- PASS: TestAccAWSNetworkAcl_basic (38.51s)
--- PASS: TestAccAWSNetworkAcl_CaseSensitivityNoChanges (46.29s)
--- PASS: TestAccAWSNetworkAcl_disappears (33.69s)
--- PASS: TestAccAWSNetworkAcl_Egress_ConfigMode (82.91s)
--- PASS: TestAccAWSNetworkAcl_EgressAndIngressRules (38.77s)
--- PASS: TestAccAWSNetworkAcl_espProtocol (36.38s)
--- PASS: TestAccAWSNetworkAcl_Ingress_ConfigMode (80.27s)
--- PASS: TestAccAWSNetworkAcl_ipv6ICMPRules (31.10s)
--- PASS: TestAccAWSNetworkAcl_ipv6Rules (49.98s)
--- PASS: TestAccAWSNetworkAcl_ipv6VpcRules (34.61s)
--- PASS: TestAccAWSNetworkAcl_OnlyEgressRules (43.51s)
--- PASS: TestAccAWSNetworkAcl_OnlyIngressRules_basic (47.89s)
--- PASS: TestAccAWSNetworkAcl_OnlyIngressRules_update (71.35s)
--- PASS: TestAccAWSNetworkAcl_SubnetChange (74.18s)
--- PASS: TestAccAWSNetworkAcl_Subnets (74.71s)
--- PASS: TestAccAWSNetworkAcl_SubnetsDelete (82.26s)

--- PASS: TestAccAWSSpotFleetRequest_associatePublicIpAddress (372.99s)
--- PASS: TestAccAWSSpotFleetRequest_basic (231.12s)
--- PASS: TestAccAWSSpotFleetRequest_changePriceForcesNewRequest (582.29s)
--- PASS: TestAccAWSSpotFleetRequest_diversifiedAllocation (350.94s)
--- PASS: TestAccAWSSpotFleetRequest_fleetType (241.77s)
--- PASS: TestAccAWSSpotFleetRequest_iamInstanceProfileArn (272.75s)
--- PASS: TestAccAWSSpotFleetRequest_instanceInterruptionBehavior (242.11s)
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDevice_KmsKeyId (147.02s)
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDevice_KmsKeyId (146.75s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList (265.13s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion (355.97s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList (264.26s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstancePools (286.87s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz (297.89s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet (264.21s)
--- PASS: TestAccAWSSpotFleetRequest_overriddingSpotPrice (261.23s)
--- PASS: TestAccAWSSpotFleetRequest_placementTenancyAndGroup (60.68s)
--- PASS: TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy (554.15s)
--- PASS: TestAccAWSSpotFleetRequest_updateTargetCapacity (750.82s)
--- PASS: TestAccAWSSpotFleetRequest_withEBSDisk (333.68s)
--- PASS: TestAccAWSSpotFleetRequest_WithELBs (345.96s)
--- PASS: TestAccAWSSpotFleetRequest_withoutSpotPrice (266.18s)
--- PASS: TestAccAWSSpotFleetRequest_withTags (254.92s)
--- PASS: TestAccAWSSpotFleetRequest_WithTargetGroups (430.77s)
--- PASS: TestAccAWSSpotFleetRequest_withWeightedCapacity (295.99s)

--- PASS: TestAccAWSSubnet_availabilityZoneId (30.67s)
--- PASS: TestAccAWSSubnet_basic (30.59s)
--- PASS: TestAccAWSSubnet_enableIpv6 (50.96s)
--- PASS: TestAccAWSSubnet_ignoreTags (56.29s)
--- PASS: TestAccAWSSubnet_ipv6 (77.14s)

--- PASS: TestAccAWSVpc_AssignGeneratedIpv6CidrBlock (73.30s)
--- PASS: TestAccAWSVpc_basic (29.97s)
--- PASS: TestAccAWSVpc_bothDnsOptionsSet (33.54s)
--- PASS: TestAccAWSVpc_classiclinkDnsSupportOptionSet (31.49s)
--- PASS: TestAccAWSVpc_classiclinkOptionSet (32.05s)
--- PASS: TestAccAWSVpc_coreMismatchedDiffs (25.26s)
--- PASS: TestAccAWSVpc_DisabledDnsSupport (31.22s)
--- PASS: TestAccAWSVpc_disappears (16.78s)
--- PASS: TestAccAWSVpc_ignoreTags (50.85s)
--- PASS: TestAccAWSVpc_tags (51.10s)
--- PASS: TestAccAWSVpc_Tenancy (74.07s)
--- PASS: TestAccAWSVpc_update (44.39s)

--- PASS: TestAccAWSVpcEndpointService_AllowedPrincipalsAndTags (286.82s)
--- PASS: TestAccAWSVpcEndpointService_basic (266.19s)
--- PASS: TestAccAWSVpcEndpointService_removed (303.85s)
```
