### PR TITLE
resource/aws_qldb_ledger: Remove deprecated (helper/schema.ResourceData).Partial() and (helper/schema.ResourceData).SetPartial()

### DIFF
--- a/aws/resource_aws_qldb_ledger.go
+++ b/aws/resource_aws_qldb_ledger.go
@@ -155,9 +155,6 @@ func resourceAwsQLDBLedgerRead(d *schema.ResourceData, meta interface{}) error {
 func resourceAwsQLDBLedgerUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).qldbconn
 
-	// Turn on partial mode
-	d.Partial(true)
-
 	if d.HasChange("deletion_protection") {
 		val := d.Get("deletion_protection").(bool)
 		modifyOpts := &qldb.UpdateLedgerInput{
@@ -171,8 +168,6 @@ func resourceAwsQLDBLedgerUpdate(d *schema.ResourceData, meta interface{}) error
 
 			return err
 		}
-
-		d.SetPartial("deletion_protection")
 	}
 
 	if d.HasChange("tags") {
@@ -182,7 +177,6 @@ func resourceAwsQLDBLedgerUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	d.Partial(false)
 	return resourceAwsQLDBLedgerRead(d, meta)
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12083
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12087

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
aws/resource_aws_qldb_ledger.go:159:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_qldb_ledger.go:175:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_qldb_ledger.go:185:2: R007: deprecated (schema.ResourceData).Partial
```

Output from acceptance testing:

```
--- PASS: TestAccAWSQLDBLedger_basic (47.45s)
--- PASS: TestAccAWSQLDBLedger_Tags (69.25s)
```
