### PR TITLE
Expand data.aws_workspaces_bundle With Owner/Name Filtering

### DIFF
--- a/aws/data_source_aws_workspaces_bundle.go
+++ b/aws/data_source_aws_workspaces_bundle.go
@@ -86,13 +86,13 @@ func dataSourceAwsWorkspaceBundleRead(d *schema.ResourceData, meta interface{}) 
 		}
 
 		if len(resp.Bundles) != 1 {
-			return fmt.Errorf("expect 1 result for workspace bundle %q, got %d", bundleID, len(resp.Bundles))
+			return fmt.Errorf("expected 1 result for Workspace bundle %q, found %d", bundleID, len(resp.Bundles))
 		}
 
 		bundle = resp.Bundles[0]
 
 		if bundle == nil {
-			return fmt.Errorf("not found workspace bundle with ID %q", bundleID)
+			return fmt.Errorf("no Workspace bundle with ID %q found", bundleID)
 		}
 	}
 
@@ -116,7 +116,7 @@ func dataSourceAwsWorkspaceBundleRead(d *schema.ResourceData, meta interface{}) 
 		}
 
 		if bundle == nil {
-			return fmt.Errorf("not found workspace bundle with name %q", name)
+			return fmt.Errorf("no Workspace bundle with name %q found", name)
 		}
 	}
 

--- a/aws/data_source_aws_workspaces_bundle.go
+++ b/aws/data_source_aws_workspaces_bundle.go
@@ -14,18 +14,21 @@ func dataSourceAwsWorkspaceBundle() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"bundle_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"description": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"owner", "name"},
 			},
 			"name": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"bundle_id"},
 			},
 			"owner": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"bundle_id"},
+			},
+			"description": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -72,25 +75,56 @@ func dataSourceAwsWorkspaceBundle() *schema.Resource {
 func dataSourceAwsWorkspaceBundleRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).workspacesconn
 
-	bundleID := d.Get("bundle_id").(string)
-	input := &workspaces.DescribeWorkspaceBundlesInput{
-		BundleIds: []*string{aws.String(bundleID)},
+	var bundle *workspaces.WorkspaceBundle
+
+	if bundleID, ok := d.GetOk("bundle_id"); ok {
+		resp, err := conn.DescribeWorkspaceBundles(&workspaces.DescribeWorkspaceBundlesInput{
+			BundleIds: []*string{aws.String(bundleID.(string))},
+		})
+		if err != nil {
+			return err
+		}
+
+		if len(resp.Bundles) != 1 {
+			return fmt.Errorf("expect 1 result for workspace bundle %q, got %d", bundleID, len(resp.Bundles))
+		}
+
+		bundle = resp.Bundles[0]
+
+		if bundle == nil {
+			return fmt.Errorf("not found workspace bundle with ID %q", bundleID)
+		}
 	}
 
-	resp, err := conn.DescribeWorkspaceBundles(input)
-	if err != nil {
-		return err
+	if name, ok := d.GetOk("name"); ok {
+		name := name.(string)
+		input := &workspaces.DescribeWorkspaceBundlesInput{
+			Owner: aws.String(d.Get("owner").(string)),
+		}
+		err := conn.DescribeWorkspaceBundlesPages(input, func(out *workspaces.DescribeWorkspaceBundlesOutput, lastPage bool) bool {
+			for _, b := range out.Bundles {
+				if aws.StringValue(b.Name) == name {
+					bundle = b
+					return true
+				}
+			}
+
+			return !lastPage
+		})
+		if err != nil {
+			return err
+		}
+
+		if bundle == nil {
+			return fmt.Errorf("not found workspace bundle with name %q", name)
+		}
 	}
 
-	if len(resp.Bundles) != 1 {
-		return fmt.Errorf("The number of Workspace Bundle (%s) should be 1, but %d", bundleID, len(resp.Bundles))
-	}
-
-	bundle := resp.Bundles[0]
-	d.SetId(bundleID)
-	d.Set("description", bundle.Description)
-	d.Set("name", bundle.Name)
-	d.Set("owner", bundle.Owner)
+	d.SetId(aws.StringValue(bundle.BundleId))
+	d.Set("bundle_id", aws.StringValue(bundle.BundleId))
+	d.Set("description", aws.StringValue(bundle.Description))
+	d.Set("name", aws.StringValue(bundle.Name))
+	d.Set("owner", aws.StringValue(bundle.Owner))
 
 	computeType := make([]map[string]interface{}, 1)
 	if bundle.ComputeType != nil {

--- a/aws/data_source_aws_workspaces_bundle_test.go
+++ b/aws/data_source_aws_workspaces_bundle_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -33,10 +34,68 @@ func TestAccDataSourceAwsWorkspaceBundle_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAwsWorkspaceBundle_byOwnerName(t *testing.T) {
+	dataSourceName := "data.aws_workspaces_bundle.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsWorkspaceBundleConfig_byOwnerName("AMAZON", "Value with Windows 10 and Office 2016"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "bundle_id", "wsb-df76rqys9"),
+					resource.TestCheckResourceAttr(dataSourceName, "compute_type.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "compute_type.0.name", "VALUE"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "description"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", "Value with Windows 10 and Office 2016"),
+					resource.TestCheckResourceAttr(dataSourceName, "owner", "Amazon"),
+					resource.TestCheckResourceAttr(dataSourceName, "root_storage.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "root_storage.0.capacity", "80"),
+					resource.TestCheckResourceAttr(dataSourceName, "user_storage.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "user_storage.0.capacity", "10"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsWorkspaceBundle_bundleIDAndNameConflict(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSourceAwsWorkspaceBundleConfig_bundleIDAndOwnerNameConflict("wsb-df76rqys9", "AMAZON", "Value with Windows 10 and Office 2016"),
+				ExpectError: regexp.MustCompile("\"bundle_id\": conflicts with owner"),
+			},
+		},
+	})
+}
+
 func testAccDataSourceAwsWorkspaceBundleConfig(bundleID string) string {
 	return fmt.Sprintf(`
 data "aws_workspaces_bundle" "test" {
   bundle_id = %q
 }
 `, bundleID)
+}
+
+func testAccDataSourceAwsWorkspaceBundleConfig_byOwnerName(owner, name string) string {
+	return fmt.Sprintf(`
+data "aws_workspaces_bundle" "test" {
+  owner = %q
+  name  = %q
+}
+`, owner, name)
+}
+
+func testAccDataSourceAwsWorkspaceBundleConfig_bundleIDAndOwnerNameConflict(bundleID, owner, name string) string {
+	return fmt.Sprintf(`
+data "aws_workspaces_bundle" "test" {
+  bundle_id = %q
+  owner = %q
+  name  = %q
+}
+`, bundleID, owner, name)
 }

--- a/website/docs/d/workspaces_bundle.html.markdown
+++ b/website/docs/d/workspaces_bundle.html.markdown
@@ -16,19 +16,27 @@ Use this data source to get information about a WorkSpaces Bundle.
 data "aws_workspaces_bundle" "example" {
   bundle_id = "wsb-b0s22j3d7"
 }
+
+data "aws_workspaces_bundle" "example" {
+  owner = "AMAZON"
+  name  = "Value with Windows 10 and Office 2016"
+}
 ```
 
 ## Argument Reference
 
 The following arguments are supported:
 
-* `bundle_id` – (Required) The ID of the bundle.
+* `bundle_id` – (Optional) The ID of the bundle.
+* `owner` – (Optional) The owner of the bundles. You cannot combine this parameter with `bundle_id`.
+* `name` – (Optional) The name of the bundle. You cannot combine this parameter with `bundle_id`.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
 * `description` – The description of the bundle.
+* `bundle_id` – The ID of the bundle.
 * `name` – The name of the bundle.
 * `owner` – The owner of the bundle.
 * `compute_type` – The compute type. See supported fields below.

--- a/website/docs/d/workspaces_bundle.html.markdown
+++ b/website/docs/d/workspaces_bundle.html.markdown
@@ -28,7 +28,7 @@ data "aws_workspaces_bundle" "example" {
 The following arguments are supported:
 
 * `bundle_id` – (Optional) The ID of the bundle.
-* `owner` – (Optional) The owner of the bundles. You cannot combine this parameter with `bundle_id`.
+* `owner` – (Optional) The owner of the bundles. You have to leave it blank for own bundles. You cannot combine this parameter with `bundle_id`.
 * `name` – (Optional) The name of the bundle. You cannot combine this parameter with `bundle_id`.
 
 ## Attributes Reference


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #12496

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsWorkspaceBundle'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsWorkspaceBundle -timeout 120m
=== RUN   TestAccDataSourceAwsWorkspaceBundle_basic
=== PAUSE TestAccDataSourceAwsWorkspaceBundle_basic
=== RUN   TestAccDataSourceAwsWorkspaceBundle_byOwnerName
=== PAUSE TestAccDataSourceAwsWorkspaceBundle_byOwnerName
=== RUN   TestAccDataSourceAwsWorkspaceBundle_bundleIDAndNameConflict
=== PAUSE TestAccDataSourceAwsWorkspaceBundle_bundleIDAndNameConflict
=== CONT  TestAccDataSourceAwsWorkspaceBundle_basic
=== CONT  TestAccDataSourceAwsWorkspaceBundle_bundleIDAndNameConflict
=== CONT  TestAccDataSourceAwsWorkspaceBundle_byOwnerName
--- PASS: TestAccDataSourceAwsWorkspaceBundle_bundleIDAndNameConflict (3.01s)
--- PASS: TestAccDataSourceAwsWorkspaceBundle_basic (21.38s)
--- PASS: TestAccDataSourceAwsWorkspaceBundle_byOwnerName (23.41s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	24.821s
```