### PR TITLE
provider: Update preview ignore tags handling to configuration block and shared struct type

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -167,10 +167,9 @@ type Config struct {
 	AllowedAccountIds   []string
 	ForbiddenAccountIds []string
 
-	Endpoints         map[string]string
-	IgnoreTagPrefixes []string
-	IgnoreTags        []string
-	Insecure          bool
+	Endpoints        map[string]string
+	IgnoreTagsConfig *keyvaluetags.IgnoreConfig
+	Insecure         bool
 
 	SkipCredsValidation     bool
 	SkipGetEC2Platforms     bool
@@ -254,8 +253,7 @@ type AWSClient struct {
 	guarddutyconn                       *guardduty.GuardDuty
 	greengrassconn                      *greengrass.Greengrass
 	iamconn                             *iam.IAM
-	ignoreTagPrefixes                   keyvaluetags.KeyValueTags
-	ignoreTags                          keyvaluetags.KeyValueTags
+	IgnoreTagsConfig                    *keyvaluetags.IgnoreConfig
 	imagebuilderconn                    *imagebuilder.Imagebuilder
 	inspectorconn                       *inspector.Inspector
 	iotconn                             *iot.IoT
@@ -472,8 +470,7 @@ func (c *Config) Client() (interface{}, error) {
 		guarddutyconn:                       guardduty.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["guardduty"])})),
 		greengrassconn:                      greengrass.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["greengrass"])})),
 		iamconn:                             iam.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["iam"])})),
-		ignoreTagPrefixes:                   keyvaluetags.New(c.IgnoreTagPrefixes),
-		ignoreTags:                          keyvaluetags.New(c.IgnoreTags),
+		IgnoreTagsConfig:                    c.IgnoreTagsConfig,
 		imagebuilderconn:                    imagebuilder.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["imagebuilder"])})),
 		inspectorconn:                       inspector.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["inspector"])})),
 		iotconn:                             iot.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["iot"])})),

--- a/aws/internal/keyvaluetags/key_value_tags.go
+++ b/aws/internal/keyvaluetags/key_value_tags.go
@@ -19,6 +19,12 @@ const (
 	RdsTagKeyPrefix              = `rds:`
 )
 
+// IgnoreConfig contains various options for removing resource tags.
+type IgnoreConfig struct {
+	Keys        KeyValueTags
+	KeyPrefixes KeyValueTags
+}
+
 // KeyValueTags is a standard implementation for AWS key-value resource tags.
 // The AWS Go SDK is split into multiple service packages, each service with
 // its own Go struct type representing a resource tag. To standardize logic
@@ -34,6 +40,18 @@ func (tags KeyValueTags) IgnoreAws() KeyValueTags {
 			result[k] = v
 		}
 	}
+
+	return result
+}
+
+// IgnoreConfig returns any tags not removed by a given configuration.
+func (tags KeyValueTags) IgnoreConfig(config *IgnoreConfig) KeyValueTags {
+	if config == nil {
+		return tags
+	}
+
+	result := tags.IgnorePrefixes(config.KeyPrefixes)
+	result = result.Ignore(config.Keys)
 
 	return result
 }

--- a/aws/internal/keyvaluetags/key_value_tags_test.go
+++ b/aws/internal/keyvaluetags/key_value_tags_test.go
@@ -60,6 +60,203 @@ func TestKeyValueTagsIgnoreAws(t *testing.T) {
 	}
 }
 
+func TestKeyValueTagsIgnoreConfig(t *testing.T) {
+	testCases := []struct {
+		name         string
+		tags         KeyValueTags
+		ignoreConfig *IgnoreConfig
+		want         map[string]string
+	}{
+		{
+			name: "empty config",
+			tags: New(map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			}),
+			ignoreConfig: &IgnoreConfig{},
+			want: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			},
+		},
+		{
+			name: "no config",
+			tags: New(map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			}),
+			ignoreConfig: nil,
+			want: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			},
+		},
+		{
+			name: "no tags",
+			tags: New(map[string]string{}),
+			ignoreConfig: &IgnoreConfig{
+				KeyPrefixes: New([]string{
+					"key1",
+					"key2",
+					"key3",
+				}),
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "keys all matching",
+			tags: New(map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			}),
+			ignoreConfig: &IgnoreConfig{
+				Keys: New(map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+					"key3": "value3",
+				}),
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "keys some matching",
+			tags: New(map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			}),
+			ignoreConfig: &IgnoreConfig{
+				Keys: New(map[string]string{
+					"key1": "value1",
+				}),
+			},
+			want: map[string]string{
+				"key2": "value2",
+				"key3": "value3",
+			},
+		},
+		{
+			name: "keys none matching",
+			tags: New(map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			}),
+			ignoreConfig: &IgnoreConfig{
+				Keys: New(map[string]string{
+					"key4": "value4",
+					"key5": "value5",
+					"key6": "value6",
+				}),
+			},
+			want: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			},
+		},
+		{
+			name: "keys and key prefixes",
+			tags: New(map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			}),
+			ignoreConfig: &IgnoreConfig{
+				Keys: New([]string{
+					"key1",
+				}),
+				KeyPrefixes: New([]string{
+					"key2",
+				}),
+			},
+			want: map[string]string{
+				"key3": "value3",
+			},
+		},
+		{
+			name: "key prefixes all exact",
+			tags: New(map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			}),
+			ignoreConfig: &IgnoreConfig{
+				KeyPrefixes: New([]string{
+					"key1",
+					"key2",
+					"key3",
+				}),
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "key prefixes all prefixed",
+			tags: New(map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			}),
+			ignoreConfig: &IgnoreConfig{
+				KeyPrefixes: New([]string{
+					"key",
+				}),
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "key prefixes some prefixed",
+			tags: New(map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			}),
+			ignoreConfig: &IgnoreConfig{
+				KeyPrefixes: New([]string{
+					"key1",
+				}),
+			},
+			want: map[string]string{
+				"key2": "value2",
+				"key3": "value3",
+			},
+		},
+		{
+			name: "key prefixes none prefixed",
+			tags: New(map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			}),
+			ignoreConfig: &IgnoreConfig{
+				KeyPrefixes: New([]string{
+					"key4",
+					"key5",
+					"key6",
+				}),
+			},
+			want: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := testCase.tags.IgnoreConfig(testCase.ignoreConfig)
+
+			testKeyValueTagsVerifyMap(t, got.Map(), testCase.want)
+		})
+	}
+}
+
 func TestKeyValueTagsIgnoreElasticbeanstalk(t *testing.T) {
 	testCases := []struct {
 		name string

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	homedir "github.com/mitchellh/go-homedir"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 // Provider returns a terraform.ResourceProvider.
@@ -90,20 +91,29 @@ func Provider() terraform.ResourceProvider {
 
 			"endpoints": endpointsSchema(),
 
-			"ignore_tag_prefixes": {
-				Type:        schema.TypeSet,
-				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Set:         schema.HashString,
-				Description: "Resource tag key prefixes to ignore across all resources.",
-			},
-
 			"ignore_tags": {
-				Type:        schema.TypeSet,
+				Type:        schema.TypeList,
 				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Set:         schema.HashString,
-				Description: "Resource tag keys to ignore across all resources.",
+				MaxItems:    1,
+				Description: "Configuration block with settings to ignore resource tags across all resources.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"keys": {
+							Type:        schema.TypeSet,
+							Optional:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Set:         schema.HashString,
+							Description: "Resource tag keys to ignore across all resources.",
+						},
+						"key_prefixes": {
+							Type:        schema.TypeSet,
+							Optional:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Set:         schema.HashString,
+							Description: "Resource tag key prefixes to ignore across all resources.",
+						},
+					},
+				},
 			},
 
 			"insecure": {
@@ -1108,6 +1118,7 @@ func providerConfigure(d *schema.ResourceData, terraformVersion string) (interfa
 		Region:                  d.Get("region").(string),
 		Endpoints:               make(map[string]string),
 		MaxRetries:              d.Get("max_retries").(int),
+		IgnoreTagsConfig:        expandProviderIgnoreTags(d.Get("ignore_tags").([]interface{})),
 		Insecure:                d.Get("insecure").(bool),
 		SkipCredsValidation:     d.Get("skip_credentials_validation").(bool),
 		SkipGetEC2Platforms:     d.Get("skip_get_ec2_platforms").(bool),
@@ -1148,18 +1159,6 @@ func providerConfigure(d *schema.ResourceData, terraformVersion string) (interfa
 		endpoints := endpointsSetI.(map[string]interface{})
 		for _, endpointServiceName := range endpointServiceNames {
 			config.Endpoints[endpointServiceName] = endpoints[endpointServiceName].(string)
-		}
-	}
-
-	if v, ok := d.GetOk("ignore_tag_prefixes"); ok {
-		for _, ignoreTagPrefixRaw := range v.(*schema.Set).List() {
-			config.IgnoreTagPrefixes = append(config.IgnoreTagPrefixes, ignoreTagPrefixRaw.(string))
-		}
-	}
-
-	if v, ok := d.GetOk("ignore_tags"); ok {
-		for _, ignoreTagRaw := range v.(*schema.Set).List() {
-			config.IgnoreTags = append(config.IgnoreTags, ignoreTagRaw.(string))
 		}
 	}
 
@@ -1239,4 +1238,23 @@ func endpointsSchema() *schema.Schema {
 			Schema: endpointsAttributes,
 		},
 	}
+}
+
+func expandProviderIgnoreTags(l []interface{}) *keyvaluetags.IgnoreConfig {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	ignoreConfig := &keyvaluetags.IgnoreConfig{}
+	m := l[0].(map[string]interface{})
+
+	if v, ok := m["keys"].(*schema.Set); ok {
+		ignoreConfig.Keys = keyvaluetags.New(v.List())
+	}
+
+	if v, ok := m["key_prefixes"].(*schema.Set); ok {
+		ignoreConfig.KeyPrefixes = keyvaluetags.New(v.List())
+	}
+
+	return ignoreConfig
 }

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -483,20 +483,24 @@ provider "aws" {
 `, testAccGetAlternateRegion())
 }
 
-func testAccProviderConfigIgnoreTagPrefixes1(keyPrefix1 string) string {
+func testAccProviderConfigIgnoreTagsKeyPrefixes1(keyPrefix1 string) string {
 	//lintignore:AT004
 	return fmt.Sprintf(`
 provider "aws" {
-  ignore_tag_prefixes = [%[1]q]
+  ignore_tags {
+    key_prefixes = [%[1]q]
+  }
 }
 `, keyPrefix1)
 }
 
-func testAccProviderConfigIgnoreTags1(key1 string) string {
+func testAccProviderConfigIgnoreTagsKeys1(key1 string) string {
 	//lintignore:AT004
 	return fmt.Sprintf(`
 provider "aws" {
-  ignore_tags = [%[1]q]
+  ignore_tags {
+    keys = [%[1]q]
+  }
 }
 `, key1)
 }
@@ -691,7 +695,7 @@ func TestAccAWSProvider_Endpoints_Deprecated(t *testing.T) {
 	})
 }
 
-func TestAccAWSProvider_IgnoreTagPrefixes_None(t *testing.T) {
+func TestAccAWSProvider_IgnoreTags_EmptyConfigurationBlock(t *testing.T) {
 	var providers []*schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -700,16 +704,17 @@ func TestAccAWSProvider_IgnoreTagPrefixes_None(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSProviderConfigIgnoreTagPrefixes0(),
+				Config: testAccAWSProviderConfigIgnoreTagsEmptyConfigurationBlock(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSProviderIgnoreTagPrefixes(&providers, []string{}),
+					testAccCheckAWSProviderIgnoreTagsKeys(&providers, []string{}),
+					testAccCheckAWSProviderIgnoreTagsKeyPrefixes(&providers, []string{}),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAWSProvider_IgnoreTagPrefixes_One(t *testing.T) {
+func TestAccAWSProvider_IgnoreTags_KeyPrefixes_None(t *testing.T) {
 	var providers []*schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -718,16 +723,16 @@ func TestAccAWSProvider_IgnoreTagPrefixes_One(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSProviderConfigIgnoreTagPrefixes1("test"),
+				Config: testAccAWSProviderConfigIgnoreTagsKeyPrefixes0(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSProviderIgnoreTagPrefixes(&providers, []string{"test"}),
+					testAccCheckAWSProviderIgnoreTagsKeyPrefixes(&providers, []string{}),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAWSProvider_IgnoreTagPrefixes_Multiple(t *testing.T) {
+func TestAccAWSProvider_IgnoreTags_KeyPrefixes_One(t *testing.T) {
 	var providers []*schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -736,16 +741,16 @@ func TestAccAWSProvider_IgnoreTagPrefixes_Multiple(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSProviderConfigIgnoreTagPrefixes2("test1", "test2"),
+				Config: testAccAWSProviderConfigIgnoreTagsKeyPrefixes1("test"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSProviderIgnoreTagPrefixes(&providers, []string{"test1", "test2"}),
+					testAccCheckAWSProviderIgnoreTagsKeyPrefixes(&providers, []string{"test"}),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAWSProvider_IgnoreTags_None(t *testing.T) {
+func TestAccAWSProvider_IgnoreTags_KeyPrefixes_Multiple(t *testing.T) {
 	var providers []*schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -754,16 +759,16 @@ func TestAccAWSProvider_IgnoreTags_None(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSProviderConfigIgnoreTags0(),
+				Config: testAccAWSProviderConfigIgnoreTagsKeyPrefixes2("test1", "test2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSProviderIgnoreTags(&providers, []string{}),
+					testAccCheckAWSProviderIgnoreTagsKeyPrefixes(&providers, []string{"test1", "test2"}),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAWSProvider_IgnoreTags_One(t *testing.T) {
+func TestAccAWSProvider_IgnoreTags_Keys_None(t *testing.T) {
 	var providers []*schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -772,16 +777,16 @@ func TestAccAWSProvider_IgnoreTags_One(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSProviderConfigIgnoreTags1("test"),
+				Config: testAccAWSProviderConfigIgnoreTagsKeys0(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSProviderIgnoreTags(&providers, []string{"test"}),
+					testAccCheckAWSProviderIgnoreTagsKeys(&providers, []string{}),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAWSProvider_IgnoreTags_Multiple(t *testing.T) {
+func TestAccAWSProvider_IgnoreTags_Keys_One(t *testing.T) {
 	var providers []*schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -790,9 +795,27 @@ func TestAccAWSProvider_IgnoreTags_Multiple(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSProviderConfigIgnoreTags2("test1", "test2"),
+				Config: testAccAWSProviderConfigIgnoreTagsKeys1("test"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSProviderIgnoreTags(&providers, []string{"test1", "test2"}),
+					testAccCheckAWSProviderIgnoreTagsKeys(&providers, []string{"test"}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSProvider_IgnoreTags_Keys_Multiple(t *testing.T) {
+	var providers []*schema.Provider
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories(&providers),
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSProviderConfigIgnoreTagsKeys2("test1", "test2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSProviderIgnoreTagsKeys(&providers, []string{"test1", "test2"}),
 				),
 			},
 		},
@@ -1009,7 +1032,7 @@ func testAccCheckAWSProviderEndpointsDeprecated(providers *[]*schema.Provider) r
 	}
 }
 
-func testAccCheckAWSProviderIgnoreTagPrefixes(providers *[]*schema.Provider, expectedIgnoreTagPrefixes []string) resource.TestCheckFunc {
+func testAccCheckAWSProviderIgnoreTagsKeyPrefixes(providers *[]*schema.Provider, expectedKeyPrefixes []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if providers == nil {
 			return fmt.Errorf("no providers initialized")
@@ -1021,17 +1044,26 @@ func testAccCheckAWSProviderIgnoreTagPrefixes(providers *[]*schema.Provider, exp
 			}
 
 			providerClient := provider.Meta().(*AWSClient)
+			ignoreTagsConfig := providerClient.IgnoreTagsConfig
 
-			actualIgnoreTagPrefixes := providerClient.ignoreTagPrefixes.Keys()
+			if ignoreTagsConfig == nil || ignoreTagsConfig.KeyPrefixes == nil {
+				if len(expectedKeyPrefixes) != 0 {
+					return fmt.Errorf("expected key_prefixes (%d) length, got: 0", len(expectedKeyPrefixes))
+				}
 
-			if len(actualIgnoreTagPrefixes) != len(expectedIgnoreTagPrefixes) {
-				return fmt.Errorf("expected ignore_tag_prefixes (%d) length, got: %d", len(expectedIgnoreTagPrefixes), len(actualIgnoreTagPrefixes))
+				continue
 			}
 
-			for _, expectedElement := range expectedIgnoreTagPrefixes {
+			actualKeyPrefixes := ignoreTagsConfig.KeyPrefixes.Keys()
+
+			if len(actualKeyPrefixes) != len(expectedKeyPrefixes) {
+				return fmt.Errorf("expected key_prefixes (%d) length, got: %d", len(expectedKeyPrefixes), len(actualKeyPrefixes))
+			}
+
+			for _, expectedElement := range expectedKeyPrefixes {
 				var found bool
 
-				for _, actualElement := range actualIgnoreTagPrefixes {
+				for _, actualElement := range actualKeyPrefixes {
 					if actualElement == expectedElement {
 						found = true
 						break
@@ -1039,14 +1071,14 @@ func testAccCheckAWSProviderIgnoreTagPrefixes(providers *[]*schema.Provider, exp
 				}
 
 				if !found {
-					return fmt.Errorf("expected ignore_tag_prefixes element, but was missing: %s", expectedElement)
+					return fmt.Errorf("expected key_prefixes element, but was missing: %s", expectedElement)
 				}
 			}
 
-			for _, actualElement := range actualIgnoreTagPrefixes {
+			for _, actualElement := range actualKeyPrefixes {
 				var found bool
 
-				for _, expectedElement := range expectedIgnoreTagPrefixes {
+				for _, expectedElement := range expectedKeyPrefixes {
 					if actualElement == expectedElement {
 						found = true
 						break
@@ -1054,7 +1086,7 @@ func testAccCheckAWSProviderIgnoreTagPrefixes(providers *[]*schema.Provider, exp
 				}
 
 				if !found {
-					return fmt.Errorf("unexpected ignore_tag_prefixes element: %s", actualElement)
+					return fmt.Errorf("unexpected key_prefixes element: %s", actualElement)
 				}
 			}
 		}
@@ -1063,7 +1095,7 @@ func testAccCheckAWSProviderIgnoreTagPrefixes(providers *[]*schema.Provider, exp
 	}
 }
 
-func testAccCheckAWSProviderIgnoreTags(providers *[]*schema.Provider, expectedIgnoreTags []string) resource.TestCheckFunc {
+func testAccCheckAWSProviderIgnoreTagsKeys(providers *[]*schema.Provider, expectedKeys []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if providers == nil {
 			return fmt.Errorf("no providers initialized")
@@ -1075,17 +1107,26 @@ func testAccCheckAWSProviderIgnoreTags(providers *[]*schema.Provider, expectedIg
 			}
 
 			providerClient := provider.Meta().(*AWSClient)
+			ignoreTagsConfig := providerClient.IgnoreTagsConfig
 
-			actualIgnoreTags := providerClient.ignoreTags.Keys()
+			if ignoreTagsConfig == nil || ignoreTagsConfig.Keys == nil {
+				if len(expectedKeys) != 0 {
+					return fmt.Errorf("expected keys (%d) length, got: 0", len(expectedKeys))
+				}
 
-			if len(actualIgnoreTags) != len(expectedIgnoreTags) {
-				return fmt.Errorf("expected ignore_tags (%d) length, got: %d", len(expectedIgnoreTags), len(actualIgnoreTags))
+				continue
 			}
 
-			for _, expectedElement := range expectedIgnoreTags {
+			actualKeys := ignoreTagsConfig.Keys.Keys()
+
+			if len(actualKeys) != len(expectedKeys) {
+				return fmt.Errorf("expected keys (%d) length, got: %d", len(expectedKeys), len(actualKeys))
+			}
+
+			for _, expectedElement := range expectedKeys {
 				var found bool
 
-				for _, actualElement := range actualIgnoreTags {
+				for _, actualElement := range actualKeys {
 					if actualElement == expectedElement {
 						found = true
 						break
@@ -1093,14 +1134,14 @@ func testAccCheckAWSProviderIgnoreTags(providers *[]*schema.Provider, expectedIg
 				}
 
 				if !found {
-					return fmt.Errorf("expected ignore_tags element, but was missing: %s", expectedElement)
+					return fmt.Errorf("expected keys element, but was missing: %s", expectedElement)
 				}
 			}
 
-			for _, actualElement := range actualIgnoreTags {
+			for _, actualElement := range actualKeys {
 				var found bool
 
-				for _, expectedElement := range expectedIgnoreTags {
+				for _, expectedElement := range expectedKeys {
 					if actualElement == expectedElement {
 						found = true
 						break
@@ -1108,7 +1149,7 @@ func testAccCheckAWSProviderIgnoreTags(providers *[]*schema.Provider, expectedIg
 				}
 
 				if !found {
-					return fmt.Errorf("unexpected ignore_tags element: %s", actualElement)
+					return fmt.Errorf("unexpected keys element: %s", actualElement)
 				}
 			}
 		}
@@ -1207,7 +1248,26 @@ data "aws_arn" "test" {
 `, endpoints)
 }
 
-func testAccAWSProviderConfigIgnoreTagPrefixes0() string {
+func testAccAWSProviderConfigIgnoreTagsEmptyConfigurationBlock() string {
+	//lintignore:AT004
+	return fmt.Sprintf(`
+provider "aws" {
+  ignore_tags {}
+
+  skip_credentials_validation = true
+  skip_get_ec2_platforms      = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+}
+
+# Required to initialize the provider
+data "aws_arn" "test" {
+  arn = "arn:aws:s3:::test"
+}
+`)
+}
+
+func testAccAWSProviderConfigIgnoreTagsKeyPrefixes0() string {
 	//lintignore:AT004
 	return fmt.Sprintf(`
 provider "aws" {
@@ -1224,11 +1284,14 @@ data "aws_arn" "test" {
 `)
 }
 
-func testAccAWSProviderConfigIgnoreTagPrefixes1(tagPrefix1 string) string {
+func testAccAWSProviderConfigIgnoreTagsKeyPrefixes1(tagPrefix1 string) string {
 	//lintignore:AT004
 	return fmt.Sprintf(`
 provider "aws" {
-  ignore_tag_prefixes         = [%[1]q]
+  ignore_tags {
+    key_prefixes = [%[1]q]
+  }
+
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
@@ -1242,11 +1305,14 @@ data "aws_arn" "test" {
 `, tagPrefix1)
 }
 
-func testAccAWSProviderConfigIgnoreTagPrefixes2(tagPrefix1, tagPrefix2 string) string {
+func testAccAWSProviderConfigIgnoreTagsKeyPrefixes2(tagPrefix1, tagPrefix2 string) string {
 	//lintignore:AT004
 	return fmt.Sprintf(`
 provider "aws" {
-  ignore_tag_prefixes         = [%[1]q, %[2]q]
+  ignore_tags {
+    key_prefixes = [%[1]q, %[2]q]
+  }
+
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
@@ -1260,7 +1326,7 @@ data "aws_arn" "test" {
 `, tagPrefix1, tagPrefix2)
 }
 
-func testAccAWSProviderConfigIgnoreTags0() string {
+func testAccAWSProviderConfigIgnoreTagsKeys0() string {
 	//lintignore:AT004
 	return fmt.Sprintf(`
 provider "aws" {
@@ -1277,11 +1343,14 @@ data "aws_arn" "test" {
 `)
 }
 
-func testAccAWSProviderConfigIgnoreTags1(tag1 string) string {
+func testAccAWSProviderConfigIgnoreTagsKeys1(tag1 string) string {
 	//lintignore:AT004
 	return fmt.Sprintf(`
 provider "aws" {
-  ignore_tags                 = [%[1]q]
+  ignore_tags {
+    keys = [%[1]q]
+  }
+
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
@@ -1295,11 +1364,14 @@ data "aws_arn" "test" {
 `, tag1)
 }
 
-func testAccAWSProviderConfigIgnoreTags2(tag1, tag2 string) string {
+func testAccAWSProviderConfigIgnoreTagsKeys2(tag1, tag2 string) string {
 	//lintignore:AT004
 	return fmt.Sprintf(`
 provider "aws" {
-  ignore_tags                 = [%[1]q, %[2]q]
+  ignore_tags {
+    keys = [%[1]q, %[2]q]
+  }
+
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true

--- a/aws/resource_aws_subnet.go
+++ b/aws/resource_aws_subnet.go
@@ -208,8 +208,7 @@ func resourceAwsSubnetCreate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
-	ignoreTags := meta.(*AWSClient).ignoreTags
-	ignoreTagPrefixes := meta.(*AWSClient).ignoreTagPrefixes
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
 	resp, err := conn.DescribeSubnets(&ec2.DescribeSubnetsInput{
 		SubnetIds: []*string{aws.String(d.Id())},
@@ -250,7 +249,7 @@ func resourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("arn", subnet.SubnetArn)
 
-	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(subnet.Tags).IgnoreAws().IgnorePrefixes(ignoreTagPrefixes).Ignore(ignoreTags).Map()); err != nil {
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(subnet.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -192,11 +192,11 @@ func TestAccAWSSubnet_ignoreTags(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config:   testAccProviderConfigIgnoreTagPrefixes1("ignorekey") + testAccSubnetConfig,
+				Config:   testAccProviderConfigIgnoreTagsKeyPrefixes1("ignorekey") + testAccSubnetConfig,
 				PlanOnly: true,
 			},
 			{
-				Config:   testAccProviderConfigIgnoreTags1("ignorekey1") + testAccSubnetConfig,
+				Config:   testAccProviderConfigIgnoreTagsKeys1("ignorekey1") + testAccSubnetConfig,
 				PlanOnly: true,
 			},
 		},

--- a/aws/resource_aws_vpc.go
+++ b/aws/resource_aws_vpc.go
@@ -266,8 +266,7 @@ func resourceAwsVpcCreate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
-	ignoreTags := meta.(*AWSClient).ignoreTags
-	ignoreTagPrefixes := meta.(*AWSClient).ignoreTagPrefixes
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
 	// Refresh the VPC state
 	vpcRaw, _, err := VPCStateRefreshFunc(conn, d.Id())()
@@ -296,7 +295,7 @@ func resourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 	}.String()
 	d.Set("arn", arn)
 
-	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(vpc.Tags).IgnoreAws().IgnorePrefixes(ignoreTagPrefixes).Ignore(ignoreTags).Map()); err != nil {
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(vpc.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 

--- a/aws/resource_aws_vpc_test.go
+++ b/aws/resource_aws_vpc_test.go
@@ -176,11 +176,11 @@ func TestAccAWSVpc_ignoreTags(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config:   testAccProviderConfigIgnoreTagPrefixes1("ignorekey") + testAccVpcConfigTags,
+				Config:   testAccProviderConfigIgnoreTagsKeyPrefixes1("ignorekey") + testAccVpcConfigTags,
 				PlanOnly: true,
 			},
 			{
-				Config:   testAccProviderConfigIgnoreTags1("ignorekey1") + testAccVpcConfigTags,
+				Config:   testAccProviderConfigIgnoreTagsKeys1("ignorekey1") + testAccVpcConfigTags,
 				PlanOnly: true,
 			},
 		},

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -200,11 +200,7 @@ for more information about connecting to alternate AWS endpoints or AWS compatib
   potentially end up destroying a live environment). Conflicts with
   `allowed_account_ids`.
 
-* `ignore_tag_prefixes` - (Optional) **NOTE: This functionality is in public preview and there are no compatibility promises with future versions of the Terraform AWS Provider until a general availability announcement.** List of resource tag key prefixes to ignore across all resources handled by this provider (see the [Terraform multiple provider instances documentation](/docs/configuration/providers.html#alias-multiple-provider-instances) for more information about additional provider configurations). This is designed for situations where external systems are managing certain resource tags. It prevents Terraform from returning any tag key matching the prefixes in any `tags` attributes and displaying any configuration difference for those tag values. If any resource configuration still has a tag matching one of the prefixes configured in the `tags` argument, it will display a perpetual difference until the tag is removed from the argument or [`ignore_changes`](/docs/configuration/resources.html#ignore_changes) is also used. This functionality is only supported in the following resources:
-  - `aws_subnet`
-  - `aws_vpc`
-
-* `ignore_tags` - (Optional) **NOTE: This functionality is in public preview and there are no compatibility promises with future versions of the Terraform AWS Provider until a general availability announcement.** List of exact resource tag keys to ignore across all resources handled by this provider (see the [Terraform multiple provider instances documentation](/docs/configuration/providers.html#alias-multiple-provider-instances) for more information about additional provider configurations). This is designed for situations where external systems are managing certain resource tags. It prevents Terraform from returning the tag in any `tags` attributes and displaying any configuration difference for the tag value. If any resource configuration still has this tag key configured in the `tags` argument, it will display a perpetual difference until the tag is removed from the argument or [`ignore_changes`](/docs/configuration/resources.html#ignore_changes) is also used. This functionality is only supported in the following resources:
+* `ignore_tags` - (Optional) **NOTE: This functionality is in public preview and there are no compatibility promises with future versions of the Terraform AWS Provider until a general availability announcement.** Configuration block with resource tag settings to ignore across all resources handled by this provider for situations where external systems are managing certain resource tags. Arguments to the configuration block are described below in the `ignore_tags` Configuration Block section. See the [Terraform multiple provider instances documentation](/docs/configuration/providers.html#alias-multiple-provider-instances) for more information about additional provider configurations. This functionality is only supported in the following resources:
   - `aws_subnet`
   - `aws_vpc`
 
@@ -283,7 +279,9 @@ for more information about connecting to alternate AWS endpoints or AWS compatib
   virtual hosted bucket addressing, `http://BUCKET.s3.amazonaws.com/KEY`,
   when possible. Specific to the Amazon S3 service.
 
-The nested `assume_role` block supports the following:
+### assume_role Configuration Block
+
+The `assume_role` configuration block supports the following arguments:
 
 * `role_arn` - (Required) The ARN of the role to assume.
 
@@ -297,6 +295,25 @@ The nested `assume_role` block supports the following:
 This gives you a way to further restrict the permissions for the resulting temporary
 security credentials. You cannot use the passed policy to grant permissions that are
 in excess of those allowed by the access policy of the role that is being assumed.
+
+### ignore_tags Configuration Block
+
+~> **NOTE:** This functionality is in public preview and there are no compatibility promises with future versions of the Terraform AWS Provider until a general availability announcement.
+
+Example:
+
+```hcl
+provider "aws" {
+  ignore_tags {
+    keys = ["TagKey1"]
+  }
+}
+```
+
+The `ignore_tags` configuration block supports the following arguments:
+
+* `keys` - (Optional) List of exact resource tag keys to ignore across all resources handled by this provider. This configuration prevents Terraform from returning the tag in any `tags` attributes and displaying any configuration difference for the tag value. If any resource configuration still has this tag key configured in the `tags` argument, it will display a perpetual difference until the tag is removed from the argument or [`ignore_changes`](/docs/configuration/resources.html#ignore_changes) is also used.
+* `key_prefixes` - (Optional) List of resource tag key prefixes to ignore across all resources handled by this provider. This configuration prevents Terraform from returning any tag key matching the prefixes in any `tags` attributes and displaying any configuration difference for those tag values. If any resource configuration still has a tag matching one of the prefixes configured in the `tags` argument, it will display a perpetual difference until the tag is removed from the argument or [`ignore_changes`](/docs/configuration/resources.html#ignore_changes) is also used.
 
 ## Getting the Account ID
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/10689

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

``````release-note
BREAKING CHANGES:

* provider: The configuration for the preview ignore tags functionality has been updated to include a wrapping configuration block. For example:

```hcl
provider "aws" {
  ignore_tags {
    keys = ["TagKey1"]
  }
}
```
``````

Based on feedback and for future extensibility.

Output from acceptance testing:

```
--- PASS: TestAccAWSProvider_Endpoints (4.06s)
--- PASS: TestAccAWSProvider_Endpoints_Deprecated (4.04s)
--- PASS: TestAccAWSProvider_IgnoreTags_EmptyConfigurationBlock (3.99s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_Multiple (4.01s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_None (4.00s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_One (4.02s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_Multiple (4.02s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_None (3.96s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_One (4.01s)
--- PASS: TestAccAWSProvider_Region_AwsChina (3.83s)
--- PASS: TestAccAWSProvider_Region_AwsCommercial (3.83s)
--- PASS: TestAccAWSProvider_Region_AwsGovCloudUs (3.77s)

--- PASS: TestAccAWSSubnet_availabilityZoneId (30.61s)
--- PASS: TestAccAWSSubnet_basic (30.88s)
--- PASS: TestAccAWSSubnet_enableIpv6 (49.79s)
--- PASS: TestAccAWSSubnet_ignoreTags (57.70s)
--- PASS: TestAccAWSSubnet_ipv6 (79.46s)

--- PASS: TestAccAWSVpc_AssignGeneratedIpv6CidrBlock (70.48s)
--- PASS: TestAccAWSVpc_basic (29.30s)
--- PASS: TestAccAWSVpc_bothDnsOptionsSet (30.18s)
--- PASS: TestAccAWSVpc_classiclinkDnsSupportOptionSet (31.10s)
--- PASS: TestAccAWSVpc_classiclinkOptionSet (30.48s)
--- PASS: TestAccAWSVpc_coreMismatchedDiffs (25.43s)
--- PASS: TestAccAWSVpc_DisabledDnsSupport (29.98s)
--- PASS: TestAccAWSVpc_disappears (15.64s)
--- PASS: TestAccAWSVpc_ignoreTags (51.16s)
--- PASS: TestAccAWSVpc_tags (48.55s)
--- PASS: TestAccAWSVpc_Tenancy (70.60s)
--- PASS: TestAccAWSVpc_update (44.36s)
```
