### PR TITLE
resource/aws_s3_bucket: Prevent various panics with empty configuration blocks

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -2482,7 +2482,12 @@ func validateS3BucketName(value string, region string) error {
 
 func grantHash(v interface{}) int {
 	var buf bytes.Buffer
-	m := v.(map[string]interface{})
+	m, ok := v.(map[string]interface{})
+
+	if !ok {
+		return 0
+	}
+
 	if v, ok := m["id"]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
 	}
@@ -2500,7 +2505,12 @@ func grantHash(v interface{}) int {
 
 func expirationHash(v interface{}) int {
 	var buf bytes.Buffer
-	m := v.(map[string]interface{})
+	m, ok := v.(map[string]interface{})
+
+	if !ok {
+		return 0
+	}
+
 	if v, ok := m["date"]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
 	}
@@ -2515,7 +2525,12 @@ func expirationHash(v interface{}) int {
 
 func transitionHash(v interface{}) int {
 	var buf bytes.Buffer
-	m := v.(map[string]interface{})
+	m, ok := v.(map[string]interface{})
+
+	if !ok {
+		return 0
+	}
+
 	if v, ok := m["date"]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
 	}
@@ -2530,7 +2545,11 @@ func transitionHash(v interface{}) int {
 
 func rulesHash(v interface{}) int {
 	var buf bytes.Buffer
-	m := v.(map[string]interface{})
+	m, ok := v.(map[string]interface{})
+
+	if !ok {
+		return 0
+	}
 
 	if v, ok := m["id"]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
@@ -2558,7 +2577,12 @@ func rulesHash(v interface{}) int {
 
 func replicationRuleFilterHash(v interface{}) int {
 	var buf bytes.Buffer
-	m := v.(map[string]interface{})
+	m, ok := v.(map[string]interface{})
+
+	if !ok {
+		return 0
+	}
+
 	if v, ok := m["prefix"]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
 	}
@@ -2570,7 +2594,11 @@ func replicationRuleFilterHash(v interface{}) int {
 
 func destinationHash(v interface{}) int {
 	var buf bytes.Buffer
-	m := v.(map[string]interface{})
+	m, ok := v.(map[string]interface{})
+
+	if !ok {
+		return 0
+	}
 
 	if v, ok := m["bucket"]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
@@ -2591,12 +2619,12 @@ func destinationHash(v interface{}) int {
 }
 
 func accessControlTranslationHash(v interface{}) int {
-	// v is nil if empty access_control_translation is given.
-	if v == nil {
+	var buf bytes.Buffer
+	m, ok := v.(map[string]interface{})
+
+	if !ok {
 		return 0
 	}
-	var buf bytes.Buffer
-	m := v.(map[string]interface{})
 
 	if v, ok := m["owner"]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
@@ -2605,12 +2633,12 @@ func accessControlTranslationHash(v interface{}) int {
 }
 
 func sourceSelectionCriteriaHash(v interface{}) int {
-	// v is nil if empty source_selection_criteria is given.
-	if v == nil {
+	var buf bytes.Buffer
+	m, ok := v.(map[string]interface{})
+
+	if !ok {
 		return 0
 	}
-	var buf bytes.Buffer
-	m := v.(map[string]interface{})
 
 	if v, ok := m["sse_kms_encrypted_objects"].(*schema.Set); ok && v.Len() > 0 {
 		buf.WriteString(fmt.Sprintf("%d-", sourceSseKmsObjectsHash(v.List()[0])))
@@ -2620,7 +2648,11 @@ func sourceSelectionCriteriaHash(v interface{}) int {
 
 func sourceSseKmsObjectsHash(v interface{}) int {
 	var buf bytes.Buffer
-	m := v.(map[string]interface{})
+	m, ok := v.(map[string]interface{})
+
+	if !ok {
+		return 0
+	}
 
 	if v, ok := m["enabled"]; ok {
 		buf.WriteString(fmt.Sprintf("%t-", v.(bool)))


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11420
Closes #12480

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_s3_bucket: Prevent various panics with empty configuration blocks
```

This does not contain a fully reproducible configuration for #12480 after a few timeboxed attempts, but left a test that adds `access_control_translation` since that most closely mimics what was reported and was previously untested. The addition of an empty configuration block in the plan difference appears to be a bug in the Terraform Plugin SDK or Terraform core logic.

If/when these various S3 configurations are potentially moved to their own resources, we should try to remove the Set hashing functions then. Generally they are unnecessary except in specific situations.

Previously:

```
=== CONT  TestAccAWSS3Bucket_LifecycleRule_Expiration_EmptyConfigurationBlock
panic: interface conversion: interface {} is nil, not map[string]interface {}

goroutine 228 [running]:
github.com/terraform-providers/terraform-provider-aws/aws.expirationHash(0x0, 0x0, 0xc000e4bf10)
	/Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_s3_bucket.go:2503 +0x3d6
github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Set).hash(0xc000e4bf00, 0x0, 0x0, 0x746172697078652e, 0x2e302e6e6f69)
	/Users/bflad/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.8.0/helper/schema/set.go:221 +0x3d
```

Output from acceptance testing:

```
--- PASS: TestAccAWSS3Bucket_acceleration (62.39s)
--- PASS: TestAccAWSS3Bucket_AclToGrant (62.44s)
--- PASS: TestAccAWSS3Bucket_basic (37.44s)
--- PASS: TestAccAWSS3Bucket_Bucket_EmptyString (35.25s)
--- PASS: TestAccAWSS3Bucket_Cors_Delete (30.46s)
--- PASS: TestAccAWSS3Bucket_Cors_EmptyOrigin (37.46s)
--- PASS: TestAccAWSS3Bucket_Cors_Update (64.62s)
--- PASS: TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled (62.63s)
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed (36.77s)
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical (64.54s)
--- PASS: TestAccAWSS3Bucket_forceDestroy (34.28s)
--- PASS: TestAccAWSS3Bucket_forceDestroyWithEmptyPrefixes (33.82s)
--- PASS: TestAccAWSS3Bucket_forceDestroyWithObjectLockEnabled (40.74s)
--- PASS: TestAccAWSS3Bucket_generatedName (34.28s)
--- PASS: TestAccAWSS3Bucket_GrantToAcl (55.10s)
--- PASS: TestAccAWSS3Bucket_LifecycleBasic (85.90s)
--- PASS: TestAccAWSS3Bucket_LifecycleExpireMarkerOnly (60.69s)
--- PASS: TestAccAWSS3Bucket_LifecycleRule_Expiration_EmptyConfigurationBlock (29.75s)
--- PASS: TestAccAWSS3Bucket_Logging (53.50s)
--- PASS: TestAccAWSS3Bucket_namePrefix (34.09s)
--- PASS: TestAccAWSS3Bucket_objectLock (61.56s)
--- PASS: TestAccAWSS3Bucket_Policy (88.91s)
--- PASS: TestAccAWSS3Bucket_region (35.91s)
--- PASS: TestAccAWSS3Bucket_Replication (173.40s)
--- PASS: TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation (109.21s)
--- PASS: TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AddAccessControlTranslation (87.98s)
--- PASS: TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError (27.38s)
--- PASS: TestAccAWSS3Bucket_ReplicationSchemaV2 (150.14s)
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutPrefix (51.20s)
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutStorageClass (51.04s)
--- PASS: TestAccAWSS3Bucket_RequestPayer (61.18s)
--- PASS: TestAccAWSS3Bucket_shouldFailNotFound (17.00s)
--- PASS: TestAccAWSS3Bucket_tagsWithNoSystemTags (114.98s)
--- PASS: TestAccAWSS3Bucket_tagsWithSystemTags (148.05s)
--- PASS: TestAccAWSS3Bucket_UpdateAcl (60.53s)
--- PASS: TestAccAWSS3Bucket_UpdateGrant (90.89s)
--- PASS: TestAccAWSS3Bucket_Versioning (89.97s)
--- PASS: TestAccAWSS3Bucket_Website_Simple (89.17s)
--- PASS: TestAccAWSS3Bucket_WebsiteRedirect (89.72s)
--- PASS: TestAccAWSS3Bucket_WebsiteRoutingRules (63.15s)
```
