### PR TITLE
resource/aws_route53_health_check: normalize ipv6 addresses in healthchecks

### DIFF
--- a/aws/resource_aws_route53_health_check_test.go
+++ b/aws/resource_aws_route53_health_check_test.go
@@ -185,6 +185,37 @@ func TestAccAWSRoute53HealthCheck_IpConfig(t *testing.T) {
 	})
 }
 
+func TestAccAWSRoute53HealthCheck_Ipv6Config(t *testing.T) {
+	resourceName := "aws_route53_health_check.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53HealthCheckIpV6Form1Config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53HealthCheckExists(resourceName),
+				),
+			},
+			{
+				// Expect no diff if we write ipv6 addresses in an alternate form
+				Config:   testAccRoute53HealthCheckIpV6Form2Config,
+				PlanOnly: true,
+			},
+			{
+				Config:   testAccRoute53HealthCheckIpV6Form1Config,
+				PlanOnly: true,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSRoute53HealthCheck_CloudWatchAlarmCheck(t *testing.T) {
 	resourceName := "aws_route53_health_check.test"
 	resource.ParallelTest(t, resource.TestCase{
@@ -527,6 +558,36 @@ resource "aws_route53_health_check" "test" {
   measure_latency = true
   invert_healthcheck = true
   enable_sni = false
+
+  tags = {
+    Name = "tf-test-health-check"
+   }
+}
+`
+
+const testAccRoute53HealthCheckIpV6Form1Config = `
+resource "aws_route53_health_check" "test" {
+  ip_address = "2001:DB8::1"
+  port = 80
+  type = "HTTP"
+  resource_path = "/"
+  failure_threshold = "2"
+  request_interval = "30"
+
+  tags = {
+    Name = "tf-test-health-check"
+   }
+}
+`
+
+const testAccRoute53HealthCheckIpV6Form2Config = `
+resource "aws_route53_health_check" "test" {
+  ip_address = "2001:DB8:0:0:0:0:0:1"
+  port = 80
+  type = "HTTP"
+  resource_path = "/"
+  failure_threshold = "2"
+  request_interval = "30"
 
   tags = {
     Name = "tf-test-health-check"


### PR DESCRIPTION
Without this change, terraform will generate a recreate plan each time
if the resource is specified with an ipv6 address that differs from how
aws stores it.

This includes recreating if the same configuration, using a
non-aws-canonical ipv6 form, is applied twice in a row.

Fix this by normalizing the value to whatever go's `net.IP.String()`
formats it as.

<!--- Please keep this note for the community --->

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
IPv6 addresses in route53 healthchecks are now normalized to avoid spurious recreates.
```

(or `NONE` for release notes, I could see either making sense)

Output from acceptance testing:

```
 $ make testacc TESTARGS='-run TestAccAWSRoute53HealthCheck_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run TestAccAWSRoute53HealthCheck_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSRoute53HealthCheck_basic
=== PAUSE TestAccAWSRoute53HealthCheck_basic
=== RUN   TestAccAWSRoute53HealthCheck_tags
=== PAUSE TestAccAWSRoute53HealthCheck_tags
=== RUN   TestAccAWSRoute53HealthCheck_withSearchString
=== PAUSE TestAccAWSRoute53HealthCheck_withSearchString
=== RUN   TestAccAWSRoute53HealthCheck_withChildHealthChecks
=== PAUSE TestAccAWSRoute53HealthCheck_withChildHealthChecks
=== RUN   TestAccAWSRoute53HealthCheck_withHealthCheckRegions
=== PAUSE TestAccAWSRoute53HealthCheck_withHealthCheckRegions
=== RUN   TestAccAWSRoute53HealthCheck_IpConfig
=== PAUSE TestAccAWSRoute53HealthCheck_IpConfig
=== RUN   TestAccAWSRoute53HealthCheck_Ipv6Config
=== PAUSE TestAccAWSRoute53HealthCheck_Ipv6Config
=== RUN   TestAccAWSRoute53HealthCheck_CloudWatchAlarmCheck
=== PAUSE TestAccAWSRoute53HealthCheck_CloudWatchAlarmCheck
=== RUN   TestAccAWSRoute53HealthCheck_withSNI
=== PAUSE TestAccAWSRoute53HealthCheck_withSNI
=== CONT  TestAccAWSRoute53HealthCheck_basic
=== CONT  TestAccAWSRoute53HealthCheck_IpConfig
=== CONT  TestAccAWSRoute53HealthCheck_withSNI
=== CONT  TestAccAWSRoute53HealthCheck_withSearchString
=== CONT  TestAccAWSRoute53HealthCheck_Ipv6Config
=== CONT  TestAccAWSRoute53HealthCheck_withChildHealthChecks
=== CONT  TestAccAWSRoute53HealthCheck_withHealthCheckRegions
=== CONT  TestAccAWSRoute53HealthCheck_tags
=== CONT  TestAccAWSRoute53HealthCheck_CloudWatchAlarmCheck
--- PASS: TestAccAWSRoute53HealthCheck_withHealthCheckRegions (28.78s)
--- PASS: TestAccAWSRoute53HealthCheck_IpConfig (28.87s)
--- PASS: TestAccAWSRoute53HealthCheck_CloudWatchAlarmCheck (30.56s)
--- PASS: TestAccAWSRoute53HealthCheck_withChildHealthChecks (33.79s)
--- PASS: TestAccAWSRoute53HealthCheck_Ipv6Config (42.17s)
--- PASS: TestAccAWSRoute53HealthCheck_basic (48.21s)
--- PASS: TestAccAWSRoute53HealthCheck_withSearchString (48.45s)
--- PASS: TestAccAWSRoute53HealthCheck_withSNI (73.40s)
--- PASS: TestAccAWSRoute53HealthCheck_tags (80.28s)
PASS
```
