### PR TITLE
resource/aws_lambda_function: Remove deprecated (helper/schema.ResourceData).Partial() and (helper/schema.ResourceData).SetPartial()

### DIFF
--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -671,8 +671,6 @@ func needsFunctionCodeUpdate(d resourceDiffer) bool {
 func resourceAwsLambdaFunctionUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).lambdaconn
 
-	d.Partial(true)
-
 	arn := d.Get("arn").(string)
 	if d.HasChange("tags") {
 		o, n := d.GetChange("tags")
@@ -837,12 +835,6 @@ func resourceAwsLambdaFunctionUpdate(d *schema.ResourceData, meta interface{}) e
 		if err := waitForLambdaFunctionUpdate(conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return fmt.Errorf("error waiting for Lambda Function (%s) update: %s", d.Id(), err)
 		}
-
-		d.SetPartial("description")
-		d.SetPartial("handler")
-		d.SetPartial("memory_size")
-		d.SetPartial("role")
-		d.SetPartial("timeout")
 	}
 
 	codeUpdate := needsFunctionCodeUpdate(d)
@@ -880,12 +872,6 @@ func resourceAwsLambdaFunctionUpdate(d *schema.ResourceData, meta interface{}) e
 		if err != nil {
 			return fmt.Errorf("Error modifying Lambda Function Code %s: %s", d.Id(), err)
 		}
-
-		d.SetPartial("filename")
-		d.SetPartial("source_code_hash")
-		d.SetPartial("s3_bucket")
-		d.SetPartial("s3_key")
-		d.SetPartial("s3_object_version")
 	}
 
 	if d.HasChange("reserved_concurrent_executions") {
@@ -927,8 +913,6 @@ func resourceAwsLambdaFunctionUpdate(d *schema.ResourceData, meta interface{}) e
 			return fmt.Errorf("Error publishing Lambda Function Version %s: %s", d.Id(), err)
 		}
 	}
-
-	d.Partial(false)
 
 	return resourceAwsLambdaFunctionRead(d, meta)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12083
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12087

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
aws/resource_aws_lambda_function.go:674:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_lambda_function.go:841:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_lambda_function.go:842:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_lambda_function.go:843:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_lambda_function.go:844:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_lambda_function.go:845:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_lambda_function.go:884:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_lambda_function.go:885:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_lambda_function.go:886:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_lambda_function.go:887:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_lambda_function.go:888:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_lambda_function.go:931:2: R007: deprecated (schema.ResourceData).Partial
```

Output from acceptance testing:

```
--- PASS: TestAccAWSLambdaFunction_basic (64.06s)
--- PASS: TestAccAWSLambdaFunction_concurrency (493.45s)
--- PASS: TestAccAWSLambdaFunction_concurrencyCycle (529.28s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfig (536.23s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfigUpdated (148.43s)
--- PASS: TestAccAWSLambdaFunction_disappears (94.71s)
--- PASS: TestAccAWSLambdaFunction_EmptyVpcConfig (68.70s)
--- PASS: TestAccAWSLambdaFunction_encryptedEnvVariables (561.28s)
--- PASS: TestAccAWSLambdaFunction_envVariables (579.67s)
--- PASS: TestAccAWSLambdaFunction_expectFilenameAndS3Attributes (24.88s)
--- PASS: TestAccAWSLambdaFunction_KmsKeyArn_NoEnvironmentVariables (151.22s)
--- PASS: TestAccAWSLambdaFunction_Layers (514.42s)
--- PASS: TestAccAWSLambdaFunction_LayersUpdate (170.54s)
--- PASS: TestAccAWSLambdaFunction_localUpdate (523.11s)
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (486.27s)
--- PASS: TestAccAWSLambdaFunction_nilDeadLetterConfig (492.13s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_java11 (83.49s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_java8 (78.16s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_NodeJs10x (514.99s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_NodeJs12x (513.46s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_noRuntime (2.32s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_provided (71.48s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python27 (56.73s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python36 (97.54s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python37 (50.94s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python38 (89.93s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_ruby25 (109.39s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_ruby27 (117.27s)
--- PASS: TestAccAWSLambdaFunction_s3 (44.11s)
--- PASS: TestAccAWSLambdaFunction_s3Update_basic (74.22s)
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (68.76s)
--- PASS: TestAccAWSLambdaFunction_tags (140.89s)
--- PASS: TestAccAWSLambdaFunction_tracingConfig (535.70s)
--- PASS: TestAccAWSLambdaFunction_updateRuntime (511.04s)
--- PASS: TestAccAWSLambdaFunction_versioned (514.26s)
--- PASS: TestAccAWSLambdaFunction_versionedUpdate (607.45s)
--- PASS: TestAccAWSLambdaFunction_VPC (2148.53s)
--- PASS: TestAccAWSLambdaFunction_VPC_withInvocation (1848.27s)
--- PASS: TestAccAWSLambdaFunction_VpcConfig_ProperIamDependencies (1568.41s)
--- PASS: TestAccAWSLambdaFunction_VPCRemoval (2046.17s)
--- PASS: TestAccAWSLambdaFunction_VPCUpdate (2526.06s)
```
