### PR TITLE
Fixes Elastic Beanstalk Application and Environment Sweepers and Tests

### DIFF
--- a/aws/resource_aws_elastic_beanstalk_application_test.go
+++ b/aws/resource_aws_elastic_beanstalk_application_test.go
@@ -87,9 +87,10 @@ func TestAccAWSElasticBeanstalkApplication_basic(t *testing.T) {
 func testAccBeanstalkAppImportConfig(name string) string {
 	return fmt.Sprintf(`
 resource "aws_elastic_beanstalk_application" "tftest" {
-	  name = "%s"
-	  description = "tf-test-desc"
-	}`, name)
+  name        = "%s"
+  description = "tf-test-desc"
+}
+`, name)
 }
 
 func TestAccAWSBeanstalkApp_basic(t *testing.T) {
@@ -286,7 +287,7 @@ func testAccCheckBeanstalkAppExists(n string, app *elasticbeanstalk.ApplicationD
 func testAccBeanstalkAppConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_elastic_beanstalk_application" "tftest" {
-  name = "%s"
+  name        = "%s"
   description = "tf-test-desc"
 }
 `, rName)

--- a/aws/resource_aws_elastic_beanstalk_application_test.go
+++ b/aws/resource_aws_elastic_beanstalk_application_test.go
@@ -6,14 +6,13 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/elasticbeanstalk"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-// initialize sweeper
 func init() {
 	resource.AddTestSweepers("aws_elastic_beanstalk_application", &resource.Sweeper{
 		Name:         "aws_elastic_beanstalk_application",
@@ -35,7 +34,7 @@ func testSweepElasticBeanstalkApplications(region string) error {
 			log.Printf("[WARN] Skipping Elastic Beanstalk Application sweep for %s: %s", region, err)
 			return nil
 		}
-		return fmt.Errorf("Error retrieving beanstalk application: %s", err)
+		return fmt.Errorf("error retrieving beanstalk application: %w", err)
 	}
 
 	if len(resp.Applications) == 0 {
@@ -43,23 +42,24 @@ func testSweepElasticBeanstalkApplications(region string) error {
 		return nil
 	}
 
+	var errors error
 	for _, bsa := range resp.Applications {
+		applicationName := aws.StringValue(bsa.ApplicationName)
 		_, err := beanstalkconn.DeleteApplication(
 			&elasticbeanstalk.DeleteApplicationInput{
 				ApplicationName: bsa.ApplicationName,
 			})
 		if err != nil {
-			elasticbeanstalkerr, ok := err.(awserr.Error)
-			if ok && (elasticbeanstalkerr.Code() == "InvalidConfiguration.NotFound" || elasticbeanstalkerr.Code() == "ValidationError") {
-				log.Printf("[DEBUG] beanstalk application (%s) not found", *bsa.ApplicationName)
-				return nil
+			if isAWSErr(err, "InvalidConfiguration.NotFound", "") || isAWSErr(err, "ValidationError", "") {
+				log.Printf("[DEBUG] beanstalk application %q not found", applicationName)
+				continue
 			}
 
-			return err
+			errors = multierror.Append(fmt.Errorf("error deleting Elastic Beanstalk Application %q: %w", applicationName, err))
 		}
 	}
 
-	return nil
+	return errors
 }
 
 func TestAccAWSElasticBeanstalkApplication_basic(t *testing.T) {
@@ -243,16 +243,10 @@ func testAccCheckBeanstalkAppDestroy(s *terraform.State) error {
 			if len(resp.Applications) > 0 {
 				return fmt.Errorf("Elastic Beanstalk Application still exists.")
 			}
-
 			return nil
 		}
 
-		// Verify the error is what we want
-		ec2err, ok := err.(awserr.Error)
-		if !ok {
-			return err
-		}
-		if ec2err.Code() != "InvalidBeanstalkAppID.NotFound" {
+		if !isAWSErr(err, "InvalidBeanstalkAppID.NotFound", "") {
 			return err
 		}
 	}

--- a/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/aws/resource_aws_elastic_beanstalk_environment.go
@@ -237,7 +237,7 @@ func resourceAwsElasticBeanstalkEnvironmentCreate(d *schema.ResourceData, meta i
 
 	if cnamePrefix != "" {
 		if tier != "WebServer" {
-			return fmt.Errorf("Cannot set cname_prefix for tier: %s.", tier)
+			return fmt.Errorf("cannot set cname_prefix for tier: %s", tier)
 		}
 		createOpts.CNAMEPrefix = aws.String(cnamePrefix)
 	}
@@ -308,9 +308,7 @@ func resourceAwsElasticBeanstalkEnvironmentCreate(d *schema.ResourceData, meta i
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf(
-			"Error waiting for Elastic Beanstalk Environment (%s) to become ready: %s",
-			d.Id(), err)
+		return fmt.Errorf("Error waiting for Elastic Beanstalk Environment (%s) to become ready: %w", d.Id(), err)
 	}
 
 	envErrors, err := getBeanstalkEnvironmentErrors(conn, d.Id(), t)
@@ -792,9 +790,7 @@ func resourceAwsElasticBeanstalkEnvironmentDelete(d *schema.ResourceData, meta i
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf(
-			"Error waiting for Elastic Beanstalk Environment (%s) to become terminated: %s",
-			d.Id(), err)
+		return fmt.Errorf("Error waiting for Elastic Beanstalk Environment (%s) to become terminated: %w", d.Id(), err)
 	}
 
 	envErrors, err := getBeanstalkEnvironmentErrors(conn, d.Id(), t)
@@ -984,7 +980,7 @@ func getBeanstalkEnvironmentErrors(conn *elasticbeanstalk.ElasticBeanstalk, envi
 	})
 
 	if err != nil {
-		return nil, fmt.Errorf("Unable to get Elastic Beanstalk Evironment events: %s", err)
+		return nil, fmt.Errorf("unable to get Elastic Beanstalk Environment events: %w", err)
 	}
 
 	var events beanstalkEnvironmentErrors

--- a/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/aws/resource_aws_elastic_beanstalk_environment.go
@@ -760,7 +760,7 @@ func deleteElasticBeanstalkEnvironment(conn *elasticbeanstalk.ElasticBeanstalk, 
 	stateConf := &resource.StateChangeConf{
 		Pending:      []string{"Terminating"},
 		Target:       []string{"Terminated"},
-		Refresh:      elasticBeanstalkEnvironmentStateIgnoreErrorEventsRefreshFunc(conn, id),
+		Refresh:      elasticBeanstalkEnvironmentIgnoreErrorEventsStateRefreshFunc(conn, id),
 		Timeout:      timeout,
 		Delay:        10 * time.Second,
 		PollInterval: pollInterval,
@@ -794,7 +794,7 @@ func waitForElasticBeanstalkEnvironmentReadyIgnoreErrorEvents(conn *elasticbeans
 	stateConf := &resource.StateChangeConf{
 		Pending:      []string{"Launching", "Updating"},
 		Target:       []string{"Ready"},
-		Refresh:      elasticBeanstalkEnvironmentStateIgnoreErrorEventsRefreshFunc(conn, id),
+		Refresh:      elasticBeanstalkEnvironmentIgnoreErrorEventsStateRefreshFunc(conn, id),
 		Timeout:      timeout,
 		Delay:        10 * time.Second,
 		PollInterval: pollInterval,
@@ -846,7 +846,7 @@ func elasticBeanstalkEnvironmentStateRefreshFunc(conn *elasticbeanstalk.ElasticB
 	}
 }
 
-func elasticBeanstalkEnvironmentStateIgnoreErrorEventsRefreshFunc(conn *elasticbeanstalk.ElasticBeanstalk, environmentID string) resource.StateRefreshFunc {
+func elasticBeanstalkEnvironmentIgnoreErrorEventsStateRefreshFunc(conn *elasticbeanstalk.ElasticBeanstalk, environmentID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		resp, err := conn.DescribeEnvironments(&elasticbeanstalk.DescribeEnvironmentsInput{
 			EnvironmentIds: []*string{aws.String(environmentID)},

--- a/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/aws/resource_aws_elastic_beanstalk_environment.go
@@ -315,12 +315,12 @@ func resourceAwsElasticBeanstalkEnvironmentCreate(d *schema.ResourceData, meta i
 func resourceAwsElasticBeanstalkEnvironmentUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).elasticbeanstalkconn
 
-	envId := d.Id()
+	envID := d.Id()
 
 	var hasChange bool
 
 	updateOpts := elasticbeanstalk.UpdateEnvironmentInput{
-		EnvironmentId: aws.String(envId),
+		EnvironmentId: aws.String(envID),
 	}
 
 	if d.HasChange("description") {
@@ -476,9 +476,7 @@ func resourceAwsElasticBeanstalkEnvironmentUpdate(d *schema.ResourceData, meta i
 
 		err = waitForElasticBeanstalkEnvironmentReady(conn, d.Id(), waitForReadyTimeOut, pollInterval, t)
 		if err != nil {
-			return fmt.Errorf(
-				"Error waiting for Elastic Beanstalk Environment (%s) to become ready: %s",
-				d.Id(), err)
+			return fmt.Errorf("error waiting for Elastic Beanstalk Environment %q to become ready: %w", d.Id(), err)
 		}
 
 		envErrors, err := getBeanstalkEnvironmentErrors(conn, d.Id(), t)
@@ -496,12 +494,12 @@ func resourceAwsElasticBeanstalkEnvironmentUpdate(d *schema.ResourceData, meta i
 func resourceAwsElasticBeanstalkEnvironmentRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).elasticbeanstalkconn
 
-	envId := d.Id()
+	envID := d.Id()
 
 	log.Printf("[DEBUG] Elastic Beanstalk environment read %s: id %s", d.Get("name").(string), d.Id())
 
 	resp, err := conn.DescribeEnvironments(&elasticbeanstalk.DescribeEnvironmentsInput{
-		EnvironmentIds: []*string{aws.String(envId)},
+		EnvironmentIds: []*string{aws.String(envID)},
 	})
 
 	if err != nil {
@@ -527,7 +525,7 @@ func resourceAwsElasticBeanstalkEnvironmentRead(d *schema.ResourceData, meta int
 	}
 
 	resources, err := conn.DescribeEnvironmentResources(&elasticbeanstalk.DescribeEnvironmentResourcesInput{
-		EnvironmentId: aws.String(envId),
+		EnvironmentId: aws.String(envID),
 	})
 
 	if err != nil {
@@ -771,7 +769,7 @@ func deleteElasticBeanstalkEnvironment(conn *elasticbeanstalk.ElasticBeanstalk, 
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("Error waiting for Elastic Beanstalk Environment %q to become terminated: %w", d.Id(), err)
+		return fmt.Errorf("error waiting for Elastic Beanstalk Environment %q to become terminated: %w", id, err)
 	}
 
 	return nil
@@ -827,7 +825,7 @@ func elasticBeanstalkEnvironmentStateRefreshFunc(conn *elasticbeanstalk.ElasticB
 
 		var env *elasticbeanstalk.EnvironmentDescription
 		for _, e := range resp.Environments {
-			if environmentId == *e.EnvironmentId {
+			if environmentID == aws.StringValue(e.EnvironmentId) {
 				env = e
 			}
 		}
@@ -836,7 +834,7 @@ func elasticBeanstalkEnvironmentStateRefreshFunc(conn *elasticbeanstalk.ElasticB
 			return -1, "failed", fmt.Errorf("Error finding Elastic Beanstalk Environment, environment not found")
 		}
 
-		envErrors, err := getBeanstalkEnvironmentErrors(conn, environmentId, t)
+		envErrors, err := getBeanstalkEnvironmentErrors(conn, environmentID, t)
 		if err != nil {
 			return -1, "failed", err
 		}

--- a/aws/resource_aws_elastic_beanstalk_environment_test.go
+++ b/aws/resource_aws_elastic_beanstalk_environment_test.go
@@ -453,7 +453,7 @@ func TestAccAWSBeanstalkEnv_platformArn(t *testing.T) {
 				Config: testAccBeanstalkEnvConfig_platform_arn(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBeanstalkEnvExists(resourceName, &app),
-					testAccCheckResourceAttrRegionalARNNoAccount(resourceName, "platform_arn", "elasticbeanstalk", "platform/Python 3.6 running on 64bit Amazon Linux/2.9.4"),
+					testAccCheckResourceAttrRegionalARNNoAccount(resourceName, "platform_arn", "elasticbeanstalk", "platform/Python 3.6 running on 64bit Amazon Linux/2.9.6"),
 				),
 			},
 			{

--- a/aws/resource_aws_elastic_beanstalk_environment_test.go
+++ b/aws/resource_aws_elastic_beanstalk_environment_test.go
@@ -846,7 +846,7 @@ func testAccBeanstalkEnvConfig_platform_arn(rName string) string {
 resource "aws_elastic_beanstalk_environment" "test" {
   application  = aws_elastic_beanstalk_application.test.name
   name         = %[1]q
-  platform_arn = "arn:${data.aws_partition.current.partition}:elasticbeanstalk:${data.aws_region.current.name}::platform/Python 3.6 running on 64bit Amazon Linux/2.9.4"
+  platform_arn = "arn:${data.aws_partition.current.partition}:elasticbeanstalk:${data.aws_region.current.name}::platform/Python 3.6 running on 64bit Amazon Linux/2.9.6"
 
   setting {
     namespace = "aws:ec2:vpc"

--- a/aws/resource_aws_elastic_beanstalk_environment_test.go
+++ b/aws/resource_aws_elastic_beanstalk_environment_test.go
@@ -73,20 +73,18 @@ func testSweepElasticBeanstalkEnvironments(region string) error {
 		pollInterval, _ := time.ParseDuration("10s")
 
 		// poll for deletion
-		t := time.Now()
 		stateConf := &resource.StateChangeConf{
 			Pending:      []string{"Terminating"},
 			Target:       []string{"Terminated"},
-			Refresh:      environmentStateRefreshFunc(beanstalkconn, environmentID, t),
+			Refresh:      elasticBeanstalkEnvironmentStateIgnoreErrorEventsRefreshFunc(beanstalkconn, environmentID),
 			Timeout:      waitForReadyTimeOut,
 			Delay:        10 * time.Second,
 			PollInterval: pollInterval,
 			MinTimeout:   3 * time.Second,
 		}
-
 		_, err = stateConf.WaitForState()
 		if err != nil {
-			errors = multierror.Append(fmt.Errorf("Error waiting for Elastic Beanstalk Environment %q to become terminated: %w", environmentID, err))
+			errors = multierror.Append(fmt.Errorf("error waiting for Elastic Beanstalk Environment %q to become terminated: %w", environmentID, err))
 			continue
 		}
 		log.Printf("> Terminated (%s) (%s)", environmentName, environmentID)

--- a/aws/resource_aws_elastic_beanstalk_environment_test.go
+++ b/aws/resource_aws_elastic_beanstalk_environment_test.go
@@ -727,6 +727,10 @@ data "aws_availability_zones" "available" {
   # after waiting upwards of one hour to initialize the Auto Scaling Group.
   blacklisted_zone_ids = ["usw2-az4"]
   state                = "available"
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
 }
 
 data "aws_elastic_beanstalk_solution_stack" "test" {

--- a/aws/resource_aws_elastic_beanstalk_environment_test.go
+++ b/aws/resource_aws_elastic_beanstalk_environment_test.go
@@ -10,15 +10,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/elasticbeanstalk"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
-// initialize sweeper
 func init() {
 	resource.AddTestSweepers("aws_elastic_beanstalk_environment", &resource.Sweeper{
 		Name: "aws_elastic_beanstalk_environment",
@@ -29,7 +28,7 @@ func init() {
 func testSweepElasticBeanstalkEnvironments(region string) error {
 	client, err := sharedClientForRegion(region)
 	if err != nil {
-		return fmt.Errorf("error getting client: %s", err)
+		return fmt.Errorf("error getting client: %w", err)
 	}
 	beanstalkconn := client.(*AWSClient).elasticbeanstalkconn
 
@@ -42,7 +41,7 @@ func testSweepElasticBeanstalkEnvironments(region string) error {
 			log.Printf("[WARN] Skipping Elastic Beanstalk Environment sweep for %s: %s", region, err)
 			return nil
 		}
-		return fmt.Errorf("Error retrieving beanstalk environment: %s", err)
+		return fmt.Errorf("error retrieving beanstalk environment: %w", err)
 	}
 
 	if len(resp.Environments) == 0 {
@@ -50,8 +49,11 @@ func testSweepElasticBeanstalkEnvironments(region string) error {
 		return nil
 	}
 
+	var errors error
 	for _, bse := range resp.Environments {
-		log.Printf("Trying to terminate (%s) (%s)", *bse.EnvironmentName, *bse.EnvironmentId)
+		environmentName := aws.StringValue(bse.EnvironmentName)
+		environmentID := aws.StringValue(bse.EnvironmentId)
+		log.Printf("Trying to terminate (%s) (%s)", environmentName, environmentID)
 
 		_, err := beanstalkconn.TerminateEnvironment(
 			&elasticbeanstalk.TerminateEnvironmentInput{
@@ -60,13 +62,11 @@ func testSweepElasticBeanstalkEnvironments(region string) error {
 			})
 
 		if err != nil {
-			elasticbeanstalkerr, ok := err.(awserr.Error)
-			if ok && (elasticbeanstalkerr.Code() == "InvalidConfiguration.NotFound" || elasticbeanstalkerr.Code() == "ValidationError") {
-				log.Printf("[DEBUG] beanstalk environment (%s) not found", *bse.EnvironmentName)
-				return nil
+			if isAWSErr(err, "InvalidConfiguration.NotFound", "") || isAWSErr(err, "ValidationError", "") {
+				log.Printf("[DEBUG] Elastic Beanstalk Environment %q not found", environmentName)
+				continue
 			}
-
-			return err
+			errors = multierror.Append(fmt.Errorf("error terminating Elastic Beanstalk Environment %q: %w", environmentName, err))
 		}
 
 		waitForReadyTimeOut, _ := time.ParseDuration("5m")
@@ -77,7 +77,7 @@ func testSweepElasticBeanstalkEnvironments(region string) error {
 		stateConf := &resource.StateChangeConf{
 			Pending:      []string{"Terminating"},
 			Target:       []string{"Terminated"},
-			Refresh:      environmentStateRefreshFunc(beanstalkconn, *bse.EnvironmentId, t),
+			Refresh:      environmentStateRefreshFunc(beanstalkconn, environmentID, t),
 			Timeout:      waitForReadyTimeOut,
 			Delay:        10 * time.Second,
 			PollInterval: pollInterval,
@@ -86,14 +86,13 @@ func testSweepElasticBeanstalkEnvironments(region string) error {
 
 		_, err = stateConf.WaitForState()
 		if err != nil {
-			return fmt.Errorf(
-				"Error waiting for Elastic Beanstalk Environment (%s) to become terminated: %s",
-				*bse.EnvironmentId, err)
+			errors = multierror.Append(fmt.Errorf("Error waiting for Elastic Beanstalk Environment %q to become terminated: %w", environmentID, err))
+			continue
 		}
-		log.Printf("> Terminated (%s) (%s)", *bse.EnvironmentName, *bse.EnvironmentId)
+		log.Printf("> Terminated (%s) (%s)", environmentName, environmentID)
 	}
 
-	return nil
+	return errors
 }
 
 func TestAccAWSBeanstalkEnv_basic(t *testing.T) {
@@ -106,7 +105,7 @@ func TestAccAWSBeanstalkEnv_basic(t *testing.T) {
 	beanstalkElbNameRegexp := regexp.MustCompile("awseb.+?EBLoa[^,]+")
 	beanstalkInstancesNameRegexp := regexp.MustCompile("i-([0-9a-fA-F]{8}|[0-9a-fA-F]{17})")
 	beanstalkLcNameRegexp := regexp.MustCompile("awseb.+?AutoScalingLaunch[^,]+")
-	beanstalkEndpointUrl := regexp.MustCompile("awseb.+?EBLoa[^,].+?elb.amazonaws.com")
+	beanstalkEndpointURL := regexp.MustCompile("awseb.+?EBLoa[^,].+?elb.amazonaws.com")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -119,7 +118,7 @@ func TestAccAWSBeanstalkEnv_basic(t *testing.T) {
 					testAccCheckBeanstalkEnvExists(resourceName, &app),
 					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "elasticbeanstalk", fmt.Sprintf("environment/%s/%s", rName, rName)),
 					resource.TestMatchResourceAttr(resourceName, "autoscaling_groups.0", beanstalkAsgNameRegexp),
-					resource.TestMatchResourceAttr(resourceName, "endpoint_url", beanstalkEndpointUrl),
+					resource.TestMatchResourceAttr(resourceName, "endpoint_url", beanstalkEndpointURL),
 					resource.TestMatchResourceAttr(resourceName, "instances.0", beanstalkInstancesNameRegexp),
 					resource.TestMatchResourceAttr(resourceName, "launch_configurations.0", beanstalkLcNameRegexp),
 					resource.TestMatchResourceAttr(resourceName, "load_balancers.0", beanstalkElbNameRegexp),
@@ -544,7 +543,7 @@ func testAccVerifyBeanstalkConfig(env *elasticbeanstalk.EnvironmentDescription, 
 		sort.Strings(testStrings)
 		sort.Strings(expected)
 		if !reflect.DeepEqual(testStrings, expected) {
-			return fmt.Errorf("Error matching strings, expected:\n\n%#v\n\ngot:\n\n%#v\n", testStrings, foundEnvs)
+			return fmt.Errorf("error matching strings, expected:\n\n%#v\n\ngot:\n\n%#v", testStrings, foundEnvs)
 		}
 
 		return nil
@@ -567,23 +566,18 @@ func testAccCheckBeanstalkEnvDestroy(s *terraform.State) error {
 		if err == nil {
 			switch {
 			case len(resp.Environments) > 1:
-				return fmt.Errorf("Error %d environments match, expected 1", len(resp.Environments))
+				return fmt.Errorf("error %d environments match, expected 1", len(resp.Environments))
 			case len(resp.Environments) == 1:
 				if *resp.Environments[0].Status == "Terminated" {
 					return nil
 				}
-				return fmt.Errorf("Elastic Beanstalk ENV still exists.")
+				return fmt.Errorf("Elastic Beanstalk ENV still exists")
 			default:
 				return nil
 			}
 		}
 
-		// Verify the error is what we want
-		ec2err, ok := err.(awserr.Error)
-		if !ok {
-			return err
-		}
-		if ec2err.Code() != "InvalidBeanstalkEnvID.NotFound" {
+		if !isAWSErr(err, "InvalidBeanstalkEnvID.NotFound", "") {
 			return err
 		}
 	}
@@ -746,10 +740,10 @@ func describeBeanstalkEnv(conn *elasticbeanstalk.ElasticBeanstalk,
 		return &elasticbeanstalk.EnvironmentDescription{}, err
 	}
 	if len(resp.Environments) == 0 {
-		return &elasticbeanstalk.EnvironmentDescription{}, fmt.Errorf("Elastic Beanstalk ENV not found.")
+		return &elasticbeanstalk.EnvironmentDescription{}, fmt.Errorf("Elastic Beanstalk ENV not found")
 	}
 	if len(resp.Environments) > 1 {
-		return &elasticbeanstalk.EnvironmentDescription{}, fmt.Errorf("Found %d environments, expected 1.", len(resp.Environments))
+		return &elasticbeanstalk.EnvironmentDescription{}, fmt.Errorf("found %d environments, expected 1", len(resp.Environments))
 	}
 	return resp.Environments[0], nil
 }


### PR DESCRIPTION
The Elastic Beanstalk Environment sweeper was failing when attempting to destroy incomplete Environments. This was because:
* The resource deletion code was passing through error events from CloudFormation trying to delete resource that had not been created
* The Environment sweeper was stopping after the first failure

```
$ make sweep SWEEPARGS='-sweep-run=aws_elastic_beanstalk_application'

Trying to terminate (tf-acc-test-4432723836753776799) (e-3khb62yj7n)
[DEBUG] Waiting for state to become: [Terminated]
[ERROR] Error running Sweeper (aws_elastic_beanstalk_environment) in region (us-west-2): Error waiting for Elastic Beanstalk Environment (e-3khb62yj7n) to become terminated: 1 error occurred:
	* 2020-03-23 18:45:51.548 +0000 UTC (e-3khb62yj7n) : Service:AmazonCloudFormation, Message:Resource AWSEBAutoScalingGroup does not exist for stack awseb-e-3khb62yj7n-stack
```

Resource deletion now ignores internal errors as long as the Elastic Beanstalk Environment is deleted.

During investigation, the Application sweeper was found to also stop after the first failure.

Finally, the acceptance tests are failing due to Local Zones, so this PR depends on #12400.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSBeanstalkEnv_'

--- PASS: TestAccAWSBeanstalkEnv_basic (378.42s)
--- PASS: TestAccAWSBeanstalkEnv_platformArn (400.21s)
--- PASS: TestAccAWSBeanstalkEnv_settingWithJsonValue (446.82s)
--- PASS: TestAccAWSBeanstalkEnv_resource (525.19s)
--- PASS: TestAccAWSBeanstalkEnv_tier (586.89s)
--- PASS: TestAccAWSBeanstalkEnv_cname_prefix (588.81s)
--- PASS: TestAccAWSBeanstalkEnv_tags (683.86s)
--- PASS: TestAccAWSBeanstalkEnv_config (691.65s)
--- PASS: TestAccAWSBeanstalkEnv_template_change (696.11s)
--- PASS: TestAccAWSBeanstalkEnv_settings_update (722.33s)
--- PASS: TestAccAWSBeanstalkEnv_version_label (762.56s)
```
```
$ make testacc TESTARGS='-run=TestAccAWSBeanstalkApp_'

--- PASS: TestAccAWSBeanstalkApp_basic (19.55s)
--- PASS: TestAccAWSBeanstalkApp_tags (59.19s)
--- PASS: TestAccAWSBeanstalkApp_appversionlifecycle (60.55s)
```
```
$ make sweep SWEEPARGS='-sweep-run=aws_elastic_beanstalk_application'

Sweeper Tests ran successfully:
	- aws_elastic_beanstalk_environment
	- aws_elastic_beanstalk_application
```
