### PR TITLE
resource/aws_route53_zone: Guard against missing ChangeInfo during creation

### DIFF
--- a/aws/resource_aws_route53_zone.go
+++ b/aws/resource_aws_route53_zone.go
@@ -142,8 +142,10 @@ func resourceAwsRoute53ZoneCreate(d *schema.ResourceData, meta interface{}) erro
 
 	d.SetId(cleanZoneID(aws.StringValue(output.HostedZone.Id)))
 
-	if err := route53WaitForChangeSynchronization(conn, cleanChangeID(aws.StringValue(output.ChangeInfo.Id))); err != nil {
-		return fmt.Errorf("error waiting for Route53 Hosted Zone (%s) creation: %s", d.Id(), err)
+	if output.ChangeInfo != nil {
+		if err := route53WaitForChangeSynchronization(conn, cleanChangeID(aws.StringValue(output.ChangeInfo.Id))); err != nil {
+			return fmt.Errorf("error waiting for Route53 Hosted Zone (%s) creation: %s", d.Id(), err)
+		}
 	}
 
 	if err := keyvaluetags.Route53UpdateTags(conn, d.Id(), route53.TagResourceTypeHostedzone, map[string]interface{}{}, d.Get("tags").(map[string]interface{})); err != nil {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #8370
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12361
Reference: https://github.com/hashicorp/terraform/pull/10798

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_route53_zone: Prevent panic with APIs missing ChangeInfo during creation (best effort fix for LocalStack)
```

Prevent a crash with non-compliant Route 53 APIs during creation, e.g. LocalStack. This continues best effort support by adding object reference safety, which we should be doing anyways. This change skips synchronization checking rather than raising an error, which seems like the correct and operator friendly behavior in this situation.

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSRoute53Zone_disappears (48.02s)
--- PASS: TestAccAWSRoute53Zone_basic (51.48s)
--- PASS: TestAccAWSRoute53Zone_DelegationSetID (56.24s)
--- PASS: TestAccAWSRoute53Zone_multiple (57.08s)
--- PASS: TestAccAWSRoute53Zone_Comment (63.31s)
--- PASS: TestAccAWSRoute53Zone_Tags (79.33s)
--- PASS: TestAccAWSRoute53Zone_VPC_Single (99.31s)
--- PASS: TestAccAWSRoute53Zone_VPC_Multiple (179.74s)
--- PASS: TestAccAWSRoute53Zone_ForceDestroy_TrailingPeriod (189.14s)
--- PASS: TestAccAWSRoute53Zone_ForceDestroy (189.54s)
--- PASS: TestAccAWSRoute53Zone_VPC_Updates (265.16s)
```
