### PR TITLE
r/elastic_transcoder - remove setmap

### DIFF
--- a/aws/resource_aws_elastic_transcoder_pipeline.go
+++ b/aws/resource_aws_elastic_transcoder_pipeline.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/elastictranscoder"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 func resourceAwsElasticTranscoderPipeline() *schema.Resource {
@@ -64,7 +65,15 @@ func resourceAwsElasticTranscoderPipeline() *schema.Resource {
 						"access": {
 							Type:     schema.TypeList,
 							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+								ValidateFunc: validation.StringInSlice([]string{
+									"READ",
+									"READ_ACP",
+									"WRITE_ACP",
+									"FULL_CONTROL",
+								}, true),
+							},
 						},
 						"grantee": {
 							Type:     schema.TypeString,
@@ -173,7 +182,15 @@ func resourceAwsElasticTranscoderPipeline() *schema.Resource {
 						"access": {
 							Type:     schema.TypeList,
 							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+								ValidateFunc: validation.StringInSlice([]string{
+									"READ",
+									"READ_ACP",
+									"WRITE_ACP",
+									"FULL_CONTROL",
+								}, true),
+							},
 						},
 						"grantee": {
 							Type:     schema.TypeString,
@@ -279,13 +296,14 @@ func flattenETNotifications(n *elastictranscoder.Notifications) []map[string]int
 		return nil
 	}
 
-	m := setMap(make(map[string]interface{}))
+	result := map[string]interface{}{
+		"completed":   aws.StringValue(n.Completed),
+		"error":       aws.StringValue(n.Error),
+		"progressing": aws.StringValue(n.Progressing),
+		"warning":     aws.StringValue(n.Warning),
+	}
 
-	m.SetString("completed", n.Completed)
-	m.SetString("error", n.Error)
-	m.SetString("progressing", n.Progressing)
-	m.SetString("warning", n.Warning)
-	return m.MapList()
+	return []map[string]interface{}{result}
 }
 
 func expandETPiplineOutputConfig(d *schema.ResourceData, key string) *elastictranscoder.PipelineOutputConfig {
@@ -317,12 +335,16 @@ func expandETPiplineOutputConfig(d *schema.ResourceData, key string) *elastictra
 }
 
 func flattenETPipelineOutputConfig(cfg *elastictranscoder.PipelineOutputConfig) []map[string]interface{} {
-	m := setMap(make(map[string]interface{}))
+	if cfg == nil {
+		return nil
+	}
 
-	m.SetString("bucket", cfg.Bucket)
-	m.SetString("storage_class", cfg.StorageClass)
+	result := map[string]interface{}{
+		"bucket":        aws.StringValue(cfg.Bucket),
+		"storage_class": aws.StringValue(cfg.StorageClass),
+	}
 
-	return m.MapList()
+	return []map[string]interface{}{result}
 }
 
 func expandETPermList(permissions *schema.Set) []*elastictranscoder.Permission {
@@ -350,12 +372,13 @@ func flattenETPermList(perms []*elastictranscoder.Permission) []map[string]inter
 	var set []map[string]interface{}
 
 	for _, p := range perms {
-		m := setMap(make(map[string]interface{}))
-		m.Set("access", flattenStringList(p.Access))
-		m.SetString("grantee", p.Grantee)
-		m.SetString("grantee_type", p.GranteeType)
+		result := map[string]interface{}{
+			"access":       flattenStringList(p.Access),
+			"grantee":      aws.StringValue(p.Grantee),
+			"grantee_type": aws.StringValue(p.GranteeType),
+		}
 
-		set = append(set, m)
+		set = append(set, result)
 	}
 	return set
 }

--- a/aws/resource_aws_elastic_transcoder_pipeline.go
+++ b/aws/resource_aws_elastic_transcoder_pipeline.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/elastictranscoder"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 func resourceAwsElasticTranscoderPipeline() *schema.Resource {
@@ -65,15 +64,7 @@ func resourceAwsElasticTranscoderPipeline() *schema.Resource {
 						"access": {
 							Type:     schema.TypeList,
 							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-								ValidateFunc: validation.StringInSlice([]string{
-									"READ",
-									"READ_ACP",
-									"WRITE_ACP",
-									"FULL_CONTROL",
-								}, true),
-							},
+							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"grantee": {
 							Type:     schema.TypeString,
@@ -182,15 +173,7 @@ func resourceAwsElasticTranscoderPipeline() *schema.Resource {
 						"access": {
 							Type:     schema.TypeList,
 							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-								ValidateFunc: validation.StringInSlice([]string{
-									"READ",
-									"READ_ACP",
-									"WRITE_ACP",
-									"FULL_CONTROL",
-								}, true),
-							},
+							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"grantee": {
 							Type:     schema.TypeString,

--- a/aws/resource_aws_elastic_transcoder_preset.go
+++ b/aws/resource_aws_elastic_transcoder_preset.go
@@ -622,15 +622,19 @@ func resourceAwsElasticTranscoderPresetRead(d *schema.ResourceData, meta interfa
 }
 
 func flattenETAudioParameters(audio *elastictranscoder.AudioParameters) []map[string]interface{} {
-	m := setMap(make(map[string]interface{}))
+	if audio == nil {
+		return nil
+	}
 
-	m.SetString("audio_packing_mode", audio.AudioPackingMode)
-	m.SetString("bit_rate", audio.BitRate)
-	m.SetString("channels", audio.Channels)
-	m.SetString("codec", audio.Codec)
-	m.SetString("sample_rate", audio.SampleRate)
+	result := map[string]interface{}{
+		"audio_packing_mode": aws.StringValue(audio.AudioPackingMode),
+		"bit_rate":           aws.StringValue(audio.BitRate),
+		"channels":           aws.StringValue(audio.Channels),
+		"codec":              aws.StringValue(audio.Codec),
+		"sample_rate":        aws.StringValue(audio.SampleRate),
+	}
 
-	return m.MapList()
+	return []map[string]interface{}{result}
 }
 
 func flattenETAudioCodecOptions(opts *elastictranscoder.AudioCodecOptions) []map[string]interface{} {
@@ -638,79 +642,87 @@ func flattenETAudioCodecOptions(opts *elastictranscoder.AudioCodecOptions) []map
 		return nil
 	}
 
-	m := setMap(make(map[string]interface{}))
+	result := map[string]interface{}{
+		"bit_depth": aws.StringValue(opts.BitDepth),
+		"bit_order": aws.StringValue(opts.BitOrder),
+		"profile":   aws.StringValue(opts.Profile),
+		"signed":    aws.StringValue(opts.Signed),
+	}
 
-	m.SetString("bit_depth", opts.BitDepth)
-	m.SetString("bit_order", opts.BitOrder)
-	m.SetString("profile", opts.Profile)
-	m.SetString("signed", opts.Signed)
-
-	return m.MapList()
+	return []map[string]interface{}{result}
 }
 
 func flattenETThumbnails(thumbs *elastictranscoder.Thumbnails) []map[string]interface{} {
-	m := setMap(make(map[string]interface{}))
+	if thumbs == nil {
+		return nil
+	}
 
-	m.SetString("aspect_ratio", thumbs.AspectRatio)
-	m.SetString("format", thumbs.Format)
-	m.SetString("interval", thumbs.Interval)
-	m.SetString("max_height", thumbs.MaxHeight)
-	m.SetString("max_width", thumbs.MaxWidth)
-	m.SetString("padding_policy", thumbs.PaddingPolicy)
-	m.SetString("resolution", thumbs.Resolution)
-	m.SetString("sizing_policy", thumbs.SizingPolicy)
+	result := map[string]interface{}{
+		"aspect_ratio":   aws.StringValue(thumbs.AspectRatio),
+		"format":         aws.StringValue(thumbs.Format),
+		"interval":       aws.StringValue(thumbs.Interval),
+		"max_height":     aws.StringValue(thumbs.MaxHeight),
+		"max_width":      aws.StringValue(thumbs.MaxWidth),
+		"padding_policy": aws.StringValue(thumbs.PaddingPolicy),
+		"resolution":     aws.StringValue(thumbs.Resolution),
+		"sizing_policy":  aws.StringValue(thumbs.SizingPolicy),
+	}
 
-	return m.MapList()
+	return []map[string]interface{}{result}
 }
 
 func flattenETVideoParams(video *elastictranscoder.VideoParameters) []map[string]interface{} {
-	m := setMap(make(map[string]interface{}))
+	if video == nil {
+		return nil
+	}
 
-	m.SetString("aspect_ratio", video.AspectRatio)
-	m.SetString("bit_rate", video.BitRate)
-	m.SetString("codec", video.Codec)
-	m.SetString("display_aspect_ratio", video.DisplayAspectRatio)
-	m.SetString("fixed_gop", video.FixedGOP)
-	m.SetString("frame_rate", video.FrameRate)
-	m.SetString("keyframes_max_dist", video.KeyframesMaxDist)
-	m.SetString("max_frame_rate", video.MaxFrameRate)
-	m.SetString("max_height", video.MaxHeight)
-	m.SetString("max_width", video.MaxWidth)
-	m.SetString("padding_policy", video.PaddingPolicy)
-	m.SetString("resolution", video.Resolution)
-	m.SetString("sizing_policy", video.SizingPolicy)
+	result := map[string]interface{}{
+		"aspect_ratio":         aws.StringValue(video.AspectRatio),
+		"bit_rate":             aws.StringValue(video.BitRate),
+		"codec":                aws.StringValue(video.Codec),
+		"display_aspect_ratio": aws.StringValue(video.DisplayAspectRatio),
+		"fixed_gop":            aws.StringValue(video.FixedGOP),
+		"frame_rate":           aws.StringValue(video.FrameRate),
+		"keyframes_max_dist":   aws.StringValue(video.KeyframesMaxDist),
+		"max_frame_rate":       aws.StringValue(video.MaxFrameRate),
+		"max_height":           aws.StringValue(video.MaxHeight),
+		"max_width":            aws.StringValue(video.MaxWidth),
+		"padding_policy":       aws.StringValue(video.PaddingPolicy),
+		"resolution":           aws.StringValue(video.Resolution),
+		"sizing_policy":        aws.StringValue(video.SizingPolicy),
+	}
 
-	return m.MapList()
+	return []map[string]interface{}{result}
 }
 
 func flattenETWatermarks(watermarks []*elastictranscoder.PresetWatermark) []map[string]interface{} {
 	var watermarkSet []map[string]interface{}
 
 	for _, w := range watermarks {
-		watermark := setMap(make(map[string]interface{}))
+		watermark := map[string]interface{}{
+			"horizontal_align":  aws.StringValue(w.HorizontalAlign),
+			"horizontal_offset": aws.StringValue(w.HorizontalOffset),
+			"id":                aws.StringValue(w.Id),
+			"max_height":        aws.StringValue(w.MaxHeight),
+			"max_width":         aws.StringValue(w.MaxWidth),
+			"opacity":           aws.StringValue(w.Opacity),
+			"sizing_policy":     aws.StringValue(w.SizingPolicy),
+			"target":            aws.StringValue(w.Target),
+			"vertical_align":    aws.StringValue(w.VerticalAlign),
+			"vertical_offset":   aws.StringValue(w.VerticalOffset),
+		}
 
-		watermark.SetString("horizontal_align", w.HorizontalAlign)
-		watermark.SetString("horizontal_offset", w.HorizontalOffset)
-		watermark.SetString("id", w.Id)
-		watermark.SetString("max_height", w.MaxHeight)
-		watermark.SetString("max_width", w.MaxWidth)
-		watermark.SetString("opacity", w.Opacity)
-		watermark.SetString("sizing_policy", w.SizingPolicy)
-		watermark.SetString("target", w.Target)
-		watermark.SetString("vertical_align", w.VerticalAlign)
-		watermark.SetString("vertical_offset", w.VerticalOffset)
-
-		watermarkSet = append(watermarkSet, watermark.Map())
+		watermarkSet = append(watermarkSet, watermark)
 	}
 
 	return watermarkSet
 }
 
 func resourceAwsElasticTranscoderPresetDelete(d *schema.ResourceData, meta interface{}) error {
-	elastictranscoderconn := meta.(*AWSClient).elastictranscoderconn
+	conn := meta.(*AWSClient).elastictranscoderconn
 
 	log.Printf("[DEBUG] Elastic Transcoder Delete Preset: %s", d.Id())
-	_, err := elastictranscoderconn.DeletePreset(&elastictranscoder.DeletePresetInput{
+	_, err := conn.DeletePreset(&elastictranscoder.DeletePresetInput{
 		Id: aws.String(d.Id()),
 	})
 

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -2067,39 +2067,6 @@ func flattenApiGatewayThrottleSettings(settings *apigateway.ThrottleSettings) []
 
 // TODO: refactor some of these helper functions and types in the terraform/helper packages
 
-// a convenience wrapper type for the schema.Set map[string]interface{}
-// Set operations only alter the underlying map if the value is not nil
-type setMap map[string]interface{}
-
-// SetString sets m[key] = *value only if `value != nil`
-func (s setMap) SetString(key string, value *string) {
-	if value == nil {
-		return
-	}
-
-	s[key] = *value
-}
-
-// Set assigns value to s[key] if value isn't nil
-func (s setMap) Set(key string, value interface{}) {
-	if reflect.ValueOf(value).IsNil() {
-		return
-	}
-
-	s[key] = value
-}
-
-// Map returns the raw map type for a shorter type conversion
-func (s setMap) Map() map[string]interface{} {
-	return map[string]interface{}(s)
-}
-
-// MapList returns the map[string]interface{} as a single element in a slice to
-// match the schema.Set data type used for structs.
-func (s setMap) MapList() []map[string]interface{} {
-	return []map[string]interface{}{s.Map()}
-}
-
 // Takes the result of flatmap.Expand for an array of policy attributes and
 // returns ELB API compatible objects
 func expandPolicyAttributes(configured []interface{}) ([]*elb.PolicyAttribute, error) {
@@ -3681,10 +3648,11 @@ func flattenWafAction(n *waf.WafAction) []map[string]interface{} {
 		return nil
 	}
 
-	m := setMap(make(map[string]interface{}))
+	result := map[string]interface{}{
+		"type": aws.StringValue(n.Type),
+	}
 
-	m.SetString("type", n.Type)
-	return m.MapList()
+	return []map[string]interface{}{result}
 }
 
 func flattenWafWebAclRules(ts []*waf.ActivatedRule) []map[string]interface{} {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12621

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSElasticTranscoderPreset_|TestAccAWSElasticTranscoderPipeline_'

--- PASS: TestAccAWSElasticTranscoderPreset_basic (108.18s)
--- PASS: TestAccAWSElasticTranscoderPreset_disappears (29.32s)

--- PASS: TestAccAWSElasticTranscoderPipeline_disappears (80.39s)
--- PASS: TestAccAWSElasticTranscoderPipeline_basic (99.69s)
--- PASS: TestAccAWSElasticTranscoderPipeline_notifications (143.04s)
--- PASS: TestAccAWSElasticTranscoderPipeline_withContentConfig (231.52s)
--- PASS: TestAccAWSElasticTranscoderPipeline_withPermissions (115.09s)
--- PASS: TestAccAWSElasticTranscoderPipeline_kmsKey (165.97s)
```
