### PR TITLE
tests/provider: Introduce regional sweeper AWSClient cache

### DIFF
--- a/aws/aws_sweeper_test.go
+++ b/aws/aws_sweeper_test.go
@@ -8,13 +8,22 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
+// sweeperAwsClients is a shared cache of regional AWSClient
+// This prevents client re-initialization for every resource with no benefit.
+var sweeperAwsClients map[string]interface{}
+
 func TestMain(m *testing.M) {
+	sweeperAwsClients = make(map[string]interface{})
 	resource.TestMain(m)
 }
 
 // sharedClientForRegion returns a common AWSClient setup needed for the sweeper
 // functions for a given region
 func sharedClientForRegion(region string) (interface{}, error) {
+	if client, ok := sweeperAwsClients[region]; ok {
+		return client, nil
+	}
+
 	if os.Getenv("AWS_PROFILE") == "" && (os.Getenv("AWS_ACCESS_KEY_ID") == "" || os.Getenv("AWS_SECRET_ACCESS_KEY") == "") {
 		return nil, fmt.Errorf("must provide environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY or environment variable AWS_PROFILE")
 	}
@@ -29,6 +38,8 @@ func sharedClientForRegion(region string) (interface{}, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error getting AWS client")
 	}
+
+	sweeperAwsClients[region] = client
 
 	return client, nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Allows the sweepers to initialize the AWS Go SDK Client once per region, rather than once per resource. Saves roughly 80% of runtime during full sweep with no operations.

Previously without cache:

```
ok    github.com/terraform-providers/terraform-provider-aws/aws 441.621s
go test ./aws -v -timeout=10h -sweep=us-west-2,us-east-1 -sweep-allow-failure  73.86s user 10.36s system 17% cpu 7:48.21 total
```

With cache:

```
ok    github.com/terraform-providers/terraform-provider-aws/aws 94.949s
go test ./aws -v -timeout=10h -sweep=us-west-2,us-east-1 -sweep-allow-failure  21.03s user 4.95s system 25% cpu 1:43.66 total
```