### PR TITLE
New resource: aws_apigatewayv2_vpc_link

### DIFF
--- a/aws/internal/service/apigatewayv2/waiter/status.go
+++ b/aws/internal/service/apigatewayv2/waiter/status.go
@@ -31,3 +31,26 @@ func DeploymentStatus(conn *apigatewayv2.ApiGatewayV2, apiId, deploymentId strin
 		return output, aws.StringValue(output.DeploymentStatus), nil
 	}
 }
+
+// VpcLinkStatus fetches the VPC Link and its Status
+func VpcLinkStatus(conn *apigatewayv2.ApiGatewayV2, vpcLinkId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		input := &apigatewayv2.GetVpcLinkInput{
+			VpcLinkId: aws.String(vpcLinkId),
+		}
+
+		output, err := conn.GetVpcLink(input)
+
+		if err != nil {
+			return nil, apigatewayv2.VpcLinkStatusFailed, err
+		}
+
+		// Error messages can also be contained in the response with FAILED status
+
+		if aws.StringValue(output.VpcLinkStatus) == apigatewayv2.VpcLinkStatusFailed {
+			return output, apigatewayv2.VpcLinkStatusFailed, fmt.Errorf("%s", aws.StringValue(output.VpcLinkStatusMessage))
+		}
+
+		return output, aws.StringValue(output.VpcLinkStatus), nil
+	}
+}

--- a/aws/internal/service/apigatewayv2/waiter/waiter.go
+++ b/aws/internal/service/apigatewayv2/waiter/waiter.go
@@ -10,6 +10,12 @@ import (
 const (
 	// Maximum amount of time to wait for a Deployment to return Deployed
 	DeploymentDeployedTimeout = 5 * time.Minute
+
+	// Maximum amount of time to wait for a VPC Link to return Available
+	VpcLinkAvailableTimeout = 10 * time.Minute
+
+	// Maximum amount of time to wait for a VPC Link to return Deleted
+	VpcLinkDeletedTimeout = 10 * time.Minute
 )
 
 // DeploymentDeployed waits for a Deployment to return Deployed
@@ -24,6 +30,42 @@ func DeploymentDeployed(conn *apigatewayv2.ApiGatewayV2, apiId, deploymentId str
 	outputRaw, err := stateConf.WaitForState()
 
 	if v, ok := outputRaw.(*apigatewayv2.GetDeploymentOutput); ok {
+		return v, err
+	}
+
+	return nil, err
+}
+
+// VpcLinkAvailable waits for a VPC Link to return Available
+func VpcLinkAvailable(conn *apigatewayv2.ApiGatewayV2, vpcLinkId string) (*apigatewayv2.GetVpcLinkOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{apigatewayv2.VpcLinkStatusPending},
+		Target:  []string{apigatewayv2.VpcLinkStatusAvailable},
+		Refresh: VpcLinkStatus(conn, vpcLinkId),
+		Timeout: VpcLinkAvailableTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if v, ok := outputRaw.(*apigatewayv2.GetVpcLinkOutput); ok {
+		return v, err
+	}
+
+	return nil, err
+}
+
+// VpcLinkAvailable waits for a VPC Link to return Deleted
+func VpcLinkDeleted(conn *apigatewayv2.ApiGatewayV2, vpcLinkId string) (*apigatewayv2.GetVpcLinkOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{apigatewayv2.VpcLinkStatusDeleting},
+		Target:  []string{apigatewayv2.VpcLinkStatusFailed},
+		Refresh: VpcLinkStatus(conn, vpcLinkId),
+		Timeout: VpcLinkDeletedTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if v, ok := outputRaw.(*apigatewayv2.GetVpcLinkOutput); ok {
 		return v, err
 	}
 

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -376,6 +376,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_apigatewayv2_route":                                  resourceAwsApiGatewayV2Route(),
 			"aws_apigatewayv2_route_response":                         resourceAwsApiGatewayV2RouteResponse(),
 			"aws_apigatewayv2_stage":                                  resourceAwsApiGatewayV2Stage(),
+			"aws_apigatewayv2_vpc_link":                               resourceAwsApiGatewayV2VpcLink(),
 			"aws_app_cookie_stickiness_policy":                        resourceAwsAppCookieStickinessPolicy(),
 			"aws_appautoscaling_target":                               resourceAwsAppautoscalingTarget(),
 			"aws_appautoscaling_policy":                               resourceAwsAppautoscalingPolicy(),

--- a/aws/resource_aws_apigatewayv2_vpc_link.go
+++ b/aws/resource_aws_apigatewayv2_vpc_link.go
@@ -1,0 +1,210 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/apigatewayv2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+const (
+	apigatewayv2VpcLinkStatusDeleted = "DELETED"
+)
+
+func resourceAwsApiGatewayV2VpcLink() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsApiGatewayV2VpcLinkCreate,
+		Read:   resourceAwsApiGatewayV2VpcLinkRead,
+		Update: resourceAwsApiGatewayV2VpcLinkUpdate,
+		Delete: resourceAwsApiGatewayV2VpcLinkDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 128),
+			},
+			"security_group_ids": {
+				Type:     schema.TypeSet,
+				Required: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"subnet_ids": {
+				Type:     schema.TypeSet,
+				Required: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsApiGatewayV2VpcLinkCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).apigatewayv2conn
+
+	req := &apigatewayv2.CreateVpcLinkInput{
+		Name:             aws.String(d.Get("name").(string)),
+		SecurityGroupIds: expandStringSet(d.Get("security_group_ids").(*schema.Set)),
+		SubnetIds:        expandStringSet(d.Get("subnet_ids").(*schema.Set)),
+		Tags:             keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().Apigatewayv2Tags(),
+	}
+
+	log.Printf("[DEBUG] Creating API Gateway v2 VPC Link: %s", req)
+	resp, err := conn.CreateVpcLink(req)
+	if err != nil {
+		return fmt.Errorf("error creating API Gateway v2 VPC Link: %s", err)
+	}
+
+	d.SetId(aws.StringValue(resp.VpcLinkId))
+
+	if err := waitForApigatewayv2VpcLinkCreation(conn, d.Id()); err != nil {
+		return fmt.Errorf("error waiting for API Gateway v2 VPC Link (%s) availability: %s", d.Id(), err)
+	}
+
+	return resourceAwsApiGatewayV2VpcLinkRead(d, meta)
+}
+
+func resourceAwsApiGatewayV2VpcLinkRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).apigatewayv2conn
+
+	respRaw, state, err := apigatewayv2VpcLinkStateRefresh(conn, d.Id())()
+	if err != nil {
+		return fmt.Errorf("error reading API Gateway v2 VPC Link (%s): %s", d.Id(), err)
+	}
+	if state == apigatewayv2VpcLinkStatusDeleted {
+		log.Printf("[WARN] API Gateway v2 VPC Link (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	resp := respRaw.(*apigatewayv2.GetVpcLinkOutput)
+
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Service:   "apigateway",
+		Region:    meta.(*AWSClient).region,
+		Resource:  fmt.Sprintf("/vpclinks/%s", d.Id()),
+	}.String()
+	d.Set("arn", arn)
+	d.Set("name", resp.Name)
+	if err := d.Set("security_group_ids", flattenStringSet(resp.SecurityGroupIds)); err != nil {
+		return fmt.Errorf("error setting security_group_ids: %s", err)
+	}
+	if err := d.Set("subnet_ids", flattenStringSet(resp.SubnetIds)); err != nil {
+		return fmt.Errorf("error setting subnet_ids: %s", err)
+	}
+	if err := d.Set("tags", keyvaluetags.Apigatewayv2KeyValueTags(resp.Tags).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsApiGatewayV2VpcLinkUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).apigatewayv2conn
+
+	if d.HasChange("name") {
+		req := &apigatewayv2.UpdateVpcLinkInput{
+			VpcLinkId: aws.String(d.Id()),
+			Name:      aws.String(d.Get("name").(string)),
+		}
+
+		log.Printf("[DEBUG] Updating API Gateway v2 VPC Link: %s", req)
+		_, err := conn.UpdateVpcLink(req)
+		if err != nil {
+			return fmt.Errorf("error updating API Gateway v2 VPC Link (%s): %s", d.Id(), err)
+		}
+	}
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+		if err := keyvaluetags.Apigatewayv2UpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating API Gateway v2 VPC Link (%s) tags: %s", d.Id(), err)
+		}
+	}
+
+	return resourceAwsApiGatewayV2VpcLinkRead(d, meta)
+}
+
+func resourceAwsApiGatewayV2VpcLinkDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).apigatewayv2conn
+
+	log.Printf("[DEBUG] Deleting API Gateway v2 VPC Link (%s)", d.Id())
+	_, err := conn.DeleteVpcLink(&apigatewayv2.DeleteVpcLinkInput{
+		VpcLinkId: aws.String(d.Id()),
+	})
+	if isAWSErr(err, apigatewayv2.ErrCodeNotFoundException, "") {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error deleting API Gateway v2 VPC Link (%s): %s", d.Id(), err)
+	}
+
+	if err := waitForApigatewayv2VpcLinkDeletion(conn, d.Id()); err != nil {
+		return fmt.Errorf("error waiting for API Gateway v2 VPC Link (%s) deletion: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func apigatewayv2VpcLinkStateRefresh(conn *apigatewayv2.ApiGatewayV2, vpcLinkId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := conn.GetVpcLink(&apigatewayv2.GetVpcLinkInput{
+			VpcLinkId: aws.String(vpcLinkId),
+		})
+		if isAWSErr(err, apigatewayv2.ErrCodeNotFoundException, "") {
+			return "", apigatewayv2VpcLinkStatusDeleted, nil
+		}
+		if err != nil {
+			return nil, "", err
+		}
+
+		return resp, aws.StringValue(resp.VpcLinkStatus), nil
+	}
+}
+
+func waitForApigatewayv2VpcLinkCreation(conn *apigatewayv2.ApiGatewayV2, vpcLinkId string) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{apigatewayv2.VpcLinkStatusPending},
+		Target:  []string{apigatewayv2.VpcLinkStatusAvailable},
+		Refresh: apigatewayv2VpcLinkStateRefresh(conn, vpcLinkId),
+		Timeout: 10 * time.Minute,
+	}
+
+	log.Printf("[DEBUG] Waiting for API Gateway v2 VPC Link (%s) availability", vpcLinkId)
+	_, err := stateConf.WaitForState()
+
+	return err
+}
+
+func waitForApigatewayv2VpcLinkDeletion(conn *apigatewayv2.ApiGatewayV2, vpcLinkId string) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{apigatewayv2.VpcLinkStatusDeleting},
+		Target:  []string{apigatewayv2VpcLinkStatusDeleted},
+		Refresh: apigatewayv2VpcLinkStateRefresh(conn, vpcLinkId),
+		Timeout: 10 * time.Minute,
+	}
+
+	log.Printf("[DEBUG] Waiting for API Gateway v2 VPC Link (%s) deletion", vpcLinkId)
+	_, err := stateConf.WaitForState()
+
+	return err
+}

--- a/aws/resource_aws_apigatewayv2_vpc_link_test.go
+++ b/aws/resource_aws_apigatewayv2_vpc_link_test.go
@@ -1,0 +1,311 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/apigatewayv2"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_apigatewayv2_vpc_link", &resource.Sweeper{
+		Name: "aws_apigatewayv2_vpc_link",
+		F:    testSweepAPIGatewayV2VpcLinks,
+	})
+}
+
+func testSweepAPIGatewayV2VpcLinks(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).apigatewayv2conn
+	input := &apigatewayv2.GetVpcLinksInput{}
+	var sweeperErrs *multierror.Error
+
+	for {
+		output, err := conn.GetVpcLinks(input)
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping API Gateway v2 VPC Link sweep for %s: %s", region, err)
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("error retrieving API Gateway v2 VPC Links: %s", err)
+		}
+
+		for _, link := range output.Items {
+			log.Printf("[INFO] Deleting API Gateway v2 VPC Link: %s", aws.StringValue(link.VpcLinkId))
+			_, err := conn.DeleteVpcLink(&apigatewayv2.DeleteVpcLinkInput{
+				VpcLinkId: link.VpcLinkId,
+			})
+			if isAWSErr(err, apigatewayv2.ErrCodeNotFoundException, "") {
+				continue
+			}
+			if err != nil {
+				sweeperErr := fmt.Errorf("error deleting API Gateway v2 VPC Link (%s): %w", aws.StringValue(link.VpcLinkId), err)
+				log.Printf("[ERROR] %s", sweeperErr)
+				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+				continue
+			}
+
+			if err := waitForApigatewayv2VpcLinkDeletion(conn, aws.StringValue(link.VpcLinkId)); err != nil {
+				sweeperErr := fmt.Errorf("error waiting for API Gateway v2 VPC Link (%s) deletion: %w", aws.StringValue(link.VpcLinkId), err)
+				log.Printf("[ERROR] %s", sweeperErr)
+				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+				continue
+			}
+		}
+
+		if aws.StringValue(output.NextToken) == "" {
+			break
+		}
+		input.NextToken = output.NextToken
+	}
+
+	return sweeperErrs.ErrorOrNil()
+}
+
+func TestAccAWSAPIGatewayV2VpcLink_basic(t *testing.T) {
+	var v apigatewayv2.GetVpcLinkOutput
+	resourceName := "aws_apigatewayv2_vpc_link.test"
+	rName1 := acctest.RandomWithPrefix("tf-acc-test")
+	rName2 := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayV2VpcLinkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayV2VpcLinkConfig_basic(rName1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2VpcLinkExists(resourceName, &v),
+					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/vpclinks/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName1),
+					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				Config: testAccAWSAPIGatewayV2VpcLinkConfig_basic(rName2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2VpcLinkExists(resourceName, &v),
+					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/vpclinks/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName2),
+					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayV2VpcLink_disappears(t *testing.T) {
+	var v apigatewayv2.GetVpcLinkOutput
+	resourceName := "aws_apigatewayv2_vpc_link.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayV2VpcLinkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayV2VpcLinkConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2VpcLinkExists(resourceName, &v),
+					testAccCheckAWSAPIGatewayV2VpcLinkDisappears(&v),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayV2VpcLink_Tags(t *testing.T) {
+	var v apigatewayv2.GetVpcLinkOutput
+	resourceName := "aws_apigatewayv2_vpc_link.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayV2VpcLinkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayV2VpcLinkConfig_tags(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2VpcLinkExists(resourceName, &v),
+					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/vpclinks/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "Value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "Value2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSAPIGatewayV2VpcLinkConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2VpcLinkExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSAPIGatewayV2VpcLinkDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).apigatewayv2conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_apigatewayv2_vpc_link" {
+			continue
+		}
+
+		_, err := conn.GetVpcLink(&apigatewayv2.GetVpcLinkInput{
+			VpcLinkId: aws.String(rs.Primary.ID),
+		})
+		if isAWSErr(err, apigatewayv2.ErrCodeNotFoundException, "") {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+
+		return fmt.Errorf("API Gateway v2 VPC Link %s still exists", rs.Primary.ID)
+	}
+
+	return nil
+}
+
+func testAccCheckAWSAPIGatewayV2VpcLinkDisappears(v *apigatewayv2.GetVpcLinkOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).apigatewayv2conn
+
+		if _, err := conn.DeleteVpcLink(&apigatewayv2.DeleteVpcLinkInput{
+			VpcLinkId: v.VpcLinkId,
+		}); err != nil {
+			return err
+		}
+
+		if err := waitForApigatewayv2VpcLinkDeletion(conn, aws.StringValue(v.VpcLinkId)); err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSAPIGatewayV2VpcLinkExists(n string, v *apigatewayv2.GetVpcLinkOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No API Gateway v2 VPC Link ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).apigatewayv2conn
+
+		resp, err := conn.GetVpcLink(&apigatewayv2.GetVpcLinkInput{
+			VpcLinkId: aws.String(rs.Primary.ID),
+		})
+		if err != nil {
+			return err
+		}
+
+		*v = *resp
+
+		return nil
+	}
+}
+
+func testAccAWSAPIGatewayV2VpcLinkConfig_base(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_subnet" "test" {
+  count = 2
+
+  vpc_id            = "${aws_vpc.test.id}"
+  cidr_block        = "${cidrsubnet(aws_vpc.test.cidr_block, 2, count.index)}"
+  availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_security_group" "test" {
+  vpc_id = "${aws_vpc.test.id}"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName)
+}
+
+func testAccAWSAPIGatewayV2VpcLinkConfig_basic(rName string) string {
+	return testAccAWSAPIGatewayV2VpcLinkConfig_base(rName) + fmt.Sprintf(`
+resource "aws_apigatewayv2_vpc_link" "test" {
+  name               = %[1]q
+  security_group_ids = ["${aws_security_group.test.id}"]
+  subnet_ids         = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
+}
+`, rName)
+}
+
+func testAccAWSAPIGatewayV2VpcLinkConfig_tags(rName string) string {
+	return testAccAWSAPIGatewayV2VpcLinkConfig_base(rName) + fmt.Sprintf(`
+resource "aws_apigatewayv2_vpc_link" "test" {
+  name               = %[1]q
+  security_group_ids = ["${aws_security_group.test.id}"]
+  subnet_ids         = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
+
+  tags = {
+    Key1 = "Value1"
+    Key2 = "Value2"
+  }
+}
+`, rName)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -248,6 +248,9 @@
                                 <li>
                                     <a href="/docs/providers/aws/r/apigatewayv2_stage.html">aws_apigatewayv2_stage</a>
                                 </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/apigatewayv2_vpc_link.html">aws_apigatewayv2_vpc_link</a>
+                                </li>
                             </ul>
                         </li>
                     </ul>

--- a/website/docs/r/api_gateway_vpc_link.html.markdown
+++ b/website/docs/r/api_gateway_vpc_link.html.markdown
@@ -10,6 +10,9 @@ description: |-
 
 Provides an API Gateway VPC Link.
 
+-> **Note:** Amazon API Gateway Version 1 VPC Links enable private integrations that connect REST APIs to private resources in a VPC.
+To enable private integration for HTTP APIs, use the Amazon API Gateway Version 2 VPC Link [resource](/docs/providers/aws/r/apigatewayv2_vpc_link.html).
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/apigatewayv2_vpc_link.html.markdown
+++ b/website/docs/r/apigatewayv2_vpc_link.html.markdown
@@ -1,0 +1,52 @@
+---
+subcategory: "API Gateway v2 (WebSocket and HTTP APIs)"
+layout: "aws"
+page_title: "AWS: aws_apigatewayv2_vpc_link"
+description: |-
+  Manages an Amazon API Gateway Version 2 VPC Link.
+---
+
+# Resource: aws_apigatewayv2_vpc_link
+
+Manages an Amazon API Gateway Version 2 VPC Link.
+
+-> **Note:** Amazon API Gateway Version 2 VPC Links enable private integrations that connect HTTP APIs to private resources in a VPC.
+To enable private integration for REST APIs, use the Amazon API Gateway Version 1 VPC Link [resource](/docs/providers/aws/r/api_gateway_vpc_link.html).
+
+## Example Usage
+
+```hcl
+resource "aws_apigatewayv2_vpc_link" "example" {
+  name               = "example"
+  security_group_ids = [data.aws_security_group.example.id]
+  subnet_ids         = data.aws_subnet_ids.example.ids
+
+  tags = {
+    Usage = "example"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the VPC Link.
+* `security_group_ids` - (Required) Security group IDs for the VPC Link.
+* `subnet_ids` - (Required) Subnet IDs for the VPC Link.
+* `tags` - (Optional) A mapping of tags to assign to the VPC Link.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The VPC Link identifier.
+* `arn` - The VPC Link ARN.
+
+## Import
+
+`aws_apigatewayv2_vpc_link` can be imported by using the VPC Link identifier, e.g.
+
+```
+$ terraform import aws_apigatewayv2_vpc_link.example aabbccddee
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/terraform-providers/terraform-provider-aws/issues/11148.

Adds a new resource, `aws_apigatewayv2_vpc_link`.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_apigatewayv2_vpc_link: New resource
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAPIGatewayV2VpcLink_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAPIGatewayV2VpcLink_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayV2VpcLink_basic
=== PAUSE TestAccAWSAPIGatewayV2VpcLink_basic
=== RUN   TestAccAWSAPIGatewayV2VpcLink_disappears
=== PAUSE TestAccAWSAPIGatewayV2VpcLink_disappears
=== RUN   TestAccAWSAPIGatewayV2VpcLink_Tags
=== PAUSE TestAccAWSAPIGatewayV2VpcLink_Tags
=== CONT  TestAccAWSAPIGatewayV2VpcLink_basic
=== CONT  TestAccAWSAPIGatewayV2VpcLink_Tags
=== CONT  TestAccAWSAPIGatewayV2VpcLink_disappears
--- PASS: TestAccAWSAPIGatewayV2VpcLink_disappears (170.21s)
--- PASS: TestAccAWSAPIGatewayV2VpcLink_basic (223.88s)
--- PASS: TestAccAWSAPIGatewayV2VpcLink_Tags (227.01s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	227.051s

$ TEST=./aws SWEEP=us-west-2 SWEEPARGS=-sweep-run=aws_apigatewayv2_vpc_link make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=us-west-2 -sweep-run=aws_apigatewayv2_vpc_link -timeout 60m
2020/03/30 08:03:19 [DEBUG] Running Sweepers for region (us-west-2):
2020/03/30 08:03:19 [DEBUG] Running Sweeper (aws_apigatewayv2_vpc_link) in region (us-west-2)
2020/03/30 08:03:19 [INFO] Building AWS auth structure
2020/03/30 08:03:19 [INFO] Setting AWS metadata API timeout to 100ms
2020/03/30 08:03:21 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2020/03/30 08:03:21 [INFO] AWS Auth provider used: "EnvProvider"
2020/03/30 08:03:21 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/03/30 08:03:21 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/03/30 08:03:22 [INFO] Deleting API Gateway v2 VPC Link: wv9xr6
2020/03/30 08:03:22 [DEBUG] Waiting for API Gateway v2 VPC Link (wv9xr6) deletion
2020/03/30 08:03:22 [DEBUG] Waiting for state to become: [DELETED]
2020/03/30 08:03:23 [TRACE] Waiting 200ms before next try
2020/03/30 08:03:23 [TRACE] Waiting 400ms before next try
2020/03/30 08:03:24 [TRACE] Waiting 800ms before next try
2020/03/30 08:03:26 Sweeper Tests ran successfully:
	- aws_apigatewayv2_vpc_link
ok  	github.com/terraform-providers/terraform-provider-aws/aws	6.624s
```
