### PR TITLE
r/api_gateway_authorizer - fix to allow zero value for `authorizer_result_ttl_in_seconds`

### DIFF
--- a/aws/resource_aws_api_gateway_authorizer.go
+++ b/aws/resource_aws_api_gateway_authorizer.go
@@ -108,7 +108,7 @@ func resourceAwsApiGatewayAuthorizerCreate(d *schema.ResourceData, meta interfac
 	if v, ok := d.GetOk("authorizer_credentials"); ok {
 		input.AuthorizerCredentials = aws.String(v.(string))
 	}
-	if v, ok := d.GetOk("authorizer_result_ttl_in_seconds"); ok {
+	if v, ok := d.GetOkExists("authorizer_result_ttl_in_seconds"); ok {
 		input.AuthorizerResultTtlInSeconds = aws.Int64(int64(v.(int)))
 	}
 	if v, ok := d.GetOk("identity_validation_expression"); ok {

--- a/aws/resource_aws_api_gateway_authorizer.go
+++ b/aws/resource_aws_api_gateway_authorizer.go
@@ -36,9 +36,8 @@ func resourceAwsApiGatewayAuthorizer() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"authorizer_uri": {
-				Type:         schema.TypeString,
-				Optional:     true, // authorizer_uri is required for authorizer TOKEN/REQUEST
-				ValidateFunc: validateArn,
+				Type:     schema.TypeString,
+				Optional: true, // authorizer_uri is required for authorizer TOKEN/REQUEST
 			},
 			"identity_source": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_api_gateway_authorizer.go
+++ b/aws/resource_aws_api_gateway_authorizer.go
@@ -304,7 +304,7 @@ func validateAuthorizerType(d *schema.ResourceData) error {
 	}
 	// provider_arns is required for authorizer COGNITO_USER_POOLS.
 	if authType == apigateway.AuthorizerTypeCognitoUserPools {
-		if v, ok := d.GetOk("provider_arns"); !ok || len(v.(*schema.Set).List()) == 0 {
+		if v, ok := d.GetOk("provider_arns"); !ok || v.(*schema.Set).Len() == 0 {
 			return fmt.Errorf("provider_arns must be set non-empty when authorizer type is %s", authType)
 		}
 	}

--- a/aws/resource_aws_api_gateway_authorizer_test.go
+++ b/aws/resource_aws_api_gateway_authorizer_test.go
@@ -16,13 +16,10 @@ import (
 
 func TestAccAWSAPIGatewayAuthorizer_basic(t *testing.T) {
 	var conf apigateway.Authorizer
-	apiGatewayName := acctest.RandomWithPrefix("tf-acctest-apigw")
-	authorizerName := acctest.RandomWithPrefix("tf-acctest-igw-authorizer")
-	lambdaName := acctest.RandomWithPrefix("tf-acctest-igw-auth-lambda")
-
-	resourceName := "aws_api_gateway_authorizer.acctest"
-	lambdaResourceName := "aws_lambda_function.authorizer"
-	roleResourceName := "aws_iam_role.invocation_role"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_api_gateway_authorizer.test"
+	lambdaResourceName := "aws_lambda_function.test"
+	roleResourceName := "aws_iam_role.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -30,12 +27,12 @@ func TestAccAWSAPIGatewayAuthorizer_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSAPIGatewayAuthorizerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSAPIGatewayAuthorizerConfig_lambda(apiGatewayName, authorizerName, lambdaName),
+				Config: testAccAWSAPIGatewayAuthorizerConfig_lambda(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayAuthorizerExists(resourceName, &conf),
 					resource.TestCheckResourceAttrPair(resourceName, "authorizer_uri", lambdaResourceName, "invoke_arn"),
 					resource.TestCheckResourceAttr(resourceName, "identity_source", "method.request.header.Authorization"),
-					resource.TestCheckResourceAttr(resourceName, "name", authorizerName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "type", "TOKEN"),
 					resource.TestCheckResourceAttrPair(resourceName, "authorizer_credentials", roleResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", strconv.Itoa(defaultAuthorizerTTL)),
@@ -49,12 +46,12 @@ func TestAccAWSAPIGatewayAuthorizer_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSAPIGatewayAuthorizerConfig_lambdaUpdate(apiGatewayName, authorizerName, lambdaName),
+				Config: testAccAWSAPIGatewayAuthorizerConfig_lambdaUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayAuthorizerExists(resourceName, &conf),
 					resource.TestCheckResourceAttrPair(resourceName, "authorizer_uri", lambdaResourceName, "invoke_arn"),
 					resource.TestCheckResourceAttr(resourceName, "identity_source", "method.request.header.Authorization"),
-					resource.TestCheckResourceAttr(resourceName, "name", authorizerName+"_modified"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName+"_modified"),
 					resource.TestCheckResourceAttr(resourceName, "type", "TOKEN"),
 					resource.TestCheckResourceAttrPair(resourceName, "authorizer_credentials", roleResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", strconv.Itoa(360)),
@@ -66,11 +63,8 @@ func TestAccAWSAPIGatewayAuthorizer_basic(t *testing.T) {
 }
 
 func TestAccAWSAPIGatewayAuthorizer_cognito(t *testing.T) {
-	apiGatewayName := acctest.RandomWithPrefix("tf-acctest-apigw")
-	authorizerName := acctest.RandomWithPrefix("tf-acctest-igw-authorizer")
-	cognitoName := acctest.RandomWithPrefix("tf-acctest-cognito-user-pool")
-
-	resourceName := "aws_api_gateway_authorizer.acctest"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_api_gateway_authorizer.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -78,9 +72,9 @@ func TestAccAWSAPIGatewayAuthorizer_cognito(t *testing.T) {
 		CheckDestroy: testAccCheckAWSAPIGatewayAuthorizerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSAPIGatewayAuthorizerConfig_cognito(apiGatewayName, authorizerName, cognitoName),
+				Config: testAccAWSAPIGatewayAuthorizerConfig_cognito(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", authorizerName+"-cognito"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "type", "COGNITO_USER_POOLS"),
 					resource.TestCheckResourceAttr(resourceName, "provider_arns.#", "2"),
 				),
@@ -92,9 +86,9 @@ func TestAccAWSAPIGatewayAuthorizer_cognito(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSAPIGatewayAuthorizerConfig_cognitoUpdate(apiGatewayName, authorizerName, cognitoName),
+				Config: testAccAWSAPIGatewayAuthorizerConfig_cognitoUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", authorizerName+"-cognito-update"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "type", "COGNITO_USER_POOLS"),
 					resource.TestCheckResourceAttr(resourceName, "provider_arns.#", "3"),
 				),
@@ -104,14 +98,10 @@ func TestAccAWSAPIGatewayAuthorizer_cognito(t *testing.T) {
 }
 
 func TestAccAWSAPIGatewayAuthorizer_switchAuthType(t *testing.T) {
-	apiGatewayName := acctest.RandomWithPrefix("tf-acctest-apigw")
-	authorizerName := acctest.RandomWithPrefix("tf-acctest-igw-authorizer")
-	lambdaName := acctest.RandomWithPrefix("tf-acctest-igw-auth-lambda")
-	cognitoName := acctest.RandomWithPrefix("tf-acctest-cognito-user-pool")
-
-	resourceName := "aws_api_gateway_authorizer.acctest"
-	lambdaResourceName := "aws_lambda_function.authorizer"
-	roleResourceName := "aws_iam_role.invocation_role"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_api_gateway_authorizer.test"
+	lambdaResourceName := "aws_lambda_function.test"
+	roleResourceName := "aws_iam_role.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -119,9 +109,9 @@ func TestAccAWSAPIGatewayAuthorizer_switchAuthType(t *testing.T) {
 		CheckDestroy: testAccCheckAWSAPIGatewayAuthorizerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSAPIGatewayAuthorizerConfig_lambda(apiGatewayName, authorizerName, lambdaName),
+				Config: testAccAWSAPIGatewayAuthorizerConfig_lambda(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", authorizerName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "type", "TOKEN"),
 					resource.TestCheckResourceAttrPair(resourceName, "authorizer_uri", lambdaResourceName, "invoke_arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "authorizer_credentials", roleResourceName, "arn"),
@@ -134,17 +124,17 @@ func TestAccAWSAPIGatewayAuthorizer_switchAuthType(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSAPIGatewayAuthorizerConfig_cognito(apiGatewayName, authorizerName, cognitoName),
+				Config: testAccAWSAPIGatewayAuthorizerConfig_cognito(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", authorizerName+"-cognito"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "type", "COGNITO_USER_POOLS"),
 					resource.TestCheckResourceAttr(resourceName, "provider_arns.#", "2"),
 				),
 			},
 			{
-				Config: testAccAWSAPIGatewayAuthorizerConfig_lambdaUpdate(apiGatewayName, authorizerName, lambdaName),
+				Config: testAccAWSAPIGatewayAuthorizerConfig_lambdaUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", authorizerName+"_modified"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName+"_modified"),
 					resource.TestCheckResourceAttr(resourceName, "type", "TOKEN"),
 					resource.TestCheckResourceAttrPair(resourceName, "authorizer_uri", lambdaResourceName, "invoke_arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "authorizer_credentials", roleResourceName, "arn"),
@@ -156,10 +146,8 @@ func TestAccAWSAPIGatewayAuthorizer_switchAuthType(t *testing.T) {
 
 func TestAccAWSAPIGatewayAuthorizer_switchAuthorizerTTL(t *testing.T) {
 	var conf apigateway.Authorizer
-	apiGatewayName := acctest.RandomWithPrefix("tf-acctest-apigw")
-	authorizerName := acctest.RandomWithPrefix("tf-acctest-igw-authorizer")
-	lambdaName := acctest.RandomWithPrefix("tf-acctest-igw-auth-lambda")
-	resourceName := "aws_api_gateway_authorizer.acctest"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_api_gateway_authorizer.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -167,7 +155,7 @@ func TestAccAWSAPIGatewayAuthorizer_switchAuthorizerTTL(t *testing.T) {
 		CheckDestroy: testAccCheckAWSAPIGatewayAuthorizerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSAPIGatewayAuthorizerConfig_lambda(apiGatewayName, authorizerName, lambdaName),
+				Config: testAccAWSAPIGatewayAuthorizerConfig_lambda(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayAuthorizerExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", strconv.Itoa(defaultAuthorizerTTL)),
@@ -180,21 +168,21 @@ func TestAccAWSAPIGatewayAuthorizer_switchAuthorizerTTL(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSAPIGatewayAuthorizerConfig_lambdaUpdate(apiGatewayName, authorizerName, lambdaName),
+				Config: testAccAWSAPIGatewayAuthorizerConfig_lambdaUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayAuthorizerExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", strconv.Itoa(360)),
 				),
 			},
 			{
-				Config: testAccAWSAPIGatewayAuthorizerConfig_lambdaNoCache(apiGatewayName, authorizerName, lambdaName),
+				Config: testAccAWSAPIGatewayAuthorizerConfig_lambdaNoCache(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayAuthorizerExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", strconv.Itoa(0)),
 				),
 			},
 			{
-				Config: testAccAWSAPIGatewayAuthorizerConfig_lambda(apiGatewayName, authorizerName, lambdaName),
+				Config: testAccAWSAPIGatewayAuthorizerConfig_lambda(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayAuthorizerExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", strconv.Itoa(defaultAuthorizerTTL)),
@@ -205,10 +193,7 @@ func TestAccAWSAPIGatewayAuthorizer_switchAuthorizerTTL(t *testing.T) {
 }
 
 func TestAccAWSAPIGatewayAuthorizer_authTypeValidation(t *testing.T) {
-	apiGatewayName := acctest.RandomWithPrefix("tf-acctest-apigw")
-	authorizerName := acctest.RandomWithPrefix("tf-acctest-igw-authorizer")
-	lambdaName := acctest.RandomWithPrefix("tf-acctest-igw-auth-lambda")
-	cognitoName := acctest.RandomWithPrefix("tf-acctest-cognito-user-pool")
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -216,15 +201,15 @@ func TestAccAWSAPIGatewayAuthorizer_authTypeValidation(t *testing.T) {
 		CheckDestroy: testAccCheckAWSAPIGatewayAuthorizerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAWSAPIGatewayAuthorizerConfig_authTypeValidationDefaultToken(apiGatewayName, authorizerName, lambdaName),
+				Config:      testAccAWSAPIGatewayAuthorizerConfig_authTypeValidationDefaultToken(rName),
 				ExpectError: regexp.MustCompile(`authorizer_uri must be set non-empty when authorizer type is TOKEN`),
 			},
 			{
-				Config:      testAccAWSAPIGatewayAuthorizerConfig_authTypeValidationRequest(apiGatewayName, authorizerName, lambdaName),
+				Config:      testAccAWSAPIGatewayAuthorizerConfig_authTypeValidationRequest(rName),
 				ExpectError: regexp.MustCompile(`authorizer_uri must be set non-empty when authorizer type is REQUEST`),
 			},
 			{
-				Config:      testAccAWSAPIGatewayAuthorizerConfig_authTypeValidationCognito(apiGatewayName, authorizerName, cognitoName),
+				Config:      testAccAWSAPIGatewayAuthorizerConfig_authTypeValidationCognito(rName),
 				ExpectError: regexp.MustCompile(`provider_arns must be set non-empty when authorizer type is COGNITO_USER_POOLS`),
 			},
 		},
@@ -233,10 +218,8 @@ func TestAccAWSAPIGatewayAuthorizer_authTypeValidation(t *testing.T) {
 
 func TestAccAWSAPIGatewayAuthorizer_zero_ttl(t *testing.T) {
 	var conf apigateway.Authorizer
-	apiGatewayName := acctest.RandomWithPrefix("tf-acctest-apigw")
-	authorizerName := acctest.RandomWithPrefix("tf-acctest-igw-authorizer")
-	lambdaName := acctest.RandomWithPrefix("tf-acctest-igw-auth-lambda")
-	resourceName := "aws_api_gateway_authorizer.acctest"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_api_gateway_authorizer.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -244,7 +227,7 @@ func TestAccAWSAPIGatewayAuthorizer_zero_ttl(t *testing.T) {
 		CheckDestroy: testAccCheckAWSAPIGatewayAuthorizerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSAPIGatewayAuthorizerConfig_lambdaNoCache(apiGatewayName, authorizerName, lambdaName),
+				Config: testAccAWSAPIGatewayAuthorizerConfig_lambdaNoCache(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayAuthorizerExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", "0"),
@@ -262,10 +245,8 @@ func TestAccAWSAPIGatewayAuthorizer_zero_ttl(t *testing.T) {
 
 func TestAccAWSAPIGatewayAuthorizer_disappears(t *testing.T) {
 	var conf apigateway.Authorizer
-	apiGatewayName := acctest.RandomWithPrefix("tf-acctest-apigw")
-	authorizerName := acctest.RandomWithPrefix("tf-acctest-igw-authorizer")
-	lambdaName := acctest.RandomWithPrefix("tf-acctest-igw-auth-lambda")
-	resourceName := "aws_api_gateway_authorizer.acctest"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_api_gateway_authorizer.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -273,7 +254,7 @@ func TestAccAWSAPIGatewayAuthorizer_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAWSAPIGatewayAuthorizerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSAPIGatewayAuthorizerConfig_lambda(apiGatewayName, authorizerName, lambdaName),
+				Config: testAccAWSAPIGatewayAuthorizerConfig_lambda(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayAuthorizerExists(resourceName, &conf),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsApiGatewayAuthorizer(), resourceName),
@@ -355,14 +336,14 @@ func testAccAWSAPIGatewayAuthorizerImportStateIdFunc(resourceName string) resour
 	}
 }
 
-func testAccAWSAPIGatewayAuthorizerConfig_baseLambda(apiGatewayName, lambdaName string) string {
+func testAccAWSAPIGatewayAuthorizerConfigBase(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_api_gateway_rest_api" "acctest" {
-  name = "%s"
+resource "aws_api_gateway_rest_api" "test" {
+  name = %[1]q
 }
 
-resource "aws_iam_role" "invocation_role" {
-  name = "%s_auth_invocation_role"
+resource "aws_iam_role" "test" {
+  name = %[1]q
   path = "/"
 
   assume_role_policy = <<EOF
@@ -382,9 +363,9 @@ resource "aws_iam_role" "invocation_role" {
 EOF
 }
 
-resource "aws_iam_role_policy" "invocation_policy" {
-  name = "default"
-  role = aws_iam_role.invocation_role.id
+resource "aws_iam_role_policy" "test" {
+  name = %[1]q
+  role = aws_iam_role.test.id
 
   policy = <<EOF
 {
@@ -393,15 +374,15 @@ resource "aws_iam_role_policy" "invocation_policy" {
     {
       "Action": "lambda:InvokeFunction",
       "Effect": "Allow",
-      "Resource": "${aws_lambda_function.authorizer.arn}"
+      "Resource": "${aws_lambda_function.test.arn}"
     }
   ]
 }
 EOF
 }
 
-resource "aws_iam_role" "iam_for_lambda" {
-  name = "%s_authorizer_lambda"
+resource "aws_iam_role" "lambda" {
+  name = "%[1]s-lambda"
 
   assume_role_policy = <<EOF
 {
@@ -420,130 +401,130 @@ resource "aws_iam_role" "iam_for_lambda" {
 EOF
 }
 
-resource "aws_lambda_function" "authorizer" {
+resource "aws_lambda_function" "test" {
   filename         = "test-fixtures/lambdatest.zip"
   source_code_hash = filebase64sha256("test-fixtures/lambdatest.zip")
-  function_name    = "%s"
-  role             = aws_iam_role.iam_for_lambda.arn
+  function_name    = %[1]q
+  role             = aws_iam_role.lambda.arn
   handler          = "exports.example"
   runtime          = "nodejs12.x"
 }
-`, apiGatewayName, apiGatewayName, apiGatewayName, lambdaName)
+`, rName)
 }
 
-func testAccAWSAPIGatewayAuthorizerConfig_lambda(apiGatewayName, authorizerName, lambdaName string) string {
-	return testAccAWSAPIGatewayAuthorizerConfig_baseLambda(apiGatewayName, lambdaName) + fmt.Sprintf(`
-resource "aws_api_gateway_authorizer" "acctest" {
-  name                   = "%s"
-  rest_api_id            = aws_api_gateway_rest_api.acctest.id
-  authorizer_uri         = aws_lambda_function.authorizer.invoke_arn
-  authorizer_credentials = aws_iam_role.invocation_role.arn
+func testAccAWSAPIGatewayAuthorizerConfig_lambda(rName string) string {
+	return testAccAWSAPIGatewayAuthorizerConfigBase(rName) + fmt.Sprintf(`
+resource "aws_api_gateway_authorizer" "test" {
+  name                   = %[1]q
+  rest_api_id            = aws_api_gateway_rest_api.test.id
+  authorizer_uri         = aws_lambda_function.test.invoke_arn
+  authorizer_credentials = aws_iam_role.test.arn
 }
-`, authorizerName)
+`, rName)
 }
 
-func testAccAWSAPIGatewayAuthorizerConfig_lambdaUpdate(apiGatewayName, authorizerName, lambdaName string) string {
-	return testAccAWSAPIGatewayAuthorizerConfig_baseLambda(apiGatewayName, lambdaName) + fmt.Sprintf(`
-resource "aws_api_gateway_authorizer" "acctest" {
-  name                             = "%s_modified"
-  rest_api_id                      = aws_api_gateway_rest_api.acctest.id
-  authorizer_uri                   = aws_lambda_function.authorizer.invoke_arn
-  authorizer_credentials           = aws_iam_role.invocation_role.arn
+func testAccAWSAPIGatewayAuthorizerConfig_lambdaUpdate(rName string) string {
+	return testAccAWSAPIGatewayAuthorizerConfigBase(rName) + fmt.Sprintf(`
+resource "aws_api_gateway_authorizer" "test" {
+  name                             = "%[1]s_modified"
+  rest_api_id                      = aws_api_gateway_rest_api.test.id
+  authorizer_uri                   = aws_lambda_function.test.invoke_arn
+  authorizer_credentials           = aws_iam_role.test.arn
   authorizer_result_ttl_in_seconds = 360
   identity_validation_expression   = ".*"
 }
-`, authorizerName)
+`, rName)
 }
 
-func testAccAWSAPIGatewayAuthorizerConfig_lambdaNoCache(apiGatewayName, authorizerName, lambdaName string) string {
-	return testAccAWSAPIGatewayAuthorizerConfig_baseLambda(apiGatewayName, lambdaName) + fmt.Sprintf(`
-resource "aws_api_gateway_authorizer" "acctest" {
-  name                             = "%s_modified"
-  rest_api_id                      = aws_api_gateway_rest_api.acctest.id
-  authorizer_uri                   = aws_lambda_function.authorizer.invoke_arn
-  authorizer_credentials           = aws_iam_role.invocation_role.arn
+func testAccAWSAPIGatewayAuthorizerConfig_lambdaNoCache(rName string) string {
+	return testAccAWSAPIGatewayAuthorizerConfigBase(rName) + fmt.Sprintf(`
+resource "aws_api_gateway_authorizer" "test" {
+  name                             = "%[1]s_modified"
+  rest_api_id                      = aws_api_gateway_rest_api.test.id
+  authorizer_uri                   = aws_lambda_function.test.invoke_arn
+  authorizer_credentials           = aws_iam_role.test.arn
   authorizer_result_ttl_in_seconds = 0
   identity_validation_expression   = ".*"
 }
-`, authorizerName)
+`, rName)
 }
 
-func testAccAWSAPIGatewayAuthorizerConfig_cognito(apiGatewayName, authorizerName, cognitoName string) string {
+func testAccAWSAPIGatewayAuthorizerConfig_cognito(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_api_gateway_rest_api" "acctest" {
-  name = "%s"
+resource "aws_api_gateway_rest_api" "test" {
+  name = %[1]q
 }
 
-resource "aws_cognito_user_pool" "acctest" {
+resource "aws_cognito_user_pool" "test" {
   count = 2
-  name  = "%s-${count.index}"
+  name  = "%[1]s-${count.index}"
 }
 
-resource "aws_api_gateway_authorizer" "acctest" {
-  name          = "%s-cognito"
+resource "aws_api_gateway_authorizer" "test" {
+  name          = %[1]q
   type          = "COGNITO_USER_POOLS"
-  rest_api_id   = aws_api_gateway_rest_api.acctest.id
-  provider_arns = aws_cognito_user_pool.acctest[*].arn
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  provider_arns = aws_cognito_user_pool.test[*].arn
 }
-`, apiGatewayName, cognitoName, authorizerName)
+`, rName)
 }
 
-func testAccAWSAPIGatewayAuthorizerConfig_cognitoUpdate(apiGatewayName, authorizerName, cognitoName string) string {
+func testAccAWSAPIGatewayAuthorizerConfig_cognitoUpdate(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_api_gateway_rest_api" "acctest" {
-  name = "%s"
+resource "aws_api_gateway_rest_api" "test" {
+  name = %[1]q
 }
 
-resource "aws_cognito_user_pool" "acctest_update" {
+resource "aws_cognito_user_pool" "test" {
   count = 3
-  name  = "%s-${count.index}-update"
+  name  = "%[1]s-${count.index}-update"
 }
 
-resource "aws_api_gateway_authorizer" "acctest" {
-  name          = "%s-cognito-update"
+resource "aws_api_gateway_authorizer" "test" {
+  name          = %[1]q
   type          = "COGNITO_USER_POOLS"
-  rest_api_id   = aws_api_gateway_rest_api.acctest.id
-  provider_arns = aws_cognito_user_pool.acctest_update[*].arn
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  provider_arns = aws_cognito_user_pool.test[*].arn
 }
-`, apiGatewayName, cognitoName, authorizerName)
+`, rName)
 }
 
-func testAccAWSAPIGatewayAuthorizerConfig_authTypeValidationDefaultToken(apiGatewayName, authorizerName, lambdaName string) string {
-	return testAccAWSAPIGatewayAuthorizerConfig_baseLambda(apiGatewayName, lambdaName) + fmt.Sprintf(`
-resource "aws_api_gateway_authorizer" "acctest" {
+func testAccAWSAPIGatewayAuthorizerConfig_authTypeValidationDefaultToken(rName string) string {
+	return testAccAWSAPIGatewayAuthorizerConfigBase(rName) + fmt.Sprintf(`
+resource "aws_api_gateway_authorizer" "test" {
   name                   = "%s"
-  rest_api_id            = aws_api_gateway_rest_api.acctest.id
-  authorizer_credentials = aws_iam_role.invocation_role.arn
+  rest_api_id            = aws_api_gateway_rest_api.test.id
+  authorizer_credentials = aws_iam_role.test.arn
 }
-`, authorizerName)
+`, rName)
 }
 
-func testAccAWSAPIGatewayAuthorizerConfig_authTypeValidationRequest(apiGatewayName, authorizerName, lambdaName string) string {
-	return testAccAWSAPIGatewayAuthorizerConfig_baseLambda(apiGatewayName, lambdaName) + fmt.Sprintf(`
-resource "aws_api_gateway_authorizer" "acctest" {
+func testAccAWSAPIGatewayAuthorizerConfig_authTypeValidationRequest(rName string) string {
+	return testAccAWSAPIGatewayAuthorizerConfigBase(rName) + fmt.Sprintf(`
+resource "aws_api_gateway_authorizer" "test" {
   name                   = "%s"
   type                   = "REQUEST"
-  rest_api_id            = aws_api_gateway_rest_api.acctest.id
-  authorizer_credentials = aws_iam_role.invocation_role.arn
+  rest_api_id            = aws_api_gateway_rest_api.test.id
+  authorizer_credentials = aws_iam_role.test.arn
 }
-`, authorizerName)
+`, rName)
 }
 
-func testAccAWSAPIGatewayAuthorizerConfig_authTypeValidationCognito(apiGatewayName, authorizerName, cognitoName string) string {
+func testAccAWSAPIGatewayAuthorizerConfig_authTypeValidationCognito(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_api_gateway_rest_api" "acctest" {
-  name = "%s"
+resource "aws_api_gateway_rest_api" "test" {
+  name = %[1]q
 }
 
-resource "aws_cognito_user_pool" "acctest" {
+resource "aws_cognito_user_pool" "test" {
   count = 2
-  name  = "%s-${count.index}"
+  name  = "%[1]s-${count.index}"
 }
 
-resource "aws_api_gateway_authorizer" "acctest" {
-  name        = "%s-cognito"
+resource "aws_api_gateway_authorizer" "test" {
+  name        = %[1]q
   type        = "COGNITO_USER_POOLS"
-  rest_api_id = aws_api_gateway_rest_api.acctest.id
+  rest_api_id = aws_api_gateway_rest_api.test.id
 }
-`, apiGatewayName, cognitoName, authorizerName)
+`, rName)
 }

--- a/aws/resource_aws_api_gateway_authorizer_test.go
+++ b/aws/resource_aws_api_gateway_authorizer_test.go
@@ -477,7 +477,7 @@ resource "aws_api_gateway_rest_api" "test" {
 
 resource "aws_cognito_user_pool" "test" {
   count = 3
-  name  = "%[1]s-${count.index}-update"
+  name  = "%[1]s-${count.index}"
 }
 
 resource "aws_api_gateway_authorizer" "test" {

--- a/aws/resource_aws_api_gateway_authorizer_test.go
+++ b/aws/resource_aws_api_gateway_authorizer_test.go
@@ -231,6 +231,35 @@ func TestAccAWSAPIGatewayAuthorizer_authTypeValidation(t *testing.T) {
 	})
 }
 
+func TestAccAWSAPIGatewayAuthorizer_zero_ttl(t *testing.T) {
+	var conf apigateway.Authorizer
+	apiGatewayName := acctest.RandomWithPrefix("tf-acctest-apigw")
+	authorizerName := acctest.RandomWithPrefix("tf-acctest-igw-authorizer")
+	lambdaName := acctest.RandomWithPrefix("tf-acctest-igw-auth-lambda")
+	resourceName := "aws_api_gateway_authorizer.acctest"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayAuthorizerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayAuthorizerConfig_lambdaNoCache(apiGatewayName, authorizerName, lambdaName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayAuthorizerExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAPIGatewayAuthorizerImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSAPIGatewayAuthorizer_disappears(t *testing.T) {
 	var conf apigateway.Authorizer
 	apiGatewayName := acctest.RandomWithPrefix("tf-acctest-apigw")


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12633

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_api_gateway_authorizer - fix to allow zero value for `authorizer_result_ttl_in_seconds`
resource_aws_api_gateway_authorizer - add validations for `authorizer_credentials`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSAPIGatewayAuthorizer_zero_ttl'
--- PASS: TestAccAWSAPIGatewayAuthorizer_zero_ttl (76.41s)
```
