### PR TITLE
resource/aws_iam_instance_profile: Remove deprecated (helper/schema.ResourceData).Partial() and (helper/schema.ResourceData).SetPartial()

### DIFF
--- a/aws/resource_aws_iam_instance_profile.go
+++ b/aws/resource_aws_iam_instance_profile.go
@@ -197,8 +197,6 @@ func instanceProfileSetRoles(d *schema.ResourceData, iamconn *iam.IAM) error {
 
 	currentRoles := schema.CopySet(oldRoles)
 
-	d.Partial(true)
-
 	for _, role := range oldRoles.Difference(newRoles).List() {
 		err := instanceProfileRemoveRole(iamconn, d.Id(), role.(string))
 		if err != nil {
@@ -206,7 +204,6 @@ func instanceProfileSetRoles(d *schema.ResourceData, iamconn *iam.IAM) error {
 		}
 		currentRoles.Remove(role)
 		d.Set("roles", currentRoles)
-		d.SetPartial("roles")
 	}
 
 	for _, role := range newRoles.Difference(oldRoles).List() {
@@ -216,10 +213,7 @@ func instanceProfileSetRoles(d *schema.ResourceData, iamconn *iam.IAM) error {
 		}
 		currentRoles.Add(role)
 		d.Set("roles", currentRoles)
-		d.SetPartial("roles")
 	}
-
-	d.Partial(false)
 
 	return nil
 }
@@ -246,8 +240,6 @@ func instanceProfileRemoveAllRoles(d *schema.ResourceData, iamconn *iam.IAM) err
 func resourceAwsIamInstanceProfileUpdate(d *schema.ResourceData, meta interface{}) error {
 	iamconn := meta.(*AWSClient).iamconn
 
-	d.Partial(true)
-
 	if d.HasChange("role") {
 		oldRole, newRole := d.GetChange("role")
 
@@ -264,15 +256,11 @@ func resourceAwsIamInstanceProfileUpdate(d *schema.ResourceData, meta interface{
 				return fmt.Errorf("Error adding role %s to IAM instance profile %s: %s", newRole.(string), d.Id(), err)
 			}
 		}
-
-		d.SetPartial("role")
 	}
 
 	if d.HasChange("roles") {
 		return instanceProfileSetRoles(d, iamconn)
 	}
-
-	d.Partial(false)
 
 	return nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12083
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12087

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
aws/resource_aws_iam_instance_profile.go:200:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_iam_instance_profile.go:209:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_iam_instance_profile.go:219:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_iam_instance_profile.go:222:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_iam_instance_profile.go:249:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_iam_instance_profile.go:268:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_iam_instance_profile.go:275:2: R007: deprecated (schema.ResourceData).Partial
```

Output from acceptance testing:

```
--- PASS: TestAccAWSIAMInstanceProfile_withoutRole (13.88s)
--- PASS: TestAccAWSIAMInstanceProfile_basic (14.58s)
--- PASS: TestAccAWSIAMInstanceProfile_withRoleNotRoles (14.64s)
--- PASS: TestAccAWSIAMInstanceProfile_namePrefix (14.70s)
```
