### PR TITLE
Implement aws_storagegateway_nfs_file_share.path

### DIFF
--- a/aws/resource_aws_storagegateway_nfs_file_share.go
+++ b/aws/resource_aws_storagegateway_nfs_file_share.go
@@ -40,10 +40,6 @@ func resourceAwsStorageGatewayNfsFileShare() *schema.Resource {
 				MaxItems: 100,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"path": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"default_storage_class": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -129,6 +125,10 @@ func resourceAwsStorageGatewayNfsFileShare() *schema.Resource {
 					storagegateway.ObjectACLPublicRead,
 					storagegateway.ObjectACLPublicReadWrite,
 				}, false),
+			},
+			"path": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"read_only": {
 				Type:     schema.TypeBool,

--- a/aws/resource_aws_storagegateway_nfs_file_share.go
+++ b/aws/resource_aws_storagegateway_nfs_file_share.go
@@ -40,6 +40,10 @@ func resourceAwsStorageGatewayNfsFileShare() *schema.Resource {
 				MaxItems: 100,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"path": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"default_storage_class": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/aws/resource_aws_storagegateway_nfs_file_share_test.go
+++ b/aws/resource_aws_storagegateway_nfs_file_share_test.go
@@ -42,6 +42,7 @@ func TestAccAWSStorageGatewayNfsFileShare_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "requester_pays", "false"),
 					resource.TestMatchResourceAttr(resourceName, "role_arn", regexp.MustCompile(`^arn:`)),
 					resource.TestCheckResourceAttr(resourceName, "squash", "RootSquash"),
+					resource.TestMatchResourceAttr(resourceName, "path", regexp.MustCompile(`^/.+`)),
 				),
 			},
 			{

--- a/aws/resource_aws_storagegateway_nfs_file_share_test.go
+++ b/aws/resource_aws_storagegateway_nfs_file_share_test.go
@@ -38,11 +38,11 @@ func TestAccAWSStorageGatewayNfsFileShare_basic(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceName, "location_arn", regexp.MustCompile(`^arn:`)),
 					resource.TestCheckResourceAttr(resourceName, "nfs_file_share_defaults.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "object_acl", storagegateway.ObjectACLPrivate),
+					resource.TestMatchResourceAttr(resourceName, "path", regexp.MustCompile(`^/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "read_only", "false"),
 					resource.TestCheckResourceAttr(resourceName, "requester_pays", "false"),
 					resource.TestMatchResourceAttr(resourceName, "role_arn", regexp.MustCompile(`^arn:`)),
 					resource.TestCheckResourceAttr(resourceName, "squash", "RootSquash"),
-					resource.TestMatchResourceAttr(resourceName, "path", regexp.MustCompile(`^/.+`)),
 				),
 			},
 			{


### PR DESCRIPTION
This value is retrieved after the resources is created/updated but since it was missing from the schema it was not available as per the documentation.

Closes #12527


<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* Expose the `path` attribute on `aws_storagegateway_nfs_file_share` (see #12527)
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSStorageGatewayNfsFileShare.*'

...
```