### PR TITLE
r/aws_spot_instance_request: Remove metadata_options

### DIFF
--- a/aws/resource_aws_spot_instance_request.go
+++ b/aws/resource_aws_spot_instance_request.go
@@ -30,6 +30,9 @@ func resourceAwsSpotInstanceRequest() *schema.Resource {
 			// The Spot Instance Request Schema is based on the AWS Instance schema.
 			s := resourceAwsInstance().Schema
 
+			// Remove things that are not used in spot instance requests
+			delete(s, "metadata_options")
+
 			// Everything on a spot instance is ForceNew except tags
 			for k, v := range s {
 				if k == "tags" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

---

Today I was surprised to see this in a plan for an `aws_spot_instance_request`:
```
      + metadata_options {
          + http_endpoint               = (known after apply)
          + http_put_response_hop_limit = (known after apply)
          + http_tokens                 = (known after apply)
        }
```

I was a bit surprised because we only added this to `aws_instance` and `aws_launch_template`, and it's very unlikely that AWS will add support to good old ancient spot instance requests. Opening the code reveals, as I suspected, that it inherits the schema from `aws_instance`.

I couldn't spot any other things that should be removed, but let me know if you know of any.

Changelog may not be required for a tiny change like this?

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_spot_instance_request: Resource should not accept `metadata_options`
```
