### PR TITLE
r/firehose_delivery_stream - add support for elasticsearch cluster_endpoint + validations

### DIFF
--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -1956,11 +1956,11 @@ func createElasticsearchConfig(d *schema.ResourceData, s3Config *firehose.S3Dest
 		S3Configuration: s3Config,
 	}
 
-	if v, ok := es["domain_arn"]; ok {
+	if v, ok := es["domain_arn"]; ok && v.(string) != "" {
 		config.DomainARN = aws.String(v.(string))
 	}
 
-	if v, ok := es["cluster_endpoint"]; ok {
+	if v, ok := es["cluster_endpoint"]; ok && v.(string) != "" {
 		config.ClusterEndpoint = aws.String(v.(string))
 	}
 
@@ -2004,11 +2004,11 @@ func updateElasticsearchConfig(d *schema.ResourceData, s3Update *firehose.S3Dest
 		S3Update:       s3Update,
 	}
 
-	if v, ok := es["domain_arn"]; ok {
+	if v, ok := es["domain_arn"]; ok && v.(string) != "" {
 		update.DomainARN = aws.String(v.(string))
 	}
 
-	if v, ok := es["cluster_endpoint"]; ok {
+	if v, ok := es["cluster_endpoint"]; ok && v.(string) != "" {
 		update.ClusterEndpoint = aws.String(v.(string))
 	}
 

--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -83,15 +83,10 @@ func s3ConfigurationSchema() *schema.Schema {
 				},
 
 				"compression_format": {
-					Type:     schema.TypeString,
-					Optional: true,
-					Default:  firehose.CompressionFormatUncompressed,
-					ValidateFunc: validation.StringInSlice([]string{
-						firehose.CompressionFormatUncompressed,
-						firehose.CompressionFormatGzip,
-						firehose.CompressionFormatSnappy,
-						firehose.CompressionFormatZip,
-					}, false),
+					Type:         schema.TypeString,
+					Optional:     true,
+					Default:      firehose.CompressionFormatUncompressed,
+					ValidateFunc: validation.StringInSlice(firehose.CompressionFormat_Values(), false),
 				},
 
 				"kms_key_arn": {
@@ -140,15 +135,9 @@ func processingConfigurationSchema() *schema.Schema {
 								Elem: &schema.Resource{
 									Schema: map[string]*schema.Schema{
 										"parameter_name": {
-											Type:     schema.TypeString,
-											Required: true,
-											ValidateFunc: validation.StringInSlice([]string{
-												firehose.ProcessorParameterNameLambdaArn,
-												firehose.ProcessorParameterNameNumberOfRetries,
-												firehose.ProcessorParameterNameRoleArn,
-												firehose.ProcessorParameterNameBufferSizeInMbs,
-												firehose.ProcessorParameterNameBufferIntervalInSeconds,
-											}, false),
+											Type:         schema.TypeString,
+											Required:     true,
+											ValidateFunc: validation.StringInSlice(firehose.ProcessorParameterName_Values(), false),
 										},
 										"parameter_value": {
 											Type:         schema.TypeString,
@@ -159,11 +148,9 @@ func processingConfigurationSchema() *schema.Schema {
 								},
 							},
 							"type": {
-								Type:     schema.TypeString,
-								Required: true,
-								ValidateFunc: validation.StringInSlice([]string{
-									firehose.ProcessorTypeLambda,
-								}, false),
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringInSlice(firehose.ProcessorType_Values(), false),
 							},
 						},
 					},
@@ -813,15 +800,10 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 						},
 
 						"compression_format": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  firehose.CompressionFormatUncompressed,
-							ValidateFunc: validation.StringInSlice([]string{
-								firehose.CompressionFormatUncompressed,
-								firehose.CompressionFormatGzip,
-								firehose.CompressionFormatSnappy,
-								firehose.CompressionFormatZip,
-							}, false),
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      firehose.CompressionFormatUncompressed,
+							ValidateFunc: validation.StringInSlice(firehose.CompressionFormat_Values(), false),
 						},
 
 						"data_format_conversion_configuration": {
@@ -931,14 +913,10 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 																			Default:  0.05,
 																		},
 																		"compression": {
-																			Type:     schema.TypeString,
-																			Optional: true,
-																			Default:  firehose.OrcCompressionSnappy,
-																			ValidateFunc: validation.StringInSlice([]string{
-																				firehose.OrcCompressionNone,
-																				firehose.OrcCompressionSnappy,
-																				firehose.OrcCompressionZlib,
-																			}, false),
+																			Type:         schema.TypeString,
+																			Optional:     true,
+																			Default:      firehose.OrcCompressionSnappy,
+																			ValidateFunc: validation.StringInSlice(firehose.OrcCompression_Values(), false),
 																		},
 																		"dictionary_key_threshold": {
 																			Type:     schema.TypeFloat,
@@ -951,13 +929,10 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 																			Default:  false,
 																		},
 																		"format_version": {
-																			Type:     schema.TypeString,
-																			Optional: true,
-																			Default:  firehose.OrcFormatVersionV012,
-																			ValidateFunc: validation.StringInSlice([]string{
-																				firehose.OrcFormatVersionV011,
-																				firehose.OrcFormatVersionV012,
-																			}, false),
+																			Type:         schema.TypeString,
+																			Optional:     true,
+																			Default:      firehose.OrcFormatVersionV012,
+																			ValidateFunc: validation.StringInSlice(firehose.OrcFormatVersion_Values(), false),
 																		},
 																		"padding_tolerance": {
 																			Type:     schema.TypeFloat,
@@ -997,14 +972,10 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 																			ValidateFunc: validation.IntAtLeast(67108864),
 																		},
 																		"compression": {
-																			Type:     schema.TypeString,
-																			Optional: true,
-																			Default:  firehose.ParquetCompressionSnappy,
-																			ValidateFunc: validation.StringInSlice([]string{
-																				firehose.ParquetCompressionGzip,
-																				firehose.ParquetCompressionSnappy,
-																				firehose.ParquetCompressionUncompressed,
-																			}, false),
+																			Type:         schema.TypeString,
+																			Optional:     true,
+																			Default:      firehose.ParquetCompressionSnappy,
+																			ValidateFunc: validation.StringInSlice(firehose.ParquetCompression_Values(), false),
 																		},
 																		"enable_dictionary_compression": {
 																			Type:     schema.TypeBool,
@@ -1025,13 +996,10 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 																			ValidateFunc: validation.IntAtLeast(65536),
 																		},
 																		"writer_version": {
-																			Type:     schema.TypeString,
-																			Optional: true,
-																			Default:  firehose.ParquetWriterVersionV1,
-																			ValidateFunc: validation.StringInSlice([]string{
-																				firehose.ParquetWriterVersionV1,
-																				firehose.ParquetWriterVersionV2,
-																			}, false),
+																			Type:         schema.TypeString,
+																			Optional:     true,
+																			Default:      firehose.ParquetWriterVersionV1,
+																			ValidateFunc: validation.StringInSlice(firehose.ParquetWriterVersion_Values(), false),
 																		},
 																	},
 																},
@@ -1106,13 +1074,10 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 						},
 
 						"s3_backup_mode": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  firehose.S3BackupModeDisabled,
-							ValidateFunc: validation.StringInSlice([]string{
-								firehose.S3BackupModeDisabled,
-								firehose.S3BackupModeEnabled,
-							}, false),
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      firehose.S3BackupModeDisabled,
+							ValidateFunc: validation.StringInSlice(firehose.S3BackupMode_Values(), false),
 						},
 
 						"s3_backup_configuration": s3ConfigurationSchema(),
@@ -1155,13 +1120,10 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 						},
 
 						"s3_backup_mode": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  firehose.S3BackupModeDisabled,
-							ValidateFunc: validation.StringInSlice([]string{
-								firehose.S3BackupModeDisabled,
-								firehose.S3BackupModeEnabled,
-							}, false),
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      firehose.S3BackupModeDisabled,
+							ValidateFunc: validation.StringInSlice(firehose.S3BackupMode_Values(), false),
 						},
 
 						"s3_backup_configuration": s3ConfigurationSchema(),
@@ -1170,7 +1132,7 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							Default:      3600,
-							ValidateFunc: validation.StringLenBetween(0, 7200),
+							ValidateFunc: validation.IntBetween(0, 7200),
 						},
 
 						"copy_options": {
@@ -1226,16 +1188,10 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 						},
 
 						"index_rotation_period": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  firehose.ElasticsearchIndexRotationPeriodOneDay,
-							ValidateFunc: validation.StringInSlice([]string{
-								firehose.ElasticsearchIndexRotationPeriodNoRotation,
-								firehose.ElasticsearchIndexRotationPeriodOneHour,
-								firehose.ElasticsearchIndexRotationPeriodOneDay,
-								firehose.ElasticsearchIndexRotationPeriodOneWeek,
-								firehose.ElasticsearchIndexRotationPeriodOneMonth,
-							}, false),
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      firehose.ElasticsearchIndexRotationPeriodOneDay,
+							ValidateFunc: validation.StringInSlice(firehose.ElasticsearchIndexRotationPeriod_Values(), false),
 						},
 
 						"retry_duration": {
@@ -1252,14 +1208,11 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 						},
 
 						"s3_backup_mode": {
-							Type:     schema.TypeString,
-							ForceNew: true,
-							Optional: true,
-							Default:  firehose.ElasticsearchS3BackupModeFailedDocumentsOnly,
-							ValidateFunc: validation.StringInSlice([]string{
-								firehose.ElasticsearchS3BackupModeFailedDocumentsOnly,
-								firehose.ElasticsearchS3BackupModeAllDocuments,
-							}, false),
+							Type:         schema.TypeString,
+							ForceNew:     true,
+							Optional:     true,
+							Default:      firehose.ElasticsearchS3BackupModeFailedDocumentsOnly,
+							ValidateFunc: validation.StringInSlice(firehose.ElasticsearchS3BackupMode_Values(), false),
 						},
 
 						"type_name": {

--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -2557,6 +2557,11 @@ resource "aws_elasticsearch_domain" "test_cluster" {
     instance_type = "m4.large.elasticsearch"
   }
 
+  domain_endpoint_options {
+    enforce_https       = true
+    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+  }
+
   ebs_options {
     ebs_enabled = true
     volume_size = 10
@@ -2813,7 +2818,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
     bucket_arn = "${aws_s3_bucket.bucket.arn}"
   }
   elasticsearch_configuration {
-    cluster_endpoint = "${aws_elasticsearch_domain.test_cluster.endpoint}"
+    cluster_endpoint = "https://${aws_elasticsearch_domain.test_cluster.endpoint}"
     role_arn = "${aws_iam_role.firehose.arn}"
     index_name = "test"
     type_name = "test"
@@ -2831,7 +2836,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
     bucket_arn = "${aws_s3_bucket.bucket.arn}"
   }
   elasticsearch_configuration {
-    cluster_endpoint = "${aws_elasticsearch_domain.test_cluster.endpoint}"
+    cluster_endpoint = "https://${aws_elasticsearch_domain.test_cluster.endpoint}"
     role_arn = "${aws_iam_role.firehose.arn}"
     index_name = "test"
     type_name = "test"

--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -1050,10 +1050,10 @@ func TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates(t *testi
 	policyName := fmt.Sprintf("tf_acc_policy_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_%s", rString)
 	preConfig := fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_ElasticsearchBasic,
-		ri, ri, ri, ri, ri)
+		ri, ri, ri, ri, ri, ri)
 	postConfig := testAccFirehoseAWSLambdaConfigBasic(funcName, policyName, roleName) +
 		fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_ElasticsearchUpdate,
-			ri, ri, ri, ri, ri)
+			ri, ri, ri, ri, ri, ri)
 
 	updatedElasticSearchConfig := &firehose.ElasticsearchDestinationDescription{
 		BufferingHints: &firehose.ElasticsearchBufferingHints{
@@ -1083,7 +1083,7 @@ func TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates(t *testi
 			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKinesisFirehoseDeliveryStreamExists("aws_kinesis_firehose_delivery_stream.test", &stream),
+					testAccCheckKinesisFirehoseDeliveryStreamExists(resourceName, &stream),
 					testAccCheckAWSKinesisFirehoseDeliveryStreamAttributes(&stream, nil, nil, nil, nil, nil),
 				),
 			},
@@ -1095,7 +1095,70 @@ func TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates(t *testi
 			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKinesisFirehoseDeliveryStreamExists("aws_kinesis_firehose_delivery_stream.test", &stream),
+					testAccCheckKinesisFirehoseDeliveryStreamExists(resourceName, &stream),
+					testAccCheckAWSKinesisFirehoseDeliveryStreamAttributes(&stream, nil, nil, nil, updatedElasticSearchConfig, nil),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigEndpointUpdates(t *testing.T) {
+	var stream firehose.DeliveryStreamDescription
+
+	resourceName := "aws_kinesis_firehose_delivery_stream.test"
+	ri := acctest.RandInt()
+	rString := acctest.RandString(8)
+	funcName := fmt.Sprintf("aws_kinesis_firehose_delivery_stream_test_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_%s", rString)
+	preConfig := fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_ElasticsearchEndpoint,
+		ri, ri, ri, ri, ri, ri)
+	postConfig := testAccFirehoseAWSLambdaConfigBasic(funcName, policyName, roleName) +
+		fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_ElasticsearchEndpointUpdate,
+			ri, ri, ri, ri, ri, ri)
+
+	updatedElasticSearchConfig := &firehose.ElasticsearchDestinationDescription{
+		BufferingHints: &firehose.ElasticsearchBufferingHints{
+			IntervalInSeconds: aws.Int64(500),
+		},
+		ProcessingConfiguration: &firehose.ProcessingConfiguration{
+			Enabled: aws.Bool(true),
+			Processors: []*firehose.Processor{
+				{
+					Type: aws.String("Lambda"),
+					Parameters: []*firehose.ProcessorParameter{
+						{
+							ParameterName:  aws.String("LambdaArn"),
+							ParameterValue: aws.String("valueNotTested"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisFirehoseDeliveryStreamDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: preConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisFirehoseDeliveryStreamExists(resourceName, &stream),
+					testAccCheckAWSKinesisFirehoseDeliveryStreamAttributes(&stream, nil, nil, nil, nil, nil),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: postConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisFirehoseDeliveryStreamExists(resourceName, &stream),
 					testAccCheckAWSKinesisFirehoseDeliveryStreamAttributes(&stream, nil, nil, nil, updatedElasticSearchConfig, nil),
 				),
 			},
@@ -1629,7 +1692,7 @@ data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 resource "aws_iam_role" "firehose" {
-  name = "tf_acctest_firehose_delivery_role_%d"
+  name = "tf-acc-test-%[1]d"
 
   assume_role_policy = <<EOF
 {
@@ -1654,7 +1717,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "firehose" {
-  name = "tf_acctest_firehose_delivery_policy_%d"
+  name = "tf-acc-test-%[1]d"
   role = aws_iam_role.firehose.id
 
   policy = <<EOF
@@ -1692,22 +1755,22 @@ EOF
 }
 
 resource "aws_s3_bucket" "bucket" {
-  bucket = "tf-test-bucket-%d"
+  bucket = "tf-test-bucket-%[1]d"
   acl    = "private"
 }
 
 resource "aws_cloudwatch_log_group" "test" {
-  name = "example-%d"
+  name = "tf-acc-test-%[1]d"
 }
 
 resource "aws_cloudwatch_log_stream" "test" {
-  name           = "sample-log-stream-test-%d"
+  name           = "tf-acc-test-%[1]d"
   log_group_name = aws_cloudwatch_log_group.test.name
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on  = [aws_iam_role_policy.firehose]
-  name        = "terraform-kinesis-firehose-cloudwatch-%d"
+  name        = "tf-acc-test-%[1]d"
   destination = "s3"
 
   s3_configuration {
@@ -1721,7 +1784,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
     }
   }
 }
-`, rInt, rInt, rInt, rInt, rInt, rInt)
+`, rInt)
 }
 
 var testAccKinesisFirehoseDeliveryStreamConfig_s3basic = testAccKinesisFirehoseDeliveryStreamBaseConfig + `
@@ -1883,12 +1946,12 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 func testAccKinesisFirehoseDeliveryStreamConfig_ExtendedS3_DataFormatConversionConfiguration_Enabled(rName string, rInt int, enabled bool) string {
 	return fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamBaseConfig, rInt, rInt, rInt) + fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
-  name = "%s"
+  name = %[1]q
 }
 
 resource "aws_glue_catalog_table" "test" {
   database_name = aws_glue_catalog_database.test.name
-  name          = "%s"
+  name          = %[1]q
 
   storage_descriptor {
     columns {
@@ -1900,7 +1963,7 @@ resource "aws_glue_catalog_table" "test" {
 
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   destination = "extended_s3"
-  name        = "%s"
+  name        = %[1]q
 
   extended_s3_configuration {
     bucket_arn = aws_s3_bucket.bucket.arn
@@ -1909,7 +1972,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
     role_arn    = aws_iam_role.firehose.arn
 
     data_format_conversion_configuration {
-      enabled = %t
+      enabled = %[2]t
 
       input_format_configuration {
         deserializer {
@@ -1933,18 +1996,18 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
   depends_on = [aws_iam_role_policy.firehose]
 }
-`, rName, rName, rName, enabled)
+`, rName, enabled)
 }
 
 func testAccKinesisFirehoseDeliveryStreamConfig_ExtendedS3_DataFormatConversionConfiguration_HiveJsonSerDe_Empty(rName string, rInt int) string {
 	return fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamBaseConfig, rInt, rInt, rInt) + fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
-  name = "%s"
+  name = %[1]q
 }
 
 resource "aws_glue_catalog_table" "test" {
   database_name = aws_glue_catalog_database.test.name
-  name          = "%s"
+  name          = %[1]q
 
   storage_descriptor {
     columns {
@@ -1956,7 +2019,7 @@ resource "aws_glue_catalog_table" "test" {
 
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   destination = "extended_s3"
-  name        = "%s"
+  name        = %[1]q
 
   extended_s3_configuration {
     bucket_arn = aws_s3_bucket.bucket.arn
@@ -1987,7 +2050,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
   depends_on = [aws_iam_role_policy.firehose]
 }
-`, rName, rName, rName)
+`, rName)
 }
 
 func testAccKinesisFirehoseDeliveryStreamConfig_ExtendedS3_ExternalUpdate(rName string, rInt int) string {
@@ -2007,12 +2070,12 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 func testAccKinesisFirehoseDeliveryStreamConfig_ExtendedS3_DataFormatConversionConfiguration_OpenXJsonSerDe_Empty(rName string, rInt int) string {
 	return fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamBaseConfig, rInt, rInt, rInt) + fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
-  name = "%s"
+  name = %[1]q
 }
 
 resource "aws_glue_catalog_table" "test" {
   database_name = aws_glue_catalog_database.test.name
-  name          = "%s"
+  name          = %[1]q
 
   storage_descriptor {
     columns {
@@ -2024,7 +2087,7 @@ resource "aws_glue_catalog_table" "test" {
 
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   destination = "extended_s3"
-  name        = "%s"
+  name        = %[1]q
 
   extended_s3_configuration {
     bucket_arn = aws_s3_bucket.bucket.arn
@@ -2055,18 +2118,18 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
   depends_on = [aws_iam_role_policy.firehose]
 }
-`, rName, rName, rName)
+`, rName)
 }
 
 func testAccKinesisFirehoseDeliveryStreamConfig_ExtendedS3_DataFormatConversionConfiguration_OrcSerDe_Empty(rName string, rInt int) string {
 	return fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamBaseConfig, rInt, rInt, rInt) + fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
-  name = "%s"
+  name = %[1]q
 }
 
 resource "aws_glue_catalog_table" "test" {
   database_name = aws_glue_catalog_database.test.name
-  name          = "%s"
+  name          = %[1]q
 
   storage_descriptor {
     columns {
@@ -2078,7 +2141,7 @@ resource "aws_glue_catalog_table" "test" {
 
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   destination = "extended_s3"
-  name        = "%s"
+  name        = %[1]q
 
   extended_s3_configuration {
     bucket_arn = aws_s3_bucket.bucket.arn
@@ -2109,18 +2172,18 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
   depends_on = [aws_iam_role_policy.firehose]
 }
-`, rName, rName, rName)
+`, rName)
 }
 
 func testAccKinesisFirehoseDeliveryStreamConfig_ExtendedS3_DataFormatConversionConfiguration_ParquetSerDe_Empty(rName string, rInt int) string {
 	return fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamBaseConfig, rInt, rInt, rInt) + fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
-  name = "%s"
+  name = %[1]q
 }
 
 resource "aws_glue_catalog_table" "test" {
   database_name = aws_glue_catalog_database.test.name
-  name          = "%s"
+  name          = %[1]q
 
   storage_descriptor {
     columns {
@@ -2132,7 +2195,7 @@ resource "aws_glue_catalog_table" "test" {
 
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   destination = "extended_s3"
-  name        = "%s"
+  name        = %[1]q
 
   extended_s3_configuration {
     bucket_arn = aws_s3_bucket.bucket.arn
@@ -2163,7 +2226,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
   depends_on = [aws_iam_role_policy.firehose]
 }
-`, rName, rName, rName)
+`, rName)
 }
 
 func testAccKinesisFirehoseDeliveryStreamConfig_ExtendedS3_ErrorOutputPrefix(rName string, rInt int, errorOutputPrefix string) string {
@@ -2501,9 +2564,8 @@ resource "aws_elasticsearch_domain" "test_cluster" {
 }
 
 resource "aws_iam_role_policy" "firehose-elasticsearch" {
-  name = "elasticsearch"
+  name = "tf-acc-test-%d"
   role = aws_iam_role.firehose.id
-
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -2740,12 +2802,59 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 	}
   }`
 
+var testAccKinesisFirehoseDeliveryStreamConfig_ElasticsearchEndpoint = testAccKinesisFirehoseDeliveryStreamBaseElasticsearchConfig + `
+resource "aws_kinesis_firehose_delivery_stream" "test" {
+  depends_on = ["aws_iam_role_policy.firehose-elasticsearch"]
+
+  name = "terraform-kinesis-firehose-es-%d"
+  destination = "elasticsearch"
+  s3_configuration {
+    role_arn = "${aws_iam_role.firehose.arn}"
+    bucket_arn = "${aws_s3_bucket.bucket.arn}"
+  }
+  elasticsearch_configuration {
+    cluster_endpoint = "${aws_elasticsearch_domain.test_cluster.endpoint}"
+    role_arn = "${aws_iam_role.firehose.arn}"
+    index_name = "test"
+    type_name = "test"
+  }
+}`
+
+var testAccKinesisFirehoseDeliveryStreamConfig_ElasticsearchEndpointUpdate = testAccKinesisFirehoseDeliveryStreamBaseElasticsearchConfig + `
+resource "aws_kinesis_firehose_delivery_stream" "test" {
+  depends_on = ["aws_iam_role_policy.firehose-elasticsearch"]
+
+  name = "terraform-kinesis-firehose-es-%d"
+  destination = "elasticsearch"
+  s3_configuration {
+    role_arn = "${aws_iam_role.firehose.arn}"
+    bucket_arn = "${aws_s3_bucket.bucket.arn}"
+  }
+  elasticsearch_configuration {
+    cluster_endpoint = "${aws_elasticsearch_domain.test_cluster.endpoint}"
+    role_arn = "${aws_iam_role.firehose.arn}"
+    index_name = "test"
+    type_name = "test"
+    buffering_interval = 500
+    processing_configuration {
+      enabled = false
+      processors {
+        type = "Lambda"
+        parameters {
+          parameter_name = "LambdaArn"
+          parameter_value = "${aws_lambda_function.lambda_function_test.arn}:$LATEST"
+        }
+      }
+    }
+  }
+}`
+
 func testAccKinesisFirehoseDeliveryStreamConfig_missingProcessingConfiguration(rInt int) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
 resource "aws_iam_role" "firehose" {
-  name = "tf_acctest_firehose_delivery_role_%d"
+  name = "tf_acctest_firehose_delivery_role_%[1]d"
 
   assume_role_policy = <<EOF
 {
@@ -2765,7 +2874,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "firehose" {
-  name = "tf_acctest_firehose_delivery_policy_%d"
+  name = "tf_acctest_firehose_delivery_policy_%[1]d"
   role = aws_iam_role.firehose.id
 
   policy = <<EOF
@@ -2803,12 +2912,12 @@ EOF
 }
 
 resource "aws_s3_bucket" "bucket" {
-  bucket = "tf-test-bucket-%d"
+  bucket = "tf-test-bucket-%[1]d"
   acl    = "private"
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "test" {
-  name        = "terraform-kinesis-firehose-mpc-%d"
+  name        = "terraform-kinesis-firehose-mpc-%[1]d"
   destination = "extended_s3"
 
   extended_s3_configuration {
@@ -2820,5 +2929,5 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
     bucket_arn         = aws_s3_bucket.bucket.arn
   }
 }
-`, rInt, rInt, rInt, rInt)
+`, rInt)
 }

--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -2811,17 +2811,19 @@ var testAccKinesisFirehoseDeliveryStreamConfig_ElasticsearchEndpoint = testAccKi
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on = ["aws_iam_role_policy.firehose-elasticsearch"]
 
-  name = "terraform-kinesis-firehose-es-%d"
+  name        = "terraform-kinesis-firehose-es-%d"
   destination = "elasticsearch"
+
   s3_configuration {
-    role_arn = "${aws_iam_role.firehose.arn}"
-    bucket_arn = "${aws_s3_bucket.bucket.arn}"
+    role_arn   = aws_iam_role.firehose.arn
+    bucket_arn = aws_s3_bucket.bucket.arn
   }
+
   elasticsearch_configuration {
     cluster_endpoint = "https://${aws_elasticsearch_domain.test_cluster.endpoint}"
-    role_arn = "${aws_iam_role.firehose.arn}"
-    index_name = "test"
-    type_name = "test"
+    role_arn         = aws_iam_role.firehose.arn
+    index_name       = "test"
+    type_name        = "test"
   }
 }`
 
@@ -2829,24 +2831,29 @@ var testAccKinesisFirehoseDeliveryStreamConfig_ElasticsearchEndpointUpdate = tes
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on = ["aws_iam_role_policy.firehose-elasticsearch"]
 
-  name = "terraform-kinesis-firehose-es-%d"
+  name        = "terraform-kinesis-firehose-es-%d"
   destination = "elasticsearch"
+
   s3_configuration {
-    role_arn = "${aws_iam_role.firehose.arn}"
-    bucket_arn = "${aws_s3_bucket.bucket.arn}"
+    role_arn   = aws_iam_role.firehose.arn
+    bucket_arn = aws_s3_bucket.bucket.arn
   }
+
   elasticsearch_configuration {
-    cluster_endpoint = "https://${aws_elasticsearch_domain.test_cluster.endpoint}"
-    role_arn = "${aws_iam_role.firehose.arn}"
-    index_name = "test"
-    type_name = "test"
+    cluster_endpoint   = "https://${aws_elasticsearch_domain.test_cluster.endpoint}"
+    role_arn           = "${aws_iam_role.firehose.arn}"
+    index_name         = "test"
+    type_name          = "test"
     buffering_interval = 500
+
     processing_configuration {
       enabled = false
+
       processors {
         type = "Lambda"
+
         parameters {
-          parameter_name = "LambdaArn"
+          parameter_name  = "LambdaArn"
           parameter_value = "${aws_lambda_function.lambda_function_test.arn}:$LATEST"
         }
       }

--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -1770,7 +1770,7 @@ resource "aws_cloudwatch_log_stream" "test" {
 
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on  = [aws_iam_role_policy.firehose]
-  name        = "tf-acc-test-%[1]d"
+  name        = "terraform-kinesis-firehose-%[1]d"
   destination = "s3"
 
   s3_configuration {

--- a/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
@@ -397,7 +397,8 @@ The `elasticsearch_configuration` object supports the following:
 
 * `buffering_interval` - (Optional) Buffer incoming data for the specified period of time, in seconds between 60 to 900, before delivering it to the destination.  The default value is 300s.
 * `buffering_size` - (Optional) Buffer incoming data to the specified size, in MBs between 1 to 100, before delivering it to the destination.  The default value is 5MB.
-* `domain_arn` - (Required) The ARN of the Amazon ES domain.  The IAM role must have permission for `DescribeElasticsearchDomain`, `DescribeElasticsearchDomains`, and `DescribeElasticsearchDomainConfig` after assuming `RoleARN`.  The pattern needs to be `arn:.*`.
+* `domain_arn` - (Optional) The ARN of the Amazon ES domain.  The IAM role must have permission for `DescribeElasticsearchDomain`, `DescribeElasticsearchDomains`, and `DescribeElasticsearchDomainConfig` after assuming `RoleARN`.  The pattern needs to be `arn:.*`. Conflicts with `cluster_endpoint`.
+* `cluster_endpoint` - (Optional) The endpoint to use when communicating with the cluster. Conflicts with `domain_arn`.
 * `index_name` - (Required) The Elasticsearch index name.
 * `index_rotation_period` - (Optional) The Elasticsearch index rotation period.  Index rotation appends a timestamp to the IndexName to facilitate expiration of old data.  Valid values are `NoRotation`, `OneHour`, `OneDay`, `OneWeek`, and `OneMonth`.  The default value is `OneDay`.
 * `retry_duration` - (Optional) After an initial failure to deliver to Amazon Elasticsearch, the total amount of time, in seconds between 0 to 7200, during which Firehose re-attempts delivery (including the first attempt).  After this time has elapsed, the failed documents are written to Amazon S3.  The default value is 300s.  There will be no retry if the value is 0.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10623
Relates #13624

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_firehose_delivery_stream: add support for `cluster_endpoint` in `elasticserach_configuration`

resource_aws_firehose_delivery_stream: plan time validations for `bucket_arn`, `buffer_size`, `buffer_interval`, `compression_format`, `role_arn`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSKinesisFirehoseDeliveryStream_'
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_basic (183.65s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basic (154.23s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithSSE (559.93s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithTags (336.71s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource (181.64s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3WithCloudwatchLogging (179.94s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3ConfigUpdates (301.67s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic (195.71s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Enabled (328.87s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ExternalUpdate (243.77s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Deserializer_Update (223.10s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_HiveJsonSerDe_Empty (173.16s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_HiveJsonSerDe_Empty (173.16s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OrcSerDe_Empty (224.00s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_ParquetSerDe_Empty (202.04s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Serializer_Update (287.97s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ErrorOutputPrefix (253.96s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3KmsKeyArn (243.57s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3Updates (377.56s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_RedshiftConfigUpdates (564.50s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_SplunkConfigUpdates (305.58s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_missingProcessingConfiguration (188.65s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates (1117.34s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigEndpointUpdates (1352.41s)
```
