### PR TITLE
Do not swallow error when detaching volume

### DIFF
--- a/aws/resource_aws_volume_attachment.go
+++ b/aws/resource_aws_volume_attachment.go
@@ -245,8 +245,8 @@ func resourceAwsVolumeAttachmentDelete(d *schema.ResourceData, meta interface{})
 	_, err = stateConf.WaitForState()
 	if err != nil {
 		return fmt.Errorf(
-			"Error waiting for Volume (%s) to detach from Instance: %s",
-			vID, iID)
+			"Error waiting for Volume (%s) to detach from Instance (%s): %s",
+			vID, iID, err)
 	}
 
 	return nil


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request


```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSVolumeAttachment*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSVolumeAttachment* -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSVolumeAttachment_basic
=== PAUSE TestAccAWSVolumeAttachment_basic
=== RUN   TestAccAWSVolumeAttachment_skipDestroy
=== PAUSE TestAccAWSVolumeAttachment_skipDestroy
=== RUN   TestAccAWSVolumeAttachment_attachStopped
=== PAUSE TestAccAWSVolumeAttachment_attachStopped
=== RUN   TestAccAWSVolumeAttachment_update
=== PAUSE TestAccAWSVolumeAttachment_update
=== CONT  TestAccAWSVolumeAttachment_basic
=== CONT  TestAccAWSVolumeAttachment_update
=== CONT  TestAccAWSVolumeAttachment_skipDestroy
=== CONT  TestAccAWSVolumeAttachment_attachStopped
...
```
