### PR TITLE
Add path_part attribute to aws_api_gateway_deployment documentation

### DIFF
--- a/website/docs/r/api_gateway_resource.html.markdown
+++ b/website/docs/r/api_gateway_resource.html.markdown
@@ -39,6 +39,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource's identifier.
 * `path` - The complete path for this API resource, including all parent paths.
+* `path_part` - The last path segment of this API resource.
 
 ## Import
 


### PR DESCRIPTION
## Changelog
* Add the `path_part` attribute, as I was able to refer to this in the latest Terraform version.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
