### PR TITLE
r/glue_partition - add new resource

### DIFF
--- a/aws/internal/service/glue/id.go
+++ b/aws/internal/service/glue/id.go
@@ -1,0 +1,32 @@
+package glue
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func ReadAwsGluePartitionID(id string) (catalogID string, dbName string, tableName string, values []string, error error) {
+	idParts := strings.Split(id, ":")
+	if len(idParts) != 4 {
+		return "", "", "", []string{}, fmt.Errorf("expected ID in format catalog-id:database-name:table-name:values, received: %s", id)
+	}
+	vals := strings.Split(idParts[3], "#")
+	return idParts[0], idParts[1], idParts[2], vals, nil
+}
+
+func CreateAwsGluePartitionID(catalogID, dbName, tableName string, values *schema.Set) string {
+	return fmt.Sprintf("%s:%s:%s:%s", catalogID, dbName, tableName, stringifyAwsGluePartition(values))
+}
+
+func stringifyAwsGluePartition(partValues *schema.Set) string {
+	var b bytes.Buffer
+	for _, val := range partValues.List() {
+		b.WriteString(fmt.Sprintf("%s#", val.(string)))
+	}
+	vals := strings.Trim(b.String(), "#")
+
+	return vals
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -641,6 +641,7 @@ func Provider() *schema.Provider {
 			"aws_glue_crawler":                                        resourceAwsGlueCrawler(),
 			"aws_glue_job":                                            resourceAwsGlueJob(),
 			"aws_glue_ml_transform":                                   resourceAwsGlueMLTransform(),
+			"aws_glue_partition":                                      resourceAwsGluePartition(),
 			"aws_glue_security_configuration":                         resourceAwsGlueSecurityConfiguration(),
 			"aws_glue_trigger":                                        resourceAwsGlueTrigger(),
 			"aws_glue_user_defined_function":                          resourceAwsGlueUserDefinedFunction(),

--- a/aws/resource_aws_glue_partition.go
+++ b/aws/resource_aws_glue_partition.go
@@ -46,9 +46,7 @@ func resourceAwsGluePartition() *schema.Resource {
 				Type:     schema.TypeSet,
 				Required: true,
 				ForceNew: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"storage_descriptor": {
 				Type:     schema.TypeList,
@@ -222,7 +220,7 @@ func resourceAwsGluePartitionCreate(d *schema.ResourceData, meta interface{}) er
 	log.Printf("[DEBUG] Creating Glue Partition: %#v", input)
 	_, err := conn.CreatePartition(input)
 	if err != nil {
-		return fmt.Errorf("error creating Glue Partition: %s", err)
+		return fmt.Errorf("error creating Glue Partition: %w", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s:%s:%s", catalogID, dbName, tableName, stringifyAwsGluePartition(values)))
@@ -255,7 +253,7 @@ func resourceAwsGluePartitionRead(d *schema.ResourceData, meta interface{}) erro
 			return nil
 		}
 
-		return fmt.Errorf("error reading Glue Partition: %s", err)
+		return fmt.Errorf("error reading Glue Partition: %w", err)
 	}
 
 	partition := out.Partition
@@ -278,11 +276,11 @@ func resourceAwsGluePartitionRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if err := d.Set("storage_descriptor", flattenGlueStorageDescriptor(partition.StorageDescriptor)); err != nil {
-		return fmt.Errorf("error setting storage_descriptor: %s", err)
+		return fmt.Errorf("error setting storage_descriptor: %w", err)
 	}
 
 	if err := d.Set("parameters", aws.StringValueMap(partition.Parameters)); err != nil {
-		return fmt.Errorf("error setting parameters: %s", err)
+		return fmt.Errorf("error setting parameters: %w", err)
 	}
 
 	return nil
@@ -306,7 +304,7 @@ func resourceAwsGluePartitionUpdate(d *schema.ResourceData, meta interface{}) er
 
 	log.Printf("[DEBUG] Updating Glue Partition: %#v", input)
 	if _, err := conn.UpdatePartition(input); err != nil {
-		return fmt.Errorf("error updating Glue Partition: %s", err)
+		return fmt.Errorf("error updating Glue Partition: %w", err)
 	}
 
 	return resourceAwsGluePartitionRead(d, meta)
@@ -328,7 +326,7 @@ func resourceAwsGluePartitionDelete(d *schema.ResourceData, meta interface{}) er
 		PartitionValues: aws.StringSlice(values),
 	})
 	if err != nil {
-		return fmt.Errorf("Error deleting Glue Partition: %s", err.Error())
+		return fmt.Errorf("Error deleting Glue Partition: %w", err)
 	}
 	return nil
 }

--- a/aws/resource_aws_glue_partition.go
+++ b/aws/resource_aws_glue_partition.go
@@ -42,7 +42,7 @@ func resourceAwsGluePartition() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validation.StringLenBetween(1, 255),
 			},
-			"values": {
+			"partition_values": {
 				Type:     schema.TypeSet,
 				Required: true,
 				ForceNew: true,
@@ -210,7 +210,7 @@ func resourceAwsGluePartitionCreate(d *schema.ResourceData, meta interface{}) er
 	catalogID := createAwsGlueCatalogID(d, meta.(*AWSClient).accountid)
 	dbName := d.Get("database_name").(string)
 	tableName := d.Get("table_name").(string)
-	values := d.Get("values").(*schema.Set)
+	values := d.Get("partition_values").(*schema.Set)
 
 	input := &glue.CreatePartitionInput{
 		CatalogId:      aws.String(catalogID),
@@ -263,7 +263,7 @@ func resourceAwsGluePartitionRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("table_name", partition.TableName)
 	d.Set("catalog_id", catalogID)
 	d.Set("database_name", partition.DatabaseName)
-	d.Set("values", flattenStringSet(partition.Values))
+	d.Set("partition_values", flattenStringSet(partition.Values))
 
 	if partition.LastAccessTime != nil {
 		d.Set("last_accessed_time", partition.LastAccessTime.Format(time.RFC3339))
@@ -344,7 +344,7 @@ func expandGluePartitionInput(d *schema.ResourceData) *glue.PartitionInput {
 		tableInput.Parameters = stringMapToPointers(v.(map[string]interface{}))
 	}
 
-	if v, ok := d.GetOk("values"); ok && v.(*schema.Set).Len() > 0 {
+	if v, ok := d.GetOk("partition_values"); ok && v.(*schema.Set).Len() > 0 {
 		tableInput.Values = expandStringSet(v.(*schema.Set))
 	}
 

--- a/aws/resource_aws_glue_partition.go
+++ b/aws/resource_aws_glue_partition.go
@@ -1,0 +1,315 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/glue"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"log"
+	"strings"
+)
+
+func resourceAwsGluePartition() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsGluePartitionCreate,
+		Read:   resourceAwsGluePartitionRead,
+		Update: resourceAwsGluePartitionUpdate,
+		Delete: resourceAwsGluePartitionDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"catalog_id": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+				Computed: true,
+			},
+			"database_name": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"table_name": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"storage_descriptor": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"bucket_columns": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"columns": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"comment": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"compressed": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"input_format": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"location": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"number_of_buckets": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"output_format": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"parameters": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"ser_de_info": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"parameters": {
+										Type:     schema.TypeMap,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"serialization_library": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"skewed_info": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"skewed_column_names": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"skewed_column_values": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"skewed_column_value_location_maps": {
+										Type:     schema.TypeMap,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+						"sort_columns": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"column": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"sort_order": {
+										Type:     schema.TypeInt,
+										Required: true,
+									},
+								},
+							},
+						},
+						"stored_as_sub_directories": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"parameters": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"values": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func readAwsGluePartitionID(id string) (catalogID string, dbName string, tableName string, error error) {
+	idParts := strings.Split(id, ":")
+	if len(idParts) != 3 {
+		return "", "", "", fmt.Errorf("expected ID in format catalog-id:database-name:table-name, received: %s", id)
+	}
+	return idParts[0], idParts[1], idParts[2], nil
+}
+
+func resourceAwsGluePartitionCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).glueconn
+	catalogID := createAwsGlueCatalogID(d, meta.(*AWSClient).accountid)
+	dbName := d.Get("database_name").(string)
+	tableName := d.Get("table_name").(string)
+
+	input := &glue.CreatePartitionInput{
+		CatalogId:      aws.String(catalogID),
+		DatabaseName:   aws.String(dbName),
+		TableName:      aws.String(tableName),
+		PartitionInput: expandGluePartitionInput(d),
+	}
+
+	_, err := conn.CreatePartition(input)
+	if err != nil {
+		return fmt.Errorf("Error creating Glue Partition: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("%s:%s:%s:", catalogID, dbName, tableName))
+
+	return resourceAwsGluePartitionRead(d, meta)
+}
+
+func resourceAwsGluePartitionRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).glueconn
+
+	catalogID, dbName, tableName, err := readAwsGluePartitionID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	input := &glue.GetPartitionInput{
+		CatalogId:    aws.String(catalogID),
+		DatabaseName: aws.String(dbName),
+		TableName:    aws.String(tableName),
+	}
+
+	out, err := conn.GetPartition(input)
+	if err != nil {
+
+		if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
+			log.Printf("[WARN] Glue Partition (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error reading Glue Partition: %s", err)
+	}
+
+	partition := out.Partition
+
+	d.Set("table_name", partition.TableName)
+	d.Set("catalog_id", catalogID)
+	d.Set("database_name", partition.DatabaseName)
+	d.Set("values", flattenStringSet(partition.Values))
+
+	if err := d.Set("storage_descriptor", flattenGlueStorageDescriptor(partition.StorageDescriptor)); err != nil {
+		return fmt.Errorf("error setting storage_descriptor: %s", err)
+	}
+
+	if err := d.Set("parameters", aws.StringValueMap(partition.Parameters)); err != nil {
+		return fmt.Errorf("error setting parameters: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsGluePartitionUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).glueconn
+
+	catalogID, dbName, tableName, err := readAwsGluePartitionID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	input := &glue.UpdatePartitionInput{
+		CatalogId:      aws.String(catalogID),
+		DatabaseName:   aws.String(dbName),
+		TableName:      aws.String(tableName),
+		PartitionInput: expandGluePartitionInput(d),
+	}
+
+	if _, err := conn.UpdatePartition(input); err != nil {
+		return fmt.Errorf("Error updating Glue Partition: %s", err)
+	}
+
+	return resourceAwsGluePartitionRead(d, meta)
+}
+
+func resourceAwsGluePartitionDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).glueconn
+
+	catalogID, dbName, tableName, tableErr := readAwsGluePartitionID(d.Id())
+	if tableErr != nil {
+		return tableErr
+	}
+
+	log.Printf("[DEBUG] Glue Partition: %s:%s:%s", catalogID, dbName, tableName)
+	_, err := conn.DeletePartition(&glue.DeletePartitionInput{
+		CatalogId:    aws.String(catalogID),
+		TableName:    aws.String(tableName),
+		DatabaseName: aws.String(dbName),
+	})
+	if err != nil {
+		return fmt.Errorf("Error deleting Glue Partition: %s", err.Error())
+	}
+	return nil
+}
+
+func expandGluePartitionInput(d *schema.ResourceData) *glue.PartitionInput {
+	tableInput := &glue.PartitionInput{}
+
+	if v, ok := d.GetOk("storage_descriptor"); ok {
+		tableInput.StorageDescriptor = expandGlueStorageDescriptor(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("parameters"); ok {
+		paramsMap := map[string]string{}
+		for key, value := range v.(map[string]interface{}) {
+			paramsMap[key] = value.(string)
+		}
+		tableInput.Parameters = aws.StringMap(paramsMap)
+	}
+
+	if v, ok := d.GetOk("values"); ok && v.(*schema.Set).Len() > 0 {
+		tableInput.Values = expandStringSet(v.(*schema.Set))
+	}
+
+	return tableInput
+}

--- a/aws/resource_aws_glue_partition.go
+++ b/aws/resource_aws_glue_partition.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/glue"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceAwsGluePartition() *schema.Resource {

--- a/aws/resource_aws_glue_partition_test.go
+++ b/aws/resource_aws_glue_partition_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	tfglue "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/glue"
 )
 
 func TestAccAWSGluePartition_basic(t *testing.T) {
@@ -70,7 +71,7 @@ func testAccCheckGluePartitionDestroy(s *terraform.State) error {
 			continue
 		}
 
-		catalogID, dbName, tableName, values, err := readAwsGluePartitionID(rs.Primary.ID)
+		catalogID, dbName, tableName, values, err := tfglue.ReadAwsGluePartitionID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -104,7 +105,7 @@ func testAccCheckGluePartitionExists(name string) resource.TestCheckFunc {
 			return fmt.Errorf("No ID is set")
 		}
 
-		catalogID, dbName, tableName, values, err := readAwsGluePartitionID(rs.Primary.ID)
+		catalogID, dbName, tableName, values, err := tfglue.ReadAwsGluePartitionID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/aws/resource_aws_glue_partition_test.go
+++ b/aws/resource_aws_glue_partition_test.go
@@ -1,0 +1,202 @@
+package aws
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/glue"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccAWSGluePartition_basic(t *testing.T) {
+	var partition glue.Partition
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	parValue := acctest.RandString(10)
+	resourceName := "aws_glue_partition.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGluePartitionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGluePartitionConfig(rName, parValue),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGluePartitionExists(resourceName, &partition),
+					resource.TestCheckResourceAttr(resourceName, "database_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "values.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "creation_time"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccGluePartitionConfigBase(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+}
+
+resource "aws_glue_catalog_table" "test" {
+  name          = %[1]q
+  database_name = "${aws_glue_catalog_database.test.name}"
+
+  storage_descriptor {
+    bucket_columns            = ["bucket_column_1"]
+    compressed                = false
+    input_format              = "SequenceFileInputFormat"
+    location                  = "my_location"
+    number_of_buckets         = 1
+    output_format             = "SequenceFileInputFormat"
+    stored_as_sub_directories = false
+
+    parameters = {
+      param1 = "param1_val"
+    }
+
+    columns {
+      name    = "my_column_1"
+      type    = "int"
+      comment = "my_column1_comment"
+    }
+
+    columns {
+      name    = "my_column_2"
+      type    = "string"
+      comment = "my_column2_comment"
+    }
+
+    ser_de_info {
+      name = "ser_de_name"
+
+      parameters = {
+        param1 = "param_val_1"
+      }
+
+      serialization_library = "org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe"
+    }
+
+    sort_columns {
+      column     = "my_column_1"
+      sort_order = 1
+    }
+
+    skewed_info {
+      skewed_column_names = [
+        "my_column_1",
+      ]
+
+      skewed_column_value_location_maps = {
+        my_column_1 = "my_column_1_val_loc_map"
+      }
+
+      skewed_column_values = [
+        "skewed_val_1",
+      ]
+    }
+  }
+
+  partition_keys {
+    name    = "my_column_12"
+    type    = "date"
+    comment = "my_column_1_comment2"
+  }
+}
+`, rName)
+}
+
+func testAccGluePartitionConfig(rName string, parValue string) string {
+	return testAccGluePartitionConfigBase(rName) +
+		fmt.Sprintf(`
+resource "aws_glue_partition" "test" {
+  database_name = "${aws_glue_catalog_database.test.name}"
+  table_name    = "${aws_glue_catalog_table.test.name}"
+  values        =  ["%[2]s"]
+}
+`, rName, parValue)
+}
+
+func testAccCheckGluePartitionDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).glueconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_glue_partition" {
+			continue
+		}
+
+		catalogID, dbName, tableName, values, err := readAwsGluePartitionID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		input := &glue.GetPartitionInput{
+			DatabaseName:    aws.String(dbName),
+			CatalogId:       aws.String(catalogID),
+			TableName:       aws.String(tableName),
+			PartitionValues: aws.StringSlice(values),
+		}
+		if _, err := conn.GetPartition(input); err != nil {
+			//Verify the error is what we want
+			if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
+				continue
+			}
+
+			return err
+		}
+		return fmt.Errorf("still exists")
+	}
+	return nil
+}
+
+func testAccCheckGluePartitionExists(name string, partition *glue.Partition) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		catalogID, dbName, tableName, values, err := readAwsGluePartitionID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).glueconn
+		out, err := conn.GetPartition(&glue.GetPartitionInput{
+			DatabaseName:    aws.String(dbName),
+			CatalogId:       aws.String(catalogID),
+			TableName:       aws.String(tableName),
+			PartitionValues: aws.StringSlice(values),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if out.Partition == nil {
+			return fmt.Errorf("No Glue Partition Found")
+		}
+
+		if !reflect.DeepEqual(aws.StringValueSlice(out.Partition.Values), values) {
+			return fmt.Errorf("Glue Partition Mismatch")
+		}
+
+		*partition = *out.Partition
+
+		return nil
+	}
+}

--- a/aws/resource_aws_glue_partition_test.go
+++ b/aws/resource_aws_glue_partition_test.go
@@ -28,7 +28,7 @@ func TestAccAWSGluePartition_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGluePartitionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "database_name", rName),
-					resource.TestCheckResourceAttr(resourceName, "values.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "partition_values.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "creation_time"),
 				),
 			},
@@ -214,7 +214,7 @@ func testAccGluePartitionConfig(rName string, parValue string) string {
 resource "aws_glue_partition" "test" {
   database_name = "${aws_glue_catalog_database.test.name}"
   table_name    = "${aws_glue_catalog_table.test.name}"
-  values        =  ["%[1]s"]
+  partition_values        =  ["%[1]s"]
 }
 `, parValue)
 }

--- a/aws/resource_aws_glue_partition_test.go
+++ b/aws/resource_aws_glue_partition_test.go
@@ -7,10 +7,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/glue"
-
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccAWSGluePartition_basic(t *testing.T) {

--- a/aws/resource_aws_glue_partition_test.go
+++ b/aws/resource_aws_glue_partition_test.go
@@ -305,7 +305,7 @@ resource "aws_glue_partition" "test" {
   partition_values = ["%[1]s"]
 
   parameters = {
-    %[2]q = %[3]q 
+    %[2]q = %[3]q
   }
 }
 `, parValue, key1, value1)
@@ -321,7 +321,7 @@ resource "aws_glue_partition" "test" {
 
   parameters = {
     %[2]q = %[3]q
-    %[4]q = %[5]q     
+    %[4]q = %[5]q
   }
 }
 `, parValue, key1, value1, key2, value2)

--- a/aws/resource_aws_glue_partition_test.go
+++ b/aws/resource_aws_glue_partition_test.go
@@ -329,6 +329,10 @@ resource "aws_glue_partition" "test" {
 
 func testAccGluePartitionMultiplePartValueConfig(rName, parValue, parValue2 string) string {
 	return fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+}
+
 resource "aws_glue_catalog_table" "test" {
   name          = %[1]q
   database_name = aws_glue_catalog_database.test.name

--- a/aws/resource_aws_glue_partition_test.go
+++ b/aws/resource_aws_glue_partition_test.go
@@ -141,7 +141,7 @@ resource "aws_glue_catalog_database" "test" {
 
 resource "aws_glue_catalog_table" "test" {
   name          = %[1]q
-  database_name = "${aws_glue_catalog_database.test.name}"
+  database_name = aws_glue_catalog_database.test.name
 
   storage_descriptor {
     bucket_columns            = ["bucket_column_1"]
@@ -211,9 +211,9 @@ func testAccGluePartitionConfig(rName string, parValue string) string {
 	return testAccGluePartitionConfigBase(rName) +
 		fmt.Sprintf(`
 resource "aws_glue_partition" "test" {
-  database_name = "${aws_glue_catalog_database.test.name}"
-  table_name    = "${aws_glue_catalog_table.test.name}"
-  partition_values        =  ["%[1]s"]
+  database_name    = aws_glue_catalog_database.test.name
+  table_name       = aws_glue_catalog_table.test.name
+  partition_values =  ["%[1]s"]
 }
 `, parValue)
 }

--- a/aws/resource_aws_glue_partition_test.go
+++ b/aws/resource_aws_glue_partition_test.go
@@ -213,7 +213,7 @@ func testAccGluePartitionConfig(rName string, parValue string) string {
 resource "aws_glue_partition" "test" {
   database_name    = aws_glue_catalog_database.test.name
   table_name       = aws_glue_catalog_table.test.name
-  partition_values =  ["%[1]s"]
+  partition_values = ["%[1]s"]
 }
 `, parValue)
 }

--- a/aws/resource_aws_glue_partition_test.go
+++ b/aws/resource_aws_glue_partition_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	tfglue "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/glue"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func TestAccAWSGluePartition_basic(t *testing.T) {
@@ -24,11 +25,14 @@ func TestAccAWSGluePartition_basic(t *testing.T) {
 		CheckDestroy: testAccCheckGluePartitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGluePartitionConfig(rName, parValue),
+				Config: testAccGluePartitionBasicConfig(rName, parValue),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGluePartitionExists(resourceName),
+					testAccCheckResourceAttrAccountID(resourceName, "catalog_id"),
 					resource.TestCheckResourceAttr(resourceName, "database_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "partition_values.#", "1"),
+					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "partition_values.*", parValue),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "0"),
 					resource.TestCheckResourceAttrSet(resourceName, "creation_time"),
 				),
 			},
@@ -36,6 +40,79 @@ func TestAccAWSGluePartition_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSGluePartition_multipleValues(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	parValue := acctest.RandString(10)
+	parValue2 := acctest.RandString(11)
+	resourceName := "aws_glue_partition.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGluePartitionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGluePartitionMultiplePartValueConfig(rName, parValue, parValue2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGluePartitionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "partition_values.#", "2"),
+					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "partition_values.*", parValue),
+					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "partition_values.*", parValue2),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSGluePartition_parameters(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	parValue := acctest.RandString(10)
+	resourceName := "aws_glue_partition.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGluePartitionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGluePartitionParametersConfig1(rName, parValue, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGluePartitionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccGluePartitionParametersConfig2(rName, parValue, "key1", "valueUpdated1", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGluePartitionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.key1", "valueUpdated1"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccGluePartitionParametersConfig1(rName, parValue, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGluePartitionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.key2", "value2"),
+				),
 			},
 		},
 	})
@@ -52,7 +129,7 @@ func TestAccAWSGluePartition_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckGluePartitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGluePartitionConfig(rName, parValue),
+				Config: testAccGluePartitionBasicConfig(rName, parValue),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGluePartitionExists(resourceName),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsGluePartition(), resourceName),
@@ -208,7 +285,7 @@ resource "aws_glue_catalog_table" "test" {
 `, rName)
 }
 
-func testAccGluePartitionConfig(rName string, parValue string) string {
+func testAccGluePartitionBasicConfig(rName, parValue string) string {
 	return testAccGluePartitionConfigBase(rName) +
 		fmt.Sprintf(`
 resource "aws_glue_partition" "test" {
@@ -217,4 +294,117 @@ resource "aws_glue_partition" "test" {
   partition_values = ["%[1]s"]
 }
 `, parValue)
+}
+
+func testAccGluePartitionParametersConfig1(rName, parValue, key1, value1 string) string {
+	return testAccGluePartitionConfigBase(rName) +
+		fmt.Sprintf(`
+resource "aws_glue_partition" "test" {
+  database_name    = aws_glue_catalog_database.test.name
+  table_name       = aws_glue_catalog_table.test.name
+  partition_values = ["%[1]s"]
+
+  parameters {
+    %[2]q = %[3]q 
+  }
+}
+`, parValue, key1, value1)
+}
+
+func testAccGluePartitionParametersConfig2(rName, parValue, key1, value1, key2, value2 string) string {
+	return testAccGluePartitionConfigBase(rName) +
+		fmt.Sprintf(`
+resource "aws_glue_partition" "test" {
+  database_name    = aws_glue_catalog_database.test.name
+  table_name       = aws_glue_catalog_table.test.name
+  partition_values = ["%[1]s"]
+
+  parameters {
+    %[2]q = %[3]q
+    %[4]q = %[5]q     
+  }
+}
+`, parValue, key1, value1, key2, value2)
+}
+
+func testAccGluePartitionMultiplePartValueConfig(rName, parValue, parValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_catalog_table" "test" {
+  name          = %[1]q
+  database_name = aws_glue_catalog_database.test.name
+
+  storage_descriptor {
+    bucket_columns            = ["bucket_column_1"]
+    compressed                = false
+    input_format              = "SequenceFileInputFormat"
+    location                  = "my_location"
+    number_of_buckets         = 1
+    output_format             = "SequenceFileInputFormat"
+    stored_as_sub_directories = false
+
+    parameters = {
+      param1 = "param1_val"
+    }
+
+    columns {
+      name    = "my_column_1"
+      type    = "int"
+      comment = "my_column1_comment"
+    }
+
+    columns {
+      name    = "my_column_2"
+      type    = "string"
+      comment = "my_column2_comment"
+    }
+
+    ser_de_info {
+      name = "ser_de_name"
+
+      parameters = {
+        param1 = "param_val_1"
+      }
+
+      serialization_library = "org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe"
+    }
+
+    sort_columns {
+      column     = "my_column_1"
+      sort_order = 1
+    }
+
+    skewed_info {
+      skewed_column_names = [
+        "my_column_1",
+      ]
+
+      skewed_column_value_location_maps = {
+        my_column_1 = "my_column_1_val_loc_map"
+      }
+
+      skewed_column_values = [
+        "skewed_val_1",
+      ]
+    }
+  }
+
+  partition_keys {
+    name    = "my_column_12"
+    type    = "date"
+    comment = "my_column_1_comment2"
+  }
+
+  partition_keys {
+    name    = "my_column_11"
+    type    = "date"
+    comment = "my_column_1_comment2"
+  }
+}
+
+resource "aws_glue_partition" "test" {
+  database_name    = aws_glue_catalog_database.test.name
+  table_name       = aws_glue_catalog_table.test.name
+  partition_values = ["%[2]s", "%[3]s"]
+}
+`, rName, parValue, parValue2)
 }

--- a/aws/resource_aws_glue_partition_test.go
+++ b/aws/resource_aws_glue_partition_test.go
@@ -304,7 +304,7 @@ resource "aws_glue_partition" "test" {
   table_name       = aws_glue_catalog_table.test.name
   partition_values = ["%[1]s"]
 
-  parameters {
+  parameters = {
     %[2]q = %[3]q 
   }
 }
@@ -319,7 +319,7 @@ resource "aws_glue_partition" "test" {
   table_name       = aws_glue_catalog_table.test.name
   partition_values = ["%[1]s"]
 
-  parameters {
+  parameters = {
     %[2]q = %[3]q
     %[4]q = %[5]q     
   }

--- a/website/docs/r/glue_partition.html.markdown
+++ b/website/docs/r/glue_partition.html.markdown
@@ -1,0 +1,86 @@
+---
+subcategory: "Glue"
+layout: "aws"
+page_title: "AWS: aws_glue_partition"
+description: |-
+  Provides a Glue Partition.
+---
+
+# Resource: aws_glue_partition
+
+Provides a Glue Partition Resource.
+
+## Example Usage
+
+```hcl
+resource "aws_glue_partition" "example" {
+  database_name = "some-database"
+  table_name    = "some-table"
+  values        =  ["some-value"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `database_name` - (Required) Name of the metadata database where the table metadata resides. For Hive compatibility, this must be all lowercase.
+* `partition_values` - (Required) The values that define the partition.
+* `catalog_id` - (Optional) ID of the Glue Catalog and database to create the table in. If omitted, this defaults to the AWS Account ID plus the database name.
+* `storage_descriptor` - (Optional) A [storage descriptor](#storage_descriptor) object containing information about the physical storage of this table. You can refer to the [Glue Developer Guide](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-tables.html#aws-glue-api-catalog-tables-StorageDescriptor) for a full explanation of this object.
+* `parameters` - (Optional) Properties associated with this table, as a list of key-value pairs.
+
+##### storage_descriptor
+
+* `columns` - (Optional) A list of the [Columns](#column) in the table.
+* `location` - (Optional) The physical location of the table. By default this takes the form of the warehouse location, followed by the database location in the warehouse, followed by the table name.
+* `input_format` - (Optional) The input format: SequenceFileInputFormat (binary), or TextInputFormat, or a custom format.
+* `output_format` - (Optional) The output format: SequenceFileOutputFormat (binary), or IgnoreKeyTextOutputFormat, or a custom format.
+* `compressed` - (Optional) True if the data in the table is compressed, or False if not.
+* `number_of_buckets` - (Optional) Must be specified if the table contains any dimension columns.
+* `ser_de_info` - (Optional) [Serialization/deserialization (SerDe)](#ser_de_info) information.
+* `bucket_columns` - (Optional) A list of reducer grouping columns, clustering columns, and bucketing columns in the table.
+* `sort_columns` - (Optional) A list of [Order](#sort_column) objects specifying the sort order of each bucket in the table.
+* `parameters` - (Optional) User-supplied properties in key-value form.
+* `skewed_info` - (Optional) Information about values that appear very frequently in a column (skewed values).
+* `stored_as_sub_directories` - (Optional) True if the table data is stored in subdirectories, or False if not.
+
+##### column
+
+* `name` - (Required) The name of the Column.
+* `type` - (Optional) The datatype of data in the Column.
+* `comment` - (Optional) Free-form text comment.
+
+##### ser_de_info
+
+* `name` - (Optional) Name of the SerDe.
+* `parameters` - (Optional) A map of initialization parameters for the SerDe, in key-value form.
+* `serialization_library` - (Optional) Usually the class that implements the SerDe. An example is: org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe.
+
+##### sort_columns
+
+* `column` - (Required) The name of the column.
+* `sort_order` - (Required) Indicates that the column is sorted in ascending order (== 1), or in descending order (==0).
+
+##### skewed_info
+
+* `skewed_column_names` - (Optional) A list of names of columns that contain skewed values.
+* `skewed_column_value_location_maps` - (Optional) A list of values that appear so frequently as to be considered skewed.
+* `skewed_column_values` - (Optional) A map of skewed values to the columns that contain them.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - partition id.
+* `creation_time` - The time at which the partition was created.
+* `last_analyzed_time` - The last time at which column statistics were computed for this partition.
+* `last_accessed_time` - The last time at which the partition was accessed.
+
+## Import
+
+Glue Partitions can be imported with their catalog ID (usually AWS account ID), database name, table name and partition values e.g.
+
+```
+$ terraform import aws_glue_partition.part 123456789012:MyDatabase:MyTable:val1#val2
+```

--- a/website/docs/r/glue_partition.html.markdown
+++ b/website/docs/r/glue_partition.html.markdown
@@ -16,7 +16,7 @@ Provides a Glue Partition Resource.
 resource "aws_glue_partition" "example" {
   database_name = "some-database"
   table_name    = "some-table"
-  values        =  ["some-value"]
+  values        = ["some-value"]
 }
 ```
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #3878

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_glue_partition: add new resource
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSGluePartition_'
--- PASS: TestAccAWSGluePartition_basic (65.18s)
--- PASS: TestAccAWSGluePartition_parameters (166.56s)
--- PASS: TestAccAWSGluePartition_disappears (52.11s)
--- PASS: TestAccAWSGluePartition_multipleValues (66.00s)
```
