### PR TITLE
resource/aws_fsx_windows_file_system: Prevent panic when update includes `self_managed_active_directory` settings

### DIFF
--- a/aws/resource_aws_fsx_windows_file_system.go
+++ b/aws/resource_aws_fsx_windows_file_system.go
@@ -410,7 +410,7 @@ func expandFsxSelfManagedActiveDirectoryConfigurationUpdate(l []interface{}) *fs
 
 	data := l[0].(map[string]interface{})
 	req := &fsx.SelfManagedActiveDirectoryConfigurationUpdates{
-		DnsIps:   expandStringList(data["dns_ips"].([]interface{})),
+		DnsIps:   expandStringSet(data["dns_ips"].(*schema.Set)),
 		Password: aws.String(data["password"].(string)),
 		UserName: aws.String(data["username"].(string)),
 	}

--- a/aws/resource_aws_fsx_windows_file_system_test.go
+++ b/aws/resource_aws_fsx_windows_file_system_test.go
@@ -362,6 +362,43 @@ func TestAccAWSFsxWindowsFileSystem_SelfManagedActiveDirectory(t *testing.T) {
 	})
 }
 
+func TestAccAWSFsxWindowsFileSystem_SelfManagedActiveDirectory_Username(t *testing.T) {
+	var filesystem fsx.FileSystem
+	resourceName := "aws_fsx_windows_file_system.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckFsxWindowsFileSystemDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsFsxWindowsFileSystemConfigSelfManagedActiveDirectoryUsername("Admin"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFsxWindowsFileSystemExists(resourceName, &filesystem),
+					resource.TestCheckResourceAttr(resourceName, "self_managed_active_directory.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"security_group_ids",
+					"self_managed_active_directory",
+					"skip_final_backup",
+				},
+			},
+			{
+				Config: testAccAwsFsxWindowsFileSystemConfigSelfManagedActiveDirectoryUsername("Administrator"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFsxWindowsFileSystemExists(resourceName, &filesystem),
+					resource.TestCheckResourceAttr(resourceName, "self_managed_active_directory.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSFsxWindowsFileSystem_StorageCapacity(t *testing.T) {
 	var filesystem1, filesystem2 fsx.FileSystem
 	resourceName := "aws_fsx_windows_file_system.test"
@@ -825,6 +862,23 @@ resource "aws_fsx_windows_file_system" "test" {
   }
 }
 `)
+}
+
+func testAccAwsFsxWindowsFileSystemConfigSelfManagedActiveDirectoryUsername(username string) string {
+	return testAccAwsFsxWindowsFileSystemConfigBase() + fmt.Sprintf(`
+resource "aws_fsx_windows_file_system" "test" {
+  skip_final_backup   = true
+  storage_capacity    = 32
+  subnet_ids          = ["${aws_subnet.test1.id}"]
+  throughput_capacity = 8
+  self_managed_active_directory {
+    dns_ips     = aws_directory_service_directory.test.dns_ip_addresses
+    domain_name = aws_directory_service_directory.test.name
+    password    = aws_directory_service_directory.test.password
+    username    = %[1]q
+  }
+}
+`, username)
 }
 
 func testAccAwsFsxWindowsFileSystemConfigStorageCapacity(storageCapacity int) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11500

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_fsx_windows_file_system: Prevent panic when update includes `self_managed_active_directory` settings
```

Previously:

```
=== CONT  TestAccAWSFsxWindowsFileSystem_SelfManagedActiveDirectory_Username
panic: interface conversion: interface {} is *schema.Set, not []interface {}

goroutine 4434 [running]:
github.com/terraform-providers/terraform-provider-aws/aws.expandFsxSelfManagedActiveDirectoryConfigurationUpdate(0xc000488de0, 0x1, 0x1, 0x5b2f000)
	/Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_fsx_windows_file_system.go:413 +0x2d7
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsFsxWindowsFileSystemUpdate(0xc00004ed20, 0x62e3060, 0xc0003c3900, 0x0, 0x0)
	/Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_fsx_windows_file_system.go:269 +0x637
github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Resource).Apply(0xc00099b580, 0xc001cf2cd0, 0xc000ddebe0, 0x62e3060, 0xc0003c3900, 0x6168e01, 0xc001e73760, 0xc001914db0)
	/Users/bflad/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.8.0/helper/schema/resource.go:311 +0x263
```

Output from acceptance testing:

```
--- PASS: TestAccAWSFsxWindowsFileSystem_AutomaticBackupRetentionDays (3063.70s)
--- PASS: TestAccAWSFsxWindowsFileSystem_basic (2915.15s)
--- PASS: TestAccAWSFsxWindowsFileSystem_CopyTagsToBackups (4140.35s)
--- PASS: TestAccAWSFsxWindowsFileSystem_DailyAutomaticBackupStartTime (3034.18s)
--- PASS: TestAccAWSFsxWindowsFileSystem_disappears (3045.25s)
--- PASS: TestAccAWSFsxWindowsFileSystem_KmsKeyId (4148.71s)
--- PASS: TestAccAWSFsxWindowsFileSystem_SecurityGroupIds (4179.82s)
--- PASS: TestAccAWSFsxWindowsFileSystem_SelfManagedActiveDirectory (2905.75s)
--- PASS: TestAccAWSFsxWindowsFileSystem_SelfManagedActiveDirectory_Username (3731.46s)
--- PASS: TestAccAWSFsxWindowsFileSystem_StorageCapacity (4120.68s)
--- PASS: TestAccAWSFsxWindowsFileSystem_Tags (2968.90s)
--- PASS: TestAccAWSFsxWindowsFileSystem_ThroughputCapacity (4056.94s)
--- PASS: TestAccAWSFsxWindowsFileSystem_WeeklyMaintenanceStartTime (3012.74s)
```