### PR TITLE
Fix: AppSync datasource name can't be updated

### DIFF
--- a/aws/resource_aws_appsync_datasource.go
+++ b/aws/resource_aws_appsync_datasource.go
@@ -237,7 +237,7 @@ func resourceAwsAppsyncDatasourceUpdate(d *schema.ResourceData, meta interface{}
 	conn := meta.(*AWSClient).appsyncconn
 	region := meta.(*AWSClient).region
 
-	apiID, name, err := decodeAppsyncDataSourceID(d.Id())
+	apiID, _, err := decodeAppsyncDataSourceID(d.Id())
 
 	if err != nil {
 		return err
@@ -245,7 +245,7 @@ func resourceAwsAppsyncDatasourceUpdate(d *schema.ResourceData, meta interface{}
 
 	input := &appsync.UpdateDataSourceInput{
 		ApiId: aws.String(apiID),
-		Name:  aws.String(name),
+		Name:  aws.String(d.Get("name").(string)),
 		Type:  aws.String(d.Get("type").(string)),
 	}
 
@@ -277,6 +277,9 @@ func resourceAwsAppsyncDatasourceUpdate(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return err
 	}
+
+	d.SetId(apiID + "-" + d.Get("name").(string))
+
 	return resourceAwsAppsyncDatasourceRead(d, meta)
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

Reference: [UpdateDataSource - AWS AppSync](https://docs.aws.amazon.com/appsync/latest/APIReference/API_UpdateDataSource.html)

The URI parameter  `name` should be the new name for the data source.

https://docs.aws.amazon.com/appsync/latest/APIReference/API_UpdateDataSource.html
![image](https://user-images.githubusercontent.com/1885716/78315306-921b5e00-7597-11ea-957a-3c43bdbb2a2e.png)



<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12608

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
