### PR TITLE
Assign EfsVolumeConfiguration when present

### DIFF
--- a/aws/structure.go
+++ b/aws/structure.go
@@ -699,7 +699,7 @@ func flattenEcsVolumes(list []*ecs.Volume) []map[string]interface{} {
 			l["docker_volume_configuration"] = flattenDockerVolumeConfiguration(volume.DockerVolumeConfiguration)
 		}
 
-		if volume.DockerVolumeConfiguration != nil {
+		if volume.EfsVolumeConfiguration != nil {
 			l["efs_volume_configuration"] = flattenEFSVolumeConfiguration(volume.EfsVolumeConfiguration)
 		}
 


### PR DESCRIPTION
# EFS never assigned?
I could be totally wrong, but I think this statement was copypasta from the if statement before.


<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEcsTaskDefinition_withEFSVolumeMinimal'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEcsTaskDefinition_withEFSVolumeMinimal -timeout 120m
=== RUN   TestAccAWSEcsTaskDefinition_withEFSVolumeMinimal
=== PAUSE TestAccAWSEcsTaskDefinition_withEFSVolumeMinimal
=== CONT  TestAccAWSEcsTaskDefinition_withEFSVolumeMinimal
--- PASS: TestAccAWSEcsTaskDefinition_withEFSVolumeMinimal (26.98s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       28.360s
...
```
