### PR TITLE
resource/aws_globalaccelerator_accelerator: Remove deprecated (helper/schema.ResourceData).Partial() and (helper/schema.ResourceData).SetPartial()

### DIFF
--- a/aws/resource_aws_globalaccelerator_accelerator.go
+++ b/aws/resource_aws_globalaccelerator_accelerator.go
@@ -262,8 +262,6 @@ func resourceAwsGlobalAcceleratorAcceleratorRetrieve(conn *globalaccelerator.Glo
 func resourceAwsGlobalAcceleratorAcceleratorUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).globalacceleratorconn
 
-	d.Partial(true)
-
 	if d.HasChange("name") || d.HasChange("ip_address_type") || d.HasChange("enabled") {
 		opts := &globalaccelerator.UpdateAcceleratorInput{
 			AcceleratorArn: aws.String(d.Id()),
@@ -282,10 +280,6 @@ func resourceAwsGlobalAcceleratorAcceleratorUpdate(d *schema.ResourceData, meta 
 			return fmt.Errorf("Error updating Global Accelerator accelerator: %s", err)
 		}
 
-		d.SetPartial("name")
-		d.SetPartial("ip_address_type")
-		d.SetPartial("enabled")
-
 		err = resourceAwsGlobalAcceleratorAcceleratorWaitForDeployedState(conn, d.Id())
 		if err != nil {
 			return err
@@ -298,10 +292,7 @@ func resourceAwsGlobalAcceleratorAcceleratorUpdate(d *schema.ResourceData, meta 
 			if err != nil {
 				return err
 			}
-
 		}
-
-		d.SetPartial("attributes")
 	}
 
 	if d.HasChange("tags") {
@@ -310,11 +301,7 @@ func resourceAwsGlobalAcceleratorAcceleratorUpdate(d *schema.ResourceData, meta 
 		if err := keyvaluetags.GlobalacceleratorUpdateTags(conn, d.Id(), o, n); err != nil {
 			return fmt.Errorf("error updating Global Accelerator accelerator (%s) tags: %s", d.Id(), err)
 		}
-
-		d.SetPartial("tags")
 	}
-
-	d.Partial(false)
 
 	return resourceAwsGlobalAcceleratorAcceleratorRead(d, meta)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12083
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12087

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
aws/resource_aws_globalaccelerator_accelerator.go:265:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_globalaccelerator_accelerator.go:285:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_globalaccelerator_accelerator.go:286:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_globalaccelerator_accelerator.go:287:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_globalaccelerator_accelerator.go:304:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_globalaccelerator_accelerator.go:314:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_globalaccelerator_accelerator.go:317:2: R007: deprecated (schema.ResourceData).Partial
```

Output from acceptance testing:

```
--- PASS: TestAccAwsGlobalAcceleratorAccelerator_basic (55.91s)
--- PASS: TestAccAwsGlobalAcceleratorAccelerator_update (84.82s)
--- PASS: TestAccAwsGlobalAcceleratorAccelerator_tags (92.89s)
--- PASS: TestAccAwsGlobalAcceleratorAccelerator_attributes (97.79s)
```
