### PR TITLE
resource/aws_glue_catalog_table: Prevent various panics with empty configuration blocks

### DIFF
--- a/aws/resource_aws_glue_catalog_table.go
+++ b/aws/resource_aws_glue_catalog_table.go
@@ -388,7 +388,7 @@ func expandGlueTableInput(d *schema.ResourceData) *glue.TableInput {
 }
 
 func expandGlueStorageDescriptor(l []interface{}) *glue.StorageDescriptor {
-	if len(l) == 0 {
+	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
@@ -479,7 +479,7 @@ func expandGlueColumns(columns []interface{}) []*glue.Column {
 }
 
 func expandGlueSerDeInfo(l []interface{}) *glue.SerDeInfo {
-	if len(l) == 0 {
+	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
@@ -526,7 +526,7 @@ func expandGlueSortColumns(columns []interface{}) []*glue.Order {
 }
 
 func expandGlueSkewedInfo(l []interface{}) *glue.SkewedInfo {
-	if len(l) == 0 {
+	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 

--- a/aws/resource_aws_glue_catalog_table_test.go
+++ b/aws/resource_aws_glue_catalog_table_test.go
@@ -338,6 +338,72 @@ func TestAccAWSGlueCatalogTable_update_replaceValues(t *testing.T) {
 	})
 }
 
+// Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/11784
+func TestAccAWSGlueCatalogTable_StorageDescriptor_EmptyConfigurationBlock(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_glue_catalog_table.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGlueTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlueCatalogTableConfigStorageDescriptorEmptyConfigurationBlock(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlueCatalogTableExists(resourceName),
+				),
+				// Expect non-empty instead of panic
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/11784
+func TestAccAWSGlueCatalogTable_StorageDescriptor_SerDeInfo_EmptyConfigurationBlock(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_glue_catalog_table.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGlueTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlueCatalogTableConfigStorageDescriptorSerDeInfoEmptyConfigurationBlock(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlueCatalogTableExists(resourceName),
+				),
+				// Expect non-empty instead of panic
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/11784
+func TestAccAWSGlueCatalogTable_StorageDescriptor_SkewedInfo_EmptyConfigurationBlock(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_glue_catalog_table.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGlueTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlueCatalogTableConfigStorageDescriptorSkewedInfoEmptyConfigurationBlock(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlueCatalogTableExists(resourceName),
+				),
+				// Expect non-empty instead of panic
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccGlueCatalogTable_basic(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
@@ -534,6 +600,95 @@ resource "aws_glue_catalog_table" "test" {
   }
 }
 `, rInt, rInt)
+}
+
+func testAccGlueCatalogTableConfigStorageDescriptorEmptyConfigurationBlock(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+}
+
+resource "aws_glue_catalog_table" "test" {
+  database_name = aws_glue_catalog_database.test.name
+  name          = %[1]q
+
+  storage_descriptor {}
+}
+`, rName)
+}
+
+func testAccGlueCatalogTableConfigStorageDescriptorSerDeInfoEmptyConfigurationBlock(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+}
+
+resource "aws_glue_catalog_table" "test" {
+  database_name = aws_glue_catalog_database.test.name
+  name          = %[1]q
+
+  storage_descriptor {
+    // bucket_columns            = []
+    // compressed                = false
+    // input_format              = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
+    // location                  = "s3://issue_bucket/issue_table"
+    // number_of_buckets         = -1
+    // output_format             = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
+    // parameters                = {}
+    // stored_as_sub_directories = false
+
+    // columns {
+    //   name = "issue_column"
+    //   type = "string"
+    // }
+
+    ser_de_info {}
+  }
+}
+`, rName)
+}
+
+func testAccGlueCatalogTableConfigStorageDescriptorSkewedInfoEmptyConfigurationBlock(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+}
+
+resource "aws_glue_catalog_table" "test" {
+  database_name = aws_glue_catalog_database.test.name
+  name          = %[1]q
+
+  storage_descriptor {
+    // bucket_columns            = []
+    // compressed                = false
+    // input_format              = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
+    // location                  = "s3://issue_bucket/issue_table"
+    // number_of_buckets         = -1
+    // output_format             = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
+    // parameters                = {}
+    // stored_as_sub_directories = false
+
+    // columns {
+    //   name = "issue_column"
+    //   type = "string"
+    // }
+
+    // ser_de_info {
+    //   name = "SerDe"
+    //   parameters            = {
+    //     "serialization.format" = "1"
+    //   }
+    //   serialization_library = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
+    // }
+
+    skewed_info {
+      skewed_column_names               = []
+      skewed_column_value_location_maps = {}
+      skewed_column_values              = []
+    }
+  }
+}
+`, rName)
 }
 
 func testAccCheckGlueTableDestroy(s *terraform.State) error {

--- a/aws/resource_aws_glue_catalog_table_test.go
+++ b/aws/resource_aws_glue_catalog_table_test.go
@@ -628,20 +628,6 @@ resource "aws_glue_catalog_table" "test" {
   name          = %[1]q
 
   storage_descriptor {
-    // bucket_columns            = []
-    // compressed                = false
-    // input_format              = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
-    // location                  = "s3://issue_bucket/issue_table"
-    // number_of_buckets         = -1
-    // output_format             = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
-    // parameters                = {}
-    // stored_as_sub_directories = false
-
-    // columns {
-    //   name = "issue_column"
-    //   type = "string"
-    // }
-
     ser_de_info {}
   }
 }
@@ -659,28 +645,6 @@ resource "aws_glue_catalog_table" "test" {
   name          = %[1]q
 
   storage_descriptor {
-    // bucket_columns            = []
-    // compressed                = false
-    // input_format              = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
-    // location                  = "s3://issue_bucket/issue_table"
-    // number_of_buckets         = -1
-    // output_format             = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
-    // parameters                = {}
-    // stored_as_sub_directories = false
-
-    // columns {
-    //   name = "issue_column"
-    //   type = "string"
-    // }
-
-    // ser_de_info {
-    //   name = "SerDe"
-    //   parameters            = {
-    //     "serialization.format" = "1"
-    //   }
-    //   serialization_library = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
-    // }
-
     skewed_info {
       skewed_column_names               = []
       skewed_column_value_location_maps = {}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11610
Closes #11784

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_glue_catalog_table: Prevent various panics with empty configuration blocks
```

Previously:

```
=== CONT  TestAccAWSGlueCatalogTable_StorageDescriptor_EmptyConfigurationBlock
panic: interface conversion: interface {} is nil, not map[string]interface {}

goroutine 366 [running]:
github.com/terraform-providers/terraform-provider-aws/aws.expandGlueStorageDescriptor(0xc000f536b0, 0x1, 0x1, 0x5b2c600)
  /Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_glue_catalog_table.go:395 +0xd86
github.com/terraform-providers/terraform-provider-aws/aws.expandGlueTableInput(0xc000721570, 0xc000f535e0)
  /Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_glue_catalog_table.go:359 +0x1f5
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsGlueCatalogTableCreate(0xc000721570, 0x62e06e0, 0xc0005a8f00, 0x2, 0xb611ee0)
  /Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_glue_catalog_table.go:235 +0x1ae
github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Resource).Apply(0xc000a00480, 0xc0001cbb30, 0xc000ecaf40, 0x62e06e0, 0xc0005a8f00, 0x6166401, 0xc001e41968, 0xc000df4c30)
  /Users/bflad/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.8.0/helper/schema/resource.go:305 +0x365

=== CONT  TestAccAWSGlueCatalogTable_StorageDescriptor_SerDeInfo_EmptyConfigurationBlock
panic: interface conversion: interface {} is nil, not map[string]interface {}

goroutine 358 [running]:
github.com/terraform-providers/terraform-provider-aws/aws.expandGlueSerDeInfo(0xc00169d630, 0x1, 0x1, 0xb)
  /Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_glue_catalog_table.go:486 +0x4ab
github.com/terraform-providers/terraform-provider-aws/aws.expandGlueStorageDescriptor(0xc00169d600, 0x1, 0x1, 0x5b2c600)
  /Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_glue_catalog_table.go:424 +0x30a
github.com/terraform-providers/terraform-provider-aws/aws.expandGlueTableInput(0xc00083a310, 0xc00169d550)
  /Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_glue_catalog_table.go:359 +0x1f5
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsGlueCatalogTableCreate(0xc00083a310, 0x62e06e0, 0xc0001bef00, 0x2, 0xb611ee0)
  /Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_glue_catalog_table.go:235 +0x1ae
github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Resource).Apply(0xc00093a480, 0xc000c84190, 0xc000be0820, 0x62e06e0, 0xc0001bef00, 0x6166401, 0xc00167d228, 0xc00168b020)
  /Users/bflad/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.8.0/helper/schema/resource.go:305 +0x365

=== CONT  TestAccAWSGlueCatalogTable_StorageDescriptor_SkewedInfo_EmptyConfigurationBlock
panic: interface conversion: interface {} is nil, not map[string]interface {}

goroutine 390 [running]:
github.com/terraform-providers/terraform-provider-aws/aws.expandGlueSkewedInfo(0xc000f658e0, 0x1, 0x1, 0xb)
  /Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_glue_catalog_table.go:533 +0x6df
github.com/terraform-providers/terraform-provider-aws/aws.expandGlueStorageDescriptor(0xc000f658b0, 0x1, 0x1, 0x5b2bf60)
  /Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_glue_catalog_table.go:440 +0x5ee
github.com/terraform-providers/terraform-provider-aws/aws.expandGlueTableInput(0xc000595570, 0xc000f65790)
  /Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_glue_catalog_table.go:359 +0x1f5
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsGlueCatalogTableCreate(0xc000595570, 0x62e0040, 0xc0003bf400, 0x2, 0xb60fea0)
  /Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_glue_catalog_table.go:235 +0x1ae
github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Resource).Apply(0xc000626480, 0xc0007ae780, 0xc000ea3400, 0x62e0040, 0xc0003bf400, 0x6165e01, 0xc001dd76f8, 0xc000c02720)
  /Users/bflad/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.8.0/helper/schema/resource.go:305 +0x365
```

Output from acceptance testing:

```
--- PASS: TestAccAWSGlueCatalogTable_StorageDescriptor_EmptyConfigurationBlock (18.91s)
--- PASS: TestAccAWSGlueCatalogTable_StorageDescriptor_SerDeInfo_EmptyConfigurationBlock (19.64s)
--- PASS: TestAccAWSGlueCatalogTable_StorageDescriptor_SkewedInfo_EmptyConfigurationBlock (20.32s)
--- PASS: TestAccAWSGlueCatalogTable_full (20.75s)
--- PASS: TestAccAWSGlueCatalogTable_basic (20.75s)
--- PASS: TestAccAWSGlueCatalogTable_recreates (25.31s)
--- PASS: TestAccAWSGlueCatalogTable_update_replaceValues (33.98s)
--- PASS: TestAccAWSGlueCatalogTable_update_addValues (34.06s)
```
