### PR TITLE
resource/aws_opsworks_rds_db_instance: Remove deprecated (helper/schema.ResourceData).Partial() and (helper/schema.ResourceData).SetPartial()

### DIFF
--- a/aws/resource_aws_opsworks_rds_db_instance.go
+++ b/aws/resource_aws_opsworks_rds_db_instance.go
@@ -43,21 +43,16 @@ func resourceAwsOpsworksRdsDbInstance() *schema.Resource {
 func resourceAwsOpsworksRdsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*AWSClient).opsworksconn
 
-	d.Partial(true)
-
-	d.SetPartial("rds_db_instance_arn")
 	req := &opsworks.UpdateRdsDbInstanceInput{
 		RdsDbInstanceArn: aws.String(d.Get("rds_db_instance_arn").(string)),
 	}
 
 	requestUpdate := false
 	if d.HasChange("db_user") {
-		d.SetPartial("db_user")
 		req.DbUser = aws.String(d.Get("db_user").(string))
 		requestUpdate = true
 	}
 	if d.HasChange("db_password") {
-		d.SetPartial("db_password")
 		req.DbPassword = aws.String(d.Get("db_password").(string))
 		requestUpdate = true
 	}
@@ -70,8 +65,6 @@ func resourceAwsOpsworksRdsDbInstanceUpdate(d *schema.ResourceData, meta interfa
 			return fmt.Errorf("Error updating Opsworks RDS DB instance: %s", err)
 		}
 	}
-
-	d.Partial(false)
 
 	return resourceAwsOpsworksRdsDbInstanceRead(d, meta)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12083
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12087

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
aws/resource_aws_opsworks_rds_db_instance.go:46:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_opsworks_rds_db_instance.go:48:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_opsworks_rds_db_instance.go:55:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_opsworks_rds_db_instance.go:60:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_opsworks_rds_db_instance.go:74:2: R007: deprecated (schema.ResourceData).Partial
```

Output from acceptance testing:

```
--- PASS: TestAccAWSOpsworksRdsDbInstance (971.17s)
```
