### PR TITLE
Fixed documentation example for aws_api_gateway_deployment

### DIFF
--- a/website/docs/r/api_gateway_deployment.html.markdown
+++ b/website/docs/r/api_gateway_deployment.html.markdown
@@ -11,7 +11,7 @@ description: |-
 Provides an API Gateway REST Deployment.
 
 -> **Note:** Depends on having `aws_api_gateway_integration` inside your rest api (which in turn depends on `aws_api_gateway_method`). To avoid race conditions
-you might need to add an explicit `depends_on = ["aws_api_gateway_integration.name"]`.
+you might need to add an explicit `depends_on = ["${aws_api_gateway_integration.name}"]`.
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ resource "aws_api_gateway_integration" "MyDemoIntegration" {
 }
 
 resource "aws_api_gateway_deployment" "MyDemoDeployment" {
-  depends_on = ["aws_api_gateway_integration.MyDemoIntegration"]
+  depends_on = ["${aws_api_gateway_integration.MyDemoIntegration}"]
 
   rest_api_id = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
   stage_name  = "test"


### PR DESCRIPTION
The current example in [the documentation page for `api_gateway_deployment`](https://www.terraform.io/docs/providers/aws/r/api_gateway_deployment.html) is broken as the argument in the array to `depends_on` exists as a simple string literal and will not be evaluated. 

I've wrapped the variable within the interpolation syntax as a string template which fixes this.

I feel that newcomers not very familiar with HCL syntax may not be able to identify this small mistake within the example, leading to potential headache. So while a small fix, I think it would be valuable to have this change made.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request



Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```