### PR TITLE
New Data Source: WAF/Regional Subscribed rule group

### DIFF
--- a/aws/data_source_aws_waf_subscribed_rule_group.go
+++ b/aws/data_source_aws_waf_subscribed_rule_group.go
@@ -1,0 +1,65 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/waf"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAwsWafSubscribedRuleGroup() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsWafSubscribedRuleGroupRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"metric_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsWafSubscribedRuleGroupRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafconn
+	name := d.Get("name").(string)
+	rules := make([]*waf.SubscribedRuleGroupSummary, 0)
+
+	input := &waf.ListSubscribedRuleGroupsInput{}
+	for {
+		output, err := conn.ListSubscribedRuleGroups(input)
+		if err != nil {
+			return fmt.Errorf("error reading WAF Subscribed Rule Group: %s", err)
+		}
+		for _, rule := range output.RuleGroups {
+			if aws.StringValue(rule.Name) == name {
+				rules = append(rules, rule)
+			}
+		}
+
+		if output.NextMarker == nil {
+			break
+		}
+		input.NextMarker = output.NextMarker
+	}
+
+	if len(rules) == 0 {
+		return fmt.Errorf("WAF Subscribed Rule Group not found for the given name: %s", name)
+	}
+
+	if len(rules) > 1 {
+		return fmt.Errorf("multiple WAF Subscribed Rule Group found for the given name: %s", name)
+	}
+
+	rule := rules[0]
+
+	d.SetId(aws.StringValue(rule.RuleGroupId))
+	d.Set("metric_name", rule.MetricName)
+
+	return nil
+}

--- a/aws/data_source_aws_waf_subscribed_rule_group_test.go
+++ b/aws/data_source_aws_waf_subscribed_rule_group_test.go
@@ -1,0 +1,42 @@
+package aws
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceAwsWafSubscribedRuleGroup_Basic(t *testing.T) {
+	datasourceName := "data.aws_waf_subscribed_rule_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSourceAwsWafSubscribedRuleGroupNonExistent,
+				ExpectError: regexp.MustCompile(`WAF Subscribed Rule Group not found`),
+			},
+			{
+				Config: testAccDataSourceAwsWafSubscribedRuleGroupConfigName,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(datasourceName, "name", "Fortinet Managed Rules for AWS WAF - SQLi/XSS"),
+					resource.TestCheckResourceAttr(datasourceName, "metric_name", "FortinetAWSXSSAndSQLiRuleset"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceAwsWafSubscribedRuleGroupConfigName = `
+data "aws_waf_subscribed_rule_group" "test" {
+  name = "Fortinet Managed Rules for AWS WAF - SQLi/XSS"
+}
+`
+
+const testAccDataSourceAwsWafSubscribedRuleGroupNonExistent = `
+data "aws_waf_subscribed_rule_group" "test" {
+  name = "tf-acc-test-does-not-exist"
+}
+`

--- a/aws/data_source_aws_wafregional_subscribed_rule_group.go
+++ b/aws/data_source_aws_wafregional_subscribed_rule_group.go
@@ -1,0 +1,65 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/waf"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAwsWafRegionalSubscribedRuleGroup() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsWafRegionalSubscribedRuleGroupRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"metric_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsWafRegionalSubscribedRuleGroupRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafregionalconn
+	name := d.Get("name").(string)
+	rules := make([]*waf.SubscribedRuleGroupSummary, 0)
+
+	input := &waf.ListSubscribedRuleGroupsInput{}
+	for {
+		output, err := conn.ListSubscribedRuleGroups(input)
+		if err != nil {
+			return fmt.Errorf("error reading WAF Regional Subscribed Rule Group: %s", err)
+		}
+		for _, rule := range output.RuleGroups {
+			if aws.StringValue(rule.Name) == name {
+				rules = append(rules, rule)
+			}
+		}
+
+		if output.NextMarker == nil {
+			break
+		}
+		input.NextMarker = output.NextMarker
+	}
+
+	if len(rules) == 0 {
+		return fmt.Errorf("WAF Regional Subscribed Rule Group not found for the given name: %s", name)
+	}
+
+	if len(rules) > 1 {
+		return fmt.Errorf("multiple WAF Regional Subscribed Rule Group found for the given name: %s", name)
+	}
+
+	rule := rules[0]
+
+	d.SetId(aws.StringValue(rule.RuleGroupId))
+	d.Set("metric_name", rule.MetricName)
+
+	return nil
+}

--- a/aws/data_source_aws_wafregional_subscribed_rule_group_test.go
+++ b/aws/data_source_aws_wafregional_subscribed_rule_group_test.go
@@ -1,0 +1,42 @@
+package aws
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceAwsWafRegionalSubscribedRuleGroup_Basic(t *testing.T) {
+	datasourceName := "data.aws_wafregional_subscribed_rule_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSourceAwsWafRegionalSubscribedRuleGroupNonExistent,
+				ExpectError: regexp.MustCompile(`WAF Regional Subscribed Rule Group not found`),
+			},
+			{
+				Config: testAccDataSourceAwsWafRegionalSubscribedRuleGroupConfigName,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(datasourceName, "name", "Fortinet Managed Rules for AWS WAF - SQLi/XSS"),
+					resource.TestCheckResourceAttr(datasourceName, "metric_name", "FortinetAWSXSSAndSQLiRuleset"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceAwsWafRegionalSubscribedRuleGroupConfigName = `
+data "aws_wafregional_subscribed_rule_group" "test" {
+  name = "Fortinet Managed Rules for AWS WAF - SQLi/XSS"
+}
+`
+
+const testAccDataSourceAwsWafRegionalSubscribedRuleGroupNonExistent = `
+data "aws_wafregional_subscribed_rule_group" "test" {
+  name = "tf-acc-test-does-not-exist"
+}
+`

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -306,10 +306,12 @@ func Provider() terraform.ResourceProvider {
 			"aws_waf_ipset":                                 dataSourceAwsWafIpSet(),
 			"aws_waf_rule":                                  dataSourceAwsWafRule(),
 			"aws_waf_rate_based_rule":                       dataSourceAwsWafRateBasedRule(),
+			"aws_waf_subscribed_rule_group":                 dataSourceAwsWafSubscribedRuleGroup(),
 			"aws_waf_web_acl":                               dataSourceAwsWafWebAcl(),
 			"aws_wafregional_ipset":                         dataSourceAwsWafRegionalIpSet(),
 			"aws_wafregional_rule":                          dataSourceAwsWafRegionalRule(),
 			"aws_wafregional_rate_based_rule":               dataSourceAwsWafRegionalRateBasedRule(),
+			"aws_wafregional_subscribed_rule_group":         dataSourceAwsWafRegionalSubscribedRuleGroup(),
 			"aws_wafregional_web_acl":                       dataSourceAwsWafRegionalWebAcl(),
 			"aws_workspaces_bundle":                         dataSourceAwsWorkspaceBundle(),
 

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -3341,7 +3341,7 @@
                                     <a href="/docs/providers/aws/d/waf_rate_based_rule.html">aws_waf_rate_based_rule</a>
                                 </li>
                                 <li>
-                                    <a href="/docs/providers/aws/d/aws_waf_subscribed_rule_group.html">aws_waf_subscribed_rule_group</a>
+                                    <a href="/docs/providers/aws/d/waf_subscribed_rule_group.html">aws_waf_subscribed_rule_group</a>
                                 </li>
                             </ul>
                         </li>
@@ -3407,7 +3407,7 @@
                                     <a href="/docs/providers/aws/d/wafregional_rate_based_rule.html">aws_wafregional_rate_based_rule</a>
                                 </li>
                                 <li>
-                                    <a href="/docs/providers/aws/d/aws_wafregional_subscribed_rule_group.html">aws_wafregional_subscribed_rule_group</a>
+                                    <a href="/docs/providers/aws/d/wafregional_subscribed_rule_group.html">aws_wafregional_subscribed_rule_group</a>
                                 </li>
                             </ul>
                         </li>

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -3340,6 +3340,9 @@
                                 <li>
                                     <a href="/docs/providers/aws/d/waf_rate_based_rule.html">aws_waf_rate_based_rule</a>
                                 </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/aws_waf_subscribed_rule_group.html">aws_waf_subscribed_rule_group</a>
+                                </li>
                             </ul>
                         </li>
                         <li>
@@ -3402,6 +3405,9 @@
                                 </li>
                                 <li>
                                     <a href="/docs/providers/aws/d/wafregional_rate_based_rule.html">aws_wafregional_rate_based_rule</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/aws_wafregional_subscribed_rule_group.html">aws_wafregional_subscribed_rule_group</a>
                                 </li>
                             </ul>
                         </li>

--- a/website/docs/d/waf_subscribed_rule_group.html.markdown
+++ b/website/docs/d/waf_subscribed_rule_group.html.markdown
@@ -1,0 +1,31 @@
+---
+subcategory: "WAF"
+layout: "aws"
+page_title: "AWS: aws_waf_subscribed_rule_group"
+description: |-
+  Retrieves an AWS WAF Subscribed Rule Group id.
+---
+
+# Data Source: aws_waf_subscribed_rule_group
+
+`aws_waf_subscribed_rule_group` Retrieves a WAF Subscribed Rule Group Resource Id.
+
+## Example Usage
+
+```hcl
+data "aws_waf_subscribed_rule_group" "example" {
+  name = "tfWAFRule"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the WAF subscribed rule group.
+
+## Attributes Reference
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the WAF subscribed rule group.
+* `metric_name` - The Metric Name of the WAF subscribed rule group.

--- a/website/docs/d/wafregional_subscribed_rule_group.html.markdown
+++ b/website/docs/d/wafregional_subscribed_rule_group.html.markdown
@@ -1,0 +1,31 @@
+---
+subcategory: "WAF Regional"
+layout: "aws"
+page_title: "AWS: aws_wafregional_subscribed_rule_group"
+description: |-
+  Retrieves an AWS WAF Regional Subscribed Rule Group id.
+---
+
+# Data Source: aws_wafregional_subscribed_rule_group
+
+`aws_wafregional_subscribed_rule_group` Retrieves a WAF Regional Subscribed Rule Group Resource Id.
+
+## Example Usage
+
+```hcl
+data "aws_wafregional_subscribed_rule_group" "example" {
+  name = "tfWAFRule"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the WAF Regional subscribed rule group.
+
+## Attributes Reference
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the WAF Regional subscribed rule group.
+* `metric_name` - The Metric Name of the WAF Regional subscribed rule group.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12407

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data_source_aws_wafregional_subscribed_rule_group: add new data source
data_source_aws_waf_subscribed_rule_group: add new data source
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccDataSourceAwsWafRegionalSubscribedRuleGroup_Basic'
--- PASS: TestAccDataSourceAwsWafRegionalSubscribedRuleGroup_Basic (53.61s)
```

```
$ make testacc TESTARGS='-run=TestAccDataSourceAwsWafSubscribedRuleGroup_Basic'
--- PASS: TestAccDataSourceAwsWafSubscribedRuleGroup_Basic (52.60s)
```
