### PR TITLE
r/directory_service_service_directory - fix import + add attributes

### DIFF
--- a/aws/data_source_aws_directory_service_directory.go
+++ b/aws/data_source_aws_directory_service_directory.go
@@ -56,6 +56,15 @@ func dataSourceAwsDirectoryServiceDirectory() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"security_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"availability_zones": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
 					},
 				},
 			},
@@ -89,6 +98,20 @@ func dataSourceAwsDirectoryServiceDirectory() *schema.Resource {
 						"vpc_id": {
 							Type:     schema.TypeString,
 							Computed: true,
+						},
+						"security_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"connect_ips": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"availability_zones": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 					},
 				},
@@ -160,8 +183,15 @@ func dataSourceAwsDirectoryServiceDirectoryRead(d *schema.ResourceData, meta int
 	d.Set("size", dir.Size)
 	d.Set("edition", dir.Edition)
 	d.Set("type", dir.Type)
-	d.Set("vpc_settings", flattenDSVpcSettings(dir.VpcSettings))
-	d.Set("connect_settings", flattenDSConnectSettings(dir.DnsIpAddrs, dir.ConnectSettings))
+
+	if err := d.Set("vpc_settings", flattenDSVpcSettings(dir.VpcSettings)); err != nil {
+		return fmt.Errorf("error setting VPC settings: %s", err)
+	}
+
+	if err := d.Set("connect_settings", flattenDSConnectSettings(dir.DnsIpAddrs, dir.ConnectSettings)); err != nil {
+		return fmt.Errorf("error setting connect settings: %s", err)
+	}
+
 	d.Set("enable_sso", dir.SsoEnabled)
 
 	if aws.StringValue(dir.Type) == directoryservice.DirectoryTypeAdconnector {

--- a/aws/data_source_aws_directory_service_directory.go
+++ b/aws/data_source_aws_directory_service_directory.go
@@ -56,10 +56,6 @@ func dataSourceAwsDirectoryServiceDirectory() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"security_group_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
 						"availability_zones": {
 							Type:     schema.TypeSet,
 							Computed: true,
@@ -98,15 +94,6 @@ func dataSourceAwsDirectoryServiceDirectory() *schema.Resource {
 						"vpc_id": {
 							Type:     schema.TypeString,
 							Computed: true,
-						},
-						"security_group_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"connect_ips": {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"availability_zones": {
 							Type:     schema.TypeSet,

--- a/aws/resource_aws_directory_service_directory.go
+++ b/aws/resource_aws_directory_service_directory.go
@@ -82,6 +82,15 @@ func resourceAwsDirectoryServiceDirectory() *schema.Resource {
 							Required: true,
 							ForceNew: true,
 						},
+						"security_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"availability_zones": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
 					},
 				},
 			},

--- a/aws/resource_aws_directory_service_directory.go
+++ b/aws/resource_aws_directory_service_directory.go
@@ -107,8 +107,11 @@ func resourceAwsDirectoryServiceDirectory() *schema.Resource {
 							Type:     schema.TypeSet,
 							Required: true,
 							ForceNew: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-							Set:      schema.HashString,
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validation.SingleIP(),
+							},
+							Set: schema.HashString,
 						},
 						"subnet_ids": {
 							Type:     schema.TypeSet,
@@ -135,8 +138,11 @@ func resourceAwsDirectoryServiceDirectory() *schema.Resource {
 				Computed: true,
 			},
 			"dns_ip_addresses": {
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.SingleIP(),
+				},
 				Set:      schema.HashString,
 				Computed: true,
 			},
@@ -153,6 +159,7 @@ func resourceAwsDirectoryServiceDirectory() *schema.Resource {
 					directoryservice.DirectoryTypeAdconnector,
 					directoryservice.DirectoryTypeMicrosoftAd,
 					directoryservice.DirectoryTypeSimpleAd,
+					directoryservice.DirectoryTypeSharedMicrosoftAd,
 				}, false),
 			},
 			"edition": {
@@ -463,17 +470,24 @@ func resourceAwsDirectoryServiceDirectoryRead(d *schema.ResourceData, meta inter
 	d.Set("description", dir.Description)
 
 	if *dir.Type == directoryservice.DirectoryTypeAdconnector {
-		d.Set("dns_ip_addresses", schema.NewSet(schema.HashString, flattenStringList(dir.ConnectSettings.ConnectIps)))
+		d.Set("dns_ip_addresses", flattenStringSet(dir.ConnectSettings.ConnectIps))
 	} else {
-		d.Set("dns_ip_addresses", schema.NewSet(schema.HashString, flattenStringList(dir.DnsIpAddrs)))
+		d.Set("dns_ip_addresses", flattenStringSet(dir.DnsIpAddrs))
 	}
 	d.Set("name", dir.Name)
 	d.Set("short_name", dir.ShortName)
 	d.Set("size", dir.Size)
 	d.Set("edition", dir.Edition)
 	d.Set("type", dir.Type)
-	d.Set("vpc_settings", flattenDSVpcSettings(dir.VpcSettings))
-	d.Set("connect_settings", flattenDSConnectSettings(dir.DnsIpAddrs, dir.ConnectSettings))
+
+	if err := d.Set("vpc_settings", flattenDSVpcSettings(dir.VpcSettings)); err != nil {
+		return fmt.Errorf("error setting VPC settings: %s", err)
+	}
+
+	if err := d.Set("connect_settings", flattenDSConnectSettings(dir.DnsIpAddrs, dir.ConnectSettings)); err != nil {
+		return fmt.Errorf("error setting connect settings: %s", err)
+	}
+
 	d.Set("enable_sso", dir.SsoEnabled)
 
 	if aws.StringValue(dir.Type) == directoryservice.DirectoryTypeAdconnector {

--- a/aws/resource_aws_directory_service_directory.go
+++ b/aws/resource_aws_directory_service_directory.go
@@ -114,7 +114,7 @@ func resourceAwsDirectoryServiceDirectory() *schema.Resource {
 							ForceNew: true,
 							Elem: &schema.Schema{
 								Type:         schema.TypeString,
-								ValidateFunc: validation.IsIPAddress(),
+								ValidateFunc: validation.IsIPAddress,
 							},
 							Set: schema.HashString,
 						},

--- a/aws/resource_aws_directory_service_directory.go
+++ b/aws/resource_aws_directory_service_directory.go
@@ -161,11 +161,8 @@ func resourceAwsDirectoryServiceDirectory() *schema.Resource {
 				Computed: true,
 			},
 			"dns_ip_addresses": {
-				Type: schema.TypeSet,
-				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: validation.SingleIP(),
-				},
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 				Computed: true,
 			},

--- a/aws/resource_aws_directory_service_directory.go
+++ b/aws/resource_aws_directory_service_directory.go
@@ -82,10 +82,6 @@ func resourceAwsDirectoryServiceDirectory() *schema.Resource {
 							Required: true,
 							ForceNew: true,
 						},
-						"security_group_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
 						"availability_zones": {
 							Type:     schema.TypeSet,
 							Computed: true,
@@ -133,15 +129,6 @@ func resourceAwsDirectoryServiceDirectory() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,
-						},
-						"security_group_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"connect_ips": {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"availability_zones": {
 							Type:     schema.TypeSet,

--- a/aws/resource_aws_directory_service_directory.go
+++ b/aws/resource_aws_directory_service_directory.go
@@ -125,6 +125,20 @@ func resourceAwsDirectoryServiceDirectory() *schema.Resource {
 							Required: true,
 							ForceNew: true,
 						},
+						"security_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"connect_ips": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"availability_zones": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
 					},
 				},
 			},

--- a/aws/resource_aws_directory_service_directory.go
+++ b/aws/resource_aws_directory_service_directory.go
@@ -114,7 +114,7 @@ func resourceAwsDirectoryServiceDirectory() *schema.Resource {
 							ForceNew: true,
 							Elem: &schema.Schema{
 								Type:         schema.TypeString,
-								ValidateFunc: validation.SingleIP(),
+								ValidateFunc: validation.IsIPAddress(),
 							},
 							Set: schema.HashString,
 						},

--- a/aws/resource_aws_directory_service_directory_test.go
+++ b/aws/resource_aws_directory_service_directory_test.go
@@ -229,7 +229,7 @@ func TestAccAWSDirectoryServiceDirectory_connector(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceDirectoryExists(resourceName, &ds),
 					resource.TestCheckResourceAttrSet(resourceName, "security_group_id"),
-					resource.TestCheckResourceAttrSet("aws_directory_service_directory.connector", "connect_settings.0.connect_ips.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "connect_settings.0.connect_ips.#"),
 				),
 			},
 			{

--- a/aws/resource_aws_directory_service_directory_test.go
+++ b/aws/resource_aws_directory_service_directory_test.go
@@ -511,23 +511,23 @@ data "aws_availability_zones" "available" {
   }
 }
 
-resource "aws_vpc" "main" {
+resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 	tags = {
 		Name = "terraform-testacc-directory-service-directory-tags"
 	}
 }
 
-resource "aws_subnet" "foo" {
-  vpc_id = "${aws_vpc.main.id}"
+resource "aws_subnet" "test1" {
+  vpc_id = "${aws_vpc.test.id}"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   cidr_block = "10.0.1.0/24"
   tags = {
     Name = "tf-acc-directory-service-directory-foo"
   }
 }
-resource "aws_subnet" "test" {
-  vpc_id = "${aws_vpc.main.id}"
+resource "aws_subnet" "test2" {
+  vpc_id = "${aws_vpc.test.id}"
   availability_zone = "${data.aws_availability_zones.available.names[1]}"
   cidr_block = "10.0.2.0/24"
   tags = {
@@ -543,8 +543,8 @@ resource "aws_directory_service_directory" "test" {
   size = "Small"
 
   vpc_settings {
-    vpc_id = "${aws_vpc.main.id}"
-    subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.test.id}"]
+    vpc_id = "${aws_vpc.test.id}"
+    subnet_ids = ["${aws_subnet.test1.id}", "${aws_subnet.test2.id}"]
   }
 }
 `
@@ -556,8 +556,8 @@ resource "aws_directory_service_directory" "test" {
   size = "Small"
 
   vpc_settings {
-    vpc_id = "${aws_vpc.main.id}"
-    subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.test.id}"]
+    vpc_id = "${aws_vpc.test.id}"
+    subnet_ids = ["${aws_subnet.test1.id}", "${aws_subnet.test2.id}"]
   }
 
   tags = {
@@ -574,8 +574,8 @@ resource "aws_directory_service_directory" "test" {
   size = "Small"
 
   vpc_settings {
-    vpc_id = "${aws_vpc.main.id}"
-    subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.test.id}"]
+    vpc_id = "${aws_vpc.test.id}"
+    subnet_ids = ["${aws_subnet.test1.id}", "${aws_subnet.test2.id}"]
   }
 
   tags = {
@@ -593,8 +593,8 @@ resource "aws_directory_service_directory" "test" {
   size = "Small"
 
   vpc_settings {
-    vpc_id = "${aws_vpc.main.id}"
-    subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.test.id}"]
+    vpc_id = "${aws_vpc.test.id}"
+    subnet_ids = ["${aws_subnet.test1.id}", "${aws_subnet.test2.id}"]
   }
 
   tags = {
@@ -610,8 +610,8 @@ resource "aws_directory_service_directory" "base" {
   size = "Small"
 
   vpc_settings {
-    vpc_id = "${aws_vpc.main.id}"
-    subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.test.id}"]
+    vpc_id = "${aws_vpc.test.id}"
+    subnet_ids = ["${aws_subnet.test1.id}", "${aws_subnet.test2.id}"]
   }
 }
 
@@ -624,8 +624,8 @@ resource "aws_directory_service_directory" "test" {
   connect_settings {
     customer_dns_ips = aws_directory_service_directory.base.dns_ip_addresses
     customer_username = "Administrator"
-    vpc_id = "${aws_vpc.main.id}"
-    subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.test.id}"]
+    vpc_id = "${aws_vpc.test.id}"
+    subnet_ids = ["${aws_subnet.test1.id}", "${aws_subnet.test2.id}"]
   }
 }
 `
@@ -637,8 +637,8 @@ resource "aws_directory_service_directory" "test" {
   type = "MicrosoftAD"
 
   vpc_settings {
-    vpc_id = "${aws_vpc.main.id}"
-    subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.test.id}"]
+    vpc_id = "${aws_vpc.test.id}"
+    subnet_ids = ["${aws_subnet.test1.id}", "${aws_subnet.test2.id}"]
   }
 }
 `
@@ -651,8 +651,8 @@ resource "aws_directory_service_directory" "test" {
   edition = "Standard"
 
   vpc_settings {
-    vpc_id = "${aws_vpc.main.id}"
-    subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.test.id}"]
+    vpc_id = "${aws_vpc.test.id}"
+    subnet_ids = ["${aws_subnet.test1.id}", "${aws_subnet.test2.id}"]
   }
 }
 `
@@ -666,8 +666,8 @@ resource "aws_directory_service_directory" "test" {
   alias = %[1]q
 
   vpc_settings {
-    vpc_id = "${aws_vpc.main.id}"
-    subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.test.id}"]
+    vpc_id = "${aws_vpc.test.id}"
+    subnet_ids = ["${aws_subnet.test1.id}", "${aws_subnet.test2.id}"]
   }
 }
 `, alias)
@@ -683,8 +683,8 @@ resource "aws_directory_service_directory" "test" {
   enable_sso = true
 
   vpc_settings {
-    vpc_id = "${aws_vpc.main.id}"
-    subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.test.id}"]
+    vpc_id = "${aws_vpc.test.id}"
+    subnet_ids = ["${aws_subnet.test1.id}", "${aws_subnet.test2.id}"]
   }
 }
 `, alias)
@@ -700,8 +700,8 @@ resource "aws_directory_service_directory" "test" {
   enable_sso = false
 
   vpc_settings {
-    vpc_id = "${aws_vpc.main.id}"
-    subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.test.id}"]
+    vpc_id = "${aws_vpc.test.id}"
+    subnet_ids = ["${aws_subnet.test1.id}", "${aws_subnet.test2.id}"]
   }
 }
 `, alias)

--- a/aws/resource_aws_directory_service_directory_test.go
+++ b/aws/resource_aws_directory_service_directory_test.go
@@ -340,7 +340,7 @@ func TestAccAWSDirectoryServiceDirectory_disappears(t *testing.T) {
 				Config: testAccDirectoryServiceDirectoryConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceDirectoryExists(resourceName, &ds),
-					testAccCheckServiceDirectoryDisappears(&ds),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsDirectoryServiceDirectory(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -378,27 +378,6 @@ func testAccCheckServiceDirectoryExists(name string, ds *directoryservice.Direct
 		}
 
 		*ds = *out.DirectoryDescriptions[0]
-
-		return nil
-	}
-}
-
-func testAccCheckServiceDirectoryDisappears(ds *directoryservice.DirectoryDescription) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		dsconn := testAccProvider.Meta().(*AWSClient).dsconn
-		_, err := dsconn.DeleteDirectory(&directoryservice.DeleteDirectoryInput{
-			DirectoryId: ds.DirectoryId,
-		})
-		if err != nil {
-			return err
-		}
-
-		dsId := aws.StringValue(ds.DirectoryId)
-		log.Printf("[DEBUG] Waiting for Directory Service Directory (%q) to be deleted", dsId)
-		err = waitForDirectoryServiceDirectoryDeletion(dsconn, dsId)
-		if err != nil {
-			return fmt.Errorf("error waiting for Directory Service (%s) to be deleted: %s", dsId, err)
-		}
 
 		return nil
 	}

--- a/aws/resource_aws_directory_service_directory_test.go
+++ b/aws/resource_aws_directory_service_directory_test.go
@@ -72,6 +72,7 @@ func testSweepDirectoryServiceDirectories(region string) error {
 }
 
 func TestAccAWSDirectoryServiceDirectory_basic(t *testing.T) {
+	var ds directoryservice.DirectoryDescription
 	resourceName := "aws_directory_service_directory.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -86,8 +87,8 @@ func TestAccAWSDirectoryServiceDirectory_basic(t *testing.T) {
 			{
 				Config: testAccDirectoryServiceDirectoryConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceDirectoryExists("aws_directory_service_directory.test"),
-					resource.TestCheckResourceAttrSet("aws_directory_service_directory.test", "security_group_id"),
+					testAccCheckServiceDirectoryExists(resourceName, &ds),
+					resource.TestCheckResourceAttrSet(resourceName, "security_group_id"),
 				),
 			},
 			{
@@ -103,6 +104,7 @@ func TestAccAWSDirectoryServiceDirectory_basic(t *testing.T) {
 }
 
 func TestAccAWSDirectoryServiceDirectory_tags(t *testing.T) {
+	var ds directoryservice.DirectoryDescription
 	resourceName := "aws_directory_service_directory.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -117,10 +119,10 @@ func TestAccAWSDirectoryServiceDirectory_tags(t *testing.T) {
 			{
 				Config: testAccDirectoryServiceDirectoryTagsConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceDirectoryExists("aws_directory_service_directory.test"),
-					resource.TestCheckResourceAttr("aws_directory_service_directory.test", "tags.%", "2"),
-					resource.TestCheckResourceAttr("aws_directory_service_directory.test", "tags.foo", "test"),
-					resource.TestCheckResourceAttr("aws_directory_service_directory.test", "tags.project", "test"),
+					testAccCheckServiceDirectoryExists(resourceName, &ds),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.project", "test"),
 				),
 			},
 			{
@@ -134,19 +136,19 @@ func TestAccAWSDirectoryServiceDirectory_tags(t *testing.T) {
 			{
 				Config: testAccDirectoryServiceDirectoryUpdateTagsConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceDirectoryExists("aws_directory_service_directory.test"),
-					resource.TestCheckResourceAttr("aws_directory_service_directory.test", "tags.%", "3"),
-					resource.TestCheckResourceAttr("aws_directory_service_directory.test", "tags.foo", "test"),
-					resource.TestCheckResourceAttr("aws_directory_service_directory.test", "tags.project", "test2"),
-					resource.TestCheckResourceAttr("aws_directory_service_directory.test", "tags.fizz", "buzz"),
+					testAccCheckServiceDirectoryExists(resourceName, &ds),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.project", "test2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.fizz", "buzz"),
 				),
 			},
 			{
 				Config: testAccDirectoryServiceDirectoryRemoveTagsConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceDirectoryExists("aws_directory_service_directory.test"),
-					resource.TestCheckResourceAttr("aws_directory_service_directory.test", "tags.%", "1"),
-					resource.TestCheckResourceAttr("aws_directory_service_directory.test", "tags.foo", "test"),
+					testAccCheckServiceDirectoryExists(resourceName, &ds),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "test"),
 				),
 			},
 		},
@@ -154,6 +156,7 @@ func TestAccAWSDirectoryServiceDirectory_tags(t *testing.T) {
 }
 
 func TestAccAWSDirectoryServiceDirectory_microsoft(t *testing.T) {
+	var ds directoryservice.DirectoryDescription
 	resourceName := "aws_directory_service_directory.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -164,8 +167,8 @@ func TestAccAWSDirectoryServiceDirectory_microsoft(t *testing.T) {
 			{
 				Config: testAccDirectoryServiceDirectoryConfig_microsoft,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceDirectoryExists("aws_directory_service_directory.test"),
-					resource.TestCheckResourceAttr("aws_directory_service_directory.test", "edition", directoryservice.DirectoryEditionEnterprise),
+					testAccCheckServiceDirectoryExists(resourceName, &ds),
+					resource.TestCheckResourceAttr(resourceName, "edition", directoryservice.DirectoryEditionEnterprise),
 				),
 			},
 			{
@@ -181,6 +184,7 @@ func TestAccAWSDirectoryServiceDirectory_microsoft(t *testing.T) {
 }
 
 func TestAccAWSDirectoryServiceDirectory_microsoftStandard(t *testing.T) {
+	var ds directoryservice.DirectoryDescription
 	resourceName := "aws_directory_service_directory.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -191,8 +195,8 @@ func TestAccAWSDirectoryServiceDirectory_microsoftStandard(t *testing.T) {
 			{
 				Config: testAccDirectoryServiceDirectoryConfig_microsoftStandard,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceDirectoryExists("aws_directory_service_directory.test"),
-					resource.TestCheckResourceAttr("aws_directory_service_directory.test", "edition", directoryservice.DirectoryEditionStandard),
+					testAccCheckServiceDirectoryExists(resourceName, &ds),
+					resource.TestCheckResourceAttr(resourceName, "edition", directoryservice.DirectoryEditionStandard),
 				),
 			},
 			{
@@ -208,6 +212,7 @@ func TestAccAWSDirectoryServiceDirectory_microsoftStandard(t *testing.T) {
 }
 
 func TestAccAWSDirectoryServiceDirectory_connector(t *testing.T) {
+	var ds directoryservice.DirectoryDescription
 	resourceName := "aws_directory_service_directory.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -222,8 +227,8 @@ func TestAccAWSDirectoryServiceDirectory_connector(t *testing.T) {
 			{
 				Config: testAccDirectoryServiceDirectoryConfig_connector,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceDirectoryExists("aws_directory_service_directory.connector"),
-					resource.TestCheckResourceAttrSet("aws_directory_service_directory.connector", "security_group_id"),
+					testAccCheckServiceDirectoryExists(resourceName, &ds),
+					resource.TestCheckResourceAttrSet(resourceName, "security_group_id"),
 					resource.TestCheckResourceAttrSet("aws_directory_service_directory.connector", "connect_settings.0.connect_ips.#"),
 				),
 			},
@@ -240,8 +245,9 @@ func TestAccAWSDirectoryServiceDirectory_connector(t *testing.T) {
 }
 
 func TestAccAWSDirectoryServiceDirectory_withAliasAndSso(t *testing.T) {
+	var ds directoryservice.DirectoryDescription
 	alias := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_directory_service_directory.test2"
+	resourceName := "aws_directory_service_directory.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -255,9 +261,9 @@ func TestAccAWSDirectoryServiceDirectory_withAliasAndSso(t *testing.T) {
 			{
 				Config: testAccDirectoryServiceDirectoryConfig_withAlias(alias),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceDirectoryExists("aws_directory_service_directory.test2"),
-					testAccCheckServiceDirectoryAlias("aws_directory_service_directory.test2", alias),
-					testAccCheckServiceDirectorySso("aws_directory_service_directory.test2", false),
+					testAccCheckServiceDirectoryExists(resourceName, &ds),
+					testAccCheckServiceDirectoryAlias(resourceName, alias),
+					testAccCheckServiceDirectorySso(resourceName, false),
 				),
 			},
 			{
@@ -271,17 +277,17 @@ func TestAccAWSDirectoryServiceDirectory_withAliasAndSso(t *testing.T) {
 			{
 				Config: testAccDirectoryServiceDirectoryConfig_withSso(alias),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceDirectoryExists("aws_directory_service_directory.test2"),
-					testAccCheckServiceDirectoryAlias("aws_directory_service_directory.test2", alias),
-					testAccCheckServiceDirectorySso("aws_directory_service_directory.test2", true),
+					testAccCheckServiceDirectoryExists(resourceName, &ds),
+					testAccCheckServiceDirectoryAlias(resourceName, alias),
+					testAccCheckServiceDirectorySso(resourceName, true),
 				),
 			},
 			{
 				Config: testAccDirectoryServiceDirectoryConfig_withSso_modified(alias),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceDirectoryExists("aws_directory_service_directory.test2"),
-					testAccCheckServiceDirectoryAlias("aws_directory_service_directory.test2", alias),
-					testAccCheckServiceDirectorySso("aws_directory_service_directory.test2", false),
+					testAccCheckServiceDirectoryExists(resourceName, &ds),
+					testAccCheckServiceDirectoryAlias(resourceName, alias),
+					testAccCheckServiceDirectorySso(resourceName, false),
 				),
 			},
 		},
@@ -301,7 +307,7 @@ func testAccCheckDirectoryServiceDirectoryDestroy(s *terraform.State) error {
 		}
 		out, err := dsconn.DescribeDirectories(&input)
 
-		if isAWSErr(err, "EntityDoesNotExistException", "") {
+		if isAWSErr(err, directoryservice.ErrCodeEntityDoesNotExistException, "") {
 			continue
 		}
 
@@ -317,7 +323,32 @@ func testAccCheckDirectoryServiceDirectoryDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckServiceDirectoryExists(name string) resource.TestCheckFunc {
+func TestAccAWSDirectoryServiceDirectory_disappears(t *testing.T) {
+	var ds directoryservice.DirectoryDescription
+	resourceName := "aws_directory_service_directory.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSDirectoryService(t)
+			testAccPreCheckAWSDirectoryServiceSimpleDirectory(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDirectoryServiceDirectoryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDirectoryServiceDirectoryConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceDirectoryExists(resourceName, &ds),
+					testAccCheckServiceDirectoryDisappears(&ds),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckServiceDirectoryExists(name string, ds *directoryservice.DirectoryDescription) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -344,6 +375,29 @@ func testAccCheckServiceDirectoryExists(name string) resource.TestCheckFunc {
 		if *out.DirectoryDescriptions[0].DirectoryId != rs.Primary.ID {
 			return fmt.Errorf("DS directory ID mismatch - existing: %q, state: %q",
 				*out.DirectoryDescriptions[0].DirectoryId, rs.Primary.ID)
+		}
+
+		*ds = *out.DirectoryDescriptions[0]
+
+		return nil
+	}
+}
+
+func testAccCheckServiceDirectoryDisappears(ds *directoryservice.DirectoryDescription) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		dsconn := testAccProvider.Meta().(*AWSClient).dsconn
+		_, err := dsconn.DeleteDirectory(&directoryservice.DeleteDirectoryInput{
+			DirectoryId: ds.DirectoryId,
+		})
+		if err != nil {
+			return err
+		}
+
+		dsId := aws.StringValue(ds.DirectoryId)
+		log.Printf("[DEBUG] Waiting for Directory Service Directory (%q) to be deleted", dsId)
+		err = waitForDirectoryServiceDirectoryDeletion(dsconn, dsId)
+		if err != nil {
+			return fmt.Errorf("error waiting for Directory Service (%s) to be deleted: %s", dsId, err)
 		}
 
 		return nil
@@ -447,7 +501,7 @@ func testAccPreCheckAWSDirectoryServiceSimpleDirectory(t *testing.T) {
 	}
 }
 
-const testAccDirectoryServiceDirectoryConfig = `
+const testAccDirectoryServiceDirectoryConfigBase = `
 data "aws_availability_zones" "available" {
   state = "available"
 
@@ -457,21 +511,10 @@ data "aws_availability_zones" "available" {
   }
 }
 
-resource "aws_directory_service_directory" "test" {
-  name = "corp.notexample.com"
-  password = "SuperSecretPassw0rd"
-  size = "Small"
-
-  vpc_settings {
-    vpc_id = "${aws_vpc.main.id}"
-    subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.test.id}"]
-  }
-}
-
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
 	tags = {
-		Name = "terraform-testacc-directory-service-directory"
+		Name = "terraform-testacc-directory-service-directory-tags"
 	}
 }
 
@@ -493,16 +536,20 @@ resource "aws_subnet" "test" {
 }
 `
 
-const testAccDirectoryServiceDirectoryTagsConfig = `
-data "aws_availability_zones" "available" {
-  state = "available"
+const testAccDirectoryServiceDirectoryConfig = testAccDirectoryServiceDirectoryConfigBase + `
+resource "aws_directory_service_directory" "test" {
+  name = "corp.notexample.com"
+  password = "SuperSecretPassw0rd"
+  size = "Small"
 
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
+  vpc_settings {
+    vpc_id = "${aws_vpc.main.id}"
+    subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.test.id}"]
   }
 }
+`
 
+const testAccDirectoryServiceDirectoryTagsConfig = testAccDirectoryServiceDirectoryConfigBase + `
 resource "aws_directory_service_directory" "test" {
   name = "corp.notexample.com"
   password = "SuperSecretPassw0rd"
@@ -518,42 +565,9 @@ resource "aws_directory_service_directory" "test" {
 		project = "test"
 	}
 }
-
-resource "aws_vpc" "main" {
-  cidr_block = "10.0.0.0/16"
-	tags = {
-		Name = "terraform-testacc-directory-service-directory-tags"
-	}
-}
-
-resource "aws_subnet" "foo" {
-  vpc_id = "${aws_vpc.main.id}"
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  cidr_block = "10.0.1.0/24"
-  tags = {
-    Name = "tf-acc-directory-service-directory-tags-foo"
-  }
-}
-resource "aws_subnet" "test" {
-  vpc_id = "${aws_vpc.main.id}"
-  availability_zone = "${data.aws_availability_zones.available.names[1]}"
-  cidr_block = "10.0.2.0/24"
-  tags = {
-    Name = "tf-acc-directory-service-directory-tags-test"
-  }
-}
 `
 
-const testAccDirectoryServiceDirectoryUpdateTagsConfig = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+const testAccDirectoryServiceDirectoryUpdateTagsConfig = testAccDirectoryServiceDirectoryConfigBase + `
 resource "aws_directory_service_directory" "test" {
   name = "corp.notexample.com"
   password = "SuperSecretPassw0rd"
@@ -570,42 +584,9 @@ resource "aws_directory_service_directory" "test" {
 		fizz = "buzz"
 	}
 }
-
-resource "aws_vpc" "main" {
-  cidr_block = "10.0.0.0/16"
-	tags = {
-		Name = "terraform-testacc-directory-service-directory-tags"
-	}
-}
-
-resource "aws_subnet" "foo" {
-  vpc_id = "${aws_vpc.main.id}"
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  cidr_block = "10.0.1.0/24"
-  tags = {
-    Name = "tf-acc-directory-service-directory-tags-foo"
-  }
-}
-resource "aws_subnet" "test" {
-  vpc_id = "${aws_vpc.main.id}"
-  availability_zone = "${data.aws_availability_zones.available.names[1]}"
-  cidr_block = "10.0.2.0/24"
-  tags = {
-    Name = "tf-acc-directory-service-directory-tags-test"
-  }
-}
 `
 
-const testAccDirectoryServiceDirectoryRemoveTagsConfig = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+const testAccDirectoryServiceDirectoryRemoveTagsConfig = testAccDirectoryServiceDirectoryConfigBase + `
 resource "aws_directory_service_directory" "test" {
   name = "corp.notexample.com"
   password = "SuperSecretPassw0rd"
@@ -620,43 +601,10 @@ resource "aws_directory_service_directory" "test" {
 		foo = "test"
 	}
 }
-
-resource "aws_vpc" "main" {
-  cidr_block = "10.0.0.0/16"
-	tags = {
-		Name = "terraform-testacc-directory-service-directory-tags"
-	}
-}
-
-resource "aws_subnet" "foo" {
-  vpc_id = "${aws_vpc.main.id}"
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  cidr_block = "10.0.1.0/24"
-  tags = {
-    Name = "tf-acc-directory-service-directory-tags-foo"
-  }
-}
-resource "aws_subnet" "test" {
-  vpc_id = "${aws_vpc.main.id}"
-  availability_zone = "${data.aws_availability_zones.available.names[1]}"
-  cidr_block = "10.0.2.0/24"
-  tags = {
-    Name = "tf-acc-directory-service-directory-tags-test"
-  }
-}
 `
 
-const testAccDirectoryServiceDirectoryConfig_connector = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
-resource "aws_directory_service_directory" "test" {
+const testAccDirectoryServiceDirectoryConfig_connector = testAccDirectoryServiceDirectoryConfigBase + `
+resource "aws_directory_service_directory" "base" {
   name = "corp.notexample.com"
   password = "SuperSecretPassw0rd"
   size = "Small"
@@ -667,55 +615,22 @@ resource "aws_directory_service_directory" "test" {
   }
 }
 
-resource "aws_directory_service_directory" "connector" {
+resource "aws_directory_service_directory" "test" {
   name = "corp.notexample.com"
   password = "SuperSecretPassw0rd"
   size = "Small"
   type = "ADConnector"
 
   connect_settings {
-    customer_dns_ips = aws_directory_service_directory.test.dns_ip_addresses
+    customer_dns_ips = aws_directory_service_directory.base.dns_ip_addresses
     customer_username = "Administrator"
     vpc_id = "${aws_vpc.main.id}"
     subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.test.id}"]
   }
 }
-
-resource "aws_vpc" "main" {
-  cidr_block = "10.0.0.0/16"
-	tags = {
-		Name = "terraform-testacc-directory-service-directory-connector"
-	}
-}
-
-resource "aws_subnet" "foo" {
-  vpc_id = "${aws_vpc.main.id}"
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  cidr_block = "10.0.1.0/24"
-  tags = {
-    Name = "tf-acc-directory-service-directory-connector-foo"
-  }
-}
-resource "aws_subnet" "test" {
-  vpc_id = "${aws_vpc.main.id}"
-  availability_zone = "${data.aws_availability_zones.available.names[1]}"
-  cidr_block = "10.0.2.0/24"
-  tags = {
-    Name = "tf-acc-directory-service-directory-connector-test"
-  }
-}
 `
 
-const testAccDirectoryServiceDirectoryConfig_microsoft = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+const testAccDirectoryServiceDirectoryConfig_microsoft = testAccDirectoryServiceDirectoryConfigBase + `
 resource "aws_directory_service_directory" "test" {
   name = "corp.notexample.com"
   password = "SuperSecretPassw0rd"
@@ -726,42 +641,9 @@ resource "aws_directory_service_directory" "test" {
     subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.test.id}"]
   }
 }
-
-resource "aws_vpc" "main" {
-  cidr_block = "10.0.0.0/16"
-	tags = {
-		Name = "terraform-testacc-directory-service-directory-microsoft"
-	}
-}
-
-resource "aws_subnet" "foo" {
-  vpc_id = "${aws_vpc.main.id}"
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  cidr_block = "10.0.1.0/24"
-  tags = {
-    Name = "tf-acc-directory-service-directory-microsoft-foo"
-  }
-}
-resource "aws_subnet" "test" {
-  vpc_id = "${aws_vpc.main.id}"
-  availability_zone = "${data.aws_availability_zones.available.names[1]}"
-  cidr_block = "10.0.2.0/24"
-  tags = {
-    Name = "tf-acc-directory-service-directory-microsoft-test"
-  }
-}
 `
 
-const testAccDirectoryServiceDirectoryConfig_microsoftStandard = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+const testAccDirectoryServiceDirectoryConfig_microsoftStandard = testAccDirectoryServiceDirectoryConfigBase + `
 resource "aws_directory_service_directory" "test" {
   name = "corp.notexample.com"
   password = "SuperSecretPassw0rd"
@@ -773,44 +655,11 @@ resource "aws_directory_service_directory" "test" {
     subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.test.id}"]
   }
 }
-
-resource "aws_vpc" "main" {
-  cidr_block = "10.0.0.0/16"
-	tags = {
-		Name = "terraform-testacc-directory-service-directory-microsoft"
-	}
-}
-
-resource "aws_subnet" "foo" {
-  vpc_id = "${aws_vpc.main.id}"
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  cidr_block = "10.0.1.0/24"
-  tags = {
-    Name = "tf-acc-directory-service-directory-microsoft-foo"
-  }
-}
-resource "aws_subnet" "test" {
-  vpc_id = "${aws_vpc.main.id}"
-  availability_zone = "${data.aws_availability_zones.available.names[1]}"
-  cidr_block = "10.0.2.0/24"
-  tags = {
-    Name = "tf-acc-directory-service-directory-microsoft-test"
-  }
-}
 `
 
 func testAccDirectoryServiceDirectoryConfig_withAlias(alias string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
-resource "aws_directory_service_directory" "test2" {
+	return testAccDirectoryServiceDirectoryConfigBase + fmt.Sprintf(`
+resource "aws_directory_service_directory" "test" {
   name = "corp.notexample.com"
   password = "SuperSecretPassw0rd"
   size = "Small"
@@ -821,45 +670,12 @@ resource "aws_directory_service_directory" "test2" {
     subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.test.id}"]
   }
 }
-
-resource "aws_vpc" "main" {
-  cidr_block = "10.0.0.0/16"
-	tags = {
-		Name = "terraform-testacc-directory-service-directory-with-alias"
-	}
-}
-
-resource "aws_subnet" "foo" {
-  vpc_id = "${aws_vpc.main.id}"
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  cidr_block = "10.0.1.0/24"
-  tags = {
-    Name = "tf-acc-directory-service-directory-with-alias-foo"
-  }
-}
-resource "aws_subnet" "test" {
-  vpc_id = "${aws_vpc.main.id}"
-  availability_zone = "${data.aws_availability_zones.available.names[1]}"
-  cidr_block = "10.0.2.0/24"
-  tags = {
-    Name = "tf-acc-directory-service-directory-with-alias-test"
-  }
-}
 `, alias)
 }
 
 func testAccDirectoryServiceDirectoryConfig_withSso(alias string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
-resource "aws_directory_service_directory" "test2" {
+	return testAccDirectoryServiceDirectoryConfigBase + fmt.Sprintf(`
+resource "aws_directory_service_directory" "test" {
   name = "corp.notexample.com"
   password = "SuperSecretPassw0rd"
   size = "Small"
@@ -871,45 +687,12 @@ resource "aws_directory_service_directory" "test2" {
     subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.test.id}"]
   }
 }
-
-resource "aws_vpc" "main" {
-  cidr_block = "10.0.0.0/16"
-	tags = {
-		Name = "terraform-testacc-directory-service-directory-with-sso"
-	}
-}
-
-resource "aws_subnet" "foo" {
-  vpc_id = "${aws_vpc.main.id}"
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  cidr_block = "10.0.1.0/24"
-  tags = {
-    Name = "tf-acc-directory-service-directory-with-sso-foo"
-  }
-}
-resource "aws_subnet" "test" {
-  vpc_id = "${aws_vpc.main.id}"
-  availability_zone = "${data.aws_availability_zones.available.names[1]}"
-  cidr_block = "10.0.2.0/24"
-  tags = {
-    Name = "tf-acc-directory-service-directory-with-sso-test"
-  }
-}
 `, alias)
 }
 
 func testAccDirectoryServiceDirectoryConfig_withSso_modified(alias string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
-resource "aws_directory_service_directory" "test2" {
+	return testAccDirectoryServiceDirectoryConfigBase + fmt.Sprintf(`
+resource "aws_directory_service_directory" "test" {
   name = "corp.notexample.com"
   password = "SuperSecretPassw0rd"
   size = "Small"
@@ -919,30 +702,6 @@ resource "aws_directory_service_directory" "test2" {
   vpc_settings {
     vpc_id = "${aws_vpc.main.id}"
     subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.test.id}"]
-  }
-}
-
-resource "aws_vpc" "main" {
-  cidr_block = "10.0.0.0/16"
-	tags = {
-		Name = "terraform-testacc-directory-service-directory-with-sso-modified"
-	}
-}
-
-resource "aws_subnet" "foo" {
-  vpc_id = "${aws_vpc.main.id}"
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  cidr_block = "10.0.1.0/24"
-  tags = {
-    Name = "tf-acc-directory-service-directory-with-sso-foo"
-  }
-}
-resource "aws_subnet" "test" {
-  vpc_id = "${aws_vpc.main.id}"
-  availability_zone = "${data.aws_availability_zones.available.names[1]}"
-  cidr_block = "10.0.2.0/24"
-  tags = {
-    Name = "tf-acc-directory-service-directory-with-sso-test"
   }
 }
 `, alias)

--- a/aws/resource_aws_directory_service_directory_test.go
+++ b/aws/resource_aws_directory_service_directory_test.go
@@ -295,7 +295,7 @@ func TestAccAWSDirectoryServiceDirectory_withAliasAndSso(t *testing.T) {
 }
 
 func testAccCheckDirectoryServiceDirectoryDestroy(s *terraform.State) error {
-	dsconn := testAccProvider.Meta().(*AWSClient).dsconn
+	conn := testAccProvider.Meta().(*AWSClient).dsconn
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_directory_service_directory" {
@@ -305,7 +305,7 @@ func testAccCheckDirectoryServiceDirectoryDestroy(s *terraform.State) error {
 		input := directoryservice.DescribeDirectoriesInput{
 			DirectoryIds: []*string{aws.String(rs.Primary.ID)},
 		}
-		out, err := dsconn.DescribeDirectories(&input)
+		out, err := conn.DescribeDirectories(&input)
 
 		if isAWSErr(err, directoryservice.ErrCodeEntityDoesNotExistException, "") {
 			continue
@@ -359,8 +359,8 @@ func testAccCheckServiceDirectoryExists(name string, ds *directoryservice.Direct
 			return fmt.Errorf("No ID is set")
 		}
 
-		dsconn := testAccProvider.Meta().(*AWSClient).dsconn
-		out, err := dsconn.DescribeDirectories(&directoryservice.DescribeDirectoriesInput{
+		conn := testAccProvider.Meta().(*AWSClient).dsconn
+		out, err := conn.DescribeDirectories(&directoryservice.DescribeDirectoriesInput{
 			DirectoryIds: []*string{aws.String(rs.Primary.ID)},
 		})
 
@@ -394,8 +394,8 @@ func testAccCheckServiceDirectoryAlias(name, alias string) resource.TestCheckFun
 			return fmt.Errorf("No ID is set")
 		}
 
-		dsconn := testAccProvider.Meta().(*AWSClient).dsconn
-		out, err := dsconn.DescribeDirectories(&directoryservice.DescribeDirectoriesInput{
+		conn := testAccProvider.Meta().(*AWSClient).dsconn
+		out, err := conn.DescribeDirectories(&directoryservice.DescribeDirectoriesInput{
 			DirectoryIds: []*string{aws.String(rs.Primary.ID)},
 		})
 
@@ -423,8 +423,8 @@ func testAccCheckServiceDirectorySso(name string, ssoEnabled bool) resource.Test
 			return fmt.Errorf("No ID is set")
 		}
 
-		dsconn := testAccProvider.Meta().(*AWSClient).dsconn
-		out, err := dsconn.DescribeDirectories(&directoryservice.DescribeDirectoriesInput{
+		conn := testAccProvider.Meta().(*AWSClient).dsconn
+		out, err := conn.DescribeDirectories(&directoryservice.DescribeDirectoriesInput{
 			DirectoryIds: []*string{aws.String(rs.Primary.ID)},
 		})
 

--- a/aws/resource_aws_directory_service_directory_test.go
+++ b/aws/resource_aws_directory_service_directory_test.go
@@ -560,10 +560,10 @@ resource "aws_directory_service_directory" "test" {
     subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.test.id}"]
   }
 
-	tags = {
-		foo = "test"
-		project = "test"
-	}
+  tags = {
+    foo = "test"
+    project = "test"
+  }
 }
 `
 
@@ -578,11 +578,11 @@ resource "aws_directory_service_directory" "test" {
     subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.test.id}"]
   }
 
-	tags = {
-		foo = "test"
-		project = "test2"
-		fizz = "buzz"
-	}
+  tags = {
+    foo = "test"
+    project = "test2"
+    fizz = "buzz"
+  }
 }
 `
 
@@ -597,9 +597,9 @@ resource "aws_directory_service_directory" "test" {
     subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.test.id}"]
   }
 
-	tags = {
-		foo = "test"
-	}
+  tags = {
+    foo = "test"
+  }
 }
 `
 

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -1620,8 +1620,8 @@ func flattenDSVpcSettings(
 		return nil
 	}
 
-	settings["subnet_ids"] = schema.NewSet(schema.HashString, flattenStringList(s.SubnetIds))
-	settings["vpc_id"] = *s.VpcId
+	settings["subnet_ids"] = flattenStringSet(s.SubnetIds)
+	settings["vpc_id"] = aws.StringValue(s.VpcId)
 
 	return []map[string]interface{}{settings}
 }
@@ -1736,11 +1736,11 @@ func flattenDSConnectSettings(
 
 	settings := make(map[string]interface{})
 
-	settings["customer_dns_ips"] = schema.NewSet(schema.HashString, flattenStringList(customerDnsIps))
-	settings["connect_ips"] = schema.NewSet(schema.HashString, flattenStringList(s.ConnectIps))
-	settings["customer_username"] = *s.CustomerUserName
-	settings["subnet_ids"] = schema.NewSet(schema.HashString, flattenStringList(s.SubnetIds))
-	settings["vpc_id"] = *s.VpcId
+	settings["customer_dns_ips"] = flattenStringSet(customerDnsIps)
+	settings["connect_ips"] = flattenStringSet(s.ConnectIps)
+	settings["customer_username"] = aws.StringValue(s.CustomerUserName)
+	settings["subnet_ids"] = flattenStringSet(s.SubnetIds)
+	settings["vpc_id"] = aws.StringValue(s.VpcId)
 
 	return []map[string]interface{}{settings}
 }

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -1622,6 +1622,8 @@ func flattenDSVpcSettings(
 
 	settings["subnet_ids"] = flattenStringSet(s.SubnetIds)
 	settings["vpc_id"] = aws.StringValue(s.VpcId)
+	settings["security_group_id"] = aws.StringValue(s.SecurityGroupId)
+	settings["availability_zones"] = flattenStringSet(s.AvailabilityZones)
 
 	return []map[string]interface{}{settings}
 }

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -1741,6 +1741,8 @@ func flattenDSConnectSettings(
 	settings["customer_username"] = aws.StringValue(s.CustomerUserName)
 	settings["subnet_ids"] = flattenStringSet(s.SubnetIds)
 	settings["vpc_id"] = aws.StringValue(s.VpcId)
+	settings["security_group_id"] = aws.StringValue(s.SecurityGroupId)
+	settings["availability_zones"] = flattenStringSet(s.AvailabilityZones)
 
 	return []map[string]interface{}{settings}
 }

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -1738,6 +1738,7 @@ func flattenDSConnectSettings(
 	settings := make(map[string]interface{})
 
 	settings["customer_dns_ips"] = flattenStringSet(customerDnsIps)
+	settings["connect_ips"] = flattenStringSet(s.ConnectIps)
 	settings["customer_username"] = aws.StringValue(s.CustomerUserName)
 	settings["subnet_ids"] = flattenStringSet(s.SubnetIds)
 	settings["vpc_id"] = aws.StringValue(s.VpcId)

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -1622,7 +1622,6 @@ func flattenDSVpcSettings(
 
 	settings["subnet_ids"] = flattenStringSet(s.SubnetIds)
 	settings["vpc_id"] = aws.StringValue(s.VpcId)
-	settings["security_group_id"] = aws.StringValue(s.SecurityGroupId)
 	settings["availability_zones"] = flattenStringSet(s.AvailabilityZones)
 
 	return []map[string]interface{}{settings}
@@ -1739,11 +1738,9 @@ func flattenDSConnectSettings(
 	settings := make(map[string]interface{})
 
 	settings["customer_dns_ips"] = flattenStringSet(customerDnsIps)
-	settings["connect_ips"] = flattenStringSet(s.ConnectIps)
 	settings["customer_username"] = aws.StringValue(s.CustomerUserName)
 	settings["subnet_ids"] = flattenStringSet(s.SubnetIds)
 	settings["vpc_id"] = aws.StringValue(s.VpcId)
-	settings["security_group_id"] = aws.StringValue(s.SecurityGroupId)
 	settings["availability_zones"] = flattenStringSet(s.AvailabilityZones)
 
 	return []map[string]interface{}{settings}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10716

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_directory_service_service_directory: add `availability_zones` attribute to `vpc_settings` block.
resource_aws_directory_service_service_directory: add `availability_zones` attribute to `connect_settings` block.
resource_aws_directory_service_service_directory: add plan time validation to `customer_dns_ips` in `connect_settings` block.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSDirectoryServiceDirectory_'
--- PASS: TestAccAWSDirectoryServiceDirectory_disappears (814.29s)
--- PASS: TestAccAWSDirectoryServiceDirectory_basic (596.66s)
--- PASS: TestAccAWSDirectoryServiceDirectory_microsoft (1876.52s)
--- PASS: TestAccAWSDirectoryServiceDirectory_microsoftStandard (1694.06s)
--- PASS: TestAccAWSDirectoryServiceDirectory_connector (1092.28s)
--- PASS: TestAccAWSDirectoryServiceDirectory_withAliasAndSso (837.93s)
--- PASS: TestAccAWSDirectoryServiceDirectory_tags (803.25s)
```
