### PR TITLE
resource/aws_route53_zone: Remove deprecated (helper/schema.ResourceData).Partial() and (helper/schema.ResourceData).SetPartial()

### DIFF
--- a/aws/resource_aws_route53_zone.go
+++ b/aws/resource_aws_route53_zone.go
@@ -242,8 +242,6 @@ func resourceAwsRoute53ZoneUpdate(d *schema.ResourceData, meta interface{}) erro
 	conn := meta.(*AWSClient).r53conn
 	region := meta.(*AWSClient).region
 
-	d.Partial(true)
-
 	if d.HasChange("comment") {
 		input := route53.UpdateHostedZoneCommentInput{
 			Id:      aws.String(d.Id()),
@@ -255,8 +253,6 @@ func resourceAwsRoute53ZoneUpdate(d *schema.ResourceData, meta interface{}) erro
 		if err != nil {
 			return fmt.Errorf("error updating Route53 Hosted Zone (%s) comment: %s", d.Id(), err)
 		}
-
-		d.SetPartial("comment")
 	}
 
 	if d.HasChange("tags") {
@@ -298,11 +294,7 @@ func resourceAwsRoute53ZoneUpdate(d *schema.ResourceData, meta interface{}) erro
 				return err
 			}
 		}
-
-		d.SetPartial("vpc")
 	}
-
-	d.Partial(false)
 
 	return resourceAwsRoute53ZoneRead(d, meta)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12083
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12087

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
aws/resource_aws_route53_zone.go:245:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_route53_zone.go:259:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_route53_zone.go:302:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_route53_zone.go:305:2: R007: deprecated (schema.ResourceData).Partial
```

Output from acceptance testing:

```
--- PASS: TestAccAWSRoute53Zone_disappears (46.86s)
--- PASS: TestAccAWSRoute53Zone_basic (51.82s)
--- PASS: TestAccAWSRoute53Zone_DelegationSetID (54.36s)
--- PASS: TestAccAWSRoute53Zone_multiple (55.84s)
--- PASS: TestAccAWSRoute53Zone_Comment (63.72s)
--- PASS: TestAccAWSRoute53Zone_Tags (76.39s)
--- PASS: TestAccAWSRoute53Zone_VPC_Single (100.74s)
--- PASS: TestAccAWSRoute53Zone_VPC_Multiple (162.98s)
--- PASS: TestAccAWSRoute53Zone_ForceDestroy (183.10s)
--- PASS: TestAccAWSRoute53Zone_ForceDestroy_TrailingPeriod (184.32s)
--- PASS: TestAccAWSRoute53Zone_VPC_Updates (238.08s)
```
