### PR TITLE
d/ec2_transit_gateway_dx_gateway_attachement - filter support

### DIFF
--- a/aws/data_source_aws_ec2_transit_gateway_dx_gateway_attachment.go
+++ b/aws/data_source_aws_ec2_transit_gateway_dx_gateway_attachment.go
@@ -18,13 +18,14 @@ func dataSourceAwsEc2TransitGatewayDxGatewayAttachment() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"dx_gateway_id": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"tags": tagsSchemaComputed(),
 			"transit_gateway_id": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
+			"filter": dataSourceFiltersSchema(),
 		},
 	}
 }
@@ -32,21 +33,41 @@ func dataSourceAwsEc2TransitGatewayDxGatewayAttachment() *schema.Resource {
 func dataSourceAwsEc2TransitGatewayDxGatewayAttachmentRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
+	filters, filtersOk := d.GetOk("filter")
+	tags, tagsOk := d.GetOk("tags")
+	dxGatewayId, dxGatewayIdOk := d.GetOk("dx_gateway_id")
+	transitGatewayId, transitGatewayIdOk := d.GetOk("transit_gateway_id")
+
 	input := &ec2.DescribeTransitGatewayAttachmentsInput{
 		Filters: []*ec2.Filter{
 			{
+				Name:   aws.String("resource-type"),
+				Values: []*string{aws.String(ec2.TransitGatewayAttachmentResourceTypeDirectConnectGateway)},
+			},
+		},
+	}
+	if filtersOk {
+		input.Filters = append(input.Filters, buildAwsDataSourceFilters(filters.(*schema.Set))...)
+	}
+	if tagsOk {
+		input.Filters = append(input.Filters, ec2TagFiltersFromMap(tags.(map[string]interface{}))...)
+	}
+	// to preserve original functionality
+	if dxGatewayIdOk && transitGatewayIdOk {
+		input.Filters = []*ec2.Filter{
+			{
 				Name:   aws.String("resource-id"),
-				Values: []*string{aws.String(d.Get("dx_gateway_id").(string))},
+				Values: []*string{aws.String(dxGatewayId.(string))},
 			},
 			{
 				Name:   aws.String("resource-type"),
-				Values: []*string{aws.String("direct-connect-gateway")}, // Not yet defined in ec2/api.go.
+				Values: []*string{aws.String(ec2.TransitGatewayAttachmentResourceTypeDirectConnectGateway)},
 			},
 			{
 				Name:   aws.String("transit-gateway-id"),
-				Values: []*string{aws.String(d.Get("transit_gateway_id").(string))},
+				Values: []*string{aws.String(transitGatewayId.(string))},
 			},
-		},
+		}
 	}
 
 	log.Printf("[DEBUG] Reading EC2 Transit Gateway Direct Connect Gateway Attachments: %s", input)

--- a/aws/data_source_aws_ec2_transit_gateway_dx_gateway_attachment.go
+++ b/aws/data_source_aws_ec2_transit_gateway_dx_gateway_attachment.go
@@ -53,21 +53,18 @@ func dataSourceAwsEc2TransitGatewayDxGatewayAttachmentRead(d *schema.ResourceDat
 		input.Filters = append(input.Filters, ec2TagFiltersFromMap(tags.(map[string]interface{}))...)
 	}
 	// to preserve original functionality
-	if dxGatewayIdOk && transitGatewayIdOk {
-		input.Filters = []*ec2.Filter{
-			{
-				Name:   aws.String("resource-id"),
-				Values: []*string{aws.String(dxGatewayId.(string))},
-			},
-			{
-				Name:   aws.String("resource-type"),
-				Values: []*string{aws.String(ec2.TransitGatewayAttachmentResourceTypeDirectConnectGateway)},
-			},
-			{
-				Name:   aws.String("transit-gateway-id"),
-				Values: []*string{aws.String(transitGatewayId.(string))},
-			},
-		}
+	if dxGatewayIdOk {
+		input.Filters = append(input.Filters, &ec2.Filter{
+			Name:   aws.String("resource-id"),
+			Values: []*string{aws.String(dxGatewayId.(string))},
+		})
+	}
+
+	if transitGatewayIdOk {
+		input.Filters = append(input.Filters, &ec2.Filter{
+			Name:   aws.String("transit-gateway-id"),
+			Values: []*string{aws.String(transitGatewayId.(string))},
+		})
 	}
 
 	log.Printf("[DEBUG] Reading EC2 Transit Gateway Direct Connect Gateway Attachments: %s", input)

--- a/aws/data_source_aws_ec2_transit_gateway_dx_gateway_attachment_test.go
+++ b/aws/data_source_aws_ec2_transit_gateway_dx_gateway_attachment_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestAccAWSEc2TransitGatewayDxGatewayAttachmentDataSource_TransitGatewayIdAndDxGatewayId(t *testing.T) {
-	rName := fmt.Sprintf("terraform-testacc-tgwdxgwattach-%d", acctest.RandInt())
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	rBgpAsn := randIntRange(64512, 65534)
 	dataSourceName := "data.aws_ec2_transit_gateway_dx_gateway_attachment.test"
 	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
@@ -25,6 +25,33 @@ func TestAccAWSEc2TransitGatewayDxGatewayAttachmentDataSource_TransitGatewayIdAn
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSEc2TransitGatewayVpnAttachmentDataSourceConfigTransitGatewayIdAndDxGatewayId(rName, rBgpAsn),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "transit_gateway_id", transitGatewayResourceName, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "dx_gateway_id", dxGatewayResourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEc2TransitGatewayDxGatewayAttachmentDataSource_filter(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rBgpAsn := randIntRange(64512, 65534)
+	dataSourceName := "data.aws_ec2_transit_gateway_dx_gateway_attachment.test"
+	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
+	dxGatewayResourceName := "aws_dx_gateway.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSEc2TransitGateway(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEc2TransitGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEc2TransitGatewayVpnAttachmentDataSourceConfigFilter(rName, rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "transit_gateway_id", transitGatewayResourceName, "id"),
@@ -61,6 +88,38 @@ resource "aws_dx_gateway_association" "test" {
 data "aws_ec2_transit_gateway_dx_gateway_attachment" "test" {
   transit_gateway_id = "${aws_dx_gateway_association.test.associated_gateway_id}"
   dx_gateway_id      = "${aws_dx_gateway_association.test.dx_gateway_id}"
+}
+`, rName, rBgpAsn)
+}
+
+func testAccAWSEc2TransitGatewayVpnAttachmentDataSourceConfigFilter(rName string, rBgpAsn int) string {
+	return fmt.Sprintf(`
+resource "aws_dx_gateway" "test" {
+  name            = %[1]q
+  amazon_side_asn = "%[2]d"
+}
+
+resource "aws_ec2_transit_gateway" "test" {
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_dx_gateway_association" "test" {
+  dx_gateway_id         = "${aws_dx_gateway.test.id}"
+  associated_gateway_id = "${aws_ec2_transit_gateway.test.id}"
+
+  allowed_prefixes = [
+    "10.255.255.0/30",
+    "10.255.255.8/30",
+  ]
+}
+
+data "aws_ec2_transit_gateway_dx_gateway_attachment" "test" {
+  filter {
+    name   = "resource-id"
+    values = ["${aws_dx_gateway.test.id}"]
+  }
 }
 `, rName, rBgpAsn)
 }

--- a/aws/data_source_aws_ec2_transit_gateway_dx_gateway_attachment_test.go
+++ b/aws/data_source_aws_ec2_transit_gateway_dx_gateway_attachment_test.go
@@ -35,7 +35,7 @@ func TestAccAWSEc2TransitGatewayDxGatewayAttachmentDataSource_TransitGatewayIdAn
 	})
 }
 
-func TestAccAWSEc2TransitGatewayGatewayAttachmentDataSource_filter(t *testing.T) {
+func TestAccAWSEc2TransitGatewayDxGatewayAttachmentDataSource_filter(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	rBgpAsn := randIntRange(64512, 65534)
 	dataSourceName := "data.aws_ec2_transit_gateway_dx_gateway_attachment.test"

--- a/aws/data_source_aws_ec2_transit_gateway_dx_gateway_attachment_test.go
+++ b/aws/data_source_aws_ec2_transit_gateway_dx_gateway_attachment_test.go
@@ -24,7 +24,7 @@ func TestAccAWSEc2TransitGatewayDxGatewayAttachmentDataSource_TransitGatewayIdAn
 		CheckDestroy: testAccCheckAWSEc2TransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEc2TransitGatewayVpnAttachmentDataSourceConfigTransitGatewayIdAndDxGatewayId(rName, rBgpAsn),
+				Config: testAccAWSEc2TransitGatewayDxAttachmentDataSourceConfig(rName, rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "transit_gateway_id", transitGatewayResourceName, "id"),
@@ -35,7 +35,7 @@ func TestAccAWSEc2TransitGatewayDxGatewayAttachmentDataSource_TransitGatewayIdAn
 	})
 }
 
-func TestAccAWSEc2TransitGatewayDxGatewayAttachmentDataSource_filter(t *testing.T) {
+func TestAccAWSEc2TransitGatewayGatewayAttachmentDataSource_filter(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	rBgpAsn := randIntRange(64512, 65534)
 	dataSourceName := "data.aws_ec2_transit_gateway_dx_gateway_attachment.test"
@@ -51,7 +51,7 @@ func TestAccAWSEc2TransitGatewayDxGatewayAttachmentDataSource_filter(t *testing.
 		CheckDestroy: testAccCheckAWSEc2TransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEc2TransitGatewayVpnAttachmentDataSourceConfigFilter(rName, rBgpAsn),
+				Config: testAccAWSEc2TransitGatewayDxAttachmentDataSourceConfigFilter(rName, rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "transit_gateway_id", transitGatewayResourceName, "id"),
@@ -62,7 +62,7 @@ func TestAccAWSEc2TransitGatewayDxGatewayAttachmentDataSource_filter(t *testing.
 	})
 }
 
-func testAccAWSEc2TransitGatewayVpnAttachmentDataSourceConfigTransitGatewayIdAndDxGatewayId(rName string, rBgpAsn int) string {
+func testAccAWSEc2TransitGatewayDxAttachmentDataSourceConfig(rName string, rBgpAsn int) string {
 	return fmt.Sprintf(`
 resource "aws_dx_gateway" "test" {
   name            = %[1]q
@@ -92,7 +92,7 @@ data "aws_ec2_transit_gateway_dx_gateway_attachment" "test" {
 `, rName, rBgpAsn)
 }
 
-func testAccAWSEc2TransitGatewayVpnAttachmentDataSourceConfigFilter(rName string, rBgpAsn int) string {
+func testAccAWSEc2TransitGatewayDxAttachmentDataSourceConfigFilter(rName string, rBgpAsn int) string {
 	return fmt.Sprintf(`
 resource "aws_dx_gateway" "test" {
   name            = %[1]q

--- a/aws/data_source_aws_ec2_transit_gateway_dx_gateway_attachment_test.go
+++ b/aws/data_source_aws_ec2_transit_gateway_dx_gateway_attachment_test.go
@@ -118,7 +118,7 @@ resource "aws_dx_gateway_association" "test" {
 data "aws_ec2_transit_gateway_dx_gateway_attachment" "test" {
   filter {
     name   = "resource-id"
-    values = ["${aws_dx_gateway.test.id}"]
+    values = ["${aws_dx_gateway_association.test.dx_gateway_id}"]
   }
 }
 `, rName, rBgpAsn)

--- a/website/docs/d/ec2_transit_gateway_dx_gateway_attachment.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_dx_gateway_attachment.html.markdown
@@ -28,6 +28,7 @@ The following arguments are supported:
 * `transit_gateway_id` - (Optional) Identifier of the EC2 Transit Gateway.
 * `dx_gateway_id` - (Optional) Identifier of the Direct Connect Gateway.
 * `filter` - (Optional) Configuration block(s) for filtering. Detailed below.
+* `tags` - (Optional) A mapping of tags, each pair of which must exactly match a pair on the desired Transit Gateway Direct Connect Gateway Attachment.
 
 ### filter Configuration Block
 

--- a/website/docs/d/ec2_transit_gateway_dx_gateway_attachment.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_dx_gateway_attachment.html.markdown
@@ -25,8 +25,16 @@ data "aws_ec2_transit_gateway_dx_gateway_attachment" "example" {
 
 The following arguments are supported:
 
-* `transit_gateway_id` - (Required) Identifier of the EC2 Transit Gateway.
-* `dx_gateway_id` - (Required) Identifier of the Direct Connect Gateway.
+* `transit_gateway_id` - (Optional) Identifier of the EC2 Transit Gateway.
+* `dx_gateway_id` - (Optional) Identifier of the Direct Connect Gateway.
+* `filter` - (Optional) Configuration block(s) for filtering. Detailed below.
+
+### filter Configuration Block
+
+The following arguments are supported by the `filter` configuration block:
+
+* `name` - (Required) The name of the filter field. Valid values can be found in the [EC2 DescribeTransitGatewayAttachments API Reference](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeTransitGatewayAttachments.html).
+* `values` - (Required) Set of values that are accepted for the given filter field. Results will be selected if any given value matches.
 
 ## Attribute Reference
 


### PR DESCRIPTION
…source

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11994

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data_source_aws_ec2_transit_gateway_dx_gateway_attachement  - add filter support

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEc2TransitGatewayDxGatewayAttachmentDataSource_'
Cant run these for some reason i get error on delete of the transit gateway:

2020/03/24 23:21:59 [ERROR] <root>: eval: *terraform.EvalApplyPost, err: error deleting EC2 Transit Gateway: IncorrectState: tgw-031b5b37743c10646 has non-deleted DirectConnect Gateway Attachments: tgw-attach-0f0dc47327d18b997.


this error is consistent for me, fails regardless of the change
```
