### PR TITLE
rd/aws_instance and rd/aws_launch_template: Add support for metadata_options

### DIFF
--- a/aws/data_source_aws_instance.go
+++ b/aws/data_source_aws_instance.go
@@ -279,6 +279,26 @@ func dataSourceAwsInstance() *schema.Resource {
 					},
 				},
 			},
+			"metadata_options": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"http_endpoint": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"http_tokens": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"http_put_response_hop_limit": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"disable_api_termination": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -484,6 +504,16 @@ func instanceDescriptionAttributes(d *schema.ResourceData, instance *ec2.Instanc
 
 	if err := d.Set("credit_specification", creditSpecifications); err != nil {
 		return fmt.Errorf("error setting credit_specification: %s", err)
+	}
+
+	if instance.MetadataOptions != nil {
+		mo := make(map[string]interface{})
+		mo["http_endpoint"] = instance.MetadataOptions.HttpEndpoint
+		mo["http_tokens"] = instance.MetadataOptions.HttpTokens
+		mo["http_put_response_hop_limit"] = instance.MetadataOptions.HttpPutResponseHopLimit
+		var metadataOptions []map[string]interface{}
+		metadataOptions = append(metadataOptions, mo)
+		d.Set("metadata_options", metadataOptions)
 	}
 
 	return nil

--- a/aws/data_source_aws_instance.go
+++ b/aws/data_source_aws_instance.go
@@ -506,14 +506,8 @@ func instanceDescriptionAttributes(d *schema.ResourceData, instance *ec2.Instanc
 		return fmt.Errorf("error setting credit_specification: %s", err)
 	}
 
-	if instance.MetadataOptions != nil {
-		mo := make(map[string]interface{})
-		mo["http_endpoint"] = instance.MetadataOptions.HttpEndpoint
-		mo["http_tokens"] = instance.MetadataOptions.HttpTokens
-		mo["http_put_response_hop_limit"] = instance.MetadataOptions.HttpPutResponseHopLimit
-		var metadataOptions []map[string]interface{}
-		metadataOptions = append(metadataOptions, mo)
-		d.Set("metadata_options", metadataOptions)
+	if err := d.Set("metadata_options", flattenEc2InstanceMetadataOptions(instance.MetadataOptions)); err != nil {
+		return fmt.Errorf("error setting metadata_options: %s", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_instance_test.go
+++ b/aws/data_source_aws_instance_test.go
@@ -23,9 +23,6 @@ func TestAccAWSInstanceDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "ami", resourceName, "ami"),
 					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
 					resource.TestCheckResourceAttrPair(datasourceName, "instance_type", resourceName, "instance_type"),
-					resource.TestCheckResourceAttrPair(datasourceName, "metadata_options.0.http_endpoint", resourceName, "metadata_options.0.http_endpoint"),
-					resource.TestCheckResourceAttrPair(datasourceName, "metadata_options.0.http_tokens", resourceName, "metadata_options.0.http_tokens"),
-					resource.TestCheckResourceAttrPair(datasourceName, "metadata_options.0.http_put_response_hop_limit", resourceName, "metadata_options.0.http_put_response_hop_limit"),
 					resource.TestMatchResourceAttr(datasourceName, "arn", regexp.MustCompile(`^arn:[^:]+:ec2:[^:]+:\d{12}:instance/i-.+`)),
 					resource.TestCheckNoResourceAttr(datasourceName, "user_data_base64"),
 				),
@@ -453,11 +450,6 @@ resource "aws_instance" "test" {
   # us-west-2
   ami = "ami-4fccb37f"
   instance_type = "m1.small"
-  metadata_options {
-    http_endpoint = "enabled"
-    http_tokens = "optional"
-    http_put_response_hop_limit = 10
-  }
   tags = {
     Name = "HelloWorld"
   }

--- a/aws/data_source_aws_instance_test.go
+++ b/aws/data_source_aws_instance_test.go
@@ -25,6 +25,7 @@ func TestAccAWSInstanceDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "instance_type", resourceName, "instance_type"),
 					resource.TestCheckResourceAttrPair(datasourceName, "metadata_options.0.http_endpoint", resourceName, "metadata_options.0.http_endpoint"),
 					resource.TestCheckResourceAttrPair(datasourceName, "metadata_options.0.http_tokens", resourceName, "metadata_options.0.http_tokens"),
+					resource.TestCheckResourceAttrPair(datasourceName, "metadata_options.0.http_put_response_hop_limit", resourceName, "metadata_options.0.http_put_response_hop_limit"),
 					resource.TestMatchResourceAttr(datasourceName, "arn", regexp.MustCompile(`^arn:[^:]+:ec2:[^:]+:\d{12}:instance/i-.+`)),
 					resource.TestCheckNoResourceAttr(datasourceName, "user_data_base64"),
 				),
@@ -455,6 +456,7 @@ resource "aws_instance" "test" {
   metadata_options {
     http_endpoint = "enabled"
     http_tokens = "optional"
+    http_put_response_hop_limit = 10
   }
   tags = {
     Name = "HelloWorld"

--- a/aws/data_source_aws_instance_test.go
+++ b/aws/data_source_aws_instance_test.go
@@ -23,6 +23,8 @@ func TestAccAWSInstanceDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "ami", resourceName, "ami"),
 					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
 					resource.TestCheckResourceAttrPair(datasourceName, "instance_type", resourceName, "instance_type"),
+					resource.TestCheckResourceAttrPair(datasourceName, "metadata_options.0.http_endpoint", resourceName, "metadata_options.0.http_endpoint"),
+					resource.TestCheckResourceAttrPair(datasourceName, "metadata_options.0.http_tokens", resourceName, "metadata_options.0.http_tokens"),
 					resource.TestMatchResourceAttr(datasourceName, "arn", regexp.MustCompile(`^arn:[^:]+:ec2:[^:]+:\d{12}:instance/i-.+`)),
 					resource.TestCheckNoResourceAttr(datasourceName, "user_data_base64"),
 				),
@@ -450,6 +452,10 @@ resource "aws_instance" "test" {
   # us-west-2
   ami = "ami-4fccb37f"
   instance_type = "m1.small"
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens = "optional"
+  }
   tags = {
     Name = "HelloWorld"
   }

--- a/aws/data_source_aws_launch_template.go
+++ b/aws/data_source_aws_launch_template.go
@@ -476,7 +476,7 @@ func dataSourceAwsLaunchTemplateRead(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("error setting instance_market_options: %s", err)
 	}
 
-	if err := d.Set("metadata_options", getMetadataOptions(ltData.MetadataOptions)); err != nil {
+	if err := d.Set("metadata_options", flattenLaunchTemplateInstanceMetadataOptions(ltData.MetadataOptions)); err != nil {
 		return fmt.Errorf("error setting metadata_options: %s", err)
 	}
 

--- a/aws/data_source_aws_launch_template.go
+++ b/aws/data_source_aws_launch_template.go
@@ -202,6 +202,26 @@ func dataSourceAwsLaunchTemplate() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"metadata_options": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"http_endpoint": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"http_tokens": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"http_put_response_hop_limit": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"monitoring": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -454,6 +474,10 @@ func dataSourceAwsLaunchTemplateRead(d *schema.ResourceData, meta interface{}) e
 
 	if err := d.Set("instance_market_options", getInstanceMarketOptions(ltData.InstanceMarketOptions)); err != nil {
 		return fmt.Errorf("error setting instance_market_options: %s", err)
+	}
+
+	if err := d.Set("metadata_options", getMetadataOptions(ltData.MetadataOptions)); err != nil {
+		return fmt.Errorf("error setting metadata_options: %s", err)
 	}
 
 	if err := d.Set("monitoring", getMonitoring(ltData.Monitoring)); err != nil {

--- a/aws/data_source_aws_launch_template_test.go
+++ b/aws/data_source_aws_launch_template_test.go
@@ -79,6 +79,29 @@ func TestAccAWSLaunchTemplateDataSource_filter_tags(t *testing.T) {
 	})
 }
 
+func TestAccAWSLaunchTemplateDataSource_metadataOptions(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceName := "data.aws_launch_template.test"
+	resourceName := "aws_launch_template.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchTemplateDataSourceConfig_metadataOptions(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "metadata_options.#", resourceName, "metadata_options.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "metadata_options.0.http_endpoint", resourceName, "metadata_options.0.http_endpoint"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "metadata_options.0.http_tokens", resourceName, "metadata_options.0.http_tokens"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "metadata_options.0.http_put_response_hop_limit", resourceName, "metadata_options.0.http_put_response_hop_limit"),
+				),
+			},
+		},
+	})
+}
+
 func testAccAWSLaunchTemplateDataSourceConfig_Basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_launch_template" "test" {
@@ -123,4 +146,22 @@ data "aws_launch_template" "test" {
   }
 }
 `, rName, rInt)
+}
+
+func testAccAWSLaunchTemplateDataSourceConfig_metadataOptions(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_launch_template" "test" {
+  name = %[1]q
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+}
+
+data "aws_launch_template" "test" {
+  name = aws_launch_template.test.name
+}
+`, rName)
 }

--- a/aws/diff_suppress_funcs.go
+++ b/aws/diff_suppress_funcs.go
@@ -132,3 +132,10 @@ func suppressRoute53ZoneNameWithTrailingDot(k, old, new string, d *schema.Resour
 	}
 	return strings.TrimSuffix(old, ".") == strings.TrimSuffix(new, ".")
 }
+
+func suppressMetadataOptionsHttpEndpointDisabled(k, old, new string, d *schema.ResourceData) bool {
+	// Suppress diff if http_endpoint is disabled
+	i := strings.LastIndexByte(k, '.')
+	state := d.Get(k[:i+1] + "http_endpoint").(string)
+	return state == "disabled"
+}

--- a/aws/diff_suppress_funcs.go
+++ b/aws/diff_suppress_funcs.go
@@ -132,10 +132,3 @@ func suppressRoute53ZoneNameWithTrailingDot(k, old, new string, d *schema.Resour
 	}
 	return strings.TrimSuffix(old, ".") == strings.TrimSuffix(new, ".")
 }
-
-func suppressMetadataOptionsHttpEndpointDisabled(k, old, new string, d *schema.ResourceData) bool {
-	// Suppress diff if http_endpoint is disabled
-	i := strings.LastIndexByte(k, '.')
-	state := d.Get(k[:i+1] + "http_endpoint").(string)
-	return state == "disabled"
-}

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -538,27 +538,18 @@ func resourceAwsInstance() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{ec2.InstanceMetadataEndpointStateEnabled, ec2.InstanceMetadataEndpointStateDisabled}, false),
 						},
 						"http_tokens": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Default:      ec2.HttpTokensStateOptional,
-							ValidateFunc: validation.StringInSlice([]string{ec2.HttpTokensStateOptional, ec2.HttpTokensStateRequired}, false),
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								// Suppress diff if http_endpoint is not enabled
-								i := strings.LastIndexByte(k, '.')
-								state := d.Get(k[:i+1] + "http_endpoint").(string)
-								return state != ec2.InstanceMetadataEndpointStateEnabled
-							},
+							Type:             schema.TypeString,
+							Optional:         true,
+							Default:          ec2.HttpTokensStateOptional,
+							ValidateFunc:     validation.StringInSlice([]string{ec2.HttpTokensStateOptional, ec2.HttpTokensStateRequired}, false),
+							DiffSuppressFunc: suppressMetadataOptionsHttpEndpointDisabled,
 						},
 						"http_put_response_hop_limit": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  1,
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								// Suppress diff if http_endpoint is not enabled
-								i := strings.LastIndexByte(k, '.')
-								state := d.Get(k[:i+1] + "http_endpoint").(string)
-								return state != ec2.InstanceMetadataEndpointStateEnabled
-							},
+							Type:             schema.TypeInt,
+							Optional:         true,
+							Default:          1,
+							ValidateFunc:     validation.IntBetween(1, 64),
+							DiffSuppressFunc: suppressMetadataOptionsHttpEndpointDisabled,
 						},
 					},
 				},

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -1261,10 +1261,10 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 					HttpEndpoint: aws.String(mo["http_endpoint"].(string)),
 				}
 				if mo["http_endpoint"].(string) == ec2.InstanceMetadataEndpointStateEnabled {
-					// This parameter is not allowed unless HttpEndpoint is enabled
+					// These parameters are not allowed unless HttpEndpoint is enabled
 					input.HttpTokens = aws.String(mo["http_tokens"].(string))
+					input.HttpPutResponseHopLimit = aws.Int64(int64(mo["http_put_response_hop_limit"].(int)))
 				}
-				input.HttpPutResponseHopLimit = aws.Int64(int64(mo["http_put_response_hop_limit"].(int)))
 				_, err := conn.ModifyInstanceMetadataOptions(input)
 				if err != nil {
 					return fmt.Errorf("Error updating metadata options: %s", err)
@@ -1924,7 +1924,7 @@ func buildAwsInstanceOpts(
 				HttpEndpoint: aws.String(mo["http_endpoint"].(string)),
 			}
 			if mo["http_endpoint"].(string) == ec2.InstanceMetadataEndpointStateEnabled {
-				// This parameter is not allowed unless HttpEndpoint is enabled
+				// These parameters are not allowed unless HttpEndpoint is enabled
 				opts.MetadataOptions.HttpTokens = aws.String(mo["http_tokens"].(string))
 				opts.MetadataOptions.HttpPutResponseHopLimit = aws.Int64(int64(mo["http_put_response_hop_limit"].(int)))
 			}

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -290,9 +290,6 @@ func TestAccAWSInstance_basic(t *testing.T) {
 						resourceName,
 						"arn",
 						regexp.MustCompile(`^arn:[^:]+:ec2:[^:]+:\d{12}:instance/i-.+`)),
-					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_endpoint", "enabled"),
-					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_tokens", "optional"),
-					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_put_response_hop_limit", "10"),
 				),
 			},
 			{
@@ -2871,12 +2868,6 @@ resource "aws_instance" "test" {
   instance_type   = "m1.small"
   security_groups = ["${aws_security_group.tf_test_test.name}"]
   user_data       = "foo:-with-character's"
-
-  metadata_options {
-    http_endpoint = "enabled"
-    http_tokens = "optional"
-    http_put_response_hop_limit = 10
-  }
 }
 `, rInt)
 }
@@ -4256,7 +4247,7 @@ data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
     name   = "name"
     values = ["amzn-ami-minimal-hvm-*"]
   }
-  
+
   filter {
     name   = "root-device-type"
     values = ["ebs"]

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -290,6 +290,8 @@ func TestAccAWSInstance_basic(t *testing.T) {
 						resourceName,
 						"arn",
 						regexp.MustCompile(`^arn:[^:]+:ec2:[^:]+:\d{12}:instance/i-.+`)),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_endpoint", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_tokens", "optional"),
 				),
 			},
 			{
@@ -2868,6 +2870,11 @@ resource "aws_instance" "test" {
   instance_type   = "m1.small"
   security_groups = ["${aws_security_group.tf_test_test.name}"]
   user_data       = "foo:-with-character's"
+
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens = "optional"
+  }
 }
 `, rInt)
 }

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -292,6 +292,7 @@ func TestAccAWSInstance_basic(t *testing.T) {
 						regexp.MustCompile(`^arn:[^:]+:ec2:[^:]+:\d{12}:instance/i-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_endpoint", "enabled"),
 					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_tokens", "optional"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_put_response_hop_limit", "10"),
 				),
 			},
 			{
@@ -2874,6 +2875,7 @@ resource "aws_instance" "test" {
   metadata_options {
     http_endpoint = "enabled"
     http_tokens = "optional"
+    http_put_response_hop_limit = 10
   }
 }
 `, rInt)

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -2529,6 +2529,52 @@ func TestAccAWSInstance_hibernation(t *testing.T) {
 	})
 }
 
+func TestAccAWSInstance_metadataOptions(t *testing.T) {
+	var v ec2.Instance
+	resourceName := "aws_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	instanceType := "m1.small"
+
+	resource.ParallelTest(t, resource.TestCase{
+		// No subnet_id specified requires default VPC or EC2-Classic.
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckHasDefaultVpcOrEc2Classic(t)
+			testAccPreCheckOffersEc2InstanceType(t, instanceType)
+		},
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfigMetadataOptions(rName, instanceType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_endpoint", "disabled"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_tokens", "optional"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_put_response_hop_limit", "1"),
+				),
+			},
+			{
+				Config: testAccInstanceConfigMetadataOptionsUpdated(rName, instanceType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_endpoint", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_tokens", "required"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_put_response_hop_limit", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckInstanceNotRecreated(t *testing.T,
 	before, after *ec2.Instance) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -4284,4 +4330,44 @@ resource "aws_instance" "test" {
   }
 }
 `, hibernation)
+}
+
+func testAccInstanceConfigMetadataOptions(rName, instanceType string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
+resource "aws_instance" "test" {
+  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type = %[2]q
+
+  tags = {
+    Name = %[1]q
+  }
+
+  metadata_options {
+    http_endpoint = "disabled"
+  }
+}
+
+data "aws_instance" "test" {
+  instance_id = aws_instance.test.id
+}
+`, rName, instanceType)
+}
+
+func testAccInstanceConfigMetadataOptionsUpdated(rName, instanceType string) string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
+resource "aws_instance" "test" {
+  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type = %[2]q
+
+  tags = {
+    Name = %[1]q
+  }
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+}
+`, rName, instanceType)
 }

--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -355,6 +355,36 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 				},
 			},
 
+			"metadata_options": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"http_endpoint": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      ec2.LaunchTemplateInstanceMetadataEndpointStateEnabled,
+							ValidateFunc: validation.StringInSlice([]string{ec2.LaunchTemplateInstanceMetadataEndpointStateEnabled, ec2.LaunchTemplateInstanceMetadataEndpointStateDisabled}, false),
+						},
+						"http_tokens": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							Default:          ec2.LaunchTemplateHttpTokensStateOptional,
+							ValidateFunc:     validation.StringInSlice([]string{ec2.LaunchTemplateHttpTokensStateOptional, ec2.LaunchTemplateHttpTokensStateRequired}, false),
+							DiffSuppressFunc: suppressMetadataOptionsHttpEndpointDisabled,
+						},
+						"http_put_response_hop_limit": {
+							Type:             schema.TypeInt,
+							Optional:         true,
+							Default:          1,
+							ValidateFunc:     validation.IntBetween(1, 64),
+							DiffSuppressFunc: suppressMetadataOptionsHttpEndpointDisabled,
+						},
+					},
+				},
+			},
+
 			"monitoring": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -697,6 +727,10 @@ func resourceAwsLaunchTemplateRead(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("error setting license_specification: %s", err)
 	}
 
+	if err := d.Set("metadata_options", getMetadataOptions(ltData.MetadataOptions)); err != nil {
+		return fmt.Errorf("error setting metadata_options: %s", err)
+	}
+
 	if err := d.Set("monitoring", getMonitoring(ltData.Monitoring)); err != nil {
 		return fmt.Errorf("error setting monitoring: %s", err)
 	}
@@ -939,6 +973,19 @@ func getLicenseSpecifications(licenseSpecifications []*ec2.LaunchTemplateLicense
 	return s
 }
 
+func getMetadataOptions(metadataOptions *ec2.LaunchTemplateInstanceMetadataOptions) []interface{} {
+	s := []interface{}{}
+	if metadataOptions != nil {
+		mo := map[string]interface{}{
+			"http_endpoint":               aws.StringValue(metadataOptions.HttpEndpoint),
+			"http_tokens":                 aws.StringValue(metadataOptions.HttpTokens),
+			"http_put_response_hop_limit": aws.Int64Value(metadataOptions.HttpPutResponseHopLimit),
+		}
+		s = append(s, mo)
+	}
+	return s
+}
+
 func getMonitoring(m *ec2.LaunchTemplatesMonitoring) []interface{} {
 	s := []interface{}{}
 	if m != nil {
@@ -1172,6 +1219,22 @@ func buildLaunchTemplateData(d *schema.ResourceData) (*ec2.RequestLaunchTemplate
 			licenseSpecifications = append(licenseSpecifications, readLicenseSpecificationFromConfig(ls.(map[string]interface{})))
 		}
 		opts.LicenseSpecifications = licenseSpecifications
+	}
+
+	if v, ok := d.GetOk("metadata_options"); ok {
+		m := v.([]interface{})
+		if len(m) > 0 && m[0] != nil {
+			mo := m[0].(map[string]interface{})
+			metadataOptions := &ec2.LaunchTemplateInstanceMetadataOptionsRequest{
+				HttpEndpoint: aws.String(mo["http_endpoint"].(string)),
+			}
+			if mo["http_endpoint"].(string) == ec2.LaunchTemplateInstanceMetadataEndpointStateEnabled {
+				// These parameters are not allowed unless HttpEndpoint is enabled
+				metadataOptions.HttpTokens = aws.String(mo["http_tokens"].(string))
+				metadataOptions.HttpPutResponseHopLimit = aws.Int64(int64(mo["http_put_response_hop_limit"].(int)))
+			}
+			opts.MetadataOptions = metadataOptions
+		}
 	}
 
 	if v, ok := d.GetOk("monitoring"); ok {

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -836,6 +836,35 @@ func TestAccAWSLaunchTemplate_licenseSpecification(t *testing.T) {
 	})
 }
 
+func TestAccAWSLaunchTemplate_metadataOptions(t *testing.T) {
+	var template ec2.LaunchTemplate
+	resourceName := "aws_launch_template.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchTemplateConfig_metadataOptions(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_endpoint", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_tokens", "required"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_put_response_hop_limit", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAWSLaunchTemplateExists(n string, t *ec2.LaunchTemplate) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -1507,3 +1536,17 @@ resource "aws_autoscaling_group" "test" {
   }
 }
 `
+
+func testAccAWSLaunchTemplateConfig_metadataOptions(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_launch_template" "test" {
+  name = %[1]q
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+}
+`, rName)
+}

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -309,6 +309,7 @@ func TestAccAWSLaunchTemplate_data(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "instance_type"),
 					resource.TestCheckResourceAttrSet(resourceName, "kernel_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "key_name"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "monitoring.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.security_groups.#", "1"),
@@ -1102,6 +1103,12 @@ resource "aws_launch_template" "test" {
   kernel_id = "aki-a12bc3de"
 
   key_name = "test"
+
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens = "optional"
+    http_put_response_hop_limit = 10
+  }
 
   monitoring {
     enabled = true

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -309,7 +309,6 @@ func TestAccAWSLaunchTemplate_data(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "instance_type"),
 					resource.TestCheckResourceAttrSet(resourceName, "kernel_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "key_name"),
-					resource.TestCheckResourceAttr(resourceName, "metadata_options.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "monitoring.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.security_groups.#", "1"),
@@ -1103,12 +1102,6 @@ resource "aws_launch_template" "test" {
   kernel_id = "aki-a12bc3de"
 
   key_name = "test"
-
-  metadata_options {
-    http_endpoint = "enabled"
-    http_tokens = "optional"
-    http_put_response_hop_limit = 10
-  }
 
   monitoring {
     enabled = true

--- a/website/docs/d/instance.html.markdown
+++ b/website/docs/d/instance.html.markdown
@@ -112,5 +112,9 @@ interpolation.
 * `host_id` - The Id of the dedicated host the instance will be assigned to.
 * `vpc_security_group_ids` - The associated security groups in a non-default VPC.
 * `credit_specification` - The credit specification of the Instance.
+* `metadata_options` - The metadata options of the Instance.
+  * `http_endpoint` - The state of the metadata service: `enabled`, `disabled`.
+  * `http_tokens` - If session tokens are required: `optional`, `required`.
+  * `http_put_response_hop_limit` - The desired HTTP PUT response hop limit for instance metadata requests.
 
 [1]: http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html

--- a/website/docs/d/launch_template.html.markdown
+++ b/website/docs/d/launch_template.html.markdown
@@ -71,6 +71,10 @@ In addition to all arguments above, the following attributes are exported:
 * `instance_type` - The type of the instance.
 * `kernel_id` - The kernel ID.
 * `key_name` - The key name to use for the instance.
+* `metadata_options` - The metadata options for the instance.
+  * `http_endpoint` - The state of the metadata service: `enabled`, `disabled`.
+  * `http_tokens` - If session tokens are required: `optional`, `required`.
+  * `http_put_response_hop_limit` - The desired HTTP PUT response hop limit for instance metadata requests.
 * `monitoring` - The monitoring option for the instance.
 * `network_interfaces` - Customize network interfaces to be attached at instance boot time. See [Network
   Interfaces](#network-interfaces) below for more details.

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -106,6 +106,7 @@ instances. See [Shutdown Behavior](https://docs.aws.amazon.com/AWSEC2/latest/Use
 * `network_interface` - (Optional) Customize network interfaces to be attached at instance boot time. See [Network Interfaces](#network-interfaces) below for more details.
 * `credit_specification` - (Optional) Customize the credit specification of the instance. See [Credit Specification](#credit-specification) below for more details.
 * `hibernation` - (Optional) If true, the launched EC2 instance will support hibernation.
+* `metadata_options` - (Optional) Customize the metadata options of the instance. See [Metadata Options](#metadata-options) below for more details.
 
 ### Timeouts
 
@@ -196,6 +197,18 @@ Credit specification can be applied/modified to the EC2 Instance at any time.
 The `credit_specification` block supports the following:
 
 * `cpu_credits` - (Optional) The credit option for CPU usage. Can be `"standard"` or `"unlimited"`. T3 instances are launched as unlimited by default. T2 instances are launched as standard by default.
+
+### Metadata Options
+
+Metadata options can be applied/modified to the EC2 Instance at any time.
+
+The `metadata_options` block supports the following:
+
+* `http_endpoint` - (Optional) Whether the metadata service is available. Can be `"enabled"` or `"disabled"`. (Default: `"enabled"`).
+* `http_tokens` - (Optional) Whether or not the metadata service requires session tokens, also referred to as _Instance Metadata Service Version 2_. Can be `"optional"` or `"required"`. (Default: `"optional"`).
+* `http_put_response_hop_limit` - (Optional) The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. Can be an integer from `1` to `64`. (Default: `1`).
+
+For more information, see the documentation on the [Instance Metadata Service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html).
 
 ### Example
 

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -71,6 +71,12 @@ resource "aws_launch_template" "foo" {
     license_configuration_arn = "arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef"
   }
 
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens = "required"
+    http_put_response_hop_limit = 1
+  }
+
   monitoring {
     enabled = true
   }
@@ -129,6 +135,7 @@ The following arguments are supported:
 * `kernel_id` - The kernel ID.
 * `key_name` - The key name to use for the instance.
 * `license_specification` - A list of license specifications to associate with. See [License Specification](#license-specification) below for more details.
+* `metadata_options` - (Optional) Customize the metadata options for the instance. See [Metadata Options](#metadata-options) below for more details.
 * `monitoring` - The monitoring option for the instance. See [Monitoring](#monitoring) below for more details.
 * `network_interfaces` - Customize network interfaces to be attached at instance boot time. See [Network
   Interfaces](#network-interfaces) below for more details.
@@ -252,6 +259,18 @@ The `spot_options` block supports the following:
 * `max_price` - The maximum hourly price you're willing to pay for the Spot Instances.
 * `spot_instance_type` - The Spot Instance request type. Can be `one-time`, or `persistent`.
 * `valid_until` - The end date of the request.
+
+### Metadata Options
+
+The metadata options for the instances.
+
+The `metadata_options` block supports the following:
+
+* `http_endpoint` - (Optional) Whether the metadata service is available. Can be `"enabled"` or `"disabled"`. (Default: `"enabled"`).
+* `http_tokens` - (Optional) Whether or not the metadata service requires session tokens, also referred to as _Instance Metadata Service Version 2_. Can be `"optional"` or `"required"`. (Default: `"optional"`).
+* `http_put_response_hop_limit` - (Optional) The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. Can be an integer from `1` to `64`. (Default: `1`).
+
+For more information, see the documentation on the [Instance Metadata Service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html).
 
 ### Monitoring
 

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -72,8 +72,8 @@ resource "aws_launch_template" "foo" {
   }
 
   metadata_options {
-    http_endpoint = "enabled"
-    http_tokens = "required"
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
     http_put_response_hop_limit = 1
   }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10949.
Closes #11794.

Continuation of https://github.com/terraform-providers/terraform-provider-aws/pull/11076.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_instance: Add support for `metadata_options` parameter
data-source/aws_instance: Add `metadata_options` attributes
resource/aws_launch_template: Add support for `metadata_options` parameter
data-source/aws_launch_template: Add `metadata_options` attributes
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
# New acceptance tests:
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSInstance_metadataOptions'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSInstance_metadataOptions -timeout 120m
=== RUN   TestAccAWSInstance_metadataOptions
=== PAUSE TestAccAWSInstance_metadataOptions
=== CONT  TestAccAWSInstance_metadataOptions
--- PASS: TestAccAWSInstance_metadataOptions (151.88s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	151.906s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSInstanceDataSource_metadataOptions'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSInstanceDataSource_metadataOptions -timeout 120m
=== RUN   TestAccAWSInstanceDataSource_metadataOptions
=== PAUSE TestAccAWSInstanceDataSource_metadataOptions
=== CONT  TestAccAWSInstanceDataSource_metadataOptions
--- PASS: TestAccAWSInstanceDataSource_metadataOptions (134.65s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	134.684s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSLaunchTemplate_metadataOptions'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSLaunchTemplate_metadataOptions -timeout 120m
=== RUN   TestAccAWSLaunchTemplate_metadataOptions
=== PAUSE TestAccAWSLaunchTemplate_metadataOptions
=== CONT  TestAccAWSLaunchTemplate_metadataOptions
--- PASS: TestAccAWSLaunchTemplate_metadataOptions (24.47s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	24.508s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSLaunchTemplateDataSource_metadataOptions'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSLaunchTemplateDataSource_metadataOptions -timeout 120m
=== RUN   TestAccAWSLaunchTemplateDataSource_metadataOptions
=== PAUSE TestAccAWSLaunchTemplateDataSource_metadataOptions
=== CONT  TestAccAWSLaunchTemplateDataSource_metadataOptions
--- PASS: TestAccAWSLaunchTemplateDataSource_metadataOptions (34.95s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	34.972s

# Verified no regressions:
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSInstance_basic -timeout 120m
=== RUN   TestAccAWSInstance_basic
=== PAUSE TestAccAWSInstance_basic
=== CONT  TestAccAWSInstance_basic
--- PASS: TestAccAWSInstance_basic (288.54s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	288.569s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSInstanceDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSInstanceDataSource_basic -timeout 120m
=== RUN   TestAccAWSInstanceDataSource_basic
=== PAUSE TestAccAWSInstanceDataSource_basic
=== CONT  TestAccAWSInstanceDataSource_basic
--- PASS: TestAccAWSInstanceDataSource_basic (297.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	297.036s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSLaunchTemplate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSLaunchTemplate_basic -timeout 120m
=== RUN   TestAccAWSLaunchTemplate_basic
=== PAUSE TestAccAWSLaunchTemplate_basic
=== CONT  TestAccAWSLaunchTemplate_basic
--- PASS: TestAccAWSLaunchTemplate_basic (25.21s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	25.235s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSLaunchTemplateDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSLaunchTemplateDataSource_basic -timeout 120m
=== RUN   TestAccAWSLaunchTemplateDataSource_basic
=== PAUSE TestAccAWSLaunchTemplateDataSource_basic
=== CONT  TestAccAWSLaunchTemplateDataSource_basic
--- PASS: TestAccAWSLaunchTemplateDataSource_basic (28.04s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	28.079s
```
