### PR TITLE
r/backup_vault_notifications - Add new resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -433,6 +433,7 @@ func Provider() *schema.Provider {
 			"aws_backup_plan":                                         resourceAwsBackupPlan(),
 			"aws_backup_selection":                                    resourceAwsBackupSelection(),
 			"aws_backup_vault":                                        resourceAwsBackupVault(),
+			"aws_backup_vault_notifications":                          resourceAwsBackupVaultNotifications(),
 			"aws_budgets_budget":                                      resourceAwsBudgetsBudget(),
 			"aws_cloud9_environment_ec2":                              resourceAwsCloud9EnvironmentEc2(),
 			"aws_cloudformation_stack":                                resourceAwsCloudFormationStack(),

--- a/aws/resource_aws_backup_vault_notifications.go
+++ b/aws/resource_aws_backup_vault_notifications.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/backup"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceAwsBackupVaultNotifications() *schema.Resource {
@@ -22,10 +22,13 @@ func resourceAwsBackupVaultNotifications() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"backup_vault_name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9\-\_\.]{1,50}$`), "must consist of lowercase letters, numbers, and hyphens."),
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9\-\_\.]$`), "must consist of lowercase letters, numbers, and hyphens."),
+					validation.StringLenBetween(1, 50),
+				),
 			},
 			"sns_topic_arn": {
 				Type:         schema.TypeString,
@@ -38,24 +41,8 @@ func resourceAwsBackupVaultNotifications() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 				Elem: &schema.Schema{
-					Type: schema.TypeString,
-					ValidateFunc: validation.StringInSlice([]string{
-						backup.VaultEventBackupJobStarted,
-						backup.VaultEventBackupJobCompleted,
-						backup.VaultEventBackupJobSuccessful,
-						backup.VaultEventBackupJobFailed,
-						backup.VaultEventBackupJobExpired,
-						backup.VaultEventRestoreJobStarted,
-						backup.VaultEventRestoreJobSuccessful,
-						backup.VaultEventRestoreJobCompleted,
-						backup.VaultEventRestoreJobFailed,
-						backup.VaultEventCopyJobFailed,
-						backup.VaultEventCopyJobStarted,
-						backup.VaultEventCopyJobSuccessful,
-						backup.VaultEventRecoveryPointModified,
-						backup.VaultEventBackupPlanCreated,
-						backup.VaultEventBackupPlanModified,
-					}, false),
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringInSlice(backup.VaultEvent_Values(), false),
 				},
 			},
 			"backup_vault_arn": {

--- a/aws/resource_aws_backup_vault_notifications.go
+++ b/aws/resource_aws_backup_vault_notifications.go
@@ -22,13 +22,10 @@ func resourceAwsBackupVaultNotifications() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"backup_vault_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.All(
-					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9\-\_\.]$`), "must consist of lowercase letters, numbers, and hyphens."),
-					validation.StringLenBetween(1, 50),
-				),
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9\-\_\.]{1,50}$`), "must consist of lowercase letters, numbers, and hyphens."),
 			},
 			"sns_topic_arn": {
 				Type:         schema.TypeString,

--- a/aws/resource_aws_backup_vault_notifications.go
+++ b/aws/resource_aws_backup_vault_notifications.go
@@ -77,7 +77,7 @@ func resourceAwsBackupVaultNotificationsCreate(d *schema.ResourceData, meta inte
 
 	_, err := conn.PutBackupVaultNotifications(input)
 	if err != nil {
-		return fmt.Errorf("error creating Backup Vault Notification (%s): %w", d.Id(), err)
+		return fmt.Errorf("error creating Backup Vault Notifications (%s): %w", d.Id(), err)
 	}
 
 	d.SetId(d.Get("backup_vault_name").(string))

--- a/aws/resource_aws_backup_vault_notifications.go
+++ b/aws/resource_aws_backup_vault_notifications.go
@@ -124,7 +124,7 @@ func resourceAwsBackupVaultNotificationsDelete(d *schema.ResourceData, meta inte
 		if isAWSErr(err, backup.ErrCodeResourceNotFoundException, "") {
 			return nil
 		}
-		return fmt.Errorf("error deleting Backup Vault Notification (%s): %w", d.Id(), err)
+		return fmt.Errorf("error deleting Backup Vault Notifications (%s): %w", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_backup_vault_notifications.go
+++ b/aws/resource_aws_backup_vault_notifications.go
@@ -100,7 +100,7 @@ func resourceAwsBackupVaultNotificationsRead(d *schema.ResourceData, meta interf
 	}
 
 	if err != nil {
-		return fmt.Errorf("error reading Backup Vault (%s): %w", d.Id(), err)
+		return fmt.Errorf("error reading Backup Vault Notifications (%s): %w", d.Id(), err)
 	}
 	d.Set("backup_vault_name", resp.BackupVaultName)
 	d.Set("sns_topic_arn", resp.SNSTopicArn)

--- a/aws/resource_aws_backup_vault_notifications.go
+++ b/aws/resource_aws_backup_vault_notifications.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -92,6 +93,11 @@ func resourceAwsBackupVaultNotificationsRead(d *schema.ResourceData, meta interf
 	}
 
 	resp, err := conn.GetBackupVaultNotifications(input)
+	if isAWSErr(err, backup.ErrCodeResourceNotFoundException, "") {
+		log.Printf("[WARN] Backup Vault Notifcations %s not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
 
 	if err != nil {
 		return fmt.Errorf("error reading Backup Vault (%s): %s", d.Id(), err)

--- a/aws/resource_aws_backup_vault_notifications.go
+++ b/aws/resource_aws_backup_vault_notifications.go
@@ -58,7 +58,7 @@ func resourceAwsBackupVaultNotifications() *schema.Resource {
 					}, false),
 				},
 			},
-			"arn": {
+			"backup_vault_arn": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -104,7 +104,7 @@ func resourceAwsBackupVaultNotificationsRead(d *schema.ResourceData, meta interf
 	}
 	d.Set("backup_vault_name", resp.BackupVaultName)
 	d.Set("sns_topic_arn", resp.SNSTopicArn)
-	d.Set("arn", resp.BackupVaultArn)
+	d.Set("backup_vault_arn", resp.BackupVaultArn)
 	d.Set("backup_vault_events", flattenStringSet(resp.BackupVaultEvents))
 
 	return nil

--- a/aws/resource_aws_backup_vault_notifications.go
+++ b/aws/resource_aws_backup_vault_notifications.go
@@ -105,7 +105,9 @@ func resourceAwsBackupVaultNotificationsRead(d *schema.ResourceData, meta interf
 	d.Set("backup_vault_name", resp.BackupVaultName)
 	d.Set("sns_topic_arn", resp.SNSTopicArn)
 	d.Set("backup_vault_arn", resp.BackupVaultArn)
-	d.Set("backup_vault_events", flattenStringSet(resp.BackupVaultEvents))
+	if err := d.Set("backup_vault_events", flattenStringSet(resp.BackupVaultEvents)); err != nil {
+	  return fmt.Errorf("error setting backup_vault_events: %w", err)
+	}
 
 	return nil
 }

--- a/aws/resource_aws_backup_vault_notifications.go
+++ b/aws/resource_aws_backup_vault_notifications.go
@@ -106,7 +106,7 @@ func resourceAwsBackupVaultNotificationsRead(d *schema.ResourceData, meta interf
 	d.Set("sns_topic_arn", resp.SNSTopicArn)
 	d.Set("backup_vault_arn", resp.BackupVaultArn)
 	if err := d.Set("backup_vault_events", flattenStringSet(resp.BackupVaultEvents)); err != nil {
-	  return fmt.Errorf("error setting backup_vault_events: %w", err)
+		return fmt.Errorf("error setting backup_vault_events: %w", err)
 	}
 
 	return nil

--- a/aws/resource_aws_backup_vault_notifications.go
+++ b/aws/resource_aws_backup_vault_notifications.go
@@ -1,0 +1,120 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func resourceAwsBackupVaultNotifications() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsBackupVaultNotificationsCreate,
+		Read:   resourceAwsBackupVaultNotificationsRead,
+		Delete: resourceAwsBackupVaultNotificationsDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"backup_vault_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9\-\_\.]{1,50}$`), "must consist of lowercase letters, numbers, and hyphens."),
+			},
+			"sns_topic_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
+			},
+			"backup_vault_events": {
+				Type:     schema.TypeSet,
+				Required: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					ValidateFunc: validation.StringInSlice([]string{
+						backup.VaultEventBackupJobStarted,
+						backup.VaultEventBackupJobCompleted,
+						backup.VaultEventBackupJobSuccessful,
+						backup.VaultEventBackupJobFailed,
+						backup.VaultEventBackupJobExpired,
+						backup.VaultEventRestoreJobStarted,
+						backup.VaultEventRestoreJobSuccessful,
+						backup.VaultEventRestoreJobCompleted,
+						backup.VaultEventRestoreJobFailed,
+						backup.VaultEventCopyJobFailed,
+						backup.VaultEventCopyJobStarted,
+						backup.VaultEventCopyJobSuccessful,
+						backup.VaultEventRecoveryPointModified,
+						backup.VaultEventBackupPlanCreated,
+						backup.VaultEventBackupPlanModified,
+					}, false),
+				},
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsBackupVaultNotificationsCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).backupconn
+
+	input := &backup.PutBackupVaultNotificationsInput{
+		BackupVaultName:   aws.String(d.Get("backup_vault_name").(string)),
+		SNSTopicArn:       aws.String(d.Get("sns_topic_arn").(string)),
+		BackupVaultEvents: expandStringSet(d.Get("backup_vault_events").(*schema.Set)),
+	}
+
+	_, err := conn.PutBackupVaultNotifications(input)
+	if err != nil {
+		return fmt.Errorf("error creating Backup Vault Notification (%s): %s", d.Id(), err)
+	}
+
+	d.SetId(d.Get("backup_vault_name").(string))
+
+	return resourceAwsBackupVaultNotificationsRead(d, meta)
+}
+
+func resourceAwsBackupVaultNotificationsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).backupconn
+
+	input := &backup.GetBackupVaultNotificationsInput{
+		BackupVaultName: aws.String(d.Id()),
+	}
+
+	resp, err := conn.GetBackupVaultNotifications(input)
+
+	if err != nil {
+		return fmt.Errorf("error reading Backup Vault (%s): %s", d.Id(), err)
+	}
+	d.Set("backup_vault_name", resp.BackupVaultName)
+	d.Set("sns_topic_arn", resp.SNSTopicArn)
+	d.Set("arn", resp.BackupVaultArn)
+	d.Set("backup_vault_events", flattenStringSet(resp.BackupVaultEvents))
+
+	return nil
+}
+
+func resourceAwsBackupVaultNotificationsDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).backupconn
+
+	input := &backup.DeleteBackupVaultNotificationsInput{
+		BackupVaultName: aws.String(d.Id()),
+	}
+
+	_, err := conn.DeleteBackupVaultNotifications(input)
+	if err != nil {
+		return fmt.Errorf("error deleting Backup Vault Notification (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_backup_vault_notifications.go
+++ b/aws/resource_aws_backup_vault_notifications.go
@@ -77,7 +77,7 @@ func resourceAwsBackupVaultNotificationsCreate(d *schema.ResourceData, meta inte
 
 	_, err := conn.PutBackupVaultNotifications(input)
 	if err != nil {
-		return fmt.Errorf("error creating Backup Vault Notification (%s): %s", d.Id(), err)
+		return fmt.Errorf("error creating Backup Vault Notification (%s): %w", d.Id(), err)
 	}
 
 	d.SetId(d.Get("backup_vault_name").(string))
@@ -100,7 +100,7 @@ func resourceAwsBackupVaultNotificationsRead(d *schema.ResourceData, meta interf
 	}
 
 	if err != nil {
-		return fmt.Errorf("error reading Backup Vault (%s): %s", d.Id(), err)
+		return fmt.Errorf("error reading Backup Vault (%s): %w", d.Id(), err)
 	}
 	d.Set("backup_vault_name", resp.BackupVaultName)
 	d.Set("sns_topic_arn", resp.SNSTopicArn)
@@ -119,7 +119,10 @@ func resourceAwsBackupVaultNotificationsDelete(d *schema.ResourceData, meta inte
 
 	_, err := conn.DeleteBackupVaultNotifications(input)
 	if err != nil {
-		return fmt.Errorf("error deleting Backup Vault Notification (%s): %s", d.Id(), err)
+		if isAWSErr(err, backup.ErrCodeResourceNotFoundException, "") {
+			return nil
+		}
+		return fmt.Errorf("error deleting Backup Vault Notification (%s): %w", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_backup_vault_notifications_test.go
+++ b/aws/resource_aws_backup_vault_notifications_test.go
@@ -191,13 +191,13 @@ data "aws_iam_policy_document" "test" {
 }
 
 resource "aws_sns_topic_policy" "test" {
-  arn = "${aws_sns_topic.test.arn}"
-  policy = "${data.aws_iam_policy_document.test.json}"
+  arn    = aws_sns_topic.test.arn
+  policy = data.aws_iam_policy_document.test.json
 }
 
 resource "aws_backup_vault_notifications" "test" {
-  backup_vault_name   = "${aws_backup_vault.test.name}"
-  sns_topic_arn       = "${aws_sns_topic.test.arn}"
+  backup_vault_name   = aws_backup_vault.test.name
+  sns_topic_arn       = aws_sns_topic.test.arn
   backup_vault_events = ["BACKUP_JOB_STARTED", "RESTORE_JOB_COMPLETED"] 
 }
 `, rName)

--- a/aws/resource_aws_backup_vault_notifications_test.go
+++ b/aws/resource_aws_backup_vault_notifications_test.go
@@ -51,7 +51,7 @@ func TestAccAwsBackupVaultNotification_disappears(t *testing.T) {
 				Config: testAccBackupVaultNotificationConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsBackupVaultNotificationExists(resourceName, &vault),
-					testAccCheckAwsBackupVaultNotificationDisappears(&vault),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsBackupVaultNotifications(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -101,18 +101,6 @@ func testAccCheckAwsBackupVaultNotificationExists(name string, vault *backup.Get
 		*vault = *resp
 
 		return nil
-	}
-}
-
-func testAccCheckAwsBackupVaultNotificationDisappears(vault *backup.GetBackupVaultNotificationsOutput) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).backupconn
-		params := &backup.DeleteBackupVaultNotificationsInput{
-			BackupVaultName: vault.BackupVaultName,
-		}
-		_, err := conn.DeleteBackupVaultNotifications(params)
-
-		return err
 	}
 }
 

--- a/aws/resource_aws_backup_vault_notifications_test.go
+++ b/aws/resource_aws_backup_vault_notifications_test.go
@@ -2,15 +2,15 @@ package aws
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-multierror"
 	"log"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/backup"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func init() {

--- a/aws/resource_aws_backup_vault_notifications_test.go
+++ b/aws/resource_aws_backup_vault_notifications_test.go
@@ -121,6 +121,21 @@ resource "aws_sns_topic" "test" {
   name = %[1]q
 }
 
+resource "aws_sns_topic_policy" "test" {
+	arn = "${aws_sns_topic.test.arn}"
+	policy = <<POLICY
+{
+      "Sid": "My-statement-id",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "backup.amazonaws.com"
+      },
+      "Action": "SNS:Publish",
+      "Resource": "${aws_sns_topic.test.arn}"
+}
+POLICY
+}
+
 resource "aws_backup_vault_notifications" "test" {
   backup_vault_name   = "${aws_backup_vault.test.name}"
   sns_topic_arn       = "${aws_sns_topic.test.arn}"

--- a/aws/resource_aws_backup_vault_notifications_test.go
+++ b/aws/resource_aws_backup_vault_notifications_test.go
@@ -1,0 +1,130 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccAwsBackupVaultNotification_basic(t *testing.T) {
+	var vault backup.GetBackupVaultNotificationsOutput
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_backup_vault_notifications.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsBackupVaultNotificationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBackupVaultNotificationConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBackupVaultNotificationExists(resourceName, &vault),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsBackupVaultNotification_disappears(t *testing.T) {
+	var vault backup.GetBackupVaultNotificationsOutput
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_backup_vault_notifications.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsBackupVaultNotificationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBackupVaultNotificationConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBackupVaultNotificationExists(resourceName, &vault),
+					testAccCheckAwsBackupVaultNotificationDisappears(&vault),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAwsBackupVaultNotificationDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).backupconn
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_backup_vault_notifications" {
+			continue
+		}
+
+		input := &backup.DeleteBackupVaultNotificationsInput{
+			BackupVaultName: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.DeleteBackupVaultNotifications(input)
+
+		return err
+	}
+
+	return nil
+}
+
+func testAccCheckAwsBackupVaultNotificationExists(name string, vault *backup.GetBackupVaultNotificationsOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).backupconn
+		params := &backup.GetBackupVaultNotificationsInput{
+			BackupVaultName: aws.String(rs.Primary.ID),
+		}
+		resp, err := conn.GetBackupVaultNotifications(params)
+		if err != nil {
+			return err
+		}
+
+		*vault = *resp
+
+		return nil
+	}
+}
+
+func testAccCheckAwsBackupVaultNotificationDisappears(vault *backup.GetBackupVaultNotificationsOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).backupconn
+		params := &backup.DeleteBackupVaultNotificationsInput{
+			BackupVaultName: vault.BackupVaultName,
+		}
+		_, err := conn.DeleteBackupVaultNotifications(params)
+
+		return err
+	}
+}
+
+func testAccBackupVaultNotificationConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_backup_vault" "test" {
+  name = %[1]q
+}
+
+resource "aws_sns_topic" "test" {
+  name = %[1]q
+}
+
+resource "aws_backup_vault_notifications" "test" {
+  backup_vault_name   = "${aws_backup_vault.test.name}"
+  sns_topic_arn       = "${aws_sns_topic.test.arn}"
+  backup_vault_events = ["BACKUP_JOB_STARTED", "RESTORE_JOB_COMPLETED"] 
+}
+`, rName)
+}

--- a/aws/resource_aws_backup_vault_notifications_test.go
+++ b/aws/resource_aws_backup_vault_notifications_test.go
@@ -22,7 +22,7 @@ func init() {
 func testSweepBackupVaultNotifications(region string) error {
 	client, err := sharedClientForRegion(region)
 	if err != nil {
-		return fmt.Errorf("Error getting client: %s", err)
+		return fmt.Errorf("Error getting client: %w", err)
 	}
 	conn := client.(*AWSClient).backupconn
 
@@ -35,7 +35,7 @@ func testSweepBackupVaultNotifications(region string) error {
 				log.Printf("[WARN] Skipping Backup Vault Notifications sweep for %s: %s", region, err)
 				return nil
 			}
-			return fmt.Errorf("Error retrieving Backup Vault Notifications: %s", err)
+			return fmt.Errorf("Error retrieving Backup Vault Notifications: %w", err)
 		}
 
 		if len(output.BackupVaultList) == 0 {
@@ -51,7 +51,7 @@ func testSweepBackupVaultNotifications(region string) error {
 				BackupVaultName: aws.String(name),
 			})
 			if err != nil {
-				return fmt.Errorf("Error deleting Backup Vault Notifications %s: %s", name, err)
+				return fmt.Errorf("Error deleting Backup Vault Notifications %s: %w", name, err)
 			}
 		}
 
@@ -126,7 +126,7 @@ func testAccCheckAwsBackupVaultNotificationDestroy(s *terraform.State) error {
 		resp, err := conn.GetBackupVaultNotifications(input)
 
 		if err == nil {
-			if *resp.BackupVaultName == rs.Primary.ID {
+			if aws.StringValue(resp.BackupVaultName) == rs.Primary.ID {
 				return fmt.Errorf("Backup Plan notifications '%s' was not deleted properly", rs.Primary.ID)
 			}
 		}

--- a/aws/resource_aws_sns_topic_test.go
+++ b/aws/resource_aws_sns_topic_test.go
@@ -21,6 +21,7 @@ func init() {
 		F:    testSweepSnsTopics,
 		Dependencies: []string{
 			"aws_autoscaling_group",
+			"aws_backup_vault_notifications",
 			"aws_budgets_budget",
 			"aws_config_delivery_channel",
 			"aws_dax_cluster",

--- a/website/docs/r/backup_vault_notifications.html.markdown
+++ b/website/docs/r/backup_vault_notifications.html.markdown
@@ -48,7 +48,7 @@ resource "aws_sns_topic_policy" "test" {
 resource "aws_backup_vault_notifications" "test" {
   backup_vault_name   = "example_backup_vault"
   sns_topic_arn       = "${sns_topic_arn.test.arn}"
-  backup_vault_events = ["BACKUP_JOB_STARTED", "RESTORE_JOB_COMPLETED"] 
+  backup_vault_events = ["BACKUP_JOB_STARTED", "RESTORE_JOB_COMPLETED"]
 }
 ```
 

--- a/website/docs/r/backup_vault_notifications.html.markdown
+++ b/website/docs/r/backup_vault_notifications.html.markdown
@@ -33,7 +33,7 @@ data "aws_iam_policy_document" "test" {
     }
 
     resources = [
-      "${aws_sns_topic.test.arn}",
+      aws_sns_topic.test.arn,
     ]
 
     sid = "__default_statement_ID"

--- a/website/docs/r/backup_vault_notifications.html.markdown
+++ b/website/docs/r/backup_vault_notifications.html.markdown
@@ -65,7 +65,7 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The name of the vault.
-* `arn` - The ARN of the vault.
+* `backup_vault_arn` - The ARN of the vault.
 
 ## Import
 

--- a/website/docs/r/backup_vault_notifications.html.markdown
+++ b/website/docs/r/backup_vault_notifications.html.markdown
@@ -41,13 +41,13 @@ data "aws_iam_policy_document" "test" {
 }
 
 resource "aws_sns_topic_policy" "test" {
-  arn    = "${aws_sns_topic.test.arn}"
-  policy = "${data.aws_iam_policy_document.test.json}"
+  arn    = aws_sns_topic.test.arn
+  policy = data.aws_iam_policy_document.test.json
 }
 
 resource "aws_backup_vault_notifications" "test" {
   backup_vault_name   = "example_backup_vault"
-  sns_topic_arn       = "${sns_topic_arn.test.arn}"
+  sns_topic_arn       = sns_topic_arn.test.arn
   backup_vault_events = ["BACKUP_JOB_STARTED", "RESTORE_JOB_COMPLETED"]
 }
 ```

--- a/website/docs/r/backup_vault_notifications.html.markdown
+++ b/website/docs/r/backup_vault_notifications.html.markdown
@@ -1,0 +1,44 @@
+---
+subcategory: "Backup"
+layout: "aws"
+page_title: "AWS: aws_backup_vault_notifications"
+description: |-
+  Provides an AWS Backup vault notifications resource.
+---
+
+# Resource: aws_backup_vault_notifications
+
+Provides an AWS Backup vault notifications resource.
+
+## Example Usage
+
+```hcl
+resource "aws_backup_vault_notifications" "test" {
+  backup_vault_name   = "example_backup_vault"
+  sns_topic_arn       = "${sns_topic_arn.test.arn}"
+  backup_vault_events = ["BACKUP_JOB_STARTED", "RESTORE_JOB_COMPLETED"] 
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the backup vault to add notifications for.
+* `sns_topic_arn` - (Required) The Amazon Resource Name (ARN) that specifies the topic for a backup vault’s events
+* `backup_vault_events` - (Required) An array of events that indicate the status of jobs to back up resources to the backup vault.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The name of the vault.
+* `arn` - The ARN of the vault.
+
+## Import
+
+Backup vault notifications can be imported using the `name`, e.g.
+
+```
+$ terraform import aws_backup_vault_notifications.test TestVault
+```

--- a/website/docs/r/backup_vault_notifications.html.markdown
+++ b/website/docs/r/backup_vault_notifications.html.markdown
@@ -17,19 +17,32 @@ resource "aws_sns_topic" "test" {
   name = "backup-vault-events"
 }
 
-resource "aws_sns_topic_policy" "test" {
-	arn = "${aws_sns_topic.test.arn}"
-	policy = <<POLICY
-{
-      "Sid": "My-statement-id",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "backup.amazonaws.com"
-      },
-      "Action": "SNS:Publish",
-      "Resource": "${aws_sns_topic.test.arn}"
+data "aws_iam_policy_document" "test" {
+  policy_id = "__default_policy_ID"
+
+  statement {
+    actions = [
+      "SNS:Publish",
+    ]
+
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["backup.amazonaws.com"]
+    }
+
+    resources = [
+      "${aws_sns_topic.test.arn}",
+    ]
+
+    sid = "__default_statement_ID"
+  }
 }
-POLICY
+
+resource "aws_sns_topic_policy" "test" {
+  arn = "${aws_sns_topic.test.arn}"
+  policy = "${data.aws_iam_policy_document.test.json}"
 }
 
 resource "aws_backup_vault_notifications" "test" {

--- a/website/docs/r/backup_vault_notifications.html.markdown
+++ b/website/docs/r/backup_vault_notifications.html.markdown
@@ -43,7 +43,7 @@ resource "aws_backup_vault_notifications" "test" {
 
 The following arguments are supported:
 
-* `name` - (Required) Name of the backup vault to add notifications for.
+* `backup_vault_name` - (Required) Name of the backup vault to add notifications for.
 * `sns_topic_arn` - (Required) The Amazon Resource Name (ARN) that specifies the topic for a backup vault’s events
 * `backup_vault_events` - (Required) An array of events that indicate the status of jobs to back up resources to the backup vault.
 

--- a/website/docs/r/backup_vault_notifications.html.markdown
+++ b/website/docs/r/backup_vault_notifications.html.markdown
@@ -13,6 +13,25 @@ Provides an AWS Backup vault notifications resource.
 ## Example Usage
 
 ```hcl
+resource "aws_sns_topic" "test" {
+  name = "backup-vault-events"
+}
+
+resource "aws_sns_topic_policy" "test" {
+	arn = "${aws_sns_topic.test.arn}"
+	policy = <<POLICY
+{
+      "Sid": "My-statement-id",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "backup.amazonaws.com"
+      },
+      "Action": "SNS:Publish",
+      "Resource": "${aws_sns_topic.test.arn}"
+}
+POLICY
+}
+
 resource "aws_backup_vault_notifications" "test" {
   backup_vault_name   = "example_backup_vault"
   sns_topic_arn       = "${sns_topic_arn.test.arn}"

--- a/website/docs/r/backup_vault_notifications.html.markdown
+++ b/website/docs/r/backup_vault_notifications.html.markdown
@@ -41,7 +41,7 @@ data "aws_iam_policy_document" "test" {
 }
 
 resource "aws_sns_topic_policy" "test" {
-  arn = "${aws_sns_topic.test.arn}"
+  arn    = "${aws_sns_topic.test.arn}"
   policy = "${data.aws_iam_policy_document.test.json}"
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #8727

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_backup_vault_notifications; add new resource
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsBackupVaultNotification_'
--- PASS: TestAccAwsBackupVaultNotification_basic (54.58s)
--- PASS: TestAccAwsBackupVaultNotification_disappears (53.07s)
```
