### PR TITLE
resource/aws_kinesis_firehose_delivery_stream: Prevent panic with empty `processing_configuration` configuration block

### DIFF
--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -1728,7 +1728,7 @@ func expandFirehoseSchemaConfiguration(l []interface{}) *firehose.SchemaConfigur
 
 func extractProcessingConfiguration(s3 map[string]interface{}) *firehose.ProcessingConfiguration {
 	config := s3["processing_configuration"].([]interface{})
-	if len(config) == 0 {
+	if len(config) == 0 || config[0] == nil {
 		// It is possible to just pass nil here, but this seems to be the
 		// canonical form that AWS uses, and is less likely to produce diffs.
 		return &firehose.ProcessingConfiguration{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12600

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_kinesis_firehose_delivery_stream: Prevent panic with empty `processing_configuration` configuration block
```

Previously:

```
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ProcessingConfiguration_Empty
panic: interface conversion: interface {} is nil, not map[string]interface {}

goroutine 118 [running]:
github.com/terraform-providers/terraform-provider-aws/aws.extractProcessingConfiguration(0xc00184d260, 0xc00184d260)
  /Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_kinesis_firehose_delivery_stream.go:1740 +0x2c8
github.com/terraform-providers/terraform-provider-aws/aws.createExtendedS3Config(0xc00046aaf0, 0x6e20c0a)
  /Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_kinesis_firehose_delivery_stream.go:1447 +0x87d
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsKinesisFirehoseDeliveryStreamCreate(0xc00046aaf0, 0x62e1d20, 0xc0006cc500, 0x2, 0xb612ec0)
  /Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_kinesis_firehose_delivery_stream.go:2119 +0xee2
github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Resource).Apply(0xc000a7c400, 0xc00018e230, 0xc0008dc980, 0x62e1d20, 0xc0006cc500, 0x6167b01, 0xc001428fa8, 0xc001690d50)
  /Users/bflad/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.8.0/helper/schema/resource.go:305 +0x365
```

Output from acceptance testing:

```
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_basic (133.73s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates (827.20s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Deserializer_Update (125.27s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Enabled (147.94s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_HiveJsonSerDe_Empty (125.16s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OpenXJsonSerDe_Empty (117.24s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OrcSerDe_Empty (124.51s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_ParquetSerDe_Empty (90.80s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Serializer_Update (110.44s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ErrorOutputPrefix (116.60s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ExternalUpdate (133.58s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ProcessingConfiguration_Empty (101.05s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic (140.86s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3KmsKeyArn (138.74s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3Updates (192.36s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_missingProcessingConfiguration (101.08s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_RedshiftConfigUpdates (419.73s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basic (98.32s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithSSE (231.02s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithTags (153.05s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3ConfigUpdates (199.63s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource (105.65s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3WithCloudwatchLogging (118.33s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_SplunkConfigUpdates (159.89s)
```