### PR TITLE
resource/aws_codestarnotifications_notification_rule: Remove deprecated (helper/schema.ResourceData).Partial() and (helper/schema.ResourceData).SetPartial()

### DIFF
--- a/aws/resource_aws_codestarnotifications_notification_rule.go
+++ b/aws/resource_aws_codestarnotifications_notification_rule.go
@@ -233,8 +233,6 @@ func cleanupCodeStarNotificationsNotificationRuleTargets(conn *codestarnotificat
 func resourceAwsCodeStarNotificationsNotificationRuleUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).codestarnotificationsconn
 
-	d.Partial(true)
-
 	params := &codestarnotifications.UpdateNotificationRuleInput{
 		Arn:          aws.String(d.Id()),
 		DetailType:   aws.String(d.Get("detail_type").(string)),
@@ -247,11 +245,6 @@ func resourceAwsCodeStarNotificationsNotificationRuleUpdate(d *schema.ResourceDa
 	if _, err := conn.UpdateNotificationRule(params); err != nil {
 		return fmt.Errorf("error updating codestar notification rule: %s", err)
 	}
-
-	d.SetPartial("detail_type")
-	d.SetPartial("event_type_ids")
-	d.SetPartial("name")
-	d.SetPartial("target")
 
 	if d.HasChange("tags") {
 		o, n := d.GetChange("tags")
@@ -266,8 +259,6 @@ func resourceAwsCodeStarNotificationsNotificationRuleUpdate(d *schema.ResourceDa
 			return err
 		}
 	}
-
-	d.Partial(false)
 
 	return resourceAwsCodeStarNotificationsNotificationRuleRead(d, meta)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12083
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12087

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
aws/resource_aws_codestarnotifications_notification_rule.go:236:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_codestarnotifications_notification_rule.go:251:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_codestarnotifications_notification_rule.go:252:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_codestarnotifications_notification_rule.go:253:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_codestarnotifications_notification_rule.go:254:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_codestarnotifications_notification_rule.go:270:2: R007: deprecated (schema.ResourceData).Partial
```

Output from acceptance testing:

```
--- PASS: TestAccAWSCodeStarNotificationsNotificationRule_Basic (26.58s)
--- PASS: TestAccAWSCodeStarNotificationsNotificationRule_EventTypeIds (49.15s)
--- PASS: TestAccAWSCodeStarNotificationsNotificationRule_Status (61.55s)
--- PASS: TestAccAWSCodeStarNotificationsNotificationRule_Tags (49.81s)
--- PASS: TestAccAWSCodeStarNotificationsNotificationRule_Targets (48.94s)
```
