### PR TITLE
r/glue_user_defined_function - add new resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -627,6 +627,7 @@ func Provider() *schema.Provider {
 			"aws_glue_job":                                            resourceAwsGlueJob(),
 			"aws_glue_security_configuration":                         resourceAwsGlueSecurityConfiguration(),
 			"aws_glue_trigger":                                        resourceAwsGlueTrigger(),
+			"aws_glue_user_defined_function":                          resourceAwsGlueUserDefinedFunction(),
 			"aws_glue_workflow":                                       resourceAwsGlueWorkflow(),
 			"aws_guardduty_detector":                                  resourceAwsGuardDutyDetector(),
 			"aws_guardduty_publishing_destination":                    resourceAwsGuardDutyPublishingDestination(),

--- a/aws/resource_aws_glue_user_defined_function.go
+++ b/aws/resource_aws_glue_user_defined_function.go
@@ -126,8 +126,7 @@ func resourceAwsGlueUserDefinedFunctionUpdate(d *schema.ResourceData, meta inter
 		FunctionInput: expandAwsGlueUserDefinedFunctionInput(d),
 	}
 
-	if d.HasChange("owner_name") || d.HasChange("owner_type") ||
-		d.HasChange("class_name") || d.HasChange("resource_uris") {
+	if d.HasChanges("owner_name", "owner_type", "class_name", "resource_uris") {
 		if _, err := conn.UpdateUserDefinedFunction(input); err != nil {
 			return err
 		}

--- a/aws/resource_aws_glue_user_defined_function.go
+++ b/aws/resource_aws_glue_user_defined_function.go
@@ -9,8 +9,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/glue"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceAwsGlueUserDefinedFunction() *schema.Resource {

--- a/aws/resource_aws_glue_user_defined_function.go
+++ b/aws/resource_aws_glue_user_defined_function.go
@@ -55,13 +55,9 @@ func resourceAwsGlueUserDefinedFunction() *schema.Resource {
 				ValidateFunc: validation.StringLenBetween(1, 255),
 			},
 			"owner_type": {
-				Type:     schema.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					glue.PrincipalTypeGroup,
-					glue.PrincipalTypeRole,
-					glue.PrincipalTypeUser,
-				}, false),
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(glue.PrincipalType_Values(), false),
 			},
 			"resource_uris": {
 				Type:     schema.TypeSet,
@@ -70,13 +66,9 @@ func resourceAwsGlueUserDefinedFunction() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"resource_type": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								glue.ResourceTypeArchive,
-								glue.ResourceTypeFile,
-								glue.ResourceTypeJar,
-							}, false),
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(glue.ResourceType_Values(), false),
 						},
 						"uri": {
 							Type:         schema.TypeString,
@@ -108,7 +100,7 @@ func resourceAwsGlueUserDefinedFunctionCreate(d *schema.ResourceData, meta inter
 
 	_, err := conn.CreateUserDefinedFunction(input)
 	if err != nil {
-		return fmt.Errorf("error creating Glue User Defined Function: %s", err)
+		return fmt.Errorf("error creating Glue User Defined Function: %w", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s:%s", catalogID, dbName, funcName))
@@ -163,7 +155,7 @@ func resourceAwsGlueUserDefinedFunctionRead(d *schema.ResourceData, meta interfa
 			return nil
 		}
 
-		return fmt.Errorf("error reading Glue User Defined Function: %s", err.Error())
+		return fmt.Errorf("error reading Glue User Defined Function: %w", err)
 	}
 
 	udf := out.UserDefinedFunction
@@ -207,7 +199,7 @@ func resourceAwsGlueUserDefinedFunctionDelete(d *schema.ResourceData, meta inter
 		FunctionName: aws.String(funcName),
 	})
 	if err != nil {
-		return fmt.Errorf("error deleting Glue User Defined Function: %s", err.Error())
+		return fmt.Errorf("error deleting Glue User Defined Function: %w", err)
 	}
 	return nil
 }

--- a/aws/resource_aws_glue_user_defined_function.go
+++ b/aws/resource_aws_glue_user_defined_function.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/glue"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -23,6 +24,10 @@ func resourceAwsGlueUserDefinedFunction() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"catalog_id": {
 				Type:     schema.TypeString,
 				ForceNew: true,
@@ -162,6 +167,16 @@ func resourceAwsGlueUserDefinedFunctionRead(d *schema.ResourceData, meta interfa
 	}
 
 	udf := out.UserDefinedFunction
+
+	udfArn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Service:   "glue",
+		Region:    meta.(*AWSClient).region,
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("userDefinedFunction/%s/%s", dbName, aws.StringValue(udf.FunctionName)),
+	}.String()
+
+	d.Set("arn", udfArn)
 	d.Set("name", udf.FunctionName)
 	d.Set("catalog_id", catalogID)
 	d.Set("database_name", dbName)

--- a/aws/resource_aws_glue_user_defined_function.go
+++ b/aws/resource_aws_glue_user_defined_function.go
@@ -123,10 +123,8 @@ func resourceAwsGlueUserDefinedFunctionUpdate(d *schema.ResourceData, meta inter
 		FunctionInput: expandAwsGlueUserDefinedFunctionInput(d),
 	}
 
-	if d.HasChanges("owner_name", "owner_type", "class_name", "resource_uris") {
-		if _, err := conn.UpdateUserDefinedFunction(input); err != nil {
-			return err
-		}
+	if _, err := conn.UpdateUserDefinedFunction(input); err != nil {
+		return fmt.Errorf("error updating Glue User Defined Function (%s): %w", d.Id(), err)
 	}
 
 	return resourceAwsGlueUserDefinedFunctionRead(d, meta)

--- a/aws/resource_aws_glue_user_defined_function.go
+++ b/aws/resource_aws_glue_user_defined_function.go
@@ -90,7 +90,7 @@ func resourceAwsGlueUserDefinedFunction() *schema.Resource {
 }
 
 func resourceAwsGlueUserDefinedFunctionCreate(d *schema.ResourceData, meta interface{}) error {
-	glueconn := meta.(*AWSClient).glueconn
+	conn := meta.(*AWSClient).glueconn
 	catalogID := createAwsGlueCatalogID(d, meta.(*AWSClient).accountid)
 	dbName := d.Get("database_name").(string)
 	funcName := d.Get("name").(string)
@@ -101,7 +101,7 @@ func resourceAwsGlueUserDefinedFunctionCreate(d *schema.ResourceData, meta inter
 		FunctionInput: expandAwsGlueUserDefinedFunctionInput(d),
 	}
 
-	_, err := glueconn.CreateUserDefinedFunction(input)
+	_, err := conn.CreateUserDefinedFunction(input)
 	if err != nil {
 		return fmt.Errorf("error creating Glue User Defined Function: %s", err)
 	}
@@ -112,7 +112,7 @@ func resourceAwsGlueUserDefinedFunctionCreate(d *schema.ResourceData, meta inter
 }
 
 func resourceAwsGlueUserDefinedFunctionUpdate(d *schema.ResourceData, meta interface{}) error {
-	glueconn := meta.(*AWSClient).glueconn
+	conn := meta.(*AWSClient).glueconn
 
 	catalogID, dbName, funcName, err := readAwsGlueUDFID(d.Id())
 	if err != nil {
@@ -128,7 +128,7 @@ func resourceAwsGlueUserDefinedFunctionUpdate(d *schema.ResourceData, meta inter
 
 	if d.HasChange("owner_name") || d.HasChange("owner_type") ||
 		d.HasChange("class_name") || d.HasChange("resource_uris") {
-		if _, err := glueconn.UpdateUserDefinedFunction(input); err != nil {
+		if _, err := conn.UpdateUserDefinedFunction(input); err != nil {
 			return err
 		}
 	}
@@ -137,7 +137,7 @@ func resourceAwsGlueUserDefinedFunctionUpdate(d *schema.ResourceData, meta inter
 }
 
 func resourceAwsGlueUserDefinedFunctionRead(d *schema.ResourceData, meta interface{}) error {
-	glueconn := meta.(*AWSClient).glueconn
+	conn := meta.(*AWSClient).glueconn
 
 	catalogID, dbName, funcName, err := readAwsGlueUDFID(d.Id())
 	if err != nil {
@@ -150,7 +150,7 @@ func resourceAwsGlueUserDefinedFunctionRead(d *schema.ResourceData, meta interfa
 		FunctionName: aws.String(funcName),
 	}
 
-	out, err := glueconn.GetUserDefinedFunction(input)
+	out, err := conn.GetUserDefinedFunction(input)
 	if err != nil {
 
 		if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
@@ -180,14 +180,14 @@ func resourceAwsGlueUserDefinedFunctionRead(d *schema.ResourceData, meta interfa
 }
 
 func resourceAwsGlueUserDefinedFunctionDelete(d *schema.ResourceData, meta interface{}) error {
-	glueconn := meta.(*AWSClient).glueconn
+	conn := meta.(*AWSClient).glueconn
 	catalogID, dbName, funcName, err := readAwsGlueUDFID(d.Id())
 	if err != nil {
 		return err
 	}
 
 	log.Printf("[DEBUG] Glue User Defined Function: %s", d.Id())
-	_, err = glueconn.DeleteUserDefinedFunction(&glue.DeleteUserDefinedFunctionInput{
+	_, err = conn.DeleteUserDefinedFunction(&glue.DeleteUserDefinedFunctionInput{
 		CatalogId:    aws.String(catalogID),
 		DatabaseName: aws.String(dbName),
 		FunctionName: aws.String(funcName),

--- a/aws/resource_aws_glue_user_defined_function.go
+++ b/aws/resource_aws_glue_user_defined_function.go
@@ -1,0 +1,244 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/glue"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func resourceAwsGlueUserDefinedFunction() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsGlueUserDefinedFunctionCreate,
+		Read:   resourceAwsGlueUserDefinedFunctionRead,
+		Update: resourceAwsGlueUserDefinedFunctionUpdate,
+		Delete: resourceAwsGlueUserDefinedFunctionDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"catalog_id": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"database_name": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"class_name": {
+				Type:     schema.TypeList,
+				Required: true,
+			},
+			"owner_name": {
+				Type:     schema.TypeList,
+				Required: true,
+			},
+			"owner_type": {
+				Type:     schema.TypeList,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					glue.PrincipalTypeGroup,
+					glue.PrincipalTypeRole,
+					glue.PrincipalTypeUser,
+				}, false),
+			},
+			"resource_uris": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"resource_type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								glue.ResourceTypeArchive,
+								glue.ResourceTypeFile,
+								glue.ResourceTypeJar,
+							}, false),
+						},
+						"uri": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"create_time": {
+				Type:     schema.TypeList,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsGlueUserDefinedFunctionCreate(d *schema.ResourceData, meta interface{}) error {
+	glueconn := meta.(*AWSClient).glueconn
+	catalogID := createAwsGlueCatalogID(d, meta.(*AWSClient).accountid)
+	dbName := d.Get("database_name").(string)
+	funcName := d.Get("name").(string)
+
+	input := &glue.CreateUserDefinedFunctionInput{
+		CatalogId:     aws.String(catalogID),
+		DatabaseName:  aws.String(dbName),
+		FunctionInput: expandAwsGlueUserDefinedFunctionInput(d),
+	}
+
+	_, err := glueconn.CreateUserDefinedFunction(input)
+	if err != nil {
+		return fmt.Errorf("error creating Glue User Defined Function: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("%s:%s:%s", catalogID, dbName, funcName))
+
+	return resourceAwsGlueUserDefinedFunctionUpdate(d, meta)
+}
+
+func resourceAwsGlueUserDefinedFunctionUpdate(d *schema.ResourceData, meta interface{}) error {
+	glueconn := meta.(*AWSClient).glueconn
+
+	catalogID, dbName, funcName, err := readAwsGlueUDFID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	input := &glue.UpdateUserDefinedFunctionInput{
+		CatalogId:     aws.String(catalogID),
+		DatabaseName:  aws.String(dbName),
+		FunctionName:  aws.String(funcName),
+		FunctionInput: expandAwsGlueUserDefinedFunctionInput(d),
+	}
+
+	if d.HasChange("owner_name") || d.HasChange("owner_type") ||
+		d.HasChange("class_name") || d.HasChange("resource_uris") {
+		if _, err := glueconn.UpdateUserDefinedFunction(input); err != nil {
+			return err
+		}
+	}
+
+	return resourceAwsGlueUserDefinedFunctionRead(d, meta)
+}
+
+func resourceAwsGlueUserDefinedFunctionRead(d *schema.ResourceData, meta interface{}) error {
+	glueconn := meta.(*AWSClient).glueconn
+
+	catalogID, dbName, funcName, err := readAwsGlueUDFID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	input := &glue.GetUserDefinedFunctionInput{
+		CatalogId:    aws.String(catalogID),
+		DatabaseName: aws.String(dbName),
+		FunctionName: aws.String(funcName),
+	}
+
+	out, err := glueconn.GetUserDefinedFunction(input)
+	if err != nil {
+
+		if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
+			log.Printf("[WARN] Glue User Defined Function (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("error reading Glue User Defined Function: %s", err.Error())
+	}
+
+	udf := out.UserDefinedFunction
+	d.Set("name", udf.FunctionName)
+	d.Set("catalog_id", catalogID)
+	d.Set("owner_type", udf.OwnerType)
+	d.Set("owner_name", udf.OwnerName)
+	d.Set("class_name", udf.ClassName)
+	if udf.CreateTime != nil {
+		d.Set("create_time", udf.CreateTime.Format(time.RFC3339))
+	}
+	if err := d.Set("resource_uris", flattenAwsGlueUserDefinedFunctionResourceUri(udf.ResourceUris)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceAwsGlueUserDefinedFunctionDelete(d *schema.ResourceData, meta interface{}) error {
+	glueconn := meta.(*AWSClient).glueconn
+	catalogID, dbName, funcName, err := readAwsGlueUDFID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Glue User Defined Function: %s", d.Id())
+	_, err = glueconn.DeleteUserDefinedFunction(&glue.DeleteUserDefinedFunctionInput{
+		CatalogId:    aws.String(catalogID),
+		DatabaseName: aws.String(dbName),
+		FunctionName: aws.String(funcName),
+	})
+	if err != nil {
+		return fmt.Errorf("error deleting Glue User Defined Function: %s", err.Error())
+	}
+	return nil
+}
+
+func readAwsGlueUDFID(id string) (catalogID string, dbName string, funcName string, err error) {
+	idParts := strings.Split(id, ":")
+	if len(idParts) != 3 {
+		return "", "", "", fmt.Errorf("unexpected format of ID (%q), expected CATALOG-ID:DATABASE-NAME:FUNCTION-NAME", id)
+	}
+	return idParts[0], idParts[1], idParts[2], nil
+}
+
+func expandAwsGlueUserDefinedFunctionInput(d *schema.ResourceData) *glue.UserDefinedFunctionInput {
+
+	udf := &glue.UserDefinedFunctionInput{
+		ClassName:    aws.String(d.Get("class_name").(string)),
+		FunctionName: aws.String(d.Get("name").(string)),
+		OwnerName:    aws.String(d.Get("owner_name").(string)),
+		OwnerType:    aws.String(d.Get("owner_type").(string)),
+		ResourceUris: expandAwsGlueUserDefinedFunctionResourceUri(d.Get("resource_uris").(*schema.Set)),
+	}
+
+	return udf
+}
+
+func expandAwsGlueUserDefinedFunctionResourceUri(conf *schema.Set) []*glue.ResourceUri {
+	result := make([]*glue.ResourceUri, 0, conf.Len())
+
+	for _, r := range conf.List() {
+		uriRaw := r.(map[string]interface{})
+		uri := &glue.ResourceUri{
+			ResourceType: aws.String(uriRaw["resource_type"].(string)),
+			Uri:          aws.String(uriRaw["uri"].(string)),
+		}
+
+		result = append(result, uri)
+	}
+
+	return result
+}
+
+func flattenAwsGlueUserDefinedFunctionResourceUri(uris []*glue.ResourceUri) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(uris))
+
+	for _, i := range uris {
+		l := map[string]interface{}{
+			"resource_type": aws.StringValue(i.ResourceType),
+			"uri":           aws.StringValue(i.Uri),
+		}
+
+		result = append(result, l)
+	}
+	return result
+}

--- a/aws/resource_aws_glue_user_defined_function.go
+++ b/aws/resource_aws_glue_user_defined_function.go
@@ -230,7 +230,12 @@ func expandAwsGlueUserDefinedFunctionResourceUri(conf *schema.Set) []*glue.Resou
 	result := make([]*glue.ResourceUri, 0, conf.Len())
 
 	for _, r := range conf.List() {
-		uriRaw := r.(map[string]interface{})
+		uriRaw, ok := r.(map[string]interface{})
+
+		if !ok {
+			continue
+		}
+
 		uri := &glue.ResourceUri{
 			ResourceType: aws.String(uriRaw["resource_type"].(string)),
 			Uri:          aws.String(uriRaw["uri"].(string)),

--- a/aws/resource_aws_glue_user_defined_function.go
+++ b/aws/resource_aws_glue_user_defined_function.go
@@ -26,7 +26,7 @@ func resourceAwsGlueUserDefinedFunction() *schema.Resource {
 			"catalog_id": {
 				Type:     schema.TypeString,
 				ForceNew: true,
-				Required: true,
+				Optional: true,
 			},
 			"database_name": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_glue_user_defined_function_test.go
+++ b/aws/resource_aws_glue_user_defined_function_test.go
@@ -85,7 +85,6 @@ func TestAccAWSGlueUserDefinedFunction_resource_uri(t *testing.T) {
 			},
 			{
 				Config:  testAccGlueUserDefinedFunctionResourceURIConfig1(rName),
-				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlueUserDefinedFunctionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "resource_uris.#", "1"),

--- a/aws/resource_aws_glue_user_defined_function_test.go
+++ b/aws/resource_aws_glue_user_defined_function_test.go
@@ -6,10 +6,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/glue"
-
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccAWSGlueUserDefinedFunction_basic(t *testing.T) {

--- a/aws/resource_aws_glue_user_defined_function_test.go
+++ b/aws/resource_aws_glue_user_defined_function_test.go
@@ -196,8 +196,8 @@ resource "aws_glue_catalog_database" "test" {
 
 resource "aws_glue_user_defined_function" "test" {
   name          = %[1]q
-  catalog_id    = "${aws_glue_catalog_database.test.catalog_id}"
-  database_name = "${aws_glue_catalog_database.test.name}"
+  catalog_id    = aws_glue_catalog_database.test.catalog_id
+  database_name = aws_glue_catalog_database.test.name
   class_name    = %[2]q
   owner_name    = %[2]q
   owner_type    = "GROUP"
@@ -213,8 +213,8 @@ resource "aws_glue_catalog_database" "test" {
 
 resource "aws_glue_user_defined_function" "test" {
   name          = %[1]q
-  catalog_id    = "${aws_glue_catalog_database.test.catalog_id}"
-  database_name = "${aws_glue_catalog_database.test.name}"
+  catalog_id    = aws_glue_catalog_database.test.catalog_id
+  database_name = aws_glue_catalog_database.test.name
   class_name    = %[1]q
   owner_name    = %[1]q
   owner_type    = "GROUP"
@@ -235,8 +235,8 @@ resource "aws_glue_catalog_database" "test" {
 
 resource "aws_glue_user_defined_function" "test" {
   name          = %[1]q
-  catalog_id    = "${aws_glue_catalog_database.test.catalog_id}"
-  database_name = "${aws_glue_catalog_database.test.name}"
+  catalog_id    = aws_glue_catalog_database.test.catalog_id
+  database_name = aws_glue_catalog_database.test.name
   class_name    = %[1]q
   owner_name    = %[1]q
   owner_type    = "GROUP"

--- a/aws/resource_aws_glue_user_defined_function_test.go
+++ b/aws/resource_aws_glue_user_defined_function_test.go
@@ -23,7 +23,6 @@ func TestAccAWSGlueUserDefinedFunction_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:  testAccGlueUserDefinedFunctionBasicConfig(rName, rName),
-				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlueUserDefinedFunctionExists(resourceName),
 					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("userDefinedFunction/%s/%s", rName, rName)),

--- a/aws/resource_aws_glue_user_defined_function_test.go
+++ b/aws/resource_aws_glue_user_defined_function_test.go
@@ -22,7 +22,7 @@ func TestAccAWSGlueUserDefinedFunction_basic(t *testing.T) {
 		CheckDestroy: testAccCheckGlueUDFDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:  testAccGlueUserDefinedFunctionBasicConfig(rName, rName),
+				Config: testAccGlueUserDefinedFunctionBasicConfig(rName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlueUserDefinedFunctionExists(resourceName),
 					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("userDefinedFunction/%s/%s", rName, rName)),
@@ -38,7 +38,7 @@ func TestAccAWSGlueUserDefinedFunction_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config:  testAccGlueUserDefinedFunctionBasicConfig(rName, updated),
+				Config: testAccGlueUserDefinedFunctionBasicConfig(rName, updated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlueUserDefinedFunctionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -61,7 +61,7 @@ func TestAccAWSGlueUserDefinedFunction_resource_uri(t *testing.T) {
 		CheckDestroy: testAccCheckGlueUDFDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:  testAccGlueUserDefinedFunctionResourceURIConfig1(rName),
+				Config: testAccGlueUserDefinedFunctionResourceURIConfig1(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlueUserDefinedFunctionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "resource_uris.#", "1"),
@@ -73,14 +73,14 @@ func TestAccAWSGlueUserDefinedFunction_resource_uri(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config:  testAccGlueUserDefinedFunctionResourceURIConfig2(rName),
+				Config: testAccGlueUserDefinedFunctionResourceURIConfig2(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlueUserDefinedFunctionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "resource_uris.#", "2"),
 				),
 			},
 			{
-				Config:  testAccGlueUserDefinedFunctionResourceURIConfig1(rName),
+				Config: testAccGlueUserDefinedFunctionResourceURIConfig1(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlueUserDefinedFunctionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "resource_uris.#", "1"),
@@ -100,7 +100,7 @@ func TestAccAWSGlueUserDefinedFunction_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckGlueUDFDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:  testAccGlueUserDefinedFunctionBasicConfig(rName, rName),
+				Config: testAccGlueUserDefinedFunctionBasicConfig(rName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlueUserDefinedFunctionExists(resourceName),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsGlueUserDefinedFunction(), resourceName),

--- a/aws/resource_aws_glue_user_defined_function_test.go
+++ b/aws/resource_aws_glue_user_defined_function_test.go
@@ -64,7 +64,6 @@ func TestAccAWSGlueUserDefinedFunction_resource_uri(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:  testAccGlueUserDefinedFunctionResourceURIConfig1(rName),
-				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlueUserDefinedFunctionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "resource_uris.#", "1"),

--- a/aws/resource_aws_glue_user_defined_function_test.go
+++ b/aws/resource_aws_glue_user_defined_function_test.go
@@ -77,7 +77,6 @@ func TestAccAWSGlueUserDefinedFunction_resource_uri(t *testing.T) {
 			},
 			{
 				Config:  testAccGlueUserDefinedFunctionResourceURIConfig2(rName),
-				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlueUserDefinedFunctionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "resource_uris.#", "2"),

--- a/aws/resource_aws_glue_user_defined_function_test.go
+++ b/aws/resource_aws_glue_user_defined_function_test.go
@@ -176,7 +176,7 @@ func testAccCheckGlueUserDefinedFunctionExists(name string) resource.TestCheckFu
 		}
 
 		if out.UserDefinedFunction == nil {
-			return fmt.Errorf("No Glue Database Found")
+			return fmt.Errorf("No Glue User Defined Function Found")
 		}
 
 		if *out.UserDefinedFunction.FunctionName != funcName {

--- a/aws/resource_aws_glue_user_defined_function_test.go
+++ b/aws/resource_aws_glue_user_defined_function_test.go
@@ -1,0 +1,151 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/glue"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccAWSGlueUserDefinedFunction_basic(t *testing.T) {
+	var udf glue.UserDefinedFunction
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	updated := "test"
+	resourceName := "aws_glue_user_defined_function.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGlueUDFDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:  testAccGlueUserDefinedFunctionBasicConfig(rName, rName),
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlueUserDefinedFunctionExists(resourceName, &udf),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "class_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "owner_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "owner_type", "GROUP"),
+					resource.TestCheckResourceAttr(resourceName, "resource_uris.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:  testAccGlueUserDefinedFunctionBasicConfig(rName, updated),
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlueUserDefinedFunctionExists(resourceName, &udf),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "class_name", updated),
+					resource.TestCheckResourceAttr(resourceName, "owner_name", updated),
+					resource.TestCheckResourceAttr(resourceName, "owner_type", "GROUP"),
+					resource.TestCheckResourceAttr(resourceName, "resource_uris.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckGlueUDFDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).glueconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_glue_user_defined_function" {
+			continue
+		}
+
+		catalogId, dbName, funcName, err := readAwsGlueUDFID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		input := &glue.GetUserDefinedFunctionInput{
+			CatalogId:    aws.String(catalogId),
+			DatabaseName: aws.String(dbName),
+			FunctionName: aws.String(funcName),
+		}
+		if _, err := conn.GetUserDefinedFunction(input); err != nil {
+			//Verify the error is what we want
+			if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
+				continue
+			}
+
+			return err
+		}
+		return fmt.Errorf("still exists")
+	}
+	return nil
+}
+
+func testAccGlueUserDefinedFunctionBasicConfig(rName string, name string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+}
+
+resource "aws_glue_user_defined_function" "test" {
+  name          = %[1]q
+  catalog_id    = "${aws_glue_catalog_database.test.catalog_id}"
+  database_name = "${aws_glue_catalog_database.test.name}"
+  class_name    = %[2]q
+  owner_name    = %[2]q
+  owner_type    = "GROUP"
+
+  resource_uris {
+    resource_type = "ARCHIVE"
+    uri           = %[2]q
+  }
+}
+`, rName, name)
+}
+
+func testAccCheckGlueUserDefinedFunctionExists(name string, udf *glue.UserDefinedFunction) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		catalogId, dbName, funcName, err := readAwsGlueUDFID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		glueconn := testAccProvider.Meta().(*AWSClient).glueconn
+		out, err := glueconn.GetUserDefinedFunction(&glue.GetUserDefinedFunctionInput{
+			CatalogId:    aws.String(catalogId),
+			DatabaseName: aws.String(dbName),
+			FunctionName: aws.String(funcName),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if out.UserDefinedFunction == nil {
+			return fmt.Errorf("No Glue Database Found")
+		}
+
+		if *out.UserDefinedFunction.FunctionName != funcName {
+			return fmt.Errorf("Glue UDF Mismatch - existing: %q, state: %q",
+				*out.UserDefinedFunction.FunctionName, funcName)
+		}
+
+		*udf = *out.UserDefinedFunction
+
+		return nil
+	}
+}

--- a/aws/resource_aws_glue_user_defined_function_test.go
+++ b/aws/resource_aws_glue_user_defined_function_test.go
@@ -40,7 +40,6 @@ func TestAccAWSGlueUserDefinedFunction_basic(t *testing.T) {
 			},
 			{
 				Config:  testAccGlueUserDefinedFunctionBasicConfig(rName, updated),
-				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlueUserDefinedFunctionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),

--- a/aws/resource_aws_glue_user_defined_function_test.go
+++ b/aws/resource_aws_glue_user_defined_function_test.go
@@ -27,6 +27,7 @@ func TestAccAWSGlueUserDefinedFunction_basic(t *testing.T) {
 				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlueUserDefinedFunctionExists(resourceName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("userDefinedFunction/%s/%s", rName, rName)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "class_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "owner_name", rName),

--- a/aws/resource_aws_glue_user_defined_function_test.go
+++ b/aws/resource_aws_glue_user_defined_function_test.go
@@ -106,7 +106,6 @@ func TestAccAWSGlueUserDefinedFunction_disappears(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:  testAccGlueUserDefinedFunctionBasicConfig(rName, rName),
-				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlueUserDefinedFunctionExists(resourceName),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsGlueUserDefinedFunction(), resourceName),

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -265,6 +265,7 @@ for more information about connecting to alternate AWS endpoints or AWS compatib
     - [`aws_glue_crawler` resource](/docs/providers/aws/r/glue_crawler.html)
     - [`aws_glue_job` resource](/docs/providers/aws/r/glue_job.html)
     - [`aws_glue_trigger` resource](/docs/providers/aws/r/glue_trigger.html)
+    - [`aws_glue_user_defined_function` resource](/docs/providers/aws/r/glue_user_defined_function.html)    
     - [`aws_guardduty_detector` resource](/docs/providers/aws/r/guardduty_detector.html)
     - [`aws_guardduty_ipset` resource](/docs/providers/aws/r/guardduty_ipset.html)
     - [`aws_guardduty_threatintelset` resource](/docs/providers/aws/r/guardduty_threatintelset.html)

--- a/website/docs/r/glue_user_defined_function.html.markdown
+++ b/website/docs/r/glue_user_defined_function.html.markdown
@@ -1,0 +1,64 @@
+---
+subcategory: "Glue"
+layout: "aws"
+page_title: "AWS: aws_glue_user_defined_function"
+description: |-
+  Provides a Glue User Defined Function.
+---
+
+# Resource: aws_glue_user_defined_function
+
+Provides a Glue User Defined Function Resource.
+
+## Example Usage
+
+```hcl
+resource "aws_glue_catalog_database" "example" {
+  name = "my_database"
+}
+
+resource "aws_glue_user_defined_function" "example" {
+  name          = "my_func"
+  catalog_id    = "${aws_glue_catalog_database.example.catalog_id}"
+  database_name = "${aws_glue_catalog_database.example.name}"
+  class_name    = "class"
+  owner_name    = "owner"
+  owner_type    = "GROUP"
+
+  resource_uris {
+   resource_type = "ARCHIVE"
+   uri           = "uri"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the function.
+* `catalog_id` - (Optional) ID of the Glue Catalog to create the function in. If omitted, this defaults to the AWS Account ID.
+* `database_name` - (Required) The name of the Database to create the Function.
+* `class_name` - (Required) The Java class that contains the function code.
+* `owner_name` - (Required) The owner of the function.
+* `owner_type` - (Required) The owner type. can be one of `USER`, `ROLE`, and `GROUP`.
+* `resource_uris` - (Optional) The configuration block for Resource URIs. See [resource uris](#resource-uris) below for more details.
+
+### Resource URIs
+
+* `resource_type` - (Required) The type of the resource. can be one of `JAR`, `FILE`, and `ARCHIVE`.
+* `uri` - (Required) The URI for accessing the resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `create_date`- The time at which the function was created.
+
+## Import
+
+Glue User Defined Functions can be imported using the `catalog_id:database_name:function_name`. If you have not set a Catalog ID specify the AWS Account ID that the database is in, e.g.
+
+```
+$ terraform import aws_glue_user_defined_function.func 123456789012:my_database:my_func
+```

--- a/website/docs/r/glue_user_defined_function.html.markdown
+++ b/website/docs/r/glue_user_defined_function.html.markdown
@@ -19,8 +19,8 @@ resource "aws_glue_catalog_database" "example" {
 
 resource "aws_glue_user_defined_function" "example" {
   name          = "my_func"
-  catalog_id    = "${aws_glue_catalog_database.example.catalog_id}"
-  database_name = "${aws_glue_catalog_database.example.name}"
+  catalog_id    = aws_glue_catalog_database.example.catalog_id
+  database_name = aws_glue_catalog_database.example.name
   class_name    = "class"
   owner_name    = "owner"
   owner_type    = "GROUP"

--- a/website/docs/r/glue_user_defined_function.html.markdown
+++ b/website/docs/r/glue_user_defined_function.html.markdown
@@ -26,8 +26,8 @@ resource "aws_glue_user_defined_function" "example" {
   owner_type    = "GROUP"
 
   resource_uris {
-   resource_type = "ARCHIVE"
-   uri           = "uri"
+    resource_type = "ARCHIVE"
+    uri           = "uri"
   }
 }
 ```

--- a/website/docs/r/glue_user_defined_function.html.markdown
+++ b/website/docs/r/glue_user_defined_function.html.markdown
@@ -53,6 +53,8 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `id`- The id of the Glue User Defined Function.
+* `arn`- The ARN of the Glue User Defined Function.
 * `create_date`- The time at which the function was created.
 
 ## Import


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #3883

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resrouce_aws_glue_user_defined_function: add new resource
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSGlueUserDefinedFunction_'
--- PASS: TestAccAWSGlueUserDefinedFunction_basic (78.63s)
--- PASS: TestAccAWSGlueUserDefinedFunction_resource_uri (106.27s)
--- PASS: TestAccAWSGlueUserDefinedFunction_disappears (40.61s)
```
