### PR TITLE
(docs) show AWS recommended EFS volume mount options

### DIFF
--- a/website/docs/r/ecs_task_definition.html.markdown
+++ b/website/docs/r/ecs_task_definition.html.markdown
@@ -15,7 +15,7 @@ Manages a revision of an ECS task definition to be used in `aws_ecs_service`.
 ```hcl
 resource "aws_ecs_task_definition" "service" {
   family                = "service"
-  container_definitions = "${file("task-definitions/service.json")}"
+  container_definitions = file("task-definitions/service.json")
 
   volume {
     name      = "service-storage"
@@ -70,7 +70,7 @@ contains only a small subset of the available parameters.
 ```hcl
 resource "aws_ecs_task_definition" "service" {
   family                = "service"
-  container_definitions = "${file("task-definitions/service.json")}"
+  container_definitions = file("task-definitions/service.json")
 
   proxy_configuration {
     type           = "APPMESH"
@@ -137,7 +137,7 @@ For more information, see [Specifying a Docker volume in your Task Definition De
 ```hcl
 resource "aws_ecs_task_definition" "service" {
   family                = "service"
-  container_definitions = "${file("task-definitions/service.json")}"
+  container_definitions = file("task-definitions/service.json")
 
   volume {
     name = "service-storage"
@@ -150,7 +150,7 @@ resource "aws_ecs_task_definition" "service" {
       driver_opts = {
         "type"   = "nfs"
         "device" = "${aws_efs_file_system.fs.dns_name}:/"
-        "o"      = "addr=${aws_efs_file_system.fs.dns_name},nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,nosuid"
+        "o"      = "addr=${aws_efs_file_system.fs.dns_name},rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport"
       }
     }
   }
@@ -175,7 +175,7 @@ resource "aws_ecs_task_definition" "service" {
     name = "service-storage"
 
     efs_volume_configuration {
-      file_system_id = "${aws_efs_file_system.fs.id}"
+      file_system_id = aws_efs_file_system.fs.id
       root_directory = "/opt/data"
     }
   }


### PR DESCRIPTION
# Show AWS Recommend EFS mount options
Looking at the [AWS docs for volume mounts in EFS](https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-general.html) here i think we should change the example (which people often copypaste) to reflect those best practices (mainly adding:`noresvport`).

Also we are hopefully working to remove the deprecated interpolation-only strings from docs, e.g.: `my_var = "${no.reason.for.interpoaltion}"` as they throw warnings during `terraform validate`


<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
