### PR TITLE
Clarify replicate_source_db for cross-region

### DIFF
--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -164,7 +164,9 @@ logs, and it will be stored in the state file.
 accessible. Default is `false`.
 * `replicate_source_db` - (Optional) Specifies that this resource is a Replicate
 database, and to use this value as the source database. This correlates to the
-`identifier` of another Amazon RDS Database to replicate. Note that if you are
+`identifier` of another Amazon RDS Database to replicate (if replicating within
+a single region) or ARN of the Amazon RDS Database to replicate (if replicating
+cross-region). Note that if you are
 creating a cross-region replica of an encrypted database you will also need to
 specify a `kms_key_id`. See [DB Instance Replication][1] and [Working with
 PostgreSQL and MySQL Read Replicas](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html)


### PR DESCRIPTION
This change clarifies that you need to specify `replicate_source_db` as a DB Instance Identifier when building a read replica within the same region as the source instance, and you need to specify `replicate_source_db` as an ARN when building a cross-region replica.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

N/A, no code change, just documentation.

This clarifies the documentation to state that when building a read-replica within the same region as the source DB instance, specify `replicate_source_db` as a DB Instance Identifier. When building a cross-region replica, specify an ARN.

See the [API docs](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstanceReadReplica.html), ctrl-f for `SourceDBInstanceIdentifier` and check the `Constraints`.