### PR TITLE
Add CodePipeline cross-region action support

### DIFF
--- a/aws/resource_aws_codepipeline.go
+++ b/aws/resource_aws_codepipeline.go
@@ -252,7 +252,7 @@ func expandAwsCodePipelineArtifactStore(d *schema.ResourceData) *codepipeline.Ar
 }
 
 func expandAwsCodePipelineArtifactStores(d *schema.ResourceData) map[string]*codepipeline.ArtifactStore {
-	configs := d.Get("artifact_stores").([]interface{})
+	configs := d.Get("artifact_stores").(map[string]*schema.ResourceData)
 
 	if configs == nil {
 		return nil
@@ -260,23 +260,8 @@ func expandAwsCodePipelineArtifactStores(d *schema.ResourceData) map[string]*cod
 
 	pipelineArtifactStores := make(map[string]*codepipeline.ArtifactStore)
 
-	for _, config := range configs {
-		data := config.(map[string]interface{})
-		pipelineArtifactStores[data["region"].(string)] = &codepipeline.ArtifactStore{
-			Location: aws.String(data["location"].(string)),
-			Type:     aws.String(data["type"].(string)),
-		}
-
-		tek := data["encryption_key"].([]interface{})
-
-		if len(tek) > 0 {
-			vk := tek[0].(map[string]interface{})
-			ek := codepipeline.EncryptionKey{
-				Type: aws.String(vk["type"].(string)),
-				Id:   aws.String(vk["id"].(string)),
-			}
-			pipelineArtifactStores[data["region"].(string)].EncryptionKey = &ek
-		}
+	for region, config := range configs {
+		pipelineArtifactStores[region] = expandAwsCodePipelineArtifactStore(config)
 	}
 
 	return pipelineArtifactStores

--- a/aws/resource_aws_codepipeline.go
+++ b/aws/resource_aws_codepipeline.go
@@ -155,6 +155,11 @@ func resourceAwsCodePipeline() *schema.Resource {
 										Optional: true,
 										Computed: true,
 									},
+									"region": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
 								},
 							},
 						},
@@ -319,6 +324,10 @@ func expandAwsCodePipelineActions(s []interface{}) []*codepipeline.ActionDeclara
 		if ro > 0 {
 			action.RunOrder = aws.Int64(int64(ro))
 		}
+		r := data["region"].(string)
+		if r != "" {
+			action.Region = aws.String(r)
+		}
 		actions = append(actions, &action)
 	}
 	return actions
@@ -358,6 +367,10 @@ func flattenAwsCodePipelineStageActions(actions []*codepipeline.ActionDeclaratio
 
 		if action.RunOrder != nil {
 			values["run_order"] = int(*action.RunOrder)
+		}
+
+		if action.Region != nil {
+			values["region"] = *action.Region
 		}
 
 		actionsList = append(actionsList, values)

--- a/aws/resource_aws_codepipeline.go
+++ b/aws/resource_aws_codepipeline.go
@@ -15,6 +15,43 @@ import (
 )
 
 func resourceAwsCodePipeline() *schema.Resource {
+	var artifactStoreSchema = map[string]*schema.Schema{
+		"location": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+
+		"type": {
+			Type:     schema.TypeString,
+			Required: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				codepipeline.ArtifactStoreTypeS3,
+			}, false),
+		},
+
+		"encryption_key": {
+			Type:     schema.TypeList,
+			MaxItems: 1,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"id": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+
+					"type": {
+						Type:     schema.TypeString,
+						Required: true,
+						ValidateFunc: validation.StringInSlice([]string{
+							codepipeline.EncryptionKeyTypeKms,
+						}, false),
+					},
+				},
+			},
+		},
+	}
+
 	return &schema.Resource{
 		Create: resourceAwsCodePipelineCreate,
 		Read:   resourceAwsCodePipelineRead,
@@ -44,96 +81,13 @@ func resourceAwsCodePipeline() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"location": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-
-						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								codepipeline.ArtifactStoreTypeS3,
-							}, false),
-						},
-
-						"encryption_key": {
-							Type:     schema.TypeList,
-							MaxItems: 1,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"id": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-
-									"type": {
-										Type:     schema.TypeString,
-										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											codepipeline.EncryptionKeyTypeKms,
-										}, false),
-									},
-								},
-							},
-						},
-					},
-				},
+				Elem:     artifactStoreSchema,
 			},
 			"artifact_stores": {
 				Type:     schema.TypeMap,
 				Optional: true,
 				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"artifact_store": {
-							Type:     schema.TypeList,
-							Required: false,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"location": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"type": {
-										Type:     schema.TypeString,
-										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											codepipeline.ArtifactStoreTypeS3,
-										}, false),
-									},
-									"encryption_key": {
-										Type:     schema.TypeList,
-										MaxItems: 1,
-										Optional: true,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"id": {
-													Type:     schema.TypeString,
-													Required: true,
-												},
-
-												"type": {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.StringInSlice([]string{
-														codepipeline.EncryptionKeyTypeKms,
-													}, false),
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-						"region": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
+					Schema: artifactStoreSchema,
 				},
 			},
 			"stage": {

--- a/aws/resource_aws_codepipeline.go
+++ b/aws/resource_aws_codepipeline.go
@@ -96,7 +96,6 @@ func resourceAwsCodePipeline() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: artifactStoreSchema,
 				},
-				Set: resourceAwsCodePipelineArtifactStoreHash,
 			},
 			"stage": {
 				Type:     schema.TypeList,

--- a/aws/resource_aws_codepipeline_test.go
+++ b/aws/resource_aws_codepipeline_test.go
@@ -280,10 +280,13 @@ func testAccCheckAWSCodePipelineDestroy(s *terraform.State) error {
 		if err == nil {
 			return fmt.Errorf("Expected AWS CodePipeline to be gone, but was still found")
 		}
-		return nil
+		if isAWSErr(err, "PipelineNotFoundException", "") {
+			return nil
+		}
+		return err
 	}
 
-	return fmt.Errorf("Default error in CodePipeline Test")
+	return nil
 }
 
 func testAccPreCheckAWSCodePipeline(t *testing.T) {

--- a/aws/resource_aws_codepipeline_test.go
+++ b/aws/resource_aws_codepipeline_test.go
@@ -33,7 +33,7 @@ func TestAccAWSCodePipeline_basic(t *testing.T) {
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "codepipeline", regexp.MustCompile(fmt.Sprintf("test-pipeline-%s", name))),
 					resource.TestCheckResourceAttr(resourceName, "artifact_store.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "artifact_store.0.type", "S3"),
-					resource.TestCheckResourceAttrPair(resourceName, "artifact_store.0.location", "aws_s3_bucket.foo", "bucket"),
+					resource.TestCheckResourceAttrPair(resourceName, "artifact_store.0.location", "aws_s3_bucket.test", "bucket"),
 					resource.TestCheckResourceAttr(resourceName, "artifact_store.0.encryption_key.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "artifact_store.0.encryption_key.0.id", "1234"),
 					resource.TestCheckResourceAttr(resourceName, "artifact_store.0.encryption_key.0.type", "KMS"),
@@ -96,19 +96,19 @@ func TestAccAWSCodePipeline_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.name", "Source"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.input_artifacts.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_artifacts.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_artifacts.0", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_artifacts.0", "artifacts"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.%", "3"),
-					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.Owner", "foo-terraform"),
-					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.Repo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.Owner", "test-terraform"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.Repo", "test-repo"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.Branch", "stable"),
 
 					resource.TestCheckResourceAttr(resourceName, "stage.1.name", "Build"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.name", "Build"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.input_artifacts.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.input_artifacts.0", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.input_artifacts.0", "artifacts"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.configuration.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.configuration.ProjectName", "foo"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.configuration.ProjectName", "test"),
 				),
 			},
 		},
@@ -397,8 +397,8 @@ resource "aws_iam_role_policy" "codepipeline_policy" {
         "s3:GetBucketVersioning"
       ],
       "Resource": [
-        "${aws_s3_bucket.foo.arn}",
-        "${aws_s3_bucket.foo.arn}/*"
+        "${aws_s3_bucket.test.arn}",
+        "${aws_s3_bucket.test.arn}/*"
       ]
     },
     {
@@ -453,8 +453,8 @@ resource "aws_iam_role_policy" "codepipeline_policy" {
         "s3:GetBucketVersioning"
       ],
       "Resource": [
-        "${aws_s3_bucket.foo.arn}",
-        "${aws_s3_bucket.foo.arn}/*"
+        "${aws_s3_bucket.test.arn}",
+        "${aws_s3_bucket.test.arn}/*"
       ]
     },
     {
@@ -489,7 +489,7 @@ resource "aws_codepipeline" "test" {
   role_arn = "${aws_iam_role.codepipeline_role.arn}"
 
   artifact_store {
-    location = "${aws_s3_bucket.foo.bucket}"
+    location = "${aws_s3_bucket.test.bucket}"
     type     = "S3"
 
     encryption_key {
@@ -547,7 +547,7 @@ resource "aws_codepipeline" "test" {
   role_arn = "${aws_iam_role.codepipeline_role.arn}"
 
   artifact_store {
-    location = "${aws_s3_bucket.foo.bucket}"
+    location = "${aws_s3_bucket.updated.bucket}"
     type     = "S3"
 
     encryption_key {
@@ -565,11 +565,11 @@ resource "aws_codepipeline" "test" {
       owner            = "ThirdParty"
       provider         = "GitHub"
       version          = "1"
-      output_artifacts = ["bar"]
+      output_artifacts = ["artifacts"]
 
       configuration = {
-        Owner  = "foo-terraform"
-        Repo   = "bar"
+        Owner  = "test-terraform"
+        Repo   = "test-repo"
         Branch = "stable"
       }
     }
@@ -583,11 +583,11 @@ resource "aws_codepipeline" "test" {
       category        = "Build"
       owner           = "AWS"
       provider        = "CodeBuild"
-      input_artifacts = ["bar"]
+      input_artifacts = ["artifacts"]
       version         = "1"
 
       configuration = {
-        ProjectName = "foo"
+        ProjectName = "test"
       }
     }
   }
@@ -605,7 +605,7 @@ resource "aws_codepipeline" "test" {
   role_arn = "${aws_iam_role.codepipeline_role.arn}"
 
   artifact_store {
-    location = "${aws_s3_bucket.foo.bucket}"
+    location = "${aws_s3_bucket.test.bucket}"
     type     = "S3"
   }
 
@@ -688,8 +688,8 @@ resource "aws_iam_role_policy" "codepipeline_action_policy" {
         "s3:GetBucketVersioning"
       ],
       "Resource": [
-        "${aws_s3_bucket.foo.arn}",
-        "${aws_s3_bucket.foo.arn}/*"
+        "${aws_s3_bucket.test.arn}",
+        "${aws_s3_bucket.test.arn}/*"
       ]
     }
   ]
@@ -710,7 +710,7 @@ resource "aws_codepipeline" "test" {
   role_arn = "${aws_iam_role.codepipeline_role.arn}"
 
   artifact_store {
-    location = "${aws_s3_bucket.foo.bucket}"
+    location = "${aws_s3_bucket.test.bucket}"
     type     = "S3"
 
     encryption_key {
@@ -728,11 +728,11 @@ resource "aws_codepipeline" "test" {
       owner            = "ThirdParty"
       provider         = "GitHub"
       version          = "1"
-      output_artifacts = ["bar"]
+      output_artifacts = ["artifacts"]
 
       configuration = {
-        Owner  = "foo-terraform"
-        Repo   = "bar"
+        Owner  = "test-terraform"
+        Repo   = "test-repo"
         Branch = "stable"
       }
     }
@@ -746,12 +746,12 @@ resource "aws_codepipeline" "test" {
       category         = "Build"
       owner            = "AWS"
       provider         = "CodeBuild"
-      input_artifacts  = ["bar"]
-      output_artifacts = ["baz"]
+      input_artifacts  = ["artifacts"]
+      output_artifacts = ["artifacts2"]
       version          = "1"
 
       configuration = {
-        ProjectName = "foo"
+        ProjectName = "test"
       }
     }
   }
@@ -764,7 +764,7 @@ resource "aws_codepipeline" "test" {
       category        = "Deploy"
       owner           = "AWS"
       provider        = "CloudFormation"
-      input_artifacts = ["baz"]
+      input_artifacts = ["artifacts2"]
       role_arn        = "${aws_iam_role.codepipeline_action_role.arn}"
       version         = "1"
 
@@ -772,7 +772,7 @@ resource "aws_codepipeline" "test" {
         ActionMode    = "CHANGE_SET_REPLACE"
         ChangeSetName = "changeset"
         StackName     = "stack"
-        TemplatePath  = "baz::template.yaml"
+        TemplatePath  = "artifacts2::template.yaml"
       }
     }
   }
@@ -790,7 +790,7 @@ resource "aws_codepipeline" "test" {
   role_arn = "${aws_iam_role.codepipeline_role.arn}"
 
   artifact_store {
-    location = "${aws_s3_bucket.foo.bucket}"
+    location = "${aws_s3_bucket.test.bucket}"
     type     = "S3"
 
     encryption_key {

--- a/aws/resource_aws_codepipeline_test.go
+++ b/aws/resource_aws_codepipeline_test.go
@@ -182,6 +182,34 @@ func TestAccAWSCodePipeline_tags(t *testing.T) {
 	})
 }
 
+func TestAccAWSCodePipeline_basic_multiregion(t *testing.T) {
+	if os.Getenv("GITHUB_TOKEN") == "" {
+		t.Skip("Environment variable GITHUB_TOKEN is not set")
+	}
+
+	name := acctest.RandString(10)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodePipelineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodePipelineConfig_multiregion(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodePipelineExists("aws_codepipeline.bar"),
+					resource.TestCheckResourceAttr("aws_codepipeline.bar", "stage.2.name", "Build"),
+					resource.TestCheckResourceAttr("aws_codepipeline.bar", "stage.2.action.0.region", "eu-west-1"),
+					resource.TestCheckResourceAttr("aws_codepipeline.bar", "stage.2.action.1.region", "eu-central-1"),
+					resource.TestMatchResourceAttr(
+						"aws_codepipeline.bar", "stage.2.action.0.role_arn",
+						regexp.MustCompile("^arn:aws:iam::[0-9]{12}:role/codepipeline-action-role.*")),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSCodePipelineExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -875,4 +903,148 @@ resource "aws_codepipeline" "test" {
   }
 }
 `, rName, tag1, tag2)
+}
+
+func testAccAWSCodePipelineConfig_multiregion(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "eu-west-1" {
+  bucket = "tf-test-pipeline-eu-west-1-%s"
+  acl    = "private"
+}
+
+resource "aws_s3_bucket" "eu-central-1" {
+  bucket = "tf-test-pipeline-eu-central-1-%s"
+  acl    = "private"
+}
+
+resource "aws_iam_role" "codepipeline_role" {
+  name = "codepipeline-role-%s"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "codepipeline.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "codepipeline_policy" {
+  name = "codepipeline_policy"
+  role = "${aws_iam_role.codepipeline_role.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect":"Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:GetObjectVersion",
+        "s3:GetBucketVersioning"
+      ],
+      "Resource": [
+        "${aws_s3_bucket.foo.arn}",
+        "${aws_s3_bucket.foo.arn}/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "codebuild:BatchGetBuilds",
+        "codebuild:StartBuild"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_codepipeline" "bar" {
+  name     = "test-pipeline-%s"
+  role_arn = "${aws_iam_role.codepipeline_role.arn}"
+
+  artifact_stores {
+	  eu-west-1 = {
+			location = "${aws_s3_bucket.eu-west-1.bucket}"
+			type     = "S3"
+
+			encryption_key {
+				id   = "1234"
+				type = "KMS"
+			}
+		}
+
+		eu-central-1 = {
+			location = "${aws_s3_bucket.eu-central-1.bucket}"
+			type     = "S3"
+
+			encryption_key {
+				id   = "1234"
+				type = "KMS"
+			}
+		}
+	}
+
+  stage {
+    name = "Source"
+
+    action {
+      name             = "Source"
+      category         = "Source"
+      owner            = "ThirdParty"
+      provider         = "GitHub"
+      version          = "1"
+      output_artifacts = ["test"]
+
+      configuration = {
+        Owner  = "lifesum-terraform"
+        Repo   = "test"
+        Branch = "master"
+      }
+    }
+  }
+
+  stage {
+    name = "Build"
+
+    action {
+		  region          = "eu-west-1"
+      name            = "EuWest1Build"
+      category        = "Build"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      input_artifacts = ["test"]
+      version         = "1"
+
+      configuration = {
+        ProjectName = "EuWest1Test"
+      }
+    }
+
+    action {
+		  region          = "eu-central-1"
+      name            = "EuCentral1Build"
+      category        = "Build"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      input_artifacts = ["test"]
+      version         = "1"
+
+      configuration = {
+        ProjectName = "EuCentral1Test"
+      }
+    }
+  }
+}
+`, rName, rName, rName, rName)
 }

--- a/aws/resource_aws_codepipeline_webhook_test.go
+++ b/aws/resource_aws_codepipeline_webhook_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -13,10 +12,6 @@ import (
 )
 
 func TestAccAWSCodePipelineWebhook_basic(t *testing.T) {
-	if os.Getenv("GITHUB_TOKEN") == "" {
-		t.Skip("Environment variable GITHUB_TOKEN is not set")
-	}
-
 	var v codepipeline.ListWebhookItem
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_codepipeline_webhook.test"
@@ -48,10 +43,6 @@ func TestAccAWSCodePipelineWebhook_basic(t *testing.T) {
 }
 
 func TestAccAWSCodePipelineWebhook_ipAuth(t *testing.T) {
-	if os.Getenv("GITHUB_TOKEN") == "" {
-		t.Skip("Environment variable GITHUB_TOKEN is not set")
-	}
-
 	var v codepipeline.ListWebhookItem
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_codepipeline_webhook.test"
@@ -83,10 +74,6 @@ func TestAccAWSCodePipelineWebhook_ipAuth(t *testing.T) {
 }
 
 func TestAccAWSCodePipelineWebhook_unauthenticated(t *testing.T) {
-	if os.Getenv("GITHUB_TOKEN") == "" {
-		t.Skip("Environment variable GITHUB_TOKEN is not set")
-	}
-
 	var v codepipeline.ListWebhookItem
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_codepipeline_webhook.test"
@@ -116,10 +103,6 @@ func TestAccAWSCodePipelineWebhook_unauthenticated(t *testing.T) {
 }
 
 func TestAccAWSCodePipelineWebhook_tags(t *testing.T) {
-	if os.Getenv("GITHUB_TOKEN") == "" {
-		t.Skip("Environment variable GITHUB_TOKEN is not set")
-	}
-
 	var v1, v2, v3 codepipeline.ListWebhookItem
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_codepipeline_webhook.test"
@@ -182,10 +165,6 @@ func TestAccAWSCodePipelineWebhook_tags(t *testing.T) {
 }
 
 func TestAccAWSCodePipelineWebhook_UpdateAuthenticationConfiguration_SecretToken(t *testing.T) {
-	if os.Getenv("GITHUB_TOKEN") == "" {
-		t.Skip("Environment variable GITHUB_TOKEN is not set")
-	}
-
 	var v1, v2 codepipeline.ListWebhookItem
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_codepipeline_webhook.test"

--- a/aws/resource_aws_codepipeline_webhook_test.go
+++ b/aws/resource_aws_codepipeline_webhook_test.go
@@ -15,7 +15,6 @@ func TestAccAWSCodePipelineWebhook_basic(t *testing.T) {
 	var v codepipeline.ListWebhookItem
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_codepipeline_webhook.test"
-	pipelineResourceName := "aws_codepipeline.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCodePipeline(t) },
@@ -25,7 +24,6 @@ func TestAccAWSCodePipelineWebhook_basic(t *testing.T) {
 			{
 				Config: testAccAWSCodePipelineWebhookConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodePipelineExists(pipelineResourceName),
 					testAccCheckAWSCodePipelineWebhookExists(resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "url"),
@@ -46,7 +44,6 @@ func TestAccAWSCodePipelineWebhook_ipAuth(t *testing.T) {
 	var v codepipeline.ListWebhookItem
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_codepipeline_webhook.test"
-	pipelineResourceName := "aws_codepipeline.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCodePipeline(t) },
@@ -56,7 +53,6 @@ func TestAccAWSCodePipelineWebhook_ipAuth(t *testing.T) {
 			{
 				Config: testAccAWSCodePipelineWebhookConfig_ipAuth(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodePipelineExists(pipelineResourceName),
 					testAccCheckAWSCodePipelineWebhookExists(resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "url"),
@@ -77,7 +73,6 @@ func TestAccAWSCodePipelineWebhook_unauthenticated(t *testing.T) {
 	var v codepipeline.ListWebhookItem
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_codepipeline_webhook.test"
-	pipelineResourceName := "aws_codepipeline.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCodePipeline(t) },
@@ -87,7 +82,6 @@ func TestAccAWSCodePipelineWebhook_unauthenticated(t *testing.T) {
 			{
 				Config: testAccAWSCodePipelineWebhookConfig_unauthenticated(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodePipelineExists(pipelineResourceName),
 					testAccCheckAWSCodePipelineWebhookExists(resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "url"),
@@ -106,7 +100,6 @@ func TestAccAWSCodePipelineWebhook_tags(t *testing.T) {
 	var v1, v2, v3 codepipeline.ListWebhookItem
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_codepipeline_webhook.test"
-	pipelineResourceName := "aws_codepipeline.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCodePipeline(t) },
@@ -116,7 +109,6 @@ func TestAccAWSCodePipelineWebhook_tags(t *testing.T) {
 			{
 				Config: testAccAWSCodePipelineWebhookConfigWithTags(rName, "tag1value", "tag2value"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodePipelineExists(pipelineResourceName),
 					testAccCheckAWSCodePipelineWebhookExists(resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
@@ -127,7 +119,6 @@ func TestAccAWSCodePipelineWebhook_tags(t *testing.T) {
 			{
 				Config: testAccAWSCodePipelineWebhookConfigWithTags(rName, "tag1valueUpdate", "tag2valueUpdate"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodePipelineExists(pipelineResourceName),
 					testAccCheckAWSCodePipelineWebhookExists(resourceName, &v2),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
@@ -149,7 +140,6 @@ func TestAccAWSCodePipelineWebhook_tags(t *testing.T) {
 			{
 				Config: testAccAWSCodePipelineWebhookConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodePipelineExists(pipelineResourceName),
 					testAccCheckAWSCodePipelineWebhookExists(resourceName, &v3),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					func(s *terraform.State) error {
@@ -168,7 +158,6 @@ func TestAccAWSCodePipelineWebhook_UpdateAuthenticationConfiguration_SecretToken
 	var v1, v2 codepipeline.ListWebhookItem
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_codepipeline_webhook.test"
-	pipelineResourceName := "aws_codepipeline.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCodePipeline(t) },
@@ -178,7 +167,6 @@ func TestAccAWSCodePipelineWebhook_UpdateAuthenticationConfiguration_SecretToken
 			{
 				Config: testAccAWSCodePipelineWebhookConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodePipelineExists(pipelineResourceName),
 					testAccCheckAWSCodePipelineWebhookExists(resourceName, &v1),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "url"),
@@ -189,7 +177,6 @@ func TestAccAWSCodePipelineWebhook_UpdateAuthenticationConfiguration_SecretToken
 			{
 				Config: testAccAWSCodePipelineWebhookConfig_secretTokenUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodePipelineExists(pipelineResourceName),
 					testAccCheckAWSCodePipelineWebhookExists(resourceName, &v2),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "url"),

--- a/website/docs/r/codepipeline.markdown
+++ b/website/docs/r/codepipeline.markdown
@@ -190,6 +190,7 @@ A `action` block supports the following arguments:
 * `output_artifacts` - (Optional) A list of artifact names to output. Output artifact names must be unique within a pipeline.
 * `role_arn` - (Optional) The ARN of the IAM service role that will perform the declared action. This is assumed through the roleArn for the pipeline.
 * `run_order` - (Optional) The order in which actions are run.
+* `region` - (Optional) The region in which to run the action.
 
 ~> **Note:** The input artifact of an action must exactly match the output artifact declared in a preceding action, but the input artifact does not have to be the next action in strict sequence from the action that provided the output artifact. Actions in parallel can declare different output artifacts, which are in turn consumed by different following actions.
 

--- a/website/docs/r/codepipeline.markdown
+++ b/website/docs/r/codepipeline.markdown
@@ -157,16 +157,17 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the pipeline.
 * `role_arn` - (Required) A service role Amazon Resource Name (ARN) that grants AWS CodePipeline permission to make calls to AWS services on your behalf.
-* `artifact_store` (Required) An artifact_store block. Artifact stores are documented below.
+* `artifact_store` (Required) One or more artifact_store blocks. Artifact stores are documented below.
 * `stage` (Minimum of at least two `stage` blocks is required) A stage block. Stages are documented below.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 
 An `artifact_store` block supports the following arguments:
 
-* `location` - (Required) The location where AWS CodePipeline stores artifacts for a pipeline, such as an S3 bucket.
+* `location` - (Required) The location where AWS CodePipeline stores artifacts for a pipeline; currently only `S3` is supported.
 * `type` - (Required) The type of the artifact store, such as Amazon S3
 * `encryption_key` - (Optional) The encryption key block AWS CodePipeline uses to encrypt the data in the artifact store, such as an AWS Key Management Service (AWS KMS) key. If you don't specify a key, AWS CodePipeline uses the default key for Amazon Simple Storage Service (Amazon S3). An `encryption_key` block is documented below.
+* `region` - (Optional) The region where the artifact store is located. Required for a cross-region CodePipeline, do not provide for a single-region CodePipeline.
 
 An `encryption_key` block supports the following arguments:
 
@@ -178,7 +179,7 @@ A `stage` block supports the following arguments:
 * `name` - (Required) The name of the stage.
 * `action` - (Required) The action(s) to include in the stage. Defined as an `action` block below
 
-A `action` block supports the following arguments:
+An `action` block supports the following arguments:
 
 * `category` - (Required) A category defines what kind of action can be taken in the stage, and constrains the provider type for the action. Possible values are `Approval`, `Build`, `Deploy`, `Invoke`, `Source` and `Test`.
 * `owner` - (Required) The creator of the action being called. Possible values are `AWS`, `Custom` and `ThirdParty`.


### PR DESCRIPTION
This PR picks up on the work done by @bashton-ajenkins in #7866 to add cross-region actions.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #7866
Closes #6871

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_codepipeline: Adds cross-region action support
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCodePipeline_'

--- PASS: TestAccAWSCodePipeline_emptyArtifacts (33.68s)
--- PASS: TestAccAWSCodePipeline_deployWithServiceRole (43.31s)
--- PASS: TestAccAWSCodePipeline_multiregion_basic (43.95s)
--- PASS: TestAccAWSCodePipeline_basic (57.33s)
--- PASS: TestAccAWSCodePipeline_multiregion_Update (66.48s)
--- PASS: TestAccAWSCodePipeline_tags (76.28s)
--- PASS: TestAccAWSCodePipeline_multiregion_ConvertSingleRegion (82.51s)
```
