### PR TITLE
Correcting possible values for encryption_option in athena_workgroup documentation

### DIFF
--- a/website/docs/r/athena_workgroup.html.markdown
+++ b/website/docs/r/athena_workgroup.html.markdown
@@ -62,8 +62,8 @@ The `result_configuration` configuration block within the `configuration` suppor
 
 The `encryption_configuration` configuration block within the `result_configuration` of the `configuration` supports the following arguments:
 
-* `encryption_option` - (Required) Indicates whether Amazon S3 server-side encryption with Amazon S3-managed keys (SSE-S3), server-side encryption with KMS-managed keys (SSE-KMS), or client-side encryption with KMS-managed keys (CSE-KMS) is used. If a query runs in a workgroup and the workgroup overrides client-side settings, then the workgroup's setting for encryption is used. It specifies whether query results must be encrypted, for all queries that run in this workgroup.
-* `kms_key_arn` - (Optional) For SSE-KMS and CSE-KMS, this is the KMS key Amazon Resource Name (ARN).
+* `encryption_option` - (Required) Indicates whether Amazon S3 server-side encryption with Amazon S3-managed keys (`SSE_S3`), server-side encryption with KMS-managed keys (`SSE_KMS`), or client-side encryption with KMS-managed keys (`CSE_KMS`) is used. If a query runs in a workgroup and the workgroup overrides client-side settings, then the workgroup's setting for encryption is used. It specifies whether query results must be encrypted, for all queries that run in this workgroup.
+* `kms_key_arn` - (Optional) For `SSE_KMS` and `CSE_KMS`, this is the KMS key Amazon Resource Name (ARN).
 
 ## Attributes Reference
 


### PR DESCRIPTION
Updated documentation for athena_workgroup. These were listed with -'s but the correct values are one of CSE_KMS, SSE_KMS or SSE_S3.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
