### PR TITLE
r/elastic_transcoder_preset remove `stringptr` + refactor

### DIFF
--- a/aws/resource_aws_elastic_transcoder_preset_test.go
+++ b/aws/resource_aws_elastic_transcoder_preset_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/elastictranscoder"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
@@ -14,44 +14,7 @@ import (
 func TestAccAWSElasticTranscoderPreset_basic(t *testing.T) {
 	preset := &elastictranscoder.Preset{}
 	name := "aws_elastictranscoder_preset.test"
-
-	// make sure the old preset was destroyed on each intermediate step
-	// these are very easy to leak
-	checkExists := func(replaced bool) resource.TestCheckFunc {
-		return func(s *terraform.State) error {
-			conn := testAccProvider.Meta().(*AWSClient).elastictranscoderconn
-
-			if replaced {
-				_, err := conn.ReadPreset(&elastictranscoder.ReadPresetInput{Id: preset.Id})
-				if err != nil {
-					return nil
-				}
-
-				return fmt.Errorf("Preset Id %v should not exist", *preset.Id)
-			}
-
-			rs, ok := s.RootModule().Resources[name]
-			if !ok {
-				return fmt.Errorf("Not found: %s", name)
-			}
-			if rs.Primary.ID == "" {
-				return fmt.Errorf("No Preset ID is set")
-			}
-
-			out, err := conn.ReadPreset(&elastictranscoder.ReadPresetInput{
-				Id: aws.String(rs.Primary.ID),
-			})
-
-			if err != nil {
-				return err
-			}
-
-			preset = out.Preset
-
-			return nil
-
-		}
-	}
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSElasticTranscoder(t) },
@@ -59,9 +22,9 @@ func TestAccAWSElasticTranscoderPreset_basic(t *testing.T) {
 		CheckDestroy: testAccCheckElasticTranscoderPresetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: awsElasticTranscoderPresetConfig,
+				Config: awsElasticTranscoderPresetConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					checkExists(false),
+					testAccCheckElasticTranscoderPresetExists(name, preset),
 				),
 			},
 			{
@@ -70,9 +33,9 @@ func TestAccAWSElasticTranscoderPreset_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: awsElasticTranscoderPresetConfig2,
+				Config: awsElasticTranscoderPresetConfig2(rName),
 				Check: resource.ComposeTestCheckFunc(
-					checkExists(true),
+					testAccCheckElasticTranscoderPresetExists(name, preset),
 				),
 			},
 			{
@@ -81,9 +44,9 @@ func TestAccAWSElasticTranscoderPreset_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: awsElasticTranscoderPresetConfig3,
+				Config: awsElasticTranscoderPresetConfig3(rName),
 				Check: resource.ComposeTestCheckFunc(
-					checkExists(true),
+					testAccCheckElasticTranscoderPresetExists(name, preset),
 				),
 			},
 			{
@@ -93,6 +56,65 @@ func TestAccAWSElasticTranscoderPreset_basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccAWSElasticTranscoderPreset_disappears(t *testing.T) {
+	preset := &elastictranscoder.Preset{}
+	name := "aws_elastictranscoder_preset.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSElasticTranscoder(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckElasticTranscoderPresetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: awsElasticTranscoderPresetConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckElasticTranscoderPresetExists(name, preset),
+					testAccCheckElasticTranscoderPresetDisappears(preset),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckElasticTranscoderPresetExists(name string, preset *elastictranscoder.Preset) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).elastictranscoderconn
+
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Preset ID is set")
+		}
+
+		out, err := conn.ReadPreset(&elastictranscoder.ReadPresetInput{
+			Id: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		preset = out.Preset
+
+		return nil
+	}
+}
+
+func testAccCheckElasticTranscoderPresetDisappears(preset *elastictranscoder.Preset) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).elastictranscoderconn
+		_, err := conn.DeletePreset(&elastictranscoder.DeletePresetInput{
+			Id: preset.Id,
+		})
+
+		return err
+	}
 }
 
 func testAccCheckElasticTranscoderPresetDestroy(s *terraform.State) error {
@@ -113,24 +135,20 @@ func testAccCheckElasticTranscoderPresetDestroy(s *terraform.State) error {
 			}
 		}
 
-		awsErr, ok := err.(awserr.Error)
-		if !ok {
-			return err
-		}
-
-		if awsErr.Code() != "ResourceNotFoundException" {
-			return fmt.Errorf("unexpected error: %s", awsErr)
+		if !isAWSErr(err, elastictranscoder.ErrCodeResourceNotFoundException, "") {
+			return fmt.Errorf("unexpected error: %s", err)
 		}
 
 	}
 	return nil
 }
 
-const awsElasticTranscoderPresetConfig = `
+func awsElasticTranscoderPresetConfig(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_elastictranscoder_preset" "test" {
   container   = "mp4"
   description = "elastic transcoder preset test 1"
-  name        = "aws_elastictranscoder_preset_tf_test_"
+  name        = %[1]q
 
   audio {
     audio_packing_mode = "SingleTrack"
@@ -140,13 +158,15 @@ resource "aws_elastictranscoder_preset" "test" {
     sample_rate        = 44100
   }
 }
-`
+`, rName)
+}
 
-const awsElasticTranscoderPresetConfig2 = `
+func awsElasticTranscoderPresetConfig2(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_elastictranscoder_preset" "test" {
   container   = "mp4"
   description = "elastic transcoder preset test 2"
-  name        = "aws_elastictranscoder_preset_tf_test_"
+  name        = %[1]q
 
   audio {
     audio_packing_mode = "SingleTrack"
@@ -190,13 +210,15 @@ resource "aws_elastictranscoder_preset" "test" {
     sizing_policy  = "Fit"
   }
 }
-`
+`, rName)
+}
 
-const awsElasticTranscoderPresetConfig3 = `
+func awsElasticTranscoderPresetConfig3(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_elastictranscoder_preset" "test" {
   container   = "mp4"
   description = "elastic transcoder preset test 3"
-  name        = "aws_elastictranscoder_preset_tf_test_"
+  name        = %[1]q
 
   audio {
     audio_packing_mode = "SingleTrack"
@@ -234,8 +256,8 @@ resource "aws_elastictranscoder_preset" "test" {
 
   video_watermarks {
     id                = "Terraform Test"
-    max_width         = "20%"
-    max_height        = "20%"
+    max_width         = "20%%"
+    max_height        = "20%%"
     sizing_policy     = "ShrinkToFit"
     horizontal_align  = "Right"
     horizontal_offset = "10px"
@@ -254,4 +276,5 @@ resource "aws_elastictranscoder_preset" "test" {
     sizing_policy  = "Fit"
   }
 }
-`
+`, rName)
+}

--- a/aws/resource_aws_elastic_transcoder_preset_test.go
+++ b/aws/resource_aws_elastic_transcoder_preset_test.go
@@ -100,7 +100,7 @@ func testAccCheckElasticTranscoderPresetExists(name string, preset *elastictrans
 			return err
 		}
 
-		preset = out.Preset
+		*preset = *out.Preset
 
 		return nil
 	}

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -2067,38 +2067,6 @@ func flattenApiGatewayThrottleSettings(settings *apigateway.ThrottleSettings) []
 
 // TODO: refactor some of these helper functions and types in the terraform/helper packages
 
-// getStringPtr returns a *string version of the value taken from m, where m
-// can be a map[string]interface{} or a *schema.ResourceData. If the key isn't
-// present or is empty, getNilString returns nil.
-func getStringPtr(m interface{}, key string) *string {
-	switch m := m.(type) {
-	case map[string]interface{}:
-		v := m[key]
-
-		if v == nil {
-			return nil
-		}
-
-		s := v.(string)
-		if s == "" {
-			return nil
-		}
-
-		return &s
-
-	case *schema.ResourceData:
-		if v, ok := m.GetOk(key); ok {
-			if v == nil || v.(string) == "" {
-				return nil
-			}
-			s := v.(string)
-			return &s
-		}
-	}
-
-	return nil
-}
-
 // a convenience wrapper type for the schema.Set map[string]interface{}
 // Set operations only alter the underlying map if the value is not nil
 type setMap map[string]interface{}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #5983

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSElasticTranscoderPreset'
--- PASS: TestAccAWSElasticTranscoderPreset_basic (109.38s)
--- PASS: TestAccAWSElasticTranscoderPreset_disappears (28.04s)
```
