### PR TITLE
add validation checks for aws_glue_catalog_table resource properties

### DIFF
--- a/aws/resource_aws_glue_catalog_table.go
+++ b/aws/resource_aws_glue_catalog_table.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/glue"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceAwsGlueCatalogTable() *schema.Resource {
@@ -142,8 +143,9 @@ func resourceAwsGlueCatalogTable() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"name": {
-										Type:     schema.TypeString,
-										Optional: true,
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
 									},
 									"parameters": {
 										Type:     schema.TypeMap,
@@ -151,8 +153,9 @@ func resourceAwsGlueCatalogTable() *schema.Resource {
 										Elem:     &schema.Schema{Type: schema.TypeString},
 									},
 									"serialization_library": {
-										Type:     schema.TypeString,
-										Optional: true,
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
 									},
 								},
 							},
@@ -644,9 +647,15 @@ func flattenGlueSerDeInfo(s *glue.SerDeInfo) []map[string]interface{} {
 	serDeInfos := make([]map[string]interface{}, 1)
 	serDeInfo := make(map[string]interface{})
 
-	serDeInfo["name"] = aws.StringValue(s.Name)
+	if v := aws.StringValue(s.Name); v != "" {
+		serDeInfo["name"] = v
+	}
+
 	serDeInfo["parameters"] = aws.StringValueMap(s.Parameters)
-	serDeInfo["serialization_library"] = aws.StringValue(s.SerializationLibrary)
+
+	if v := aws.StringValue(s.SerializationLibrary); v != "" {
+		serDeInfo["serialization_library"] = v
+	}
 
 	serDeInfos[0] = serDeInfo
 	return serDeInfos


### PR DESCRIPTION


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12519

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
add validation checks for aws_glue_catalog_table resource properties
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSGlueCatalogTable_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSGlueCatalogTable_basic -timeout 120m
=== RUN   TestAccAWSGlueCatalogTable_basic
=== PAUSE TestAccAWSGlueCatalogTable_basic
=== CONT  TestAccAWSGlueCatalogTable_basic
--- PASS: TestAccAWSGlueCatalogTable_basic (24.64s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	24.725s

...
```
