### PR TITLE
Add valid available services for cost_filters in aws_budgets_budget

### DIFF
--- a/website/docs/r/budgets_budget.html.markdown
+++ b/website/docs/r/budgets_budget.html.markdown
@@ -165,7 +165,7 @@ Valid keys for `cost_filters` parameter vary depending on the `budget_type` valu
   * `LinkedAccount`
   * `Operation`
   * `PurchaseType`
-  * `Service`
+  * [`Service`](#Services)
   * `TagKeyValue`
 * `usage`
   * `AZ`
@@ -175,42 +175,44 @@ Valid keys for `cost_filters` parameter vary depending on the `budget_type` valu
   * `UsageType:<service name>`
   * `TagKeyValue`
 
-Refer to [AWS CostFilter documentation](http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/data-type-filter.html) for further detail.
+Refer to [AWS CostFilter documentation](https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_budgets_Budget.html#awscostmanagement-Type-budgets_Budget-CostFilters) for further detail.
 
 #### Services
 
 Valid keys for `Service` parameter in `cost_filters`
 
-* Amazon Athena
-* Amazon Elastic Compute Cloud - Compute
-* Amazon EC2 Container Registry (ECR)
-* Amazon EC2 Container Service
-* Amazon Elastic Block Store
-* AWS CloudTrail
-* AmazonCloudWatch
-* Amazon DynamoDB
-* Amazon ElastiCache
-* Amazon Elasticsearch Service
-* Amazon Elastic Load Balancing
-* Amazon API Gateway
-* AWS Glue
-* AWS Key Management Service
-* AWS Lambda
-* Matillion ETL for Amazon Redshift
-* Amazon Polly
-* Amazon Rekognition
-* Amazon Relational Database Service
-* Amazon Redshift
-* Amazon Simple Storage Service
-* AWS Transfer for SFTP
-* Amazon Route 53
-* Amazon SageMaker
-* AWS Secrets Manager
-* Amazon Simple Notification Service
-* Amazon Simple Queue Service
-* Tax
-* AWS WAF
-* AWS X-Ray
+```
+Amazon Athena
+Amazon Elastic Compute Cloud - Compute
+Amazon EC2 Container Registry (ECR)
+Amazon EC2 Container Service
+Amazon Elastic Block Store
+AWS CloudTrail
+AmazonCloudWatch
+Amazon DynamoDB
+Amazon ElastiCache
+Amazon Elasticsearch Service
+Amazon Elastic Load Balancing
+Amazon API Gateway
+AWS Glue
+AWS Key Management Service
+AWS Lambda
+Matillion ETL for Amazon Redshift
+Amazon Polly
+Amazon Rekognition
+Amazon Relational Database Service
+Amazon Redshift
+Amazon Simple Storage Service
+AWS Transfer for SFTP
+Amazon Route 53
+Amazon SageMaker
+AWS Secrets Manager
+Amazon Simple Notification Service
+Amazon Simple Queue Service
+Tax
+AWS WAF
+AWS X-Ray
+```
 
 ### BudgetNotification
 

--- a/website/docs/r/budgets_budget.html.markdown
+++ b/website/docs/r/budgets_budget.html.markdown
@@ -177,6 +177,41 @@ Valid keys for `cost_filters` parameter vary depending on the `budget_type` valu
 
 Refer to [AWS CostFilter documentation](http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/data-type-filter.html) for further detail.
 
+#### Services
+
+Valid keys for `Service` parameter in `cost_filters`
+
+* Amazon Athena
+* Amazon Elastic Compute Cloud - Compute
+* Amazon EC2 Container Registry (ECR)
+* Amazon EC2 Container Service
+* Amazon Elastic Block Store
+* AWS CloudTrail
+* AmazonCloudWatch
+* Amazon DynamoDB
+* Amazon ElastiCache
+* Amazon Elasticsearch Service
+* Amazon Elastic Load Balancing
+* Amazon API Gateway
+* AWS Glue
+* AWS Key Management Service
+* AWS Lambda
+* Matillion ETL for Amazon Redshift
+* Amazon Polly
+* Amazon Rekognition
+* Amazon Relational Database Service
+* Amazon Redshift
+* Amazon Simple Storage Service
+* AWS Transfer for SFTP
+* Amazon Route 53
+* Amazon SageMaker
+* AWS Secrets Manager
+* Amazon Simple Notification Service
+* Amazon Simple Queue Service
+* Tax
+* AWS WAF
+* AWS X-Ray
+
 ### BudgetNotification
 
 Valid keys for `notification` parameter.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

#### Motivation

The module `aws_budgets_budget` has support to specify AWS services in `cost_filters`, the problem is that this name should be strictly valid to make the filter work. I created this PR to include in the documentation a list of valid services available to filter.

```hcl
resource "aws_budgets_budget" "ec2" {
 ...
  cost_filters = {
    Service = "Amazon Elastic Compute Cloud - Compute"
  }
}
```

To date, valid services are:

```
* Amazon Athena
* Amazon Elastic Compute Cloud - Compute
* Amazon EC2 Container Registry (ECR)
* Amazon EC2 Container Service
* Amazon Elastic Block Store
* AWS CloudTrail
* AmazonCloudWatch
* Amazon DynamoDB
* Amazon ElastiCache
* Amazon Elasticsearch Service
* Amazon Elastic Load Balancing
* Amazon API Gateway
* AWS Glue
* AWS Key Management Service
* AWS Lambda
* Matillion ETL for Amazon Redshift
* Amazon Polly
* Amazon Rekognition
* Amazon Relational Database Service
* Amazon Redshift
* Amazon Simple Storage Service
* AWS Transfer for SFTP
* Amazon Route 53
* Amazon SageMaker
* AWS Secrets Manager
* Amazon Simple Notification Service
* Amazon Simple Queue Service
* Tax
* AWS WAF
* AWS X-Ray
```

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
