### PR TITLE
service/rds: Remove deprecated (helper/schema.ResourceData).Partial() and (helper/schema.ResourceData).SetPartial()

### DIFF
--- a/aws/resource_aws_db_cluster_snapshot.go
+++ b/aws/resource_aws_db_cluster_snapshot.go
@@ -193,8 +193,6 @@ func resourceAwsdbClusterSnapshotUpdate(d *schema.ResourceData, meta interface{}
 		if err := keyvaluetags.RdsUpdateTags(conn, d.Get("db_cluster_snapshot_arn").(string), o, n); err != nil {
 			return fmt.Errorf("error updating RDS DB Cluster Snapshot (%s) tags: %s", d.Get("db_cluster_snapshot_arn").(string), err)
 		}
-
-		d.SetPartial("tags")
 	}
 
 	return nil

--- a/aws/resource_aws_db_event_subscription.go
+++ b/aws/resource_aws_db_event_subscription.go
@@ -236,7 +236,6 @@ func resourceAwsDbEventSubscriptionRetrieve(name string, conn *rds.RDS) (*rds.Ev
 func resourceAwsDbEventSubscriptionUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).rdsconn
 
-	d.Partial(true)
 	requestUpdate := false
 
 	req := &rds.ModifyEventSubscriptionInput{
@@ -293,10 +292,6 @@ func resourceAwsDbEventSubscriptionUpdate(d *schema.ResourceData, meta interface
 		if err != nil {
 			return fmt.Errorf("Modifying RDS Event Subscription %s failed: %s", d.Id(), err)
 		}
-		d.SetPartial("event_categories")
-		d.SetPartial("enabled")
-		d.SetPartial("sns_topic")
-		d.SetPartial("source_type")
 	}
 
 	if d.HasChange("tags") {
@@ -305,8 +300,6 @@ func resourceAwsDbEventSubscriptionUpdate(d *schema.ResourceData, meta interface
 		if err := keyvaluetags.RdsUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
 			return fmt.Errorf("error updating RDS Event Subscription (%s) tags: %s", d.Get("arn").(string), err)
 		}
-
-		d.SetPartial("tags")
 	}
 
 	if d.HasChange("source_ids") {
@@ -348,10 +341,7 @@ func resourceAwsDbEventSubscriptionUpdate(d *schema.ResourceData, meta interface
 				}
 			}
 		}
-		d.SetPartial("source_ids")
 	}
-
-	d.Partial(false)
 
 	return nil
 }

--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -1470,14 +1470,10 @@ func waitUntilAwsDbInstanceIsDeleted(id string, conn *rds.RDS, timeout time.Dura
 func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).rdsconn
 
-	d.Partial(true)
-
 	req := &rds.ModifyDBInstanceInput{
 		ApplyImmediately:     aws.Bool(d.Get("apply_immediately").(bool)),
 		DBInstanceIdentifier: aws.String(d.Id()),
 	}
-
-	d.SetPartial("apply_immediately")
 
 	if !aws.BoolValue(req.ApplyImmediately) {
 		log.Println("[INFO] Only settings updating, instance changes will be applied in next maintenance window")
@@ -1485,66 +1481,53 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 
 	requestUpdate := false
 	if d.HasChange("allocated_storage") || d.HasChange("iops") {
-		d.SetPartial("allocated_storage")
-		d.SetPartial("iops")
 		req.Iops = aws.Int64(int64(d.Get("iops").(int)))
 		req.AllocatedStorage = aws.Int64(int64(d.Get("allocated_storage").(int)))
 		requestUpdate = true
 	}
 	if d.HasChange("allow_major_version_upgrade") {
-		d.SetPartial("allow_major_version_upgrade")
 		req.AllowMajorVersionUpgrade = aws.Bool(d.Get("allow_major_version_upgrade").(bool))
 		// Having allowing_major_version_upgrade by itself should not trigger ModifyDBInstance
 		// as it results in InvalidParameterCombination: No modifications were requested
 	}
 	if d.HasChange("backup_retention_period") {
-		d.SetPartial("backup_retention_period")
 		req.BackupRetentionPeriod = aws.Int64(int64(d.Get("backup_retention_period").(int)))
 		requestUpdate = true
 	}
 	if d.HasChange("copy_tags_to_snapshot") {
-		d.SetPartial("copy_tags_to_snapshot")
 		req.CopyTagsToSnapshot = aws.Bool(d.Get("copy_tags_to_snapshot").(bool))
 		requestUpdate = true
 	}
 	if d.HasChange("ca_cert_identifier") {
-		d.SetPartial("ca_cert_identifier")
 		req.CACertificateIdentifier = aws.String(d.Get("ca_cert_identifier").(string))
 		requestUpdate = true
 	}
 	if d.HasChange("deletion_protection") {
-		d.SetPartial("deletion_protection")
 		req.DeletionProtection = aws.Bool(d.Get("deletion_protection").(bool))
 		requestUpdate = true
 	}
 	if d.HasChange("instance_class") {
-		d.SetPartial("instance_class")
 		req.DBInstanceClass = aws.String(d.Get("instance_class").(string))
 		requestUpdate = true
 	}
 	if d.HasChange("parameter_group_name") {
-		d.SetPartial("parameter_group_name")
 		req.DBParameterGroupName = aws.String(d.Get("parameter_group_name").(string))
 		requestUpdate = true
 	}
 	if d.HasChange("engine_version") {
-		d.SetPartial("engine_version")
 		req.EngineVersion = aws.String(d.Get("engine_version").(string))
 		req.AllowMajorVersionUpgrade = aws.Bool(d.Get("allow_major_version_upgrade").(bool))
 		requestUpdate = true
 	}
 	if d.HasChange("backup_window") {
-		d.SetPartial("backup_window")
 		req.PreferredBackupWindow = aws.String(d.Get("backup_window").(string))
 		requestUpdate = true
 	}
 	if d.HasChange("maintenance_window") {
-		d.SetPartial("maintenance_window")
 		req.PreferredMaintenanceWindow = aws.String(d.Get("maintenance_window").(string))
 		requestUpdate = true
 	}
 	if d.HasChange("max_allocated_storage") {
-		d.SetPartial("max_allocated_storage")
 		mas := d.Get("max_allocated_storage").(int)
 
 		// The API expects the max allocated storage value to be set to the allocated storage
@@ -1558,22 +1541,18 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 		requestUpdate = true
 	}
 	if d.HasChange("password") {
-		d.SetPartial("password")
 		req.MasterUserPassword = aws.String(d.Get("password").(string))
 		requestUpdate = true
 	}
 	if d.HasChange("multi_az") {
-		d.SetPartial("multi_az")
 		req.MultiAZ = aws.Bool(d.Get("multi_az").(bool))
 		requestUpdate = true
 	}
 	if d.HasChange("publicly_accessible") {
-		d.SetPartial("publicly_accessible")
 		req.PubliclyAccessible = aws.Bool(d.Get("publicly_accessible").(bool))
 		requestUpdate = true
 	}
 	if d.HasChange("storage_type") {
-		d.SetPartial("storage_type")
 		req.StorageType = aws.String(d.Get("storage_type").(string))
 		requestUpdate = true
 
@@ -1582,19 +1561,16 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 	if d.HasChange("auto_minor_version_upgrade") {
-		d.SetPartial("auto_minor_version_upgrade")
 		req.AutoMinorVersionUpgrade = aws.Bool(d.Get("auto_minor_version_upgrade").(bool))
 		requestUpdate = true
 	}
 
 	if d.HasChange("monitoring_role_arn") {
-		d.SetPartial("monitoring_role_arn")
 		req.MonitoringRoleArn = aws.String(d.Get("monitoring_role_arn").(string))
 		requestUpdate = true
 	}
 
 	if d.HasChange("monitoring_interval") {
-		d.SetPartial("monitoring_interval")
 		req.MonitoringInterval = aws.Int64(int64(d.Get("monitoring_interval").(int)))
 		requestUpdate = true
 	}
@@ -1614,24 +1590,20 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if d.HasChange("option_group_name") {
-		d.SetPartial("option_group_name")
 		req.OptionGroupName = aws.String(d.Get("option_group_name").(string))
 		requestUpdate = true
 	}
 
 	if d.HasChange("port") {
-		d.SetPartial("port")
 		req.DBPortNumber = aws.Int64(int64(d.Get("port").(int)))
 		requestUpdate = true
 	}
 	if d.HasChange("db_subnet_group_name") {
-		d.SetPartial("db_subnet_group_name")
 		req.DBSubnetGroupName = aws.String(d.Get("db_subnet_group_name").(string))
 		requestUpdate = true
 	}
 
 	if d.HasChange("enabled_cloudwatch_logs_exports") {
-		d.SetPartial("enabled_cloudwatch_logs_exports")
 		req.CloudwatchLogsExportConfiguration = buildCloudwatchLogsExportConfiguration(d)
 		requestUpdate = true
 	}
@@ -1642,24 +1614,19 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if d.HasChange("domain") || d.HasChange("domain_iam_role_name") {
-		d.SetPartial("domain")
-		d.SetPartial("domain_iam_role_name")
 		req.Domain = aws.String(d.Get("domain").(string))
 		req.DomainIAMRoleName = aws.String(d.Get("domain_iam_role_name").(string))
 		requestUpdate = true
 	}
 
 	if d.HasChange("performance_insights_enabled") || d.HasChange("performance_insights_kms_key_id") || d.HasChange("performance_insights_retention_period") {
-		d.SetPartial("performance_insights_enabled")
 		req.EnablePerformanceInsights = aws.Bool(d.Get("performance_insights_enabled").(bool))
 
 		if v, ok := d.GetOk("performance_insights_kms_key_id"); ok {
-			d.SetPartial("performance_insights_kms_key_id")
 			req.PerformanceInsightsKMSKeyId = aws.String(v.(string))
 		}
 
 		if v, ok := d.GetOk("performance_insights_retention_period"); ok {
-			d.SetPartial("performance_insights_retention_period")
 			req.PerformanceInsightsRetentionPeriod = aws.Int64(int64(v.(int)))
 		}
 
@@ -1729,10 +1696,7 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 			return fmt.Errorf("error updating RDS DB Instance (%s) tags: %s", d.Get("arn").(string), err)
 		}
 
-		d.SetPartial("tags")
 	}
-
-	d.Partial(false)
 
 	return resourceAwsDbInstanceRead(d, meta)
 }

--- a/aws/resource_aws_db_option_group.go
+++ b/aws/resource_aws_db_option_group.go
@@ -285,7 +285,6 @@ func resourceAwsDbOptionGroupUpdate(d *schema.ResourceData, meta interface{}) er
 			if err != nil {
 				return fmt.Errorf("Error modifying DB Option Group: %s", err)
 			}
-			d.SetPartial("option")
 		}
 	}
 
@@ -295,8 +294,6 @@ func resourceAwsDbOptionGroupUpdate(d *schema.ResourceData, meta interface{}) er
 		if err := keyvaluetags.RdsUpdateTags(rdsconn, d.Get("arn").(string), o, n); err != nil {
 			return fmt.Errorf("error updating RDS Option Group (%s) tags: %s", d.Get("arn").(string), err)
 		}
-
-		d.SetPartial("tags")
 	}
 
 	return resourceAwsDbOptionGroupRead(d, meta)

--- a/aws/resource_aws_db_parameter_group.go
+++ b/aws/resource_aws_db_parameter_group.go
@@ -113,12 +113,6 @@ func resourceAwsDbParameterGroupCreate(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error creating DB Parameter Group: %s", err)
 	}
 
-	d.Partial(true)
-	d.SetPartial("name")
-	d.SetPartial("family")
-	d.SetPartial("description")
-	d.Partial(false)
-
 	d.SetId(aws.StringValue(resp.DBParameterGroup.DBParameterGroupName))
 	d.Set("arn", resp.DBParameterGroup.DBParameterGroupArn)
 	log.Printf("[INFO] DB Parameter Group ID: %s", d.Id())
@@ -246,8 +240,6 @@ func resourceAwsDbParameterGroupRead(d *schema.ResourceData, meta interface{}) e
 func resourceAwsDbParameterGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	rdsconn := meta.(*AWSClient).rdsconn
 
-	d.Partial(true)
-
 	if d.HasChange("parameter") {
 		o, n := d.GetChange("parameter")
 		if o == nil {
@@ -327,11 +319,7 @@ func resourceAwsDbParameterGroupUpdate(d *schema.ResourceData, meta interface{})
 		if err := keyvaluetags.RdsUpdateTags(rdsconn, d.Get("arn").(string), o, n); err != nil {
 			return fmt.Errorf("error updating RDS DB Parameter Group (%s) tags: %s", d.Get("arn").(string), err)
 		}
-
-		d.SetPartial("tags")
 	}
-
-	d.Partial(false)
 
 	return resourceAwsDbParameterGroupRead(d, meta)
 }

--- a/aws/resource_aws_db_security_group.go
+++ b/aws/resource_aws_db_security_group.go
@@ -196,16 +196,12 @@ func resourceAwsDbSecurityGroupRead(d *schema.ResourceData, meta interface{}) er
 func resourceAwsDbSecurityGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).rdsconn
 
-	d.Partial(true)
-
 	if d.HasChange("tags") {
 		o, n := d.GetChange("tags")
 
 		if err := keyvaluetags.RdsUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
 			return fmt.Errorf("error updating RDS DB Security Group (%s) tags: %s", d.Get("arn").(string), err)
 		}
-
-		d.SetPartial("tags")
 	}
 
 	if d.HasChange("ingress") {
@@ -243,7 +239,6 @@ func resourceAwsDbSecurityGroupUpdate(d *schema.ResourceData, meta interface{}) 
 			}
 		}
 	}
-	d.Partial(false)
 
 	return resourceAwsDbSecurityGroupRead(d, meta)
 }

--- a/aws/resource_aws_db_snapshot.go
+++ b/aws/resource_aws_db_snapshot.go
@@ -220,8 +220,6 @@ func resourceAwsDbSnapshotUpdate(d *schema.ResourceData, meta interface{}) error
 		if err := keyvaluetags.RdsUpdateTags(conn, d.Get("db_snapshot_arn").(string), o, n); err != nil {
 			return fmt.Errorf("error updating RDS DB Snapshot (%s) tags: %s", d.Get("db_snapshot_arn").(string), err)
 		}
-
-		d.SetPartial("tags")
 	}
 
 	return nil

--- a/aws/resource_aws_db_subnet_group.go
+++ b/aws/resource_aws_db_subnet_group.go
@@ -195,8 +195,6 @@ func resourceAwsDbSubnetGroupUpdate(d *schema.ResourceData, meta interface{}) er
 		if err := keyvaluetags.RdsUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
 			return fmt.Errorf("error updating RDS DB Subnet Group (%s) tags: %s", d.Get("arn").(string), err)
 		}
-
-		d.SetPartial("tags")
 	}
 
 	return resourceAwsDbSubnetGroupRead(d, meta)

--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -1118,7 +1118,6 @@ func resourceAwsRDSClusterUpdate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if d.HasChange("db_cluster_parameter_group_name") {
-		d.SetPartial("db_cluster_parameter_group_name")
 		req.DBClusterParameterGroupName = aws.String(d.Get("db_cluster_parameter_group_name").(string))
 		requestUpdate = true
 	}
@@ -1134,19 +1133,16 @@ func resourceAwsRDSClusterUpdate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if d.HasChange("enabled_cloudwatch_logs_exports") {
-		d.SetPartial("enabled_cloudwatch_logs_exports")
 		req.CloudwatchLogsExportConfiguration = buildCloudwatchLogsExportConfiguration(d)
 		requestUpdate = true
 	}
 
 	if d.HasChange("scaling_configuration") {
-		d.SetPartial("scaling_configuration")
 		req.ScalingConfiguration = expandRdsClusterScalingConfiguration(d.Get("scaling_configuration").([]interface{}), d.Get("engine_mode").(string))
 		requestUpdate = true
 	}
 
 	if d.HasChange("enable_http_endpoint") {
-		d.SetPartial("enable_http_endpoint")
 		req.EnableHttpEndpoint = aws.Bool(d.Get("enable_http_endpoint").(bool))
 		requestUpdate = true
 	}
@@ -1242,8 +1238,6 @@ func resourceAwsRDSClusterUpdate(d *schema.ResourceData, meta interface{}) error
 
 		if err := keyvaluetags.RdsUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
 			return fmt.Errorf("error updating tags: %s", err)
-		} else {
-			d.SetPartial("tags")
 		}
 	}
 

--- a/aws/resource_aws_rds_cluster_instance.go
+++ b/aws/resource_aws_rds_cluster_instance.go
@@ -490,17 +490,14 @@ func resourceAwsRDSClusterInstanceUpdate(d *schema.ResourceData, meta interface{
 	}
 
 	if d.HasChange("monitoring_role_arn") {
-		d.SetPartial("monitoring_role_arn")
 		req.MonitoringRoleArn = aws.String(d.Get("monitoring_role_arn").(string))
 		requestUpdate = true
 	}
 
 	if d.HasChange("performance_insights_enabled") || d.HasChange("performance_insights_kms_key_id") {
-		d.SetPartial("performance_insights_enabled")
 		req.EnablePerformanceInsights = aws.Bool(d.Get("performance_insights_enabled").(bool))
 
 		if v, ok := d.GetOk("performance_insights_kms_key_id"); ok {
-			d.SetPartial("performance_insights_kms_key_id")
 			req.PerformanceInsightsKMSKeyId = aws.String(v.(string))
 		}
 
@@ -508,49 +505,41 @@ func resourceAwsRDSClusterInstanceUpdate(d *schema.ResourceData, meta interface{
 	}
 
 	if d.HasChange("preferred_backup_window") {
-		d.SetPartial("preferred_backup_window")
 		req.PreferredBackupWindow = aws.String(d.Get("preferred_backup_window").(string))
 		requestUpdate = true
 	}
 
 	if d.HasChange("preferred_maintenance_window") {
-		d.SetPartial("preferred_maintenance_window")
 		req.PreferredMaintenanceWindow = aws.String(d.Get("preferred_maintenance_window").(string))
 		requestUpdate = true
 	}
 
 	if d.HasChange("monitoring_interval") {
-		d.SetPartial("monitoring_interval")
 		req.MonitoringInterval = aws.Int64(int64(d.Get("monitoring_interval").(int)))
 		requestUpdate = true
 	}
 
 	if d.HasChange("auto_minor_version_upgrade") {
-		d.SetPartial("auto_minor_version_upgrade")
 		req.AutoMinorVersionUpgrade = aws.Bool(d.Get("auto_minor_version_upgrade").(bool))
 		requestUpdate = true
 	}
 
 	if d.HasChange("copy_tags_to_snapshot") {
-		d.SetPartial("copy_tags_to_snapshot")
 		req.CopyTagsToSnapshot = aws.Bool(d.Get("copy_tags_to_snapshot").(bool))
 		requestUpdate = true
 	}
 
 	if d.HasChange("promotion_tier") {
-		d.SetPartial("promotion_tier")
 		req.PromotionTier = aws.Int64(int64(d.Get("promotion_tier").(int)))
 		requestUpdate = true
 	}
 
 	if d.HasChange("publicly_accessible") {
-		d.SetPartial("publicly_accessible")
 		req.PubliclyAccessible = aws.Bool(d.Get("publicly_accessible").(bool))
 		requestUpdate = true
 	}
 
 	if d.HasChange("ca_cert_identifier") {
-		d.SetPartial("ca_cert_identifier")
 		req.CACertificateIdentifier = aws.String(d.Get("ca_cert_identifier").(string))
 		requestUpdate = true
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12083
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12087

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
aws/resource_aws_db_cluster_snapshot.go:197:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_event_subscription.go:239:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_db_event_subscription.go:296:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_event_subscription.go:297:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_event_subscription.go:298:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_event_subscription.go:299:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_event_subscription.go:309:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_event_subscription.go:351:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_event_subscription.go:354:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_db_instance.go:1473:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_db_instance.go:1480:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_instance.go:1488:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_instance.go:1489:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_instance.go:1495:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_instance.go:1501:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_instance.go:1506:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_instance.go:1511:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_instance.go:1516:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_instance.go:1521:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_instance.go:1526:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_instance.go:1531:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_instance.go:1537:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_instance.go:1542:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_instance.go:1547:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_instance.go:1561:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_instance.go:1566:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_instance.go:1571:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_instance.go:1576:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_instance.go:1585:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_instance.go:1591:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_instance.go:1597:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_instance.go:1617:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_instance.go:1623:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_instance.go:1628:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_instance.go:1634:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_instance.go:1645:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_instance.go:1646:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_instance.go:1653:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_instance.go:1657:4: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_instance.go:1662:4: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_instance.go:1732:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_instance.go:1735:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_db_option_group.go:288:4: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_option_group.go:299:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_parameter_group.go:116:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_db_parameter_group.go:117:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_parameter_group.go:118:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_parameter_group.go:119:2: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_parameter_group.go:120:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_db_parameter_group.go:249:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_db_parameter_group.go:331:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_parameter_group.go:334:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_db_security_group.go:199:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_db_security_group.go:208:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_security_group.go:246:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_db_snapshot.go:224:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_db_subnet_group.go:199:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_rds_cluster.go:1121:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_rds_cluster.go:1137:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_rds_cluster.go:1143:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_rds_cluster.go:1149:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_rds_cluster.go:1246:4: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_rds_cluster_instance.go:493:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_rds_cluster_instance.go:499:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_rds_cluster_instance.go:503:4: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_rds_cluster_instance.go:511:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_rds_cluster_instance.go:517:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_rds_cluster_instance.go:523:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_rds_cluster_instance.go:529:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_rds_cluster_instance.go:535:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_rds_cluster_instance.go:541:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_rds_cluster_instance.go:547:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_rds_cluster_instance.go:553:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_rds_cluster_parameter_group.go:185:2: R007: deprecated (schema.ResourceData).Partial
aws/resource_aws_rds_cluster_parameter_group.go:274:3: R008: deprecated (schema.ResourceData).SetPartial
aws/resource_aws_rds_cluster_parameter_group.go:277:2: R007: deprecated (schema.ResourceData).Partial
```

Output from acceptance testing (test failures present on master):

```
--- PASS: TestAccAWSDBClusterSnapshot_basic (161.83s)
--- PASS: TestAccAWSDBClusterSnapshot_Tags (208.14s)

--- PASS: TestAccAWSDBEventSubscription_basicUpdate (127.65s)
--- PASS: TestAccAWSDBEventSubscription_categoryUpdate (125.24s)
--- PASS: TestAccAWSDBEventSubscription_disappears (78.82s)
--- PASS: TestAccAWSDBEventSubscription_withPrefix (81.72s)
--- PASS: TestAccAWSDBEventSubscription_withSourceIds (101.26s)

--- FAIL: TestAccAWSDBInstance_S3Import (671.95s)
--- PASS: TestAccAWSDBInstance_AllowMajorVersionUpgrade (443.80s)
--- PASS: TestAccAWSDBInstance_basic (566.04s)
--- PASS: TestAccAWSDBInstance_CACertificateIdentifier (623.72s)
--- PASS: TestAccAWSDBInstance_cloudwatchLogsExportConfiguration (530.77s)
--- PASS: TestAccAWSDBInstance_cloudwatchLogsExportConfigurationUpdate (956.15s)
--- PASS: TestAccAWSDBInstance_DeletionProtection (584.27s)
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_MSSQL (698.62s)
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle (760.80s)
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Postgresql (623.55s)
--- PASS: TestAccAWSDBInstance_FinalSnapshotIdentifier (813.02s)
--- PASS: TestAccAWSDBInstance_FinalSnapshotIdentifier_SkipFinalSnapshot (742.11s)
--- PASS: TestAccAWSDBInstance_generatedName (473.76s)
--- PASS: TestAccAWSDBInstance_iamAuth (423.49s)
--- PASS: TestAccAWSDBInstance_IsAlreadyBeingDeleted (539.38s)
--- PASS: TestAccAWSDBInstance_kmsKey (462.25s)
--- PASS: TestAccAWSDBInstance_MaxAllocatedStorage (625.94s)
--- PASS: TestAccAWSDBInstance_MinorVersion (496.98s)
--- PASS: TestAccAWSDBInstance_MonitoringInterval (1038.16s)
--- PASS: TestAccAWSDBInstance_MonitoringRoleArn_EnabledToDisabled (795.78s)
--- PASS: TestAccAWSDBInstance_MonitoringRoleArn_EnabledToRemoved (804.57s)
--- PASS: TestAccAWSDBInstance_MonitoringRoleArn_RemovedToEnabled (822.91s)
--- PASS: TestAccAWSDBInstance_MSSQL_Domain (3671.81s)
--- PASS: TestAccAWSDBInstance_MSSQL_DomainSnapshotRestore (2811.43s)
--- PASS: TestAccAWSDBInstance_MSSQL_TZ (1625.50s)
--- PASS: TestAccAWSDBInstance_MySQL_SnapshotRestoreWithEngineVersion (1902.87s)
--- PASS: TestAccAWSDBInstance_namePrefix (485.32s)
--- PASS: TestAccAWSDBInstance_NoDeleteAutomatedBackups (654.56s)
--- PASS: TestAccAWSDBInstance_optionGroup (499.87s)
--- PASS: TestAccAWSDBInstance_Password (574.56s)
--- PASS: TestAccAWSDBInstance_portUpdate (504.62s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb (1527.99s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AllowMajorVersionUpgrade (1476.93s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AutoMinorVersionUpgrade (1370.52s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AvailabilityZone (1482.23s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_BackupRetentionPeriod (1824.62s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_BackupWindow (1598.16s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_CACertificateIdentifier (1454.94s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_IamDatabaseAuthenticationEnabled (1538.08s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MaintenanceWindow (1582.77s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MaxAllocatedStorage (1594.36s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_Monitoring (1753.26s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MultiAZ (2145.53s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_ParameterGroupName (1695.43s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled (1860.48s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_Port (1448.57s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_VpcSecurityGroupIds (1540.51s)
--- PASS: TestAccAWSDBInstance_separate_iops_update (781.70s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier (1327.39s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AllocatedStorage (1519.07s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AllowMajorVersionUpgrade (2303.64s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AutoMinorVersionUpgrade (1187.05s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AvailabilityZone (1298.15s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod (1644.94s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod_Unset (1704.80s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupWindow (1307.64s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_DeletionProtection (1235.72s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_IamDatabaseAuthenticationEnabled (1295.56s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Io1Storage (1804.10s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MaintenanceWindow (1324.91s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MaxAllocatedStorage (1118.39s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Monitoring (1256.49s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ (1893.83s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ_SQLServer (3726.44s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_ParameterGroupName (1341.16s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_PerformanceInsightsEnabled (1369.24s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Port (1241.65s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Tags (1180.23s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds (1150.78s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds_Tags (1127.44s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds_Tags (1305.53s)
--- PASS: TestAccAWSDBInstance_subnetGroup (1056.41s)

--- PASS: TestAccAWSDBOptionGroup_basic (20.09s)
--- PASS: TestAccAWSDBOptionGroup_basicDestroyWithInstance (505.73s)
--- PASS: TestAccAWSDBOptionGroup_generatedName (25.87s)
--- PASS: TestAccAWSDBOptionGroup_multipleOptions (36.35s)
--- PASS: TestAccAWSDBOptionGroup_namePrefix (40.96s)
--- PASS: TestAccAWSDBOptionGroup_Option_OptionSettings (120.52s)
--- PASS: TestAccAWSDBOptionGroup_Option_OptionSettings_IAMRole (62.67s)
--- PASS: TestAccAWSDBOptionGroup_Option_OptionSettings_MultipleNonDefault (67.17s)
--- PASS: TestAccAWSDBOptionGroup_OracleOptionsUpdate (110.44s)
--- PASS: TestAccAWSDBOptionGroup_sqlServerOptionsUpdate (82.61s)
--- PASS: TestAccAWSDBOptionGroup_Tags (65.48s)
--- PASS: TestAccAWSDBOptionGroup_Tags_WithOptions (65.91s)
--- PASS: TestAccAWSDBOptionGroup_timeoutBlock (26.29s)

--- PASS: TestAccAWSDBParameterGroup_basic (113.24s)
--- PASS: TestAccAWSDBParameterGroup_Disappears (17.07s)
--- PASS: TestAccAWSDBParameterGroup_generatedName (41.36s)
--- PASS: TestAccAWSDBParameterGroup_limit (84.28s)
--- PASS: TestAccAWSDBParameterGroup_MatchDefault (61.75s)
--- PASS: TestAccAWSDBParameterGroup_namePrefix (48.96s)
--- PASS: TestAccAWSDBParameterGroup_Only (39.17s)
--- PASS: TestAccAWSDBParameterGroup_withApplyMethod (51.68s)

--- PASS: TestAccAWSDBSecurityGroup_basic (13.66s)

--- PASS: TestAccAWSDBSnapshot_basic (755.49s)
--- PASS: TestAccAWSDBSnapshot_disappears (617.74s)
--- PASS: TestAccAWSDBSnapshot_tags (651.91s)

--- PASS: TestAccAWSDBSubnetGroup_basic (35.79s)
--- PASS: TestAccAWSDBSubnetGroup_generatedName (35.00s)
--- PASS: TestAccAWSDBSubnetGroup_namePrefix (35.59s)
--- PASS: TestAccAWSDBSubnetGroup_updateDescription (61.68s)
--- PASS: TestAccAWSDBSubnetGroup_withUndocumentedCharacters (42.07s)

--- FAIL: TestAccAWSRDSCluster_s3Restore (1624.16s)
--- PASS: TestAccAWSRDSCluster_AvailabilityZones (240.79s)
--- PASS: TestAccAWSRDSCluster_BacktrackWindow (248.08s)
--- PASS: TestAccAWSRDSCluster_backupsUpdate (183.26s)
--- PASS: TestAccAWSRDSCluster_basic (236.10s)
--- PASS: TestAccAWSRDSCluster_ClusterIdentifierPrefix (123.32s)
--- PASS: TestAccAWSRDSCluster_copyTagsToSnapshot (224.31s)
--- PASS: TestAccAWSRDSCluster_DbSubnetGroupName (214.54s)
--- PASS: TestAccAWSRDSCluster_DeletionProtection (164.87s)
--- PASS: TestAccAWSRDSCluster_EnabledCloudwatchLogsExports (446.46s)
--- PASS: TestAccAWSRDSCluster_EnableHttpEndpoint (311.62s)
--- PASS: TestAccAWSRDSCluster_encrypted (122.89s)
--- PASS: TestAccAWSRDSCluster_EncryptedCrossRegionReplication (1804.90s)
--- PASS: TestAccAWSRDSCluster_EngineMode (414.68s)
--- PASS: TestAccAWSRDSCluster_EngineMode_Global (132.28s)
--- PASS: TestAccAWSRDSCluster_EngineMode_Multimaster (212.05s)
--- PASS: TestAccAWSRDSCluster_EngineMode_ParallelQuery (225.62s)
--- PASS: TestAccAWSRDSCluster_EngineVersion (136.38s)
--- PASS: TestAccAWSRDSCluster_EngineVersionWithPrimaryInstance (1114.96s)
--- PASS: TestAccAWSRDSCluster_generatedName (131.15s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier (203.57s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_Add (231.16s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_Remove (215.27s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_Update (210.72s)
--- PASS: TestAccAWSRDSCluster_iamAuth (131.99s)
--- PASS: TestAccAWSRDSCluster_kmsKey (150.06s)
--- PASS: TestAccAWSRDSCluster_missingUserNameCausesError (7.08s)
--- PASS: TestAccAWSRDSCluster_Port (362.74s)
--- PASS: TestAccAWSRDSCluster_ScalingConfiguration (410.44s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier (419.84s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_DeletionProtection (411.50s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EncryptedRestore (352.20s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_ParallelQuery (455.74s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Provisioned (393.86s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Different (373.62s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Equal (373.42s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_MasterPassword (459.57s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_MasterUsername (433.11s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_PreferredBackupWindow (407.91s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_PreferredMaintenanceWindow (371.35s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_Tags (374.56s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds (414.24s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds_Tags (404.15s)
--- PASS: TestAccAWSRDSCluster_Tags (152.46s)
--- PASS: TestAccAWSRDSCluster_takeFinalSnapshot (152.36s)
--- PASS: TestAccAWSRDSCluster_updateIamRoles (173.37s)

--- FAIL: TestAccAWSRDSClusterInstance_CACertificateIdentifier (819.09s)
--- PASS: TestAccAWSRDSClusterInstance_az (745.73s)
--- PASS: TestAccAWSRDSClusterInstance_basic (1460.33s)
--- PASS: TestAccAWSRDSClusterInstance_CopyTagsToSnapshot (693.56s)
--- PASS: TestAccAWSRDSClusterInstance_disappears (696.91s)
--- PASS: TestAccAWSRDSClusterInstance_generatedName (720.86s)
--- PASS: TestAccAWSRDSClusterInstance_isAlreadyBeingDeleted (708.46s)
--- PASS: TestAccAWSRDSClusterInstance_kmsKey (1376.64s)
--- PASS: TestAccAWSRDSClusterInstance_MonitoringInterval (1298.65s)
--- PASS: TestAccAWSRDSClusterInstance_MonitoringRoleArn_EnabledToDisabled (941.01s)
--- PASS: TestAccAWSRDSClusterInstance_MonitoringRoleArn_EnabledToRemoved (965.68s)
--- PASS: TestAccAWSRDSClusterInstance_MonitoringRoleArn_RemovedToEnabled (841.84s)
--- PASS: TestAccAWSRDSClusterInstance_namePrefix (1063.96s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraMysql1 (858.33s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraMysql2 (804.60s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraPostgresql (794.16s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql1 (817.10s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql1_DefaultKeyToCustomKey (764.17s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql2 (850.24s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql2_DefaultKeyToCustomKey (847.01s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraPostgresql (786.92s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraPostgresql_DefaultKeyToCustomKey (753.94s)
--- PASS: TestAccAWSRDSClusterInstance_PubliclyAccessible (762.33s)
```
