### PR TITLE
tests/data-source/aws_vpc_endpoint_service: Fix EC2 policy check

### DIFF
--- a/aws/data_source_aws_vpc_endpoint_service_test.go
+++ b/aws/data_source_aws_vpc_endpoint_service_test.go
@@ -53,7 +53,7 @@ func TestAccDataSourceAwsVpcEndpointService_interface(t *testing.T) {
 					resource.TestCheckResourceAttr(datasourceName, "owner", "amazon"),
 					resource.TestCheckResourceAttr(datasourceName, "private_dns_name", fmt.Sprintf("ec2.%s.%s", region, testAccGetPartitionDNSSuffix())),
 					resource.TestCheckResourceAttr(datasourceName, "service_type", "Interface"),
-					resource.TestCheckResourceAttr(datasourceName, "vpc_endpoint_policy_supported", "false"),
+					resource.TestCheckResourceAttr(datasourceName, "vpc_endpoint_policy_supported", "true"),
 					resource.TestCheckResourceAttr(datasourceName, "tags.%", "0"),
 				),
 			},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Recently, AWS enabled endpoint policy support for EC2 VPC Endpoint services.

Previously:

```
--- FAIL: TestAccDataSourceAwsVpcEndpointService_interface (6.11s)
    testing.go:654: Step 0 error: Check failed: Check 8/9 error: data.aws_vpc_endpoint_service.test: Attribute 'vpc_endpoint_policy_supported' expected "false", got "true"
```

Output from acceptance testing:

```
--- PASS: TestAccDataSourceAwsVpcEndpointService_interface (19.07s)
```
