### PR TITLE
provider: Switch stale handling from hashibot to official GitHub Action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+name: "Stale issues and pull requests"
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-stale: 720
+        days-before-close: 30
+        exempt-issue-label: 'needs-triage'
+        exempt-pr-label: 'needs-triage'
+        stale-issue-label: 'stale'
+        stale-issue-message: |
+          Marking this issue as stale due to inactivity. This helps our maintainers find and focus on the active issues. If this issue receives no comments in the next 30 days it will automatically be closed. Maintainers can also remove the stale label.
+
+          If this issue was automatically closed and you feel this issue should be reopened, we encourage creating a new issue linking back to this one for added context. Thank you!
+        stale-pr-label: 'stale'
+        stale-pr-message: |
+          Marking this pull request as stale due to inactivity. This helps our maintainers find and focus on the active pull requests. If this pull request receives no comments in the next 30 days it will automatically be closed. Maintainers can also remove the stale label.
+
+          If this pull request was automatically closed and you feel this pull request should be reopened, we encourage creating a new pull request linking back to this one for added context. Thank you!

--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -11,21 +11,6 @@ poll "closed_issue_locker" "locker" {
   EOF
 }
 
-poll "stale_issue_closer" "closer" {
-  schedule             = "0 22 23 * * *"
-  no_reply_in_last     = "2160h" # 90 days
-  max_issues           = 500
-  sleep_between_issues = "5s"
-  created_after        = "2019-06-01"
-  exclude_labels       = ["needs-triage", "technical-debt"]
-  extra_search_params  = "reactions:<20 no:milestone no:assignee"
-  message              = <<-EOF
-    I'm going to close this issue due to inactivity (_90 days_ without response ⏳ ). This helps our maintainers find and focus on the active issues.
-
-    If you feel this issue should be reopened, we encourage creating a new issue linking back to this one for added context. Thanks!
-    EOF
-}
-
 behavior "deprecated_import_commenter" "hashicorp_terraform" {
   import_regexp = "github.com/hashicorp/terraform/"
   marker_label  = "terraform-plugin-sdk-migration"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing: N/A

This implements very conservative stale issue and pull request handling to potentially clear out some very old backlog items that may no longer be relevant on more recent versions of Terraform CLI and the Terraform AWS Provider. We will potentially reduce the staleness time as we get through more of the actionable backlog.