### PR TITLE
resource/aws_api_gateway_stage: Remove deprecated (helper/schema.ResourceData).Partial() and (helper/schema.ResourceData).SetPartial()

### DIFF
--- a/aws/resource_aws_api_gateway_stage.go
+++ b/aws/resource_aws_api_gateway_stage.go
@@ -131,8 +131,6 @@ func resourceAwsApiGatewayStage() *schema.Resource {
 func resourceAwsApiGatewayStageCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).apigatewayconn
 
-	d.Partial(true)
-
 	input := apigateway.CreateStageInput{
 		RestApiId:    aws.String(d.Get("rest_api_id").(string)),
 		StageName:    aws.String(d.Get("stage_name").(string)),
@@ -175,13 +173,6 @@ func resourceAwsApiGatewayStageCreate(d *schema.ResourceData, meta interface{}) 
 
 	d.SetId(fmt.Sprintf("ags-%s-%s", d.Get("rest_api_id").(string), d.Get("stage_name").(string)))
 
-	d.SetPartial("rest_api_id")
-	d.SetPartial("stage_name")
-	d.SetPartial("deployment_id")
-	d.SetPartial("description")
-	d.SetPartial("variables")
-	d.SetPartial("xray_tracing_enabled")
-
 	if waitForCache && *out.CacheClusterStatus != apigateway.CacheClusterStatusNotAvailable {
 		stateConf := &resource.StateChangeConf{
 			Pending: []string{
@@ -201,10 +192,6 @@ func resourceAwsApiGatewayStageCreate(d *schema.ResourceData, meta interface{}) 
 			return err
 		}
 	}
-
-	d.SetPartial("cache_cluster_enabled")
-	d.SetPartial("cache_cluster_size")
-	d.Partial(false)
 
 	if _, ok := d.GetOk("client_certificate_id"); ok {
 		return resourceAwsApiGatewayStageUpdate(d, meta)
@@ -287,8 +274,6 @@ func resourceAwsApiGatewayStageRead(d *schema.ResourceData, meta interface{}) er
 
 func resourceAwsApiGatewayStageUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).apigatewayconn
-
-	d.Partial(true)
 
 	stageArn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
@@ -395,12 +380,6 @@ func resourceAwsApiGatewayStageUpdate(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("Updating API Gateway Stage failed: %s", err)
 	}
 
-	d.SetPartial("client_certificate_id")
-	d.SetPartial("deployment_id")
-	d.SetPartial("description")
-	d.SetPartial("xray_tracing_enabled")
-	d.SetPartial("variables")
-
 	if waitForCache && *out.CacheClusterStatus != apigateway.CacheClusterStatusNotAvailable {
 		stateConf := &resource.StateChangeConf{
 			Pending: []string{
@@ -424,10 +403,6 @@ func resourceAwsApiGatewayStageUpdate(d *schema.ResourceData, meta interface{}) 
 			return err
 		}
 	}
-
-	d.SetPartial("cache_cluster_enabled")
-	d.SetPartial("cache_cluster_size")
-	d.Partial(false)
 
 	return resourceAwsApiGatewayStageRead(d, meta)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12083
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12087

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
aws/resource_aws_api_gateway_stage.go:134:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_api_gateway_stage.go:178:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_api_gateway_stage.go:179:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_api_gateway_stage.go:180:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_api_gateway_stage.go:181:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_api_gateway_stage.go:182:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_api_gateway_stage.go:183:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_api_gateway_stage.go:205:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_api_gateway_stage.go:206:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_api_gateway_stage.go:207:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_api_gateway_stage.go:291:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_api_gateway_stage.go:398:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_api_gateway_stage.go:399:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_api_gateway_stage.go:400:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_api_gateway_stage.go:401:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_api_gateway_stage.go:402:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_api_gateway_stage.go:428:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_api_gateway_stage.go:429:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_api_gateway_stage.go:430:2: R007: deprecated (schema.ResourceData).Partial
```

Output from acceptance testing:

```
--- PASS: TestAccAWSAPIGatewayStage_accessLogSettings (260.87s)
--- PASS: TestAccAWSAPIGatewayStage_accessLogSettings_kinesis (388.36s)
--- PASS: TestAccAWSAPIGatewayStage_basic (469.04s)
```
