### PR TITLE
rd/launch_template - add hibernation options

### DIFF
--- a/aws/data_source_aws_launch_template.go
+++ b/aws/data_source_aws_launch_template.go
@@ -358,6 +358,18 @@ func dataSourceAwsLaunchTemplate() *schema.Resource {
 			},
 			"tags":   tagsSchemaComputed(),
 			"filter": dataSourceFiltersSchema(),
+			"hibernation_options": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"configured": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -490,6 +502,10 @@ func dataSourceAwsLaunchTemplateRead(d *schema.ResourceData, meta interface{}) e
 
 	if err := d.Set("placement", getPlacement(ltData.Placement)); err != nil {
 		return fmt.Errorf("error setting placement: %s", err)
+	}
+
+	if err := d.Set("hibernation_options", getHibernationOptions(ltData.HibernationOptions)); err != nil {
+		return fmt.Errorf("error setting hibernation_options: %s", err)
 	}
 
 	if err := d.Set("tag_specifications", getTagSpecifications(ltData.TagSpecifications)); err != nil {

--- a/aws/data_source_aws_launch_template.go
+++ b/aws/data_source_aws_launch_template.go
@@ -356,8 +356,6 @@ func dataSourceAwsLaunchTemplate() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":   tagsSchemaComputed(),
-			"filter": dataSourceFiltersSchema(),
 			"hibernation_options": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -370,6 +368,8 @@ func dataSourceAwsLaunchTemplate() *schema.Resource {
 					},
 				},
 			},
+			"tags":   tagsSchemaComputed(),
+			"filter": dataSourceFiltersSchema(),
 		},
 	}
 }
@@ -504,7 +504,7 @@ func dataSourceAwsLaunchTemplateRead(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("error setting placement: %s", err)
 	}
 
-	if err := d.Set("hibernation_options", getHibernationOptions(ltData.HibernationOptions)); err != nil {
+	if err := d.Set("hibernation_options", flattenLaunchTemplateHibernationOptions(ltData.HibernationOptions)); err != nil {
 		return fmt.Errorf("error setting hibernation_options: %s", err)
 	}
 

--- a/aws/data_source_aws_launch_template_test.go
+++ b/aws/data_source_aws_launch_template_test.go
@@ -25,6 +25,7 @@ func TestAccAWSLaunchTemplateDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "default_version", dataSourceName, "default_version"),
 					resource.TestCheckResourceAttrPair(resourceName, "latest_version", dataSourceName, "latest_version"),
 					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "hibernation_options", dataSourceName, "hibernation_options"),
 				),
 			},
 		},

--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -542,6 +542,19 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 			},
 
 			"tags": tagsSchema(),
+			"hibernation_options": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"configured": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+					},
+				},
+			},
 		},
 
 		CustomizeDiff: customdiff.Sequence(
@@ -740,6 +753,10 @@ func resourceAwsLaunchTemplateRead(d *schema.ResourceData, meta interface{}) err
 
 	if err := d.Set("placement", getPlacement(ltData.Placement)); err != nil {
 		return fmt.Errorf("error setting placement: %s", err)
+	}
+
+	if err := d.Set("hibernation_options", getHibernationOptions(ltData.HibernationOptions)); err != nil {
+		return fmt.Errorf("error setting hibernation_options: %s", err)
 	}
 
 	if err := d.Set("tag_specifications", getTagSpecifications(ltData.TagSpecifications)); err != nil {
@@ -1098,6 +1115,17 @@ func getPlacement(p *ec2.LaunchTemplatePlacement) []interface{} {
 	return s
 }
 
+func getHibernationOptions(m *ec2.LaunchTemplateHibernationOptions) []interface{} {
+	s := []interface{}{}
+	if m != nil {
+		mo := map[string]interface{}{
+			"configured": aws.BoolValue(m.Configured),
+		}
+		s = append(s, mo)
+	}
+	return s
+}
+
 func getTagSpecifications(t []*ec2.LaunchTemplateTagSpecification) []interface{} {
 	s := []interface{}{}
 	for _, v := range t {
@@ -1285,6 +1313,17 @@ func buildLaunchTemplateData(d *schema.ResourceData) (*ec2.RequestLaunchTemplate
 
 		if len(p) > 0 && p[0] != nil {
 			opts.Placement = readPlacementFromConfig(p[0].(map[string]interface{}))
+		}
+	}
+
+	if v, ok := d.GetOk("hibernation_options"); ok {
+		m := v.([]interface{})
+		if len(m) > 0 && m[0] != nil {
+			mData := m[0].(map[string]interface{})
+			ho := &ec2.LaunchTemplateHibernationOptionsRequest{
+				Configured: aws.Bool(mData["configured"].(bool)),
+			}
+			opts.HibernationOptions = ho
 		}
 	}
 

--- a/website/docs/d/launch_template.html.markdown
+++ b/website/docs/d/launch_template.html.markdown
@@ -86,3 +86,5 @@ In addition to all arguments above, the following attributes are exported:
 * `tag_specifications` - The tags to apply to the resources during launch.
 * `tags` - (Optional) A mapping of tags to assign to the launch template.
 * `user_data` - The Base64-encoded user data to provide when launching the instance.
+* `hibernation_options` - The hibernation options for the instance.
+

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -147,6 +147,7 @@ The following arguments are supported:
 * `tag_specifications` - The tags to apply to the resources during launch. See [Tag Specifications](#tag-specifications) below for more details.
 * `tags` - (Optional) A mapping of tags to assign to the launch template.
 * `user_data` - The Base64-encoded user data to provide when launching the instance.
+* `hibernation_options` - The hibernation options for the instance. See [Hibernation](#hibernation) below for more details.
 
 ### Block devices
 
@@ -311,6 +312,13 @@ The `placement` block supports the following:
 * `host_id` - The ID of the Dedicated Host for the instance.
 * `spread_domain` - Reserved for future use.
 * `tenancy` - The tenancy of the instance (if the instance is running in a VPC). Can be `default`, `dedicated`, or `host`.
+
+### Hibernation
+
+The `hibernation_options` block supports the following:
+
+* `configured` - If `true`, the launched EC2 instance will hibernation enabled.
+
 
 ### Tag Specifications
 

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -147,7 +147,7 @@ The following arguments are supported:
 * `tag_specifications` - The tags to apply to the resources during launch. See [Tag Specifications](#tag-specifications) below for more details.
 * `tags` - (Optional) A mapping of tags to assign to the launch template.
 * `user_data` - The Base64-encoded user data to provide when launching the instance.
-* `hibernation_options` - The hibernation options for the instance. See [Hibernation](#hibernation) below for more details.
+* `hibernation_options` - The hibernation options for the instance. See [Hibernation Options](#hibernation-options) below for more details.
 
 ### Block devices
 
@@ -313,12 +313,11 @@ The `placement` block supports the following:
 * `spread_domain` - Reserved for future use.
 * `tenancy` - The tenancy of the instance (if the instance is running in a VPC). Can be `default`, `dedicated`, or `host`.
 
-### Hibernation
+### Hibernation Options
 
 The `hibernation_options` block supports the following:
 
-* `configured` - If `true`, the launched EC2 instance will hibernation enabled.
-
+* `configured` - If set to `true`, the launched EC2 instance will hibernation enabled.
 
 ### Tag Specifications
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #6638

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_launch_template - add `hibernation_options` block
data_source_aws_launch_template - add `hibernation_options` block
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSLaunchTemplate_hibernation'
--- PASS: TestAccAWSLaunchTemplate_hibernation (476.57s)
```

```
$ make testacc TESTARGS='-run=TestAccAWSLaunchTemplateDataSource_basic'
--- PASS: TestAccAWSLaunchTemplateDataSource_basic (237.30s)
```
