### PR TITLE
Fix #12555: Error "grant not found for key id"

### DIFF
--- a/aws/resource_aws_kms_grant.go
+++ b/aws/resource_aws_kms_grant.go
@@ -196,6 +196,11 @@ func resourceAwsKmsGrantRead(d *schema.ResourceData, meta interface{}) error {
 	grant, err := findKmsGrantByIdWithRetry(conn, keyId, grantId)
 
 	if err != nil {
+		if isResourceNotFoundError(err) {
+			log.Printf("[WARN] %s KMS grant id not found for key id %s, removing from state file", grantId, keyId)
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 
@@ -293,6 +298,9 @@ func resourceAwsKmsGrantExists(d *schema.ResourceData, meta interface{}) (bool, 
 	grant, err := findKmsGrantByIdWithRetry(conn, keyId, grantId)
 
 	if err != nil {
+		if isResourceNotFoundError(err) {
+			return false, nil
+		}
 		return true, err
 	}
 	if grant != nil {

--- a/aws/resource_aws_kms_grant_test.go
+++ b/aws/resource_aws_kms_grant_test.go
@@ -170,8 +170,9 @@ func TestAccAWSKmsGrant_ARN(t *testing.T) {
 	})
 }
 
-func TestAccAWSKmsGrant_disappers(t *testing.T) {
-	timestamp := time.Now().Format(time.RFC1123)
+func TestAccAWSKmsGrant_disappears(t *testing.T) {
+	resourceName := "aws_kms_grant.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -179,10 +180,10 @@ func TestAccAWSKmsGrant_disappers(t *testing.T) {
 		CheckDestroy: testAccCheckAWSKmsGrantDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSKmsGrant_Basic("basic", timestamp, "\"Encrypt\", \"Decrypt\""),
+				Config: testAccAWSKmsGrant_Basic(rName, "\"Encrypt\", \"Decrypt\""),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsGrantExists("aws_kms_grant.basic"),
-					testAccCheckAWSKmsGrantDisappears("aws_kms_grant.basic"),
+					testAccCheckAWSKmsGrantExists(resourceName),
+					testAccCheckAWSKmsGrantDisappears(resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},


### PR DESCRIPTION
When a KMS grant was not found, terraform apply failed during
refreshing state with an error "grant not found for key id".

Now, when a KMS grant is not found, it is treated as revoked and
terraform shows the change in the plan and recreates it during apply.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12555

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_kms_grant: Fix error "grant not found for key id" during terraform apply during refreshing state
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSKmsGrant'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSKmsGrant -timeout 120m
...
--- PASS: TestAccAWSKmsGrant_ARN (38.75s)
--- PASS: TestAccAWSKmsGrant_Basic (39.18s)
--- PASS: TestAccAWSKmsGrant_withRetiringPrincipal (39.32s)
--- PASS: TestAccAWSKmsGrant_bare (40.15s)
--- PASS: TestAccAWSKmsGrant_withConstraints (46.74s)
--- PASS: TestAccAWSKmsGrant_disappears (219.23s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	220.491s
```
