### PR TITLE
Change EC2 Instance root volume size without re-creating

### DIFF
--- a/aws/data_source_aws_instance.go
+++ b/aws/data_source_aws_instance.go
@@ -235,6 +235,11 @@ func dataSourceAwsInstance() *schema.Resource {
 							Computed: true,
 						},
 
+						"device_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
 						"encrypted": {
 							Type:     schema.TypeBool,
 							Computed: true,

--- a/aws/data_source_aws_instance_test.go
+++ b/aws/data_source_aws_instance_test.go
@@ -90,6 +90,7 @@ func TestAccAWSInstanceDataSource_gp2IopsDevice(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "root_block_device.#", resourceName, "root_block_device.#"),
 					resource.TestCheckResourceAttrPair(datasourceName, "root_block_device.0.volume_size", resourceName, "root_block_device.0.volume_size"),
 					resource.TestCheckResourceAttrPair(datasourceName, "root_block_device.0.volume_type", resourceName, "root_block_device.0.volume_type"),
+					resource.TestCheckResourceAttrPair(datasourceName, "root_block_device.0.device_name", resourceName, "root_block_device.0.device_name"),
 					resource.TestCheckResourceAttrPair(datasourceName, "root_block_device.0.iops", resourceName, "root_block_device.0.iops"),
 				),
 			},
@@ -113,6 +114,7 @@ func TestAccAWSInstanceDataSource_blockDevices(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "root_block_device.#", resourceName, "root_block_device.#"),
 					resource.TestCheckResourceAttrPair(datasourceName, "root_block_device.0.volume_size", resourceName, "root_block_device.0.volume_size"),
 					resource.TestCheckResourceAttrPair(datasourceName, "root_block_device.0.volume_type", resourceName, "root_block_device.0.volume_type"),
+					resource.TestCheckResourceAttrPair(datasourceName, "root_block_device.0.device_name", resourceName, "root_block_device.0.device_name"),
 					resource.TestCheckResourceAttrPair(datasourceName, "ebs_block_device.#", resourceName, "ebs_block_device.#"),
 					//resource.TestCheckResourceAttrPair(datasourceName, "ephemeral_block_device.#", resourceName, "ephemeral_block_device.#"),
 					// ephemeral block devices don't get saved properly due to API limitations, so this can't actually be tested right now

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -1483,35 +1483,35 @@ func readBlockDevicesFromInstance(instance *ec2.Instance, conn *ec2.EC2) (map[st
 		instanceBd := instanceBlockDevices[*vol.VolumeId]
 		bd := make(map[string]interface{})
 
-		bd["volume_id"] = *vol.VolumeId
+		bd["volume_id"] = aws.StringValue(vol.VolumeId)
 
 		if instanceBd.Ebs != nil && instanceBd.Ebs.DeleteOnTermination != nil {
-			bd["delete_on_termination"] = *instanceBd.Ebs.DeleteOnTermination
+			bd["delete_on_termination"] = aws.BoolValue(instanceBd.Ebs.DeleteOnTermination)
 		}
 		if vol.Size != nil {
-			bd["volume_size"] = *vol.Size
+			bd["volume_size"] = aws.Int64Value(vol.Size)
 		}
 		if vol.VolumeType != nil {
-			bd["volume_type"] = *vol.VolumeType
+			bd["volume_type"] = aws.StringValue(vol.VolumeType)
 		}
 		if vol.Iops != nil {
-			bd["iops"] = *vol.Iops
+			bd["iops"] = aws.Int64Value(vol.Iops)
 		}
 		if vol.Encrypted != nil {
-			bd["encrypted"] = *vol.Encrypted
+			bd["encrypted"] = aws.BoolValue(vol.Encrypted)
 		}
 		if vol.KmsKeyId != nil {
-			bd["kms_key_id"] = *vol.KmsKeyId
+			bd["kms_key_id"] = aws.StringValue(vol.KmsKeyId)
 		}
 
 		if blockDeviceIsRoot(instanceBd, instance) {
 			blockDevices["root"] = bd
 		} else {
 			if instanceBd.DeviceName != nil {
-				bd["device_name"] = *instanceBd.DeviceName
+				bd["device_name"] = aws.StringValue(instanceBd.DeviceName)
 			}
 			if vol.SnapshotId != nil {
-				bd["snapshot_id"] = *vol.SnapshotId
+				bd["snapshot_id"] = aws.StringValue(vol.SnapshotId)
 			}
 
 			blockDevices["ebs"] = append(blockDevices["ebs"].([]map[string]interface{}), bd)

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -1566,7 +1566,7 @@ func TestAccAWSInstance_changeRootBlockDeviceVolumeSize(t *testing.T) {
 					testAccCheckInstanceNotRecreated(
 						t, &before, &after),
 					resource.TestCheckResourceAttr(
-						"aws_instance.foo", "root_block_device.0.volume_size", "20"),
+						"aws_instance.foo", "root_block_device.0.volume_size", "12"),
 				),
 			},
 		},

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -159,8 +158,7 @@ func TestAccAWSInstance_inDefaultVpcBySgName(t *testing.T) {
 			{
 				Config: testAccInstanceConfigInDefaultVpcBySgName(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(
-						resourceName, &v),
+					testAccCheckInstanceExists(resourceName, &v),
 				),
 			},
 			{
@@ -185,8 +183,7 @@ func TestAccAWSInstance_inDefaultVpcBySgId(t *testing.T) {
 			{
 				Config: testAccInstanceConfigInDefaultVpcBySgId(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(
-						resourceName, &v),
+					testAccCheckInstanceExists(resourceName, &v),
 				),
 			},
 			{
@@ -216,8 +213,7 @@ func TestAccAWSInstance_inEc2Classic(t *testing.T) {
 			{
 				Config: testAccInstanceConfigInEc2Classic(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(
-						resourceName, &v),
+					testAccCheckInstanceExists(resourceName, &v),
 				),
 			},
 			{
@@ -277,19 +273,11 @@ func TestAccAWSInstance_basic(t *testing.T) {
 			{
 				Config: testAccInstanceConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(
-						resourceName, &v),
+					testAccCheckInstanceExists(resourceName, &v),
 					testCheck(rInt),
-					resource.TestCheckResourceAttr(
-						resourceName,
-						"user_data",
-						"3dc39dda39be1205215e776bad998da361a5955d"),
-					resource.TestCheckResourceAttr(
-						resourceName, "ebs_block_device.#", "0"),
-					resource.TestMatchResourceAttr(
-						resourceName,
-						"arn",
-						regexp.MustCompile(`^arn:[^:]+:ec2:[^:]+:\d{12}:instance/i-.+`)),
+					resource.TestCheckResourceAttr(resourceName, "user_data", "3dc39dda39be1205215e776bad998da361a5955d"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.#", "0"),
+					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(`^arn:[^:]+:ec2:[^:]+:\d{12}:instance/i-.+`)),
 				),
 			},
 			{
@@ -303,15 +291,10 @@ func TestAccAWSInstance_basic(t *testing.T) {
 			{
 				Config: testAccInstanceConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(
-						resourceName, &v),
+					testAccCheckInstanceExists(resourceName, &v),
 					testCheck(rInt),
-					resource.TestCheckResourceAttr(
-						resourceName,
-						"user_data",
-						"3dc39dda39be1205215e776bad998da361a5955d"),
-					resource.TestCheckResourceAttr(
-						resourceName, "ebs_block_device.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "user_data", "3dc39dda39be1205215e776bad998da361a5955d"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.#", "0"),
 				),
 			},
 			// Clean up volume created above
@@ -392,12 +375,8 @@ func TestAccAWSInstance_userDataBase64(t *testing.T) {
 			{
 				Config: testAccInstanceConfigWithUserDataBase64(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(
-						resourceName, &v),
-					resource.TestCheckResourceAttr(
-						resourceName,
-						"user_data_base64",
-						"aGVsbG8gd29ybGQ="),
+					testAccCheckInstanceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "user_data_base64", "aGVsbG8gd29ybGQ="),
 				),
 			},
 			{
@@ -443,16 +422,11 @@ func TestAccAWSInstance_GP2IopsDevice(t *testing.T) {
 				Config: testAccInstanceGP2IopsDevice,
 				//Config: testAccInstanceConfigBlockDevices,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(
-						resourceName, &v),
-					resource.TestCheckResourceAttr(
-						resourceName, "root_block_device.#", "1"),
-					resource.TestCheckResourceAttr(
-						resourceName, "root_block_device.0.volume_size", "11"),
-					resource.TestCheckResourceAttr(
-						resourceName, "root_block_device.0.volume_type", "gp2"),
-					resource.TestCheckResourceAttr(
-						resourceName, "root_block_device.0.iops", "100"),
+					testAccCheckInstanceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "root_block_device.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_size", "11"),
+					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_type", "gp2"),
+					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.iops", "100"),
 					testCheck(),
 				),
 			},
@@ -541,50 +515,28 @@ func TestAccAWSInstance_blockDevices(t *testing.T) {
 			{
 				Config: testAccInstanceConfigBlockDevices,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(
-						resourceName, &v),
-					resource.TestCheckResourceAttr(
-						resourceName, "root_block_device.#", "1"),
-					resource.TestMatchResourceAttr(
-						resourceName, "root_block_device.0.volume_id", regexp.MustCompile("vol-[a-z0-9]+")),
-					resource.TestCheckResourceAttr(
-						resourceName, "root_block_device.0.volume_size", "11"),
-					resource.TestCheckResourceAttr(
-						resourceName, "root_block_device.0.volume_type", "gp2"),
-					resource.TestCheckResourceAttr(
-						resourceName, "ebs_block_device.#", "3"),
-					resource.TestCheckResourceAttr(
-						resourceName, "ebs_block_device.2576023345.device_name", "/dev/sdb"),
-					resource.TestMatchResourceAttr(
-						resourceName, "ebs_block_device.2576023345.volume_id", regexp.MustCompile("vol-[a-z0-9]+")),
-					resource.TestCheckResourceAttr(
-						resourceName, "ebs_block_device.2576023345.volume_size", "9"),
-					resource.TestCheckResourceAttr(
-						resourceName, "ebs_block_device.2576023345.volume_type", "gp2"),
-					resource.TestCheckResourceAttr(
-						resourceName, "ebs_block_device.2554893574.device_name", "/dev/sdc"),
-					resource.TestMatchResourceAttr(
-						resourceName, "ebs_block_device.2554893574.volume_id", regexp.MustCompile("vol-[a-z0-9]+")),
-					resource.TestCheckResourceAttr(
-						resourceName, "ebs_block_device.2554893574.volume_size", "10"),
-					resource.TestCheckResourceAttr(
-						resourceName, "ebs_block_device.2554893574.volume_type", "io1"),
-					resource.TestCheckResourceAttr(
-						resourceName, "ebs_block_device.2554893574.iops", "100"),
-					resource.TestCheckResourceAttr(
-						resourceName, "ebs_block_device.2634515331.device_name", "/dev/sdd"),
-					resource.TestMatchResourceAttr(
-						resourceName, "ebs_block_device.2634515331.volume_id", regexp.MustCompile("vol-[a-z0-9]+")),
-					resource.TestCheckResourceAttr(
-						resourceName, "ebs_block_device.2634515331.encrypted", "true"),
-					resource.TestCheckResourceAttr(
-						resourceName, "ebs_block_device.2634515331.volume_size", "12"),
-					resource.TestCheckResourceAttr(
-						resourceName, "ephemeral_block_device.#", "1"),
-					resource.TestCheckResourceAttr(
-						resourceName, "ephemeral_block_device.1692014856.device_name", "/dev/sde"),
-					resource.TestCheckResourceAttr(
-						resourceName, "ephemeral_block_device.1692014856.virtual_name", "ephemeral0"),
+					testAccCheckInstanceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "root_block_device.#", "1"),
+					resource.TestMatchResourceAttr(resourceName, "root_block_device.0.volume_id", regexp.MustCompile("vol-[a-z0-9]+")),
+					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_size", "11"),
+					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_type", "gp2"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2576023345.device_name", "/dev/sdb"),
+					resource.TestMatchResourceAttr(resourceName, "ebs_block_device.2576023345.volume_id", regexp.MustCompile("vol-[a-z0-9]+")),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2576023345.volume_size", "9"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2576023345.volume_type", "gp2"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2554893574.device_name", "/dev/sdc"),
+					resource.TestMatchResourceAttr(resourceName, "ebs_block_device.2554893574.volume_id", regexp.MustCompile("vol-[a-z0-9]+")),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2554893574.volume_size", "10"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2554893574.volume_type", "io1"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2554893574.iops", "100"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2634515331.device_name", "/dev/sdd"),
+					resource.TestMatchResourceAttr(resourceName, "ebs_block_device.2634515331.volume_id", regexp.MustCompile("vol-[a-z0-9]+")),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2634515331.encrypted", "true"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2634515331.volume_size", "12"),
+					resource.TestCheckResourceAttr(resourceName, "ephemeral_block_device.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ephemeral_block_device.1692014856.device_name", "/dev/sde"),
+					resource.TestCheckResourceAttr(resourceName, "ephemeral_block_device.1692014856.virtual_name", "ephemeral0"),
 					testCheck(),
 				),
 			},
@@ -621,18 +573,12 @@ func TestAccAWSInstance_rootInstanceStore(t *testing.T) {
 						instance_type = "m3.medium"
 					}`,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(
-						resourceName, &v),
-					resource.TestCheckResourceAttr(
-						resourceName, "ami", "ami-44c36524"),
-					resource.TestCheckResourceAttr(
-						resourceName, "ebs_block_device.#", "0"),
-					resource.TestCheckResourceAttr(
-						resourceName, "ebs_optimized", "false"),
-					resource.TestCheckResourceAttr(
-						resourceName, "instance_type", "m3.medium"),
-					resource.TestCheckResourceAttr(
-						resourceName, "root_block_device.#", "0"),
+					testAccCheckInstanceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "ami", "ami-44c36524"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_optimized", "false"),
+					resource.TestCheckResourceAttr(resourceName, "instance_type", "m3.medium"),
+					resource.TestCheckResourceAttr(resourceName, "root_block_device.#", "0"),
 				),
 			},
 			{
@@ -704,32 +650,19 @@ func TestAccAWSInstance_noAMIEphemeralDevices(t *testing.T) {
 						}
 					}`,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(
-						resourceName, &v),
-					resource.TestCheckResourceAttr(
-						resourceName, "ami", "ami-01f05461"),
-					resource.TestCheckResourceAttr(
-						resourceName, "ebs_optimized", "false"),
-					resource.TestCheckResourceAttr(
-						resourceName, "instance_type", "c3.large"),
-					resource.TestCheckResourceAttr(
-						resourceName, "root_block_device.#", "1"),
-					resource.TestCheckResourceAttr(
-						resourceName, "root_block_device.0.volume_size", "11"),
-					resource.TestCheckResourceAttr(
-						resourceName, "root_block_device.0.volume_type", "gp2"),
-					resource.TestCheckResourceAttr(
-						resourceName, "ebs_block_device.#", "0"),
-					resource.TestCheckResourceAttr(
-						resourceName, "ephemeral_block_device.#", "2"),
-					resource.TestCheckResourceAttr(
-						resourceName, "ephemeral_block_device.172787947.device_name", "/dev/sdb"),
-					resource.TestCheckResourceAttr(
-						resourceName, "ephemeral_block_device.172787947.no_device", "true"),
-					resource.TestCheckResourceAttr(
-						resourceName, "ephemeral_block_device.3336996981.device_name", "/dev/sdc"),
-					resource.TestCheckResourceAttr(
-						resourceName, "ephemeral_block_device.3336996981.no_device", "true"),
+					testAccCheckInstanceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "ami", "ami-01f05461"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_optimized", "false"),
+					resource.TestCheckResourceAttr(resourceName, "instance_type", "c3.large"),
+					resource.TestCheckResourceAttr(resourceName, "root_block_device.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_size", "11"),
+					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_type", "gp2"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "ephemeral_block_device.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "ephemeral_block_device.172787947.device_name", "/dev/sdb"),
+					resource.TestCheckResourceAttr(resourceName, "ephemeral_block_device.172787947.no_device", "true"),
+					resource.TestCheckResourceAttr(resourceName, "ephemeral_block_device.3336996981.device_name", "/dev/sdc"),
+					resource.TestCheckResourceAttr(resourceName, "ephemeral_block_device.3336996981.no_device", "true"),
 					testCheck(),
 				),
 			},
@@ -864,12 +797,8 @@ func TestAccAWSInstance_vpc(t *testing.T) {
 			{
 				Config: testAccInstanceConfigVPC(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(
-						resourceName, &v),
-					resource.TestCheckResourceAttr(
-						resourceName,
-						"user_data",
-						"562a3e32810edf6ff09994f050f12e799452379d"),
+					testAccCheckInstanceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "user_data", "562a3e32810edf6ff09994f050f12e799452379d"),
 				),
 			},
 			{
@@ -897,12 +826,8 @@ func TestAccAWSInstance_placementGroup(t *testing.T) {
 			{
 				Config: testAccInstanceConfigPlacementGroup(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(
-						resourceName, &v),
-					resource.TestCheckResourceAttr(
-						resourceName,
-						"placement_group",
-						rName),
+					testAccCheckInstanceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "placement_group", rName),
 				),
 			},
 			{
@@ -927,12 +852,8 @@ func TestAccAWSInstance_ipv6_supportAddressCount(t *testing.T) {
 			{
 				Config: testAccInstanceConfigIpv6Support(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(
-						resourceName, &v),
-					resource.TestCheckResourceAttr(
-						resourceName,
-						"ipv6_address_count",
-						"1"),
+					testAccCheckInstanceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", "1"),
 				),
 			},
 			{
@@ -973,12 +894,8 @@ func TestAccAWSInstance_ipv6_supportAddressCountWithIpv4(t *testing.T) {
 			{
 				Config: testAccInstanceConfigIpv6SupportWithIpv4(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(
-						resourceName, &v),
-					resource.TestCheckResourceAttr(
-						resourceName,
-						"ipv6_address_count",
-						"1"),
+					testAccCheckInstanceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", "1"),
 				),
 			},
 			{
@@ -1006,10 +923,8 @@ func TestAccAWSInstance_multipleRegions(t *testing.T) {
 			{
 				Config: testAccInstanceConfigMultipleRegions,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExistsWithProvider(resourceName, &v,
-						testAccAwsRegionProviderFunc("us-west-2", &providers)),
-					testAccCheckInstanceExistsWithProvider("aws_instance.test2", &v,
-						testAccAwsRegionProviderFunc("us-east-1", &providers)),
+					testAccCheckInstanceExistsWithProvider(resourceName, &v, testAccAwsRegionProviderFunc("us-west-2", &providers)),
+					testAccCheckInstanceExistsWithProvider("aws_instance.test2", &v, testAccAwsRegionProviderFunc("us-east-1", &providers)),
 				),
 			},
 		},
@@ -1031,8 +946,7 @@ func TestAccAWSInstance_NetworkInstanceSecurityGroups(t *testing.T) {
 			{
 				Config: testAccInstanceNetworkInstanceSecurityGroups(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(
-						resourceName, &v),
+					testAccCheckInstanceExists(resourceName, &v),
 				),
 			},
 			{
@@ -1058,12 +972,9 @@ func TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups(t *testing.T) {
 			{
 				Config: testAccInstanceNetworkInstanceVPCSecurityGroupIDs(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(
-						resourceName, &v),
-					resource.TestCheckResourceAttr(
-						resourceName, "security_groups.#", "0"),
-					resource.TestCheckResourceAttr(
-						resourceName, "vpc_security_group_ids.#", "1"),
+					testAccCheckInstanceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_security_group_ids.#", "1"),
 				),
 			},
 			{
@@ -1074,12 +985,9 @@ func TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups(t *testing.T) {
 			{
 				Config: testAccInstanceNetworkInstanceVPCRemoveSecurityGroupIDs(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(
-						resourceName, &v),
-					resource.TestCheckResourceAttr(
-						resourceName, "security_groups.#", "0"),
-					resource.TestCheckResourceAttr(
-						resourceName, "vpc_security_group_ids.#", "1"),
+					testAccCheckInstanceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_security_group_ids.#", "1"),
 				),
 				ExpectError: regexp.MustCompile(`VPC-based instances require at least one security group to be attached`),
 			},
@@ -1101,12 +1009,9 @@ func TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs(t *testing.T) {
 			{
 				Config: testAccInstanceNetworkInstanceVPCSecurityGroupIDs(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(
-						resourceName, &v),
-					resource.TestCheckResourceAttr(
-						resourceName, "security_groups.#", "0"),
-					resource.TestCheckResourceAttr(
-						resourceName, "vpc_security_group_ids.#", "1"),
+					testAccCheckInstanceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_security_group_ids.#", "1"),
 				),
 			},
 			{
@@ -1165,8 +1070,7 @@ func TestAccAWSInstance_volumeTags(t *testing.T) {
 				Config: testAccCheckInstanceConfigNoVolumeTags,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
-					resource.TestCheckNoResourceAttr(
-						resourceName, "volume_tags"),
+					resource.TestCheckNoResourceAttr(resourceName, "volume_tags"),
 				),
 			},
 			{
@@ -1179,30 +1083,24 @@ func TestAccAWSInstance_volumeTags(t *testing.T) {
 				Config: testAccCheckInstanceConfigWithVolumeTags,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
-					resource.TestCheckResourceAttr(
-						resourceName, "volume_tags.%", "1"),
-					resource.TestCheckResourceAttr(
-						resourceName, "volume_tags.Name", "acceptance-test-volume-tag"),
+					resource.TestCheckResourceAttr(resourceName, "volume_tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "volume_tags.Name", "acceptance-test-volume-tag"),
 				),
 			},
 			{
 				Config: testAccCheckInstanceConfigWithVolumeTagsUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
-					resource.TestCheckResourceAttr(
-						resourceName, "volume_tags.%", "2"),
-					resource.TestCheckResourceAttr(
-						resourceName, "volume_tags.Name", "acceptance-test-volume-tag"),
-					resource.TestCheckResourceAttr(
-						resourceName, "volume_tags.Environment", "dev"),
+					resource.TestCheckResourceAttr(resourceName, "volume_tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "volume_tags.Name", "acceptance-test-volume-tag"),
+					resource.TestCheckResourceAttr(resourceName, "volume_tags.Environment", "dev"),
 				),
 			},
 			{
 				Config: testAccCheckInstanceConfigNoVolumeTags,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
-					resource.TestCheckNoResourceAttr(
-						resourceName, "volume_tags"),
+					resource.TestCheckNoResourceAttr(resourceName, "volume_tags"),
 				),
 			},
 		},
@@ -1454,8 +1352,7 @@ func TestAccAWSInstance_rootBlockDeviceMismatch(t *testing.T) {
 				Config: testAccInstanceConfigRootBlockDeviceMismatch(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
-					resource.TestCheckResourceAttr(
-						resourceName, "root_block_device.0.volume_size", "13"),
+					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_size", "13"),
 				),
 			},
 			{
@@ -1536,17 +1433,17 @@ func TestAccAWSInstance_changeInstanceType(t *testing.T) {
 				Config: testAccInstanceConfigUpdateInstanceType,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &after),
-					testAccCheckInstanceNotRecreated(
-						t, &before, &after),
+					testAccCheckInstanceNotRecreated(t, &before, &after),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAWSInstance_changeRootBlockDeviceVolumeSize(t *testing.T) {
+func TestAccAWSInstance_changeRootBlockDeviceVolumeSize_basic(t *testing.T) {
 	var before ec2.Instance
 	var after ec2.Instance
+	resourceName := "aws_instance.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1556,17 +1453,49 @@ func TestAccAWSInstance_changeRootBlockDeviceVolumeSize(t *testing.T) {
 			{
 				Config: testAccInstanceGP2IopsDevice,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists("aws_instance.foo", &before),
+					testAccCheckInstanceExists(resourceName, &before),
 				),
 			},
 			{
 				Config: testAccInstanceGP2IopsDeviceVolumeSizeUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists("aws_instance.foo", &after),
-					testAccCheckInstanceNotRecreated(
-						t, &before, &after),
-					resource.TestCheckResourceAttr(
-						"aws_instance.foo", "root_block_device.0.volume_size", "12"),
+					testAccCheckInstanceExists(resourceName, &after),
+					testAccCheckInstanceNotRecreated(t, &before, &after),
+					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_size", "12"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSInstance_changeRootBlockDeviceVolumeSize_MultipleBlockDevices(t *testing.T) {
+	var before ec2.Instance
+	var after ec2.Instance
+	resourceName := "aws_instance.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfigBlockDevices,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2576023345.volume_size", "9"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2554893574.volume_size", "10"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2634515331.volume_size", "12"),
+				),
+			},
+			{
+				Config: testAccInstanceConfigBlockDevicesRootSizeUpdated,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(resourceName, &after),
+					testAccCheckInstanceNotRecreated(t, &before, &after),
+					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_size", "14"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2576023345.volume_size", "9"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2554893574.volume_size", "10"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2634515331.volume_size", "12"),
 				),
 			},
 		},
@@ -2637,21 +2566,15 @@ func testAccCheckInstanceDestroyWithProvider(s *terraform.State, provider *schem
 		}
 
 		// Try to find the resource
-		resp, err := conn.DescribeInstances(&ec2.DescribeInstancesInput{
-			InstanceIds: []*string{aws.String(rs.Primary.ID)},
-		})
+		instance, err := resourceAwsInstanceFindByID(conn, rs.Primary.ID)
 		if err == nil {
-			for _, r := range resp.Reservations {
-				for _, i := range r.Instances {
-					if i.State != nil && *i.State.Name != "terminated" {
-						return fmt.Errorf("Found unterminated instance: %s", i)
-					}
-				}
+			if instance.State != nil && *instance.State.Name != "terminated" {
+				return fmt.Errorf("Found unterminated instance: %s", rs.Primary.ID)
 			}
 		}
 
 		// Verify the error is what we want
-		if ae, ok := err.(awserr.Error); ok && ae.Code() == "InvalidInstanceID.NotFound" {
+		if isAWSErr(err, "InvalidInstanceID.NotFound", "") {
 			continue
 		}
 
@@ -2679,15 +2602,13 @@ func testAccCheckInstanceExistsWithProvider(n string, i *ec2.Instance, providerF
 		provider := providerF()
 
 		conn := provider.Meta().(*AWSClient).ec2conn
-		resp, err := conn.DescribeInstances(&ec2.DescribeInstancesInput{
-			InstanceIds: []*string{aws.String(rs.Primary.ID)},
-		})
+		instance, err := resourceAwsInstanceFindByID(conn, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
 
-		if len(resp.Reservations) > 0 {
-			*i = *resp.Reservations[0].Instances[0]
+		if instance != nil {
+			*i = *instance
 			return nil
 		}
 
@@ -2711,18 +2632,18 @@ func testAccCheckInstanceDisappears(conf *ec2.Instance) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckStopInstance(conf *ec2.Instance) resource.TestCheckFunc {
+func testAccCheckStopInstance(instance *ec2.Instance) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
 
 		params := &ec2.StopInstancesInput{
-			InstanceIds: []*string{conf.InstanceId},
+			InstanceIds: []*string{instance.InstanceId},
 		}
 		if _, err := conn.StopInstances(params); err != nil {
 			return err
 		}
 
-		return waitForInstanceStopping(conn, *conf.InstanceId, 10*time.Minute)
+		return waitForInstanceStopping(conn, *instance.InstanceId, 10*time.Minute)
 	}
 }
 
@@ -3038,7 +2959,7 @@ resource "aws_instance" "test" {
 `
 
 const testAccInstanceGP2IopsDeviceVolumeSizeUpdate = `
-resource "aws_instance" "foo" {
+resource "aws_instance" "test" {
 	# us-west-2
 	ami = "ami-55a7ea65"
 
@@ -3067,6 +2988,47 @@ resource "aws_instance" "test" {
 	root_block_device {
 		volume_type = "gp2"
 		volume_size = 11
+	}
+
+	ebs_block_device {
+		device_name = "/dev/sdb"
+		volume_size = 9
+	}
+
+	ebs_block_device {
+		device_name = "/dev/sdc"
+		volume_size = 10
+		volume_type = "io1"
+		iops = 100
+	}
+
+	# Encrypted ebs block device
+	ebs_block_device {
+		device_name = "/dev/sdd"
+		volume_size = 12
+		encrypted   = true
+	}
+
+	ephemeral_block_device {
+		device_name = "/dev/sde"
+		virtual_name = "ephemeral0"
+	}
+}
+`
+
+const testAccInstanceConfigBlockDevicesRootSizeUpdated = `
+resource "aws_instance" "test" {
+	# us-west-2
+	ami = "ami-55a7ea65"
+
+	# In order to attach an encrypted volume to an instance you need to have an
+	# m3.medium or larger. See "Supported Instance Types" in:
+	# http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html
+	instance_type = "m3.medium"
+
+	root_block_device {
+		volume_type = "gp2"
+		volume_size = 14
 	}
 
 	ebs_block_device {

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -1544,6 +1544,35 @@ func TestAccAWSInstance_changeInstanceType(t *testing.T) {
 	})
 }
 
+func TestAccAWSInstance_changeRootBlockDeviceVolumeSize(t *testing.T) {
+	var before ec2.Instance
+	var after ec2.Instance
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceGP2IopsDevice,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists("aws_instance.foo", &before),
+				),
+			},
+			{
+				Config: testAccInstanceGP2IopsDeviceVolumeSizeUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists("aws_instance.foo", &after),
+					testAccCheckInstanceNotRecreated(
+						t, &before, &after),
+					resource.TestCheckResourceAttr(
+						"aws_instance.foo", "root_block_device.0.volume_size", "20"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSInstance_primaryNetworkInterface(t *testing.T) {
 	var instance ec2.Instance
 	var eni ec2.NetworkInterface
@@ -3004,6 +3033,23 @@ resource "aws_instance" "test" {
 		volume_size = 11
         # configured explicitly
 		iops        = 10
+	}
+}
+`
+
+const testAccInstanceGP2IopsDeviceVolumeSizeUpdate = `
+resource "aws_instance" "foo" {
+	# us-west-2
+	ami = "ami-55a7ea65"
+
+	# In order to attach an encrypted volume to an instance you need to have an
+	# m3.medium or larger. See "Supported Instance Types" in:
+	# http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html
+	instance_type = "m3.medium"
+
+	root_block_device {
+		volume_type = "gp2"
+		volume_size = 12
 	}
 }
 `

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -256,7 +256,7 @@ func TestAccAWSInstance_basic(t *testing.T) {
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
-			// Create a volume to cover #1249
+			// Create a volume to cover https://github.com/hashicorp/terraform/issues/1249
 			{
 				// Need a resource in this config so the provisioner will be available
 				Config: testAccInstanceConfig_pre(rInt),
@@ -276,6 +276,7 @@ func TestAccAWSInstance_basic(t *testing.T) {
 					testAccCheckInstanceExists(resourceName, &v),
 					testCheck(rInt),
 					resource.TestCheckResourceAttr(resourceName, "user_data", "3dc39dda39be1205215e776bad998da361a5955d"),
+					resource.TestCheckResourceAttr(resourceName, "root_block_device.#", "0"), // This is an instance store AMI
 					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.#", "0"),
 					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(`^arn:[^:]+:ec2:[^:]+:\d{12}:instance/i-.+`)),
 				),
@@ -1434,6 +1435,32 @@ func TestAccAWSInstance_changeInstanceType(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &after),
 					testAccCheckInstanceNotRecreated(t, &before, &after),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSInstance_EbsRootDevice_basic(t *testing.T) {
+	var instance ec2.Instance
+	resourceName := "aws_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsEc2InstanceEbsRootDeviceBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(resourceName, &instance),
+					resource.TestCheckResourceAttr(resourceName, "root_block_device.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "root_block_device.0.delete_on_termination"),
+					resource.TestCheckResourceAttrSet(resourceName, "root_block_device.0.encrypted"),
+					resource.TestCheckResourceAttrSet(resourceName, "root_block_device.0.iops"),
+					resource.TestCheckResourceAttrSet(resourceName, "root_block_device.0.volume_size"),
+					resource.TestCheckResourceAttrSet(resourceName, "root_block_device.0.volume_type"),
+					resource.TestCheckResourceAttrSet(resourceName, "root_block_device.0.volume_id"),
 				),
 			},
 		},
@@ -2957,6 +2984,30 @@ resource "aws_instance" "test" {
 	}
 }
 `
+
+func testAccAwsEc2InstanceEbsRootDeviceBasic() string {
+	return fmt.Sprintf(`
+	data "aws_ami" "ami" {
+		owners      = ["amazon"]
+		most_recent = true
+
+		filter {
+			name   = "name"
+			values = ["amzn2-ami-*"]
+		}
+		filter {
+			name   = "root-device-type"
+			values = ["ebs"]
+		}
+	}
+
+	resource "aws_instance" "test" {
+		ami = data.aws_ami.ami.id
+
+		instance_type = "t2.small"
+}
+`)
+}
 
 const testAccInstanceGP2IopsDeviceVolumeSizeUpdate = `
 resource "aws_instance" "test" {

--- a/aws/resource_aws_ssm_association_test.go
+++ b/aws/resource_aws_ssm_association_test.go
@@ -20,7 +20,7 @@ func TestAccAWSSSMAssociation_basic(t *testing.T) {
 		ec2conn := testAccProvider.Meta().(*AWSClient).ec2conn
 		ssmconn := testAccProvider.Meta().(*AWSClient).ssmconn
 
-		ins, err := ec2conn.DescribeInstances(&ec2.DescribeInstancesInput{
+		ins, err := resourceAwsInstanceFind(ec2conn, &ec2.DescribeInstancesInput{
 			Filters: []*ec2.Filter{
 				{
 					Name:   aws.String("tag:Name"),
@@ -31,17 +31,17 @@ func TestAccAWSSSMAssociation_basic(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Error getting instance with tag:Name %s: %s", name, err)
 		}
-		if len(ins.Reservations) == 0 || len(ins.Reservations[0].Instances) == 0 {
+		if len(ins) == 0 {
 			t.Fatalf("No instance exists with tag:Name %s", name)
 		}
-		instanceId := ins.Reservations[0].Instances[0].InstanceId
+		instanceID := ins[0].InstanceId
 
 		_, err = ssmconn.DeleteAssociation(&ssm.DeleteAssociationInput{
 			Name:       aws.String(name),
-			InstanceId: instanceId,
+			InstanceId: instanceID,
 		})
 		if err != nil {
-			t.Fatalf("Error deleting ssm association %s/%s: %s", name, aws.StringValue(instanceId), err)
+			t.Fatalf("Error deleting ssm association %s/%s: %s", name, aws.StringValue(instanceID), err)
 		}
 	}
 

--- a/website/docs/d/instance.html.markdown
+++ b/website/docs/d/instance.html.markdown
@@ -96,6 +96,7 @@ interpolation.
   is only available if you've enabled DNS hostnames for your VPC.
 * `public_ip` - The public IP address assigned to the Instance, if applicable. **NOTE**: If you are using an [`aws_eip`](/docs/providers/aws/r/eip.html) with your instance, you should refer to the EIP's address directly and not use `public_ip`, as this field will change after the EIP is attached.
 * `root_block_device` - The root block device mappings of the Instance
+  * `device_name` - The physical name of the device.
   * `delete_on_termination` - If the root block device will be deleted on termination.
   * `encrypted` - If the EBS volume is encrypted.
   * `iops` - `0` If the volume is not a provisioned IOPS image, otherwise the supported IOPS count.

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -113,7 +113,7 @@ instances. See [Shutdown Behavior](https://docs.aws.amazon.com/AWSEC2/latest/Use
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 10 mins) Used when launching the instance (until it reaches the initial `running` state)
-* `update` - (Defaults to 20 mins) Used when stopping and starting the instance when necessary during update - e.g. when changing instance type
+* `update` - (Defaults to 10 mins) Used when stopping and starting the instance when necessary during update - e.g. when changing instance type
 * `delete` - (Defaults to 20 mins) Used when terminating the instance
 
 ### Block devices

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -141,7 +141,7 @@ replacement.
 
 Each `ebs_block_device` supports the following:
 
-* `device_name` - The name of the device to mount.
+* `device_name` - (Required) The name of the device to mount.
 * `snapshot_id` - (Optional) The Snapshot ID to mount.
 * `volume_type` - (Optional) The type of volume. Can be `"standard"`, `"gp2"`,
   or `"io1"`. (Default: `"gp2"`).
@@ -286,6 +286,8 @@ In addition to all arguments above, the following attributes are exported:
 
 For any `root_block_device` and `ebs_block_device` the `volume_id` is exported.
 e.g. `aws_instance.web.root_block_device.0.volume_id`
+
+For the `root_block_device` the `device_name` is exported.
 
 ## Import
 

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -136,7 +136,7 @@ The `root_block_device` mapping supports the following:
 * `encrypted` - (Optional) Enable volume encryption. (Default: `false`). Must be configured to perform drift detection.
 * `kms_key_id` - (Optional) Amazon Resource Name (ARN) of the KMS Key to use when encrypting the volume. Must be configured to perform drift detection.
 
-Modifying any of the `root_block_device` settings requires resource
+Modifying any of the `root_block_device` settings other than `volume_size` requires resource
 replacement.
 
 Each `ebs_block_device` supports the following:

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -113,7 +113,7 @@ instances. See [Shutdown Behavior](https://docs.aws.amazon.com/AWSEC2/latest/Use
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 10 mins) Used when launching the instance (until it reaches the initial `running` state)
-* `update` - (Defaults to 10 mins) Used when stopping and starting the instance when necessary during update - e.g. when changing instance type
+* `update` - (Defaults to 20 mins) Used when stopping and starting the instance when necessary during update - e.g. when changing instance type
 * `delete` - (Defaults to 20 mins) Used when terminating the instance
 
 ### Block devices


### PR DESCRIPTION
This PR picks up on the work done by @viscat in #1396 to allow changing EC2 instance root volume size without re-creating the instance.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1396
Closes #768
Closes #8729
Closes #4219
Closes #4196
Closes #609
Closes #418
Closes #172
Closes #139
Closes #105

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_instance: Allow changing root volume size without re-creating resource
resource/aws_instance: Exports `volume_name` for `root_block_device`
data-source/aws_instance: Returns `volume_name` for `root_block_device`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSInstance_'

--- PASS: TestAccAWSInstance_CreditSpecification_Empty_NonBurstable (279.76s)
--- PASS: TestAccAWSInstance_CreditSpecification_UnspecifiedToEmpty_NonBurstable (66.94s)
--- PASS: TestAccAWSInstance_EbsBlockDevice_KmsKeyArn (97.32s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyAll (122.86s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyDeleteOnTermination (117.01s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyIOPS (125.10s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifySize (116.33s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyType (135.45s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifyDeleteOnTermination (86.46s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifySize (127.49s)
--- PASS: TestAccAWSInstance_EbsRootDevice_basic (73.44s)
--- PASS: TestAccAWSInstance_GP2IopsDevice (90.68s)
--- PASS: TestAccAWSInstance_GP2WithIopsValue (85.17s)
--- PASS: TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups (84.62s)
--- PASS: TestAccAWSInstance_NetworkInstanceSecurityGroups (192.94s)
--- PASS: TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs (77.00s)
--- PASS: TestAccAWSInstance_RootBlockDevice_KmsKeyArn (301.24s)
--- PASS: TestAccAWSInstance_UserData_EmptyStringToUnspecified (86.14s)
--- PASS: TestAccAWSInstance_UserData_UnspecifiedToEmptyString (88.58s)
--- PASS: TestAccAWSInstance_addSecondaryInterface (129.52s)
--- PASS: TestAccAWSInstance_addSecurityGroupNetworkInterface (124.41s)
--- PASS: TestAccAWSInstance_associatePublicIPAndPrivateIP (75.43s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPrivate (105.55s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPublic (69.46s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPrivate (86.34s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPublic (71.78s)
--- PASS: TestAccAWSInstance_associatePublic_overridePrivate (89.85s)
--- PASS: TestAccAWSInstance_associatePublic_overridePublic (92.80s)
--- PASS: TestAccAWSInstance_basic (130.01s)
--- PASS: TestAccAWSInstance_blockDevices (80.54s)
--- PASS: TestAccAWSInstance_changeInstanceType (241.52s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_standardCpuCredits (110.11s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits (116.89s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited (323.91s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_updateCpuCredits (133.02s)
--- PASS: TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable (117.66s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits (93.15s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint (413.14s)
--- PASS: TestAccAWSInstance_creditSpecification_unknownCpuCredits_t2 (73.28s)
--- PASS: TestAccAWSInstance_creditSpecification_unknownCpuCredits_t3 (314.39s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits (97.38s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint (392.44s)
--- PASS: TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard (76.55s)
--- PASS: TestAccAWSInstance_creditSpecification_updateCpuCredits (113.49s)
--- PASS: TestAccAWSInstance_disableApiTermination (116.04s)
--- PASS: TestAccAWSInstance_disappears (224.59s)
--- PASS: TestAccAWSInstance_forceNewAndTagsDrift (243.26s)
--- PASS: TestAccAWSInstance_getPasswordData_falseToTrue (148.03s)
--- PASS: TestAccAWSInstance_getPasswordData_trueToFalse (170.56s)
--- PASS: TestAccAWSInstance_hibernation (365.55s)
--- PASS: TestAccAWSInstance_inDefaultVpcBySgId (83.62s)
--- PASS: TestAccAWSInstance_inDefaultVpcBySgName (64.52s)
--- PASS: TestAccAWSInstance_instanceProfileChange (195.15s)
--- PASS: TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError (10.90s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCount (85.75s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCountWithIpv4 (75.29s)
--- PASS: TestAccAWSInstance_keyPairCheck (63.96s)
--- PASS: TestAccAWSInstance_metadataOptions (117.30s)
--- PASS: TestAccAWSInstance_multipleRegions (251.16s)
--- PASS: TestAccAWSInstance_noAMIEphemeralDevices (176.35s)
--- PASS: TestAccAWSInstance_placementGroup (58.66s)
--- PASS: TestAccAWSInstance_primaryNetworkInterface (200.28s)
--- PASS: TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck (80.50s)
--- PASS: TestAccAWSInstance_privateIP (105.85s)
--- PASS: TestAccAWSInstance_rootBlockDeviceMismatch (65.40s)
--- PASS: TestAccAWSInstance_rootInstanceStore (80.19s)
--- PASS: TestAccAWSInstance_sourceDestCheck (135.51s)
--- PASS: TestAccAWSInstance_tags (117.10s)
--- PASS: TestAccAWSInstance_userDataBase64 (131.52s)
--- PASS: TestAccAWSInstance_volumeTags (103.12s)
--- PASS: TestAccAWSInstance_volumeTagsComputed (104.15s)
--- PASS: TestAccAWSInstance_vpc (105.62s)
--- PASS: TestAccAWSInstance_withIamInstanceProfile (116.03s)
```

```
$ make testacc TESTARGS='-run=TestAccAWSInstanceDataSource_'

--- PASS: TestAccAWSInstanceDataSource_AzUserData (127.32s)
--- PASS: TestAccAWSInstanceDataSource_EbsBlockDevice_KmsKeyId (120.33s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData (281.72s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData_NoUserData (121.36s)
--- PASS: TestAccAWSInstanceDataSource_PlacementGroup (91.08s)
--- PASS: TestAccAWSInstanceDataSource_RootBlockDevice_KmsKeyId (129.05s)
--- PASS: TestAccAWSInstanceDataSource_SecurityGroups (252.55s)
--- PASS: TestAccAWSInstanceDataSource_VPC (99.88s)
--- PASS: TestAccAWSInstanceDataSource_VPCSecurityGroups (82.35s)
--- PASS: TestAccAWSInstanceDataSource_basic (239.47s)
--- PASS: TestAccAWSInstanceDataSource_blockDevices (88.09s)
--- PASS: TestAccAWSInstanceDataSource_creditSpecification (94.08s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_falseToTrue (145.38s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_trueToFalse (158.64s)
--- PASS: TestAccAWSInstanceDataSource_gp2IopsDevice (185.66s)
--- PASS: TestAccAWSInstanceDataSource_keyPair (68.87s)
--- PASS: TestAccAWSInstanceDataSource_metadataOptions (164.02s)
--- PASS: TestAccAWSInstanceDataSource_privateIP (71.22s)
--- PASS: TestAccAWSInstanceDataSource_rootInstanceStore (113.55s)
--- PASS: TestAccAWSInstanceDataSource_tags (238.13s)
```

```
$ make testacc TESTARGS='-run=TestAccAWSSSMAssociation_'

--- PASS: TestAccAWSSSMAssociation_basic (75.04s)
--- PASS: TestAccAWSSSMAssociation_rateControl (19.04s)
--- PASS: TestAccAWSSSMAssociation_withAssociationName (14.00s)
--- PASS: TestAccAWSSSMAssociation_withAssociationNameAndScheduleExpression (14.62s)
--- PASS: TestAccAWSSSMAssociation_withAutomationTargetParamName (34.09s)
--- PASS: TestAccAWSSSMAssociation_withComplianceSeverity (18.50s)
--- PASS: TestAccAWSSSMAssociation_withDocumentVersion (8.35s)
--- PASS: TestAccAWSSSMAssociation_withOutputLocation (30.30s)
--- PASS: TestAccAWSSSMAssociation_withParameters (13.85s)
--- PASS: TestAccAWSSSMAssociation_withScheduleExpression (15.64s)
--- PASS: TestAccAWSSSMAssociation_withTargets (19.89s)
```

```
$ make testacc TESTARGS='-run=TestAccAWSSpotInstanceRequest'

--- PASS: TestAccAWSSpotInstanceRequestInterruptHibernate (300.50s)
--- PASS: TestAccAWSSpotInstanceRequestInterruptStop (280.14s)
--- PASS: TestAccAWSSpotInstanceRequest_NetworkInterfaceAttributes (104.42s)
--- PASS: TestAccAWSSpotInstanceRequest_SubnetAndSGAndPublicIpAddress (104.18s)
--- PASS: TestAccAWSSpotInstanceRequest_basic (117.23s)
--- PASS: TestAccAWSSpotInstanceRequest_getPasswordData (240.54s)
--- PASS: TestAccAWSSpotInstanceRequest_validUntil (99.43s)
--- PASS: TestAccAWSSpotInstanceRequest_vpc (104.18s)
--- PASS: TestAccAWSSpotInstanceRequest_withBlockDuration (109.66s)
--- PASS: TestAccAWSSpotInstanceRequest_withLaunchGroup (59.89s)
--- PASS: TestAccAWSSpotInstanceRequest_withoutSpotPrice (78.79s)
```