### PR TITLE
resource/apigatewayv2: Add support for `body` parameter

### DIFF
--- a/aws/data_source_aws_cloudformation_stack.go
+++ b/aws/data_source_aws_cloudformation_stack.go
@@ -113,7 +113,7 @@ func dataSourceAwsCloudFormationStackRead(d *schema.ResourceData, meta interface
 		return err
 	}
 
-	template, err := normalizeCloudFormationTemplate(*tOut.TemplateBody)
+	template, err := normalizeJsonOrYamlString(*tOut.TemplateBody)
 	if err != nil {
 		return fmt.Errorf("template body contains an invalid JSON or YAML: %s", err)
 	}

--- a/aws/diff_suppress_funcs.go
+++ b/aws/diff_suppress_funcs.go
@@ -97,15 +97,15 @@ func suppressOpenIdURL(k, old, new string, d *schema.ResourceData) bool {
 	return oldUrl.String() == newUrl.String()
 }
 
-func suppressCloudFormationTemplateBodyDiffs(k, old, new string, d *schema.ResourceData) bool {
-	normalizedOld, err := normalizeCloudFormationTemplate(old)
+func suppressEquivalentJsonOrYamlDiffs(k, old, new string, d *schema.ResourceData) bool {
+	normalizedOld, err := normalizeJsonOrYamlString(old)
 
 	if err != nil {
 		log.Printf("[WARN] Unable to normalize Terraform state CloudFormation template body: %s", err)
 		return false
 	}
 
-	normalizedNew, err := normalizeCloudFormationTemplate(new)
+	normalizedNew, err := normalizeJsonOrYamlString(new)
 
 	if err != nil {
 		log.Printf("[WARN] Unable to normalize Terraform configuration CloudFormation template body: %s", err)
@@ -114,8 +114,6 @@ func suppressCloudFormationTemplateBodyDiffs(k, old, new string, d *schema.Resou
 
 	return normalizedOld == normalizedNew
 }
-
-var suppressOpenAPISpecificationDiffs = suppressCloudFormationTemplateBodyDiffs
 
 // suppressEqualCIDRBlockDiffs provides custom difference suppression for CIDR blocks
 // that have different string values but represent the same CIDR.

--- a/aws/diff_suppress_funcs.go
+++ b/aws/diff_suppress_funcs.go
@@ -115,6 +115,8 @@ func suppressCloudFormationTemplateBodyDiffs(k, old, new string, d *schema.Resou
 	return normalizedOld == normalizedNew
 }
 
+var suppressOpenAPISpecificationDiffs = suppressCloudFormationTemplateBodyDiffs
+
 // suppressEqualCIDRBlockDiffs provides custom difference suppression for CIDR blocks
 // that have different string values but represent the same CIDR.
 func suppressEqualCIDRBlockDiffs(k, old, new string, d *schema.ResourceData) bool {

--- a/aws/diff_suppress_funcs_test.go
+++ b/aws/diff_suppress_funcs_test.go
@@ -71,7 +71,7 @@ func TestSuppressEquivalentTypeStringBoolean(t *testing.T) {
 	}
 }
 
-func TestSuppressCloudFormationTemplateBodyDiffs(t *testing.T) {
+func TestSuppressEquivalentJsonOrYamlDiffs(t *testing.T) {
 	testCases := []struct {
 		description string
 		equivalent  bool
@@ -253,7 +253,7 @@ Outputs:
 	}
 
 	for _, tc := range testCases {
-		value := suppressCloudFormationTemplateBodyDiffs("test_property", tc.old, tc.new, nil)
+		value := suppressEquivalentJsonOrYamlDiffs("test_property", tc.old, tc.new, nil)
 
 		if tc.equivalent && !value {
 			t.Fatalf("expected test case (%s) to be equivalent", tc.description)

--- a/aws/resource_aws_apigatewayv2_api.go
+++ b/aws/resource_aws_apigatewayv2_api.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"reflect"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
@@ -101,6 +102,12 @@ func resourceAwsApiGatewayV2Api() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validation.StringLenBetween(1, 128),
 			},
+			"body": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: suppressOpenAPISpecificationDiffs,
+				ValidateFunc:     validateOpenAPISpecification,
+			},
 			"protocol_type": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -133,6 +140,64 @@ func resourceAwsApiGatewayV2Api() *schema.Resource {
 			},
 		},
 	}
+}
+
+func resourceAwsAPIGatewayV2ImportOpenAPI(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).apigatewayv2conn
+
+	if body, ok := d.GetOk("body"); ok {
+		revertReq := &apigatewayv2.UpdateApiInput{
+			ApiId:       aws.String(d.Id()),
+			Name:        aws.String(d.Get("name").(string)),
+			Description: aws.String(d.Get("description").(string)),
+			Version:     aws.String(d.Get("version").(string)),
+		}
+
+		log.Printf("[DEBUG] Updating API Gateway from OpenAPI spec %s", d.Id())
+		importReq := &apigatewayv2.ReimportApiInput{
+			ApiId: aws.String(d.Id()),
+			Body:  aws.String(body.(string)),
+		}
+
+		_, err := conn.ReimportApi(importReq)
+
+		if err != nil {
+			return fmt.Errorf("error importing API Gateway v2 API (%s) OpenAPI specification: %s", d.Id(), err)
+		}
+
+		tags := d.Get("tags")
+		corsConfiguration := d.Get("cors_configuration")
+
+		if err := resourceAwsApiGatewayV2ApiRead(d, meta); err != nil {
+			return err
+		}
+
+		if !reflect.DeepEqual(corsConfiguration, d.Get("cors_configuration")) {
+			if len(corsConfiguration.([]interface{})) == 0 {
+				log.Printf("[DEBUG] Deleting CORS configuration for API Gateway v2 API (%s)", d.Id())
+				_, err := conn.DeleteCorsConfiguration(&apigatewayv2.DeleteCorsConfigurationInput{
+					ApiId: aws.String(d.Id()),
+				})
+				if err != nil {
+					return fmt.Errorf("error deleting CORS configuration for API Gateway v2 API (%s): %s", d.Id(), err)
+				}
+			} else {
+				revertReq.CorsConfiguration = expandApiGateway2CorsConfiguration(corsConfiguration.([]interface{}))
+			}
+		}
+
+		if err := keyvaluetags.Apigatewayv2UpdateTags(conn, d.Get("arn").(string), d.Get("tags"), tags); err != nil {
+			return fmt.Errorf("error updating API Gateway v2 API (%s) tags: %s", d.Id(), err)
+		}
+
+		log.Printf("[DEBUG] Reverting API Gateway v2 API: %s", revertReq)
+		_, err = conn.UpdateApi(revertReq)
+		if err != nil {
+			return fmt.Errorf("error updating API Gateway v2 API (%s): %s", d.Id(), err)
+		}
+	}
+
+	return nil
 }
 
 func resourceAwsApiGatewayV2ApiCreate(d *schema.ResourceData, meta interface{}) error {
@@ -176,6 +241,11 @@ func resourceAwsApiGatewayV2ApiCreate(d *schema.ResourceData, meta interface{}) 
 	}
 
 	d.SetId(aws.StringValue(resp.ApiId))
+
+	err = resourceAwsAPIGatewayV2ImportOpenAPI(d, meta)
+	if err != nil {
+		return err
+	}
 
 	return resourceAwsApiGatewayV2ApiRead(d, meta)
 }
@@ -283,6 +353,13 @@ func resourceAwsApiGatewayV2ApiUpdate(d *schema.ResourceData, meta interface{}) 
 		o, n := d.GetChange("tags")
 		if err := keyvaluetags.Apigatewayv2UpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
 			return fmt.Errorf("error updating API Gateway v2 API (%s) tags: %s", d.Id(), err)
+		}
+	}
+
+	if d.HasChange("body") {
+		err := resourceAwsAPIGatewayV2ImportOpenAPI(d, meta)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/aws/resource_aws_apigatewayv2_api.go
+++ b/aws/resource_aws_apigatewayv2_api.go
@@ -105,8 +105,8 @@ func resourceAwsApiGatewayV2Api() *schema.Resource {
 			"body": {
 				Type:             schema.TypeString,
 				Optional:         true,
-				DiffSuppressFunc: suppressOpenAPISpecificationDiffs,
-				ValidateFunc:     validateOpenAPISpecification,
+				DiffSuppressFunc: suppressEquivalentJsonOrYamlDiffs,
+				ValidateFunc:     validateStringIsJsonOrYaml,
 			},
 			"protocol_type": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_apigatewayv2_api_test.go
+++ b/aws/resource_aws_apigatewayv2_api_test.go
@@ -317,6 +317,231 @@ func TestAccAWSAPIGatewayV2Api_AllAttributesHttp(t *testing.T) {
 	})
 }
 
+func TestAccAWSAPIGatewayV2Api_Openapi(t *testing.T) {
+	var v apigatewayv2.GetApiOutput
+	resourceName := "aws_apigatewayv2_api.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayV2ApiDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayV2ApiConfig_OpenAPI(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2ApiExists(resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "api_endpoint"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "version", ""),
+					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/apis/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "protocol_type", apigatewayv2.ProtocolTypeHttp),
+					testAccCheckAWSAPIGatewayV2ApiRoutes(&v, []string{"GET /test"}),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"body"},
+			},
+			{
+				Config: testAccAWSAPIGatewayV2ApiConfig_UpdatedOpenAPIYaml(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "version", ""),
+					testAccCheckAWSAPIGatewayV2ApiExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "protocol_type", apigatewayv2.ProtocolTypeHttp),
+					testAccCheckAWSAPIGatewayV2ApiRoutes(&v, []string{"GET /update"}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayV2Api_Openapi_WithTags(t *testing.T) {
+	var v apigatewayv2.GetApiOutput
+	resourceName := "aws_apigatewayv2_api.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayV2ApiDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayV2ApiConfig_OpenAPIYaml_tags(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2ApiExists(resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "api_endpoint"),
+					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/apis/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "protocol_type", apigatewayv2.ProtocolTypeHttp),
+					testAccCheckAWSAPIGatewayV2ApiRoutes(&v, []string{"GET /test"}),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "Value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "Value2"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"body"},
+			},
+			{
+				Config: testAccAWSAPIGatewayV2ApiConfig_OpenAPIYaml_tagsUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2ApiExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "protocol_type", apigatewayv2.ProtocolTypeHttp),
+					testAccCheckAWSAPIGatewayV2ApiRoutes(&v, []string{"GET /update"}),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "Value1U"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "Value2U"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayV2Api_Openapi_WithCorsConfiguration(t *testing.T) {
+	var v apigatewayv2.GetApiOutput
+	resourceName := "aws_apigatewayv2_api.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayV2ApiDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayV2ApiConfig_OpenAPIYaml_corsConfiguration(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2ApiExists(resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "api_endpoint"),
+					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/apis/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "protocol_type", apigatewayv2.ProtocolTypeHttp),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.0.allow_methods.#", "1"),
+					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "cors_configuration.0.allow_methods.*", "delete"),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.0.allow_origins.#", "1"),
+					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "cors_configuration.0.allow_origins.*", "https://www.google.de"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"body"},
+			},
+			{
+				Config: testAccAWSAPIGatewayV2ApiConfig_OpenAPIYaml_corsConfigurationUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2ApiExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "protocol_type", apigatewayv2.ProtocolTypeHttp),
+					testAccCheckAWSAPIGatewayV2ApiRoutes(&v, []string{"GET /update"}),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.#", "0"),
+				),
+			},
+			{
+				Config: testAccAWSAPIGatewayV2ApiConfig_OpenAPIYaml_corsConfigurationUpdated2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2ApiExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "protocol_type", apigatewayv2.ProtocolTypeHttp),
+					testAccCheckAWSAPIGatewayV2ApiRoutes(&v, []string{"GET /update"}),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.0.allow_methods.#", "2"),
+					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "cors_configuration.0.allow_methods.*", "get"),
+					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "cors_configuration.0.allow_methods.*", "put"),
+					resource.TestCheckResourceAttr(resourceName, "cors_configuration.0.allow_origins.#", "2"),
+					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "cors_configuration.0.allow_origins.*", "https://www.example.com"),
+					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "cors_configuration.0.allow_origins.*", "https://www.google.de"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayV2Api_OpenapiWithMoreFields(t *testing.T) {
+	var v apigatewayv2.GetApiOutput
+	resourceName := "aws_apigatewayv2_api.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayV2ApiDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayV2ApiConfig_OpenAPIYaml(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2ApiExists(resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "api_endpoint"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "version", ""),
+					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/apis/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "protocol_type", apigatewayv2.ProtocolTypeHttp),
+					testAccCheckAWSAPIGatewayV2ApiRoutes(&v, []string{"GET /test"}),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"body"},
+			},
+			{
+				Config: testAccAWSAPIGatewayV2ApiConfig_UpdatedOpenAPI2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "description", "description test"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "version", "2017-04-21T04:08:08Z"),
+					testAccCheckAWSAPIGatewayV2ApiExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "protocol_type", apigatewayv2.ProtocolTypeHttp),
+					testAccCheckAWSAPIGatewayV2ApiRoutes(&v, []string{"GET /update"}),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"body"},
+			},
+		},
+	})
+}
+
+func testAccCheckAWSAPIGatewayV2ApiRoutes(v *apigatewayv2.GetApiOutput, routes []string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).apigatewayv2conn
+
+		resp, err := conn.GetRoutes(&apigatewayv2.GetRoutesInput{
+			ApiId: v.ApiId,
+		})
+		if err != nil {
+			return err
+		}
+
+		actualRoutePaths := map[string]bool{}
+		for _, route := range resp.Items {
+			actualRoutePaths[*route.RouteKey] = true
+		}
+
+		for _, route := range routes {
+			if _, ok := actualRoutePaths[route]; !ok {
+				return fmt.Errorf("Expected path %v but did not find it in %v", route, actualRoutePaths)
+			}
+			delete(actualRoutePaths, route)
+		}
+
+		if len(actualRoutePaths) > 0 {
+			return fmt.Errorf("Found unexpected paths %v", actualRoutePaths)
+		}
+
+		return nil
+	}
+}
+
 func TestAccAWSAPIGatewayV2Api_Tags(t *testing.T) {
 	var v apigatewayv2.GetApiOutput
 	resourceName := "aws_apigatewayv2_api.test"
@@ -764,4 +989,274 @@ resource "aws_apigatewayv2_api" "test" {
   route_key     = "GET /pets"
 }
 `, rName)
+}
+
+func testAccAWSAPIGatewayV2ApiConfig_OpenAPI(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_apigatewayv2_api" "test" {
+  name = "%s"
+  protocol_type = "HTTP"
+  body = <<EOF
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "%s_DIFFERENT",
+    "version": "1.0"
+  },
+  "paths": {
+    "/test": {
+      "get": {
+        "x-amazon-apigateway-integration": {
+          "type": "HTTP_PROXY",
+          "httpMethod": "GET",
+          "payloadFormatVersion": "1.0",
+          "uri": "https://www.google.de"
+        }
+      }
+    }
+  }
+}
+EOF
+}
+`, rName, rName)
+}
+
+func testAccAWSAPIGatewayV2ApiConfig_OpenAPIYaml(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_apigatewayv2_api" "test" {
+  name = "%s"
+  protocol_type = "HTTP"
+  body = <<EOF
+---
+openapi: 3.0.1
+info:
+  title: %s_DIFFERENT
+  version: 1.0
+paths:
+  "/test":
+    get:
+      x-amazon-apigateway-integration:
+        type: HTTP_PROXY
+        httpMethod: GET
+        payloadFormatVersion: '1.0'
+        uri: https://www.google.de
+EOF
+}
+`, rName, rName)
+}
+
+func testAccAWSAPIGatewayV2ApiConfig_OpenAPIYaml_corsConfiguration(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_apigatewayv2_api" "test" {
+  name = "%s"
+  protocol_type = "HTTP"
+  cors_configuration {
+    allow_methods = ["delete"]
+    allow_origins = ["https://www.google.de"]
+  }
+  body = <<EOF
+---
+openapi: 3.0.1
+info:
+  title: %s_DIFFERENT
+  version: 2.0
+x-amazon-apigateway-cors:
+  allow_methods:
+    - delete
+  allow_origins:
+    - https://www.google.de
+paths:
+  "/test":
+    get:
+      x-amazon-apigateway-integration:
+        type: HTTP_PROXY
+        httpMethod: GET
+        payloadFormatVersion: '1.0'
+        uri: https://www.google.de
+EOF
+}
+`, rName, rName)
+}
+
+func testAccAWSAPIGatewayV2ApiConfig_OpenAPIYaml_corsConfigurationUpdated(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_apigatewayv2_api" "test" {
+  name = "%s"
+	protocol_type = "HTTP"
+  body = <<EOF
+---
+openapi: 3.0.1
+info:
+  title: %s_DIFFERENT
+  version: 2.0
+x-amazon-apigateway-cors:
+  allow_methods:
+    - delete
+  allow_origins:
+    - https://www.google.de
+paths:
+  "/update":
+    get:
+      x-amazon-apigateway-integration:
+        type: HTTP_PROXY
+        httpMethod: GET
+        payloadFormatVersion: 1.0
+        uri: https://www.google.de
+EOF
+}
+`, rName, rName)
+}
+
+func testAccAWSAPIGatewayV2ApiConfig_OpenAPIYaml_corsConfigurationUpdated2(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_apigatewayv2_api" "test" {
+  name = "%s"
+	protocol_type = "HTTP"
+	cors_configuration {
+    allow_methods = ["put", "get"]
+    allow_origins = ["https://www.google.de", "https://www.example.com"]
+  }
+  body = <<EOF
+---
+openapi: 3.0.1
+info:
+  title: %s_DIFFERENT
+  version: 2.0
+x-amazon-apigateway-cors:
+  allow_methods:
+    - delete
+  allow_origins:
+    - https://www.google.de
+paths:
+  "/update":
+    get:
+      x-amazon-apigateway-integration:
+        type: HTTP_PROXY
+        httpMethod: GET
+        payloadFormatVersion: 1.0
+        uri: https://www.google.de
+EOF
+}
+`, rName, rName)
+}
+
+func testAccAWSAPIGatewayV2ApiConfig_OpenAPIYaml_tags(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_apigatewayv2_api" "test" {
+  name = "%s"
+  protocol_type = "HTTP"
+    tags = {
+    Key1 = "Value1"
+    Key2 = "Value2"
+  }
+  body = <<EOF
+---
+openapi: 3.0.1
+info:
+  title: %s_DIFFERENT
+  version: 2.0
+tags:
+  - name: Key1
+    x-amazon-apigateway-tag-value: Value3
+paths:
+  "/test":
+    get:
+      x-amazon-apigateway-integration:
+        type: HTTP_PROXY
+        httpMethod: GET
+        payloadFormatVersion: '1.0'
+        uri: https://www.google.de
+EOF
+}
+`, rName, rName)
+}
+
+func testAccAWSAPIGatewayV2ApiConfig_OpenAPIYaml_tagsUpdated(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_apigatewayv2_api" "test" {
+  name = "%s"
+  protocol_type = "HTTP"
+  tags = {
+    Key1 = "Value1U"
+    Key2 = "Value2U"
+  }
+  body = <<EOF
+---
+openapi: 3.0.1
+info:
+  title: %s_DIFFERENT
+  version: 2.0
+tags:
+  - name: Key3
+    x-amazon-apigateway-tag-value: Value3
+  - name: Key4
+    x-amazon-apigateway-tag-value: Value3
+paths:
+  "/update":
+    get:
+      x-amazon-apigateway-integration:
+        type: HTTP_PROXY
+        httpMethod: GET
+        payloadFormatVersion: 1.0
+        uri: https://www.google.de
+EOF
+}
+`, rName, rName)
+}
+
+func testAccAWSAPIGatewayV2ApiConfig_UpdatedOpenAPIYaml(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_apigatewayv2_api" "test" {
+  name = "%s"
+  protocol_type = "HTTP"
+  body = <<EOF
+---
+openapi: 3.0.1
+info:
+  title: %s_DIFFERENT
+  version: 2.0
+paths:
+  "/update":
+    get:
+      x-amazon-apigateway-integration:
+        type: HTTP_PROXY
+        httpMethod: GET
+        payloadFormatVersion: 1.0
+        uri: https://www.google.de
+EOF
+}
+`, rName, rName)
+}
+
+func testAccAWSAPIGatewayV2ApiConfig_UpdatedOpenAPI2(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_apigatewayv2_api" "test" {
+  name = "%s"
+  protocol_type = "HTTP"
+  version = "2017-04-21T04:08:08Z"
+  description = "description test"
+  body = <<EOF
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "%s_DIFFERENT",
+    "version": "2.0",
+    "description": "description different" 
+  },
+  "paths": {
+    "/update": {
+      "get": {
+        "x-amazon-apigateway-integration": {
+          "type": "HTTP_PROXY",
+          "httpMethod": "GET",
+          "payloadFormatVersion": "1.0",
+          "uri": "https://www.google.de"
+        }
+      }
+    }
+  }
+}
+EOF
+}
+`, rName, rName)
 }

--- a/aws/resource_aws_cloudformation_stack.go
+++ b/aws/resource_aws_cloudformation_stack.go
@@ -43,9 +43,9 @@ func resourceAwsCloudFormationStack() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validateCloudFormationTemplate,
+				ValidateFunc: validateStringIsJsonOrYaml,
 				StateFunc: func(v interface{}) string {
-					template, _ := normalizeCloudFormationTemplate(v)
+					template, _ := normalizeJsonOrYamlString(v)
 					return template
 				},
 			},
@@ -121,7 +121,7 @@ func resourceAwsCloudFormationStackCreate(d *schema.ResourceData, meta interface
 		StackName: aws.String(d.Get("name").(string)),
 	}
 	if v, ok := d.GetOk("template_body"); ok {
-		template, err := normalizeCloudFormationTemplate(v)
+		template, err := normalizeJsonOrYamlString(v)
 		if err != nil {
 			return fmt.Errorf("template body contains an invalid JSON or YAML: %s", err)
 		}
@@ -300,7 +300,7 @@ func resourceAwsCloudFormationStackRead(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	template, err := normalizeCloudFormationTemplate(*out.TemplateBody)
+	template, err := normalizeJsonOrYamlString(*out.TemplateBody)
 	if err != nil {
 		return fmt.Errorf("template body contains an invalid JSON or YAML: %s", err)
 	}
@@ -365,7 +365,7 @@ func resourceAwsCloudFormationStackUpdate(d *schema.ResourceData, meta interface
 		input.TemplateURL = aws.String(v.(string))
 	}
 	if v, ok := d.GetOk("template_body"); ok && input.TemplateURL == nil {
-		template, err := normalizeCloudFormationTemplate(v)
+		template, err := normalizeJsonOrYamlString(v)
 		if err != nil {
 			return fmt.Errorf("template body contains an invalid JSON or YAML: %s", err)
 		}

--- a/aws/resource_aws_cloudformation_stack_set.go
+++ b/aws/resource_aws_cloudformation_stack_set.go
@@ -86,8 +86,8 @@ func resourceAwsCloudFormationStackSet() *schema.Resource {
 				Optional:         true,
 				Computed:         true,
 				ConflictsWith:    []string{"template_url"},
-				DiffSuppressFunc: suppressCloudFormationTemplateBodyDiffs,
-				ValidateFunc:     validateCloudFormationTemplate,
+				DiffSuppressFunc: suppressEquivalentJsonOrYamlDiffs,
+				ValidateFunc:     validateStringIsJsonOrYaml,
 			},
 			"template_url": {
 				Type:          schema.TypeString,

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -2267,7 +2267,7 @@ func checkYamlString(yamlString interface{}) (string, error) {
 	return s, err
 }
 
-func normalizeCloudFormationTemplate(templateString interface{}) (string, error) {
+func normalizeJsonOrYamlString(templateString interface{}) (string, error) {
 	if looksLikeJsonString(templateString) {
 		return structure.NormalizeJsonString(templateString.(string))
 	}

--- a/aws/structure_test.go
+++ b/aws/structure_test.go
@@ -1266,12 +1266,12 @@ abc:
 	}
 }
 
-func TestNormalizeCloudFormationTemplate(t *testing.T) {
+func TestNormalizeJsonOrYamlString(t *testing.T) {
 	var err error
 	var actual string
 
 	validNormalizedJson := `{"abc":"1"}`
-	actual, err = normalizeCloudFormationTemplate(validNormalizedJson)
+	actual, err = normalizeJsonOrYamlString(validNormalizedJson)
 	if err != nil {
 		t.Fatalf("Expected not to throw an error while parsing template, but got: %s", err)
 	}
@@ -1281,7 +1281,7 @@ func TestNormalizeCloudFormationTemplate(t *testing.T) {
 
 	validNormalizedYaml := `abc: 1
 `
-	actual, err = normalizeCloudFormationTemplate(validNormalizedYaml)
+	actual, err = normalizeJsonOrYamlString(validNormalizedYaml)
 	if err != nil {
 		t.Fatalf("Expected not to throw an error while parsing template, but got: %s", err)
 	}

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -976,7 +976,7 @@ func validateIAMPolicyJson(v interface{}, k string) (ws []string, errors []error
 	return
 }
 
-func validateCloudFormationTemplate(v interface{}, k string) (ws []string, errors []error) {
+func validateStringIsJsonOrYaml(v interface{}, k string) (ws []string, errors []error) {
 	if looksLikeJsonString(v) {
 		if _, err := structure.NormalizeJsonString(v); err != nil {
 			errors = append(errors, fmt.Errorf("%q contains an invalid JSON: %s", k, err))
@@ -988,8 +988,6 @@ func validateCloudFormationTemplate(v interface{}, k string) (ws []string, error
 	}
 	return
 }
-
-var validateOpenAPISpecification = validateCloudFormationTemplate
 
 func validateApiGatewayIntegrationContentHandling() schema.SchemaValidateFunc {
 	return validation.StringInSlice([]string{

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -989,6 +989,8 @@ func validateCloudFormationTemplate(v interface{}, k string) (ws []string, error
 	return
 }
 
+var validateOpenAPISpecification = validateCloudFormationTemplate
+
 func validateApiGatewayIntegrationContentHandling() schema.SchemaValidateFunc {
 	return validation.StringInSlice([]string{
 		apigateway.ContentHandlingStrategyConvertToBinary,

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2,11 +2,12 @@ package aws
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/service/cognitoidentity"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/aws/aws-sdk-go/service/cognitoidentity"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 )
 
 func TestValidateTypeStringNullableBoolean(t *testing.T) {
@@ -823,7 +824,7 @@ func TestValidateIAMPolicyJsonString(t *testing.T) {
 	}
 }
 
-func TestValidateCloudFormationTemplate(t *testing.T) {
+func TestValidateStringIsJsonOrYaml(t *testing.T) {
 	type testCases struct {
 		Value    string
 		ErrCount int
@@ -841,7 +842,7 @@ func TestValidateCloudFormationTemplate(t *testing.T) {
 	}
 
 	for _, tc := range invalidCases {
-		_, errors := validateCloudFormationTemplate(tc.Value, "template")
+		_, errors := validateStringIsJsonOrYaml(tc.Value, "template")
 		if len(errors) != tc.ErrCount {
 			t.Fatalf("Expected %q to trigger a validation error.", tc.Value)
 		}
@@ -859,7 +860,7 @@ func TestValidateCloudFormationTemplate(t *testing.T) {
 	}
 
 	for _, tc := range validCases {
-		_, errors := validateCloudFormationTemplate(tc.Value, "template")
+		_, errors := validateStringIsJsonOrYaml(tc.Value, "template")
 		if len(errors) != tc.ErrCount {
 			t.Fatalf("Expected %q not to trigger a validation error.", tc.Value)
 		}

--- a/website/docs/r/apigatewayv2_api.html.markdown
+++ b/website/docs/r/apigatewayv2_api.html.markdown
@@ -52,7 +52,15 @@ Defaults to `$request.method $request.path`.
 * `target` - (Optional) Part of _quick create_. Quick create produces an API with an integration, a default catch-all route, and a default stage which is configured to automatically deploy changes.
 For HTTP integrations, specify a fully qualified URL. For Lambda integrations, specify a function ARN.
 The type of the integration will be `HTTP_PROXY` or `AWS_PROXY`, respectively. Applicable for HTTP APIs.
+* `body` - (Optional) An OpenAPI specification that defines the set of routes and integrations to create as part of the HTTP APIs. Supported only for HTTP APIs.
 * `version` - (Optional) A version identifier for the API.
+
+__Note__: If the `body` argument is provided, the OpenAPI specification will be used to configure the integrations and route for the HTTP API. If this argument is provided, the following resources should not be managed as separate ones, as updates may cause manual resource updates to be overwritten:
+
+* `aws_apigatewayv2_integration`
+* `aws_apigatewayv2_route`
+
+Further more, the `name`, `description`, `cors_configuration`, `tags` and `version` fields should be specified in the Terraform configuration and the values will override any values specified in the OpenAPI document.
 
 The `cors_configuration` object supports the following:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11148 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/apigatewayv2: Add support for `body` parameter
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSAPIGatewayV2Api_Openapi'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSAPIGatewayV2Api_Openapi -timeout 120m
=== RUN   TestAccAWSAPIGatewayV2Api_Openapi
=== PAUSE TestAccAWSAPIGatewayV2Api_Openapi
=== RUN   TestAccAWSAPIGatewayV2Api_OpenapiWithMoreFields
=== PAUSE TestAccAWSAPIGatewayV2Api_OpenapiWithMoreFields
=== CONT  TestAccAWSAPIGatewayV2Api_Openapi
=== CONT  TestAccAWSAPIGatewayV2Api_OpenapiWithMoreFields
--- PASS: TestAccAWSAPIGatewayV2Api_Openapi (86.59s)
--- PASS: TestAccAWSAPIGatewayV2Api_OpenapiWithMoreFields (91.46s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	93.017s

...
```
