### PR TITLE
resource/aws_batch_job_queue: Prevent panic when ComputeEnvironmentOrder is updated outside Terraform

### DIFF
--- a/aws/resource_aws_batch_job_queue_test.go
+++ b/aws/resource_aws_batch_job_queue_test.go
@@ -3,8 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -57,20 +55,24 @@ func testSweepBatchJobQueues(region string) error {
 }
 
 func TestAccAWSBatchJobQueue_basic(t *testing.T) {
-	var jq batch.JobQueueDetail
-	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccBatchJobQueueBasic, ri)
-	resourceName := "aws_batch_job_queue.test_queue"
+	var jobQueue1 batch.JobQueueDetail
+	resourceName := "aws_batch_job_queue.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchJobQueueDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: config,
+				Config: testAccBatchJobQueueConfigState(rName, batch.JQStateEnabled),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBatchJobQueueExists(resourceName, &jq),
-					testAccCheckBatchJobQueueAttributes(&jq),
+					testAccCheckBatchJobQueueExists(resourceName, &jobQueue1),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "batch", fmt.Sprintf("job-queue/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "compute_environments.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "priority", "1"),
+					resource.TestCheckResourceAttr(resourceName, "state", batch.JQStateEnabled),
 				),
 			},
 			{
@@ -84,8 +86,8 @@ func TestAccAWSBatchJobQueue_basic(t *testing.T) {
 
 func TestAccAWSBatchJobQueue_disappears(t *testing.T) {
 	var jobQueue1 batch.JobQueueDetail
-	resourceName := "aws_batch_job_queue.test_queue"
-	rInt := acctest.RandInt()
+	resourceName := "aws_batch_job_queue.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
@@ -93,7 +95,7 @@ func TestAccAWSBatchJobQueue_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccBatchJobQueueBasic, rInt),
+				Config: testAccBatchJobQueueConfigState(rName, batch.JQStateEnabled),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBatchJobQueueExists(resourceName, &jobQueue1),
 					testAccCheckBatchJobQueueDisappears(&jobQueue1),
@@ -104,29 +106,88 @@ func TestAccAWSBatchJobQueue_disappears(t *testing.T) {
 	})
 }
 
-func TestAccAWSBatchJobQueue_update(t *testing.T) {
-	var jq batch.JobQueueDetail
-	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccBatchJobQueueBasic, ri)
-	updateConfig := fmt.Sprintf(testAccBatchJobQueueUpdate, ri)
-	resourceName := "aws_batch_job_queue.test_queue"
+// Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/8083
+func TestAccAWSBatchJobQueue_ComputeEnvironments_ExternalOrderUpdate(t *testing.T) {
+	var jobQueue1 batch.JobQueueDetail
+	resourceName := "aws_batch_job_queue.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchJobQueueDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: config,
+				Config: testAccBatchJobQueueConfigState(rName, batch.JQStateEnabled),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBatchJobQueueExists(resourceName, &jq),
-					testAccCheckBatchJobQueueAttributes(&jq),
+					testAccCheckBatchJobQueueExists(resourceName, &jobQueue1),
+					testAccCheckBatchJobQueueComputeEnvironmentOrderUpdate(&jobQueue1),
 				),
 			},
 			{
-				Config: updateConfig,
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSBatchJobQueue_Priority(t *testing.T) {
+	var jobQueue1, jobQueue2 batch.JobQueueDetail
+	resourceName := "aws_batch_job_queue.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBatchJobQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBatchJobQueueConfigPriority(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBatchJobQueueExists(resourceName, &jq),
-					testAccCheckBatchJobQueueAttributes(&jq),
+					testAccCheckBatchJobQueueExists(resourceName, &jobQueue1),
+					resource.TestCheckResourceAttr(resourceName, "priority", "1"),
+				),
+			},
+			{
+				Config: testAccBatchJobQueueConfigPriority(rName, 2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBatchJobQueueExists(resourceName, &jobQueue2),
+					resource.TestCheckResourceAttr(resourceName, "priority", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSBatchJobQueue_State(t *testing.T) {
+	var jobQueue1, jobQueue2 batch.JobQueueDetail
+	resourceName := "aws_batch_job_queue.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBatchJobQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBatchJobQueueConfigState(rName, batch.JQStateDisabled),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBatchJobQueueExists(resourceName, &jobQueue1),
+					resource.TestCheckResourceAttr(resourceName, "state", batch.JQStateDisabled),
+				),
+			},
+			{
+				Config: testAccBatchJobQueueConfigState(rName, batch.JQStateEnabled),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBatchJobQueueExists(resourceName, &jobQueue2),
+					resource.TestCheckResourceAttr(resourceName, "state", batch.JQStateEnabled),
 				),
 			},
 			{
@@ -165,33 +226,6 @@ func testAccCheckBatchJobQueueExists(n string, jq *batch.JobQueueDetail) resourc
 	}
 }
 
-func testAccCheckBatchJobQueueAttributes(jq *batch.JobQueueDetail) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if !strings.HasPrefix(*jq.JobQueueName, "tf_acctest_batch_job_queue") {
-			return fmt.Errorf("Bad Job Queue name: %s", *jq.JobQueueName)
-		}
-		for _, rs := range s.RootModule().Resources {
-			if rs.Type != "aws_batch_job_queue" {
-				continue
-			}
-			if *jq.JobQueueArn != rs.Primary.Attributes["arn"] {
-				return fmt.Errorf("Bad Job Queue ARN\n\t expected: %s\n\tgot: %s\n", rs.Primary.Attributes["arn"], *jq.JobQueueArn)
-			}
-			if *jq.State != rs.Primary.Attributes["state"] {
-				return fmt.Errorf("Bad Job Queue State\n\t expected: %s\n\tgot: %s\n", rs.Primary.Attributes["state"], *jq.State)
-			}
-			priority, err := strconv.ParseInt(rs.Primary.Attributes["priority"], 10, 64)
-			if err != nil {
-				return err
-			}
-			if *jq.Priority != priority {
-				return fmt.Errorf("Bad Job Queue Priority\n\t expected: %s\n\tgot: %d\n", rs.Primary.Attributes["priority"], *jq.Priority)
-			}
-		}
-		return nil
-	}
-}
-
 func testAccCheckBatchJobQueueDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_batch_job_queue" {
@@ -223,11 +257,46 @@ func testAccCheckBatchJobQueueDisappears(jobQueue *batch.JobQueueDetail) resourc
 	}
 }
 
-const testAccBatchJobQueueBaseConfig = `
-########## ecs_instance_role ##########
+// testAccCheckBatchJobQueueComputeEnvironmentOrderUpdate simulates the change of a Compute Environment Order
+// An external update to the Batch Job Queue (e.g. console) may trigger changes to the value of the Order
+// parameter that do not affect the operation of the queue itself, but the resource logic needs to handle.
+// For example, Terraform may set a single Compute Environment with Order 0, but the console updates it to 1.
+func testAccCheckBatchJobQueueComputeEnvironmentOrderUpdate(jobQueue *batch.JobQueueDetail) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).batchconn
 
-resource "aws_iam_role" "ecs_instance_role" {
-  name = "ecs_instance_role_%[1]d"
+		input := &batch.UpdateJobQueueInput{
+			ComputeEnvironmentOrder: jobQueue.ComputeEnvironmentOrder,
+			JobQueue:                jobQueue.JobQueueName,
+		}
+		name := aws.StringValue(jobQueue.JobQueueName)
+
+		if len(input.ComputeEnvironmentOrder) != 1 {
+			return fmt.Errorf("expected one ComputeEnvironmentOrder in Batch Job Queue (%s)", name)
+		}
+
+		if aws.Int64Value(input.ComputeEnvironmentOrder[0].Order) != 0 {
+			return fmt.Errorf("expected first ComputeEnvironmentOrder in Batch Job Queue (%s) to have existing Order value of 0", name)
+		}
+
+		input.ComputeEnvironmentOrder[0].Order = aws.Int64(1)
+
+		_, err := conn.UpdateJobQueue(input)
+
+		if err != nil {
+			return fmt.Errorf("error updating Batch Job Queue (%s): %s", name, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccBatchJobQueueConfigBase(rName string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
   assume_role_policy = <<EOF
 {
     "Version": "2012-10-17",
@@ -236,7 +305,7 @@ resource "aws_iam_role" "ecs_instance_role" {
 	    "Action": "sts:AssumeRole",
 	    "Effect": "Allow",
 	    "Principal": {
-		"Service": "ec2.amazonaws.com"
+		"Service": "batch.${data.aws_partition.current.dns_suffix}"
 	    }
 	}
     ]
@@ -244,92 +313,75 @@ resource "aws_iam_role" "ecs_instance_role" {
 EOF
 }
 
-resource "aws_iam_role_policy_attachment" "ecs_instance_role" {
-  role       = "${aws_iam_role.ecs_instance_role.name}"
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+resource "aws_iam_role_policy_attachment" "test" {
+  role       = aws_iam_role.test.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSBatchServiceRole"
 }
 
-resource "aws_iam_instance_profile" "ecs_instance_role" {
-  name  = "ecs_instance_role_%[1]d"
-  role = "${aws_iam_role.ecs_instance_role.name}"
-}
-
-########## aws_batch_service_role ##########
-
-resource "aws_iam_role" "aws_batch_service_role" {
-  name = "aws_batch_service_role_%[1]d"
-  assume_role_policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-	{
-	    "Action": "sts:AssumeRole",
-	    "Effect": "Allow",
-	    "Principal": {
-		"Service": "batch.amazonaws.com"
-	    }
-	}
-    ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy_attachment" "aws_batch_service_role" {
-  role       = "${aws_iam_role.aws_batch_service_role.name}"
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"
-}
-
-########## security group ##########
-
-resource "aws_security_group" "test_acc" {
-  name = "aws_batch_compute_environment_security_group_%[1]d"
-}
-
-########## subnets ##########
-
-resource "aws_vpc" "test_acc" {
+resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
+
   tags = {
     Name = "terraform-testacc-batch-job-queue"
   }
 }
 
-resource "aws_subnet" "test_acc" {
-  vpc_id = "${aws_vpc.test_acc.id}"
+resource "aws_security_group" "test" {
+  name   = %[1]q
+  vpc_id = aws_vpc.test.id
+}
+
+resource "aws_subnet" "test" {
   cidr_block = "10.1.1.0/24"
+  vpc_id     = aws_vpc.test.id
+
   tags = {
     Name = "tf-acc-batch-job-queue"
   }
 }
 
-resource "aws_batch_compute_environment" "test_environment" {
-  compute_environment_name = "tf_acctest_batch_compute_environment_%[1]d"
+resource "aws_batch_compute_environment" "test" {
+  compute_environment_name = %[1]q
+  service_role             = aws_iam_role.test.arn
+  type                     = "MANAGED"
+
   compute_resources {
-    instance_role = "${aws_iam_role.aws_batch_service_role.arn}"
-    instance_type = ["m3.medium"]
-    max_vcpus = 1
-    min_vcpus = 0
-    security_group_ids = ["${aws_security_group.test_acc.id}"]
-    subnets = ["${aws_subnet.test_acc.id}"]
-    type = "EC2"
+    instance_role      = aws_iam_role.test.arn
+    instance_type      = ["c5", "m5", "r5"]
+    max_vcpus          = 1
+    min_vcpus          = 0
+    security_group_ids = [aws_security_group.test.id]
+    subnets            = [aws_subnet.test.id]
+    type               = "EC2"
   }
-  service_role = "${aws_iam_role.aws_batch_service_role.arn}"
-  type = "MANAGED"
-  depends_on = ["aws_iam_role_policy_attachment.aws_batch_service_role"]
-}`
 
-var testAccBatchJobQueueBasic = testAccBatchJobQueueBaseConfig + `
-resource "aws_batch_job_queue" "test_queue" {
-  name = "tf_acctest_batch_job_queue_%[1]d"
-  state = "ENABLED"
-  priority = 1
-  compute_environments = ["${aws_batch_compute_environment.test_environment.arn}"]
-}`
+  depends_on = ["aws_iam_role_policy_attachment.test"]
+}
+`, rName)
+}
 
-var testAccBatchJobQueueUpdate = testAccBatchJobQueueBaseConfig + `
-resource "aws_batch_job_queue" "test_queue" {
-  name = "tf_acctest_batch_job_queue_%[1]d"
-  state = "DISABLED"
-  priority = 2
-  compute_environments = ["${aws_batch_compute_environment.test_environment.arn}"]
-}`
+func testAccBatchJobQueueConfigPriority(rName string, priority int) string {
+	return composeConfig(
+		testAccBatchJobQueueConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_batch_job_queue" "test" {
+  compute_environments = [aws_batch_compute_environment.test.arn]
+  name                 = %[1]q
+  priority             = %[2]d
+  state                = "ENABLED"
+}
+`, rName, priority))
+}
+
+func testAccBatchJobQueueConfigState(rName string, state string) string {
+	return composeConfig(
+		testAccBatchJobQueueConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_batch_job_queue" "test" {
+  compute_environments = [aws_batch_compute_environment.test.arn]
+  name                 = %[1]q
+  priority             = 1
+  state                = %[2]q
+}
+`, rName, state))
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #8083

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_batch_job_queue: Prevent panic when ComputeEnvironmentOrder is updated outside Terraform
```

Also modernizes the testing.

Previously:

```
=== CONT  TestAccAWSBatchJobQueue_ComputeEnvironments_ExternalOrderUpdate
panic: runtime error: index out of range [1] with length 1

goroutine 1306 [running]:
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsBatchJobQueueRead(0xc001117c70, 0x62e4cc0, 0xc0003bcf00, 0xc001117c70, 0x0)
  /Users/bflad/src/github.com/terraform-providers/terraform-provider-aws-deux/aws/resource_aws_batch_job_queue.go:110 +0x55a
github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Resource).RefreshWithoutUpgrade(0xc0005df580, 0xc00104ae60, 0x62e4cc0, 0xc0003bcf00, 0xc000c7ec30, 0x0, 0x0)
  /Users/bflad/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.8.0/helper/schema/resource.go:455 +0x119
```

Output from acceptance testing:

```
--- PASS: TestAccAWSBatchJobQueue_basic (85.28s)
--- PASS: TestAccAWSBatchJobQueue_disappears (87.06s)
--- PASS: TestAccAWSBatchJobQueue_ComputeEnvironments_ExternalOrderUpdate (98.67s)
--- PASS: TestAccAWSBatchJobQueue_Priority (120.72s)
--- PASS: TestAccAWSBatchJobQueue_State (127.15s)
```
