### PR TITLE
resource/aws_elasticache_parameter_group: Remove deprecated (helper/schema.ResourceData).Partial() and (helper/schema.ResourceData).SetPartial()

### DIFF
--- a/aws/resource_aws_elasticache_parameter_group.go
+++ b/aws/resource_aws_elasticache_parameter_group.go
@@ -81,12 +81,6 @@ func resourceAwsElasticacheParameterGroupCreate(d *schema.ResourceData, meta int
 		return fmt.Errorf("Error creating Cache Parameter Group: %s", err)
 	}
 
-	d.Partial(true)
-	d.SetPartial("name")
-	d.SetPartial("family")
-	d.SetPartial("description")
-	d.Partial(false)
-
 	d.SetId(*resp.CacheParameterGroup.CacheParameterGroupName)
 	log.Printf("[INFO] Cache Parameter Group ID: %s", d.Id())
 
@@ -132,8 +126,6 @@ func resourceAwsElasticacheParameterGroupRead(d *schema.ResourceData, meta inter
 
 func resourceAwsElasticacheParameterGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).elasticacheconn
-
-	d.Partial(true)
 
 	if d.HasChange("parameter") {
 		o, n := d.GetChange("parameter")
@@ -306,11 +298,7 @@ func resourceAwsElasticacheParameterGroupUpdate(d *schema.ResourceData, meta int
 				return fmt.Errorf("Error modifying Cache Parameter Group: %s", err)
 			}
 		}
-
-		d.SetPartial("parameter")
 	}
-
-	d.Partial(false)
 
 	return resourceAwsElasticacheParameterGroupRead(d, meta)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12083
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12087

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
aws/resource_aws_elasticache_parameter_group.go:136:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_elasticache_parameter_group.go:310:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_elasticache_parameter_group.go:313:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_elasticache_parameter_group.go:84:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_elasticache_parameter_group.go:85:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_elasticache_parameter_group.go:86:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_elasticache_parameter_group.go:87:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_elasticache_parameter_group.go:88:2: R007: deprecated (schema.ResourceData).Partial
```

Output from acceptance testing:

```
--- PASS: TestAccAWSElasticacheParameterGroup_Description (23.39s)
--- PASS: TestAccAWSElasticacheParameterGroup_basic (25.25s)
--- PASS: TestAccAWSElasticacheParameterGroup_UppercaseName (25.32s)
--- PASS: TestAccAWSElasticacheParameterGroup_removeReservedMemoryParameter (42.06s)
--- PASS: TestAccAWSElasticacheParameterGroup_removeAllParameters (44.50s)
--- PASS: TestAccAWSElasticacheParameterGroup_addParameter (44.70s)
--- PASS: TestAccAWSElasticacheParameterGroup_updateReservedMemoryParameter (90.73s)
--- PASS: TestAccAWSElasticacheParameterGroup_switchReservedMemoryParameter (91.11s)
```