### PR TITLE
fix lint error for aws_s3_bucket resource doc

### DIFF
--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -318,15 +318,15 @@ resource "aws_s3_bucket" "bucket" {
   bucket = "mybucket"
 
   grant {
-    id         = "${data.aws_canonical_user_id.current_user.id}"
-    type       = "CanonicalUser"
+    id          = "${data.aws_canonical_user_id.current_user.id}"
+    type        = "CanonicalUser"
     permissions = ["FULL_CONTROL"]
   }
 
   grant {
-    type       = "Group"
+    type        = "Group"
     permissions = ["READ", "WRITE"]
-    uri        = "http://acs.amazonaws.com/groups/s3/LogDelivery"
+    uri         = "http://acs.amazonaws.com/groups/s3/LogDelivery"
   }
 }
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
None

Fix lint error
```
$ make website-lint
==> Checking website against linters...
website/docs/r/s3_bucket.html.markdown:314

Unexpected differences in website HCL formatting.
To see the full differences, run: terrafmt diff ./website --pattern '*.markdown'
To automatically fix the formatting, run 'make website-lint-fix' and commit the changes.
make: *** [website-lint] Error 1
```

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
None
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

