### PR TITLE
r/aws_flow_log: Add max_aggregation_interval attribute

### DIFF
--- a/aws/resource_aws_flow_log.go
+++ b/aws/resource_aws_flow_log.go
@@ -103,9 +103,11 @@ func resourceAwsFlowLog() *schema.Resource {
 			},
 
 			"max_aggregation_interval": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      600,
+				ValidateFunc: validation.IntInSlice([]int{60, 600}),
 			},
 
 			"tags": tagsSchema(),
@@ -157,6 +159,7 @@ func resourceAwsLogFlowCreate(d *schema.ResourceData, meta interface{}) error {
 	if v, ok := d.GetOk("log_group_name"); ok && v != "" {
 		opts.LogGroupName = aws.String(v.(string))
 	}
+
 	if v, ok := d.GetOk("log_format"); ok && v != "" {
 		opts.LogFormat = aws.String(v.(string))
 	}

--- a/aws/resource_aws_flow_log.go
+++ b/aws/resource_aws_flow_log.go
@@ -101,6 +101,13 @@ func resourceAwsFlowLog() *schema.Resource {
 				ForceNew: true,
 				Computed: true,
 			},
+
+			"max_aggregation_interval": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"tags": tagsSchema(),
 		},
 	}
@@ -154,6 +161,10 @@ func resourceAwsLogFlowCreate(d *schema.ResourceData, meta interface{}) error {
 		opts.LogFormat = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("max_aggregation_interval"); ok {
+		opts.MaxAggregationInterval = aws.Int64(int64(v.(int)))
+	}
+
 	if v, ok := d.GetOk("tags"); ok && len(v.(map[string]interface{})) > 0 {
 		opts.TagSpecifications = ec2TagSpecificationsFromMap(d.Get("tags").(map[string]interface{}), ec2.ResourceTypeVpcFlowLog)
 	}
@@ -205,6 +216,7 @@ func resourceAwsLogFlowRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("log_group_name", fl.LogGroupName)
 	d.Set("iam_role_arn", fl.DeliverLogsPermissionArn)
 	d.Set("log_format", fl.LogFormat)
+	d.Set("max_aggregation_interval", fl.MaxAggregationInterval)
 	var resourceKey string
 	if strings.HasPrefix(*fl.ResourceId, "vpc-") {
 		resourceKey = "vpc_id"

--- a/website/docs/r/flow_log.html.markdown
+++ b/website/docs/r/flow_log.html.markdown
@@ -102,6 +102,10 @@ The following arguments are supported:
 * `subnet_id` - (Optional) Subnet ID to attach to
 * `vpc_id` - (Optional) VPC ID to attach to
 * `log_format` - (Optional) The fields to include in the flow log record, in the order in which they should appear.
+* `max_aggregation_interval` - (Optional) The maximum interval of time
+  during which a flow of packets is captured and aggregated into a flow
+  log record. Valid Values: `60` seconds (1 minute) or `600` seconds (10
+  minutes). Default: `600`.
 * `tags` - (Optional) Key-value mapping of resource tags
 
 ## Attributes Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/11927.
Replaces https://github.com/terraform-providers/terraform-provider-aws/pull/12007.

Many thanks to @ajorpheus for starting this one.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_flow_log: Add `max_aggregation_interval` attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSFlowLog_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 2 -run=TestAccAWSFlowLog_ -timeout 120m
=== RUN   TestAccAWSFlowLog_VPCID
=== PAUSE TestAccAWSFlowLog_VPCID
=== RUN   TestAccAWSFlowLog_LogFormat
=== PAUSE TestAccAWSFlowLog_LogFormat
=== RUN   TestAccAWSFlowLog_SubnetID
=== PAUSE TestAccAWSFlowLog_SubnetID
=== RUN   TestAccAWSFlowLog_LogDestinationType_CloudWatchLogs
=== PAUSE TestAccAWSFlowLog_LogDestinationType_CloudWatchLogs
=== RUN   TestAccAWSFlowLog_LogDestinationType_S3
=== PAUSE TestAccAWSFlowLog_LogDestinationType_S3
=== RUN   TestAccAWSFlowLog_LogDestinationType_S3_Invalid
=== PAUSE TestAccAWSFlowLog_LogDestinationType_S3_Invalid
=== RUN   TestAccAWSFlowLog_LogDestinationType_MaxAggregationInterval
=== PAUSE TestAccAWSFlowLog_LogDestinationType_MaxAggregationInterval
=== RUN   TestAccAWSFlowLog_tags
=== PAUSE TestAccAWSFlowLog_tags
=== RUN   TestAccAWSFlowLog_disappears
=== PAUSE TestAccAWSFlowLog_disappears
=== CONT  TestAccAWSFlowLog_VPCID
=== CONT  TestAccAWSFlowLog_LogDestinationType_S3_Invalid
--- PASS: TestAccAWSFlowLog_LogDestinationType_S3_Invalid (22.15s)
=== CONT  TestAccAWSFlowLog_disappears
--- PASS: TestAccAWSFlowLog_disappears (33.20s)
=== CONT  TestAccAWSFlowLog_tags
--- PASS: TestAccAWSFlowLog_VPCID (59.35s)
=== CONT  TestAccAWSFlowLog_LogDestinationType_MaxAggregationInterval
--- PASS: TestAccAWSFlowLog_LogDestinationType_MaxAggregationInterval (34.55s)
=== CONT  TestAccAWSFlowLog_LogDestinationType_CloudWatchLogs
--- PASS: TestAccAWSFlowLog_LogDestinationType_CloudWatchLogs (34.79s)
=== CONT  TestAccAWSFlowLog_LogDestinationType_S3
--- PASS: TestAccAWSFlowLog_tags (79.70s)
=== CONT  TestAccAWSFlowLog_SubnetID
--- PASS: TestAccAWSFlowLog_LogDestinationType_S3 (42.05s)
=== CONT  TestAccAWSFlowLog_LogFormat
--- PASS: TestAccAWSFlowLog_SubnetID (38.51s)
--- PASS: TestAccAWSFlowLog_LogFormat (63.21s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	234.019s
```
