### PR TITLE
Add additional bandwidth options for Direct Connect

### DIFF
--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1958,6 +1958,8 @@ func validateCognitoRoles(v map[string]interface{}) (errors []error) {
 func validateDxConnectionBandWidth() schema.SchemaValidateFunc {
 	return validation.StringInSlice([]string{
 		"1Gbps",
+		"2Gbps",
+		"5Gbps",
 		"10Gbps",
 		"50Mbps",
 		"100Mbps",

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2841,6 +2841,8 @@ func TestValidateCloudFrontPublicKeyNamePrefix(t *testing.T) {
 func TestValidateDxConnectionBandWidth(t *testing.T) {
 	validBandwidths := []string{
 		"1Gbps",
+		"2Gbps",
+		"5Gbps",
 		"10Gbps",
 		"50Mbps",
 		"100Mbps",

--- a/website/docs/r/dx_connection.html.markdown
+++ b/website/docs/r/dx_connection.html.markdown
@@ -25,7 +25,7 @@ resource "aws_dx_connection" "hoge" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the connection.
-* `bandwidth` - (Required) The bandwidth of the connection. Available values: 1Gbps, 10Gbps. Case sensitive.
+* `bandwidth` - (Required) The bandwidth of the connection. Valid values for dedicated connections: 1Gbps, 10Gbps. Valid values for hosted connections: 50Mbps, 100Mbps, 200Mbps, 300Mbps, 400Mbps, 500Mbps, 1Gbps, 2Gbps, 5Gbps and 10Gbps. Case sensitive.
 * `location` - (Required) The AWS Direct Connect location where the connection is located. See [DescribeLocations](https://docs.aws.amazon.com/directconnect/latest/APIReference/API_DescribeLocations.html) for the list of AWS Direct Connect locations. Use `locationCode`.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/dx_lag.html.markdown
+++ b/website/docs/r/dx_lag.html.markdown
@@ -28,7 +28,7 @@ resource "aws_dx_lag" "hoge" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the LAG.
-* `connections_bandwidth` - (Required) The bandwidth of the individual physical connections bundled by the LAG. Available values: 1Gbps, 10Gbps. Case sensitive.
+* `connections_bandwidth` - (Required) The bandwidth of the individual physical connections bundled by the LAG. Valid values: 50Mbps, 100Mbps, 200Mbps, 300Mbps, 400Mbps, 500Mbps, 1Gbps, 2Gbps, 5Gbps and 10Gbps. Case sensitive.
 * `location` - (Required) The AWS Direct Connect location in which the LAG should be allocated. See [DescribeLocations](https://docs.aws.amazon.com/directconnect/latest/APIReference/API_DescribeLocations.html) for the list of AWS Direct Connect locations. Use `locationCode`.
 * `force_destroy` - (Optional, Default:false) A boolean that indicates all connections associated with the LAG should be deleted so that the LAG can be destroyed without error. These objects are *not* recoverable.
 * `tags` - (Optional) A mapping of tags to assign to the resource.


### PR DESCRIPTION
* https://docs.aws.amazon.com/directconnect/latest/UserGuide/WorkingWithConnections.html
* https://docs.aws.amazon.com/directconnect/latest/APIReference/API_CreateLag.html

Signed-off-by: Eddie Ramirez <eddieramirez@me.com>

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12558

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

* resource/aws_dx_connection: Support additional bandwidth speeds. [GH-12558]
* resource/aws_dx_lag: Support additional bandwidth speeds. [GH-12558]

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
 $ make testacc TESTARGS='-run=TestValidateDxConnectionBandWidth'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestValidateDxConnectionBandWidth -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestValidateDxConnectionBandWidth
--- PASS: TestValidateDxConnectionBandWidth (0.00s)
PASS

...
```
