### PR TITLE
Docs: Update examples for the post-0.12 world

### DIFF
--- a/website/docs/d/api_gateway_resource.html.markdown
+++ b/website/docs/d/api_gateway_resource.html.markdown
@@ -19,7 +19,7 @@ data "aws_api_gateway_rest_api" "my_rest_api" {
 }
 
 data "aws_api_gateway_resource" "my_resource" {
-  rest_api_id = "${data.aws_api_gateway_rest_api.my_rest_api.id}"
+  rest_api_id = data.aws_api_gateway_rest_api.my_rest_api.id
   path        = "/endpoint/path"
 }
 ```

--- a/website/docs/d/autoscaling_groups.html.markdown
+++ b/website/docs/d/autoscaling_groups.html.markdown
@@ -27,7 +27,7 @@ data "aws_autoscaling_groups" "groups" {
 }
 
 resource "aws_autoscaling_notification" "slack_notifications" {
-  group_names = ["${data.aws_autoscaling_groups.groups.names}"]
+  group_names = [data.aws_autoscaling_groups.groups.names]
 
   notifications = [
     "autoscaling:EC2_INSTANCE_LAUNCH",

--- a/website/docs/d/availability_zone.html.markdown
+++ b/website/docs/d/availability_zone.html.markdown
@@ -58,13 +58,13 @@ data "aws_availability_zone" "example" {
 
 # Create a VPC for the region associated with the AZ
 resource "aws_vpc" "example" {
-  cidr_block = "${cidrsubnet("10.0.0.0/8", 4, var.region_number[data.aws_availability_zone.example.region])}"
+  cidr_block = cidrsubnet("10.0.0.0/8", 4, var.region_number[data.aws_availability_zone.example.region])
 }
 
 # Create a subnet for the AZ within the regional VPC
 resource "aws_subnet" "example" {
-  vpc_id     = "${aws_vpc.example.id}"
-  cidr_block = "${cidrsubnet(aws_vpc.example.cidr_block, 4, var.az_number[data.aws_availability_zone.example.name_suffix])}"
+  vpc_id     = aws_vpc.example.id
+  cidr_block = cidrsubnet(aws_vpc.example.cidr_block, 4, var.az_number[data.aws_availability_zone.example.name_suffix])
 }
 ```
 

--- a/website/docs/d/billing_service_account.html.markdown
+++ b/website/docs/d/billing_service_account.html.markdown
@@ -19,38 +19,37 @@ resource "aws_s3_bucket" "billing_logs" {
   bucket = "my-billing-tf-test-bucket"
   acl    = "private"
 
-  policy = <<POLICY
-{
-  "Id": "Policy",
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "s3:GetBucketAcl", "s3:GetBucketPolicy"
-      ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:s3:::my-billing-tf-test-bucket",
-      "Principal": {
-        "AWS": [
-          "${data.aws_billing_service_account.main.arn}"
+  policy = jsonencode({
+    "Id"      = "Policy"
+    "Version" = "2012-10-17"
+    "Statement" = [
+      {
+        "Action" = [
+          "s3:GetBucketAcl", "s3:GetBucketPolicy"
         ]
-      }
-    },
-    {
-      "Action": [
-        "s3:PutObject"
-      ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:s3:::my-billing-tf-test-bucket/*",
-      "Principal": {
-        "AWS": [
-          "${data.aws_billing_service_account.main.arn}"
+        "Effect"   = "Allow"
+        "Resource" = "arn:aws:s3:::my-billing-tf-test-bucket"
+        "Principal" = {
+          "AWS" = [
+            data.aws_billing_service_account.main.arn
+          ]
+        }
+      },
+
+      {
+        "Action" = [
+          "s3:PutObject"
         ]
+        "Effect"   = "Allow"
+        "Resource" = "arn:aws:s3:::my-billing-tf-test-bucket/*"
+        "Principal" = {
+          "AWS" = [
+            data.aws_billing_service_account.main.arn
+          ]
+        }
       }
-    }
-  ]
-}
-POLICY
+    ]
+  })
 }
 ```
 

--- a/website/docs/d/caller_identity.html.markdown
+++ b/website/docs/d/caller_identity.html.markdown
@@ -18,15 +18,15 @@ which Terraform is authorized.
 data "aws_caller_identity" "current" {}
 
 output "account_id" {
-  value = "${data.aws_caller_identity.current.account_id}"
+  value = data.aws_caller_identity.current.account_id
 }
 
 output "caller_arn" {
-  value = "${data.aws_caller_identity.current.arn}"
+  value = data.aws_caller_identity.current.arn
 }
 
 output "caller_user" {
-  value = "${data.aws_caller_identity.current.user_id}"
+  value = data.aws_caller_identity.current.user_id
 }
 ```
 

--- a/website/docs/d/canonical_user_id.html.markdown
+++ b/website/docs/d/canonical_user_id.html.markdown
@@ -18,7 +18,7 @@ for the effective account in which Terraform is working.
 data "aws_canonical_user_id" "current" {}
 
 output "canonical_user_id" {
-  value = "${data.aws_canonical_user_id.current.id}"
+  value = data.aws_canonical_user_id.current.id
 }
 ```
 

--- a/website/docs/d/cloudformation_export.html.markdown
+++ b/website/docs/d/cloudformation_export.html.markdown
@@ -23,7 +23,7 @@ data "aws_cloudformation_export" "subnet_id" {
 resource "aws_instance" "web" {
   ami           = "ami-abb07bcb"
   instance_type = "t1.micro"
-  subnet_id     = "${data.aws_cloudformation_export.subnet_id.value}"
+  subnet_id     = data.aws_cloudformation_export.subnet_id.value
 }
 ```
 

--- a/website/docs/d/cloudformation_stack.html.markdown
+++ b/website/docs/d/cloudformation_stack.html.markdown
@@ -21,7 +21,7 @@ data "aws_cloudformation_stack" "network" {
 resource "aws_instance" "web" {
   ami           = "ami-abb07bcb"
   instance_type = "t1.micro"
-  subnet_id     = "${data.aws_cloudformation_stack.network.outputs["SubnetId"]}"
+  subnet_id     = data.aws_cloudformation_stack.network.outputs["SubnetId"]
 
   tags = {
     Name = "HelloWorld"

--- a/website/docs/d/cloudtrail_service_account.html.markdown
+++ b/website/docs/d/cloudtrail_service_account.html.markdown
@@ -20,31 +20,29 @@ resource "aws_s3_bucket" "bucket" {
   bucket        = "tf-cloudtrail-logging-test-bucket"
   force_destroy = true
 
-  policy = <<EOF
-{
-  "Version": "2008-10-17",
-  "Statement": [
-    {
-      "Sid": "Put bucket policy needed for trails",
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "${data.aws_cloudtrail_service_account.main.arn}"
+  policy = jsonencode({
+    "Version" = "2008-10-17"
+    "Statement" = [
+      {
+        "Sid"    = "Put bucket policy needed for trails"
+        "Effect" = "Allow"
+        "Principal" = {
+          "AWS" = data.aws_cloudtrail_service_account.main.arn
+        }
+        "Action"   = "s3:PutObject"
+        "Resource" = "arn:aws:s3:::tf-cloudtrail-logging-test-bucket/*"
       },
-      "Action": "s3:PutObject",
-      "Resource": "arn:aws:s3:::tf-cloudtrail-logging-test-bucket/*"
-    },
-    {
-      "Sid": "Get bucket policy needed for trails",
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "${data.aws_cloudtrail_service_account.main.arn}"
-      },
-      "Action": "s3:GetBucketAcl",
-      "Resource": "arn:aws:s3:::tf-cloudtrail-logging-test-bucket"
-    }
-  ]
-}
-EOF
+      {
+        "Sid"    = "Get bucket policy needed for trails"
+        "Effect" = "Allow"
+        "Principal" = {
+          "AWS" = data.aws_cloudtrail_service_account.main.arn
+        }
+        "Action"   = "s3:GetBucketAcl"
+        "Resource" = "arn:aws:s3:::tf-cloudtrail-logging-test-bucket"
+      }
+    ]
+  })
 }
 ```
 

--- a/website/docs/d/cognito_user_pools.markdown
+++ b/website/docs/d/cognito_user_pools.markdown
@@ -14,18 +14,18 @@ Use this data source to get a list of cognito user pools.
 
 ```hcl
 data "aws_api_gateway_rest_api" "selected" {
-  name = "${var.api_gateway_name}"
+  name = var.api_gateway_name
 }
 
 data "aws_cognito_user_pools" "selected" {
-  name = "${var.cognito_user_pool_name}"
+  name = var.cognito_user_pool_name
 }
 
 resource "aws_api_gateway_authorizer" "cognito" {
   name          = "cognito"
   type          = "COGNITO_USER_POOLS"
-  rest_api_id   = "${data.aws_api_gateway_rest_api.selected.id}"
-  provider_arns = ["${data.aws_cognito_user_pools.selected.arns}"]
+  rest_api_id   = data.aws_api_gateway_rest_api.selected.id
+  provider_arns = [data.aws_cognito_user_pools.selected.arns]
 }
 ```
 

--- a/website/docs/d/customer_gateway.html.markdown
+++ b/website/docs/d/customer_gateway.html.markdown
@@ -21,14 +21,14 @@ data "aws_customer_gateway" "foo" {
 }
 
 resource "aws_vpn_gateway" "main" {
-  vpc_id          = "${aws_vpc.main.id}"
+  vpc_id          = aws_vpc.main.id
   amazon_side_asn = 7224
 }
 
 resource "aws_vpn_connection" "transit" {
-  vpn_gateway_id      = "${aws_vpn_gateway.main.id}"
-  customer_gateway_id = "${data.aws_customer_gateway.foo.id}"
-  type                = "${data.aws_customer_gateway.foo.type}"
+  vpn_gateway_id      = aws_vpn_gateway.main.id
+  customer_gateway_id = data.aws_customer_gateway.foo.id
+  type                = data.aws_customer_gateway.foo.type
   static_routes_only  = false
 }
 ```

--- a/website/docs/d/db_cluster_snapshot.html.markdown
+++ b/website/docs/d/db_cluster_snapshot.html.markdown
@@ -25,7 +25,7 @@ data "aws_db_cluster_snapshot" "development_final_snapshot" {
 # a new dev database.
 resource "aws_rds_cluster" "aurora" {
   cluster_identifier   = "development_cluster"
-  snapshot_identifier  = "${data.aws_db_cluster_snapshot.development_final_snapshot.id}"
+  snapshot_identifier  = data.aws_db_cluster_snapshot.development_final_snapshot.id
   db_subnet_group_name = "my_db_subnet_group"
 
   lifecycle {
@@ -34,7 +34,7 @@ resource "aws_rds_cluster" "aurora" {
 }
 
 resource "aws_rds_cluster_instance" "aurora" {
-  cluster_identifier   = "${aws_rds_cluster.aurora.id}"
+  cluster_identifier   = aws_rds_cluster.aurora.id
   instance_class       = "db.t2.small"
   db_subnet_group_name = "my_db_subnet_group"
 }

--- a/website/docs/d/db_event_categories.html.markdown
+++ b/website/docs/d/db_event_categories.html.markdown
@@ -16,7 +16,7 @@ List the event categories of all the RDS resources.
 data "aws_db_event_categories" "example" {}
 
 output "example" {
-  value = "${data.aws_db_event_categories.example.event_categories}"
+  value = data.aws_db_event_categories.example.event_categories
 }
 ```
 
@@ -28,7 +28,7 @@ data "aws_db_event_categories" "example" {
 }
 
 output "example" {
-  value = "${data.aws_db_event_categories.example.event_categories}"
+  value = data.aws_db_event_categories.example.event_categories
 }
 ```
 

--- a/website/docs/d/db_snapshot.html.markdown
+++ b/website/docs/d/db_snapshot.html.markdown
@@ -29,7 +29,7 @@ resource "aws_db_instance" "prod" {
 }
 
 data "aws_db_snapshot" "latest_prod_snapshot" {
-  db_instance_identifier = "${aws_db_instance.prod.id}"
+  db_instance_identifier = aws_db_instance.prod.id
   most_recent            = true
 }
 
@@ -37,7 +37,7 @@ data "aws_db_snapshot" "latest_prod_snapshot" {
 resource "aws_db_instance" "dev" {
   instance_class      = "db.t2.micro"
   name                = "mydbdev"
-  snapshot_identifier = "${data.aws_db_snapshot.latest_prod_snapshot.id}"
+  snapshot_identifier = data.aws_db_snapshot.latest_prod_snapshot.id
 
   lifecycle {
     ignore_changes = ["snapshot_identifier"]

--- a/website/docs/d/directory_service_directory.html.markdown
+++ b/website/docs/d/directory_service_directory.html.markdown
@@ -14,7 +14,7 @@ Get attributes of AWS Directory Service directory (SimpleAD, Managed AD, AD Conn
 
 ```hcl
 data "aws_directory_service_directory" "example" {
-  directory_id = "${aws_directory_service_directory.main.id}"
+  directory_id = aws_directory_service_directory.main.id
 }
 ```
 

--- a/website/docs/d/ebs_default_kms_key.html.markdown
+++ b/website/docs/d/ebs_default_kms_key.html.markdown
@@ -19,7 +19,7 @@ resource "aws_ebs_volume" "example" {
   availability_zone = "us-west-2a"
 
   encrypted  = true
-  kms_key_id = "${data.aws_ebs_default_kms_key.current.key_arn}"
+  kms_key_id = data.aws_ebs_default_kms_key.current.key_arn
 
 }
 ```

--- a/website/docs/d/ec2_transit_gateway_dx_gateway_attachment.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_dx_gateway_attachment.html.markdown
@@ -16,8 +16,8 @@ Get information on an EC2 Transit Gateway's attachment to a Direct Connect Gatew
 
 ```hcl
 data "aws_ec2_transit_gateway_dx_gateway_attachment" "example" {
-  transit_gateway_id = "${aws_ec2_transit_gateway.example.id}"
-  dx_gateway_id      = "${aws_dx_gateway.example.id}"
+  transit_gateway_id = aws_ec2_transit_gateway.example.id
+  dx_gateway_id      = aws_dx_gateway.example.id
 }
 ```
 

--- a/website/docs/d/ec2_transit_gateway_vpn_attachment.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_vpn_attachment.html.markdown
@@ -16,8 +16,8 @@ Get information on an EC2 Transit Gateway VPN Attachment.
 
 ```hcl
 data "aws_ec2_transit_gateway_vpn_attachment" "example" {
-  transit_gateway_id = "${aws_ec2_transit_gateway.example.id}"
-  vpn_connection_id  = "${aws_vpn_connection.example.id}"
+  transit_gateway_id = aws_ec2_transit_gateway.example.id
+  vpn_connection_id  = aws_vpn_connection.example.id
 }
 ```
 

--- a/website/docs/d/ecs_container_definition.html.markdown
+++ b/website/docs/d/ecs_container_definition.html.markdown
@@ -15,7 +15,7 @@ a specific container within an AWS ECS service.
 
 ```hcl
 data "aws_ecs_container_definition" "ecs-mongo" {
-  task_definition = "${aws_ecs_task_definition.mongo.id}"
+  task_definition = aws_ecs_task_definition.mongo.id
   container_name  = "mongodb"
 }
 ```

--- a/website/docs/d/ecs_service.html.markdown
+++ b/website/docs/d/ecs_service.html.markdown
@@ -16,7 +16,7 @@ Service within a AWS ECS Cluster.
 ```hcl
 data "aws_ecs_service" "example" {
   service_name = "example"
-  cluster_arn  = "${data.aws_ecs_cluster.example.arn}"
+  cluster_arn  = data.aws_ecs_cluster.example.arn
 }
 ```
 

--- a/website/docs/d/ecs_task_definition.html.markdown
+++ b/website/docs/d/ecs_task_definition.html.markdown
@@ -17,7 +17,7 @@ a specific AWS ECS task definition.
 ```hcl
 # Simply specify the family to find the latest ACTIVE revision in that family.
 data "aws_ecs_task_definition" "mongo" {
-  task_definition = "${aws_ecs_task_definition.mongo.family}"
+  task_definition = aws_ecs_task_definition.mongo.family
 }
 
 resource "aws_ecs_cluster" "foo" {
@@ -47,7 +47,7 @@ DEFINITION
 
 resource "aws_ecs_service" "mongo" {
   name          = "mongo"
-  cluster       = "${aws_ecs_cluster.foo.id}"
+  cluster       = aws_ecs_cluster.foo.id
   desired_count = 2
 
   # Track the latest ACTIVE revision

--- a/website/docs/d/efs_file_system.html.markdown
+++ b/website/docs/d/efs_file_system.html.markdown
@@ -19,7 +19,7 @@ variable "file_system_id" {
 }
 
 data "aws_efs_file_system" "by_id" {
-  file_system_id = "${var.file_system_id}"
+  file_system_id = var.file_system_id
 }
 ```
 

--- a/website/docs/d/efs_mount_target.html.markdown
+++ b/website/docs/d/efs_mount_target.html.markdown
@@ -19,7 +19,7 @@ variable "mount_target_id" {
 }
 
 data "aws_efs_mount_target" "by_id" {
-  mount_target_id = "${var.mount_target_id}"
+  mount_target_id = var.mount_target_id
 }
 ```
 

--- a/website/docs/d/eks_cluster.html.markdown
+++ b/website/docs/d/eks_cluster.html.markdown
@@ -18,16 +18,16 @@ data "aws_eks_cluster" "example" {
 }
 
 output "endpoint" {
-  value = "${data.aws_eks_cluster.example.endpoint}"
+  value = data.aws_eks_cluster.example.endpoint
 }
 
 output "kubeconfig-certificate-authority-data" {
-  value = "${data.aws_eks_cluster.example.certificate_authority.0.data}"
+  value = data.aws_eks_cluster.example.certificate_authority.0.data
 }
 
 # Only available on Kubernetes version 1.13 and 1.14 clusters created or upgraded on or after September 3, 2019.
 output "identity-oidc-issuer" {
-  value = "${data.aws_eks_cluster.example.identity.0.oidc.0.issuer}"
+  value = data.aws_eks_cluster.example.identity.0.oidc.0.issuer
 }
 ```
 

--- a/website/docs/d/eks_cluster_auth.html.markdown
+++ b/website/docs/d/eks_cluster_auth.html.markdown
@@ -27,9 +27,9 @@ data "aws_eks_cluster_auth" "example" {
 }
 
 provider "kubernetes" {
-  host                   = "${data.aws_eks_cluster.example.endpoint}"
-  cluster_ca_certificate = "${base64decode(data.aws_eks_cluster.example.certificate_authority.0.data)}"
-  token                  = "${data.aws_eks_cluster_auth.example.token}"
+  host                   = data.aws_eks_cluster.example.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.example.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.example.token
   load_config_file       = false
 }
 ```

--- a/website/docs/d/elastic_beanstalk_application.html.markdown
+++ b/website/docs/d/elastic_beanstalk_application.html.markdown
@@ -18,11 +18,11 @@ data "aws_elastic_beanstalk_application" "example" {
 }
 
 output "arn" {
-  value = "${data.aws_elastic_beanstalk_application.example.arn}"
+  value = data.aws_elastic_beanstalk_application.example.arn
 }
 
 output "description" {
-  value = "${data.aws_elastic_beanstalk_application.example.description}"
+  value = data.aws_elastic_beanstalk_application.example.description
 }
 ```
 

--- a/website/docs/d/elb.html.markdown
+++ b/website/docs/d/elb.html.markdown
@@ -25,7 +25,7 @@ variable "lb_name" {
 }
 
 data "aws_elb" "test" {
-  name = "${var.lb_name}"
+  name = var.lb_name
 }
 ```
 

--- a/website/docs/d/elb_hosted_zone_id.html.markdown
+++ b/website/docs/d/elb_hosted_zone_id.html.markdown
@@ -17,13 +17,13 @@ in a given region for the purpose of using in an AWS Route53 Alias.
 data "aws_elb_hosted_zone_id" "main" {}
 
 resource "aws_route53_record" "www" {
-  zone_id = "${aws_route53_zone.primary.zone_id}"
+  zone_id = aws_route53_zone.primary.zone_id
   name    = "example.com"
   type    = "A"
 
   alias {
-    name                   = "${aws_elb.main.dns_name}"
-    zone_id                = "${data.aws_elb_hosted_zone_id.main.id}"
+    name                   = aws_elb.main.dns_name
+    zone_id                = data.aws_elb_hosted_zone_id.main.id
     evaluate_target_health = true
   }
 }

--- a/website/docs/d/elb_service_account.html.markdown
+++ b/website/docs/d/elb_service_account.html.markdown
@@ -47,7 +47,7 @@ resource "aws_elb" "bar" {
   availability_zones = ["us-west-2a"]
 
   access_logs {
-    bucket   = "${aws_s3_bucket.elb_logs.bucket}"
+    bucket   = aws_s3_bucket.elb_logs.bucket
     interval = 5
   }
 

--- a/website/docs/d/elb_service_account.html.markdown
+++ b/website/docs/d/elb_service_account.html.markdown
@@ -20,26 +20,24 @@ resource "aws_s3_bucket" "elb_logs" {
   bucket = "my-elb-tf-test-bucket"
   acl    = "private"
 
-  policy = <<POLICY
-{
-  "Id": "Policy",
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "s3:PutObject"
-      ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:s3:::my-elb-tf-test-bucket/AWSLogs/*",
-      "Principal": {
-        "AWS": [
-          "${data.aws_elb_service_account.main.arn}"
+  policy = jsonencode({
+    "Id"      = "Policy"
+    "Version" = "2012-10-17"
+    "Statement" = [
+      {
+        "Action" = [
+          "s3:PutObject"
         ]
+        "Effect"   = "Allow"
+        "Resource" = "arn:aws:s3:::my-elb-tf-test-bucket/AWSLogs/*"
+        "Principal" = {
+          "AWS" = [
+            data.aws_elb_service_account.main.arn
+          ]
+        }
       }
-    }
-  ]
-}
-POLICY
+    ]
+  })
 }
 
 resource "aws_elb" "bar" {

--- a/website/docs/d/glue_script.html.markdown
+++ b/website/docs/d/glue_script.html.markdown
@@ -110,7 +110,7 @@ data "aws_glue_script" "example" {
 }
 
 output "python_script" {
-  value = "${data.aws_glue_script.example.python_script}"
+  value = data.aws_glue_script.example.python_script
 }
 ```
 
@@ -212,7 +212,7 @@ data "aws_glue_script" "example" {
 }
 
 output "scala_code" {
-  value = "${data.aws_glue_script.example.scala_code}"
+  value = data.aws_glue_script.example.scala_code
 }
 ```
 

--- a/website/docs/d/iam_account_alias.html.markdown
+++ b/website/docs/d/iam_account_alias.html.markdown
@@ -18,7 +18,7 @@ for the effective account in which Terraform is working.
 data "aws_iam_account_alias" "current" {}
 
 output "account_id" {
-  value = "${data.aws_iam_account_alias.current.account_alias}"
+  value = data.aws_iam_account_alias.current.account_alias
 }
 ```
 

--- a/website/docs/d/iam_policy_document.html.markdown
+++ b/website/docs/d/iam_policy_document.html.markdown
@@ -67,7 +67,7 @@ data "aws_iam_policy_document" "example" {
 resource "aws_iam_policy" "example" {
   name   = "example_policy"
   path   = "/"
-  policy = "${data.aws_iam_policy_document.example.json}"
+  policy = data.aws_iam_policy_document.example.json
 }
 ```
 
@@ -182,7 +182,7 @@ data "aws_iam_policy_document" "event_stream_bucket_role_assume_role_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = ["${var.trusted_role_arn}"]
+      identifiers = [var.trusted_role_arn]
     }
   }
 }
@@ -208,7 +208,7 @@ data "aws_iam_policy_document" "source" {
 }
 
 data "aws_iam_policy_document" "source_json_example" {
-  source_json = "${data.aws_iam_policy_document.source.json}"
+  source_json = data.aws_iam_policy_document.source.json
 
   statement {
     sid = "SidToOverwrite"
@@ -232,7 +232,7 @@ data "aws_iam_policy_document" "override" {
 }
 
 data "aws_iam_policy_document" "override_json_example" {
-  override_json = "${data.aws_iam_policy_document.override.json}"
+  override_json = data.aws_iam_policy_document.override.json
 
   statement {
     actions   = ["ec2:*"]
@@ -323,8 +323,8 @@ data "aws_iam_policy_document" "override" {
 }
 
 data "aws_iam_policy_document" "politik" {
-  source_json   = "${data.aws_iam_policy_document.source.json}"
-  override_json = "${data.aws_iam_policy_document.override.json}"
+  source_json   = data.aws_iam_policy_document.source.json
+  override_json = data.aws_iam_policy_document.override.json
 }
 ```
 

--- a/website/docs/d/iam_server_certificate.html.markdown
+++ b/website/docs/d/iam_server_certificate.html.markdown
@@ -26,7 +26,7 @@ resource "aws_elb" "elb" {
     instance_protocol  = "https"
     lb_port            = 443
     lb_protocol        = "https"
-    ssl_certificate_id = "${data.aws_iam_server_certificate.my-domain.arn}"
+    ssl_certificate_id = data.aws_iam_server_certificate.my-domain.arn
   }
 }
 ```

--- a/website/docs/d/inspector_rules_packages.html.markdown
+++ b/website/docs/d/inspector_rules_packages.html.markdown
@@ -27,15 +27,15 @@ resource "aws_inspector_resource_group" "group" {
 
 resource "aws_inspector_assessment_target" "assessment" {
   name               = "test"
-  resource_group_arn = "${aws_inspector_resource_group.group.arn}"
+  resource_group_arn = aws_inspector_resource_group.group.arn
 }
 
 resource "aws_inspector_assessment_template" "assessment" {
   name       = "Test"
-  target_arn = "${aws_inspector_assessment_target.assessment.arn}"
+  target_arn = aws_inspector_assessment_target.assessment.arn
   duration   = "60"
 
-  rules_package_arns = ["${data.aws_inspector_rules_packages.rules.arns}"]
+  rules_package_arns = [data.aws_inspector_rules_packages.rules.arns]
 }
 ```
 

--- a/website/docs/d/instances.html.markdown
+++ b/website/docs/d/instances.html.markdown
@@ -38,8 +38,8 @@ data "aws_instances" "test" {
 }
 
 resource "aws_eip" "test" {
-  count    = "${length(data.aws_instances.test.ids)}"
-  instance = "${data.aws_instances.test.ids[count.index]}"
+  count    = length(data.aws_instances.test.ids)
+  instance = data.aws_instances.test.ids[count.index]
 }
 ```
 

--- a/website/docs/d/internet_gateway.html.markdown
+++ b/website/docs/d/internet_gateway.html.markdown
@@ -18,7 +18,7 @@ variable "vpc_id" {}
 data "aws_internet_gateway" "default" {
   filter {
     name   = "attachment.vpc-id"
-    values = ["${var.vpc_id}"]
+    values = [var.vpc_id]
   }
 }
 ```

--- a/website/docs/d/iot_endpoint.html.markdown
+++ b/website/docs/d/iot_endpoint.html.markdown
@@ -28,7 +28,7 @@ resource "kubernetes_pod" "agent" {
       env = [
         {
           name  = "IOT_ENDPOINT"
-          value = "${data.aws_iot_endpoint.example.endpoint_address}"
+          value = data.aws_iot_endpoint.example.endpoint_address
         },
       ]
     }

--- a/website/docs/d/ip_ranges.html.markdown
+++ b/website/docs/d/ip_ranges.html.markdown
@@ -30,8 +30,8 @@ resource "aws_security_group" "from_europe" {
   }
 
   tags = {
-    CreateDate = "${data.aws_ip_ranges.european_ec2.create_date}"
-    SyncToken  = "${data.aws_ip_ranges.european_ec2.sync_token}"
+    CreateDate = data.aws_ip_ranges.european_ec2.create_date
+    SyncToken  = data.aws_ip_ranges.european_ec2.sync_token
   }
 }
 ```

--- a/website/docs/d/kms_ciphertext.html.markdown
+++ b/website/docs/d/kms_ciphertext.html.markdown
@@ -25,7 +25,7 @@ resource "aws_kms_key" "oauth_config" {
 }
 
 data "aws_kms_ciphertext" "oauth" {
-  key_id = "${aws_kms_key.oauth_config.key_id}"
+  key_id = aws_kms_key.oauth_config.key_id
 
   plaintext = <<EOF
 {

--- a/website/docs/d/kms_secrets.html.markdown
+++ b/website/docs/d/kms_secrets.html.markdown
@@ -47,8 +47,8 @@ data "aws_kms_secrets" "example" {
 
 resource "aws_rds_cluster" "example" {
   # ... other configuration ...
-  master_password = "${data.aws_kms_secrets.example.plaintext["master_password"]}"
-  master_username = "${data.aws_kms_secrets.example.plaintext["master_username"]}"
+  master_password = data.aws_kms_secrets.example.plaintext["master_password"]
+  master_username = data.aws_kms_secrets.example.plaintext["master_username"]
 }
 ```
 

--- a/website/docs/d/lambda_function.html.markdown
+++ b/website/docs/d/lambda_function.html.markdown
@@ -18,7 +18,7 @@ variable "function_name" {
 }
 
 data "aws_lambda_function" "existing" {
-  function_name = "${var.function_name}"
+  function_name = var.function_name
 }
 ```
 

--- a/website/docs/d/lambda_invocation.html.markdown
+++ b/website/docs/d/lambda_invocation.html.markdown
@@ -16,7 +16,7 @@ invocation type.
 
 ```hcl
 data "aws_lambda_invocation" "example" {
-  function_name = "${aws_lambda_function.lambda_function_test.function_name}"
+  function_name = aws_lambda_function.lambda_function_test.function_name
 
   input = <<JSON
 {
@@ -28,13 +28,13 @@ JSON
 
 output "result" {
   description = "String result of Lambda execution"
-  value       = "${data.aws_lambda_invocation.example.result}"
+  value       = data.aws_lambda_invocation.example.result
 }
 
 # In Terraform 0.11 and earlier, the result_map attribute can be used
 # to convert a result JSON string to a map of string keys to string values.
 output "result_entry_tf011" {
-  value = "${data.aws_lambda_invocation.example.result_map["key1"]}"
+  value = data.aws_lambda_invocation.example.result_map["key1"]
 }
 
 # In Terraform 0.12 and later, the jsondecode() function can be used

--- a/website/docs/d/lambda_layer_version.html.markdown
+++ b/website/docs/d/lambda_layer_version.html.markdown
@@ -18,7 +18,7 @@ variable "layer_name" {
 }
 
 data "aws_lambda_layer_version" "existing" {
-  layer_name = "${var.layer_name}"
+  layer_name = var.layer_name
 }
 ```
 

--- a/website/docs/d/lb.html.markdown
+++ b/website/docs/d/lb.html.markdown
@@ -30,8 +30,8 @@ variable "lb_name" {
 }
 
 data "aws_lb" "test" {
-  arn  = "${var.lb_arn}"
-  name = "${var.lb_name}"
+  arn  = var.lb_arn
+  name = var.lb_name
 }
 ```
 

--- a/website/docs/d/lb_listener.html.markdown
+++ b/website/docs/d/lb_listener.html.markdown
@@ -26,7 +26,7 @@ variable "listener_arn" {
 }
 
 data "aws_lb_listener" "listener" {
-  arn = "${var.listener_arn}"
+  arn = var.listener_arn
 }
 
 # get listener from load_balancer_arn and port
@@ -36,7 +36,7 @@ data "aws_lb" "selected" {
 }
 
 data "aws_lb_listener" "selected443" {
-  load_balancer_arn = "${data.aws_lb.selected.arn}"
+  load_balancer_arn = data.aws_lb.selected.arn
   port              = 443
 }
 ```

--- a/website/docs/d/lb_target_group.html.markdown
+++ b/website/docs/d/lb_target_group.html.markdown
@@ -30,8 +30,8 @@ variable "lb_tg_name" {
 }
 
 data "aws_lb_target_group" "test" {
-  arn  = "${var.lb_tg_arn}"
-  name = "${var.lb_tg_name}"
+  arn  = var.lb_tg_arn
+  name = var.lb_tg_name
 }
 ```
 

--- a/website/docs/d/mq_broker.html.markdown
+++ b/website/docs/d/mq_broker.html.markdown
@@ -24,11 +24,11 @@ variable "broker_name" {
 }
 
 data "aws_mq_broker" "by_id" {
-  broker_id = "${var.broker_id}"
+  broker_id = var.broker_id
 }
 
 data "aws_mq_broker" "by_name" {
-  broker_name = "${var.broker_name}"
+  broker_name = var.broker_name
 }
 ```
 

--- a/website/docs/d/nat_gateway.html.markdown
+++ b/website/docs/d/nat_gateway.html.markdown
@@ -16,7 +16,7 @@ Provides details about a specific Nat Gateway.
 variable "subnet_id" {}
 
 data "aws_nat_gateway" "default" {
-  subnet_id = "${aws_subnet.public.id}"
+  subnet_id = aws_subnet.public.id
 }
 ```
 
@@ -24,7 +24,7 @@ Usage with tags:
 
 ```hcl
 data "aws_nat_gateway" "default" {
-  subnet_id = "${aws_subnet.public.id}"
+  subnet_id = aws_subnet.public.id
 
   tags = {
     Name = "gw NAT"

--- a/website/docs/d/network_acls.html.markdown
+++ b/website/docs/d/network_acls.html.markdown
@@ -14,11 +14,11 @@ The following shows outputing all network ACL ids in a vpc.
 
 ```hcl
 data "aws_network_acls" "example" {
-  vpc_id = "${var.vpc_id}"
+  vpc_id = var.vpc_id
 }
 
 output "example" {
-  value = "${data.aws_network_acls.example.ids}"
+  value = data.aws_network_acls.example.ids
 }
 ```
 
@@ -27,7 +27,7 @@ tag of `Tier` set to a value of "Private".
 
 ```hcl
 data "aws_network_acls" "example" {
-  vpc_id = "${var.vpc_id}"
+  vpc_id = var.vpc_id
 
   tags = {
     Tier = "Private"
@@ -40,11 +40,11 @@ with specific subnet.
 
 ```hcl
 data "aws_network_acls" "example" {
-  vpc_id = "${var.vpc_id}"
+  vpc_id = var.vpc_id
 
   filter {
     name   = "association.subnet-id"
-    values = ["${aws_subnet.test.id}"]
+    values = [aws_subnet.test.id]
   }
 }
 ```

--- a/website/docs/d/network_interfaces.html.markdown
+++ b/website/docs/d/network_interfaces.html.markdown
@@ -16,7 +16,7 @@ The following shows outputing all network interface ids in a region.
 data "aws_network_interfaces" "example" {}
 
 output "example" {
-  value = "${data.aws_network_interfaces.example.ids}"
+  value = data.aws_network_interfaces.example.ids
 }
 ```
 
@@ -30,7 +30,7 @@ data "aws_network_interfaces" "example" {
 }
 
 output "example1" {
-  value = "${data.aws_network_interfaces.example.ids}"
+  value = data.aws_network_interfaces.example.ids
 }
 ```
 
@@ -41,12 +41,12 @@ with specific subnet.
 data "aws_network_interfaces" "example" {
   filter {
     name   = "subnet-id"
-    values = ["${aws_subnet.test.id}"]
+    values = [aws_subnet.test.id]
   }
 }
 
 output "example" {
-  value = "${data.aws_network_interfaces.example.ids}"
+  value = data.aws_network_interfaces.example.ids
 }
 ```
 

--- a/website/docs/d/organizations_organization.html.markdown
+++ b/website/docs/d/organizations_organization.html.markdown
@@ -33,9 +33,9 @@ resource "aws_sns_topic" "sns_topic" {
 }
 
 resource "aws_sns_topic_policy" "sns_topic_policy" {
-  arn = "${aws_sns_topic.sns_topic.arn}"
+  arn = aws_sns_topic.sns_topic.arn
 
-  policy = "${data.aws_iam_policy_document.sns_topic_policy.json}"
+  policy = data.aws_iam_policy_document.sns_topic_policy.json
 }
 
 data "aws_iam_policy_document" "sns_topic_policy" {
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
       variable = "aws:PrincipalOrgID"
 
       values = [
-        "${data.aws_organizations_organization.example.id}",
+        data.aws_organizations_organization.example.id,
       ]
     }
 
@@ -62,7 +62,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
     }
 
     resources = [
-      "${aws_sns_topic.sns_topic.arn}",
+      aws_sns_topic.sns_topic.arn,
     ]
   }
 }

--- a/website/docs/d/prefix_list.html.markdown
+++ b/website/docs/d/prefix_list.html.markdown
@@ -20,25 +20,25 @@ rules.
 
 ```hcl
 resource "aws_vpc_endpoint" "private_s3" {
-  vpc_id       = "${aws_vpc.foo.id}"
+  vpc_id       = aws_vpc.foo.id
   service_name = "com.amazonaws.us-west-2.s3"
 }
 
 data "aws_prefix_list" "private_s3" {
-  prefix_list_id = "${aws_vpc_endpoint.private_s3.prefix_list_id}"
+  prefix_list_id = aws_vpc_endpoint.private_s3.prefix_list_id
 }
 
 resource "aws_network_acl" "bar" {
-  vpc_id = "${aws_vpc.foo.id}"
+  vpc_id = aws_vpc.foo.id
 }
 
 resource "aws_network_acl_rule" "private_s3" {
-  network_acl_id = "${aws_network_acl.bar.id}"
+  network_acl_id = aws_network_acl.bar.id
   rule_number    = 200
   egress         = false
   protocol       = "tcp"
   rule_action    = "allow"
-  cidr_block     = "${data.aws_prefix_list.private_s3.cidr_blocks[0]}"
+  cidr_block     = data.aws_prefix_list.private_s3.cidr_blocks[0]
   from_port      = 443
   to_port        = 443
 }

--- a/website/docs/d/redshift_cluster.html.markdown
+++ b/website/docs/d/redshift_cluster.html.markdown
@@ -22,15 +22,15 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
   destination = "redshift"
 
   s3_configuration {
-    role_arn           = "${aws_iam_role.firehose_role.arn}"
-    bucket_arn         = "${aws_s3_bucket.bucket.arn}"
+    role_arn           = aws_iam_role.firehose_role.arn
+    bucket_arn         = aws_s3_bucket.bucket.arn
     buffer_size        = 10
     buffer_interval    = 400
     compression_format = "GZIP"
   }
 
   redshift_configuration {
-    role_arn           = "${aws_iam_role.firehose_role.arn}"
+    role_arn           = aws_iam_role.firehose_role.arn
     cluster_jdbcurl    = "jdbc:redshift://${data.aws_redshift_cluster.test_cluster.endpoint}/${data.aws_redshift_cluster.test_cluster.database_name}"
     username           = "testuser"
     password           = "T3stPass"

--- a/website/docs/d/redshift_service_account.html.markdown
+++ b/website/docs/d/redshift_service_account.html.markdown
@@ -20,31 +20,29 @@ resource "aws_s3_bucket" "bucket" {
   bucket        = "tf-redshift-logging-test-bucket"
   force_destroy = true
 
-  policy = <<EOF
-{
-	"Version": "2008-10-17",
-	"Statement": [
-		{
-        			"Sid": "Put bucket policy needed for audit logging",
-        			"Effect": "Allow",
-        			"Principal": {
-						"AWS": "${data.aws_redshift_service_account.main.arn}"
-        			},
-        			"Action": "s3:PutObject",
-        			"Resource": "arn:aws:s3:::tf-redshift-logging-test-bucket/*"
-        		},
-        		{
-        			"Sid": "Get bucket policy needed for audit logging ",
-        			"Effect": "Allow",
-        			"Principal": {
-						"AWS": "${data.aws_redshift_service_account.main.arn}"
-        			},
-        			"Action": "s3:GetBucketAcl",
-        			"Resource": "arn:aws:s3:::tf-redshift-logging-test-bucket"
-        		}
-	]
-}
-EOF
+  policy = jsonencode({
+    "Version" = "2008-10-17"
+    "Statement" = [
+      {
+        "Sid"    = "Put bucket policy needed for audit logging"
+        "Effect" = "Allow"
+        "Principal" = {
+          "AWS" = data.aws_redshift_service_account.main.arn
+        }
+        "Action"   = "s3:PutObject"
+        "Resource" = "arn:aws:s3:::tf-redshift-logging-test-bucket/*"
+      },
+      {
+        "Sid"    = "Get bucket policy needed for audit logging "
+        "Effect" = "Allow"
+        "Principal" = {
+          "AWS" = data.aws_redshift_service_account.main.arn
+        }
+        "Action"   = "s3:GetBucketAcl"
+        "Resource" = "arn:aws:s3:::tf-redshift-logging-test-bucket"
+      }
+    ]
+  })
 }
 ```
 

--- a/website/docs/d/route.html.markdown
+++ b/website/docs/d/route.html.markdown
@@ -23,16 +23,16 @@ and use this to create a data source of that network interface.
 variable "subnet_id" {}
 
 data "aws_route_table" "selected" {
-  subnet_id = "${var.subnet_id}"
+  subnet_id = var.subnet_id
 }
 
 data "aws_route" "route" {
-  route_table_id         = "${aws_route_table.selected.id}"
+  route_table_id         = aws_route_table.selected.id
   destination_cidr_block = "10.0.1.0/24"
 }
 
 data "aws_network_interface" "interface" {
-  network_interface_id = "${data.aws_route.route.network_interface_id}"
+  network_interface_id = data.aws_route.route.network_interface_id
 }
 ```
 

--- a/website/docs/d/route53_zone.html.markdown
+++ b/website/docs/d/route53_zone.html.markdown
@@ -24,7 +24,7 @@ data "aws_route53_zone" "selected" {
 }
 
 resource "aws_route53_record" "www" {
-  zone_id = "${data.aws_route53_zone.selected.zone_id}"
+  zone_id = data.aws_route53_zone.selected.zone_id
   name    = "www.${data.aws_route53_zone.selected.name}"
   type    = "A"
   ttl     = "300"

--- a/website/docs/d/route_table.html.markdown
+++ b/website/docs/d/route_table.html.markdown
@@ -23,11 +23,11 @@ and use this data source to obtain the data necessary to create a route.
 variable "subnet_id" {}
 
 data "aws_route_table" "selected" {
-  subnet_id = "${var.subnet_id}"
+  subnet_id = var.subnet_id
 }
 
 resource "aws_route" "route" {
-  route_table_id            = "${data.aws_route_table.selected.id}"
+  route_table_id            = data.aws_route_table.selected.id
   destination_cidr_block    = "10.0.1.0/22"
   vpc_peering_connection_id = "pcx-45ff3dc1"
 }

--- a/website/docs/d/route_tables.html.markdown
+++ b/website/docs/d/route_tables.html.markdown
@@ -18,7 +18,7 @@ connection.
 
 ```hcl
 data "aws_route_tables" "rts" {
-  vpc_id = "${var.vpc_id}"
+  vpc_id = var.vpc_id
 
   filter {
     name   = "tag:kubernetes.io/kops/role"
@@ -27,8 +27,8 @@ data "aws_route_tables" "rts" {
 }
 
 resource "aws_route" "r" {
-  count                     = "${length(data.aws_route_tables.rts.ids)}"
-  route_table_id            = "${data.aws_route_tables.rts.ids[count.index]}"
+  count                     = length(data.aws_route_tables.rts.ids)
+  route_table_id            = data.aws_route_tables.rts.ids[count.index]
   destination_cidr_block    = "10.0.1.0/22"
   vpc_peering_connection_id = "pcx-0e9a7a9ecd137dc54"
 }

--- a/website/docs/d/s3_bucket.html.markdown
+++ b/website/docs/d/s3_bucket.html.markdown
@@ -27,13 +27,13 @@ data "aws_route53_zone" "test_zone" {
 }
 
 resource "aws_route53_record" "example" {
-  zone_id = "${data.aws_route53_zone.test_zone.id}"
+  zone_id = data.aws_route53_zone.test_zone.id
   name    = "bucket"
   type    = "A"
 
   alias {
-    name    = "${data.aws_s3_bucket.selected.website_domain}"
-    zone_id = "${data.aws_s3_bucket.selected.hosted_zone_id}"
+    name    = data.aws_s3_bucket.selected.website_domain
+    zone_id = data.aws_s3_bucket.selected.hosted_zone_id
   }
 }
 ```
@@ -47,7 +47,7 @@ data "aws_s3_bucket" "selected" {
 
 resource "aws_cloudfront_distribution" "test" {
   origin {
-    domain_name = "${data.aws_s3_bucket.selected.bucket_domain_name}"
+    domain_name = data.aws_s3_bucket.selected.bucket_domain_name
     origin_id   = "s3-selected-bucket"
   }
 }

--- a/website/docs/d/s3_bucket_object.html.markdown
+++ b/website/docs/d/s3_bucket_object.html.markdown
@@ -27,7 +27,7 @@ data "aws_s3_bucket_object" "bootstrap_script" {
 resource "aws_instance" "example" {
   instance_type = "t2.micro"
   ami           = "ami-2757f631"
-  user_data     = "${data.aws_s3_bucket_object.bootstrap_script.body}"
+  user_data     = data.aws_s3_bucket_object.bootstrap_script.body
 }
 ```
 
@@ -44,11 +44,11 @@ data "aws_s3_bucket_object" "lambda" {
 }
 
 resource "aws_lambda_function" "test_lambda" {
-  s3_bucket         = "${data.aws_s3_bucket_object.lambda.bucket}"
-  s3_key            = "${data.aws_s3_bucket_object.lambda.key}"
-  s3_object_version = "${data.aws_s3_bucket_object.lambda.version_id}"
+  s3_bucket         = data.aws_s3_bucket_object.lambda.bucket
+  s3_key            = data.aws_s3_bucket_object.lambda.key
+  s3_object_version = data.aws_s3_bucket_object.lambda.version_id
   function_name     = "lambda_function_name"
-  role              = "${aws_iam_role.iam_for_lambda.arn}" # (not shown)
+  role              = aws_iam_role.iam_for_lambda.arn # (not shown)
   handler           = "exports.test"
 }
 ```

--- a/website/docs/d/s3_bucket_objects.html.markdown
+++ b/website/docs/d/s3_bucket_objects.html.markdown
@@ -22,9 +22,9 @@ data "aws_s3_bucket_objects" "my_objects" {
 }
 
 data "aws_s3_bucket_object" "object_info" {
-  count  = "${length(data.aws_s3_bucket_objects.my_objects.keys)}"
-  key    = "${element(data.aws_s3_bucket_objects.my_objects.keys, count.index)}"
-  bucket = "${data.aws_s3_bucket_objects.my_objects.bucket}"
+  count  = length(data.aws_s3_bucket_objects.my_objects.keys)
+  key    = element(data.aws_s3_bucket_objects.my_objects.keys, count.index)
+  bucket = data.aws_s3_bucket_objects.my_objects.bucket
 }
 ```
 

--- a/website/docs/d/secretsmanager_secret_version.html.markdown
+++ b/website/docs/d/secretsmanager_secret_version.html.markdown
@@ -18,7 +18,7 @@ By default, this data sources retrieves information based on the `AWSCURRENT` st
 
 ```hcl
 data "aws_secretsmanager_secret_version" "example" {
-  secret_id = "${data.aws_secretsmanager_secret.example.id}"
+  secret_id = data.aws_secretsmanager_secret.example.id
 }
 ```
 
@@ -26,7 +26,7 @@ data "aws_secretsmanager_secret_version" "example" {
 
 ```hcl
 data "aws_secretsmanager_secret_version" "by-version-stage" {
-  secret_id     = "${data.aws_secretsmanager_secret.example.id}"
+  secret_id     = data.aws_secretsmanager_secret.example.id
   version_stage = "example"
 }
 ```

--- a/website/docs/d/security_group.html.markdown
+++ b/website/docs/d/security_group.html.markdown
@@ -23,11 +23,11 @@ and use this data source to obtain the data necessary to create a subnet.
 variable "security_group_id" {}
 
 data "aws_security_group" "selected" {
-  id = "${var.security_group_id}"
+  id = var.security_group_id
 }
 
 resource "aws_subnet" "subnet" {
-  vpc_id     = "${data.aws_security_group.selected.vpc_id}"
+  vpc_id     = data.aws_security_group.selected.vpc_id
   cidr_block = "10.0.1.0/24"
 }
 ```

--- a/website/docs/d/security_groups.html.markdown
+++ b/website/docs/d/security_groups.html.markdown
@@ -31,7 +31,7 @@ data "aws_security_groups" "test" {
 
   filter {
     name   = "vpc-id"
-    values = ["${var.vpc_id}"]
+    values = [var.vpc_id]
   }
 }
 ```

--- a/website/docs/d/ssm_document.html.markdown
+++ b/website/docs/d/ssm_document.html.markdown
@@ -21,7 +21,7 @@ data "aws_ssm_document" "foo" {
 }
 
 output "content" {
-  value = "${data.aws_ssm_document.foo.content}"
+  value = data.aws_ssm_document.foo.content
 }
 ```
 
@@ -29,7 +29,7 @@ To get the contents of the custom document.
 
 ```hcl
 data "aws_ssm_document" "test" {
-  name            = "${aws_ssm_document.test.name}"
+  name            = aws_ssm_document.test.name
   document_format = "JSON"
 }
 ```

--- a/website/docs/d/storagegateway_local_disk.html.markdown
+++ b/website/docs/d/storagegateway_local_disk.html.markdown
@@ -14,8 +14,8 @@ Retrieve information about a Storage Gateway local disk. The disk identifier is 
 
 ```hcl
 data "aws_storagegateway_local_disk" "test" {
-  disk_path   = "${aws_volume_attachment.test.device_name}"
-  gateway_arn = "${aws_storagegateway_gateway.test.arn}"
+  disk_path   = aws_volume_attachment.test.device_name
+  gateway_arn = aws_storagegateway_gateway.test.arn
 }
 ```
 

--- a/website/docs/d/subnet.html.markdown
+++ b/website/docs/d/subnet.html.markdown
@@ -24,14 +24,14 @@ group that allows connections from hosts in that subnet.
 variable "subnet_id" {}
 
 data "aws_subnet" "selected" {
-  id = "${var.subnet_id}"
+  id = var.subnet_id
 }
 
 resource "aws_security_group" "subnet" {
-  vpc_id = "${data.aws_subnet.selected.vpc_id}"
+  vpc_id = data.aws_subnet.selected.vpc_id
 
   ingress {
-    cidr_blocks = ["${data.aws_subnet.selected.cidr_block}"]
+    cidr_blocks = [data.aws_subnet.selected.cidr_block]
     from_port   = 80
     to_port     = 80
     protocol    = "tcp"

--- a/website/docs/d/vpc.html.markdown
+++ b/website/docs/d/vpc.html.markdown
@@ -24,13 +24,13 @@ within it.
 variable "vpc_id" {}
 
 data "aws_vpc" "selected" {
-  id = "${var.vpc_id}"
+  id = var.vpc_id
 }
 
 resource "aws_subnet" "example" {
-  vpc_id            = "${data.aws_vpc.selected.id}"
+  vpc_id            = data.aws_vpc.selected.id
   availability_zone = "us-west-2a"
-  cidr_block        = "${cidrsubnet(data.aws_vpc.selected.cidr_block, 4, 1)}"
+  cidr_block        = cidrsubnet(data.aws_vpc.selected.cidr_block, 4, 1)
 }
 ```
 

--- a/website/docs/d/vpc_endpoint.html.markdown
+++ b/website/docs/d/vpc_endpoint.html.markdown
@@ -16,13 +16,13 @@ a specific VPC endpoint.
 ```hcl
 # Declare the data source
 data "aws_vpc_endpoint" "s3" {
-  vpc_id       = "${aws_vpc.foo.id}"
+  vpc_id       = aws_vpc.foo.id
   service_name = "com.amazonaws.us-west-2.s3"
 }
 
 resource "aws_vpc_endpoint_route_table_association" "private_s3" {
-  vpc_endpoint_id = "${data.aws_vpc_endpoint.s3.id}"
-  route_table_id  = "${aws_route_table.private.id}"
+  vpc_endpoint_id = data.aws_vpc_endpoint.s3.id
+  route_table_id  = aws_route_table.private.id
 }
 ```
 

--- a/website/docs/d/vpc_endpoint_service.html.markdown
+++ b/website/docs/d/vpc_endpoint_service.html.markdown
@@ -28,8 +28,8 @@ resource "aws_vpc" "foo" {
 
 # Create a VPC endpoint
 resource "aws_vpc_endpoint" "ep" {
-  vpc_id       = "${aws_vpc.foo.id}"
-  service_name = "${data.aws_vpc_endpoint_service.s3.service_name}"
+  vpc_id       = aws_vpc.foo.id
+  service_name = data.aws_vpc_endpoint_service.s3.service_name
 }
 ```
 

--- a/website/docs/d/vpc_peering_connection.html.markdown
+++ b/website/docs/d/vpc_peering_connection.html.markdown
@@ -16,20 +16,20 @@ a specific VPC peering connection.
 ```hcl
 # Declare the data source
 data "aws_vpc_peering_connection" "pc" {
-  vpc_id          = "${aws_vpc.foo.id}"
+  vpc_id          = aws_vpc.foo.id
   peer_cidr_block = "10.0.1.0/22"
 }
 
 # Create a route table
 resource "aws_route_table" "rt" {
-  vpc_id = "${aws_vpc.foo.id}"
+  vpc_id = aws_vpc.foo.id
 }
 
 # Create a route
 resource "aws_route" "r" {
-  route_table_id            = "${aws_route_table.rt.id}"
-  destination_cidr_block    = "${data.aws_vpc_peering_connection.pc.peer_cidr_block}"
-  vpc_peering_connection_id = "${data.aws_vpc_peering_connection.pc.id}"
+  route_table_id            = aws_route_table.rt.id
+  destination_cidr_block    = data.aws_vpc_peering_connection.pc.peer_cidr_block
+  vpc_peering_connection_id = data.aws_vpc_peering_connection.pc.id
 }
 ```
 

--- a/website/docs/d/vpcs.html.markdown
+++ b/website/docs/d/vpcs.html.markdown
@@ -24,7 +24,7 @@ data "aws_vpcs" "foo" {
 }
 
 output "foo" {
-  value = "${data.aws_vpcs.foo.ids}"
+  value = data.aws_vpcs.foo.ids
 }
 ```
 
@@ -34,16 +34,16 @@ An example use case would be interpolate the `aws_vpcs` output into `count` of a
 data "aws_vpcs" "foo" {}
 
 resource "aws_flow_log" "test_flow_log" {
-  count = "${length(data.aws_vpcs.foo.ids)}"
+  count = length(data.aws_vpcs.foo.ids)
 
   # ...
-  vpc_id = "${element(data.aws_vpcs.foo.ids, count.index)}"
+  vpc_id = element(data.aws_vpcs.foo.ids, count.index)
 
   # ...
 }
 
 output "foo" {
-  value = "${data.aws_vpcs.foo.ids}"
+  value = data.aws_vpcs.foo.ids
 }
 ```
 

--- a/website/docs/d/vpn_gateway.html.markdown
+++ b/website/docs/d/vpn_gateway.html.markdown
@@ -22,7 +22,7 @@ data "aws_vpn_gateway" "selected" {
 }
 
 output "vpn_gateway_id" {
-  value = "${data.aws_vpn_gateway.selected.id}"
+  value = data.aws_vpn_gateway.selected.id
 }
 ```
 

--- a/website/docs/guides/version-3-upgrade.html.md
+++ b/website/docs/guides/version-3-upgrade.html.md
@@ -153,7 +153,7 @@ resource "aws_emr_cluster" "example" {
 }
 
 resource "aws_emr_instance_group" "example" {
-  cluster_id     = "${aws_emr_cluster.example.id}"
+  cluster_id     = aws_emr_cluster.example.id
   instance_count = 2
   instance_type  = "c4.xlarge"
 }

--- a/website/docs/r/acm_certificate.html.markdown
+++ b/website/docs/r/acm_certificate.html.markdown
@@ -54,7 +54,7 @@ resource "tls_private_key" "example" {
 
 resource "tls_self_signed_cert" "example" {
   key_algorithm   = "RSA"
-  private_key_pem = "${tls_private_key.example.private_key_pem}"
+  private_key_pem = tls_private_key.example.private_key_pem
 
   subject {
     common_name  = "example.com"
@@ -71,8 +71,8 @@ resource "tls_self_signed_cert" "example" {
 }
 
 resource "aws_acm_certificate" "cert" {
-  private_key      = "${tls_private_key.example.private_key_pem}"
-  certificate_body = "${tls_self_signed_cert.example.cert_pem}"
+  private_key      = tls_private_key.example.private_key_pem
+  certificate_body = tls_self_signed_cert.example.cert_pem
 }
 ```
 

--- a/website/docs/r/acm_certificate_validation.html.markdown
+++ b/website/docs/r/acm_certificate_validation.html.markdown
@@ -34,21 +34,21 @@ data "aws_route53_zone" "zone" {
 }
 
 resource "aws_route53_record" "cert_validation" {
-  name    = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_name}"
-  type    = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_type}"
-  zone_id = "${data.aws_route53_zone.zone.id}"
-  records = ["${aws_acm_certificate.cert.domain_validation_options.0.resource_record_value}"]
+  name    = aws_acm_certificate.cert.domain_validation_options.0.resource_record_name
+  type    = aws_acm_certificate.cert.domain_validation_options.0.resource_record_type
+  zone_id = data.aws_route53_zone.zone.id
+  records = [aws_acm_certificate.cert.domain_validation_options.0.resource_record_value]
   ttl     = 60
 }
 
 resource "aws_acm_certificate_validation" "cert" {
-  certificate_arn         = "${aws_acm_certificate.cert.arn}"
-  validation_record_fqdns = ["${aws_route53_record.cert_validation.fqdn}"]
+  certificate_arn         = aws_acm_certificate.cert.arn
+  validation_record_fqdns = [aws_route53_record.cert_validation.fqdn]
 }
 
 resource "aws_lb_listener" "front_end" {
   # [...]
-  certificate_arn = "${aws_acm_certificate_validation.cert.certificate_arn}"
+  certificate_arn = aws_acm_certificate_validation.cert.certificate_arn
 }
 ```
 
@@ -72,42 +72,42 @@ data "aws_route53_zone" "zone_alt" {
 }
 
 resource "aws_route53_record" "cert_validation" {
-  name    = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_name}"
-  type    = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_type}"
-  zone_id = "${data.aws_route53_zone.zone.id}"
-  records = ["${aws_acm_certificate.cert.domain_validation_options.0.resource_record_value}"]
+  name    = aws_acm_certificate.cert.domain_validation_options.0.resource_record_name
+  type    = aws_acm_certificate.cert.domain_validation_options.0.resource_record_type
+  zone_id = data.aws_route53_zone.zone.id
+  records = [aws_acm_certificate.cert.domain_validation_options.0.resource_record_value]
   ttl     = 60
 }
 
 resource "aws_route53_record" "cert_validation_alt1" {
-  name    = "${aws_acm_certificate.cert.domain_validation_options.1.resource_record_name}"
-  type    = "${aws_acm_certificate.cert.domain_validation_options.1.resource_record_type}"
-  zone_id = "${data.aws_route53_zone.zone.id}"
-  records = ["${aws_acm_certificate.cert.domain_validation_options.1.resource_record_value}"]
+  name    = aws_acm_certificate.cert.domain_validation_options.1.resource_record_name
+  type    = aws_acm_certificate.cert.domain_validation_options.1.resource_record_type
+  zone_id = data.aws_route53_zone.zone.id
+  records = [aws_acm_certificate.cert.domain_validation_options.1.resource_record_value]
   ttl     = 60
 }
 
 resource "aws_route53_record" "cert_validation_alt2" {
-  name    = "${aws_acm_certificate.cert.domain_validation_options.2.resource_record_name}"
-  type    = "${aws_acm_certificate.cert.domain_validation_options.2.resource_record_type}"
-  zone_id = "${data.aws_route53_zone.zone_alt.id}"
-  records = ["${aws_acm_certificate.cert.domain_validation_options.2.resource_record_value}"]
+  name    = aws_acm_certificate.cert.domain_validation_options.2.resource_record_name
+  type    = aws_acm_certificate.cert.domain_validation_options.2.resource_record_type
+  zone_id = data.aws_route53_zone.zone_alt.id
+  records = [aws_acm_certificate.cert.domain_validation_options.2.resource_record_value]
   ttl     = 60
 }
 
 resource "aws_acm_certificate_validation" "cert" {
-  certificate_arn = "${aws_acm_certificate.cert.arn}"
+  certificate_arn = aws_acm_certificate.cert.arn
 
   validation_record_fqdns = [
-    "${aws_route53_record.cert_validation.fqdn}",
-    "${aws_route53_record.cert_validation_alt1.fqdn}",
-    "${aws_route53_record.cert_validation_alt2.fqdn}",
+    aws_route53_record.cert_validation.fqdn,
+    aws_route53_record.cert_validation_alt1.fqdn,
+    aws_route53_record.cert_validation_alt2.fqdn,
   ]
 }
 
 resource "aws_lb_listener" "front_end" {
   # [...]
-  certificate_arn = "${aws_acm_certificate_validation.cert.certificate_arn}"
+  certificate_arn = aws_acm_certificate_validation.cert.certificate_arn
 }
 ```
 
@@ -122,7 +122,7 @@ resource "aws_acm_certificate" "cert" {
 }
 
 resource "aws_acm_certificate_validation" "cert" {
-  certificate_arn = "${aws_acm_certificate.cert.arn}"
+  certificate_arn = aws_acm_certificate.cert.arn
 }
 ```
 

--- a/website/docs/r/acmpca_certificate_authority.html.markdown
+++ b/website/docs/r/acmpca_certificate_authority.html.markdown
@@ -48,7 +48,7 @@ data "aws_iam_policy_document" "acmpca_bucket_access" {
     ]
 
     resources = [
-      "${aws_s3_bucket.example.arn}",
+      aws_s3_bucket.example.arn,
       "${aws_s3_bucket.example.arn}/*",
     ]
 
@@ -60,8 +60,8 @@ data "aws_iam_policy_document" "acmpca_bucket_access" {
 }
 
 resource "aws_s3_bucket_policy" "example" {
-  bucket = "${aws_s3_bucket.example.id}"
-  policy = "${data.aws_iam_policy_document.acmpca_bucket_access.json}"
+  bucket = aws_s3_bucket.example.id
+  policy = data.aws_iam_policy_document.acmpca_bucket_access.json
 }
 
 resource "aws_acmpca_certificate_authority" "example" {
@@ -79,7 +79,7 @@ resource "aws_acmpca_certificate_authority" "example" {
       custom_cname       = "crl.example.com"
       enabled            = true
       expiration_in_days = 7
-      s3_bucket_name     = "${aws_s3_bucket.example.id}"
+      s3_bucket_name     = aws_s3_bucket.example.id
     }
   }
 

--- a/website/docs/r/api_gateway_account.html.markdown
+++ b/website/docs/r/api_gateway_account.html.markdown
@@ -16,7 +16,7 @@ Provides a settings of an API Gateway Account. Settings is applied region-wide p
 
 ```hcl
 resource "aws_api_gateway_account" "demo" {
-  cloudwatch_role_arn = "${aws_iam_role.cloudwatch.arn}"
+  cloudwatch_role_arn = aws_iam_role.cloudwatch.arn
 }
 
 resource "aws_iam_role" "cloudwatch" {
@@ -41,7 +41,7 @@ EOF
 
 resource "aws_iam_role_policy" "cloudwatch" {
   name = "default"
-  role = "${aws_iam_role.cloudwatch.id}"
+  role = aws_iam_role.cloudwatch.id
 
   policy = <<EOF
 {

--- a/website/docs/r/api_gateway_authorizer.html.markdown
+++ b/website/docs/r/api_gateway_authorizer.html.markdown
@@ -15,9 +15,9 @@ Provides an API Gateway Authorizer.
 ```hcl
 resource "aws_api_gateway_authorizer" "demo" {
   name                   = "demo"
-  rest_api_id            = "${aws_api_gateway_rest_api.demo.id}"
-  authorizer_uri         = "${aws_lambda_function.authorizer.invoke_arn}"
-  authorizer_credentials = "${aws_iam_role.invocation_role.arn}"
+  rest_api_id            = aws_api_gateway_rest_api.demo.id
+  authorizer_uri         = aws_lambda_function.authorizer.invoke_arn
+  authorizer_credentials = aws_iam_role.invocation_role.arn
 }
 
 resource "aws_api_gateway_rest_api" "demo" {
@@ -47,7 +47,7 @@ EOF
 
 resource "aws_iam_role_policy" "invocation_policy" {
   name = "default"
-  role = "${aws_iam_role.invocation_role.id}"
+  role = aws_iam_role.invocation_role.id
 
   policy = <<EOF
 {
@@ -86,13 +86,13 @@ EOF
 resource "aws_lambda_function" "authorizer" {
   filename      = "lambda-function.zip"
   function_name = "api_gateway_authorizer"
-  role          = "${aws_iam_role.lambda.arn}"
+  role          = aws_iam_role.lambda.arn
   handler       = "exports.example"
 
   # The filebase64sha256() function is available in Terraform 0.11.12 and later
   # For Terraform 0.11.11 and earlier, use the base64sha256() function and the file() function:
-  # source_code_hash = "${base64sha256(file("lambda-function.zip"))}"
-  source_code_hash = "${filebase64sha256("lambda-function.zip")}"
+  # source_code_hash = base64sha256(file("lambda-function.zip"))
+  source_code_hash = filebase64sha256("lambda-function.zip")
 }
 ```
 

--- a/website/docs/r/api_gateway_authorizer.html.markdown
+++ b/website/docs/r/api_gateway_authorizer.html.markdown
@@ -28,59 +28,53 @@ resource "aws_iam_role" "invocation_role" {
   name = "api_gateway_auth_invocation"
   path = "/"
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "apigateway.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
+  assume_role_policy = jsonencode({
+    "Version" = "2012-10-17"
+    "Statement" = [
+      {
+        "Action" = "sts:AssumeRole"
+        "Principal" = {
+          "Service" = "apigateway.amazonaws.com"
+        }
+        "Effect" = "Allow"
+        "Sid"    = ""
+      }
+    ]
+  })
 }
 
 resource "aws_iam_role_policy" "invocation_policy" {
   name = "default"
   role = aws_iam_role.invocation_role.id
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "lambda:InvokeFunction",
-      "Effect": "Allow",
-      "Resource": "${aws_lambda_function.authorizer.arn}"
-    }
-  ]
-}
-EOF
+  policy = jsonencode({
+    "Version" = "2012-10-17"
+    "Statement" = [
+      {
+        "Action"   = "lambda:InvokeFunction"
+        "Effect"   = "Allow"
+        "Resource" = aws_lambda_function.authorizer.arn
+      }
+    ]
+  })
 }
 
 resource "aws_iam_role" "lambda" {
   name = "demo-lambda"
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "lambda.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
+  assume_role_policy = jsonencode({
+    "Version" = "2012-10-17"
+    "Statement" = [
+      {
+        "Action" = "sts:AssumeRole"
+        "Principal" = {
+          "Service" = "lambda.amazonaws.com"
+        }
+        "Effect" = "Allow"
+        "Sid"    = ""
+      }
+    ]
+  })
 }
 
 resource "aws_lambda_function" "authorizer" {

--- a/website/docs/r/api_gateway_base_path_mapping.html.markdown
+++ b/website/docs/r/api_gateway_base_path_mapping.html.markdown
@@ -17,7 +17,7 @@ custom domain name.
 ```hcl
 resource "aws_api_gateway_deployment" "example" {
   # See aws_api_gateway_rest_api docs for how to create this
-  rest_api_id = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
+  rest_api_id = aws_api_gateway_rest_api.MyDemoAPI.id
   stage_name  = "live"
 }
 
@@ -31,9 +31,9 @@ resource "aws_api_gateway_domain_name" "example" {
 }
 
 resource "aws_api_gateway_base_path_mapping" "test" {
-  api_id      = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
-  stage_name  = "${aws_api_gateway_deployment.example.stage_name}"
-  domain_name = "${aws_api_gateway_domain_name.example.domain_name}"
+  api_id      = aws_api_gateway_rest_api.MyDemoAPI.id
+  stage_name  = aws_api_gateway_deployment.example.stage_name
+  domain_name = aws_api_gateway_domain_name.example.domain_name
 }
 ```
 

--- a/website/docs/r/api_gateway_deployment.html.markdown
+++ b/website/docs/r/api_gateway_deployment.html.markdown
@@ -11,7 +11,7 @@ description: |-
 Provides an API Gateway REST Deployment.
 
 -> **Note:** Depends on having `aws_api_gateway_integration` inside your rest api (which in turn depends on `aws_api_gateway_method`). To avoid race conditions
-you might need to add an explicit `depends_on = ["${aws_api_gateway_integration.name}"]`.
+you might need to add an explicit `depends_on = [aws_api_gateway_integration.name]`.
 
 ## Example Usage
 
@@ -22,29 +22,29 @@ resource "aws_api_gateway_rest_api" "MyDemoAPI" {
 }
 
 resource "aws_api_gateway_resource" "MyDemoResource" {
-  rest_api_id = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
-  parent_id   = "${aws_api_gateway_rest_api.MyDemoAPI.root_resource_id}"
+  rest_api_id = aws_api_gateway_rest_api.MyDemoAPI.id
+  parent_id   = aws_api_gateway_rest_api.MyDemoAPI.root_resource_id
   path_part   = "test"
 }
 
 resource "aws_api_gateway_method" "MyDemoMethod" {
-  rest_api_id   = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
-  resource_id   = "${aws_api_gateway_resource.MyDemoResource.id}"
+  rest_api_id   = aws_api_gateway_rest_api.MyDemoAPI.id
+  resource_id   = aws_api_gateway_resource.MyDemoResource.id
   http_method   = "GET"
   authorization = "NONE"
 }
 
 resource "aws_api_gateway_integration" "MyDemoIntegration" {
-  rest_api_id = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
-  resource_id = "${aws_api_gateway_resource.MyDemoResource.id}"
-  http_method = "${aws_api_gateway_method.MyDemoMethod.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.MyDemoAPI.id
+  resource_id = aws_api_gateway_resource.MyDemoResource.id
+  http_method = aws_api_gateway_method.MyDemoMethod.http_method
   type        = "MOCK"
 }
 
 resource "aws_api_gateway_deployment" "MyDemoDeployment" {
-  depends_on = ["${aws_api_gateway_integration.MyDemoIntegration}"]
+  depends_on = [aws_api_gateway_integration.MyDemoIntegration]
 
-  rest_api_id = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
+  rest_api_id = aws_api_gateway_rest_api.MyDemoAPI.id
   stage_name  = "test"
 
   variables = {

--- a/website/docs/r/api_gateway_documentation_part.html.markdown
+++ b/website/docs/r/api_gateway_documentation_part.html.markdown
@@ -21,7 +21,7 @@ resource "aws_api_gateway_documentation_part" "example" {
   }
 
   properties  = "{\"description\":\"Example description\"}"
-  rest_api_id = "${aws_api_gateway_rest_api.example.id}"
+  rest_api_id = aws_api_gateway_rest_api.example.id
 }
 
 resource "aws_api_gateway_rest_api" "example" {

--- a/website/docs/r/api_gateway_documentation_version.html.markdown
+++ b/website/docs/r/api_gateway_documentation_version.html.markdown
@@ -15,7 +15,7 @@ Provides a resource to manage an API Gateway Documentation Version.
 ```hcl
 resource "aws_api_gateway_documentation_version" "example" {
   version     = "example_version"
-  rest_api_id = "${aws_api_gateway_rest_api.example.id}"
+  rest_api_id = aws_api_gateway_rest_api.example.id
   description = "Example description"
   depends_on  = ["aws_api_gateway_documentation_part.example"]
 }
@@ -30,7 +30,7 @@ resource "aws_api_gateway_documentation_part" "example" {
   }
 
   properties  = "{\"description\":\"Example\"}"
-  rest_api_id = "${aws_api_gateway_rest_api.example.id}"
+  rest_api_id = aws_api_gateway_rest_api.example.id
 }
 ```
 

--- a/website/docs/r/api_gateway_domain_name.html.markdown
+++ b/website/docs/r/api_gateway_domain_name.html.markdown
@@ -44,21 +44,21 @@ from the validation resource where it will be available after the resource creat
 
 ```hcl
 resource "aws_api_gateway_domain_name" "example" {
-  certificate_arn = "${aws_acm_certificate_validation.example.certificate_arn}"
+  certificate_arn = aws_acm_certificate_validation.example.certificate_arn
   domain_name     = "api.example.com"
 }
 
 # Example DNS record using Route53.
 # Route53 is not specifically required; any DNS host can be used.
 resource "aws_route53_record" "example" {
-  name    = "${aws_api_gateway_domain_name.example.domain_name}"
+  name    = aws_api_gateway_domain_name.example.domain_name
   type    = "A"
-  zone_id = "${aws_route53_zone.example.id}"
+  zone_id = aws_route53_zone.example.id
 
   alias {
     evaluate_target_health = true
-    name                   = "${aws_api_gateway_domain_name.example.cloudfront_domain_name}"
-    zone_id                = "${aws_api_gateway_domain_name.example.cloudfront_zone_id}"
+    name                   = aws_api_gateway_domain_name.example.cloudfront_domain_name
+    zone_id                = aws_api_gateway_domain_name.example.cloudfront_zone_id
   }
 }
 ```
@@ -78,14 +78,14 @@ resource "aws_api_gateway_domain_name" "example" {
 # Example DNS record using Route53.
 # Route53 is not specifically required; any DNS host can be used.
 resource "aws_route53_record" "example" {
-  zone_id = "${aws_route53_zone.example.id}" # See aws_route53_zone for how to create this
+  zone_id = aws_route53_zone.example.id # See aws_route53_zone for how to create this
 
-  name = "${aws_api_gateway_domain_name.example.domain_name}"
+  name = aws_api_gateway_domain_name.example.domain_name
   type = "A"
 
   alias {
-    name                   = "${aws_api_gateway_domain_name.example.cloudfront_domain_name}"
-    zone_id                = "${aws_api_gateway_domain_name.example.cloudfront_zone_id}"
+    name                   = aws_api_gateway_domain_name.example.cloudfront_domain_name
+    zone_id                = aws_api_gateway_domain_name.example.cloudfront_zone_id
     evaluate_target_health = true
   }
 }
@@ -96,7 +96,7 @@ resource "aws_route53_record" "example" {
 ```hcl
 resource "aws_api_gateway_domain_name" "example" {
   domain_name              = "api.example.com"
-  regional_certificate_arn = "${aws_acm_certificate_validation.example.certificate_arn}"
+  regional_certificate_arn = aws_acm_certificate_validation.example.certificate_arn
 
   endpoint_configuration {
     types = ["REGIONAL"]
@@ -106,14 +106,14 @@ resource "aws_api_gateway_domain_name" "example" {
 # Example DNS record using Route53.
 # Route53 is not specifically required; any DNS host can be used.
 resource "aws_route53_record" "example" {
-  name    = "${aws_api_gateway_domain_name.example.domain_name}"
+  name    = aws_api_gateway_domain_name.example.domain_name
   type    = "A"
-  zone_id = "${aws_route53_zone.example.id}"
+  zone_id = aws_route53_zone.example.id
 
   alias {
     evaluate_target_health = true
-    name                   = "${aws_api_gateway_domain_name.example.regional_domain_name}"
-    zone_id                = "${aws_api_gateway_domain_name.example.regional_zone_id}"
+    name                   = aws_api_gateway_domain_name.example.regional_domain_name
+    zone_id                = aws_api_gateway_domain_name.example.regional_zone_id
   }
 }
 ```
@@ -136,14 +136,14 @@ resource "aws_api_gateway_domain_name" "example" {
 # Example DNS record using Route53.
 # Route53 is not specifically required; any DNS host can be used.
 resource "aws_route53_record" "example" {
-  name    = "${aws_api_gateway_domain_name.example.domain_name}"
+  name    = aws_api_gateway_domain_name.example.domain_name
   type    = "A"
-  zone_id = "${aws_route53_zone.example.id}"
+  zone_id = aws_route53_zone.example.id
 
   alias {
     evaluate_target_health = true
-    name                   = "${aws_api_gateway_domain_name.example.regional_domain_name}"
-    zone_id                = "${aws_api_gateway_domain_name.example.regional_zone_id}"
+    name                   = aws_api_gateway_domain_name.example.regional_domain_name
+    zone_id                = aws_api_gateway_domain_name.example.regional_zone_id
   }
 }
 ```

--- a/website/docs/r/api_gateway_gateway_response.markdown
+++ b/website/docs/r/api_gateway_gateway_response.markdown
@@ -18,7 +18,7 @@ resource "aws_api_gateway_rest_api" "main" {
 }
 
 resource "aws_api_gateway_gateway_response" "test" {
-  rest_api_id   = "${aws_api_gateway_rest_api.main.id}"
+  rest_api_id   = aws_api_gateway_rest_api.main.id
   status_code   = "401"
   response_type = "UNAUTHORIZED"
 

--- a/website/docs/r/api_gateway_integration.html.markdown
+++ b/website/docs/r/api_gateway_integration.html.markdown
@@ -19,22 +19,22 @@ resource "aws_api_gateway_rest_api" "MyDemoAPI" {
 }
 
 resource "aws_api_gateway_resource" "MyDemoResource" {
-  rest_api_id = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
-  parent_id   = "${aws_api_gateway_rest_api.MyDemoAPI.root_resource_id}"
+  rest_api_id = aws_api_gateway_rest_api.MyDemoAPI.id
+  parent_id   = aws_api_gateway_rest_api.MyDemoAPI.root_resource_id
   path_part   = "mydemoresource"
 }
 
 resource "aws_api_gateway_method" "MyDemoMethod" {
-  rest_api_id   = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
-  resource_id   = "${aws_api_gateway_resource.MyDemoResource.id}"
+  rest_api_id   = aws_api_gateway_rest_api.MyDemoAPI.id
+  resource_id   = aws_api_gateway_resource.MyDemoResource.id
   http_method   = "GET"
   authorization = "NONE"
 }
 
 resource "aws_api_gateway_integration" "MyDemoIntegration" {
-  rest_api_id          = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
-  resource_id          = "${aws_api_gateway_resource.MyDemoResource.id}"
-  http_method          = "${aws_api_gateway_method.MyDemoMethod.http_method}"
+  rest_api_id          = aws_api_gateway_rest_api.MyDemoAPI.id
+  resource_id          = aws_api_gateway_resource.MyDemoResource.id
+  http_method          = aws_api_gateway_method.MyDemoMethod.http_method
   type                 = "MOCK"
   cache_key_parameters = ["method.request.path.param"]
   cache_namespace      = "foobar"
@@ -70,31 +70,31 @@ resource "aws_api_gateway_rest_api" "api" {
 
 resource "aws_api_gateway_resource" "resource" {
   path_part   = "resource"
-  parent_id   = "${aws_api_gateway_rest_api.api.root_resource_id}"
-  rest_api_id = "${aws_api_gateway_rest_api.api.id}"
+  parent_id   = aws_api_gateway_rest_api.api.root_resource_id
+  rest_api_id = aws_api_gateway_rest_api.api.id
 }
 
 resource "aws_api_gateway_method" "method" {
-  rest_api_id   = "${aws_api_gateway_rest_api.api.id}"
-  resource_id   = "${aws_api_gateway_resource.resource.id}"
+  rest_api_id   = aws_api_gateway_rest_api.api.id
+  resource_id   = aws_api_gateway_resource.resource.id
   http_method   = "GET"
   authorization = "NONE"
 }
 
 resource "aws_api_gateway_integration" "integration" {
-  rest_api_id             = "${aws_api_gateway_rest_api.api.id}"
-  resource_id             = "${aws_api_gateway_resource.resource.id}"
-  http_method             = "${aws_api_gateway_method.method.http_method}"
+  rest_api_id             = aws_api_gateway_rest_api.api.id
+  resource_id             = aws_api_gateway_resource.resource.id
+  http_method             = aws_api_gateway_method.method.http_method
   integration_http_method = "POST"
   type                    = "AWS_PROXY"
-  uri                     = "${aws_lambda_function.lambda.invoke_arn}"
+  uri                     = aws_lambda_function.lambda.invoke_arn
 }
 
 # Lambda
 resource "aws_lambda_permission" "apigw_lambda" {
   statement_id  = "AllowExecutionFromAPIGateway"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.lambda.function_name}"
+  function_name = aws_lambda_function.lambda.function_name
   principal     = "apigateway.amazonaws.com"
 
   # More: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-control-access-using-iam-policies-to-invoke-api.html
@@ -104,14 +104,14 @@ resource "aws_lambda_permission" "apigw_lambda" {
 resource "aws_lambda_function" "lambda" {
   filename      = "lambda.zip"
   function_name = "mylambda"
-  role          = "${aws_iam_role.role.arn}"
+  role          = aws_iam_role.role.arn
   handler       = "lambda.lambda_handler"
   runtime       = "python2.7"
 
   # The filebase64sha256() function is available in Terraform 0.11.12 and later
   # For Terraform 0.11.11 and earlier, use the base64sha256() function and the file() function:
-  # source_code_hash = "${base64sha256(file("lambda.zip"))}"
-  source_code_hash = "${filebase64sha256("lambda.zip")}"
+  # source_code_hash = base64sha256(file("lambda.zip"))
+  source_code_hash = filebase64sha256("lambda.zip")
 }
 
 # IAM
@@ -143,30 +143,30 @@ variable "name" {}
 variable "subnet_id" {}
 
 resource "aws_lb" "test" {
-  name               = "${var.name}"
+  name               = var.name
   internal           = true
   load_balancer_type = "network"
-  subnets            = ["${var.subnet_id}"]
+  subnets            = [var.subnet_id]
 }
 
 resource "aws_api_gateway_vpc_link" "test" {
-  name        = "${var.name}"
-  target_arns = ["${aws_lb.test.arn}"]
+  name        = var.name
+  target_arns = [aws_lb.test.arn]
 }
 
 resource "aws_api_gateway_rest_api" "test" {
-  name = "${var.name}"
+  name = var.name
 }
 
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id   = "${aws_api_gateway_rest_api.test.root_resource_id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
   path_part   = "test"
 }
 
 resource "aws_api_gateway_method" "test" {
-  rest_api_id   = "${aws_api_gateway_rest_api.test.id}"
-  resource_id   = "${aws_api_gateway_resource.test.id}"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
   http_method   = "GET"
   authorization = "NONE"
 
@@ -176,9 +176,9 @@ resource "aws_api_gateway_method" "test" {
 }
 
 resource "aws_api_gateway_integration" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
 
   request_templates = {
     "application/json" = ""
@@ -197,7 +197,7 @@ resource "aws_api_gateway_integration" "test" {
   content_handling        = "CONVERT_TO_TEXT"
 
   connection_type = "VPC_LINK"
-  connection_id   = "${aws_api_gateway_vpc_link.test.id}"
+  connection_id   = aws_api_gateway_vpc_link.test.id
 }
 ```
 

--- a/website/docs/r/api_gateway_integration_response.html.markdown
+++ b/website/docs/r/api_gateway_integration_response.html.markdown
@@ -22,37 +22,37 @@ resource "aws_api_gateway_rest_api" "MyDemoAPI" {
 }
 
 resource "aws_api_gateway_resource" "MyDemoResource" {
-  rest_api_id = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
-  parent_id   = "${aws_api_gateway_rest_api.MyDemoAPI.root_resource_id}"
+  rest_api_id = aws_api_gateway_rest_api.MyDemoAPI.id
+  parent_id   = aws_api_gateway_rest_api.MyDemoAPI.root_resource_id
   path_part   = "mydemoresource"
 }
 
 resource "aws_api_gateway_method" "MyDemoMethod" {
-  rest_api_id   = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
-  resource_id   = "${aws_api_gateway_resource.MyDemoResource.id}"
+  rest_api_id   = aws_api_gateway_rest_api.MyDemoAPI.id
+  resource_id   = aws_api_gateway_resource.MyDemoResource.id
   http_method   = "GET"
   authorization = "NONE"
 }
 
 resource "aws_api_gateway_integration" "MyDemoIntegration" {
-  rest_api_id = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
-  resource_id = "${aws_api_gateway_resource.MyDemoResource.id}"
-  http_method = "${aws_api_gateway_method.MyDemoMethod.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.MyDemoAPI.id
+  resource_id = aws_api_gateway_resource.MyDemoResource.id
+  http_method = aws_api_gateway_method.MyDemoMethod.http_method
   type        = "MOCK"
 }
 
 resource "aws_api_gateway_method_response" "response_200" {
-  rest_api_id = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
-  resource_id = "${aws_api_gateway_resource.MyDemoResource.id}"
-  http_method = "${aws_api_gateway_method.MyDemoMethod.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.MyDemoAPI.id
+  resource_id = aws_api_gateway_resource.MyDemoResource.id
+  http_method = aws_api_gateway_method.MyDemoMethod.http_method
   status_code = "200"
 }
 
 resource "aws_api_gateway_integration_response" "MyDemoIntegrationResponse" {
-  rest_api_id = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
-  resource_id = "${aws_api_gateway_resource.MyDemoResource.id}"
-  http_method = "${aws_api_gateway_method.MyDemoMethod.http_method}"
-  status_code = "${aws_api_gateway_method_response.response_200.status_code}"
+  rest_api_id = aws_api_gateway_rest_api.MyDemoAPI.id
+  resource_id = aws_api_gateway_resource.MyDemoResource.id
+  http_method = aws_api_gateway_method.MyDemoMethod.http_method
+  status_code = aws_api_gateway_method_response.response_200.status_code
 
   # Transforms the backend JSON response to XML
   response_templates = {

--- a/website/docs/r/api_gateway_method.html.markdown
+++ b/website/docs/r/api_gateway_method.html.markdown
@@ -19,14 +19,14 @@ resource "aws_api_gateway_rest_api" "MyDemoAPI" {
 }
 
 resource "aws_api_gateway_resource" "MyDemoResource" {
-  rest_api_id = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
-  parent_id   = "${aws_api_gateway_rest_api.MyDemoAPI.root_resource_id}"
+  rest_api_id = aws_api_gateway_rest_api.MyDemoAPI.id
+  parent_id   = aws_api_gateway_rest_api.MyDemoAPI.root_resource_id
   path_part   = "mydemoresource"
 }
 
 resource "aws_api_gateway_method" "MyDemoMethod" {
-  rest_api_id   = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
-  resource_id   = "${aws_api_gateway_resource.MyDemoResource.id}"
+  rest_api_id   = aws_api_gateway_rest_api.MyDemoAPI.id
+  resource_id   = aws_api_gateway_resource.MyDemoResource.id
   http_method   = "GET"
   authorization = "NONE"
 }
@@ -38,7 +38,7 @@ resource "aws_api_gateway_method" "MyDemoMethod" {
 variable "cognito_user_pool_name" {}
 
 data "aws_cognito_user_pools" "this" {
-  name = "${var.cognito_user_pool_name}"
+  name = var.cognito_user_pool_name
 }
 
 resource "aws_api_gateway_rest_api" "this" {
@@ -46,24 +46,24 @@ resource "aws_api_gateway_rest_api" "this" {
 }
 
 resource "aws_api_gateway_resource" "this" {
-  rest_api_id = "${aws_api_gateway_rest_api.this.id}"
-  parent_id   = "${aws_api_gateway_rest_api.this.root_resource_id}"
+  rest_api_id = aws_api_gateway_rest_api.this.id
+  parent_id   = aws_api_gateway_rest_api.this.root_resource_id
   path_part   = "{proxy+}"
 }
 
 resource "aws_api_gateway_authorizer" "this" {
   name          = "CognitoUserPoolAuthorizer"
   type          = "COGNITO_USER_POOLS"
-  rest_api_id   = "${aws_api_gateway_rest_api.this.id}"
-  provider_arns = ["${data.aws_cognito_user_pools.this.arns}"]
+  rest_api_id   = aws_api_gateway_rest_api.this.id
+  provider_arns = [data.aws_cognito_user_pools.this.arns]
 }
 
 resource "aws_api_gateway_method" "any" {
-  rest_api_id   = "${aws_api_gateway_rest_api.this.id}"
-  resource_id   = "${aws_api_gateway_resource.this.id}"
+  rest_api_id   = aws_api_gateway_rest_api.this.id
+  resource_id   = aws_api_gateway_resource.this.id
   http_method   = "ANY"
   authorization = "COGNITO_USER_POOLS"
-  authorizer_id = "${aws_api_gateway_authorizer.this.id}"
+  authorizer_id = aws_api_gateway_authorizer.this.id
 
   request_parameters = {
     "method.request.path.proxy" = true

--- a/website/docs/r/api_gateway_method_response.html.markdown
+++ b/website/docs/r/api_gateway_method_response.html.markdown
@@ -19,29 +19,29 @@ resource "aws_api_gateway_rest_api" "MyDemoAPI" {
 }
 
 resource "aws_api_gateway_resource" "MyDemoResource" {
-  rest_api_id = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
-  parent_id   = "${aws_api_gateway_rest_api.MyDemoAPI.root_resource_id}"
+  rest_api_id = aws_api_gateway_rest_api.MyDemoAPI.id
+  parent_id   = aws_api_gateway_rest_api.MyDemoAPI.root_resource_id
   path_part   = "mydemoresource"
 }
 
 resource "aws_api_gateway_method" "MyDemoMethod" {
-  rest_api_id   = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
-  resource_id   = "${aws_api_gateway_resource.MyDemoResource.id}"
+  rest_api_id   = aws_api_gateway_rest_api.MyDemoAPI.id
+  resource_id   = aws_api_gateway_resource.MyDemoResource.id
   http_method   = "GET"
   authorization = "NONE"
 }
 
 resource "aws_api_gateway_integration" "MyDemoIntegration" {
-  rest_api_id = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
-  resource_id = "${aws_api_gateway_resource.MyDemoResource.id}"
-  http_method = "${aws_api_gateway_method.MyDemoMethod.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.MyDemoAPI.id
+  resource_id = aws_api_gateway_resource.MyDemoResource.id
+  http_method = aws_api_gateway_method.MyDemoMethod.http_method
   type        = "MOCK"
 }
 
 resource "aws_api_gateway_method_response" "response_200" {
-  rest_api_id = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
-  resource_id = "${aws_api_gateway_resource.MyDemoResource.id}"
-  http_method = "${aws_api_gateway_method.MyDemoMethod.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.MyDemoAPI.id
+  resource_id = aws_api_gateway_resource.MyDemoResource.id
+  http_method = aws_api_gateway_method.MyDemoMethod.http_method
   status_code = "200"
 }
 ```

--- a/website/docs/r/api_gateway_method_settings.html.markdown
+++ b/website/docs/r/api_gateway_method_settings.html.markdown
@@ -14,8 +14,8 @@ Provides an API Gateway Method Settings, e.g. logging or monitoring.
 
 ```hcl
 resource "aws_api_gateway_method_settings" "s" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  stage_name  = "${aws_api_gateway_stage.test.stage_name}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  stage_name  = aws_api_gateway_stage.test.stage_name
   method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
 
   settings {
@@ -31,33 +31,33 @@ resource "aws_api_gateway_rest_api" "test" {
 
 resource "aws_api_gateway_deployment" "test" {
   depends_on  = ["aws_api_gateway_integration.test"]
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
   stage_name  = "dev"
 }
 
 resource "aws_api_gateway_stage" "test" {
   stage_name    = "prod"
-  rest_api_id   = "${aws_api_gateway_rest_api.test.id}"
-  deployment_id = "${aws_api_gateway_deployment.test.id}"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  deployment_id = aws_api_gateway_deployment.test.id
 }
 
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id   = "${aws_api_gateway_rest_api.test.root_resource_id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
   path_part   = "mytestresource"
 }
 
 resource "aws_api_gateway_method" "test" {
-  rest_api_id   = "${aws_api_gateway_rest_api.test.id}"
-  resource_id   = "${aws_api_gateway_resource.test.id}"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
   http_method   = "GET"
   authorization = "NONE"
 }
 
 resource "aws_api_gateway_integration" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
   type        = "MOCK"
 
   request_templates = {

--- a/website/docs/r/api_gateway_model.html.markdown
+++ b/website/docs/r/api_gateway_model.html.markdown
@@ -19,7 +19,7 @@ resource "aws_api_gateway_rest_api" "MyDemoAPI" {
 }
 
 resource "aws_api_gateway_model" "MyDemoModel" {
-  rest_api_id  = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
+  rest_api_id  = aws_api_gateway_rest_api.MyDemoAPI.id
   name         = "user"
   description  = "a JSON schema"
   content_type = "application/json"

--- a/website/docs/r/api_gateway_request_validator.html.markdown
+++ b/website/docs/r/api_gateway_request_validator.html.markdown
@@ -15,7 +15,7 @@ Manages an API Gateway Request Validator.
 ```hcl
 resource "aws_api_gateway_request_validator" "example" {
   name                        = "example"
-  rest_api_id                 = "${aws_api_gateway_rest_api.example.id}"
+  rest_api_id                 = aws_api_gateway_rest_api.example.id
   validate_request_body       = true
   validate_request_parameters = true
 }

--- a/website/docs/r/api_gateway_resource.html.markdown
+++ b/website/docs/r/api_gateway_resource.html.markdown
@@ -19,8 +19,8 @@ resource "aws_api_gateway_rest_api" "MyDemoAPI" {
 }
 
 resource "aws_api_gateway_resource" "MyDemoResource" {
-  rest_api_id = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
-  parent_id   = "${aws_api_gateway_rest_api.MyDemoAPI.root_resource_id}"
+  rest_api_id = aws_api_gateway_rest_api.MyDemoAPI.id
+  parent_id   = aws_api_gateway_rest_api.MyDemoAPI.root_resource_id
   path_part   = "mydemoresource"
 }
 ```

--- a/website/docs/r/api_gateway_stage.html.markdown
+++ b/website/docs/r/api_gateway_stage.html.markdown
@@ -15,8 +15,8 @@ Provides an API Gateway Stage.
 ```hcl
 resource "aws_api_gateway_stage" "test" {
   stage_name    = "prod"
-  rest_api_id   = "${aws_api_gateway_rest_api.test.id}"
-  deployment_id = "${aws_api_gateway_deployment.test.id}"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  deployment_id = aws_api_gateway_deployment.test.id
 }
 
 resource "aws_api_gateway_rest_api" "test" {
@@ -26,26 +26,26 @@ resource "aws_api_gateway_rest_api" "test" {
 
 resource "aws_api_gateway_deployment" "test" {
   depends_on  = ["aws_api_gateway_integration.test"]
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
   stage_name  = "dev"
 }
 
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id   = "${aws_api_gateway_rest_api.test.root_resource_id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
   path_part   = "mytestresource"
 }
 
 resource "aws_api_gateway_method" "test" {
-  rest_api_id   = "${aws_api_gateway_rest_api.test.id}"
-  resource_id   = "${aws_api_gateway_resource.test.id}"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
   http_method   = "GET"
   authorization = "NONE"
 }
 
 resource "aws_api_gateway_method_settings" "s" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  stage_name  = "${aws_api_gateway_stage.test.stage_name}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  stage_name  = aws_api_gateway_stage.test.stage_name
   method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
 
   settings {
@@ -55,9 +55,9 @@ resource "aws_api_gateway_method_settings" "s" {
 }
 
 resource "aws_api_gateway_integration" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
   type        = "MOCK"
 }
 ```
@@ -81,7 +81,7 @@ resource "aws_api_gateway_rest_api" "example" {
 resource "aws_api_gateway_stage" "example" {
   depends_on = ["aws_cloudwatch_log_group.example"]
 
-  name = "${var.stage_name}"
+  name = var.stage_name
 
   # ... other configuration ...
 }

--- a/website/docs/r/api_gateway_usage_plan.html.markdown
+++ b/website/docs/r/api_gateway_usage_plan.html.markdown
@@ -20,12 +20,12 @@ resource "aws_api_gateway_rest_api" "myapi" {
 # ...
 
 resource "aws_api_gateway_deployment" "dev" {
-  rest_api_id = "${aws_api_gateway_rest_api.myapi.id}"
+  rest_api_id = aws_api_gateway_rest_api.myapi.id
   stage_name  = "dev"
 }
 
 resource "aws_api_gateway_deployment" "prod" {
-  rest_api_id = "${aws_api_gateway_rest_api.myapi.id}"
+  rest_api_id = aws_api_gateway_rest_api.myapi.id
   stage_name  = "prod"
 }
 
@@ -35,13 +35,13 @@ resource "aws_api_gateway_usage_plan" "MyUsagePlan" {
   product_code = "MYCODE"
 
   api_stages {
-    api_id = "${aws_api_gateway_rest_api.myapi.id}"
-    stage  = "${aws_api_gateway_deployment.dev.stage_name}"
+    api_id = aws_api_gateway_rest_api.myapi.id
+    stage  = aws_api_gateway_deployment.dev.stage_name
   }
 
   api_stages {
-    api_id = "${aws_api_gateway_rest_api.myapi.id}"
-    stage  = "${aws_api_gateway_deployment.prod.stage_name}"
+    api_id = aws_api_gateway_rest_api.myapi.id
+    stage  = aws_api_gateway_deployment.prod.stage_name
   }
 
   quota_settings {

--- a/website/docs/r/api_gateway_usage_plan_key.html.markdown
+++ b/website/docs/r/api_gateway_usage_plan_key.html.markdown
@@ -23,8 +23,8 @@ resource "aws_api_gateway_usage_plan" "myusageplan" {
   name = "my_usage_plan"
 
   api_stages {
-    api_id = "${aws_api_gateway_rest_api.test.id}"
-    stage  = "${aws_api_gateway_deployment.foo.stage_name}"
+    api_id = aws_api_gateway_rest_api.test.id
+    stage  = aws_api_gateway_deployment.foo.stage_name
   }
 }
 
@@ -33,9 +33,9 @@ resource "aws_api_gateway_api_key" "mykey" {
 }
 
 resource "aws_api_gateway_usage_plan_key" "main" {
-  key_id        = "${aws_api_gateway_api_key.mykey.id}"
+  key_id        = aws_api_gateway_api_key.mykey.id
   key_type      = "API_KEY"
-  usage_plan_id = "${aws_api_gateway_usage_plan.myusageplan.id}"
+  usage_plan_id = aws_api_gateway_usage_plan.myusageplan.id
 }
 ```
 

--- a/website/docs/r/api_gateway_vpc_link.html.markdown
+++ b/website/docs/r/api_gateway_vpc_link.html.markdown
@@ -26,7 +26,7 @@ resource "aws_lb" "example" {
 resource "aws_api_gateway_vpc_link" "example" {
   name        = "example"
   description = "example description"
-  target_arns = ["${aws_lb.example.arn}"]
+  target_arns = [aws_lb.example.arn]
 }
 ```
 

--- a/website/docs/r/app_cookie_stickiness_policy.html.markdown
+++ b/website/docs/r/app_cookie_stickiness_policy.html.markdown
@@ -27,7 +27,7 @@ resource "aws_elb" "lb" {
 
 resource "aws_app_cookie_stickiness_policy" "foo" {
   name          = "foo_policy"
-  load_balancer = "${aws_elb.lb.name}"
+  load_balancer = aws_elb.lb.name
   lb_port       = 80
   cookie_name   = "MyAppCookie"
 }

--- a/website/docs/r/appautoscaling_policy.html.markdown
+++ b/website/docs/r/appautoscaling_policy.html.markdown
@@ -19,7 +19,7 @@ resource "aws_appautoscaling_target" "dynamodb_table_read_target" {
   max_capacity       = 100
   min_capacity       = 5
   resource_id        = "table/tableName"
-  role_arn           = "${data.aws_iam_role.DynamoDBAutoscaleRole.arn}"
+  role_arn           = data.aws_iam_role.DynamoDBAutoscaleRole.arn
   scalable_dimension = "dynamodb:table:ReadCapacityUnits"
   service_namespace  = "dynamodb"
 }
@@ -27,9 +27,9 @@ resource "aws_appautoscaling_target" "dynamodb_table_read_target" {
 resource "aws_appautoscaling_policy" "dynamodb_table_read_policy" {
   name               = "DynamoDBReadCapacityUtilization:${aws_appautoscaling_target.dynamodb_table_read_target.resource_id}"
   policy_type        = "TargetTrackingScaling"
-  resource_id        = "${aws_appautoscaling_target.dynamodb_table_read_target.resource_id}"
-  scalable_dimension = "${aws_appautoscaling_target.dynamodb_table_read_target.scalable_dimension}"
-  service_namespace  = "${aws_appautoscaling_target.dynamodb_table_read_target.service_namespace}"
+  resource_id        = aws_appautoscaling_target.dynamodb_table_read_target.resource_id
+  scalable_dimension = aws_appautoscaling_target.dynamodb_table_read_target.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.dynamodb_table_read_target.service_namespace
 
   target_tracking_scaling_policy_configuration {
     predefined_metric_specification {
@@ -48,7 +48,7 @@ resource "aws_appautoscaling_target" "ecs_target" {
   max_capacity       = 4
   min_capacity       = 1
   resource_id        = "service/clusterName/serviceName"
-  role_arn           = "${var.ecs_iam_role}"
+  role_arn           = var.ecs_iam_role
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"
 }
@@ -56,9 +56,9 @@ resource "aws_appautoscaling_target" "ecs_target" {
 resource "aws_appautoscaling_policy" "ecs_policy" {
   name               = "scale-down"
   policy_type        = "StepScaling"
-  resource_id        = "${aws_appautoscaling_target.ecs_target.resource_id}"
-  scalable_dimension = "${aws_appautoscaling_target.ecs_target.scalable_dimension}"
-  service_namespace  = "${aws_appautoscaling_target.ecs_target.service_namespace}"
+  resource_id        = aws_appautoscaling_target.ecs_target.resource_id
+  scalable_dimension = aws_appautoscaling_target.ecs_target.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.ecs_target.service_namespace
 
   step_scaling_policy_configuration {
     adjustment_type         = "ChangeInCapacity"
@@ -101,9 +101,9 @@ resource "aws_appautoscaling_target" "replicas" {
 
 resource "aws_appautoscaling_policy" "replicas" {
   name               = "cpu-auto-scaling"
-  service_namespace  = "${aws_appautoscaling_target.replicas.service_namespace}"
-  scalable_dimension = "${aws_appautoscaling_target.replicas.scalable_dimension}"
-  resource_id        = "${aws_appautoscaling_target.replicas.resource_id}"
+  service_namespace  = aws_appautoscaling_target.replicas.service_namespace
+  scalable_dimension = aws_appautoscaling_target.replicas.scalable_dimension
+  resource_id        = aws_appautoscaling_target.replicas.resource_id
   policy_type        = "TargetTrackingScaling"
 
   target_tracking_scaling_policy_configuration {

--- a/website/docs/r/appautoscaling_scheduled_action.html.markdown
+++ b/website/docs/r/appautoscaling_scheduled_action.html.markdown
@@ -19,16 +19,16 @@ resource "aws_appautoscaling_target" "dynamodb" {
   max_capacity       = 100
   min_capacity       = 5
   resource_id        = "table/tableName"
-  role_arn           = "${data.aws_iam_role.DynamoDBAutoscaleRole.arn}"
+  role_arn           = data.aws_iam_role.DynamoDBAutoscaleRole.arn
   scalable_dimension = "dynamodb:table:ReadCapacityUnits"
   service_namespace  = "dynamodb"
 }
 
 resource "aws_appautoscaling_scheduled_action" "dynamodb" {
   name               = "dynamodb"
-  service_namespace  = "${aws_appautoscaling_target.dynamodb.service_namespace}"
-  resource_id        = "${aws_appautoscaling_target.dynamodb.resource_id}"
-  scalable_dimension = "${aws_appautoscaling_target.dynamodb.scalable_dimension}"
+  service_namespace  = aws_appautoscaling_target.dynamodb.service_namespace
+  resource_id        = aws_appautoscaling_target.dynamodb.resource_id
+  scalable_dimension = aws_appautoscaling_target.dynamodb.scalable_dimension
   schedule           = "at(2006-01-02T15:04:05)"
 
   scalable_target_action {
@@ -45,16 +45,16 @@ resource "aws_appautoscaling_target" "ecs" {
   max_capacity       = 4
   min_capacity       = 1
   resource_id        = "service/clusterName/serviceName"
-  role_arn           = "${var.ecs_iam_role}"
+  role_arn           = var.ecs_iam_role
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"
 }
 
 resource "aws_appautoscaling_scheduled_action" "ecs" {
   name               = "ecs"
-  service_namespace  = "${aws_appautoscaling_target.ecs.service_namespace}"
-  resource_id        = "${aws_appautoscaling_target.ecs.resource_id}"
-  scalable_dimension = "${aws_appautoscaling_target.ecs.scalable_dimension}"
+  service_namespace  = aws_appautoscaling_target.ecs.service_namespace
+  resource_id        = aws_appautoscaling_target.ecs.resource_id
+  scalable_dimension = aws_appautoscaling_target.ecs.scalable_dimension
   schedule           = "at(2006-01-02T15:04:05)"
 
   scalable_target_action {

--- a/website/docs/r/appautoscaling_target.html.markdown
+++ b/website/docs/r/appautoscaling_target.html.markdown
@@ -19,7 +19,7 @@ resource "aws_appautoscaling_target" "dynamodb_table_read_target" {
   max_capacity       = 100
   min_capacity       = 5
   resource_id        = "table/${aws_dynamodb_table.example.name}"
-  role_arn           = "${data.aws_iam_role.DynamoDBAutoscaleRole.arn}"
+  role_arn           = data.aws_iam_role.DynamoDBAutoscaleRole.arn
   scalable_dimension = "dynamodb:table:ReadCapacityUnits"
   service_namespace  = "dynamodb"
 }
@@ -32,7 +32,7 @@ resource "aws_appautoscaling_target" "dynamodb_index_read_target" {
   max_capacity       = 100
   min_capacity       = 5
   resource_id        = "table/${aws_dynamodb_table.example.name}/index/${var.index_name}"
-  role_arn           = "${data.aws_iam_role.DynamoDBAutoscaleRole.arn}"
+  role_arn           = data.aws_iam_role.DynamoDBAutoscaleRole.arn
   scalable_dimension = "dynamodb:index:ReadCapacityUnits"
   service_namespace  = "dynamodb"
 }
@@ -45,7 +45,7 @@ resource "aws_appautoscaling_target" "ecs_target" {
   max_capacity       = 4
   min_capacity       = 1
   resource_id        = "service/${aws_ecs_cluster.example.name}/${aws_ecs_service.example.name}"
-  role_arn           = "${var.ecs_iam_role}"
+  role_arn           = var.ecs_iam_role
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"
 }

--- a/website/docs/r/appmesh_route.html.markdown
+++ b/website/docs/r/appmesh_route.html.markdown
@@ -17,8 +17,8 @@ Provides an AWS App Mesh route resource.
 ```hcl
 resource "aws_appmesh_route" "serviceb" {
   name                = "serviceB-route"
-  mesh_name           = "${aws_appmesh_mesh.simple.id}"
-  virtual_router_name = "${aws_appmesh_virtual_router.serviceb.name}"
+  mesh_name           = aws_appmesh_mesh.simple.id
+  virtual_router_name = aws_appmesh_virtual_router.serviceb.name
 
   spec {
     http_route {
@@ -28,12 +28,12 @@ resource "aws_appmesh_route" "serviceb" {
 
       action {
         weighted_target {
-          virtual_node = "${aws_appmesh_virtual_node.serviceb1.name}"
+          virtual_node = aws_appmesh_virtual_node.serviceb1.name
           weight       = 90
         }
 
         weighted_target {
-          virtual_node = "${aws_appmesh_virtual_node.serviceb2.name}"
+          virtual_node = aws_appmesh_virtual_node.serviceb2.name
           weight       = 10
         }
       }
@@ -47,8 +47,8 @@ resource "aws_appmesh_route" "serviceb" {
 ```hcl
 resource "aws_appmesh_route" "serviceb" {
   name                = "serviceB-route"
-  mesh_name           = "${aws_appmesh_mesh.simple.id}"
-  virtual_router_name = "${aws_appmesh_virtual_router.serviceb.name}"
+  mesh_name           = aws_appmesh_mesh.simple.id
+  virtual_router_name = aws_appmesh_virtual_router.serviceb.name
 
   spec {
     http_route {
@@ -68,7 +68,7 @@ resource "aws_appmesh_route" "serviceb" {
 
       action {
         weighted_target {
-          virtual_node = "${aws_appmesh_virtual_node.serviceb.name}"
+          virtual_node = aws_appmesh_virtual_node.serviceb.name
           weight       = 100
         }
       }
@@ -82,14 +82,14 @@ resource "aws_appmesh_route" "serviceb" {
 ```hcl
 resource "aws_appmesh_route" "serviceb" {
   name                = "serviceB-route"
-  mesh_name           = "${aws_appmesh_mesh.simple.id}"
-  virtual_router_name = "${aws_appmesh_virtual_router.serviceb.name}"
+  mesh_name           = aws_appmesh_mesh.simple.id
+  virtual_router_name = aws_appmesh_virtual_router.serviceb.name
 
   spec {
     tcp_route {
       action {
         weighted_target {
-          virtual_node = "${aws_appmesh_virtual_node.serviceb1.name}"
+          virtual_node = aws_appmesh_virtual_node.serviceb1.name
           weight       = 100
         }
       }

--- a/website/docs/r/appmesh_virtual_node.html.markdown
+++ b/website/docs/r/appmesh_virtual_node.html.markdown
@@ -28,7 +28,7 @@ The Terraform state associated with existing resources will automatically be mig
 ```hcl
 resource "aws_appmesh_virtual_node" "serviceb1" {
   name      = "serviceBv1"
-  mesh_name = "${aws_appmesh_mesh.simple.id}"
+  mesh_name = aws_appmesh_mesh.simple.id
 
   spec {
     backend {
@@ -62,7 +62,7 @@ resource "aws_service_discovery_http_namespace" "example" {
 
 resource "aws_appmesh_virtual_node" "serviceb1" {
   name      = "serviceBv1"
-  mesh_name = "${aws_appmesh_mesh.simple.id}"
+  mesh_name = aws_appmesh_mesh.simple.id
 
   spec {
     backend {
@@ -85,7 +85,7 @@ resource "aws_appmesh_virtual_node" "serviceb1" {
         }
 
         service_name   = "serviceb1"
-        namespace_name = "${aws_service_discovery_http_namespace.example.name}"
+        namespace_name = aws_service_discovery_http_namespace.example.name
       }
     }
   }
@@ -97,7 +97,7 @@ resource "aws_appmesh_virtual_node" "serviceb1" {
 ```hcl
 resource "aws_appmesh_virtual_node" "serviceb1" {
   name      = "serviceBv1"
-  mesh_name = "${aws_appmesh_mesh.simple.id}"
+  mesh_name = aws_appmesh_mesh.simple.id
 
   spec {
     backend {
@@ -136,7 +136,7 @@ resource "aws_appmesh_virtual_node" "serviceb1" {
 ```hcl
 resource "aws_appmesh_virtual_node" "serviceb1" {
   name      = "serviceBv1"
-  mesh_name = "${aws_appmesh_mesh.simple.id}"
+  mesh_name = aws_appmesh_mesh.simple.id
 
   spec {
     backend {

--- a/website/docs/r/appmesh_virtual_router.html.markdown
+++ b/website/docs/r/appmesh_virtual_router.html.markdown
@@ -27,7 +27,7 @@ The Terraform state associated with existing resources will automatically be mig
 ```hcl
 resource "aws_appmesh_virtual_router" "serviceb" {
   name      = "serviceB"
-  mesh_name = "${aws_appmesh_mesh.simple.id}"
+  mesh_name = aws_appmesh_mesh.simple.id
 
   spec {
     listener {

--- a/website/docs/r/appmesh_virtual_service.html.markdown
+++ b/website/docs/r/appmesh_virtual_service.html.markdown
@@ -17,12 +17,12 @@ Provides an AWS App Mesh virtual service resource.
 ```hcl
 resource "aws_appmesh_virtual_service" "servicea" {
   name      = "servicea.simpleapp.local"
-  mesh_name = "${aws_appmesh_mesh.simple.id}"
+  mesh_name = aws_appmesh_mesh.simple.id
 
   spec {
     provider {
       virtual_node {
-        virtual_node_name = "${aws_appmesh_virtual_node.serviceb1.name}"
+        virtual_node_name = aws_appmesh_virtual_node.serviceb1.name
       }
     }
   }
@@ -34,12 +34,12 @@ resource "aws_appmesh_virtual_service" "servicea" {
 ```hcl
 resource "aws_appmesh_virtual_service" "servicea" {
   name      = "servicea.simpleapp.local"
-  mesh_name = "${aws_appmesh_mesh.simple.id}"
+  mesh_name = aws_appmesh_mesh.simple.id
 
   spec {
     provider {
       virtual_router {
-        virtual_router_name = "${aws_appmesh_virtual_router.serviceb.name}"
+        virtual_router_name = aws_appmesh_virtual_router.serviceb.name
       }
     }
   }

--- a/website/docs/r/appsync_api_key.html.markdown
+++ b/website/docs/r/appsync_api_key.html.markdown
@@ -19,7 +19,7 @@ resource "aws_appsync_graphql_api" "example" {
 }
 
 resource "aws_appsync_api_key" "example" {
-  api_id  = "${aws_appsync_graphql_api.example.id}"
+  api_id  = aws_appsync_graphql_api.example.id
   expires = "2018-05-03T04:00:00Z"
 }
 ```

--- a/website/docs/r/appsync_datasource.html.markdown
+++ b/website/docs/r/appsync_datasource.html.markdown
@@ -46,7 +46,7 @@ EOF
 
 resource "aws_iam_role_policy" "example" {
   name = "example"
-  role = "${aws_iam_role.example.id}"
+  role = aws_iam_role.example.id
 
   policy = <<EOF
 {
@@ -72,13 +72,13 @@ resource "aws_appsync_graphql_api" "example" {
 }
 
 resource "aws_appsync_datasource" "example" {
-  api_id           = "${aws_appsync_graphql_api.example.id}"
+  api_id           = aws_appsync_graphql_api.example.id
   name             = "tf_appsync_example"
-  service_role_arn = "${aws_iam_role.example.arn}"
+  service_role_arn = aws_iam_role.example.arn
   type             = "AMAZON_DYNAMODB"
 
   dynamodb_config {
-    table_name = "${aws_dynamodb_table.example.name}"
+    table_name = aws_dynamodb_table.example.name
   }
 }
 ```

--- a/website/docs/r/appsync_datasource.html.markdown
+++ b/website/docs/r/appsync_datasource.html.markdown
@@ -28,42 +28,38 @@ resource "aws_dynamodb_table" "example" {
 resource "aws_iam_role" "example" {
   name = "example"
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "appsync.amazonaws.com"
-      },
-      "Effect": "Allow"
-    }
-  ]
-}
-EOF
+  assume_role_policy = jsonencode({
+    "Version" = "2012-10-17"
+    "Statement" = [
+      {
+        "Action" = "sts:AssumeRole"
+        "Principal" = {
+          "Service" = "appsync.amazonaws.com"
+        }
+        "Effect" = "Allow"
+      }
+    ]
+  })
 }
 
 resource "aws_iam_role_policy" "example" {
   name = "example"
   role = aws_iam_role.example.id
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "dynamodb:*"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "${aws_dynamodb_table.example.arn}"
-      ]
-    }
-  ]
-}
-EOF
+  policy = jsonencode({
+    "Version" = "2012-10-17"
+    "Statement" = [
+      {
+        "Action" = [
+          "dynamodb:*"
+        ]
+        "Effect" = "Allow"
+        "Resource" = [
+          aws_dynamodb_table.example.arn
+        ]
+      }
+    ]
+  })
 }
 
 resource "aws_appsync_graphql_api" "example" {

--- a/website/docs/r/appsync_function.html.markdown
+++ b/website/docs/r/appsync_function.html.markdown
@@ -38,7 +38,7 @@ EOF
 }
 
 resource "aws_appsync_datasource" "test" {
-  api_id = "${aws_appsync_graphql_api.test.id}"
+  api_id = aws_appsync_graphql_api.test.id
   name   = "tf-example"
   type   = "HTTP"
 
@@ -48,8 +48,8 @@ resource "aws_appsync_datasource" "test" {
 }
 
 resource "aws_appsync_function" "test" {
-  api_id                    = "${aws_appsync_graphql_api.test.id}"
-  data_source               = "${aws_appsync_datasource.test.name}"
+  api_id                    = aws_appsync_graphql_api.test.id
+  data_source               = aws_appsync_datasource.test.name
   name                      = "tf_example"
   request_mapping_template  = <<EOF
 {

--- a/website/docs/r/appsync_graphql_api.html.markdown
+++ b/website/docs/r/appsync_graphql_api.html.markdown
@@ -29,9 +29,9 @@ resource "aws_appsync_graphql_api" "example" {
   name                = "example"
 
   user_pool_config {
-    aws_region     = "${data.aws_region.current.name}"
+    aws_region     = data.aws_region.current.name
     default_action = "DENY"
-    user_pool_id   = "${aws_cognito_user_pool.example.id}"
+    user_pool_id   = aws_cognito_user_pool.example.id
   }
 }
 ```
@@ -113,14 +113,14 @@ POLICY
 
 resource "aws_iam_role_policy_attachment" "example" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSAppSyncPushToCloudWatchLogs"
-  role       = "${aws_iam_role.example.name}"
+  role       = aws_iam_role.example.name
 }
 
 resource "aws_appsync_graphql_api" "example" {
   # ... other configuration ...
 
   log_config {
-    cloudwatch_logs_role_arn = "${aws_iam_role.example.arn}"
+    cloudwatch_logs_role_arn = aws_iam_role.example.arn
     field_log_level          = "ERROR"
   }
 }

--- a/website/docs/r/appsync_resolver.html.markdown
+++ b/website/docs/r/appsync_resolver.html.markdown
@@ -39,7 +39,7 @@ EOF
 }
 
 resource "aws_appsync_datasource" "test" {
-  api_id = "${aws_appsync_graphql_api.test.id}"
+  api_id = aws_appsync_graphql_api.test.id
   name   = "tf_example"
   type   = "HTTP"
 
@@ -50,10 +50,10 @@ resource "aws_appsync_datasource" "test" {
 
 # UNIT type resolver (default)
 resource "aws_appsync_resolver" "test" {
-  api_id      = "${aws_appsync_graphql_api.test.id}"
+  api_id      = aws_appsync_graphql_api.test.id
   field       = "singlePost"
   type        = "Query"
-  data_source = "${aws_appsync_datasource.test.name}"
+  data_source = aws_appsync_datasource.test.name
 
   request_template = <<EOF
 {
@@ -78,16 +78,16 @@ EOF
 # PIPELINE type resolver
 resource "aws_appsync_resolver" "Mutation_pipelineTest" {
   type              = "Mutation"
-  api_id            = "${aws_appsync_graphql_api.test.id}"
+  api_id            = aws_appsync_graphql_api.test.id
   field             = "pipelineTest"
   request_template  = "{}"
   response_template = "$util.toJson($ctx.result)"
   kind              = "PIPELINE"
   pipeline_config {
     functions = [
-      "${aws_appsync_function.test1.function_id}",
-      "${aws_appsync_function.test2.function_id}",
-      "${aws_appsync_function.test3.function_id}"
+      aws_appsync_function.test1.function_id,
+      aws_appsync_function.test2.function_id,
+      aws_appsync_function.test3.function_id
     ]
   }
 }

--- a/website/docs/r/athena_database.html.markdown
+++ b/website/docs/r/athena_database.html.markdown
@@ -19,7 +19,7 @@ resource "aws_s3_bucket" "hoge" {
 
 resource "aws_athena_database" "hoge" {
   name   = "database_name"
-  bucket = "${aws_s3_bucket.hoge.bucket}"
+  bucket = aws_s3_bucket.hoge.bucket
 }
 ```
 

--- a/website/docs/r/athena_named_query.html.markdown
+++ b/website/docs/r/athena_named_query.html.markdown
@@ -29,7 +29,7 @@ resource "aws_athena_workgroup" "test" {
     result_configuration {
       encryption_configuration {
         encryption_option = "SSE_KMS"
-        kms_key_arn       = "${aws_kms_key.test.arn}"
+        kms_key_arn       = aws_kms_key.test.arn
       }
     }
   }
@@ -37,13 +37,13 @@ resource "aws_athena_workgroup" "test" {
 
 resource "aws_athena_database" "hoge" {
   name   = "users"
-  bucket = "${aws_s3_bucket.hoge.id}"
+  bucket = aws_s3_bucket.hoge.id
 }
 
 resource "aws_athena_named_query" "foo" {
   name      = "bar"
-  workgroup = "${aws_athena_workgroup.test.id}"
-  database  = "${aws_athena_database.hoge.name}"
+  workgroup = aws_athena_workgroup.test.id
+  database  = aws_athena_database.hoge.name
   query     = "SELECT * FROM ${aws_athena_database.hoge.name} limit 10;"
 }
 ```

--- a/website/docs/r/athena_workgroup.html.markdown
+++ b/website/docs/r/athena_workgroup.html.markdown
@@ -25,7 +25,7 @@ resource "aws_athena_workgroup" "example" {
 
       encryption_configuration {
         encryption_option = "SSE_KMS"
-        kms_key_arn       = "${aws_kms_key.example.arn}"
+        kms_key_arn       = aws_kms_key.example.arn
       }
     }
   }

--- a/website/docs/r/autoscaling_attachment.html.markdown
+++ b/website/docs/r/autoscaling_attachment.html.markdown
@@ -22,16 +22,16 @@ conflict and will overwrite attachments.
 ```hcl
 # Create a new load balancer attachment
 resource "aws_autoscaling_attachment" "asg_attachment_bar" {
-  autoscaling_group_name = "${aws_autoscaling_group.asg.id}"
-  elb                    = "${aws_elb.bar.id}"
+  autoscaling_group_name = aws_autoscaling_group.asg.id
+  elb                    = aws_elb.bar.id
 }
 ```
 
 ```hcl
 # Create a new ALB Target Group attachment
 resource "aws_autoscaling_attachment" "asg_attachment_bar" {
-  autoscaling_group_name = "${aws_autoscaling_group.asg.id}"
-  alb_target_group_arn   = "${aws_alb_target_group.test.arn}"
+  autoscaling_group_name = aws_autoscaling_group.asg.id
+  alb_target_group_arn   = aws_alb_target_group.test.arn
 }
 ```
 

--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -28,9 +28,9 @@ resource "aws_autoscaling_group" "bar" {
   health_check_type         = "ELB"
   desired_capacity          = 4
   force_delete              = true
-  placement_group           = "${aws_placement_group.test.id}"
-  launch_configuration      = "${aws_launch_configuration.foobar.name}"
-  vpc_zone_identifier       = ["${aws_subnet.example1.id}", "${aws_subnet.example2.id}"]
+  placement_group           = aws_placement_group.test.id
+  launch_configuration      = aws_launch_configuration.foobar.name
+  vpc_zone_identifier       = [aws_subnet.example1.id, aws_subnet.example2.id]
 
   initial_lifecycle_hook {
     name                 = "foobar"
@@ -82,7 +82,7 @@ resource "aws_autoscaling_group" "bar" {
   min_size           = 1
 
   launch_template {
-    id      = "${aws_launch_template.foobar.id}"
+    id      = aws_launch_template.foobar.id
     version = "$Latest"
   }
 }
@@ -93,7 +93,7 @@ resource "aws_autoscaling_group" "bar" {
 ```hcl
 resource "aws_launch_template" "example" {
   name_prefix   = "example"
-  image_id      = "${data.aws_ami.example.id}"
+  image_id      = data.aws_ami.example.id
   instance_type = "c5.large"
 }
 
@@ -106,7 +106,7 @@ resource "aws_autoscaling_group" "example" {
   mixed_instances_policy {
     launch_template {
       launch_template_specification {
-        launch_template_id = "${aws_launch_template.example.id}"
+        launch_template_id = aws_launch_template.example.id
       }
 
       override {
@@ -145,16 +145,16 @@ resource "aws_autoscaling_group" "bar" {
   name                 = "foobar3-terraform-test"
   max_size             = 5
   min_size             = 2
-  launch_configuration = "${aws_launch_configuration.foobar.name}"
-  vpc_zone_identifier  = ["${aws_subnet.example1.id}", "${aws_subnet.example2.id}"]
+  launch_configuration = aws_launch_configuration.foobar.name
+  vpc_zone_identifier  = [aws_subnet.example1.id, aws_subnet.example2.id]
 
-  tags = ["${concat(
+  tags = [concat(
     list(
       map("key", "interpolation1", "value", "value3", "propagate_at_launch", true),
       map("key", "interpolation2", "value", "value4", "propagate_at_launch", true)
     ),
     var.extra_tags)
-  }"]
+  ]
 }
 ```
 

--- a/website/docs/r/autoscaling_lifecycle_hook.html.markdown
+++ b/website/docs/r/autoscaling_lifecycle_hook.html.markdown
@@ -40,7 +40,7 @@ resource "aws_autoscaling_group" "foobar" {
 
 resource "aws_autoscaling_lifecycle_hook" "foobar" {
   name                   = "foobar"
-  autoscaling_group_name = "${aws_autoscaling_group.foobar.name}"
+  autoscaling_group_name = aws_autoscaling_group.foobar.name
   default_result         = "CONTINUE"
   heartbeat_timeout      = 2000
   lifecycle_transition   = "autoscaling:EC2_INSTANCE_LAUNCHING"

--- a/website/docs/r/autoscaling_notification.html.markdown
+++ b/website/docs/r/autoscaling_notification.html.markdown
@@ -19,8 +19,8 @@ Basic usage:
 ```hcl
 resource "aws_autoscaling_notification" "example_notifications" {
   group_names = [
-    "${aws_autoscaling_group.bar.name}",
-    "${aws_autoscaling_group.foo.name}",
+    aws_autoscaling_group.bar.name,
+    aws_autoscaling_group.foo.name,
   ]
 
   notifications = [
@@ -30,7 +30,7 @@ resource "aws_autoscaling_notification" "example_notifications" {
     "autoscaling:EC2_INSTANCE_TERMINATE_ERROR",
   ]
 
-  topic_arn = "${aws_sns_topic.example.arn}"
+  topic_arn = aws_sns_topic.example.arn
 }
 
 resource "aws_sns_topic" "example" {

--- a/website/docs/r/autoscaling_policy.html.markdown
+++ b/website/docs/r/autoscaling_policy.html.markdown
@@ -24,7 +24,7 @@ resource "aws_autoscaling_policy" "bat" {
   scaling_adjustment     = 4
   adjustment_type        = "ChangeInCapacity"
   cooldown               = 300
-  autoscaling_group_name = "${aws_autoscaling_group.bar.name}"
+  autoscaling_group_name = aws_autoscaling_group.bar.name
 }
 
 resource "aws_autoscaling_group" "bar" {
@@ -35,7 +35,7 @@ resource "aws_autoscaling_group" "bar" {
   health_check_grace_period = 300
   health_check_type         = "ELB"
   force_delete              = true
-  launch_configuration      = "${aws_launch_configuration.foo.name}"
+  launch_configuration      = aws_launch_configuration.foo.name
 }
 ```
 

--- a/website/docs/r/autoscaling_schedule.html.markdown
+++ b/website/docs/r/autoscaling_schedule.html.markdown
@@ -31,7 +31,7 @@ resource "aws_autoscaling_schedule" "foobar" {
   desired_capacity       = 0
   start_time             = "2016-12-11T18:00:00Z"
   end_time               = "2016-12-12T06:00:00Z"
-  autoscaling_group_name = "${aws_autoscaling_group.foobar.name}"
+  autoscaling_group_name = aws_autoscaling_group.foobar.name
 }
 ```
 

--- a/website/docs/r/backup_plan.html.markdown
+++ b/website/docs/r/backup_plan.html.markdown
@@ -18,7 +18,7 @@ resource "aws_backup_plan" "example" {
 
   rule {
     rule_name         = "tf_example_backup_rule"
-    target_vault_name = "${aws_backup_vault.test.name}"
+    target_vault_name = aws_backup_vault.test.name
     schedule          = "cron(0 12 * * ? *)"
   }
 }

--- a/website/docs/r/backup_selection.html.markdown
+++ b/website/docs/r/backup_selection.html.markdown
@@ -39,13 +39,13 @@ POLICY
 
 resource "aws_iam_role_policy_attachment" "example" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
-  role       = "${aws_iam_role.example.name}"
+  role       = aws_iam_role.example.name
 }
 
 resource "aws_backup_selection" "example" {
   # ... other configuration ...
 
-  iam_role_arn = "${aws_iam_role.example.arn}"
+  iam_role_arn = aws_iam_role.example.arn
 }
 ```
 
@@ -53,9 +53,9 @@ resource "aws_backup_selection" "example" {
 
 ```hcl
 resource "aws_backup_selection" "example" {
-  iam_role_arn = "${aws_iam_role.example.arn}"
+  iam_role_arn = aws_iam_role.example.arn
   name         = "tf_example_backup_selection"
-  plan_id      = "${aws_backup_plan.example.id}"
+  plan_id      = aws_backup_plan.example.id
 
   selection_tag {
     type  = "STRINGEQUALS"
@@ -69,14 +69,14 @@ resource "aws_backup_selection" "example" {
 
 ```hcl
 resource "aws_backup_selection" "example" {
-  iam_role_arn = "${aws_iam_role.example.arn}"
+  iam_role_arn = aws_iam_role.example.arn
   name         = "tf_example_backup_selection"
-  plan_id      = "${aws_backup_plan.example.id}"
+  plan_id      = aws_backup_plan.example.id
 
   resources = [
-    "${aws_db_instance.example.arn}",
-    "${aws_ebs_volume.example.arn}",
-    "${aws_efs_file_system.example.arn}",
+    aws_db_instance.example.arn,
+    aws_ebs_volume.example.arn,
+    aws_efs_file_system.example.arn,
   ]
 }
 ```

--- a/website/docs/r/backup_vault.html.markdown
+++ b/website/docs/r/backup_vault.html.markdown
@@ -15,7 +15,7 @@ Provides an AWS Backup vault resource.
 ```hcl
 resource "aws_backup_vault" "example" {
   name        = "example_backup_vault"
-  kms_key_arn = "${aws_kms_key.example.arn}"
+  kms_key_arn = aws_kms_key.example.arn
 }
 ```
 

--- a/website/docs/r/batch_compute_environment.html.markdown
+++ b/website/docs/r/batch_compute_environment.html.markdown
@@ -39,13 +39,13 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "ecs_instance_role" {
-  role       = "${aws_iam_role.ecs_instance_role.name}"
+  role       = aws_iam_role.ecs_instance_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
 }
 
 resource "aws_iam_instance_profile" "ecs_instance_role" {
   name = "ecs_instance_role"
-  role = "${aws_iam_role.ecs_instance_role.name}"
+  role = aws_iam_role.ecs_instance_role.name
 }
 
 resource "aws_iam_role" "aws_batch_service_role" {
@@ -68,7 +68,7 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "aws_batch_service_role" {
-  role       = "${aws_iam_role.aws_batch_service_role.name}"
+  role       = aws_iam_role.aws_batch_service_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"
 }
 
@@ -88,7 +88,7 @@ resource "aws_vpc" "sample" {
 }
 
 resource "aws_subnet" "sample" {
-  vpc_id     = "${aws_vpc.sample.id}"
+  vpc_id     = aws_vpc.sample.id
   cidr_block = "10.1.1.0/24"
 }
 
@@ -96,7 +96,7 @@ resource "aws_batch_compute_environment" "sample" {
   compute_environment_name = "sample"
 
   compute_resources {
-    instance_role = "${aws_iam_instance_profile.ecs_instance_role.arn}"
+    instance_role = aws_iam_instance_profile.ecs_instance_role.arn
 
     instance_type = [
       "c4.large",
@@ -106,17 +106,17 @@ resource "aws_batch_compute_environment" "sample" {
     min_vcpus = 0
 
     security_group_ids = [
-      "${aws_security_group.sample.id}",
+      aws_security_group.sample.id,
     ]
 
     subnets = [
-      "${aws_subnet.sample.id}",
+      aws_subnet.sample.id,
     ]
 
     type = "EC2"
   }
 
-  service_role = "${aws_iam_role.aws_batch_service_role.arn}"
+  service_role = aws_iam_role.aws_batch_service_role.arn
   type         = "MANAGED"
   depends_on   = ["aws_iam_role_policy_attachment.aws_batch_service_role"]
 }

--- a/website/docs/r/batch_job_queue.html.markdown
+++ b/website/docs/r/batch_job_queue.html.markdown
@@ -17,7 +17,7 @@ resource "aws_batch_job_queue" "test_queue" {
   name                 = "tf-test-batch-job-queue"
   state                = "ENABLED"
   priority             = 1
-  compute_environments = ["${aws_batch_compute_environment.test_environment_1.arn}", "${aws_batch_compute_environment.test_environment_2.arn}"]
+  compute_environments = [aws_batch_compute_environment.test_environment_1.arn, aws_batch_compute_environment.test_environment_2.arn]
 }
 ```
 

--- a/website/docs/r/cloudformation_stack_set.html.markdown
+++ b/website/docs/r/cloudformation_stack_set.html.markdown
@@ -30,12 +30,12 @@ data "aws_iam_policy_document" "AWSCloudFormationStackSetAdministrationRole_assu
 }
 
 resource "aws_iam_role" "AWSCloudFormationStackSetAdministrationRole" {
-  assume_role_policy = "${data.aws_iam_policy_document.AWSCloudFormationStackSetAdministrationRole_assume_role_policy.json}"
+  assume_role_policy = data.aws_iam_policy_document.AWSCloudFormationStackSetAdministrationRole_assume_role_policy.json
   name               = "AWSCloudFormationStackSetAdministrationRole"
 }
 
 resource "aws_cloudformation_stack_set" "example" {
-  administration_role_arn = "${aws_iam_role.AWSCloudFormationStackSetAdministrationRole.arn}"
+  administration_role_arn = aws_iam_role.AWSCloudFormationStackSetAdministrationRole.arn
   name                    = "example"
 
   parameters = {
@@ -76,8 +76,8 @@ data "aws_iam_policy_document" "AWSCloudFormationStackSetAdministrationRole_Exec
 
 resource "aws_iam_role_policy" "AWSCloudFormationStackSetAdministrationRole_ExecutionPolicy" {
   name   = "ExecutionPolicy"
-  policy = "${data.aws_iam_policy_document.AWSCloudFormationStackSetAdministrationRole_ExecutionPolicy.json}"
-  role   = "${aws_iam_role.AWSCloudFormationStackSetAdministrationRole.name}"
+  policy = data.aws_iam_policy_document.AWSCloudFormationStackSetAdministrationRole_ExecutionPolicy.json
+  role   = aws_iam_role.AWSCloudFormationStackSetAdministrationRole.name
 }
 ```
 

--- a/website/docs/r/cloudformation_stack_set_instance.html.markdown
+++ b/website/docs/r/cloudformation_stack_set_instance.html.markdown
@@ -20,7 +20,7 @@ Manages a CloudFormation StackSet Instance. Instances are managed in the account
 resource "aws_cloudformation_stack_set_instance" "example" {
   account_id     = "123456789012"
   region         = "us-east-1"
-  stack_set_name = "${aws_cloudformation_stack_set.example.name}"
+  stack_set_name = aws_cloudformation_stack_set.example.name
 }
 ```
 
@@ -33,14 +33,14 @@ data "aws_iam_policy_document" "AWSCloudFormationStackSetExecutionRole_assume_ro
     effect  = "Allow"
 
     principals {
-      identifiers = ["${aws_iam_role.AWSCloudFormationStackSetAdministrationRole.arn}"]
+      identifiers = [aws_iam_role.AWSCloudFormationStackSetAdministrationRole.arn]
       type        = "AWS"
     }
   }
 }
 
 resource "aws_iam_role" "AWSCloudFormationStackSetExecutionRole" {
-  assume_role_policy = "${data.aws_iam_policy_document.AWSCloudFormationStackSetExecutionRole_assume_role_policy.json}"
+  assume_role_policy = data.aws_iam_policy_document.AWSCloudFormationStackSetExecutionRole_assume_role_policy.json
   name               = "AWSCloudFormationStackSetExecutionRole"
 }
 
@@ -61,8 +61,8 @@ data "aws_iam_policy_document" "AWSCloudFormationStackSetExecutionRole_MinimumEx
 
 resource "aws_iam_role_policy" "AWSCloudFormationStackSetExecutionRole_MinimumExecutionPolicy" {
   name   = "MinimumExecutionPolicy"
-  policy = "${data.aws_iam_policy_document.AWSCloudFormationStackSetExecutionRole_MinimumExecutionPolicy.json}"
-  role   = "${aws_iam_role.AWSCloudFormationStackSetExecutionRole.name}"
+  policy = data.aws_iam_policy_document.AWSCloudFormationStackSetExecutionRole_MinimumExecutionPolicy.json
+  role   = aws_iam_role.AWSCloudFormationStackSetExecutionRole.name
 }
 ```
 

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -40,8 +40,8 @@ locals {
 
 resource "aws_cloudfront_distribution" "s3_distribution" {
   origin {
-    domain_name = "${aws_s3_bucket.b.bucket_regional_domain_name}"
-    origin_id   = "${local.s3_origin_id}"
+    domain_name = aws_s3_bucket.b.bucket_regional_domain_name
+    origin_id   = local.s3_origin_id
 
     s3_origin_config {
       origin_access_identity = "origin-access-identity/cloudfront/ABCDEFG1234567"
@@ -64,7 +64,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
   default_cache_behavior {
     allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
     cached_methods   = ["GET", "HEAD"]
-    target_origin_id = "${local.s3_origin_id}"
+    target_origin_id = local.s3_origin_id
 
     forwarded_values {
       query_string = false
@@ -85,7 +85,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     path_pattern     = "/content/immutable/*"
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
-    target_origin_id = "${local.s3_origin_id}"
+    target_origin_id = local.s3_origin_id
 
     forwarded_values {
       query_string = false
@@ -108,7 +108,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     path_pattern     = "/content/*"
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]
     cached_methods   = ["GET", "HEAD"]
-    target_origin_id = "${local.s3_origin_id}"
+    target_origin_id = local.s3_origin_id
 
     forwarded_values {
       query_string = false
@@ -165,20 +165,20 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
   }
 
   origin {
-    domain_name = "${aws_s3_bucket.primary.bucket_regional_domain_name}"
+    domain_name = aws_s3_bucket.primary.bucket_regional_domain_name
     origin_id   = "primaryS3"
 
     s3_origin_config {
-      origin_access_identity = "${aws_cloudfront_origin_access_identity.default.cloudfront_access_identity_path}"
+      origin_access_identity = aws_cloudfront_origin_access_identity.default.cloudfront_access_identity_path
     }
   }
 
   origin {
-    domain_name = "${aws_s3_bucket.failover.bucket_regional_domain_name}"
+    domain_name = aws_s3_bucket.failover.bucket_regional_domain_name
     origin_id   = "failoverS3"
 
     s3_origin_config {
-      origin_access_identity = "${aws_cloudfront_origin_access_identity.default.cloudfront_access_identity_path}"
+      origin_access_identity = aws_cloudfront_origin_access_identity.default.cloudfront_access_identity_path
     }
   }
 
@@ -351,7 +351,7 @@ resource "aws_cloudfront_distribution" "example" {
 
     lambda_function_association {
       event_type   = "viewer-request"
-      lambda_arn   = "${aws_lambda_function.example.qualified_arn}"
+      lambda_arn   = aws_lambda_function.example.qualified_arn
       include_body = false
     }
   }

--- a/website/docs/r/cloudfront_origin_access_identity.html.markdown
+++ b/website/docs/r/cloudfront_origin_access_identity.html.markdown
@@ -57,7 +57,7 @@ The below snippet demonstrates use with the `s3_origin_config` structure for the
 
 ```hcl
 s3_origin_config {
-  origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
+  origin_access_identity = aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path
 }
 ```
 
@@ -76,24 +76,24 @@ data "aws_iam_policy_document" "s3_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = ["${aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn}"]
+      identifiers = [aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn]
     }
   }
 
   statement {
     actions   = ["s3:ListBucket"]
-    resources = ["${aws_s3_bucket.example.arn}"]
+    resources = [aws_s3_bucket.example.arn]
 
     principals {
       type        = "AWS"
-      identifiers = ["${aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn}"]
+      identifiers = [aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn]
     }
   }
 }
 
 resource "aws_s3_bucket_policy" "example" {
-  bucket = "${aws_s3_bucket.example.id}"
-  policy = "${data.aws_iam_policy_document.s3_policy.json}"
+  bucket = aws_s3_bucket.example.id
+  policy = data.aws_iam_policy_document.s3_policy.json
 }
 ```
 

--- a/website/docs/r/cloudfront_public_key.html.markdown
+++ b/website/docs/r/cloudfront_public_key.html.markdown
@@ -15,7 +15,7 @@ The following example below creates a CloudFront public key.
 ```hcl
 resource "aws_cloudfront_public_key" "example" {
   comment     = "test public key"
-  encoded_key = "${file("public_key.pem")}"
+  encoded_key = file("public_key.pem")
   name        = "test_key"
 }
 ```

--- a/website/docs/r/cloudhsm_v2_cluster.html.markdown
+++ b/website/docs/r/cloudhsm_v2_cluster.html.markdown
@@ -25,7 +25,7 @@ The following example below creates a CloudHSM cluster.
 
 ```hcl
 provider "aws" {
-  region = "${var.aws_region}"
+  region = var.aws_region
 }
 
 data "aws_availability_zones" "available" {}
@@ -40,10 +40,10 @@ resource "aws_vpc" "cloudhsm_v2_vpc" {
 
 resource "aws_subnet" "cloudhsm_v2_subnets" {
   count                   = 2
-  vpc_id                  = "${aws_vpc.cloudhsm_v2_vpc.id}"
-  cidr_block              = "${element(var.subnets, count.index)}"
+  vpc_id                  = aws_vpc.cloudhsm_v2_vpc.id
+  cidr_block              = element(var.subnets, count.index)
   map_public_ip_on_launch = false
-  availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
+  availability_zone       = element(data.aws_availability_zones.available.names, count.index)
 
   tags = {
     Name = "example-aws_cloudhsm_v2_cluster"
@@ -52,7 +52,7 @@ resource "aws_subnet" "cloudhsm_v2_subnets" {
 
 resource "aws_cloudhsm_v2_cluster" "cloudhsm_v2_cluster" {
   hsm_type   = "hsm1.medium"
-  subnet_ids = ["${aws_subnet.cloudhsm_v2_subnets.*.id}"]
+  subnet_ids = [aws_subnet.cloudhsm_v2_subnets.*.id]
 
   tags = {
     Name = "example-aws_cloudhsm_v2_cluster"

--- a/website/docs/r/cloudhsm_v2_hsm.html.markdown
+++ b/website/docs/r/cloudhsm_v2_hsm.html.markdown
@@ -16,12 +16,12 @@ The following example below creates an HSM module in CloudHSM cluster.
 
 ```hcl
 data "aws_cloudhsm_v2_cluster" "cluster" {
-  cluster_id = "${var.cloudhsm_cluster_id}"
+  cluster_id = var.cloudhsm_cluster_id
 }
 
 resource "aws_cloudhsm_v2_hsm" "cloudhsm_v2_hsm" {
-  subnet_id  = "${data.aws_cloudhsm_v2_cluster.cluster.subnet_ids[0]}"
-  cluster_id = "${data.aws_cloudhsm_v2_cluster.cluster.cluster_id}"
+  subnet_id  = data.aws_cloudhsm_v2_cluster.cluster.subnet_ids[0]
+  cluster_id = data.aws_cloudhsm_v2_cluster.cluster.cluster_id
 }
 ```
 

--- a/website/docs/r/cloudtrail.html.markdown
+++ b/website/docs/r/cloudtrail.html.markdown
@@ -26,7 +26,7 @@ data "aws_caller_identity" "current" {}
 
 resource "aws_cloudtrail" "foobar" {
   name                          = "tf-trail-foobar"
-  s3_bucket_name                = "${aws_s3_bucket.foo.id}"
+  s3_bucket_name                = aws_s3_bucket.foo.id
   s3_key_prefix                 = "prefix"
   include_global_service_events = false
 }

--- a/website/docs/r/cloudwatch_event_permission.html.markdown
+++ b/website/docs/r/cloudwatch_event_permission.html.markdown
@@ -31,7 +31,7 @@ resource "aws_cloudwatch_event_permission" "OrganizationAccess" {
   condition {
     key   = "aws:PrincipalOrgID"
     type  = "StringEquals"
-    value = "${aws_organizations_organization.example.id}"
+    value = aws_organizations_organization.example.id
   }
 }
 ```

--- a/website/docs/r/cloudwatch_event_rule.html.markdown
+++ b/website/docs/r/cloudwatch_event_rule.html.markdown
@@ -27,9 +27,9 @@ PATTERN
 }
 
 resource "aws_cloudwatch_event_target" "sns" {
-  rule      = "${aws_cloudwatch_event_rule.console.name}"
+  rule      = aws_cloudwatch_event_rule.console.name
   target_id = "SendToSNS"
-  arn       = "${aws_sns_topic.aws_logins.arn}"
+  arn       = aws_sns_topic.aws_logins.arn
 }
 
 resource "aws_sns_topic" "aws_logins" {
@@ -37,8 +37,8 @@ resource "aws_sns_topic" "aws_logins" {
 }
 
 resource "aws_sns_topic_policy" "default" {
-  arn    = "${aws_sns_topic.aws_logins.arn}"
-  policy = "${data.aws_iam_policy_document.sns_topic_policy.json}"
+  arn    = aws_sns_topic.aws_logins.arn
+  policy = data.aws_iam_policy_document.sns_topic_policy.json
 }
 
 data "aws_iam_policy_document" "sns_topic_policy" {
@@ -51,7 +51,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
       identifiers = ["events.amazonaws.com"]
     }
 
-    resources = ["${aws_sns_topic.aws_logins.arn}"]
+    resources = [aws_sns_topic.aws_logins.arn]
   }
 }
 ```

--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -15,8 +15,8 @@ Provides a CloudWatch Event Target resource.
 ```hcl
 resource "aws_cloudwatch_event_target" "yada" {
   target_id = "Yada"
-  rule      = "${aws_cloudwatch_event_rule.console.name}"
-  arn       = "${aws_kinesis_stream.test_stream.arn}"
+  rule      = aws_cloudwatch_event_rule.console.name
+  arn       = aws_kinesis_stream.test_stream.arn
 
   run_command_targets {
     key    = "tag:Name"
@@ -84,18 +84,18 @@ data "aws_iam_policy_document" "ssm_lifecycle" {
   statement {
     effect    = "Allow"
     actions   = ["ssm:SendCommand"]
-    resources = ["${aws_ssm_document.stop_instance.arn}"]
+    resources = [aws_ssm_document.stop_instance.arn]
   }
 }
 
 resource "aws_iam_role" "ssm_lifecycle" {
   name               = "SSMLifecycle"
-  assume_role_policy = "${data.aws_iam_policy_document.ssm_lifecycle_trust.json}"
+  assume_role_policy = data.aws_iam_policy_document.ssm_lifecycle_trust.json
 }
 
 resource "aws_iam_policy" "ssm_lifecycle" {
   name   = "SSMLifecycle"
-  policy = "${data.aws_iam_policy_document.ssm_lifecycle.json}"
+  policy = data.aws_iam_policy_document.ssm_lifecycle.json
 }
 
 resource "aws_ssm_document" "stop_instance" {
@@ -131,9 +131,9 @@ resource "aws_cloudwatch_event_rule" "stop_instances" {
 
 resource "aws_cloudwatch_event_target" "stop_instances" {
   target_id = "StopInstance"
-  arn       = "${aws_ssm_document.stop_instance.arn}"
-  rule      = "${aws_cloudwatch_event_rule.stop_instances.name}"
-  role_arn  = "${aws_iam_role.ssm_lifecycle.arn}"
+  arn       = aws_ssm_document.stop_instance.arn
+  rule      = aws_cloudwatch_event_rule.stop_instances.name
+  role_arn  = aws_iam_role.ssm_lifecycle.arn
 
   run_command_targets {
     key    = "tag:Terminate"
@@ -155,8 +155,8 @@ resource "aws_cloudwatch_event_target" "stop_instances" {
   target_id = "StopInstance"
   arn       = "arn:aws:ssm:${var.aws_region}::document/AWS-RunShellScript"
   input     = "{\"commands\":[\"halt\"]}"
-  rule      = "${aws_cloudwatch_event_rule.stop_instances.name}"
-  role_arn  = "${aws_iam_role.ssm_lifecycle.arn}"
+  rule      = aws_cloudwatch_event_rule.stop_instances.name
+  role_arn  = aws_iam_role.ssm_lifecycle.arn
 
   run_command_targets {
     key    = "tag:Terminate"
@@ -190,7 +190,7 @@ DOC
 
 resource "aws_iam_role_policy" "ecs_events_run_task_with_any_role" {
   name = "ecs_events_run_task_with_any_role"
-  role = "${aws_iam_role.ecs_events.id}"
+  role = aws_iam_role.ecs_events.id
 
   policy = <<DOC
 {
@@ -213,13 +213,13 @@ DOC
 
 resource "aws_cloudwatch_event_target" "ecs_scheduled_task" {
   target_id = "run-scheduled-task-every-hour"
-  arn       = "${aws_ecs_cluster.cluster_name.arn}"
-  rule      = "${aws_cloudwatch_event_rule.every_hour.name}"
-  role_arn  = "${aws_iam_role.ecs_events.arn}"
+  arn       = aws_ecs_cluster.cluster_name.arn
+  rule      = aws_cloudwatch_event_rule.every_hour.name
+  role_arn  = aws_iam_role.ecs_events.arn
 
   ecs_target {
     task_count          = 1
-    task_definition_arn = "${aws_ecs_task_definition.task_name.arn}"
+    task_definition_arn = aws_ecs_task_definition.task_name.arn
   }
 
   input = <<DOC

--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -33,19 +33,17 @@ resource "aws_cloudwatch_event_rule" "console" {
   name        = "capture-ec2-scaling-events"
   description = "Capture all EC2 scaling events"
 
-  event_pattern = <<PATTERN
-{
-  "source": [
-    "aws.autoscaling"
-  ],
-  "detail-type": [
-    "EC2 Instance Launch Successful",
-    "EC2 Instance Terminate Successful",
-    "EC2 Instance Launch Unsuccessful",
-    "EC2 Instance Terminate Unsuccessful"
-  ]
-}
-PATTERN
+  event_pattern = jsonencode({
+    "source" = [
+      "aws.autoscaling"
+    ]
+    "detail-type" = [
+      "EC2 Instance Launch Successful",
+      "EC2 Instance Terminate Successful",
+      "EC2 Instance Launch Unsuccessful",
+      "EC2 Instance Terminate Unsuccessful",
+    ]
+  })
 }
 
 resource "aws_kinesis_stream" "test_stream" {
@@ -102,25 +100,23 @@ resource "aws_ssm_document" "stop_instance" {
   name          = "stop_instance"
   document_type = "Command"
 
-  content = <<DOC
-  {
-    "schemaVersion": "1.2",
-    "description": "Stop an instance",
-    "parameters": {
+  content = jsonencode({
+    "schemaVersion" = "1.2"
+    "description"   = "Stop an instance"
+    "parameters" = {
 
-    },
-    "runtimeConfig": {
-      "aws:runShellScript": {
-        "properties": [
+    }
+    "runtimeConfig" = {
+      "aws:runShellScript" = {
+        "properties" = [
           {
-            "id": "0.aws:runShellScript",
-            "runCommand": ["halt"]
+            "id"         = "0.aws:runShellScript"
+            "runCommand" = ["halt"]
           }
         ]
       }
     }
-  }
-DOC
+  })
 }
 
 resource "aws_cloudwatch_event_rule" "stop_instances" {
@@ -154,7 +150,7 @@ resource "aws_cloudwatch_event_rule" "stop_instances" {
 resource "aws_cloudwatch_event_target" "stop_instances" {
   target_id = "StopInstance"
   arn       = "arn:aws:ssm:${var.aws_region}::document/AWS-RunShellScript"
-  input     = "{\"commands\":[\"halt\"]}"
+  input     = jsonencode({ commands = ["halt"] })
   rule      = aws_cloudwatch_event_rule.stop_instances.name
   role_arn  = aws_iam_role.ssm_lifecycle.arn
 
@@ -171,44 +167,40 @@ resource "aws_cloudwatch_event_target" "stop_instances" {
 resource "aws_iam_role" "ecs_events" {
   name = "ecs_events"
 
-  assume_role_policy = <<DOC
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "events.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-DOC
+  assume_role_policy = jsonencode({
+    "Version" = "2012-10-17"
+    "Statement" = [
+      {
+        "Sid"    = ""
+        "Effect" = "Allow"
+        "Principal" = {
+          "Service" = "events.amazonaws.com"
+        }
+        "Action" = "sts:AssumeRole"
+      }
+    ]
+  })
 }
 
 resource "aws_iam_role_policy" "ecs_events_run_task_with_any_role" {
   name = "ecs_events_run_task_with_any_role"
   role = aws_iam_role.ecs_events.id
 
-  policy = <<DOC
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": "iam:PassRole",
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": "ecs:RunTask",
-            "Resource": "${replace(aws_ecs_task_definition.task_name.arn, "/:\\d+$/", ":*")}"
-        }
+  policy = jsonencode({
+    "Version" = "2012-10-17"
+    "Statement" = [
+      {
+        "Effect"   = "Allow"
+        "Action"   = "iam:PassRole"
+        "Resource" = "*"
+      },
+      {
+        "Effect"   = "Allow"
+        "Action"   = "ecs:RunTask"
+        "Resource" = replace(aws_ecs_task_definition.task_name.arn, "/:\\d+$/", ":*")
+      }
     ]
-}
-DOC
+  })
 }
 
 resource "aws_cloudwatch_event_target" "ecs_scheduled_task" {
@@ -222,16 +214,14 @@ resource "aws_cloudwatch_event_target" "ecs_scheduled_task" {
     task_definition_arn = aws_ecs_task_definition.task_name.arn
   }
 
-  input = <<DOC
-{
-  "containerOverrides": [
-    {
-      "name": "name-of-container-to-override",
-      "command": ["bin/console", "scheduled-task"]
-    }
-  ]
-}
-DOC
+  input = jsonencode({
+    "containerOverrides" = [
+      {
+        "name"    = "name-of-container-to-override"
+        "command" = ["bin/console", "scheduled-task"]
+      }
+    ]
+  })
 }
 ```
 

--- a/website/docs/r/cloudwatch_log_destination.html.markdown
+++ b/website/docs/r/cloudwatch_log_destination.html.markdown
@@ -15,8 +15,8 @@ Provides a CloudWatch Logs destination resource.
 ```hcl
 resource "aws_cloudwatch_log_destination" "test_destination" {
   name       = "test_destination"
-  role_arn   = "${aws_iam_role.iam_for_cloudwatch.arn}"
-  target_arn = "${aws_kinesis_stream.kinesis_for_cloudwatch.arn}"
+  role_arn   = aws_iam_role.iam_for_cloudwatch.arn
+  target_arn = aws_kinesis_stream.kinesis_for_cloudwatch.arn
 }
 ```
 

--- a/website/docs/r/cloudwatch_log_destination_policy.html.markdown
+++ b/website/docs/r/cloudwatch_log_destination_policy.html.markdown
@@ -15,8 +15,8 @@ Provides a CloudWatch Logs destination policy resource.
 ```hcl
 resource "aws_cloudwatch_log_destination" "test_destination" {
   name       = "test_destination"
-  role_arn   = "${aws_iam_role.iam_for_cloudwatch.arn}"
-  target_arn = "${aws_kinesis_stream.kinesis_for_cloudwatch.arn}"
+  role_arn   = aws_iam_role.iam_for_cloudwatch.arn
+  target_arn = aws_kinesis_stream.kinesis_for_cloudwatch.arn
 }
 
 data "aws_iam_policy_document" "test_destination_policy" {
@@ -36,14 +36,14 @@ data "aws_iam_policy_document" "test_destination_policy" {
     ]
 
     resources = [
-      "${aws_cloudwatch_log_destination.test_destination.arn}",
+      aws_cloudwatch_log_destination.test_destination.arn,
     ]
   }
 }
 
 resource "aws_cloudwatch_log_destination_policy" "test_destination_policy" {
-  destination_name = "${aws_cloudwatch_log_destination.test_destination.name}"
-  access_policy    = "${data.aws_iam_policy_document.test_destination_policy.json}"
+  destination_name = aws_cloudwatch_log_destination.test_destination.name
+  access_policy    = data.aws_iam_policy_document.test_destination_policy.json
 }
 ```
 

--- a/website/docs/r/cloudwatch_log_metric_filter.html.markdown
+++ b/website/docs/r/cloudwatch_log_metric_filter.html.markdown
@@ -16,7 +16,7 @@ Provides a CloudWatch Log Metric Filter resource.
 resource "aws_cloudwatch_log_metric_filter" "yada" {
   name           = "MyAppAccessCount"
   pattern        = ""
-  log_group_name = "${aws_cloudwatch_log_group.dada.name}"
+  log_group_name = aws_cloudwatch_log_group.dada.name
 
   metric_transformation {
     name      = "EventCount"

--- a/website/docs/r/cloudwatch_log_resource_policy.html.markdown
+++ b/website/docs/r/cloudwatch_log_resource_policy.html.markdown
@@ -33,7 +33,7 @@ data "aws_iam_policy_document" "elasticsearch-log-publishing-policy" {
 }
 
 resource "aws_cloudwatch_log_resource_policy" "elasticsearch-log-publishing-policy" {
-  policy_document = "${data.aws_iam_policy_document.elasticsearch-log-publishing-policy.json}"
+  policy_document = data.aws_iam_policy_document.elasticsearch-log-publishing-policy.json
   policy_name     = "elasticsearch-log-publishing-policy"
 }
 ```
@@ -58,7 +58,7 @@ data "aws_iam_policy_document" "route53-query-logging-policy" {
 }
 
 resource "aws_cloudwatch_log_resource_policy" "route53-query-logging-policy" {
-  policy_document = "${data.aws_iam_policy_document.route53-query-logging-policy.json}"
+  policy_document = data.aws_iam_policy_document.route53-query-logging-policy.json
   policy_name     = "route53-query-logging-policy"
 }
 ```

--- a/website/docs/r/cloudwatch_log_stream.html.markdown
+++ b/website/docs/r/cloudwatch_log_stream.html.markdown
@@ -19,7 +19,7 @@ resource "aws_cloudwatch_log_group" "yada" {
 
 resource "aws_cloudwatch_log_stream" "foo" {
   name           = "SampleLogStream1234"
-  log_group_name = "${aws_cloudwatch_log_group.yada.name}"
+  log_group_name = aws_cloudwatch_log_group.yada.name
 }
 ```
 

--- a/website/docs/r/cloudwatch_log_subscription_filter.html.markdown
+++ b/website/docs/r/cloudwatch_log_subscription_filter.html.markdown
@@ -15,10 +15,10 @@ Provides a CloudWatch Logs subscription filter resource.
 ```hcl
 resource "aws_cloudwatch_log_subscription_filter" "test_lambdafunction_logfilter" {
   name            = "test_lambdafunction_logfilter"
-  role_arn        = "${aws_iam_role.iam_for_lambda.arn}"
+  role_arn        = aws_iam_role.iam_for_lambda.arn
   log_group_name  = "/aws/lambda/example_lambda_name"
   filter_pattern  = "logtype test"
-  destination_arn = "${aws_kinesis_stream.test_logstream.arn}"
+  destination_arn = aws_kinesis_stream.test_logstream.arn
   distribution    = "Random"
 }
 ```

--- a/website/docs/r/cloudwatch_metric_alarm.html.markdown
+++ b/website/docs/r/cloudwatch_metric_alarm.html.markdown
@@ -35,7 +35,7 @@ resource "aws_autoscaling_policy" "bat" {
   scaling_adjustment     = 4
   adjustment_type        = "ChangeInCapacity"
   cooldown               = 300
-  autoscaling_group_name = "${aws_autoscaling_group.bar.name}"
+  autoscaling_group_name = aws_autoscaling_group.bar.name
 }
 
 resource "aws_cloudwatch_metric_alarm" "bat" {
@@ -49,11 +49,11 @@ resource "aws_cloudwatch_metric_alarm" "bat" {
   threshold           = "80"
 
   dimensions = {
-    AutoScalingGroupName = "${aws_autoscaling_group.bar.name}"
+    AutoScalingGroupName = aws_autoscaling_group.bar.name
   }
 
   alarm_description = "This metric monitors ec2 cpu utilization"
-  alarm_actions     = ["${aws_autoscaling_policy.bat.arn}"]
+  alarm_actions     = [aws_autoscaling_policy.bat.arn]
 }
 ```
 

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -38,7 +38,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "example" {
-  role = "${aws_iam_role.example.name}"
+  role = aws_iam_role.example.name
 
   policy = <<POLICY
 {
@@ -105,7 +105,7 @@ resource "aws_codebuild_project" "example" {
   name          = "test-project"
   description   = "test_codebuild_project"
   build_timeout = "5"
-  service_role  = "${aws_iam_role.example.arn}"
+  service_role  = aws_iam_role.example.arn
 
   artifacts {
     type = "NO_ARTIFACTS"
@@ -113,7 +113,7 @@ resource "aws_codebuild_project" "example" {
 
   cache {
     type     = "S3"
-    location = "${aws_s3_bucket.example.bucket}"
+    location = aws_s3_bucket.example.bucket
   }
 
   environment {
@@ -159,16 +159,16 @@ resource "aws_codebuild_project" "example" {
   source_version = "master"
 
   vpc_config {
-    vpc_id = "${aws_vpc.example.id}"
+    vpc_id = aws_vpc.example.id
 
     subnets = [
-      "${aws_subnet.example1.id}",
-      "${aws_subnet.example2.id}",
+      aws_subnet.example1.id,
+      aws_subnet.example2.id,
     ]
 
     security_group_ids = [
-      "${aws_security_group.example1.id}",
-      "${aws_security_group.example2.id}",
+      aws_security_group.example1.id,
+      aws_security_group.example2.id,
     ]
   }
 
@@ -183,7 +183,7 @@ resource "aws_codebuild_project" "project-with-cache" {
   build_timeout  = "5"
   queued_timeout = "5"
 
-  service_role = "${aws_iam_role.example.arn}"
+  service_role = aws_iam_role.example.arn
 
   artifacts {
     type = "NO_ARTIFACTS"

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -21,84 +21,80 @@ resource "aws_s3_bucket" "example" {
 resource "aws_iam_role" "example" {
   name = "example"
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "codebuild.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
+  assume_role_policy = jsonencode({
+    "Version" = "2012-10-17"
+    "Statement" = [
+      {
+        "Effect" = "Allow"
+        "Principal" = {
+          "Service" = "codebuild.amazonaws.com"
+        }
+        "Action" = "sts:AssumeRole"
+      }
+    ]
+  })
 }
 
 resource "aws_iam_role_policy" "example" {
   role = aws_iam_role.example.name
 
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Resource": [
-        "*"
-      ],
-      "Action": [
-        "logs:CreateLogGroup",
-        "logs:CreateLogStream",
-        "logs:PutLogEvents"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "ec2:CreateNetworkInterface",
-        "ec2:DescribeDhcpOptions",
-        "ec2:DescribeNetworkInterfaces",
-        "ec2:DeleteNetworkInterface",
-        "ec2:DescribeSubnets",
-        "ec2:DescribeSecurityGroups",
-        "ec2:DescribeVpcs"
-      ],
-      "Resource": "*"
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "ec2:CreateNetworkInterfacePermission"
-      ],
-      "Resource": [
-        "arn:aws:ec2:us-east-1:123456789012:network-interface/*"
-      ],
-      "Condition": {
-        "StringEquals": {
-          "ec2:Subnet": [
-            "${aws_subnet.example1.arn}",
-            "${aws_subnet.example2.arn}"
-          ],
-          "ec2:AuthorizedService": "codebuild.amazonaws.com"
+  policy = jsonencode({
+    "Version" = "2012-10-17"
+    "Statement" = [
+      {
+        "Effect" = "Allow"
+        "Resource" = [
+          "*"
+        ]
+        "Action" = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+        ]
+      },
+      {
+        "Effect" = "Allow"
+        "Action" = [
+          "ec2:CreateNetworkInterface",
+          "ec2:DescribeDhcpOptions",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DeleteNetworkInterface",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeVpcs",
+        ]
+        "Resource" = "*"
+      },
+      {
+        "Effect" = "Allow"
+        "Action" = [
+          "ec2:CreateNetworkInterfacePermission"
+        ]
+        "Resource" = [
+          "arn:aws:ec2:us-east-1:123456789012:network-interface/*"
+        ]
+        "Condition" = {
+          "StringEquals" = {
+            "ec2:Subnet" = [
+              aws_subnet.example1.arn,
+              aws_subnet.example2.arn,
+            ]
+            "ec2:AuthorizedService" = "codebuild.amazonaws.com"
+          }
         }
+      },
+      {
+        "Effect" = "Allow"
+        "Action" = [
+          "s3:*"
+        ]
+        "Resource" = [
+          aws_s3_bucket.example.arn,
+          "${aws_s3_bucket.example.arn}/*",
+        ]
       }
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:*"
-      ],
-      "Resource": [
-        "${aws_s3_bucket.example.arn}",
-        "${aws_s3_bucket.example.arn}/*"
-      ]
-    }
-  ]
-}
-POLICY
+    ]
+  })
 }
 
 resource "aws_codebuild_project" "example" {

--- a/website/docs/r/codebuild_webhook.html.markdown
+++ b/website/docs/r/codebuild_webhook.html.markdown
@@ -22,7 +22,7 @@ When working with [Bitbucket](https://bitbucket.org) and [GitHub](https://github
 
 ```hcl
 resource "aws_codebuild_webhook" "example" {
-  project_name = "${aws_codebuild_project.example.name}"
+  project_name = aws_codebuild_project.example.name
 
   filter_group {
     filter {
@@ -46,18 +46,18 @@ More information creating webhooks with GitHub Enterprise can be found in the [C
 
 ```hcl
 resource "aws_codebuild_webhook" "example" {
-  project_name = "${aws_codebuild_project.example.name}"
+  project_name = aws_codebuild_project.example.name
 }
 
 resource "github_repository_webhook" "example" {
   active     = true
   events     = ["push"]
   name       = "example"
-  repository = "${github_repository.example.name}"
+  repository = github_repository.example.name
 
   configuration {
-    url          = "${aws_codebuild_webhook.example.payload_url}"
-    secret       = "${aws_codebuild_webhook.example.secret}"
+    url          = aws_codebuild_webhook.example.payload_url
+    secret       = aws_codebuild_webhook.example.secret
     content_type = "json"
     insecure_ssl = false
   }

--- a/website/docs/r/codecommit_trigger.html.markdown
+++ b/website/docs/r/codecommit_trigger.html.markdown
@@ -22,12 +22,12 @@ resource "aws_codecommit_repository" "test" {
 }
 
 resource "aws_codecommit_trigger" "test" {
-  repository_name = "${aws_codecommit_repository.test.repository_name}"
+  repository_name = aws_codecommit_repository.test.repository_name
 
   trigger {
     name            = "all"
     events          = ["all"]
-    destination_arn = "${aws_sns_topic.test.arn}"
+    destination_arn = aws_sns_topic.test.arn
   }
 }
 ```

--- a/website/docs/r/codedeploy_deployment_config.html.markdown
+++ b/website/docs/r/codedeploy_deployment_config.html.markdown
@@ -25,10 +25,10 @@ resource "aws_codedeploy_deployment_config" "foo" {
 }
 
 resource "aws_codedeploy_deployment_group" "foo" {
-  app_name               = "${aws_codedeploy_app.foo_app.name}"
+  app_name               = aws_codedeploy_app.foo_app.name
   deployment_group_name  = "bar"
-  service_role_arn       = "${aws_iam_role.foo_role.arn}"
-  deployment_config_name = "${aws_codedeploy_deployment_config.foo.id}"
+  service_role_arn       = aws_iam_role.foo_role.arn
+  deployment_config_name = aws_codedeploy_deployment_config.foo.id
 
   ec2_tag_filter {
     key   = "filterkey"
@@ -72,10 +72,10 @@ resource "aws_codedeploy_deployment_config" "foo" {
 }
 
 resource "aws_codedeploy_deployment_group" "foo" {
-  app_name               = "${aws_codedeploy_app.foo_app.name}"
+  app_name               = aws_codedeploy_app.foo_app.name
   deployment_group_name  = "bar"
-  service_role_arn       = "${aws_iam_role.foo_role.arn}"
-  deployment_config_name = "${aws_codedeploy_deployment_config.foo.id}"
+  service_role_arn       = aws_iam_role.foo_role.arn
+  deployment_config_name = aws_codedeploy_deployment_config.foo.id
 
   auto_rollback_configuration {
     enabled = true

--- a/website/docs/r/codedeploy_deployment_group.html.markdown
+++ b/website/docs/r/codedeploy_deployment_group.html.markdown
@@ -37,7 +37,7 @@ EOF
 
 resource "aws_iam_role_policy_attachment" "AWSCodeDeployRole" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRole"
-  role       = "${aws_iam_role.example.name}"
+  role       = aws_iam_role.example.name
 }
 
 resource "aws_codedeploy_app" "example" {
@@ -49,9 +49,9 @@ resource "aws_sns_topic" "example" {
 }
 
 resource "aws_codedeploy_deployment_group" "example" {
-  app_name              = "${aws_codedeploy_app.example.name}"
+  app_name              = aws_codedeploy_app.example.name
   deployment_group_name = "example-group"
-  service_role_arn      = "${aws_iam_role.example.arn}"
+  service_role_arn      = aws_iam_role.example.arn
 
   ec2_tag_set {
     ec2_tag_filter {
@@ -70,7 +70,7 @@ resource "aws_codedeploy_deployment_group" "example" {
   trigger_configuration {
     trigger_events     = ["DeploymentFailure"]
     trigger_name       = "example-trigger"
-    trigger_target_arn = "${aws_sns_topic.example.arn}"
+    trigger_target_arn = aws_sns_topic.example.arn
   }
 
   auto_rollback_configuration {
@@ -94,10 +94,10 @@ resource "aws_codedeploy_app" "example" {
 }
 
 resource "aws_codedeploy_deployment_group" "example" {
-  app_name               = "${aws_codedeploy_app.example.name}"
+  app_name               = aws_codedeploy_app.example.name
   deployment_config_name = "CodeDeployDefault.ECSAllAtOnce"
   deployment_group_name  = "example"
-  service_role_arn       = "${aws_iam_role.example.arn}"
+  service_role_arn       = aws_iam_role.example.arn
 
   auto_rollback_configuration {
     enabled = true
@@ -121,22 +121,22 @@ resource "aws_codedeploy_deployment_group" "example" {
   }
 
   ecs_service {
-    cluster_name = "${aws_ecs_cluster.example.name}"
-    service_name = "${aws_ecs_service.example.name}"
+    cluster_name = aws_ecs_cluster.example.name
+    service_name = aws_ecs_service.example.name
   }
 
   load_balancer_info {
     target_group_pair_info {
       prod_traffic_route {
-        listener_arns = ["${aws_lb_listener.example.arn}"]
+        listener_arns = [aws_lb_listener.example.arn]
       }
 
       target_group {
-        name = "${aws_lb_target_group.blue.name}"
+        name = aws_lb_target_group.blue.name
       }
 
       target_group {
-        name = "${aws_lb_target_group.green.name}"
+        name = aws_lb_target_group.green.name
       }
     }
   }
@@ -151,9 +151,9 @@ resource "aws_codedeploy_app" "example" {
 }
 
 resource "aws_codedeploy_deployment_group" "example" {
-  app_name              = "${aws_codedeploy_app.example.name}"
+  app_name              = aws_codedeploy_app.example.name
   deployment_group_name = "example-group"
-  service_role_arn      = "${aws_iam_role.example.arn}"
+  service_role_arn      = aws_iam_role.example.arn
 
   deployment_style {
     deployment_option = "WITH_TRAFFIC_CONTROL"
@@ -162,7 +162,7 @@ resource "aws_codedeploy_deployment_group" "example" {
 
   load_balancer_info {
     elb_info {
-      name = "${aws_elb.example.name}"
+      name = aws_elb.example.name
     }
   }
 

--- a/website/docs/r/codepipeline.markdown
+++ b/website/docs/r/codepipeline.markdown
@@ -41,7 +41,7 @@ EOF
 
 resource "aws_iam_role_policy" "codepipeline_policy" {
   name = "codepipeline_policy"
-  role = "${aws_iam_role.codepipeline_role.id}"
+  role = aws_iam_role.codepipeline_role.id
 
   policy = <<EOF
 {
@@ -79,14 +79,14 @@ data "aws_kms_alias" "s3kmskey" {
 
 resource "aws_codepipeline" "codepipeline" {
   name     = "tf-test-pipeline"
-  role_arn = "${aws_iam_role.codepipeline_role.arn}"
+  role_arn = aws_iam_role.codepipeline_role.arn
 
   artifact_store {
-    location = "${aws_s3_bucket.codepipeline_bucket.bucket}"
+    location = aws_s3_bucket.codepipeline_bucket.bucket
     type     = "S3"
 
     encryption_key {
-      id   = "${data.aws_kms_alias.s3kmskey.arn}"
+      id   = data.aws_kms_alias.s3kmskey.arn
       type = "KMS"
     }
   }

--- a/website/docs/r/codepipeline.markdown
+++ b/website/docs/r/codepipeline.markdown
@@ -23,54 +23,50 @@ resource "aws_s3_bucket" "codepipeline_bucket" {
 resource "aws_iam_role" "codepipeline_role" {
   name = "test-role"
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "codepipeline.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
+  assume_role_policy = jsonencode({
+    "Version" = "2012-10-17"
+    "Statement" = [
+      {
+        "Effect" = "Allow"
+        "Principal" = {
+          "Service" = "codepipeline.amazonaws.com"
+        }
+        "Action" = "sts:AssumeRole"
+      }
+    ]
+  })
 }
 
 resource "aws_iam_role_policy" "codepipeline_policy" {
   name = "codepipeline_policy"
   role = aws_iam_role.codepipeline_role.id
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect":"Allow",
-      "Action": [
-        "s3:GetObject",
-        "s3:GetObjectVersion",
-        "s3:GetBucketVersioning",
-        "s3:PutObject"
-      ],
-      "Resource": [
-        "${aws_s3_bucket.codepipeline_bucket.arn}",
-        "${aws_s3_bucket.codepipeline_bucket.arn}/*"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "codebuild:BatchGetBuilds",
-        "codebuild:StartBuild"
-      ],
-      "Resource": "*"
-    }
-  ]
-}
-EOF
+  policy = jsonencode({
+    "Version" = "2012-10-17"
+    "Statement" = [
+      {
+        "Effect" = "Allow"
+        "Action" = [
+          "s3:GetObject",
+          "s3:GetObjectVersion",
+          "s3:GetBucketVersioning",
+          "s3:PutObject",
+        ]
+        "Resource" = [
+          aws_s3_bucket.codepipeline_bucket.arn,
+          "${aws_s3_bucket.codepipeline_bucket.arn}/*",
+        ]
+      },
+      {
+        "Effect" = "Allow"
+        "Action" = [
+          "codebuild:BatchGetBuilds",
+          "codebuild:StartBuild",
+        ]
+        "Resource" = "*"
+      }
+    ]
+  })
 }
 
 data "aws_kms_alias" "s3kmskey" {

--- a/website/docs/r/codepipeline_webhook.markdown
+++ b/website/docs/r/codepipeline_webhook.markdown
@@ -15,14 +15,14 @@ Provides a CodePipeline Webhook.
 ```hcl
 resource "aws_codepipeline" "bar" {
   name     = "tf-test-pipeline"
-  role_arn = "${aws_iam_role.bar.arn}"
+  role_arn = aws_iam_role.bar.arn
 
   artifact_store {
-    location = "${aws_s3_bucket.bar.bucket}"
+    location = aws_s3_bucket.bar.bucket
     type     = "S3"
 
     encryption_key {
-      id   = "${data.aws_kms_alias.s3kmskey.arn}"
+      id   = data.aws_kms_alias.s3kmskey.arn
       type = "KMS"
     }
   }
@@ -76,10 +76,10 @@ resource "aws_codepipeline_webhook" "bar" {
   name            = "test-webhook-github-bar"
   authentication  = "GITHUB_HMAC"
   target_action   = "Source"
-  target_pipeline = "${aws_codepipeline.bar.name}"
+  target_pipeline = aws_codepipeline.bar.name
 
   authentication_configuration {
-    secret_token = "${local.webhook_secret}"
+    secret_token = local.webhook_secret
   }
 
   filter {
@@ -90,15 +90,15 @@ resource "aws_codepipeline_webhook" "bar" {
 
 # Wire the CodePipeline webhook into a GitHub repository.
 resource "github_repository_webhook" "bar" {
-  repository = "${github_repository.repo.name}"
+  repository = github_repository.repo.name
 
   name = "web"
 
   configuration {
-    url          = "${aws_codepipeline_webhook.bar.url}"
+    url          = aws_codepipeline_webhook.bar.url
     content_type = "json"
     insecure_ssl = true
-    secret       = "${local.webhook_secret}"
+    secret       = local.webhook_secret
   }
 
   events = ["push"]

--- a/website/docs/r/cognito_identity_pool.markdown
+++ b/website/docs/r/cognito_identity_pool.markdown
@@ -15,7 +15,7 @@ Provides an AWS Cognito Identity Pool.
 ```hcl
 resource "aws_iam_saml_provider" "default" {
   name                   = "my-saml-provider"
-  saml_metadata_document = "${file("saml-metadata.xml")}"
+  saml_metadata_document = file("saml-metadata.xml")
 }
 
 resource "aws_cognito_identity_pool" "main" {
@@ -39,7 +39,7 @@ resource "aws_cognito_identity_pool" "main" {
     "accounts.google.com" = "123456789012.apps.googleusercontent.com"
   }
 
-  saml_provider_arns           = ["${aws_iam_saml_provider.default.arn}"]
+  saml_provider_arns           = [aws_iam_saml_provider.default.arn]
   openid_connect_provider_arns = ["arn:aws:iam::123456789012:oidc-provider/foo.example.com"]
 }
 ```

--- a/website/docs/r/cognito_identity_pool_roles_attachment.markdown
+++ b/website/docs/r/cognito_identity_pool_roles_attachment.markdown
@@ -51,7 +51,7 @@ EOF
 
 resource "aws_iam_role_policy" "authenticated" {
   name = "authenticated_policy"
-  role = "${aws_iam_role.authenticated.id}"
+  role = aws_iam_role.authenticated.id
 
   policy = <<EOF
 {
@@ -74,7 +74,7 @@ EOF
 }
 
 resource "aws_cognito_identity_pool_roles_attachment" "main" {
-  identity_pool_id = "${aws_cognito_identity_pool.main.id}"
+  identity_pool_id = aws_cognito_identity_pool.main.id
 
   role_mapping {
     identity_provider         = "graph.facebook.com"
@@ -84,13 +84,13 @@ resource "aws_cognito_identity_pool_roles_attachment" "main" {
     mapping_rule {
       claim      = "isAdmin"
       match_type = "Equals"
-      role_arn   = "${aws_iam_role.authenticated.arn}"
+      role_arn   = aws_iam_role.authenticated.arn
       value      = "paid"
     }
   }
 
   roles = {
-    "authenticated" = "${aws_iam_role.authenticated.arn}"
+    "authenticated" = aws_iam_role.authenticated.arn
   }
 }
 ```

--- a/website/docs/r/cognito_identity_pool_roles_attachment.markdown
+++ b/website/docs/r/cognito_identity_pool_roles_attachment.markdown
@@ -25,52 +25,48 @@ resource "aws_cognito_identity_pool" "main" {
 resource "aws_iam_role" "authenticated" {
   name = "cognito_authenticated"
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Federated": "cognito-identity.amazonaws.com"
-      },
-      "Action": "sts:AssumeRoleWithWebIdentity",
-      "Condition": {
-        "StringEquals": {
-          "cognito-identity.amazonaws.com:aud": "${aws_cognito_identity_pool.main.id}"
-        },
-        "ForAnyValue:StringLike": {
-          "cognito-identity.amazonaws.com:amr": "authenticated"
+  assume_role_policy = jsonencode({
+    "Version" = "2012-10-17"
+    "Statement" = [
+      {
+        "Effect" = "Allow"
+        "Principal" = {
+          "Federated" = "cognito-identity.amazonaws.com"
+        }
+        "Action" = "sts:AssumeRoleWithWebIdentity"
+        "Condition" = {
+          "StringEquals" = {
+            "cognito-identity.amazonaws.com:aud" = aws_cognito_identity_pool.main.id
+          }
+          "ForAnyValue:StringLike" = {
+            "cognito-identity.amazonaws.com:amr" = "authenticated"
+          }
         }
       }
-    }
-  ]
-}
-EOF
+    ]
+  })
 }
 
 resource "aws_iam_role_policy" "authenticated" {
   name = "authenticated_policy"
   role = aws_iam_role.authenticated.id
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "mobileanalytics:PutEvents",
-        "cognito-sync:*",
-        "cognito-identity:*"
-      ],
-      "Resource": [
-        "*"
-      ]
-    }
-  ]
-}
-EOF
+  policy = jsonencode({
+    "Version" = "2012-10-17"
+    "Statement" = [
+      {
+        "Effect" = "Allow"
+        "Action" = [
+          "mobileanalytics:PutEvents",
+          "cognito-sync:*",
+          "cognito-identity:*",
+        ]
+        "Resource" = [
+          "*"
+        ]
+      }
+    ]
+  })
 }
 
 resource "aws_cognito_identity_pool_roles_attachment" "main" {

--- a/website/docs/r/cognito_identity_provider.html.markdown
+++ b/website/docs/r/cognito_identity_provider.html.markdown
@@ -20,7 +20,7 @@ resource "aws_cognito_user_pool" "example" {
 }
 
 resource "aws_cognito_identity_provider" "example_provider" {
-  user_pool_id  = "${aws_cognito_user_pool.example.id}"
+  user_pool_id  = aws_cognito_user_pool.example.id
   provider_name = "Google"
   provider_type = "Google"
 

--- a/website/docs/r/cognito_resource_server.markdown
+++ b/website/docs/r/cognito_resource_server.markdown
@@ -24,7 +24,7 @@ resource "aws_cognito_resource_server" "resource" {
   identifier = "https://example.com"
   name       = "example"
 
-  user_pool_id = "${aws_cognito_user_pool.pool.id}"
+  user_pool_id = aws_cognito_user_pool.pool.id
 }
 ```
 
@@ -44,7 +44,7 @@ resource "aws_cognito_resource_server" "resource" {
     scope_description = "a Sample Scope Description"
   }
 
-  user_pool_id = "${aws_cognito_user_pool.pool.id}"
+  user_pool_id = aws_cognito_user_pool.pool.id
 }
 ```
 

--- a/website/docs/r/cognito_user_group.html.markdown
+++ b/website/docs/r/cognito_user_group.html.markdown
@@ -47,10 +47,10 @@ EOF
 
 resource "aws_cognito_user_group" "main" {
   name         = "user-group"
-  user_pool_id = "${aws_cognito_user_pool.main.id}"
+  user_pool_id = aws_cognito_user_pool.main.id
   description  = "Managed by Terraform"
   precedence   = 42
-  role_arn     = "${aws_iam_role.group_role.arn}"
+  role_arn     = aws_iam_role.group_role.arn
 }
 ```
 

--- a/website/docs/r/cognito_user_pool_client.markdown
+++ b/website/docs/r/cognito_user_pool_client.markdown
@@ -22,7 +22,7 @@ resource "aws_cognito_user_pool" "pool" {
 resource "aws_cognito_user_pool_client" "client" {
   name = "client"
 
-  user_pool_id = "${aws_cognito_user_pool.pool.id}"
+  user_pool_id = aws_cognito_user_pool.pool.id
 }
 ```
 
@@ -36,7 +36,7 @@ resource "aws_cognito_user_pool" "pool" {
 resource "aws_cognito_user_pool_client" "client" {
   name = "client"
 
-  user_pool_id = "${aws_cognito_user_pool.pool.id}"
+  user_pool_id = aws_cognito_user_pool.pool.id
 
   generate_secret     = true
   explicit_auth_flows = ["ADMIN_NO_SRP_AUTH"]
@@ -78,7 +78,7 @@ EOF
 
 resource "aws_iam_role_policy" "test" {
   name = "role_policy"
-  role = "${aws_iam_role.test.id}"
+  role = aws_iam_role.test.id
 
   policy = <<-EOF
   {
@@ -99,12 +99,12 @@ resource "aws_iam_role_policy" "test" {
 
 resource "aws_cognito_user_pool_client" "test" {
   name         = "pool_client"
-  user_pool_id = "${aws_cognito_user_pool.test.id}"
+  user_pool_id = aws_cognito_user_pool.test.id
 
   analytics_configuration {
-    application_id   = "${aws_pinpoint_app.test.application_id}"
+    application_id   = aws_pinpoint_app.test.application_id
     external_id      = "some_id"
-    role_arn         = "${aws_iam_role.test.arn}"
+    role_arn         = aws_iam_role.test.arn
     user_data_shared = true
   }
 }

--- a/website/docs/r/cognito_user_pool_domain.markdown
+++ b/website/docs/r/cognito_user_pool_domain.markdown
@@ -17,7 +17,7 @@ Provides a Cognito User Pool Domain resource.
 ```hcl
 resource "aws_cognito_user_pool_domain" "main" {
   domain       = "example-domain"
-  user_pool_id = "${aws_cognito_user_pool.example.id}"
+  user_pool_id = aws_cognito_user_pool.example.id
 }
 
 resource "aws_cognito_user_pool" "example" {
@@ -30,8 +30,8 @@ resource "aws_cognito_user_pool" "example" {
 ```hcl
 resource "aws_cognito_user_pool_domain" "main" {
   domain          = "example-domain.example.com"
-  certificate_arn = "${aws_acm_certificate.cert.arn}"
-  user_pool_id    = "${aws_cognito_user_pool.example.id}"
+  certificate_arn = aws_acm_certificate.cert.arn
+  user_pool_id    = aws_cognito_user_pool.example.id
 }
 
 resource "aws_cognito_user_pool" "example" {

--- a/website/docs/r/config_config_rule.html.markdown
+++ b/website/docs/r/config_config_rule.html.markdown
@@ -32,7 +32,7 @@ resource "aws_config_config_rule" "r" {
 
 resource "aws_config_configuration_recorder" "foo" {
   name     = "example"
-  role_arn = "${aws_iam_role.r.arn}"
+  role_arn = aws_iam_role.r.arn
 }
 
 resource "aws_iam_role" "r" {
@@ -57,7 +57,7 @@ POLICY
 
 resource "aws_iam_role_policy" "p" {
   name = "my-awsconfig-policy"
-  role = "${aws_iam_role.r.id}"
+  role = aws_iam_role.r.id
 
   policy = <<POLICY
 {
@@ -90,7 +90,7 @@ resource "aws_lambda_function" "example" {
 
 resource "aws_lambda_permission" "example" {
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.example.arn}"
+  function_name = aws_lambda_function.example.arn
   principal     = "config.amazonaws.com"
   statement_id  = "AllowExecutionFromConfig"
 }
@@ -100,7 +100,7 @@ resource "aws_config_config_rule" "example" {
 
   source {
     owner             = "CUSTOM_LAMBDA"
-    source_identifier = "${aws_lambda_function.example.arn}"
+    source_identifier = aws_lambda_function.example.arn
   }
 
   depends_on = ["aws_config_configuration_recorder.example", "aws_lambda_permission.example"]

--- a/website/docs/r/config_configuration_aggregator.html.markdown
+++ b/website/docs/r/config_configuration_aggregator.html.markdown
@@ -35,7 +35,7 @@ resource "aws_config_configuration_aggregator" "organization" {
 
   organization_aggregation_source {
     all_regions = true
-    role_arn    = "${aws_iam_role.organization.arn}"
+    role_arn    = aws_iam_role.organization.arn
   }
 }
 
@@ -60,7 +60,7 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "organization" {
-  role       = "${aws_iam_role.organization.name}"
+  role       = aws_iam_role.organization.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSConfigRoleForOrganizations"
 }
 ```

--- a/website/docs/r/config_configuration_recorder.html.markdown
+++ b/website/docs/r/config_configuration_recorder.html.markdown
@@ -17,7 +17,7 @@ Provides an AWS Config Configuration Recorder. Please note that this resource **
 ```hcl
 resource "aws_config_configuration_recorder" "foo" {
   name     = "example"
-  role_arn = "${aws_iam_role.r.arn}"
+  role_arn = aws_iam_role.r.arn
 }
 
 resource "aws_iam_role" "r" {

--- a/website/docs/r/config_configuration_recorder_status.html.markdown
+++ b/website/docs/r/config_configuration_recorder_status.html.markdown
@@ -16,13 +16,13 @@ Manages status (recording / stopped) of an AWS Config Configuration Recorder.
 
 ```hcl
 resource "aws_config_configuration_recorder_status" "foo" {
-  name       = "${aws_config_configuration_recorder.foo.name}"
+  name       = aws_config_configuration_recorder.foo.name
   is_enabled = true
   depends_on = ["aws_config_delivery_channel.foo"]
 }
 
 resource "aws_iam_role_policy_attachment" "a" {
-  role       = "${aws_iam_role.r.name}"
+  role       = aws_iam_role.r.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSConfigRole"
 }
 
@@ -32,12 +32,12 @@ resource "aws_s3_bucket" "b" {
 
 resource "aws_config_delivery_channel" "foo" {
   name           = "example"
-  s3_bucket_name = "${aws_s3_bucket.b.bucket}"
+  s3_bucket_name = aws_s3_bucket.b.bucket
 }
 
 resource "aws_config_configuration_recorder" "foo" {
   name     = "example"
-  role_arn = "${aws_iam_role.r.arn}"
+  role_arn = aws_iam_role.r.arn
 }
 
 resource "aws_iam_role" "r" {
@@ -62,7 +62,7 @@ POLICY
 
 resource "aws_iam_role_policy" "p" {
   name = "awsconfig-example"
-  role = "${aws_iam_role.r.id}"
+  role = aws_iam_role.r.id
 
   policy = <<POLICY
 {

--- a/website/docs/r/config_configuration_recorder_status.html.markdown
+++ b/website/docs/r/config_configuration_recorder_status.html.markdown
@@ -43,44 +43,40 @@ resource "aws_config_configuration_recorder" "foo" {
 resource "aws_iam_role" "r" {
   name = "example-awsconfig"
 
-  assume_role_policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "config.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-POLICY
+  assume_role_policy = jsonencode({
+    "Version" = "2012-10-17"
+    "Statement" = [
+      {
+        "Action" = "sts:AssumeRole"
+        "Principal" = {
+          "Service" = "config.amazonaws.com"
+        }
+        "Effect" = "Allow"
+        "Sid"    = ""
+      }
+    ]
+  })
 }
 
 resource "aws_iam_role_policy" "p" {
   name = "awsconfig-example"
   role = aws_iam_role.r.id
 
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "s3:*"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "${aws_s3_bucket.b.arn}",
-        "${aws_s3_bucket.b.arn}/*"
-      ]
-    }
-  ]
-}
-POLICY
+  policy = jsonencode({
+    "Version" = "2012-10-17"
+    "Statement" = [
+      {
+        "Action" = [
+          "s3:*"
+        ]
+        "Effect" = "Allow"
+        "Resource" = [
+          aws_s3_bucket.b.arn,
+          "${aws_s3_bucket.b.arn}/*",
+        ]
+      }
+    ]
+  })
 }
 ```
 

--- a/website/docs/r/config_delivery_channel.html.markdown
+++ b/website/docs/r/config_delivery_channel.html.markdown
@@ -17,7 +17,7 @@ Provides an AWS Config Delivery Channel.
 ```hcl
 resource "aws_config_delivery_channel" "foo" {
   name           = "example"
-  s3_bucket_name = "${aws_s3_bucket.b.bucket}"
+  s3_bucket_name = aws_s3_bucket.b.bucket
   depends_on     = ["aws_config_configuration_recorder.foo"]
 }
 
@@ -28,7 +28,7 @@ resource "aws_s3_bucket" "b" {
 
 resource "aws_config_configuration_recorder" "foo" {
   name     = "example"
-  role_arn = "${aws_iam_role.r.arn}"
+  role_arn = aws_iam_role.r.arn
 }
 
 resource "aws_iam_role" "r" {
@@ -53,7 +53,7 @@ POLICY
 
 resource "aws_iam_role_policy" "p" {
   name = "awsconfig-example"
-  role = "${aws_iam_role.r.id}"
+  role = aws_iam_role.r.id
 
   policy = <<POLICY
 {

--- a/website/docs/r/config_delivery_channel.html.markdown
+++ b/website/docs/r/config_delivery_channel.html.markdown
@@ -34,44 +34,40 @@ resource "aws_config_configuration_recorder" "foo" {
 resource "aws_iam_role" "r" {
   name = "awsconfig-example"
 
-  assume_role_policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "config.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-POLICY
+  assume_role_policy = jsonencode({
+    "Version" = "2012-10-17"
+    "Statement" = [
+      {
+        "Action" = "sts:AssumeRole"
+        "Principal" = {
+          "Service" = "config.amazonaws.com"
+        }
+        "Effect" = "Allow"
+        "Sid"    = ""
+      }
+    ]
+  })
 }
 
 resource "aws_iam_role_policy" "p" {
   name = "awsconfig-example"
   role = aws_iam_role.r.id
 
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "s3:*"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "${aws_s3_bucket.b.arn}",
-        "${aws_s3_bucket.b.arn}/*"
-      ]
-    }
-  ]
-}
-POLICY
+  policy = jsonencode({
+    "Version" = "2012-10-17"
+    "Statement" = [
+      {
+        "Action" = [
+          "s3:*"
+        ]
+        "Effect" = "Allow"
+        "Resource" = [
+          aws_s3_bucket.b.arn,
+          "${aws_s3_bucket.b.arn}/*",
+        ]
+      }
+    ]
+  })
 }
 ```
 

--- a/website/docs/r/config_organization_custom_rule.html.markdown
+++ b/website/docs/r/config_organization_custom_rule.html.markdown
@@ -19,7 +19,7 @@ Manages a Config Organization Custom Rule. More information about these rules ca
 ```hcl
 resource "aws_lambda_permission" "example" {
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.example.arn}"
+  function_name = aws_lambda_function.example.arn
   principal     = "config.amazonaws.com"
   statement_id  = "AllowExecutionFromConfig"
 }
@@ -32,7 +32,7 @@ resource "aws_organizations_organization" "example" {
 resource "aws_config_organization_custom_rule" "example" {
   depends_on = ["aws_lambda_permission.example", "aws_organizations_organization.example"]
 
-  lambda_function_arn = "${aws_lambda_function.example.arn}"
+  lambda_function_arn = aws_lambda_function.example.arn
   name                = "example"
   trigger_types       = ["ConfigurationItemChangeNotification"]
 }

--- a/website/docs/r/datasync_location_efs.html.markdown
+++ b/website/docs/r/datasync_location_efs.html.markdown
@@ -18,11 +18,11 @@ Manages an AWS DataSync EFS Location.
 resource "aws_datasync_location_efs" "example" {
   # The below example uses aws_efs_mount_target as a reference to ensure a mount target already exists when resource creation occurs.
   # You can accomplish the same behavior with depends_on or an aws_efs_mount_target data source reference.
-  efs_file_system_arn = "${aws_efs_mount_target.example.file_system_arn}"
+  efs_file_system_arn = aws_efs_mount_target.example.file_system_arn
 
   ec2_config {
-    security_group_arns = ["${aws_security_group.example.arn}"]
-    subnet_arn          = "${aws_subnet.example.arn}"
+    security_group_arns = [aws_security_group.example.arn]
+    subnet_arn          = aws_subnet.example.arn
   }
 }
 ```

--- a/website/docs/r/datasync_location_nfs.html.markdown
+++ b/website/docs/r/datasync_location_nfs.html.markdown
@@ -20,7 +20,7 @@ resource "aws_datasync_location_nfs" "example" {
   subdirectory    = "/exported/path"
 
   on_prem_config {
-    agent_arns = ["${aws_datasync_agent.example.arn}"]
+    agent_arns = [aws_datasync_agent.example.arn]
   }
 }
 ```

--- a/website/docs/r/datasync_location_s3.html.markdown
+++ b/website/docs/r/datasync_location_s3.html.markdown
@@ -14,11 +14,11 @@ Manages an S3 Location within AWS DataSync.
 
 ```hcl
 resource "aws_datasync_location_s3" "example" {
-  s3_bucket_arn = "${aws_s3_bucket.example.arn}"
+  s3_bucket_arn = aws_s3_bucket.example.arn
   subdirectory  = "/example/prefix"
 
   s3_config {
-    bucket_access_role_arn = "${aws_iam_role.example.arn}"
+    bucket_access_role_arn = aws_iam_role.example.arn
   }
 }
 ```

--- a/website/docs/r/datasync_location_smb.html.markdown
+++ b/website/docs/r/datasync_location_smb.html.markdown
@@ -22,7 +22,7 @@ resource "aws_datasync_location_smb" "example" {
   user     = "Guest"
   password = "ANotGreatPassword"
 
-  agent_arns = ["${aws_datasync_agent.example.arn}"]
+  agent_arns = [aws_datasync_agent.example.arn]
 }
 ```
 

--- a/website/docs/r/datasync_task.html.markdown
+++ b/website/docs/r/datasync_task.html.markdown
@@ -14,9 +14,9 @@ Manages an AWS DataSync Task, which represents a configuration for synchronizati
 
 ```hcl
 resource "aws_datasync_task" "example" {
-  destination_location_arn = "${aws_datasync_location_s3.destination.arn}"
+  destination_location_arn = aws_datasync_location_s3.destination.arn
   name                     = "example"
-  source_location_arn      = "${aws_datasync_location_nfs.source.arn}"
+  source_location_arn      = aws_datasync_location_nfs.source.arn
 
   options {
     bytes_per_second = -1

--- a/website/docs/r/dax_cluster.html.markdown
+++ b/website/docs/r/dax_cluster.html.markdown
@@ -15,7 +15,7 @@ Provides a DAX Cluster resource.
 ```hcl
 resource "aws_dax_cluster" "bar" {
   cluster_name       = "cluster-example"
-  iam_role_arn       = "${data.aws_iam_role.example.arn}"
+  iam_role_arn       = data.aws_iam_role.example.arn
   node_type          = "dax.r4.large"
   replication_factor = 1
 }

--- a/website/docs/r/dax_subnet_group.html.markdown
+++ b/website/docs/r/dax_subnet_group.html.markdown
@@ -15,7 +15,7 @@ Provides a DAX Subnet Group resource.
 ```hcl
 resource "aws_dax_subnet_group" "example" {
   name       = "example"
-  subnet_ids = ["${aws_subnet.example1.id}", "${aws_subnet.example2.id}"]
+  subnet_ids = [aws_subnet.example1.id, aws_subnet.example2.id]
 }
 ```
 

--- a/website/docs/r/db_cluster_snapshot.html.markdown
+++ b/website/docs/r/db_cluster_snapshot.html.markdown
@@ -14,7 +14,7 @@ Manages a RDS database cluster snapshot for Aurora clusters. For managing RDS da
 
 ```hcl
 resource "aws_db_cluster_snapshot" "example" {
-  db_cluster_identifier          = "${aws_rds_cluster.example.id}"
+  db_cluster_identifier          = aws_rds_cluster.example.id
   db_cluster_snapshot_identifier = "resourcetestsnapshot1234"
 }
 ```

--- a/website/docs/r/db_event_subscription.html.markdown
+++ b/website/docs/r/db_event_subscription.html.markdown
@@ -31,10 +31,10 @@ resource "aws_sns_topic" "default" {
 
 resource "aws_db_event_subscription" "default" {
   name      = "rds-event-sub"
-  sns_topic = "${aws_sns_topic.default.arn}"
+  sns_topic = aws_sns_topic.default.arn
 
   source_type = "db-instance"
-  source_ids  = ["${aws_db_instance.default.id}"]
+  source_ids  = [aws_db_instance.default.id]
 
   event_categories = [
     "availability",

--- a/website/docs/r/db_instance_role_association.html.markdown
+++ b/website/docs/r/db_instance_role_association.html.markdown
@@ -19,9 +19,9 @@ Manages a RDS DB Instance association with an IAM Role. Example use cases:
 
 ```hcl
 resource "aws_db_instance_role_association" "example" {
-  db_instance_identifier = "${aws_db_instance.example.id}"
+  db_instance_identifier = aws_db_instance.example.id
   feature_name           = "S3_INTEGRATION"
-  role_arn               = "${aws_iam_role.example.id}"
+  role_arn               = aws_iam_role.example.id
 }
 ```
 

--- a/website/docs/r/db_option_group.html.markdown
+++ b/website/docs/r/db_option_group.html.markdown
@@ -38,7 +38,7 @@ resource "aws_db_option_group" "example" {
 
     option_settings {
       name  = "IAM_ROLE_ARN"
-      value = "${aws_iam_role.example.arn}"
+      value = aws_iam_role.example.arn
     }
   }
 

--- a/website/docs/r/db_snapshot.html.markdown
+++ b/website/docs/r/db_snapshot.html.markdown
@@ -28,7 +28,7 @@ resource "aws_db_instance" "bar" {
 }
 
 resource "aws_db_snapshot" "test" {
-  db_instance_identifier = "${aws_db_instance.bar.id}"
+  db_instance_identifier = aws_db_instance.bar.id
   db_snapshot_identifier = "testsnapshot1234"
 }
 ```

--- a/website/docs/r/db_subnet_group.html.markdown
+++ b/website/docs/r/db_subnet_group.html.markdown
@@ -15,7 +15,7 @@ Provides an RDS DB subnet group resource.
 ```hcl
 resource "aws_db_subnet_group" "default" {
   name       = "main"
-  subnet_ids = ["${aws_subnet.frontend.id}", "${aws_subnet.backend.id}"]
+  subnet_ids = [aws_subnet.frontend.id, aws_subnet.backend.id]
 
   tags = {
     Name = "My DB subnet group"

--- a/website/docs/r/default_network_acl.html.markdown
+++ b/website/docs/r/default_network_acl.html.markdown
@@ -103,7 +103,7 @@ resource "aws_vpc" "mainvpc" {
 }
 
 resource "aws_default_network_acl" "default" {
-  default_network_acl_id = "${aws_vpc.mainvpc.default_network_acl_id}"
+  default_network_acl_id = aws_vpc.mainvpc.default_network_acl_id
 
   # no rules defined, deny all traffic in this ACL
 }

--- a/website/docs/r/default_route_table.html.markdown
+++ b/website/docs/r/default_route_table.html.markdown
@@ -44,7 +44,7 @@ a conflict of rule settings and will overwrite routes.
 
 ```hcl
 resource "aws_default_route_table" "r" {
-  default_route_table_id = "${aws_vpc.foo.default_route_table_id}"
+  default_route_table_id = aws_vpc.foo.default_route_table_id
 
   route {
     # ...

--- a/website/docs/r/default_security_group.html.markdown
+++ b/website/docs/r/default_security_group.html.markdown
@@ -46,7 +46,7 @@ resource "aws_vpc" "mainvpc" {
 }
 
 resource "aws_default_security_group" "default" {
-  vpc_id = "${aws_vpc.mainvpc.id}"
+  vpc_id = aws_vpc.mainvpc.id
 
   ingress {
     protocol  = -1
@@ -75,7 +75,7 @@ resource "aws_vpc" "mainvpc" {
 }
 
 resource "aws_default_security_group" "default" {
-  vpc_id = "${aws_vpc.mainvpc.id}"
+  vpc_id = aws_vpc.mainvpc.id
 
   ingress {
     protocol  = -1

--- a/website/docs/r/directory_service_conditional_forwarder.html.markdown
+++ b/website/docs/r/directory_service_conditional_forwarder.html.markdown
@@ -14,7 +14,7 @@ Provides a conditional forwarder for managed Microsoft AD in AWS Directory Servi
 
 ```hcl
 resource "aws_directory_service_conditional_forwarder" "example" {
-  directory_id       = "${aws_directory_service_directory.ad.id}"
+  directory_id       = aws_directory_service_directory.ad.id
   remote_domain_name = "example.com"
 
   dns_ips = [

--- a/website/docs/r/directory_service_directory.html.markdown
+++ b/website/docs/r/directory_service_directory.html.markdown
@@ -24,8 +24,8 @@ resource "aws_directory_service_directory" "bar" {
   size     = "Small"
 
   vpc_settings {
-    vpc_id     = "${aws_vpc.main.id}"
-    subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
+    vpc_id     = aws_vpc.main.id
+    subnet_ids = [aws_subnet.foo.id, aws_subnet.bar.id]
   }
 
   tags = {
@@ -38,13 +38,13 @@ resource "aws_vpc" "main" {
 }
 
 resource "aws_subnet" "foo" {
-  vpc_id            = "${aws_vpc.main.id}"
+  vpc_id            = aws_vpc.main.id
   availability_zone = "us-west-2a"
   cidr_block        = "10.0.1.0/24"
 }
 
 resource "aws_subnet" "bar" {
-  vpc_id            = "${aws_vpc.main.id}"
+  vpc_id            = aws_vpc.main.id
   availability_zone = "us-west-2b"
   cidr_block        = "10.0.2.0/24"
 }
@@ -60,8 +60,8 @@ resource "aws_directory_service_directory" "bar" {
   type     = "MicrosoftAD"
 
   vpc_settings {
-    vpc_id     = "${aws_vpc.main.id}"
-    subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
+    vpc_id     = aws_vpc.main.id
+    subnet_ids = [aws_subnet.foo.id, aws_subnet.bar.id]
   }
 
   tags = {
@@ -74,13 +74,13 @@ resource "aws_vpc" "main" {
 }
 
 resource "aws_subnet" "foo" {
-  vpc_id            = "${aws_vpc.main.id}"
+  vpc_id            = aws_vpc.main.id
   availability_zone = "us-west-2a"
   cidr_block        = "10.0.1.0/24"
 }
 
 resource "aws_subnet" "bar" {
-  vpc_id            = "${aws_vpc.main.id}"
+  vpc_id            = aws_vpc.main.id
   availability_zone = "us-west-2b"
   cidr_block        = "10.0.2.0/24"
 }
@@ -98,8 +98,8 @@ resource "aws_directory_service_directory" "connector" {
   connect_settings {
     customer_dns_ips  = ["A.B.C.D"]
     customer_username = "Admin"
-    subnet_ids        = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
-    vpc_id            = "${aws_vpc.main.id}"
+    subnet_ids        = [aws_subnet.foo.id, aws_subnet.bar.id]
+    vpc_id            = aws_vpc.main.id
   }
 }
 
@@ -108,13 +108,13 @@ resource "aws_vpc" "main" {
 }
 
 resource "aws_subnet" "foo" {
-  vpc_id            = "${aws_vpc.main.id}"
+  vpc_id            = aws_vpc.main.id
   availability_zone = "us-west-2a"
   cidr_block        = "10.0.1.0/24"
 }
 
 resource "aws_subnet" "bar" {
-  vpc_id            = "${aws_vpc.main.id}"
+  vpc_id            = aws_vpc.main.id
   availability_zone = "us-west-2b"
   cidr_block        = "10.0.2.0/24"
 }

--- a/website/docs/r/directory_service_log_subscription.html.markdown
+++ b/website/docs/r/directory_service_log_subscription.html.markdown
@@ -30,20 +30,20 @@ data "aws_iam_policy_document" "ad-log-policy" {
       type        = "Service"
     }
 
-    resources = ["${aws_cloudwatch_log_group.example.arn}"]
+    resources = [aws_cloudwatch_log_group.example.arn]
 
     effect = "Allow"
   }
 }
 
 resource "aws_cloudwatch_log_resource_policy" "ad-log-policy" {
-  policy_document = "${data.aws_iam_policy_document.ad-log-policy.json}"
+  policy_document = data.aws_iam_policy_document.ad-log-policy.json
   policy_name     = "ad-log-policy"
 }
 
 resource "aws_directory_service_log_subscription" "example" {
-  directory_id   = "${aws_directory_service_directory.example.id}"
-  log_group_name = "${aws_cloudwatch_log_group.example.name}"
+  directory_id   = aws_directory_service_directory.example.id
+  log_group_name = aws_cloudwatch_log_group.example.name
 }
 ```
 

--- a/website/docs/r/dlm_lifecycle_policy.markdown
+++ b/website/docs/r/dlm_lifecycle_policy.markdown
@@ -35,7 +35,7 @@ EOF
 
 resource "aws_iam_role_policy" "dlm_lifecycle" {
   name = "dlm-lifecycle-policy"
-  role = "${aws_iam_role.dlm_lifecycle_role.id}"
+  role = aws_iam_role.dlm_lifecycle_role.id
 
   policy = <<EOF
 {
@@ -65,7 +65,7 @@ EOF
 
 resource "aws_dlm_lifecycle_policy" "example" {
   description        = "example DLM lifecycle policy"
-  execution_role_arn = "${aws_iam_role.dlm_lifecycle_role.arn}"
+  execution_role_arn = aws_iam_role.dlm_lifecycle_role.arn
   state              = "ENABLED"
 
   policy_details {

--- a/website/docs/r/dms_replication_instance.html.markdown
+++ b/website/docs/r/dms_replication_instance.html.markdown
@@ -32,33 +32,33 @@ data "aws_iam_policy_document" "dms_assume_role" {
 }
 
 resource "aws_iam_role" "dms-access-for-endpoint" {
-  assume_role_policy = "${data.aws_iam_policy_document.dms_assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.dms_assume_role.json
   name               = "dms-access-for-endpoint"
 }
 
 resource "aws_iam_role_policy_attachment" "dms-access-for-endpoint-AmazonDMSRedshiftS3Role" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonDMSRedshiftS3Role"
-  role       = "${aws_iam_role.dms-access-for-endpoint.name}"
+  role       = aws_iam_role.dms-access-for-endpoint.name
 }
 
 resource "aws_iam_role" "dms-cloudwatch-logs-role" {
-  assume_role_policy = "${data.aws_iam_policy_document.dms_assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.dms_assume_role.json
   name               = "dms-cloudwatch-logs-role"
 }
 
 resource "aws_iam_role_policy_attachment" "dms-cloudwatch-logs-role-AmazonDMSCloudWatchLogsRole" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonDMSCloudWatchLogsRole"
-  role       = "${aws_iam_role.dms-cloudwatch-logs-role.name}"
+  role       = aws_iam_role.dms-cloudwatch-logs-role.name
 }
 
 resource "aws_iam_role" "dms-vpc-role" {
-  assume_role_policy = "${data.aws_iam_policy_document.dms_assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.dms_assume_role.json
   name               = "dms-vpc-role"
 }
 
 resource "aws_iam_role_policy_attachment" "dms-vpc-role-AmazonDMSVPCManagementRole" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonDMSVPCManagementRole"
-  role       = "${aws_iam_role.dms-vpc-role.name}"
+  role       = aws_iam_role.dms-vpc-role.name
 }
 
 # Create a new replication instance
@@ -74,7 +74,7 @@ resource "aws_dms_replication_instance" "test" {
   publicly_accessible          = true
   replication_instance_class   = "dms.t2.micro"
   replication_instance_id      = "test-dms-replication-instance-tf"
-  replication_subnet_group_id  = "${aws_dms_replication_subnet_group.test-dms-replication-subnet-group-tf.id}"
+  replication_subnet_group_id  = aws_dms_replication_subnet_group.test-dms-replication-subnet-group-tf.id
 
   tags = {
     Name = "test"

--- a/website/docs/r/dms_replication_task.html.markdown
+++ b/website/docs/r/dms_replication_task.html.markdown
@@ -17,17 +17,17 @@ Provides a DMS (Data Migration Service) replication task resource. DMS replicati
 resource "aws_dms_replication_task" "test" {
   cdc_start_time            = 1484346880
   migration_type            = "full-load"
-  replication_instance_arn  = "${aws_dms_replication_instance.test-dms-replication-instance-tf.replication_instance_arn}"
+  replication_instance_arn  = aws_dms_replication_instance.test-dms-replication-instance-tf.replication_instance_arn
   replication_task_id       = "test-dms-replication-task-tf"
   replication_task_settings = "..."
-  source_endpoint_arn       = "${aws_dms_endpoint.test-dms-source-endpoint-tf.endpoint_arn}"
+  source_endpoint_arn       = aws_dms_endpoint.test-dms-source-endpoint-tf.endpoint_arn
   table_mappings            = "{\"rules\":[{\"rule-type\":\"selection\",\"rule-id\":\"1\",\"rule-name\":\"1\",\"object-locator\":{\"schema-name\":\"%\",\"table-name\":\"%\"},\"rule-action\":\"include\"}]}"
 
   tags = {
     Name = "test"
   }
 
-  target_endpoint_arn = "${aws_dms_endpoint.test-dms-target-endpoint-tf.endpoint_arn}"
+  target_endpoint_arn = aws_dms_endpoint.test-dms-target-endpoint-tf.endpoint_arn
 }
 ```
 

--- a/website/docs/r/docdb_cluster_instance.html.markdown
+++ b/website/docs/r/docdb_cluster_instance.html.markdown
@@ -23,7 +23,7 @@ Cluster, or you may specify different Cluster Instance resources with various
 resource "aws_docdb_cluster_instance" "cluster_instances" {
   count              = 2
   identifier         = "docdb-cluster-demo-${count.index}"
-  cluster_identifier = "${aws_docdb_cluster.default.id}"
+  cluster_identifier = aws_docdb_cluster.default.id
   instance_class     = "db.r5.large"
 }
 

--- a/website/docs/r/docdb_cluster_snapshot.html.markdown
+++ b/website/docs/r/docdb_cluster_snapshot.html.markdown
@@ -14,7 +14,7 @@ Manages a DocDB database cluster snapshot for DocDB clusters.
 
 ```hcl
 resource "aws_docdb_cluster_snapshot" "example" {
-  db_cluster_identifier          = "${aws_docdb_cluster.example.id}"
+  db_cluster_identifier          = aws_docdb_cluster.example.id
   db_cluster_snapshot_identifier = "resourcetestsnapshot1234"
 }
 ```

--- a/website/docs/r/docdb_subnet_group.html.markdown
+++ b/website/docs/r/docdb_subnet_group.html.markdown
@@ -15,7 +15,7 @@ Provides an DocumentDB subnet group resource.
 ```hcl
 resource "aws_docdb_subnet_group" "default" {
   name       = "main"
-  subnet_ids = ["${aws_subnet.frontend.id}", "${aws_subnet.backend.id}"]
+  subnet_ids = [aws_subnet.frontend.id, aws_subnet.backend.id]
 
   tags = {
     Name = "My docdb subnet group"

--- a/website/docs/r/dx_bgp_peer.html.markdown
+++ b/website/docs/r/dx_bgp_peer.html.markdown
@@ -14,7 +14,7 @@ Provides a Direct Connect BGP peer resource.
 
 ```hcl
 resource "aws_dx_bgp_peer" "peer" {
-  virtual_interface_id = "${aws_dx_private_virtual_interface.foo.id}"
+  virtual_interface_id = aws_dx_private_virtual_interface.foo.id
   address_family       = "ipv6"
   bgp_asn              = 65351
 }

--- a/website/docs/r/dx_connection_association.html.markdown
+++ b/website/docs/r/dx_connection_association.html.markdown
@@ -26,8 +26,8 @@ resource "aws_dx_lag" "example" {
 }
 
 resource "aws_dx_connection_association" "example" {
-  connection_id = "${aws_dx_connection.example.id}"
-  lag_id        = "${aws_dx_lag.example.id}"
+  connection_id = aws_dx_connection.example.id
+  lag_id        = aws_dx_lag.example.id
 }
 ```
 

--- a/website/docs/r/dx_gateway_association.html.markdown
+++ b/website/docs/r/dx_gateway_association.html.markdown
@@ -29,12 +29,12 @@ resource "aws_vpc" "example" {
 }
 
 resource "aws_vpn_gateway" "example" {
-  vpc_id = "${aws_vpc.example.id}"
+  vpc_id = aws_vpc.example.id
 }
 
 resource "aws_dx_gateway_association" "example" {
-  dx_gateway_id         = "${aws_dx_gateway.example.id}"
-  associated_gateway_id = "${aws_vpn_gateway.example.id}"
+  dx_gateway_id         = aws_dx_gateway.example.id
+  associated_gateway_id = aws_vpn_gateway.example.id
 }
 ```
 
@@ -49,8 +49,8 @@ resource "aws_dx_gateway" "example" {
 resource "aws_ec2_transit_gateway" "example" {}
 
 resource "aws_dx_gateway_association" "example" {
-  dx_gateway_id         = "${aws_dx_gateway.example.id}"
-  associated_gateway_id = "${aws_ec2_transit_gateway.example.id}"
+  dx_gateway_id         = aws_dx_gateway.example.id
+  associated_gateway_id = aws_ec2_transit_gateway.example.id
 
   allowed_prefixes = [
     "10.255.255.0/30",
@@ -72,12 +72,12 @@ resource "aws_vpc" "example" {
 }
 
 resource "aws_vpn_gateway" "example" {
-  vpc_id = "${aws_vpc.example.id}"
+  vpc_id = aws_vpc.example.id
 }
 
 resource "aws_dx_gateway_association" "example" {
-  dx_gateway_id         = "${aws_dx_gateway.example.id}"
-  associated_gateway_id = "${aws_vpn_gateway.example.id}"
+  dx_gateway_id         = aws_dx_gateway.example.id
+  associated_gateway_id = aws_vpn_gateway.example.id
 
   allowed_prefixes = [
     "210.52.109.0/24",

--- a/website/docs/r/dx_gateway_association_proposal.html.markdown
+++ b/website/docs/r/dx_gateway_association_proposal.html.markdown
@@ -14,9 +14,9 @@ Manages a Direct Connect Gateway Association Proposal, typically for enabling cr
 
 ```hcl
 resource "aws_dx_gateway_association_proposal" "example" {
-  dx_gateway_id               = "${aws_dx_gateway.example.id}"
-  dx_gateway_owner_account_id = "${aws_dx_gateway.example.owner_account_id}"
-  associated_gateway_id       = "${aws_vpn_gateway.example.id}"
+  dx_gateway_id               = aws_dx_gateway.example.id
+  dx_gateway_owner_account_id = aws_dx_gateway.example.owner_account_id
+  associated_gateway_id       = aws_vpn_gateway.example.id
 }
 ```
 

--- a/website/docs/r/dx_hosted_private_virtual_interface_accepter.html.markdown
+++ b/website/docs/r/dx_hosted_private_virtual_interface_accepter.html.markdown
@@ -31,7 +31,7 @@ data "aws_caller_identity" "accepter" {
 # Creator's side of the VIF
 resource "aws_dx_hosted_private_virtual_interface" "creator" {
   connection_id    = "dxcon-zzzzzzzz"
-  owner_account_id = "${data.aws_caller_identity.accepter.account_id}"
+  owner_account_id = data.aws_caller_identity.accepter.account_id
 
   name           = "vif-foo"
   vlan           = 4094
@@ -50,8 +50,8 @@ resource "aws_vpn_gateway" "vpn_gw" {
 
 resource "aws_dx_hosted_private_virtual_interface_accepter" "accepter" {
   provider             = "aws.accepter"
-  virtual_interface_id = "${aws_dx_hosted_private_virtual_interface.creator.id}"
-  vpn_gateway_id       = "${aws_vpn_gateway.vpn_gw.id}"
+  virtual_interface_id = aws_dx_hosted_private_virtual_interface.creator.id
+  vpn_gateway_id       = aws_vpn_gateway.vpn_gw.id
 
   tags = {
     Side = "Accepter"

--- a/website/docs/r/dx_hosted_public_virtual_interface_accepter.html.markdown
+++ b/website/docs/r/dx_hosted_public_virtual_interface_accepter.html.markdown
@@ -31,7 +31,7 @@ data "aws_caller_identity" "accepter" {
 # Creator's side of the VIF
 resource "aws_dx_hosted_public_virtual_interface" "creator" {
   connection_id    = "dxcon-zzzzzzzz"
-  owner_account_id = "${data.aws_caller_identity.accepter.account_id}"
+  owner_account_id = data.aws_caller_identity.accepter.account_id
 
   name           = "vif-foo"
   vlan           = 4094
@@ -50,7 +50,7 @@ resource "aws_dx_hosted_public_virtual_interface" "creator" {
 # Accepter's side of the VIF.
 resource "aws_dx_hosted_public_virtual_interface_accepter" "accepter" {
   provider             = "aws.accepter"
-  virtual_interface_id = "${aws_dx_hosted_public_virtual_interface.creator.id}"
+  virtual_interface_id = aws_dx_hosted_public_virtual_interface.creator.id
 
   tags = {
     Side = "Accepter"

--- a/website/docs/r/dx_hosted_transit_virtual_interface.html.markdown
+++ b/website/docs/r/dx_hosted_transit_virtual_interface.html.markdown
@@ -16,7 +16,7 @@ A hosted virtual interface is a virtual interface that is owned by another AWS a
 
 ```hcl
 resource "aws_dx_hosted_transit_virtual_interface" "example" {
-  connection_id = "${aws_dx_connection.example.id}"
+  connection_id = aws_dx_connection.example.id
 
   name           = "tf-transit-vif-example"
   vlan           = 4094

--- a/website/docs/r/dx_hosted_transit_virtual_interface_accepter.html.markdown
+++ b/website/docs/r/dx_hosted_transit_virtual_interface_accepter.html.markdown
@@ -33,7 +33,7 @@ data "aws_caller_identity" "accepter" {
 # Creator's side of the VIF
 resource "aws_dx_hosted_transit_virtual_interface" "creator" {
   connection_id    = "dxcon-zzzzzzzz"
-  owner_account_id = "${data.aws_caller_identity.accepter.account_id}"
+  owner_account_id = data.aws_caller_identity.accepter.account_id
 
   name           = "tf-transit-vif-example"
   vlan           = 4094
@@ -55,8 +55,8 @@ resource "aws_dx_gateway" "example" {
 
 resource "aws_dx_hosted_transit_virtual_interface_accepter" "accepter" {
   provider             = "aws.accepter"
-  virtual_interface_id = "${aws_dx_hosted_transit_virtual_interface.creator.id}"
-  dx_gateway_id        = "${aws_dx_gateway.example.id}"
+  virtual_interface_id = aws_dx_hosted_transit_virtual_interface.creator.id
+  dx_gateway_id        = aws_dx_gateway.example.id
 
   tags = {
     Side = "Accepter"

--- a/website/docs/r/dx_transit_virtual_interface.html.markdown
+++ b/website/docs/r/dx_transit_virtual_interface.html.markdown
@@ -20,9 +20,9 @@ resource "aws_dx_gateway" "example" {
 }
 
 resource "aws_dx_transit_virtual_interface" "example" {
-  connection_id = "${aws_dx_connection.example.id}"
+  connection_id = aws_dx_connection.example.id
 
-  dx_gateway_id  = "${aws_dx_gateway.example.id}"
+  dx_gateway_id  = aws_dx_gateway.example.id
   name           = "tf-transit-vif-example"
   vlan           = 4094
   address_family = "ipv4"

--- a/website/docs/r/dynamodb_table_item.html.markdown
+++ b/website/docs/r/dynamodb_table_item.html.markdown
@@ -17,8 +17,8 @@ Provides a DynamoDB table item resource
 
 ```hcl
 resource "aws_dynamodb_table_item" "example" {
-  table_name = "${aws_dynamodb_table.example.name}"
-  hash_key   = "${aws_dynamodb_table.example.hash_key}"
+  table_name = aws_dynamodb_table.example.name
+  hash_key   = aws_dynamodb_table.example.hash_key
 
   item = <<ITEM
 {

--- a/website/docs/r/ebs_default_kms_key.html.markdown
+++ b/website/docs/r/ebs_default_kms_key.html.markdown
@@ -21,7 +21,7 @@ By using the `aws_ebs_default_kms_key` resource, you can specify a customer-mana
 
 ```hcl
 resource "aws_ebs_default_kms_key" "example" {
-  key_arn = "${aws_kms_key.example.arn}"
+  key_arn = aws_kms_key.example.arn
 }
 ```
 

--- a/website/docs/r/ebs_snapshot.html.markdown
+++ b/website/docs/r/ebs_snapshot.html.markdown
@@ -23,7 +23,7 @@ resource "aws_ebs_volume" "example" {
 }
 
 resource "aws_ebs_snapshot" "example_snapshot" {
-  volume_id = "${aws_ebs_volume.example.id}"
+  volume_id = aws_ebs_volume.example.id
 
   tags = {
     Name = "HelloWorld_snap"

--- a/website/docs/r/ebs_snapshot_copy.html.markdown
+++ b/website/docs/r/ebs_snapshot_copy.html.markdown
@@ -23,7 +23,7 @@ resource "aws_ebs_volume" "example" {
 }
 
 resource "aws_ebs_snapshot" "example_snapshot" {
-  volume_id = "${aws_ebs_volume.example.id}"
+  volume_id = aws_ebs_volume.example.id
 
   tags = {
     Name = "HelloWorld_snap"
@@ -31,7 +31,7 @@ resource "aws_ebs_snapshot" "example_snapshot" {
 }
 
 resource "aws_ebs_snapshot_copy" "example_copy" {
-  source_snapshot_id = "${aws_ebs_snapshot.example_snapshot.id}"
+  source_snapshot_id = aws_ebs_snapshot.example_snapshot.id
   source_region      = "us-west-2"
 
   tags = {

--- a/website/docs/r/ec2_client_vpn_endpoint.html.markdown
+++ b/website/docs/r/ec2_client_vpn_endpoint.html.markdown
@@ -16,18 +16,18 @@ Provides an AWS Client VPN endpoint for OpenVPN clients. For more information on
 ```hcl
 resource "aws_ec2_client_vpn_endpoint" "example" {
   description            = "terraform-clientvpn-example"
-  server_certificate_arn = "${aws_acm_certificate.cert.arn}"
+  server_certificate_arn = aws_acm_certificate.cert.arn
   client_cidr_block      = "10.0.0.0/16"
 
   authentication_options {
     type                       = "certificate-authentication"
-    root_certificate_chain_arn = "${aws_acm_certificate.root_cert.arn}"
+    root_certificate_chain_arn = aws_acm_certificate.root_cert.arn
   }
 
   connection_log_options {
     enabled               = true
-    cloudwatch_log_group  = "${aws_cloudwatch_log_group.lg.name}"
-    cloudwatch_log_stream = "${aws_cloudwatch_log_stream.ls.name}"
+    cloudwatch_log_group  = aws_cloudwatch_log_group.lg.name
+    cloudwatch_log_stream = aws_cloudwatch_log_stream.ls.name
   }
 }
 ```

--- a/website/docs/r/ec2_client_vpn_network_association.html.markdown
+++ b/website/docs/r/ec2_client_vpn_network_association.html.markdown
@@ -15,8 +15,8 @@ Provides network associations for AWS Client VPN endpoints. For more information
 
 ```hcl
 resource "aws_ec2_client_vpn_network_association" "example" {
-  client_vpn_endpoint_id = "${aws_ec2_client_vpn_endpoint.example.id}"
-  subnet_id              = "${aws_subnet.example.id}"
+  client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.example.id
+  subnet_id              = aws_subnet.example.id
 }
 ```
 

--- a/website/docs/r/ec2_fleet.html.markdown
+++ b/website/docs/r/ec2_fleet.html.markdown
@@ -16,8 +16,8 @@ Provides a resource to manage EC2 Fleets.
 resource "aws_ec2_fleet" "example" {
   launch_template_config {
     launch_template_specification {
-      launch_template_id = "${aws_launch_template.example.id}"
-      version            = "${aws_launch_template.example.latest_version}"
+      launch_template_id = aws_launch_template.example.id
+      version            = aws_launch_template.example.latest_version
     }
   }
 

--- a/website/docs/r/ec2_traffic_mirror_filter_rule.html.markdown
+++ b/website/docs/r/ec2_traffic_mirror_filter_rule.html.markdown
@@ -23,7 +23,7 @@ resource "aws_ec2_traffic_mirror_filter" "filter" {
 
 resource "aws_ec2_traffic_mirror_filter_rule" "ruleout" {
   description              = "test rule"
-  traffic_mirror_filter_id = "${aws_ec2_traffic_mirror_filter.filter.id}"
+  traffic_mirror_filter_id = aws_ec2_traffic_mirror_filter.filter.id
   destination_cidr_block   = "10.0.0.0/8"
   source_cidr_block        = "10.0.0.0/8"
   rule_number              = 1
@@ -33,7 +33,7 @@ resource "aws_ec2_traffic_mirror_filter_rule" "ruleout" {
 
 resource "aws_ec2_traffic_mirror_filter_rule" "rulein" {
   description              = "test rule"
-  traffic_mirror_filter_id = "${aws_ec2_traffic_mirror_filter.filter.id}"
+  traffic_mirror_filter_id = aws_ec2_traffic_mirror_filter.filter.id
   destination_cidr_block   = "10.0.0.0/8"
   source_cidr_block        = "10.0.0.0/8"
   rule_number              = 1

--- a/website/docs/r/ec2_traffic_mirror_session.html.markdown
+++ b/website/docs/r/ec2_traffic_mirror_session.html.markdown
@@ -22,14 +22,14 @@ resource "aws_ec2_traffic_mirror_filter" "filter" {
 }
 
 resource "aws_ec2_traffic_mirror_target" "target" {
-  network_load_balancer_arn = "${aws_lb.lb.arn}"
+  network_load_balancer_arn = aws_lb.lb.arn
 }
 
 resource "aws_ec2_traffic_mirror_session" "session" {
   description              = "traffic mirror session - terraform example"
-  network_interface_id     = "${aws_instance.test.primary_network_interface_id}"
-  traffic_mirror_filter_id = "${aws_ec2_traffic_mirror_filter.filter.id}"
-  traffic_mirror_target_id = "${aws_ec2_traffic_mirror_target.target.id}"
+  network_interface_id     = aws_instance.test.primary_network_interface_id
+  traffic_mirror_filter_id = aws_ec2_traffic_mirror_filter.filter.id
+  traffic_mirror_target_id = aws_ec2_traffic_mirror_target.target.id
 }
 ```
 

--- a/website/docs/r/ec2_traffic_mirror_target.html.markdown
+++ b/website/docs/r/ec2_traffic_mirror_target.html.markdown
@@ -18,12 +18,12 @@ To create a basic traffic mirror session
 ```hcl
 resource "aws_ec2_traffic_mirror_target" "nlb" {
   description               = "NLB target"
-  network_load_balancer_arn = "${aws_lb.lb.arn}"
+  network_load_balancer_arn = aws_lb.lb.arn
 }
 
 resource "aws_ec2_traffic_mirror_target" "eni" {
   description          = "ENI target"
-  network_interface_id = "${aws_instance.test.primary_network_interface_id}"
+  network_interface_id = aws_instance.test.primary_network_interface_id
 }
 
 ```

--- a/website/docs/r/ec2_transit_gateway_route.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_route.html.markdown
@@ -17,8 +17,8 @@ Manages an EC2 Transit Gateway Route.
 ```hcl
 resource "aws_ec2_transit_gateway_route" "example" {
   destination_cidr_block         = "0.0.0.0/0"
-  transit_gateway_attachment_id  = "${aws_ec2_transit_gateway_vpc_attachment.example.id}"
-  transit_gateway_route_table_id = "${aws_ec2_transit_gateway.example.association_default_route_table_id}"
+  transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.example.id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway.example.association_default_route_table_id
 }
 ```
 
@@ -28,7 +28,7 @@ resource "aws_ec2_transit_gateway_route" "example" {
 resource "aws_ec2_transit_gateway_route" "example" {
   destination_cidr_block         = "0.0.0.0/0"
   blackhole                      = true
-  transit_gateway_route_table_id = "${aws_ec2_transit_gateway.example.association_default_route_table_id}"
+  transit_gateway_route_table_id = aws_ec2_transit_gateway.example.association_default_route_table_id
 }
 ```
 

--- a/website/docs/r/ec2_transit_gateway_route_table.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_route_table.html.markdown
@@ -14,7 +14,7 @@ Manages an EC2 Transit Gateway Route Table.
 
 ```hcl
 resource "aws_ec2_transit_gateway_route_table" "example" {
-  transit_gateway_id = "${aws_ec2_transit_gateway.example.id}"
+  transit_gateway_id = aws_ec2_transit_gateway.example.id
 }
 ```
 

--- a/website/docs/r/ec2_transit_gateway_route_table_association.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_route_table_association.html.markdown
@@ -14,8 +14,8 @@ Manages an EC2 Transit Gateway Route Table association.
 
 ```hcl
 resource "aws_ec2_transit_gateway_route_table_association" "example" {
-  transit_gateway_attachment_id  = "${aws_ec2_transit_gateway_vpc_attachment.example.id}"
-  transit_gateway_route_table_id = "${aws_ec2_transit_gateway_route_table.example.id}"
+  transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.example.id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.example.id
 }
 ```
 

--- a/website/docs/r/ec2_transit_gateway_route_table_propagation.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_route_table_propagation.html.markdown
@@ -14,8 +14,8 @@ Manages an EC2 Transit Gateway Route Table propagation.
 
 ```hcl
 resource "aws_ec2_transit_gateway_route_table_propagation" "example" {
-  transit_gateway_attachment_id  = "${aws_ec2_transit_gateway_vpc_attachment.example.id}"
-  transit_gateway_route_table_id = "${aws_ec2_transit_gateway_route_table.example.id}"
+  transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.example.id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.example.id
 }
 ```
 

--- a/website/docs/r/ec2_transit_gateway_vpc_attachment.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_vpc_attachment.html.markdown
@@ -14,9 +14,9 @@ Manages an EC2 Transit Gateway VPC Attachment. For examples of custom route tabl
 
 ```hcl
 resource "aws_ec2_transit_gateway_vpc_attachment" "example" {
-  subnet_ids         = ["${aws_subnet.example.id}"]
-  transit_gateway_id = "${aws_ec2_transit_gateway.example.id}"
-  vpc_id             = "${aws_vpc.example.id}"
+  subnet_ids         = [aws_subnet.example.id]
+  transit_gateway_id = aws_ec2_transit_gateway.example.id
+  vpc_id             = aws_vpc.example.id
 }
 ```
 

--- a/website/docs/r/ec2_transit_gateway_vpc_attachment_accepter.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_vpc_attachment_accepter.html.markdown
@@ -20,7 +20,7 @@ connection into management.
 
 ```hcl
 resource "aws_ec2_transit_gateway_vpc_attachment_accepter" "example" {
-  transit_gateway_attachment_id = "${aws_ec2_transit_gateway_vpc_attachment.example.id}"
+  transit_gateway_attachment_id = aws_ec2_transit_gateway_vpc_attachment.example.id
 
   tags = {
     Name = "Example cross-account attachment"

--- a/website/docs/r/ecr_lifecycle_policy.html.markdown
+++ b/website/docs/r/ecr_lifecycle_policy.html.markdown
@@ -24,7 +24,7 @@ resource "aws_ecr_repository" "foo" {
 }
 
 resource "aws_ecr_lifecycle_policy" "foopolicy" {
-  repository = "${aws_ecr_repository.foo.name}"
+  repository = aws_ecr_repository.foo.name
 
   policy = <<EOF
 {
@@ -56,7 +56,7 @@ resource "aws_ecr_repository" "foo" {
 }
 
 resource "aws_ecr_lifecycle_policy" "foopolicy" {
-  repository = "${aws_ecr_repository.foo.name}"
+  repository = aws_ecr_repository.foo.name
 
   policy = <<EOF
 {

--- a/website/docs/r/ecr_repository_policy.html.markdown
+++ b/website/docs/r/ecr_repository_policy.html.markdown
@@ -20,7 +20,7 @@ resource "aws_ecr_repository" "foo" {
 }
 
 resource "aws_ecr_repository_policy" "foopolicy" {
-  repository = "${aws_ecr_repository.foo.name}"
+  repository = aws_ecr_repository.foo.name
 
   policy = <<EOF
 {

--- a/website/docs/r/ecs_service.html.markdown
+++ b/website/docs/r/ecs_service.html.markdown
@@ -19,10 +19,10 @@ See [ECS Services section in AWS developer guide](https://docs.aws.amazon.com/Am
 ```hcl
 resource "aws_ecs_service" "mongo" {
   name            = "mongodb"
-  cluster         = "${aws_ecs_cluster.foo.id}"
-  task_definition = "${aws_ecs_task_definition.mongo.arn}"
+  cluster         = aws_ecs_cluster.foo.id
+  task_definition = aws_ecs_task_definition.mongo.arn
   desired_count   = 3
-  iam_role        = "${aws_iam_role.foo.arn}"
+  iam_role        = aws_iam_role.foo.arn
   depends_on      = ["aws_iam_role_policy.foo"]
 
   ordered_placement_strategy {
@@ -31,7 +31,7 @@ resource "aws_ecs_service" "mongo" {
   }
 
   load_balancer {
-    target_group_arn = "${aws_lb_target_group.foo.arn}"
+    target_group_arn = aws_lb_target_group.foo.arn
     container_name   = "mongo"
     container_port   = 8080
   }
@@ -66,8 +66,8 @@ resource "aws_ecs_service" "example" {
 ```hcl
 resource "aws_ecs_service" "bar" {
   name                = "bar"
-  cluster             = "${aws_ecs_cluster.foo.id}"
-  task_definition     = "${aws_ecs_task_definition.bar.arn}"
+  cluster             = aws_ecs_cluster.foo.id
+  task_definition     = aws_ecs_task_definition.bar.arn
   scheduling_strategy = "DAEMON"
 }
 ```

--- a/website/docs/r/ecs_task_definition.html.markdown
+++ b/website/docs/r/ecs_task_definition.html.markdown
@@ -169,7 +169,7 @@ For more information, see [Specifying an EFS volume in your Task Definition Deve
 ```hcl
 resource "aws_ecs_task_definition" "service" {
   family                = "service"
-  container_definitions = "${file("task-definitions/service.json")}"
+  container_definitions = file("task-definitions/service.json")
 
   volume {
     name = "service-storage"

--- a/website/docs/r/efs_mount_target.html.markdown
+++ b/website/docs/r/efs_mount_target.html.markdown
@@ -14,8 +14,8 @@ Provides an Elastic File System (EFS) mount target.
 
 ```hcl
 resource "aws_efs_mount_target" "alpha" {
-  file_system_id = "${aws_efs_file_system.foo.id}"
-  subnet_id      = "${aws_subnet.alpha.id}"
+  file_system_id = aws_efs_file_system.foo.id
+  subnet_id      = aws_subnet.alpha.id
 }
 
 resource "aws_vpc" "foo" {
@@ -23,7 +23,7 @@ resource "aws_vpc" "foo" {
 }
 
 resource "aws_subnet" "alpha" {
-  vpc_id            = "${aws_vpc.foo.id}"
+  vpc_id            = aws_vpc.foo.id
   availability_zone = "us-west-2a"
   cidr_block        = "10.0.1.0/24"
 }

--- a/website/docs/r/egress_only_internet_gateway.html.markdown
+++ b/website/docs/r/egress_only_internet_gateway.html.markdown
@@ -22,7 +22,7 @@ resource "aws_vpc" "example" {
 }
 
 resource "aws_egress_only_internet_gateway" "example" {
-  vpc_id = "${aws_vpc.example.id}"
+  vpc_id = aws_vpc.example.id
 }
 ```
 

--- a/website/docs/r/eip.html.markdown
+++ b/website/docs/r/eip.html.markdown
@@ -20,7 +20,7 @@ Single EIP associated with an instance:
 
 ```hcl
 resource "aws_eip" "lb" {
-  instance = "${aws_instance.web.id}"
+  instance = aws_instance.web.id
   vpc      = true
 }
 ```
@@ -29,19 +29,19 @@ Multiple EIPs associated with a single network interface:
 
 ```hcl
 resource "aws_network_interface" "multi-ip" {
-  subnet_id   = "${aws_subnet.main.id}"
+  subnet_id   = aws_subnet.main.id
   private_ips = ["10.0.0.10", "10.0.0.11"]
 }
 
 resource "aws_eip" "one" {
   vpc                       = true
-  network_interface         = "${aws_network_interface.multi-ip.id}"
+  network_interface         = aws_network_interface.multi-ip.id
   associate_with_private_ip = "10.0.0.10"
 }
 
 resource "aws_eip" "two" {
   vpc                       = true
-  network_interface         = "${aws_network_interface.multi-ip.id}"
+  network_interface         = aws_network_interface.multi-ip.id
   associate_with_private_ip = "10.0.0.11"
 }
 ```
@@ -55,11 +55,11 @@ resource "aws_vpc" "default" {
 }
 
 resource "aws_internet_gateway" "gw" {
-  vpc_id = "${aws_vpc.default.id}"
+  vpc_id = aws_vpc.default.id
 }
 
 resource "aws_subnet" "tf_test_subnet" {
-  vpc_id                  = "${aws_vpc.default.id}"
+  vpc_id                  = aws_vpc.default.id
   cidr_block              = "10.0.0.0/24"
   map_public_ip_on_launch = true
 
@@ -72,13 +72,13 @@ resource "aws_instance" "foo" {
   instance_type = "t2.micro"
 
   private_ip = "10.0.0.12"
-  subnet_id  = "${aws_subnet.tf_test_subnet.id}"
+  subnet_id  = aws_subnet.tf_test_subnet.id
 }
 
 resource "aws_eip" "bar" {
   vpc = true
 
-  instance                  = "${aws_instance.foo.id}"
+  instance                  = aws_instance.foo.id
   associate_with_private_ip = "10.0.0.12"
   depends_on                = ["aws_internet_gateway.gw"]
 }

--- a/website/docs/r/eip_association.html.markdown
+++ b/website/docs/r/eip_association.html.markdown
@@ -20,8 +20,8 @@ pre-existing or distributed to customers or users and therefore cannot be change
 
 ```hcl
 resource "aws_eip_association" "eip_assoc" {
-  instance_id   = "${aws_instance.web.id}"
-  allocation_id = "${aws_eip.example.id}"
+  instance_id   = aws_instance.web.id
+  allocation_id = aws_eip.example.id
 }
 
 resource "aws_instance" "web" {

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -17,10 +17,10 @@ Manages an EKS Cluster.
 ```hcl
 resource "aws_eks_cluster" "example" {
   name     = "example"
-  role_arn = "${aws_iam_role.example.arn}"
+  role_arn = aws_iam_role.example.arn
 
   vpc_config {
-    subnet_ids = ["${aws_subnet.example1.id}", "${aws_subnet.example2.id}"]
+    subnet_ids = [aws_subnet.example1.id, aws_subnet.example2.id]
   }
 
   # Ensure that IAM Role permissions are created before and deleted after EKS Cluster handling.
@@ -32,11 +32,11 @@ resource "aws_eks_cluster" "example" {
 }
 
 output "endpoint" {
-  value = "${aws_eks_cluster.example.endpoint}"
+  value = aws_eks_cluster.example.endpoint
 }
 
 output "kubeconfig-certificate-authority-data" {
-  value = "${aws_eks_cluster.example.certificate_authority.0.data}"
+  value = aws_eks_cluster.example.certificate_authority.0.data
 }
 ```
 
@@ -64,12 +64,12 @@ POLICY
 
 resource "aws_iam_role_policy_attachment" "example-AmazonEKSClusterPolicy" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
-  role       = "${aws_iam_role.example.name}"
+  role       = aws_iam_role.example.name
 }
 
 resource "aws_iam_role_policy_attachment" "example-AmazonEKSServicePolicy" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
-  role       = "${aws_iam_role.example.name}"
+  role       = aws_iam_role.example.name
 }
 ```
 
@@ -89,7 +89,7 @@ resource "aws_eks_cluster" "example" {
   depends_on = ["aws_cloudwatch_log_group.example"]
 
   enabled_cluster_log_types = ["api", "audit"]
-  name                      = "${var.cluster_name}"
+  name                      = var.cluster_name
 
   # ... other configuration ...
 }
@@ -114,7 +114,7 @@ resource "aws_eks_cluster" "example" {
 resource "aws_iam_openid_connect_provider" "example" {
   client_id_list  = ["sts.amazonaws.com"]
   thumbprint_list = []
-  url             = "${aws_eks_cluster.example.identity.0.oidc.0.issuer}"
+  url             = aws_eks_cluster.example.identity.0.oidc.0.issuer
 }
 
 data "aws_caller_identity" "current" {}
@@ -131,14 +131,14 @@ data "aws_iam_policy_document" "example_assume_role_policy" {
     }
 
     principals {
-      identifiers = ["${aws_iam_openid_connect_provider.example.arn}"]
+      identifiers = [aws_iam_openid_connect_provider.example.arn]
       type        = "Federated"
     }
   }
 }
 
 resource "aws_iam_role" "example" {
-  assume_role_policy = "${data.aws_iam_policy_document.example_assume_role_policy.json}"
+  assume_role_policy = data.aws_iam_policy_document.example_assume_role_policy.json
   name               = "example"
 }
 ```

--- a/website/docs/r/elastic_beanstalk_application.html.markdown
+++ b/website/docs/r/elastic_beanstalk_application.html.markdown
@@ -23,7 +23,7 @@ resource "aws_elastic_beanstalk_application" "tftest" {
   description = "tf-test-desc"
 
   appversion_lifecycle {
-    service_role          = "${aws_iam_role.beanstalk_service.arn}"
+    service_role          = aws_iam_role.beanstalk_service.arn
     max_count             = 128
     delete_source_from_s3 = true
   }

--- a/website/docs/r/elastic_beanstalk_application_version.html.markdown
+++ b/website/docs/r/elastic_beanstalk_application_version.html.markdown
@@ -28,7 +28,7 @@ resource "aws_s3_bucket" "default" {
 }
 
 resource "aws_s3_bucket_object" "default" {
-  bucket = "${aws_s3_bucket.default.id}"
+  bucket = aws_s3_bucket.default.id
   key    = "beanstalk/go-v1.zip"
   source = "go-v1.zip"
 }
@@ -42,8 +42,8 @@ resource "aws_elastic_beanstalk_application_version" "default" {
   name        = "tf-test-version-label"
   application = "tf-test-name"
   description = "application version created by terraform"
-  bucket      = "${aws_s3_bucket.default.id}"
-  key         = "${aws_s3_bucket_object.default.id}"
+  bucket      = aws_s3_bucket.default.id
+  key         = aws_s3_bucket_object.default.id
 }
 ```
 

--- a/website/docs/r/elastic_beanstalk_configuration_template.html.markdown
+++ b/website/docs/r/elastic_beanstalk_configuration_template.html.markdown
@@ -22,7 +22,7 @@ resource "aws_elastic_beanstalk_application" "tftest" {
 
 resource "aws_elastic_beanstalk_configuration_template" "tf_template" {
   name                = "tf-test-template-config"
-  application         = "${aws_elastic_beanstalk_application.tftest.name}"
+  application         = aws_elastic_beanstalk_application.tftest.name
   solution_stack_name = "64bit Amazon Linux 2015.09 v2.0.8 running Go 1.4"
 }
 ```

--- a/website/docs/r/elastic_beanstalk_environment.html.markdown
+++ b/website/docs/r/elastic_beanstalk_environment.html.markdown
@@ -25,7 +25,7 @@ resource "aws_elastic_beanstalk_application" "tftest" {
 
 resource "aws_elastic_beanstalk_environment" "tfenvtest" {
   name                = "tf-test-name"
-  application         = "${aws_elastic_beanstalk_application.tftest.name}"
+  application         = aws_elastic_beanstalk_application.tftest.name
   solution_stack_name = "64bit Amazon Linux 2015.03 v2.0.3 running Go 1.4"
 }
 ```
@@ -87,7 +87,7 @@ resource "aws_elastic_beanstalk_application" "tftest" {
 
 resource "aws_elastic_beanstalk_environment" "tfenvtest" {
   name                = "tf-test-name"
-  application         = "${aws_elastic_beanstalk_application.tftest.name}"
+  application         = aws_elastic_beanstalk_application.tftest.name
   solution_stack_name = "64bit Amazon Linux 2015.03 v2.0.3 running Go 1.4"
 
   setting {

--- a/website/docs/r/elasticache_cluster.html.markdown
+++ b/website/docs/r/elasticache_cluster.html.markdown
@@ -55,7 +55,7 @@ These inherit their settings from the replication group.
 ```hcl
 resource "aws_elasticache_cluster" "replica" {
   cluster_id           = "cluster-example"
-  replication_group_id = "${aws_elasticache_replication_group.example.id}"
+  replication_group_id = aws_elasticache_replication_group.example.id
 }
 ```
 

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -64,7 +64,7 @@ resource "aws_elasticache_cluster" "replica" {
   count = 1
 
   cluster_id           = "tf-rep-group-1-${count.index}"
-  replication_group_id = "${aws_elasticache_replication_group.example.id}"
+  replication_group_id = aws_elasticache_replication_group.example.id
 }
 ```
 

--- a/website/docs/r/elasticache_security_group.html.markdown
+++ b/website/docs/r/elasticache_security_group.html.markdown
@@ -24,7 +24,7 @@ resource "aws_security_group" "bar" {
 
 resource "aws_elasticache_security_group" "bar" {
   name                 = "elasticache-security-group"
-  security_group_names = ["${aws_security_group.bar.name}"]
+  security_group_names = [aws_security_group.bar.name]
 }
 ```
 

--- a/website/docs/r/elasticache_subnet_group.html.markdown
+++ b/website/docs/r/elasticache_subnet_group.html.markdown
@@ -26,7 +26,7 @@ resource "aws_vpc" "foo" {
 }
 
 resource "aws_subnet" "foo" {
-  vpc_id            = "${aws_vpc.foo.id}"
+  vpc_id            = aws_vpc.foo.id
   cidr_block        = "10.0.0.0/24"
   availability_zone = "us-west-2a"
 
@@ -37,7 +37,7 @@ resource "aws_subnet" "foo" {
 
 resource "aws_elasticache_subnet_group" "bar" {
   name       = "tf-test-cache-subnet"
-  subnet_ids = ["${aws_subnet.foo.id}"]
+  subnet_ids = [aws_subnet.foo.id]
 }
 ```
 

--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -47,7 +47,7 @@ data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
 resource "aws_elasticsearch_domain" "example" {
-  domain_name = "${var.domain}"
+  domain_name = var.domain
 
   # ... other configuration ...
 
@@ -105,7 +105,7 @@ resource "aws_elasticsearch_domain" "example" {
   # .. other configuration ...
 
   log_publishing_options {
-    cloudwatch_log_group_arn = "${aws_cloudwatch_log_group.example.arn}"
+    cloudwatch_log_group_arn = aws_cloudwatch_log_group.example.arn
     log_type                 = "INDEX_SLOW_LOGS"
   }
 }
@@ -122,12 +122,12 @@ variable "domain" {
 
 data "aws_vpc" "selected" {
   tags = {
-    Name = "${var.vpc}"
+    Name = var.vpc
   }
 }
 
 data "aws_subnet_ids" "selected" {
-  vpc_id = "${data.aws_vpc.selected.id}"
+  vpc_id = data.aws_vpc.selected.id
 
   tags = {
     Tier = "private"
@@ -141,7 +141,7 @@ data "aws_caller_identity" "current" {}
 resource "aws_security_group" "es" {
   name        = "${var.vpc}-elasticsearch-${var.domain}"
   description = "Managed by Terraform"
-  vpc_id      = "${data.aws_vpc.selected.id}"
+  vpc_id      = data.aws_vpc.selected.id
 
   ingress {
     from_port = 443
@@ -149,7 +149,7 @@ resource "aws_security_group" "es" {
     protocol  = "tcp"
 
     cidr_blocks = [
-      "${data.aws_vpc.selected.cidr_block}",
+      data.aws_vpc.selected.cidr_block,
     ]
   }
 }
@@ -159,7 +159,7 @@ resource "aws_iam_service_linked_role" "es" {
 }
 
 resource "aws_elasticsearch_domain" "es" {
-  domain_name           = "${var.domain}"
+  domain_name           = var.domain
   elasticsearch_version = "6.3"
 
   cluster_config {
@@ -168,11 +168,11 @@ resource "aws_elasticsearch_domain" "es" {
 
   vpc_options {
     subnet_ids = [
-      "${data.aws_subnet_ids.selected.ids[0]}",
-      "${data.aws_subnet_ids.selected.ids[1]}",
+      data.aws_subnet_ids.selected.ids[0],
+      data.aws_subnet_ids.selected.ids[1],
     ]
 
-    security_group_ids = ["${aws_security_group.elasticsearch.id}"]
+    security_group_ids = [aws_security_group.elasticsearch.id]
   }
 
   advanced_options = {

--- a/website/docs/r/elasticsearch_domain_policy.html.markdown
+++ b/website/docs/r/elasticsearch_domain_policy.html.markdown
@@ -19,7 +19,7 @@ resource "aws_elasticsearch_domain" "example" {
 }
 
 resource "aws_elasticsearch_domain_policy" "main" {
-  domain_name = "${aws_elasticsearch_domain.example.domain_name}"
+  domain_name = aws_elasticsearch_domain.example.domain_name
 
   access_policies = <<POLICIES
 {

--- a/website/docs/r/elastictranscoder_pipeline.html.markdown
+++ b/website/docs/r/elastictranscoder_pipeline.html.markdown
@@ -14,17 +14,17 @@ Provides an Elastic Transcoder pipeline resource.
 
 ```hcl
 resource "aws_elastictranscoder_pipeline" "bar" {
-  input_bucket = "${aws_s3_bucket.input_bucket.bucket}"
+  input_bucket = aws_s3_bucket.input_bucket.bucket
   name         = "aws_elastictranscoder_pipeline_tf_test_"
-  role         = "${aws_iam_role.test_role.arn}"
+  role         = aws_iam_role.test_role.arn
 
   content_config {
-    bucket        = "${aws_s3_bucket.content_bucket.bucket}"
+    bucket        = aws_s3_bucket.content_bucket.bucket
     storage_class = "Standard"
   }
 
   thumbnail_config {
-    bucket        = "${aws_s3_bucket.thumb_bucket.bucket}"
+    bucket        = aws_s3_bucket.thumb_bucket.bucket
     storage_class = "Standard"
   }
 }

--- a/website/docs/r/elb.html.markdown
+++ b/website/docs/r/elb.html.markdown
@@ -56,7 +56,7 @@ resource "aws_elb" "bar" {
     interval            = 30
   }
 
-  instances                   = ["${aws_instance.foo.id}"]
+  instances                   = [aws_instance.foo.id]
   cross_zone_load_balancing   = true
   idle_timeout                = 400
   connection_draining         = true

--- a/website/docs/r/elb_attachment.html.markdown
+++ b/website/docs/r/elb_attachment.html.markdown
@@ -22,8 +22,8 @@ conflict and will overwrite attachments.
 ```hcl
 # Create a new load balancer attachment
 resource "aws_elb_attachment" "baz" {
-  elb      = "${aws_elb.bar.id}"
-  instance = "${aws_instance.foo.id}"
+  elb      = aws_elb.bar.id
+  instance = aws_instance.foo.id
 }
 ```
 

--- a/website/docs/r/emr_cluster.html.markdown
+++ b/website/docs/r/emr_cluster.html.markdown
@@ -37,10 +37,10 @@ EOF
   keep_job_flow_alive_when_no_steps = true
 
   ec2_attributes {
-    subnet_id                         = "${aws_subnet.main.id}"
-    emr_managed_master_security_group = "${aws_security_group.sg.id}"
-    emr_managed_slave_security_group  = "${aws_security_group.sg.id}"
-    instance_profile                  = "${aws_iam_instance_profile.emr_profile.arn}"
+    subnet_id                         = aws_subnet.main.id
+    emr_managed_master_security_group = aws_security_group.sg.id
+    emr_managed_slave_security_group  = aws_security_group.sg.id
+    instance_profile                  = aws_iam_instance_profile.emr_profile.arn
   }
 
   master_instance_group {
@@ -136,7 +136,7 @@ EOF
   ]
 EOF
 
-  service_role = "${aws_iam_role.iam_emr_service_role.arn}"
+  service_role = aws_iam_role.iam_emr_service_role.arn
 }
 ```
 
@@ -204,7 +204,7 @@ resource "aws_emr_cluster" "example" {
   ec2_attributes {
     # ... other configuration ...
 
-    subnet_id = "${aws_subnet.example.id}"
+    subnet_id = aws_subnet.example.id
   }
 
   master_instance_group {
@@ -413,10 +413,10 @@ resource "aws_emr_cluster" "cluster" {
   applications  = ["Spark"]
 
   ec2_attributes {
-    subnet_id                         = "${aws_subnet.main.id}"
-    emr_managed_master_security_group = "${aws_security_group.allow_all.id}"
-    emr_managed_slave_security_group  = "${aws_security_group.allow_all.id}"
-    instance_profile                  = "${aws_iam_instance_profile.emr_profile.arn}"
+    subnet_id                         = aws_subnet.main.id
+    emr_managed_master_security_group = aws_security_group.allow_all.id
+    emr_managed_slave_security_group  = aws_security_group.allow_all.id
+    instance_profile                  = aws_iam_instance_profile.emr_profile.arn
   }
 
   master_instance_type = "m5.xlarge"
@@ -465,13 +465,13 @@ resource "aws_emr_cluster" "cluster" {
   ]
 EOF
 
-  service_role = "${aws_iam_role.iam_emr_service_role.arn}"
+  service_role = aws_iam_role.iam_emr_service_role.arn
 }
 
 resource "aws_security_group" "allow_access" {
   name        = "allow_access"
   description = "Allow inbound traffic"
-  vpc_id      = "${aws_vpc.main.id}"
+  vpc_id      = aws_vpc.main.id
 
   ingress {
     from_port   = 0
@@ -508,7 +508,7 @@ resource "aws_vpc" "main" {
 }
 
 resource "aws_subnet" "main" {
-  vpc_id     = "${aws_vpc.main.id}"
+  vpc_id     = aws_vpc.main.id
   cidr_block = "168.31.0.0/20"
 
   tags = {
@@ -517,21 +517,21 @@ resource "aws_subnet" "main" {
 }
 
 resource "aws_internet_gateway" "gw" {
-  vpc_id = "${aws_vpc.main.id}"
+  vpc_id = aws_vpc.main.id
 }
 
 resource "aws_route_table" "r" {
-  vpc_id = "${aws_vpc.main.id}"
+  vpc_id = aws_vpc.main.id
 
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = "${aws_internet_gateway.gw.id}"
+    gateway_id = aws_internet_gateway.gw.id
   }
 }
 
 resource "aws_main_route_table_association" "a" {
-  vpc_id         = "${aws_vpc.main.id}"
-  route_table_id = "${aws_route_table.r.id}"
+  vpc_id         = aws_vpc.main.id
+  route_table_id = aws_route_table.r.id
 }
 
 ###
@@ -563,7 +563,7 @@ EOF
 
 resource "aws_iam_role_policy" "iam_emr_service_policy" {
   name = "iam_emr_service_policy"
-  role = "${aws_iam_role.iam_emr_service_role.id}"
+  role = aws_iam_role.iam_emr_service_role.id
 
   policy = <<EOF
 {
@@ -654,12 +654,12 @@ EOF
 
 resource "aws_iam_instance_profile" "emr_profile" {
   name  = "emr_profile"
-  roles = ["${aws_iam_role.iam_emr_profile_role.name}"]
+  roles = [aws_iam_role.iam_emr_profile_role.name]
 }
 
 resource "aws_iam_role_policy" "iam_emr_profile_policy" {
   name = "iam_emr_profile_policy"
-  role = "${aws_iam_role.iam_emr_profile_role.id}"
+  role = aws_iam_role.iam_emr_profile_role.id
 
   policy = <<EOF
 {

--- a/website/docs/r/emr_instance_group.html.markdown
+++ b/website/docs/r/emr_instance_group.html.markdown
@@ -19,7 +19,7 @@ Terraform will resize any Instance Group to zero when destroying the resource.
 
 ```hcl
 resource "aws_emr_instance_group" "task" {
-  cluster_id     = "${aws_emr_cluster.tf-test-cluster.id}"
+  cluster_id     = aws_emr_cluster.tf-test-cluster.id
   instance_count = 1
   instance_type  = "m5.xlarge"
   name           = "my little instance group"

--- a/website/docs/r/flow_log.html.markdown
+++ b/website/docs/r/flow_log.html.markdown
@@ -17,10 +17,10 @@ interface, subnet, or VPC. Logs are sent to a CloudWatch Log Group or a S3 Bucke
 
 ```hcl
 resource "aws_flow_log" "example" {
-  iam_role_arn    = "${aws_iam_role.example.arn}"
-  log_destination = "${aws_cloudwatch_log_group.example.arn}"
+  iam_role_arn    = aws_iam_role.example.arn
+  log_destination = aws_cloudwatch_log_group.example.arn
   traffic_type    = "ALL"
-  vpc_id          = "${aws_vpc.example.id}"
+  vpc_id          = aws_vpc.example.id
 }
 
 resource "aws_cloudwatch_log_group" "example" {
@@ -49,7 +49,7 @@ EOF
 
 resource "aws_iam_role_policy" "example" {
   name = "example"
-  role = "${aws_iam_role.example.id}"
+  role = aws_iam_role.example.id
 
   policy = <<EOF
 {
@@ -76,10 +76,10 @@ EOF
 
 ```hcl
 resource "aws_flow_log" "example" {
-  log_destination      = "${aws_s3_bucket.example.arn}"
+  log_destination      = aws_s3_bucket.example.arn
   log_destination_type = "s3"
   traffic_type         = "ALL"
-  vpc_id               = "${aws_vpc.example.id}"
+  vpc_id               = aws_vpc.example.id
 }
 
 resource "aws_s3_bucket" "example" {

--- a/website/docs/r/fsx_lustre_file_system.html.markdown
+++ b/website/docs/r/fsx_lustre_file_system.html.markdown
@@ -16,7 +16,7 @@ Manages a FSx Lustre File System. See the [FSx Lustre Guide](https://docs.aws.am
 resource "aws_fsx_lustre_file_system" "example" {
   import_path      = "s3://${aws_s3_bucket.example.bucket}"
   storage_capacity = 1200
-  subnet_ids       = ["${aws_subnet.example.id}"]
+  subnet_ids       = [aws_subnet.example.id]
 }
 ```
 
@@ -65,7 +65,7 @@ Certain resource arguments, like `security_group_ids`, do not have a FSx API met
 ```hcl
 resource "aws_fsx_lustre_file_system" "example" {
   # ... other configuration ...
-  security_group_ids = ["${aws_security_group.example.id}"]
+  security_group_ids = [aws_security_group.example.id]
 
   # There is no FSx API for reading security_group_ids
   lifecycle {

--- a/website/docs/r/fsx_windows_file_system.html.markdown
+++ b/website/docs/r/fsx_windows_file_system.html.markdown
@@ -20,10 +20,10 @@ Additional information for using AWS Directory Service with Windows File Systems
 
 ```hcl
 resource "aws_fsx_windows_file_system" "example" {
-  active_directory_id = "${aws_directory_service_directory.example.id}"
-  kms_key_id          = "${aws_kms_key.example.arn}"
+  active_directory_id = aws_directory_service_directory.example.id
+  kms_key_id          = aws_kms_key.example.arn
   storage_capacity    = 300
-  subnet_ids          = ["${aws_subnet.example.id}"]
+  subnet_ids          = [aws_subnet.example.id]
   throughput_capacity = 1024
 }
 ```
@@ -34,9 +34,9 @@ Additional information for using AWS Directory Service with Windows File Systems
 
 ```hcl
 resource "aws_fsx_windows_file_system" "example" {
-  kms_key_id          = "${aws_kms_key.example.arn}"
+  kms_key_id          = aws_kms_key.example.arn
   storage_capacity    = 300
-  subnet_ids          = ["${aws_subnet.example.id}"]
+  subnet_ids          = [aws_subnet.example.id]
   throughput_capacity = 1024
 
   self_managed_active_directory {
@@ -109,7 +109,7 @@ Certain resource arguments, like `security_group_ids` and the `self_managed_acti
 ```hcl
 resource "aws_fsx_windows_file_system" "example" {
   # ... other configuration ...
-  security_group_ids = ["${aws_security_group.example.id}"]
+  security_group_ids = [aws_security_group.example.id]
 
   # There is no FSx API for reading security_group_ids
   lifecycle {

--- a/website/docs/r/gamelift_build.html.markdown
+++ b/website/docs/r/gamelift_build.html.markdown
@@ -18,9 +18,9 @@ resource "aws_gamelift_build" "test" {
   operating_system = "WINDOWS_2012"
 
   storage_location {
-    bucket   = "${aws_s3_bucket.test.bucket}"
-    key      = "${aws_s3_bucket_object.test.key}"
-    role_arn = "${aws_iam_role.test.arn}"
+    bucket   = aws_s3_bucket.test.bucket
+    key      = aws_s3_bucket_object.test.key
+    role_arn = aws_iam_role.test.arn
   }
 
   depends_on = ["aws_iam_role_policy.test"]

--- a/website/docs/r/gamelift_fleet.html.markdown
+++ b/website/docs/r/gamelift_fleet.html.markdown
@@ -14,7 +14,7 @@ Provides a Gamelift Fleet resource.
 
 ```hcl
 resource "aws_gamelift_fleet" "example" {
-  build_id          = "${aws_gamelift_build.example.id}"
+  build_id          = aws_gamelift_build.example.id
   ec2_instance_type = "t2.micro"
   fleet_type        = "ON_DEMAND"
   name              = "example-fleet-name"

--- a/website/docs/r/gamelift_game_session_queue.html.markdown
+++ b/website/docs/r/gamelift_game_session_queue.html.markdown
@@ -17,8 +17,8 @@ resource "aws_gamelift_game_session_queue" "test" {
   name = "example-session-queue"
 
   destinations = [
-    "${aws_gamelift_fleet.us_west_2_fleet.arn}",
-    "${aws_gamelift_fleet.eu_central_1_fleet.arn}",
+    aws_gamelift_fleet.us_west_2_fleet.arn,
+    aws_gamelift_fleet.eu_central_1_fleet.arn,
   ]
 
   player_latency_policy {

--- a/website/docs/r/glacier_vault.html.markdown
+++ b/website/docs/r/glacier_vault.html.markdown
@@ -23,7 +23,7 @@ resource "aws_glacier_vault" "my_archive" {
   name = "MyArchive"
 
   notification {
-    sns_topic = "${aws_sns_topic.aws_sns_topic.arn}"
+    sns_topic = aws_sns_topic.aws_sns_topic.arn
     events    = ["ArchiveRetrievalCompleted", "InventoryRetrievalCompleted"]
   }
 

--- a/website/docs/r/glacier_vault_lock.html.markdown
+++ b/website/docs/r/glacier_vault_lock.html.markdown
@@ -27,7 +27,7 @@ data "aws_iam_policy_document" "example" {
   statement {
     actions   = ["glacier:DeleteArchive"]
     effect    = "Deny"
-    resources = ["${aws_glacier_vault.example.arn}"]
+    resources = [aws_glacier_vault.example.arn]
 
     condition {
       test     = "NumericLessThanEquals"
@@ -39,8 +39,8 @@ data "aws_iam_policy_document" "example" {
 
 resource "aws_glacier_vault_lock" "example" {
   complete_lock = false
-  policy        = "${data.aws_iam_policy_document.example.json}"
-  vault_name    = "${aws_glacier_vault.example.name}"
+  policy        = data.aws_iam_policy_document.example.json
+  vault_name    = aws_glacier_vault.example.name
 }
 ```
 
@@ -49,8 +49,8 @@ resource "aws_glacier_vault_lock" "example" {
 ```hcl
 resource "aws_glacier_vault_lock" "example" {
   complete_lock = true
-  policy        = "${data.aws_iam_policy_document.example.json}"
-  vault_name    = "${aws_glacier_vault.example.name}"
+  policy        = data.aws_iam_policy_document.example.json
+  vault_name    = aws_glacier_vault.example.name
 }
 ```
 

--- a/website/docs/r/globalaccelerator_endpoint_group.html.markdown
+++ b/website/docs/r/globalaccelerator_endpoint_group.html.markdown
@@ -14,10 +14,10 @@ Provides a Global Accelerator endpoint group.
 
 ```hcl
 resource "aws_globalaccelerator_endpoint_group" "example" {
-  listener_arn = "${aws_globalaccelerator_listener.example.id}"
+  listener_arn = aws_globalaccelerator_listener.example.id
 
   endpoint_configuration {
-    endpoint_id = "${aws_lb.example.arn}"
+    endpoint_id = aws_lb.example.arn
     weight      = 100
   }
 }

--- a/website/docs/r/globalaccelerator_listener.markdown
+++ b/website/docs/r/globalaccelerator_listener.markdown
@@ -26,7 +26,7 @@ resource "aws_globalaccelerator_accelerator" "example" {
 }
 
 resource "aws_globalaccelerator_listener" "example" {
-  accelerator_arn = "${aws_globalaccelerator_accelerator.example.id}"
+  accelerator_arn = aws_globalaccelerator_accelerator.example.id
   client_affinity = "SOURCE_IP"
   protocol        = "TCP"
 

--- a/website/docs/r/glue_connection.html.markdown
+++ b/website/docs/r/glue_connection.html.markdown
@@ -41,9 +41,9 @@ resource "aws_glue_connection" "example" {
   name = "example"
 
   physical_connection_requirements {
-    availability_zone      = "${aws_subnet.example.availability_zone}"
-    security_group_id_list = ["${aws_security_group.example.id}"]
-    subnet_id              = "${aws_subnet.example.id}"
+    availability_zone      = aws_subnet.example.availability_zone
+    security_group_id_list = [aws_security_group.example.id]
+    subnet_id              = aws_subnet.example.id
   }
 }
 ```

--- a/website/docs/r/glue_crawler.html.markdown
+++ b/website/docs/r/glue_crawler.html.markdown
@@ -16,9 +16,9 @@ Manages a Glue Crawler. More information can be found in the [AWS Glue Developer
 
 ```hcl
 resource "aws_glue_crawler" "example" {
-  database_name = "${aws_glue_catalog_database.example.name}"
+  database_name = aws_glue_catalog_database.example.name
   name          = "example"
-  role          = "${aws_iam_role.example.arn}"
+  role          = aws_iam_role.example.arn
 
   dynamodb_target {
     path = "table-name"
@@ -30,12 +30,12 @@ resource "aws_glue_crawler" "example" {
 
 ```hcl
 resource "aws_glue_crawler" "example" {
-  database_name = "${aws_glue_catalog_database.example.name}"
+  database_name = aws_glue_catalog_database.example.name
   name          = "example"
-  role          = "${aws_iam_role.example.arn}"
+  role          = aws_iam_role.example.arn
 
   jdbc_target {
-    connection_name = "${aws_glue_connection.example.name}"
+    connection_name = aws_glue_connection.example.name
     path            = "database-name/%"
   }
 }
@@ -45,9 +45,9 @@ resource "aws_glue_crawler" "example" {
 
 ```hcl
 resource "aws_glue_crawler" "example" {
-  database_name = "${aws_glue_catalog_database.example.name}"
+  database_name = aws_glue_catalog_database.example.name
   name          = "example"
-  role          = "${aws_iam_role.example.arn}"
+  role          = aws_iam_role.example.arn
 
   s3_target {
     path = "s3://${aws_s3_bucket.example.bucket}"
@@ -60,13 +60,13 @@ resource "aws_glue_crawler" "example" {
 
 ```hcl
 resource "aws_glue_crawler" "example" {
-  database_name = "${aws_glue_catalog_database.example.name}"
+  database_name = aws_glue_catalog_database.example.name
   name          = "example"
-  role          = "${aws_iam_role.example.arn}"
+  role          = aws_iam_role.example.arn
 
   catalog_target {
-    database_name = "${aws_glue_catalog_database.example.name}"
-    tables        = ["${aws_glue_catalog_table.example.name}"]
+    database_name = aws_glue_catalog_database.example.name
+    tables        = [aws_glue_catalog_table.example.name]
   }
 
   schema_change_policy {

--- a/website/docs/r/glue_job.html.markdown
+++ b/website/docs/r/glue_job.html.markdown
@@ -19,7 +19,7 @@ Provides a Glue Job resource.
 ```hcl
 resource "aws_glue_job" "example" {
   name     = "example"
-  role_arn = "${aws_iam_role.example.arn}"
+  role_arn = aws_iam_role.example.arn
 
   command {
     script_location = "s3://${aws_s3_bucket.example.bucket}/example.py"
@@ -32,7 +32,7 @@ resource "aws_glue_job" "example" {
 ```hcl
 resource "aws_glue_job" "example" {
   name     = "example"
-  role_arn = "${aws_iam_role.example.arn}"
+  role_arn = aws_iam_role.example.arn
 
   command {
     script_location = "s3://${aws_s3_bucket.example.bucket}/example.scala"
@@ -57,7 +57,7 @@ resource "aws_glue_job" "example" {
 
   default_arguments = {
     # ... potentially other arguments ...
-    "--continuous-log-logGroup"          = "${aws_cloudwatch_log_group.example.name}"
+    "--continuous-log-logGroup"          = aws_cloudwatch_log_group.example.name
     "--enable-continuous-cloudwatch-log" = "true"
     "--enable-continuous-log-filter"     = "true"
     "--enable-metrics"                   = ""

--- a/website/docs/r/glue_security_configuration.html.markdown
+++ b/website/docs/r/glue_security_configuration.html.markdown
@@ -26,7 +26,7 @@ resource "aws_glue_security_configuration" "example" {
     }
 
     s3_encryption {
-      kms_key_arn        = "${data.aws_kms_key.example.arn}"
+      kms_key_arn        = data.aws_kms_key.example.arn
       s3_encryption_mode = "SSE-KMS"
     }
   }

--- a/website/docs/r/glue_trigger.html.markdown
+++ b/website/docs/r/glue_trigger.html.markdown
@@ -20,12 +20,12 @@ resource "aws_glue_trigger" "example" {
   type = "CONDITIONAL"
 
   actions {
-    job_name = "${aws_glue_job.example1.name}"
+    job_name = aws_glue_job.example1.name
   }
 
   predicate {
     conditions {
-      job_name = "${aws_glue_job.example2.name}"
+      job_name = aws_glue_job.example2.name
       state    = "SUCCEEDED"
     }
   }
@@ -40,7 +40,7 @@ resource "aws_glue_trigger" "example" {
   type = "ON_DEMAND"
 
   actions {
-    job_name = "${aws_glue_job.example.name}"
+    job_name = aws_glue_job.example.name
   }
 }
 ```
@@ -54,7 +54,7 @@ resource "aws_glue_trigger" "example" {
   type     = "SCHEDULED"
 
   actions {
-    job_name = "${aws_glue_job.example.name}"
+    job_name = aws_glue_job.example.name
   }
 }
 ```
@@ -69,12 +69,12 @@ resource "aws_glue_trigger" "example" {
   type = "CONDITIONAL"
 
   actions {
-    crawler_name = "${aws_glue_crawler.example1.name}"
+    crawler_name = aws_glue_crawler.example1.name
   }
 
   predicate {
     conditions {
-      job_name = "${aws_glue_job.example2.name}"
+      job_name = aws_glue_job.example2.name
       state    = "SUCCEEDED"
     }
   }
@@ -91,12 +91,12 @@ resource "aws_glue_trigger" "example" {
   type = "CONDITIONAL"
 
   actions {
-    job_name = "${aws_glue_job.example1.name}"
+    job_name = aws_glue_job.example1.name
   }
 
   predicate {
     conditions {
-      crawler_name = "${aws_glue_crawler.example2.name}"
+      crawler_name = aws_glue_crawler.example2.name
       crawl_state  = "SUCCEEDED"
     }
   }

--- a/website/docs/r/glue_workflow.html.markdown
+++ b/website/docs/r/glue_workflow.html.markdown
@@ -22,7 +22,7 @@ resource "aws_glue_workflow" "example" {
 resource "aws_glue_trigger" "example-start" {
   name          = "trigger-start"
   type          = "ON_DEMAND"
-  workflow_name = "${aws_glue_workflow.example.name}"
+  workflow_name = aws_glue_workflow.example.name
 
   actions {
     job_name = "example-job"
@@ -32,7 +32,7 @@ resource "aws_glue_trigger" "example-start" {
 resource "aws_glue_trigger" "example-inner" {
   name          = "trigger-inner"
   type          = "CONDITIONAL"
-  workflow_name = "${aws_glue_workflow.example.name}"
+  workflow_name = aws_glue_workflow.example.name
 
   predicate {
     conditions {

--- a/website/docs/r/guardduty_invite_accepter.html.markdown
+++ b/website/docs/r/guardduty_invite_accepter.html.markdown
@@ -20,8 +20,8 @@ resource "aws_guardduty_detector" "member" {
 }
 
 resource "aws_guardduty_member" "dev" {
-  account_id  = "${aws_guardduty_detector.member.account_id}"
-  detector_id = "${aws_guardduty_detector.master.id}"
+  account_id  = aws_guardduty_detector.member.account_id
+  detector_id = aws_guardduty_detector.master.id
   email       = "required@example.com"
   invite      = true
 }
@@ -30,8 +30,8 @@ resource "aws_guardduty_invite_accepter" "member" {
   depends_on = ["aws_guardduty_member.dev"]
   provider   = "aws.dev"
 
-  detector_id       = "${aws_guardduty_detector.member.id}"
-  master_account_id = "${aws_guardduty_detector.master.account_id}"
+  detector_id       = aws_guardduty_detector.member.id
+  master_account_id = aws_guardduty_detector.master.account_id
 }
 ```
 

--- a/website/docs/r/guardduty_ipset.html.markdown
+++ b/website/docs/r/guardduty_ipset.html.markdown
@@ -25,13 +25,13 @@ resource "aws_s3_bucket" "bucket" {
 resource "aws_s3_bucket_object" "MyIPSet" {
   acl     = "public-read"
   content = "10.0.0.0/8\n"
-  bucket  = "${aws_s3_bucket.bucket.id}"
+  bucket  = aws_s3_bucket.bucket.id
   key     = "MyIPSet"
 }
 
 resource "aws_guardduty_ipset" "MyIPSet" {
   activate    = true
-  detector_id = "${aws_guardduty_detector.master.id}"
+  detector_id = aws_guardduty_detector.master.id
   format      = "TXT"
   location    = "https://s3.amazonaws.com/${aws_s3_bucket_object.MyIPSet.bucket}/${aws_s3_bucket_object.MyIPSet.key}"
   name        = "MyIPSet"

--- a/website/docs/r/guardduty_member.html.markdown
+++ b/website/docs/r/guardduty_member.html.markdown
@@ -24,8 +24,8 @@ resource "aws_guardduty_detector" "member" {
 }
 
 resource "aws_guardduty_member" "member" {
-  account_id         = "${aws_guardduty_detector.member.account_id}"
-  detector_id        = "${aws_guardduty_detector.master.id}"
+  account_id         = aws_guardduty_detector.member.account_id
+  detector_id        = aws_guardduty_detector.master.id
   email              = "required@example.com"
   invite             = true
   invitation_message = "please accept guardduty invitation"

--- a/website/docs/r/guardduty_threatintelset.html.markdown
+++ b/website/docs/r/guardduty_threatintelset.html.markdown
@@ -25,13 +25,13 @@ resource "aws_s3_bucket" "bucket" {
 resource "aws_s3_bucket_object" "MyThreatIntelSet" {
   acl     = "public-read"
   content = "10.0.0.0/8\n"
-  bucket  = "${aws_s3_bucket.bucket.id}"
+  bucket  = aws_s3_bucket.bucket.id
   key     = "MyThreatIntelSet"
 }
 
 resource "aws_guardduty_threatintelset" "MyThreatIntelSet" {
   activate    = true
-  detector_id = "${aws_guardduty_detector.master.id}"
+  detector_id = aws_guardduty_detector.master.id
   format      = "TXT"
   location    = "https://s3.amazonaws.com/${aws_s3_bucket_object.MyThreatIntelSet.bucket}/${aws_s3_bucket_object.MyThreatIntelSet.key}"
   name        = "MyThreatIntelSet"

--- a/website/docs/r/iam_access_key.html.markdown
+++ b/website/docs/r/iam_access_key.html.markdown
@@ -14,7 +14,7 @@ Provides an IAM access key. This is a set of credentials that allow API requests
 
 ```hcl
 resource "aws_iam_access_key" "lb" {
-  user    = "${aws_iam_user.lb.name}"
+  user    = aws_iam_user.lb.name
   pgp_key = "keybase:some_person_that_exists"
 }
 
@@ -25,7 +25,7 @@ resource "aws_iam_user" "lb" {
 
 resource "aws_iam_user_policy" "lb_ro" {
   name = "test"
-  user = "${aws_iam_user.lb.name}"
+  user = aws_iam_user.lb.name
 
   policy = <<EOF
 {
@@ -44,7 +44,7 @@ EOF
 }
 
 output "secret" {
-  value = "${aws_iam_access_key.lb.encrypted_secret}"
+  value = aws_iam_access_key.lb.encrypted_secret
 }
 ```
 

--- a/website/docs/r/iam_group_membership.html.markdown
+++ b/website/docs/r/iam_group_membership.html.markdown
@@ -24,11 +24,11 @@ resource "aws_iam_group_membership" "team" {
   name = "tf-testing-group-membership"
 
   users = [
-    "${aws_iam_user.user_one.name}",
-    "${aws_iam_user.user_two.name}",
+    aws_iam_user.user_one.name,
+    aws_iam_user.user_two.name,
   ]
 
-  group = "${aws_iam_group.group.name}"
+  group = aws_iam_group.group.name
 }
 
 resource "aws_iam_group" "group" {

--- a/website/docs/r/iam_group_policy.html.markdown
+++ b/website/docs/r/iam_group_policy.html.markdown
@@ -15,7 +15,7 @@ Provides an IAM policy attached to a group.
 ```hcl
 resource "aws_iam_group_policy" "my_developer_policy" {
   name  = "my_developer_policy"
-  group = "${aws_iam_group.my_developers.id}"
+  group = aws_iam_group.my_developers.id
 
   policy = <<EOF
 {

--- a/website/docs/r/iam_group_policy_attachment.markdown
+++ b/website/docs/r/iam_group_policy_attachment.markdown
@@ -26,8 +26,8 @@ resource "aws_iam_policy" "policy" {
 }
 
 resource "aws_iam_group_policy_attachment" "test-attach" {
-  group      = "${aws_iam_group.group.name}"
-  policy_arn = "${aws_iam_policy.policy.arn}"
+  group      = aws_iam_group.group.name
+  policy_arn = aws_iam_policy.policy.arn
 }
 ```
 

--- a/website/docs/r/iam_instance_profile.html.markdown
+++ b/website/docs/r/iam_instance_profile.html.markdown
@@ -15,7 +15,7 @@ Provides an IAM instance profile.
 ```hcl
 resource "aws_iam_instance_profile" "test_profile" {
   name = "test_profile"
-  role = "${aws_iam_role.role.name}"
+  role = aws_iam_role.role.name
 }
 
 resource "aws_iam_role" "role" {

--- a/website/docs/r/iam_policy_attachment.html.markdown
+++ b/website/docs/r/iam_policy_attachment.html.markdown
@@ -67,10 +67,10 @@ EOF
 
 resource "aws_iam_policy_attachment" "test-attach" {
   name       = "test-attachment"
-  users      = ["${aws_iam_user.user.name}"]
-  roles      = ["${aws_iam_role.role.name}"]
-  groups     = ["${aws_iam_group.group.name}"]
-  policy_arn = "${aws_iam_policy.policy.arn}"
+  users      = [aws_iam_user.user.name]
+  roles      = [aws_iam_role.role.name]
+  groups     = [aws_iam_group.group.name]
+  policy_arn = aws_iam_policy.policy.arn
 }
 ```
 

--- a/website/docs/r/iam_role.html.markdown
+++ b/website/docs/r/iam_role.html.markdown
@@ -87,7 +87,7 @@ data "aws_iam_policy_document" "instance-assume-role-policy" {
 resource "aws_iam_role" "instance" {
   name               = "instance_role"
   path               = "/system/"
-  assume_role_policy = "${data.aws_iam_policy_document.instance-assume-role-policy.json}"
+  assume_role_policy = data.aws_iam_policy_document.instance-assume-role-policy.json
 }
 ```
 

--- a/website/docs/r/iam_role_policy_attachment.markdown
+++ b/website/docs/r/iam_role_policy_attachment.markdown
@@ -56,8 +56,8 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "test-attach" {
-  role       = "${aws_iam_role.role.name}"
-  policy_arn = "${aws_iam_policy.policy.arn}"
+  role       = aws_iam_role.role.name
+  policy_arn = aws_iam_policy.policy.arn
 }
 ```
 

--- a/website/docs/r/iam_saml_provider.html.markdown
+++ b/website/docs/r/iam_saml_provider.html.markdown
@@ -15,7 +15,7 @@ Provides an IAM SAML provider.
 ```hcl
 resource "aws_iam_saml_provider" "default" {
   name                   = "myprovider"
-  saml_metadata_document = "${file("saml-metadata.xml")}"
+  saml_metadata_document = file("saml-metadata.xml")
 }
 ```
 

--- a/website/docs/r/iam_server_certificate.html.markdown
+++ b/website/docs/r/iam_server_certificate.html.markdown
@@ -29,8 +29,8 @@ Certificates][2] in AWS Documentation.
 ```hcl
 resource "aws_iam_server_certificate" "test_cert" {
   name             = "some_test_cert"
-  certificate_body = "${file("self-ca-cert.pem")}"
-  private_key      = "${file("test-key.pem")}"
+  certificate_body = file("self-ca-cert.pem")
+  private_key      = file("test-key.pem")
 }
 ```
 
@@ -66,8 +66,8 @@ dependant resources before attempting to destroy the old version.
 ```hcl
 resource "aws_iam_server_certificate" "test_cert" {
   name_prefix      = "example-cert"
-  certificate_body = "${file("self-ca-cert.pem")}"
-  private_key      = "${file("test-key.pem")}"
+  certificate_body = file("self-ca-cert.pem")
+  private_key      = file("test-key.pem")
 
   lifecycle {
     create_before_destroy = true
@@ -84,7 +84,7 @@ resource "aws_elb" "ourapp" {
     instance_protocol  = "http"
     lb_port            = 443
     lb_protocol        = "https"
-    ssl_certificate_id = "${aws_iam_server_certificate.test_cert.arn}"
+    ssl_certificate_id = aws_iam_server_certificate.test_cert.arn
   }
 }
 ```

--- a/website/docs/r/iam_user.html.markdown
+++ b/website/docs/r/iam_user.html.markdown
@@ -25,12 +25,12 @@ resource "aws_iam_user" "lb" {
 }
 
 resource "aws_iam_access_key" "lb" {
-  user = "${aws_iam_user.lb.name}"
+  user = aws_iam_user.lb.name
 }
 
 resource "aws_iam_user_policy" "lb_ro" {
   name = "test"
-  user = "${aws_iam_user.lb.name}"
+  user = aws_iam_user.lb.name
 
   policy = <<EOF
 {

--- a/website/docs/r/iam_user_group_membership.html.markdown
+++ b/website/docs/r/iam_user_group_membership.html.markdown
@@ -20,19 +20,19 @@ To exclusively manage the users in a group, see the
 
 ```hcl
 resource "aws_iam_user_group_membership" "example1" {
-  user = "${aws_iam_user.user1.name}"
+  user = aws_iam_user.user1.name
 
   groups = [
-    "${aws_iam_group.group1.name}",
-    "${aws_iam_group.group2.name}",
+    aws_iam_group.group1.name,
+    aws_iam_group.group2.name,
   ]
 }
 
 resource "aws_iam_user_group_membership" "example2" {
-  user = "${aws_iam_user.user1.name}"
+  user = aws_iam_user.user1.name
 
   groups = [
-    "${aws_iam_group.group3.name}",
+    aws_iam_group.group3.name,
   ]
 }
 

--- a/website/docs/r/iam_user_login_profile.html.markdown
+++ b/website/docs/r/iam_user_login_profile.html.markdown
@@ -22,12 +22,12 @@ resource "aws_iam_user" "example" {
 }
 
 resource "aws_iam_user_login_profile" "example" {
-  user    = "${aws_iam_user.example.name}"
+  user    = aws_iam_user.example.name
   pgp_key = "keybase:some_person_that_exists"
 }
 
 output "password" {
-  value = "${aws_iam_user_login_profile.example.encrypted_password}"
+  value = aws_iam_user_login_profile.example.encrypted_password
 }
 ```
 

--- a/website/docs/r/iam_user_policy.html.markdown
+++ b/website/docs/r/iam_user_policy.html.markdown
@@ -15,7 +15,7 @@ Provides an IAM policy attached to a user.
 ```hcl
 resource "aws_iam_user_policy" "lb_ro" {
   name = "test"
-  user = "${aws_iam_user.lb.name}"
+  user = aws_iam_user.lb.name
 
   policy = <<EOF
 {
@@ -39,7 +39,7 @@ resource "aws_iam_user" "lb" {
 }
 
 resource "aws_iam_access_key" "lb" {
-  user = "${aws_iam_user.lb.name}"
+  user = aws_iam_user.lb.name
 }
 ```
 

--- a/website/docs/r/iam_user_policy_attachment.markdown
+++ b/website/docs/r/iam_user_policy_attachment.markdown
@@ -26,8 +26,8 @@ resource "aws_iam_policy" "policy" {
 }
 
 resource "aws_iam_user_policy_attachment" "test-attach" {
-  user       = "${aws_iam_user.user.name}"
-  policy_arn = "${aws_iam_policy.policy.arn}"
+  user       = aws_iam_user.user.name
+  policy_arn = aws_iam_policy.policy.arn
 }
 ```
 

--- a/website/docs/r/iam_user_ssh_key.html.markdown
+++ b/website/docs/r/iam_user_ssh_key.html.markdown
@@ -19,7 +19,7 @@ resource "aws_iam_user" "user" {
 }
 
 resource "aws_iam_user_ssh_key" "user" {
-  username   = "${aws_iam_user.user.name}"
+  username   = aws_iam_user.user.name
   encoding   = "SSH"
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 mytest@mydomain.com"
 }

--- a/website/docs/r/inspector_assessment_target.html.markdown
+++ b/website/docs/r/inspector_assessment_target.html.markdown
@@ -22,7 +22,7 @@ resource "aws_inspector_resource_group" "bar" {
 
 resource "aws_inspector_assessment_target" "foo" {
   name               = "assessment target"
-  resource_group_arn = "${aws_inspector_resource_group.bar.arn}"
+  resource_group_arn = aws_inspector_resource_group.bar.arn
 }
 ```
 

--- a/website/docs/r/inspector_assessment_template.html.markdown
+++ b/website/docs/r/inspector_assessment_template.html.markdown
@@ -15,7 +15,7 @@ Provides a Inspector assessment template
 ```hcl
 resource "aws_inspector_assessment_template" "example" {
   name       = "example"
-  target_arn = "${aws_inspector_assessment_target.example.arn}"
+  target_arn = aws_inspector_assessment_target.example.arn
   duration   = 3600
 
   rules_package_arns = [

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -37,7 +37,7 @@ data "aws_ami" "ubuntu" {
 }
 
 resource "aws_instance" "web" {
-  ami           = "${data.aws_ami.ubuntu.id}"
+  ami           = data.aws_ami.ubuntu.id
   instance_type = "t2.micro"
 
   tags = {
@@ -222,7 +222,7 @@ resource "aws_vpc" "my_vpc" {
 }
 
 resource "aws_subnet" "my_subnet" {
-  vpc_id            = "${aws_vpc.my_vpc.id}"
+  vpc_id            = aws_vpc.my_vpc.id
   cidr_block        = "172.16.10.0/24"
   availability_zone = "us-west-2a"
 
@@ -232,7 +232,7 @@ resource "aws_subnet" "my_subnet" {
 }
 
 resource "aws_network_interface" "foo" {
-  subnet_id   = "${aws_subnet.my_subnet.id}"
+  subnet_id   = aws_subnet.my_subnet.id
   private_ips = ["172.16.10.100"]
 
   tags = {
@@ -245,7 +245,7 @@ resource "aws_instance" "foo" {
   instance_type = "t2.micro"
 
   network_interface {
-    network_interface_id = "${aws_network_interface.foo.id}"
+    network_interface_id = aws_network_interface.foo.id
     device_index         = 0
   }
 

--- a/website/docs/r/internet_gateway.html.markdown
+++ b/website/docs/r/internet_gateway.html.markdown
@@ -14,7 +14,7 @@ Provides a resource to create a VPC Internet Gateway.
 
 ```hcl
 resource "aws_internet_gateway" "gw" {
-  vpc_id = "${aws_vpc.main.id}"
+  vpc_id = aws_vpc.main.id
 
   tags = {
     Name = "main"
@@ -33,7 +33,7 @@ The following arguments are supported:
 
 ```hcl
 resource "aws_internet_gateway" "gw" {
-  vpc_id = "${aws_vpc.main.id}"
+  vpc_id = aws_vpc.main.id
 }
 
 resource "aws_instance" "foo" {

--- a/website/docs/r/iot_certificate.html.markdown
+++ b/website/docs/r/iot_certificate.html.markdown
@@ -16,7 +16,7 @@ Creates and manages an AWS IoT certificate.
 
 ```hcl
 resource "aws_iot_certificate" "cert" {
-  csr    = "${file("/my/csr.pem")}"
+  csr    = file("/my/csr.pem")
   active = true
 }
 ```

--- a/website/docs/r/iot_policy_attachment.html.markdown
+++ b/website/docs/r/iot_policy_attachment.html.markdown
@@ -33,13 +33,13 @@ EOF
 }
 
 resource "aws_iot_certificate" "cert" {
-  csr    = "${file("csr.pem")}"
+  csr    = file("csr.pem")
   active = true
 }
 
 resource "aws_iot_policy_attachment" "att" {
-  policy = "${aws_iot_policy.pubsub.name}"
-  target = "${aws_iot_certificate.cert.arn}"
+  policy = aws_iot_policy.pubsub.name
+  target = aws_iot_certificate.cert.arn
 }
 ```
 

--- a/website/docs/r/iot_role_alias.html.markdown
+++ b/website/docs/r/iot_role_alias.html.markdown
@@ -32,7 +32,7 @@ EOF
 
 resource "aws_iot_role_alias" "alias" {
   alias    = "Thermostat-dynamodb-access-role-alias"
-  role_arn = "${aws_iam_role.role.arn}"
+  role_arn = aws_iam_role.role.arn
 }
 ```
 

--- a/website/docs/r/iot_thing_principal_attachment.html.markdown
+++ b/website/docs/r/iot_thing_principal_attachment.html.markdown
@@ -18,13 +18,13 @@ resource "aws_iot_thing" "example" {
 }
 
 resource "aws_iot_certificate" "cert" {
-  csr    = "${file("csr.pem")}"
+  csr    = file("csr.pem")
   active = true
 }
 
 resource "aws_iot_thing_principal_attachment" "att" {
-  principal = "${aws_iot_certificate.cert.arn}"
-  thing     = "${aws_iot_thing.example.name}"
+  principal = aws_iot_certificate.cert.arn
+  thing     = aws_iot_thing.example.name
 }
 ```
 

--- a/website/docs/r/iot_topic_rule.html.markdown
+++ b/website/docs/r/iot_topic_rule.html.markdown
@@ -32,40 +32,36 @@ resource "aws_sns_topic" "mytopic" {
 resource "aws_iam_role" "role" {
   name = "myrole"
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "iot.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
+  assume_role_policy = jsonencode({
+    "Version" = "2012-10-17"
+    "Statement" = [
+      {
+        "Effect" = "Allow"
+        "Principal" = {
+          "Service" = "iot.amazonaws.com"
+        }
+        "Action" = "sts:AssumeRole"
+      }
+    ]
+  })
 }
 
 resource "aws_iam_role_policy" "iam_policy_for_lambda" {
   name = "mypolicy"
   role = aws_iam_role.role.id
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-        "Effect": "Allow",
-        "Action": [
-            "sns:Publish"
-        ],
-        "Resource": "${aws_sns_topic.mytopic.arn}"
-    }
-  ]
-}
-EOF
+  policy = jsonencode({
+    "Version" = "2012-10-17"
+    "Statement" = [
+      {
+        "Effect" = "Allow"
+        "Action" = [
+          "sns:Publish"
+        ]
+        "Resource" = aws_sns_topic.mytopic.arn
+      }
+    ]
+  })
 }
 ```
 

--- a/website/docs/r/iot_topic_rule.html.markdown
+++ b/website/docs/r/iot_topic_rule.html.markdown
@@ -20,8 +20,8 @@ resource "aws_iot_topic_rule" "rule" {
 
   sns {
     message_format = "RAW"
-    role_arn       = "${aws_iam_role.role.arn}"
-    target_arn     = "${aws_sns_topic.mytopic.arn}"
+    role_arn       = aws_iam_role.role.arn
+    target_arn     = aws_sns_topic.mytopic.arn
   }
 }
 
@@ -50,7 +50,7 @@ EOF
 
 resource "aws_iam_role_policy" "iam_policy_for_lambda" {
   name = "mypolicy"
-  role = "${aws_iam_role.role.id}"
+  role = aws_iam_role.role.id
 
   policy = <<EOF
 {

--- a/website/docs/r/kinesis_analytics_application.html.markdown
+++ b/website/docs/r/kinesis_analytics_application.html.markdown
@@ -28,8 +28,8 @@ resource "aws_kinesis_analytics_application" "test_application" {
     name_prefix = "test_prefix"
 
     kinesis_stream {
-      resource_arn = "${aws_kinesis_stream.test_stream.arn}"
-      role_arn     = "${aws_iam_role.test.arn}"
+      resource_arn = aws_kinesis_stream.test_stream.arn
+      role_arn     = aws_iam_role.test.arn
     }
 
     parallelism {

--- a/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
@@ -22,8 +22,8 @@ resource "aws_kinesis_firehose_delivery_stream" "extended_s3_stream" {
   destination = "extended_s3"
 
   extended_s3_configuration {
-    role_arn   = "${aws_iam_role.firehose_role.arn}"
-    bucket_arn = "${aws_s3_bucket.bucket.arn}"
+    role_arn   = aws_iam_role.firehose_role.arn
+    bucket_arn = aws_s3_bucket.bucket.arn
 
     processing_configuration {
       enabled = "true"
@@ -88,7 +88,7 @@ EOF
 resource "aws_lambda_function" "lambda_processor" {
   filename      = "lambda.zip"
   function_name = "firehose_lambda_processor"
-  role          = "${aws_iam_role.lambda_iam.arn}"
+  role          = aws_iam_role.lambda_iam.arn
   handler       = "exports.handler"
   runtime       = "nodejs8.10"
 }
@@ -127,8 +127,8 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
   destination = "s3"
 
   s3_configuration {
-    role_arn   = "${aws_iam_role.firehose_role.arn}"
-    bucket_arn = "${aws_s3_bucket.bucket.arn}"
+    role_arn   = aws_iam_role.firehose_role.arn
+    bucket_arn = aws_s3_bucket.bucket.arn
   }
 }
 ```
@@ -150,15 +150,15 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
   destination = "redshift"
 
   s3_configuration {
-    role_arn           = "${aws_iam_role.firehose_role.arn}"
-    bucket_arn         = "${aws_s3_bucket.bucket.arn}"
+    role_arn           = aws_iam_role.firehose_role.arn
+    bucket_arn         = aws_s3_bucket.bucket.arn
     buffer_size        = 10
     buffer_interval    = 400
     compression_format = "GZIP"
   }
 
   redshift_configuration {
-    role_arn           = "${aws_iam_role.firehose_role.arn}"
+    role_arn           = aws_iam_role.firehose_role.arn
     cluster_jdbcurl    = "jdbc:redshift://${aws_redshift_cluster.test_cluster.endpoint}/${aws_redshift_cluster.test_cluster.database_name}"
     username           = "testuser"
     password           = "T3stPass"
@@ -168,8 +168,8 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
     s3_backup_mode     = "Enabled"
 
     s3_backup_configuration {
-      role_arn           = "${aws_iam_role.firehose_role.arn}"
-      bucket_arn         = "${aws_s3_bucket.bucket.arn}"
+      role_arn           = aws_iam_role.firehose_role.arn
+      bucket_arn         = aws_s3_bucket.bucket.arn
       buffer_size        = 15
       buffer_interval    = 300
       compression_format = "GZIP"
@@ -190,16 +190,16 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
   destination = "elasticsearch"
 
   s3_configuration {
-    role_arn           = "${aws_iam_role.firehose_role.arn}"
-    bucket_arn         = "${aws_s3_bucket.bucket.arn}"
+    role_arn           = aws_iam_role.firehose_role.arn
+    bucket_arn         = aws_s3_bucket.bucket.arn
     buffer_size        = 10
     buffer_interval    = 400
     compression_format = "GZIP"
   }
 
   elasticsearch_configuration {
-    domain_arn = "${aws_elasticsearch_domain.test_cluster.arn}"
-    role_arn   = "${aws_iam_role.firehose_role.arn}"
+    domain_arn = aws_elasticsearch_domain.test_cluster.arn
+    role_arn   = aws_iam_role.firehose_role.arn
     index_name = "test"
     type_name  = "test"
 
@@ -228,8 +228,8 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
   destination = "splunk"
 
   s3_configuration {
-    role_arn           = "${aws_iam_role.firehose.arn}"
-    bucket_arn         = "${aws_s3_bucket.bucket.arn}"
+    role_arn           = aws_iam_role.firehose.arn
+    bucket_arn         = aws_s3_bucket.bucket.arn
     buffer_size        = 10
     buffer_interval    = 400
     compression_format = "GZIP"
@@ -383,9 +383,9 @@ resource "aws_kinesis_firehose_delivery_stream" "example" {
       }
 
       schema_configuration {
-        database_name = "${aws_glue_catalog_table.example.database_name}"
-        role_arn      = "${aws_iam_role.example.arn}"
-        table_name    = "${aws_glue_catalog_table.example.name}"
+        database_name = aws_glue_catalog_table.example.database_name
+        role_arn      = aws_iam_role.example.arn
+        table_name    = aws_glue_catalog_table.example.name
       }
     }
   }

--- a/website/docs/r/kms_alias.html.markdown
+++ b/website/docs/r/kms_alias.html.markdown
@@ -19,7 +19,7 @@ resource "aws_kms_key" "a" {}
 
 resource "aws_kms_alias" "a" {
   name          = "alias/my-key-alias"
-  target_key_id = "${aws_kms_key.a.key_id}"
+  target_key_id = aws_kms_key.a.key_id
 }
 ```
 

--- a/website/docs/r/kms_ciphertext.html.markdown
+++ b/website/docs/r/kms_ciphertext.html.markdown
@@ -25,7 +25,7 @@ resource "aws_kms_key" "oauth_config" {
 }
 
 resource "aws_kms_ciphertext" "oauth" {
-  key_id = "${aws_kms_key.oauth_config.key_id}"
+  key_id = aws_kms_key.oauth_config.key_id
 
   plaintext = <<EOF
 {

--- a/website/docs/r/kms_grant.html.markdown
+++ b/website/docs/r/kms_grant.html.markdown
@@ -37,8 +37,8 @@ EOF
 
 resource "aws_kms_grant" "a" {
   name              = "my-grant"
-  key_id            = "${aws_kms_key.a.key_id}"
-  grantee_principal = "${aws_iam_role.a.arn}"
+  key_id            = aws_kms_key.a.key_id
+  grantee_principal = aws_iam_role.a.arn
   operations        = ["Encrypt", "Decrypt", "GenerateDataKey"]
 
   constraints {

--- a/website/docs/r/lambda_alias.html.markdown
+++ b/website/docs/r/lambda_alias.html.markdown
@@ -19,7 +19,7 @@ For information about function aliases, see [CreateAlias][2] and [AliasRoutingCo
 resource "aws_lambda_alias" "test_alias" {
   name             = "testalias"
   description      = "a sample description"
-  function_name    = "${aws_lambda_function.lambda_function_test.arn}"
+  function_name    = aws_lambda_function.lambda_function_test.arn
   function_version = "1"
 
   routing_config = {

--- a/website/docs/r/lambda_event_source_mapping.html.markdown
+++ b/website/docs/r/lambda_event_source_mapping.html.markdown
@@ -19,8 +19,8 @@ For information about event source mappings, see [CreateEventSourceMapping][2] i
 
 ```hcl
 resource "aws_lambda_event_source_mapping" "example" {
-  event_source_arn  = "${aws_dynamodb_table.example.stream_arn}"
-  function_name     = "${aws_lambda_function.example.arn}"
+  event_source_arn  = aws_dynamodb_table.example.stream_arn
+  function_name     = aws_lambda_function.example.arn
   starting_position = "LATEST"
 }
 ```
@@ -29,8 +29,8 @@ resource "aws_lambda_event_source_mapping" "example" {
 
 ```hcl
 resource "aws_lambda_event_source_mapping" "example" {
-  event_source_arn  = "${aws_kinesis_stream.example.arn}"
-  function_name     = "${aws_lambda_function.example.arn}"
+  event_source_arn  = aws_kinesis_stream.example.arn
+  function_name     = aws_lambda_function.example.arn
   starting_position = "LATEST"
 }
 ```
@@ -39,8 +39,8 @@ resource "aws_lambda_event_source_mapping" "example" {
 
 ```hcl
 resource "aws_lambda_event_source_mapping" "example" {
-  event_source_arn = "${aws_sqs_queue.sqs_queue_test.arn}"
-  function_name    = "${aws_lambda_function.example.arn}"
+  event_source_arn = aws_sqs_queue.sqs_queue_test.arn
+  function_name    = aws_lambda_function.example.arn
 }
 ```
 

--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -44,13 +44,13 @@ EOF
 resource "aws_lambda_function" "test_lambda" {
   filename      = "lambda_function_payload.zip"
   function_name = "lambda_function_name"
-  role          = "${aws_iam_role.iam_for_lambda.arn}"
+  role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.test"
 
   # The filebase64sha256() function is available in Terraform 0.11.12 and later
   # For Terraform 0.11.11 and earlier, use the base64sha256() function and the file() function:
-  # source_code_hash = "${base64sha256(file("lambda_function_payload.zip"))}"
-  source_code_hash = "${filebase64sha256("lambda_function_payload.zip")}"
+  # source_code_hash = base64sha256(file("lambda_function_payload.zip"))
+  source_code_hash = filebase64sha256("lambda_function_payload.zip")
 
   runtime = "nodejs12.x"
 
@@ -73,7 +73,7 @@ resource "aws_lambda_layer_version" "example" {
 
 resource "aws_lambda_function" "example" {
   # ... other configuration ...
-  layers = ["${aws_lambda_layer_version.example.arn}"]
+  layers = [aws_lambda_layer_version.example.arn]
 }
 ```
 
@@ -83,7 +83,7 @@ For more information about CloudWatch Logs for Lambda, see the [Lambda User Guid
 
 ```hcl
 resource "aws_lambda_function" "test_lambda" {
-  function_name = "${var.lambda_function_name}"
+  function_name = var.lambda_function_name
   # ... other configuration ...
   depends_on = ["aws_iam_role_policy_attachment.lambda_logs", "aws_cloudwatch_log_group.example"]
 }
@@ -120,8 +120,8 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_logs" {
-  role       = "${aws_iam_role.iam_for_lambda.name}"
-  policy_arn = "${aws_iam_policy.lambda_logging.arn}"
+  role       = aws_iam_role.iam_for_lambda.name
+  policy_arn = aws_iam_policy.lambda_logging.arn
 }
 ```
 

--- a/website/docs/r/lambda_permission.html.markdown
+++ b/website/docs/r/lambda_permission.html.markdown
@@ -17,23 +17,23 @@ Creates a Lambda permission to allow external sources invoking the Lambda functi
 resource "aws_lambda_permission" "allow_cloudwatch" {
   statement_id  = "AllowExecutionFromCloudWatch"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.test_lambda.function_name}"
+  function_name = aws_lambda_function.test_lambda.function_name
   principal     = "events.amazonaws.com"
   source_arn    = "arn:aws:events:eu-west-1:111122223333:rule/RunDaily"
-  qualifier     = "${aws_lambda_alias.test_alias.name}"
+  qualifier     = aws_lambda_alias.test_alias.name
 }
 
 resource "aws_lambda_alias" "test_alias" {
   name             = "testalias"
   description      = "a sample description"
-  function_name    = "${aws_lambda_function.test_lambda.function_name}"
+  function_name    = aws_lambda_function.test_lambda.function_name
   function_version = "$LATEST"
 }
 
 resource "aws_lambda_function" "test_lambda" {
   filename      = "lambdatest.zip"
   function_name = "lambda_function_name"
-  role          = "${aws_iam_role.iam_for_lambda.arn}"
+  role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.handler"
   runtime       = "nodejs8.10"
 }
@@ -65,9 +65,9 @@ EOF
 resource "aws_lambda_permission" "with_sns" {
   statement_id  = "AllowExecutionFromSNS"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.func.function_name}"
+  function_name = aws_lambda_function.func.function_name
   principal     = "sns.amazonaws.com"
-  source_arn    = "${aws_sns_topic.default.arn}"
+  source_arn    = aws_sns_topic.default.arn
 }
 
 resource "aws_sns_topic" "default" {
@@ -75,15 +75,15 @@ resource "aws_sns_topic" "default" {
 }
 
 resource "aws_sns_topic_subscription" "lambda" {
-  topic_arn = "${aws_sns_topic.default.arn}"
+  topic_arn = aws_sns_topic.default.arn
   protocol  = "lambda"
-  endpoint  = "${aws_lambda_function.func.arn}"
+  endpoint  = aws_lambda_function.func.arn
 }
 
 resource "aws_lambda_function" "func" {
   filename      = "lambdatest.zip"
   function_name = "lambda_called_from_sns"
-  role          = "${aws_iam_role.default.arn}"
+  role          = aws_iam_role.default.arn
   handler       = "exports.handler"
   runtime       = "python2.7"
 }

--- a/website/docs/r/launch_configuration.html.markdown
+++ b/website/docs/r/launch_configuration.html.markdown
@@ -31,7 +31,7 @@ data "aws_ami" "ubuntu" {
 
 resource "aws_launch_configuration" "as_conf" {
   name          = "web_config"
-  image_id      = "${data.aws_ami.ubuntu.id}"
+  image_id      = data.aws_ami.ubuntu.id
   instance_type = "t2.micro"
 }
 ```
@@ -65,7 +65,7 @@ data "aws_ami" "ubuntu" {
 
 resource "aws_launch_configuration" "as_conf" {
   name_prefix   = "terraform-lc-example-"
-  image_id      = "${data.aws_ami.ubuntu.id}"
+  image_id      = data.aws_ami.ubuntu.id
   instance_type = "t2.micro"
 
   lifecycle {
@@ -75,7 +75,7 @@ resource "aws_launch_configuration" "as_conf" {
 
 resource "aws_autoscaling_group" "bar" {
   name                 = "terraform-asg-example"
-  launch_configuration = "${aws_launch_configuration.as_conf.name}"
+  launch_configuration = aws_launch_configuration.as_conf.name
   min_size             = 1
   max_size             = 2
 
@@ -116,7 +116,7 @@ data "aws_ami" "ubuntu" {
 }
 
 resource "aws_launch_configuration" "as_conf" {
-  image_id      = "${data.aws_ami.ubuntu.id}"
+  image_id      = data.aws_ami.ubuntu.id
   instance_type = "m4.large"
   spot_price    = "0.001"
 
@@ -127,7 +127,7 @@ resource "aws_launch_configuration" "as_conf" {
 
 resource "aws_autoscaling_group" "bar" {
   name                 = "terraform-asg-example"
-  launch_configuration = "${aws_launch_configuration.as_conf.name}"
+  launch_configuration = aws_launch_configuration.as_conf.name
 }
 ```
 

--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -21,13 +21,13 @@ resource "aws_lb" "test" {
   name               = "test-lb-tf"
   internal           = false
   load_balancer_type = "application"
-  security_groups    = ["${aws_security_group.lb_sg.id}"]
-  subnets            = ["${aws_subnet.public.*.id}"]
+  security_groups    = [aws_security_group.lb_sg.id]
+  subnets            = [aws_subnet.public.*.id]
 
   enable_deletion_protection = true
 
   access_logs {
-    bucket  = "${aws_s3_bucket.lb_logs.bucket}"
+    bucket  = aws_s3_bucket.lb_logs.bucket
     prefix  = "test-lb"
     enabled = true
   }
@@ -45,7 +45,7 @@ resource "aws_lb" "test" {
   name               = "test-lb-tf"
   internal           = false
   load_balancer_type = "network"
-  subnets            = ["${aws_subnet.public.*.id}"]
+  subnets            = [aws_subnet.public.*.id]
 
   enable_deletion_protection = true
 
@@ -63,13 +63,13 @@ resource "aws_lb" "example" {
   load_balancer_type = "network"
 
   subnet_mapping {
-    subnet_id     = "${aws_subnet.example1.id}"
-    allocation_id = "${aws_eip.example1.id}"
+    subnet_id     = aws_subnet.example1.id
+    allocation_id = aws_eip.example1.id
   }
 
   subnet_mapping {
-    subnet_id     = "${aws_subnet.example2.id}"
-    allocation_id = "${aws_eip.example2.id}"
+    subnet_id     = aws_subnet.example2.id
+    allocation_id = aws_eip.example2.id
   }
 }
 ```

--- a/website/docs/r/lb_cookie_stickiness_policy.html.markdown
+++ b/website/docs/r/lb_cookie_stickiness_policy.html.markdown
@@ -27,7 +27,7 @@ resource "aws_elb" "lb" {
 
 resource "aws_lb_cookie_stickiness_policy" "foo" {
   name                     = "foo-policy"
-  load_balancer            = "${aws_elb.lb.id}"
+  load_balancer            = aws_elb.lb.id
   lb_port                  = 80
   cookie_expiration_period = 600
 }

--- a/website/docs/r/lb_listener.html.markdown
+++ b/website/docs/r/lb_listener.html.markdown
@@ -26,7 +26,7 @@ resource "aws_lb_target_group" "front_end" {
 }
 
 resource "aws_lb_listener" "front_end" {
-  load_balancer_arn = "${aws_lb.front_end.arn}"
+  load_balancer_arn = aws_lb.front_end.arn
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-2016-08"
@@ -34,7 +34,7 @@ resource "aws_lb_listener" "front_end" {
 
   default_action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.front_end.arn}"
+    target_group_arn = aws_lb_target_group.front_end.arn
   }
 }
 ```
@@ -47,7 +47,7 @@ resource "aws_lb" "front_end" {
 }
 
 resource "aws_lb_listener" "front_end" {
-  load_balancer_arn = "${aws_lb.front_end.arn}"
+  load_balancer_arn = aws_lb.front_end.arn
   port              = "80"
   protocol          = "HTTP"
 
@@ -71,7 +71,7 @@ resource "aws_lb" "front_end" {
 }
 
 resource "aws_lb_listener" "front_end" {
-  load_balancer_arn = "${aws_lb.front_end.arn}"
+  load_balancer_arn = aws_lb.front_end.arn
   port              = "80"
   protocol          = "HTTP"
 
@@ -111,7 +111,7 @@ resource "aws_cognito_user_pool_domain" "domain" {
 }
 
 resource "aws_lb_listener" "front_end" {
-  load_balancer_arn = "${aws_lb.front_end.arn}"
+  load_balancer_arn = aws_lb.front_end.arn
   port              = "80"
   protocol          = "HTTP"
 
@@ -119,15 +119,15 @@ resource "aws_lb_listener" "front_end" {
     type = "authenticate-cognito"
 
     authenticate_cognito {
-      user_pool_arn       = "${aws_cognito_user_pool.pool.arn}"
-      user_pool_client_id = "${aws_cognito_user_pool_client.client.id}"
-      user_pool_domain    = "${aws_cognito_user_pool_domain.domain.domain}"
+      user_pool_arn       = aws_cognito_user_pool.pool.arn
+      user_pool_client_id = aws_cognito_user_pool_client.client.id
+      user_pool_domain    = aws_cognito_user_pool_domain.domain.domain
     }
   }
 
   default_action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.front_end.arn}"
+    target_group_arn = aws_lb_target_group.front_end.arn
   }
 }
 ```
@@ -144,7 +144,7 @@ resource "aws_lb_target_group" "front_end" {
 }
 
 resource "aws_lb_listener" "front_end" {
-  load_balancer_arn = "${aws_lb.front_end.arn}"
+  load_balancer_arn = aws_lb.front_end.arn
   port              = "80"
   protocol          = "HTTP"
 
@@ -163,7 +163,7 @@ resource "aws_lb_listener" "front_end" {
 
   default_action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.front_end.arn}"
+    target_group_arn = aws_lb_target_group.front_end.arn
   }
 }
 ```

--- a/website/docs/r/lb_listener_certificate.html.markdown
+++ b/website/docs/r/lb_listener_certificate.html.markdown
@@ -30,8 +30,8 @@ resource "aws_lb_listener" "front_end" {
 }
 
 resource "aws_lb_listener_certificate" "example" {
-  listener_arn    = "${aws_lb_listener.front_end.arn}"
-  certificate_arn = "${aws_acm_certificate.example.arn}"
+  listener_arn    = aws_lb_listener.front_end.arn
+  certificate_arn = aws_acm_certificate.example.arn
 }
 ```
 

--- a/website/docs/r/lb_listener_rule.html.markdown
+++ b/website/docs/r/lb_listener_rule.html.markdown
@@ -24,12 +24,12 @@ resource "aws_lb_listener" "front_end" {
 }
 
 resource "aws_lb_listener_rule" "static" {
-  listener_arn = "${aws_lb_listener.front_end.arn}"
+  listener_arn = aws_lb_listener.front_end.arn
   priority     = 100
 
   action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.static.arn}"
+    target_group_arn = aws_lb_target_group.static.arn
   }
 
   condition {
@@ -48,12 +48,12 @@ resource "aws_lb_listener_rule" "static" {
 # Forward action
 
 resource "aws_lb_listener_rule" "host_based_routing" {
-  listener_arn = "${aws_lb_listener.front_end.arn}"
+  listener_arn = aws_lb_listener.front_end.arn
   priority     = 99
 
   action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.static.arn}"
+    target_group_arn = aws_lb_target_group.static.arn
   }
 
   condition {
@@ -66,7 +66,7 @@ resource "aws_lb_listener_rule" "host_based_routing" {
 # Redirect action
 
 resource "aws_lb_listener_rule" "redirect_http_to_https" {
-  listener_arn = "${aws_lb_listener.front_end.arn}"
+  listener_arn = aws_lb_listener.front_end.arn
 
   action {
     type = "redirect"
@@ -89,7 +89,7 @@ resource "aws_lb_listener_rule" "redirect_http_to_https" {
 # Fixed-response action
 
 resource "aws_lb_listener_rule" "health_check" {
-  listener_arn = "${aws_lb_listener.front_end.arn}"
+  listener_arn = aws_lb_listener.front_end.arn
 
   action {
     type = "fixed-response"
@@ -128,28 +128,28 @@ resource "aws_cognito_user_pool_domain" "domain" {
 }
 
 resource "aws_lb_listener_rule" "admin" {
-  listener_arn = "${aws_lb_listener.front_end.arn}"
+  listener_arn = aws_lb_listener.front_end.arn
 
   action {
     type = "authenticate-cognito"
 
     authenticate_cognito {
-      user_pool_arn       = "${aws_cognito_user_pool.pool.arn}"
-      user_pool_client_id = "${aws_cognito_user_pool_client.client.id}"
-      user_pool_domain    = "${aws_cognito_user_pool_domain.domain.domain}"
+      user_pool_arn       = aws_cognito_user_pool.pool.arn
+      user_pool_client_id = aws_cognito_user_pool_client.client.id
+      user_pool_domain    = aws_cognito_user_pool_domain.domain.domain
     }
   }
 
   action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.static.arn}"
+    target_group_arn = aws_lb_target_group.static.arn
   }
 }
 
 # Authenticate-oidc Action
 
 resource "aws_lb_listener_rule" "admin" {
-  listener_arn = "${aws_lb_listener.front_end.arn}"
+  listener_arn = aws_lb_listener.front_end.arn
 
   action {
     type = "authenticate-oidc"
@@ -166,7 +166,7 @@ resource "aws_lb_listener_rule" "admin" {
 
   action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.static.arn}"
+    target_group_arn = aws_lb_target_group.static.arn
   }
 }
 ```

--- a/website/docs/r/lb_ssl_negotiation_policy.html.markdown
+++ b/website/docs/r/lb_ssl_negotiation_policy.html.markdown
@@ -28,7 +28,7 @@ resource "aws_elb" "lb" {
 
 resource "aws_lb_ssl_negotiation_policy" "foo" {
   name          = "foo-policy"
-  load_balancer = "${aws_elb.lb.id}"
+  load_balancer = aws_elb.lb.id
   lb_port       = 443
 
   attribute {

--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -21,7 +21,7 @@ resource "aws_lb_target_group" "test" {
   name     = "tf-example-lb-tg"
   port     = 80
   protocol = "HTTP"
-  vpc_id   = "${aws_vpc.main.id}"
+  vpc_id   = aws_vpc.main.id
 }
 
 resource "aws_vpc" "main" {
@@ -37,7 +37,7 @@ resource "aws_lb_target_group" "ip-example" {
   port        = 80
   protocol    = "HTTP"
   target_type = "ip"
-  vpc_id      = "${aws_vpc.main.id}"
+  vpc_id      = aws_vpc.main.id
 }
 
 resource "aws_vpc" "main" {

--- a/website/docs/r/lb_target_group_attachment.html.markdown
+++ b/website/docs/r/lb_target_group_attachment.html.markdown
@@ -17,8 +17,8 @@ Provides the ability to register instances and containers with an Application Lo
 
 ```hcl
 resource "aws_lb_target_group_attachment" "test" {
-  target_group_arn = "${aws_lb_target_group.test.arn}"
-  target_id        = "${aws_instance.test.id}"
+  target_group_arn = aws_lb_target_group.test.arn
+  target_id        = aws_instance.test.id
   port             = 80
 }
 
@@ -37,9 +37,9 @@ resource "aws_instance" "test" {
 resource "aws_lambda_permission" "with_lb" {
   statement_id  = "AllowExecutionFromlb"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.test.arn}"
+  function_name = aws_lambda_function.test.arn
   principal     = "elasticloadbalancing.amazonaws.com"
-  source_arn    = "${aws_lb_target_group.test.arn}"
+  source_arn    = aws_lb_target_group.test.arn
 }
 
 resource "aws_lb_target_group" "test" {
@@ -52,8 +52,8 @@ resource "aws_lambda_function" "test" {
 }
 
 resource "aws_lb_target_group_attachment" "test" {
-  target_group_arn = "${aws_lb_target_group.test.arn}"
-  target_id        = "${aws_lambda_function.test.arn}"
+  target_group_arn = aws_lb_target_group.test.arn
+  target_id        = aws_lambda_function.test.arn
   depends_on       = ["aws_lambda_permission.with_lb"]
 }
 ```

--- a/website/docs/r/licensemanager_association.markdown
+++ b/website/docs/r/licensemanager_association.markdown
@@ -26,7 +26,7 @@ data "aws_ami" "example" {
 }
 
 resource "aws_instance" "example" {
-  ami           = "${data.aws_ami.example.id}"
+  ami           = data.aws_ami.example.id
   instance_type = "t2.micro"
 }
 
@@ -36,8 +36,8 @@ resource "aws_licensemanager_license_configuration" "example" {
 }
 
 resource "aws_licensemanager_association" "example" {
-  license_configuration_arn = "${aws_licensemanager_license_configuration.example.arn}"
-  resource_arn              = "${aws_instance.example.arn}"
+  license_configuration_arn = aws_licensemanager_license_configuration.example.arn
+  resource_arn              = aws_instance.example.arn
 }
 ```
 

--- a/website/docs/r/lightsail_key_pair.html.markdown
+++ b/website/docs/r/lightsail_key_pair.html.markdown
@@ -37,7 +37,7 @@ resource "aws_lightsail_key_pair" "lg_key_pair" {
 ```hcl
 resource "aws_lightsail_key_pair" "lg_key_pair" {
   name       = "importing"
-  public_key = "${file("~/.ssh/id_rsa.pub")}"
+  public_key = file("~/.ssh/id_rsa.pub")
 }
 ```
 

--- a/website/docs/r/lightsail_static_ip_attachment.html.markdown
+++ b/website/docs/r/lightsail_static_ip_attachment.html.markdown
@@ -16,8 +16,8 @@ Provides a static IP address attachment - relationship between a Lightsail stati
 
 ```hcl
 resource "aws_lightsail_static_ip_attachment" "test" {
-  static_ip_name = "${aws_lightsail_static_ip.test.id}"
-  instance_name  = "${aws_lightsail_instance.test.id}"
+  static_ip_name = aws_lightsail_static_ip.test.id
+  instance_name  = aws_lightsail_instance.test.id
 }
 
 resource "aws_lightsail_static_ip" "test" {

--- a/website/docs/r/load_balancer_backend_server_policy.html.markdown
+++ b/website/docs/r/load_balancer_backend_server_policy.html.markdown
@@ -32,33 +32,33 @@ resource "aws_elb" "wu-tang" {
 }
 
 resource "aws_load_balancer_policy" "wu-tang-ca-pubkey-policy" {
-  load_balancer_name = "${aws_elb.wu-tang.name}"
+  load_balancer_name = aws_elb.wu-tang.name
   policy_name        = "wu-tang-ca-pubkey-policy"
   policy_type_name   = "PublicKeyPolicyType"
 
   policy_attribute {
     name  = "PublicKey"
-    value = "${file("wu-tang-pubkey")}"
+    value = file("wu-tang-pubkey")
   }
 }
 
 resource "aws_load_balancer_policy" "wu-tang-root-ca-backend-auth-policy" {
-  load_balancer_name = "${aws_elb.wu-tang.name}"
+  load_balancer_name = aws_elb.wu-tang.name
   policy_name        = "wu-tang-root-ca-backend-auth-policy"
   policy_type_name   = "BackendServerAuthenticationPolicyType"
 
   policy_attribute {
     name  = "PublicKeyPolicyName"
-    value = "${aws_load_balancer_policy.wu-tang-root-ca-pubkey-policy.policy_name}"
+    value = aws_load_balancer_policy.wu-tang-root-ca-pubkey-policy.policy_name
   }
 }
 
 resource "aws_load_balancer_backend_server_policy" "wu-tang-backend-auth-policies-443" {
-  load_balancer_name = "${aws_elb.wu-tang.name}"
+  load_balancer_name = aws_elb.wu-tang.name
   instance_port      = 443
 
   policy_names = [
-    "${aws_load_balancer_policy.wu-tang-root-ca-backend-auth-policy.policy_name}",
+    aws_load_balancer_policy.wu-tang-root-ca-backend-auth-policy.policy_name,
   ]
 }
 ```

--- a/website/docs/r/load_balancer_listener_policy.html.markdown
+++ b/website/docs/r/load_balancer_listener_policy.html.markdown
@@ -32,7 +32,7 @@ resource "aws_elb" "wu-tang" {
 }
 
 resource "aws_load_balancer_policy" "wu-tang-ssl" {
-  load_balancer_name = "${aws_elb.wu-tang.name}"
+  load_balancer_name = aws_elb.wu-tang.name
   policy_name        = "wu-tang-ssl"
   policy_type_name   = "SSLNegotiationPolicyType"
 
@@ -48,11 +48,11 @@ resource "aws_load_balancer_policy" "wu-tang-ssl" {
 }
 
 resource "aws_load_balancer_listener_policy" "wu-tang-listener-policies-443" {
-  load_balancer_name = "${aws_elb.wu-tang.name}"
+  load_balancer_name = aws_elb.wu-tang.name
   load_balancer_port = 443
 
   policy_names = [
-    "${aws_load_balancer_policy.wu-tang-ssl.policy_name}",
+    aws_load_balancer_policy.wu-tang-ssl.policy_name,
   ]
 }
 ```
@@ -80,7 +80,7 @@ resource "aws_elb" "wu-tang" {
 }
 
 resource "aws_load_balancer_policy" "wu-tang-ssl-tls-1-1" {
-  load_balancer_name = "${aws_elb.wu-tang.name}"
+  load_balancer_name = aws_elb.wu-tang.name
   policy_name        = "wu-tang-ssl"
   policy_type_name   = "SSLNegotiationPolicyType"
 
@@ -91,11 +91,11 @@ resource "aws_load_balancer_policy" "wu-tang-ssl-tls-1-1" {
 }
 
 resource "aws_load_balancer_listener_policy" "wu-tang-listener-policies-443" {
-  load_balancer_name = "${aws_elb.wu-tang.name}"
+  load_balancer_name = aws_elb.wu-tang.name
   load_balancer_port = 443
 
   policy_names = [
-    "${aws_load_balancer_policy.wu-tang-ssl-tls-1-1.policy_name}",
+    aws_load_balancer_policy.wu-tang-ssl-tls-1-1.policy_name,
   ]
 }
 ```

--- a/website/docs/r/load_balancer_policy.html.markdown
+++ b/website/docs/r/load_balancer_policy.html.markdown
@@ -31,29 +31,29 @@ resource "aws_elb" "wu-tang" {
 }
 
 resource "aws_load_balancer_policy" "wu-tang-ca-pubkey-policy" {
-  load_balancer_name = "${aws_elb.wu-tang.name}"
+  load_balancer_name = aws_elb.wu-tang.name
   policy_name        = "wu-tang-ca-pubkey-policy"
   policy_type_name   = "PublicKeyPolicyType"
 
   policy_attribute {
     name  = "PublicKey"
-    value = "${file("wu-tang-pubkey")}"
+    value = file("wu-tang-pubkey")
   }
 }
 
 resource "aws_load_balancer_policy" "wu-tang-root-ca-backend-auth-policy" {
-  load_balancer_name = "${aws_elb.wu-tang.name}"
+  load_balancer_name = aws_elb.wu-tang.name
   policy_name        = "wu-tang-root-ca-backend-auth-policy"
   policy_type_name   = "BackendServerAuthenticationPolicyType"
 
   policy_attribute {
     name  = "PublicKeyPolicyName"
-    value = "${aws_load_balancer_policy.wu-tang-root-ca-pubkey-policy.policy_name}"
+    value = aws_load_balancer_policy.wu-tang-root-ca-pubkey-policy.policy_name
   }
 }
 
 resource "aws_load_balancer_policy" "wu-tang-ssl" {
-  load_balancer_name = "${aws_elb.wu-tang.name}"
+  load_balancer_name = aws_elb.wu-tang.name
   policy_name        = "wu-tang-ssl"
   policy_type_name   = "SSLNegotiationPolicyType"
 
@@ -69,7 +69,7 @@ resource "aws_load_balancer_policy" "wu-tang-ssl" {
 }
 
 resource "aws_load_balancer_policy" "wu-tang-ssl-tls-1-1" {
-  load_balancer_name = "${aws_elb.wu-tang.name}"
+  load_balancer_name = aws_elb.wu-tang.name
   policy_name        = "wu-tang-ssl"
   policy_type_name   = "SSLNegotiationPolicyType"
 
@@ -80,20 +80,20 @@ resource "aws_load_balancer_policy" "wu-tang-ssl-tls-1-1" {
 }
 
 resource "aws_load_balancer_backend_server_policy" "wu-tang-backend-auth-policies-443" {
-  load_balancer_name = "${aws_elb.wu-tang.name}"
+  load_balancer_name = aws_elb.wu-tang.name
   instance_port      = 443
 
   policy_names = [
-    "${aws_load_balancer_policy.wu-tang-root-ca-backend-auth-policy.policy_name}",
+    aws_load_balancer_policy.wu-tang-root-ca-backend-auth-policy.policy_name,
   ]
 }
 
 resource "aws_load_balancer_listener_policy" "wu-tang-listener-policies-443" {
-  load_balancer_name = "${aws_elb.wu-tang.name}"
+  load_balancer_name = aws_elb.wu-tang.name
   load_balancer_port = 443
 
   policy_names = [
-    "${aws_load_balancer_policy.wu-tang-ssl.policy_name}",
+    aws_load_balancer_policy.wu-tang-ssl.policy_name,
   ]
 }
 ```

--- a/website/docs/r/main_route_table_association.html.markdown
+++ b/website/docs/r/main_route_table_association.html.markdown
@@ -14,8 +14,8 @@ Provides a resource for managing the main routing table of a VPC.
 
 ```hcl
 resource "aws_main_route_table_association" "a" {
-  vpc_id         = "${aws_vpc.foo.id}"
-  route_table_id = "${aws_route_table.bar.id}"
+  vpc_id         = aws_vpc.foo.id
+  route_table_id = aws_route_table.bar.id
 }
 ```
 

--- a/website/docs/r/media_store_container_policy.html.markdown
+++ b/website/docs/r/media_store_container_policy.html.markdown
@@ -22,7 +22,7 @@ resource "aws_media_store_container" "example" {
 }
 
 resource "aws_media_store_container_policy" "example" {
-  container_name = "${aws_media_store_container.example.name}"
+  container_name = aws_media_store_container.example.name
 
   policy = <<EOF
 {

--- a/website/docs/r/mq_broker.html.markdown
+++ b/website/docs/r/mq_broker.html.markdown
@@ -32,14 +32,14 @@ resource "aws_mq_broker" "example" {
   broker_name = "example"
 
   configuration {
-    id       = "${aws_mq_configuration.test.id}"
-    revision = "${aws_mq_configuration.test.latest_revision}"
+    id       = aws_mq_configuration.test.id
+    revision = aws_mq_configuration.test.latest_revision
   }
 
   engine_type        = "ActiveMQ"
   engine_version     = "5.15.0"
   host_instance_type = "mq.t2.micro"
-  security_groups    = ["${aws_security_group.test.id}"]
+  security_groups    = [aws_security_group.test.id]
 
   user {
     username = "ExampleUser"

--- a/website/docs/r/msk_cluster.html.markdown
+++ b/website/docs/r/msk_cluster.html.markdown
@@ -23,25 +23,25 @@ data "aws_availability_zones" "azs" {
 }
 
 resource "aws_subnet" "subnet_az1" {
-  availability_zone = "${data.aws_availability_zones.azs.names[0]}"
+  availability_zone = data.aws_availability_zones.azs.names[0]
   cidr_block        = "192.168.0.0/24"
-  vpc_id            = "${aws_vpc.vpc.id}"
+  vpc_id            = aws_vpc.vpc.id
 }
 
 resource "aws_subnet" "subnet_az2" {
-  availability_zone = "${data.aws_availability_zones.azs.names[1]}"
+  availability_zone = data.aws_availability_zones.azs.names[1]
   cidr_block        = "192.168.1.0/24"
-  vpc_id            = "${aws_vpc.vpc.id}"
+  vpc_id            = aws_vpc.vpc.id
 }
 
 resource "aws_subnet" "subnet_az3" {
-  availability_zone = "${data.aws_availability_zones.azs.names[2]}"
+  availability_zone = data.aws_availability_zones.azs.names[2]
   cidr_block        = "192.168.2.0/24"
-  vpc_id            = "${aws_vpc.vpc.id}"
+  vpc_id            = aws_vpc.vpc.id
 }
 
 resource "aws_security_group" "sg" {
-  vpc_id = "${aws_vpc.vpc.id}"
+  vpc_id = aws_vpc.vpc.id
 }
 
 resource "aws_kms_key" "kms" {
@@ -82,8 +82,8 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
   destination = "s3"
 
   s3_configuration {
-    role_arn   = "${aws_iam_role.firehose_role.arn}"
-    bucket_arn = "${aws_s3_bucket.bucket.arn}"
+    role_arn   = aws_iam_role.firehose_role.arn
+    bucket_arn = aws_s3_bucket.bucket.arn
   }
 
   tags = {
@@ -106,15 +106,15 @@ resource "aws_msk_cluster" "example" {
     instance_type   = "kafka.m5.large"
     ebs_volume_size = 1000
     client_subnets = [
-      "${aws_subnet.subnet_az1.id}",
-      "${aws_subnet.subnet_az2.id}",
-      "${aws_subnet.subnet_az3.id}",
+      aws_subnet.subnet_az1.id,
+      aws_subnet.subnet_az2.id,
+      aws_subnet.subnet_az3.id,
     ]
-    security_groups = ["${aws_security_group.sg.id}"]
+    security_groups = [aws_security_group.sg.id]
   }
 
   encryption_info {
-    encryption_at_rest_kms_key_arn = "${aws_kms_key.kms.arn}"
+    encryption_at_rest_kms_key_arn = aws_kms_key.kms.arn
   }
 
   open_monitoring {
@@ -132,15 +132,15 @@ resource "aws_msk_cluster" "example" {
     broker_logs {
       cloudwatch_logs {
         enabled   = true
-        log_group = "${aws_cloudwatch_log_group.test.name}"
+        log_group = aws_cloudwatch_log_group.test.name
       }
       firehose {
         enabled         = true
-        delivery_stream = "${aws_kinesis_firehose_delivery_stream.test_stream.name}"
+        delivery_stream = aws_kinesis_firehose_delivery_stream.test_stream.name
       }
       s3 {
         enabled = true
-        bucket  = "${aws_s3_bucket.bucket.id}"
+        bucket  = aws_s3_bucket.bucket.id
         prefix  = "logs/msk-"
       }
     }
@@ -152,17 +152,17 @@ resource "aws_msk_cluster" "example" {
 }
 
 output "zookeeper_connect_string" {
-  value = "${aws_msk_cluster.example.zookeeper_connect_string}"
+  value = aws_msk_cluster.example.zookeeper_connect_string
 }
 
 output "bootstrap_brokers" {
   description = "Plaintext connection host:port pairs"
-  value       = "${aws_msk_cluster.example.bootstrap_brokers}"
+  value       = aws_msk_cluster.example.bootstrap_brokers
 }
 
 output "bootstrap_brokers_tls" {
   description = "TLS connection host:port pairs"
-  value       = "${aws_msk_cluster.example.bootstrap_brokers_tls}"
+  value       = aws_msk_cluster.example.bootstrap_brokers_tls
 }
 ```
 

--- a/website/docs/r/nat_gateway.html.markdown
+++ b/website/docs/r/nat_gateway.html.markdown
@@ -14,8 +14,8 @@ Provides a resource to create a VPC NAT Gateway.
 
 ```hcl
 resource "aws_nat_gateway" "gw" {
-  allocation_id = "${aws_eip.nat.id}"
-  subnet_id     = "${aws_subnet.public.id}"
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.public.id
 }
 ```
 
@@ -23,8 +23,8 @@ Usage with tags:
 
 ```hcl
 resource "aws_nat_gateway" "gw" {
-  allocation_id = "${aws_eip.nat.id}"
-  subnet_id     = "${aws_subnet.public.id}"
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.public.id
 
   tags = {
     Name = "gw NAT"
@@ -44,7 +44,7 @@ The following arguments are supported:
 
 ```hcl
 resource "aws_internet_gateway" "gw" {
-  vpc_id = "${aws_vpc.main.id}"
+  vpc_id = aws_vpc.main.id
 }
 
 resource "aws_nat_gateway" "gw" {

--- a/website/docs/r/neptune_cluster_instance.html.markdown
+++ b/website/docs/r/neptune_cluster_instance.html.markdown
@@ -31,7 +31,7 @@ resource "aws_neptune_cluster" "default" {
 
 resource "aws_neptune_cluster_instance" "example" {
   count              = 2
-  cluster_identifier = "${aws_neptune_cluster.default.id}"
+  cluster_identifier = aws_neptune_cluster.default.id
   engine             = "neptune"
   instance_class     = "db.r4.large"
   apply_immediately  = true

--- a/website/docs/r/neptune_cluster_snapshot.html.markdown
+++ b/website/docs/r/neptune_cluster_snapshot.html.markdown
@@ -14,7 +14,7 @@ Manages a Neptune database cluster snapshot.
 
 ```hcl
 resource "aws_neptune_cluster_snapshot" "example" {
-  db_cluster_identifier          = "${aws_neptune_cluster.example.id}"
+  db_cluster_identifier          = aws_neptune_cluster.example.id
   db_cluster_snapshot_identifier = "resourcetestsnapshot1234"
 }
 ```

--- a/website/docs/r/neptune_event_subscription.html.markdown
+++ b/website/docs/r/neptune_event_subscription.html.markdown
@@ -23,7 +23,7 @@ resource "aws_neptune_cluster" "default" {
 
 resource "aws_neptune_cluster_instance" "example" {
   count              = 1
-  cluster_identifier = "${aws_neptune_cluster.default.id}"
+  cluster_identifier = aws_neptune_cluster.default.id
   engine             = "neptune"
   instance_class     = "db.r4.large"
   apply_immediately  = "true"
@@ -35,10 +35,10 @@ resource "aws_sns_topic" "default" {
 
 resource "aws_neptune_event_subscription" "default" {
   name          = "neptune-event-sub"
-  sns_topic_arn = "${aws_sns_topic.default.arn}"
+  sns_topic_arn = aws_sns_topic.default.arn
 
   source_type = "db-instance"
-  source_ids  = ["${aws_neptune_cluster_instance.example.id}"]
+  source_ids  = [aws_neptune_cluster_instance.example.id]
 
   event_categories = [
     "maintenance",

--- a/website/docs/r/neptune_subnet_group.html.markdown
+++ b/website/docs/r/neptune_subnet_group.html.markdown
@@ -15,7 +15,7 @@ Provides an Neptune subnet group resource.
 ```hcl
 resource "aws_neptune_subnet_group" "default" {
   name       = "main"
-  subnet_ids = ["${aws_subnet.frontend.id}", "${aws_subnet.backend.id}"]
+  subnet_ids = [aws_subnet.frontend.id, aws_subnet.backend.id]
 
   tags = {
     Name = "My neptune subnet group"

--- a/website/docs/r/network_acl.html.markdown
+++ b/website/docs/r/network_acl.html.markdown
@@ -21,7 +21,7 @@ a conflict of rule settings and will overwrite rules.
 
 ```hcl
 resource "aws_network_acl" "main" {
-  vpc_id = "${aws_vpc.main.id}"
+  vpc_id = aws_vpc.main.id
 
   egress {
     protocol   = "tcp"

--- a/website/docs/r/network_interface.markdown
+++ b/website/docs/r/network_interface.markdown
@@ -14,12 +14,12 @@ Provides an Elastic network interface (ENI) resource.
 
 ```hcl
 resource "aws_network_interface" "test" {
-  subnet_id       = "${aws_subnet.public_a.id}"
+  subnet_id       = aws_subnet.public_a.id
   private_ips     = ["10.0.0.50"]
-  security_groups = ["${aws_security_group.web.id}"]
+  security_groups = [aws_security_group.web.id]
 
   attachment {
-    instance     = "${aws_instance.test.id}"
+    instance     = aws_instance.test.id
     device_index = 1
   }
 }

--- a/website/docs/r/network_interface_attachment.html.markdown
+++ b/website/docs/r/network_interface_attachment.html.markdown
@@ -14,8 +14,8 @@ Attach an Elastic network interface (ENI) resource with EC2 instance.
 
 ```hcl
 resource "aws_network_interface_attachment" "test" {
-  instance_id          = "${aws_instance.test.id}"
-  network_interface_id = "${aws_network_interface.test.id}"
+  instance_id          = aws_instance.test.id
+  network_interface_id = aws_network_interface.test.id
   device_index         = 0
 }
 ```

--- a/website/docs/r/network_interface_sg_attachment.html.markdown
+++ b/website/docs/r/network_interface_sg_attachment.html.markdown
@@ -44,7 +44,7 @@ data "aws_ami" "ami" {
 
 resource "aws_instance" "instance" {
   instance_type = "t2.micro"
-  ami           = "${data.aws_ami.ami.id}"
+  ami           = data.aws_ami.ami.id
 
   tags = {
     "type" = "terraform-test-instance"
@@ -58,8 +58,8 @@ resource "aws_security_group" "sg" {
 }
 
 resource "aws_network_interface_sg_attachment" "sg_attachment" {
-  security_group_id    = "${aws_security_group.sg.id}"
-  network_interface_id = "${aws_instance.instance.primary_network_interface_id}"
+  security_group_id    = aws_security_group.sg.id
+  network_interface_id = aws_instance.instance.primary_network_interface_id
 }
 ```
 
@@ -79,8 +79,8 @@ resource "aws_security_group" "sg" {
 }
 
 resource "aws_network_interface_sg_attachment" "sg_attachment" {
-  security_group_id    = "${aws_security_group.sg.id}"
-  network_interface_id = "${data.aws_instance.instance.network_interface_id}"
+  security_group_id    = aws_security_group.sg.id
+  network_interface_id = data.aws_instance.instance.network_interface_id
 }
 ```
 

--- a/website/docs/r/opsworks_application.html.markdown
+++ b/website/docs/r/opsworks_application.html.markdown
@@ -16,7 +16,7 @@ Provides an OpsWorks application resource.
 resource "aws_opsworks_application" "foo-app" {
   name        = "foobar application"
   short_name  = "foobar"
-  stack_id    = "${aws_opsworks_stack.main.id}"
+  stack_id    = aws_opsworks_stack.main.id
   type        = "rails"
   description = "This is a Rails application"
 
@@ -40,8 +40,8 @@ resource "aws_opsworks_application" "foo-app" {
   enable_ssl = true
 
   ssl_configuration {
-    private_key = "${file("./foobar.key")}"
-    certificate = "${file("./foobar.crt")}"
+    private_key = file("./foobar.key")
+    certificate = file("./foobar.crt")
   }
 
   document_root         = "public"

--- a/website/docs/r/opsworks_custom_layer.html.markdown
+++ b/website/docs/r/opsworks_custom_layer.html.markdown
@@ -16,7 +16,7 @@ Provides an OpsWorks custom layer resource.
 resource "aws_opsworks_custom_layer" "custlayer" {
   name       = "My Awesome Custom Layer"
   short_name = "awesome"
-  stack_id   = "${aws_opsworks_stack.main.id}"
+  stack_id   = aws_opsworks_stack.main.id
 }
 ```
 

--- a/website/docs/r/opsworks_ganglia_layer.html.markdown
+++ b/website/docs/r/opsworks_ganglia_layer.html.markdown
@@ -14,7 +14,7 @@ Provides an OpsWorks Ganglia layer resource.
 
 ```hcl
 resource "aws_opsworks_ganglia_layer" "monitor" {
-  stack_id = "${aws_opsworks_stack.main.id}"
+  stack_id = aws_opsworks_stack.main.id
   password = "foobarbaz"
 }
 ```

--- a/website/docs/r/opsworks_haproxy_layer.html.markdown
+++ b/website/docs/r/opsworks_haproxy_layer.html.markdown
@@ -14,7 +14,7 @@ Provides an OpsWorks haproxy layer resource.
 
 ```hcl
 resource "aws_opsworks_haproxy_layer" "lb" {
-  stack_id       = "${aws_opsworks_stack.main.id}"
+  stack_id       = aws_opsworks_stack.main.id
   stats_password = "foobarbaz"
 }
 ```

--- a/website/docs/r/opsworks_instance.html.markdown
+++ b/website/docs/r/opsworks_instance.html.markdown
@@ -14,10 +14,10 @@ Provides an OpsWorks instance resource.
 
 ```hcl
 resource "aws_opsworks_instance" "my-instance" {
-  stack_id = "${aws_opsworks_stack.main.id}"
+  stack_id = aws_opsworks_stack.main.id
 
   layer_ids = [
-    "${aws_opsworks_custom_layer.my-layer.id}",
+    aws_opsworks_custom_layer.my-layer.id,
   ]
 
   instance_type = "t2.micro"

--- a/website/docs/r/opsworks_java_app_layer.html.markdown
+++ b/website/docs/r/opsworks_java_app_layer.html.markdown
@@ -14,7 +14,7 @@ Provides an OpsWorks Java application layer resource.
 
 ```hcl
 resource "aws_opsworks_java_app_layer" "app" {
-  stack_id = "${aws_opsworks_stack.main.id}"
+  stack_id = aws_opsworks_stack.main.id
 }
 ```
 

--- a/website/docs/r/opsworks_memcached_layer.html.markdown
+++ b/website/docs/r/opsworks_memcached_layer.html.markdown
@@ -14,7 +14,7 @@ Provides an OpsWorks memcached layer resource.
 
 ```hcl
 resource "aws_opsworks_memcached_layer" "cache" {
-  stack_id = "${aws_opsworks_stack.main.id}"
+  stack_id = aws_opsworks_stack.main.id
 }
 ```
 

--- a/website/docs/r/opsworks_mysql_layer.html.markdown
+++ b/website/docs/r/opsworks_mysql_layer.html.markdown
@@ -17,7 +17,7 @@ Provides an OpsWorks MySQL layer resource.
 
 ```hcl
 resource "aws_opsworks_mysql_layer" "db" {
-  stack_id = "${aws_opsworks_stack.main.id}"
+  stack_id = aws_opsworks_stack.main.id
 }
 ```
 

--- a/website/docs/r/opsworks_nodejs_app_layer.html.markdown
+++ b/website/docs/r/opsworks_nodejs_app_layer.html.markdown
@@ -14,7 +14,7 @@ Provides an OpsWorks NodeJS application layer resource.
 
 ```hcl
 resource "aws_opsworks_nodejs_app_layer" "app" {
-  stack_id = "${aws_opsworks_stack.main.id}"
+  stack_id = aws_opsworks_stack.main.id
 }
 ```
 

--- a/website/docs/r/opsworks_permission.html.markdown
+++ b/website/docs/r/opsworks_permission.html.markdown
@@ -17,8 +17,8 @@ resource "aws_opsworks_permission" "my_stack_permission" {
   allow_ssh  = true
   allow_sudo = true
   level      = "iam_only"
-  user_arn   = "${aws_iam_user.user.arn}"
-  stack_id   = "${aws_opsworks_stack.stack.id}"
+  user_arn   = aws_iam_user.user.arn
+  stack_id   = aws_opsworks_stack.stack.id
 }
 ```
 

--- a/website/docs/r/opsworks_php_app_layer.html.markdown
+++ b/website/docs/r/opsworks_php_app_layer.html.markdown
@@ -14,7 +14,7 @@ Provides an OpsWorks PHP application layer resource.
 
 ```hcl
 resource "aws_opsworks_php_app_layer" "app" {
-  stack_id = "${aws_opsworks_stack.main.id}"
+  stack_id = aws_opsworks_stack.main.id
 }
 ```
 

--- a/website/docs/r/opsworks_rails_app_layer.html.markdown
+++ b/website/docs/r/opsworks_rails_app_layer.html.markdown
@@ -14,7 +14,7 @@ Provides an OpsWorks Ruby on Rails application layer resource.
 
 ```hcl
 resource "aws_opsworks_rails_app_layer" "app" {
-  stack_id = "${aws_opsworks_stack.main.id}"
+  stack_id = aws_opsworks_stack.main.id
 }
 ```
 

--- a/website/docs/r/opsworks_rds_db_instance.html.markdown
+++ b/website/docs/r/opsworks_rds_db_instance.html.markdown
@@ -17,8 +17,8 @@ Provides an OpsWorks RDS DB Instance resource.
 
 ```hcl
 resource "aws_opsworks_rds_db_instance" "my_instance" {
-  stack_id            = "${aws_opsworks_stack.my_stack.id}"
-  rds_db_instance_arn = "${aws_db_instance.my_instance.arn}"
+  stack_id            = aws_opsworks_stack.my_stack.id
+  rds_db_instance_arn = aws_db_instance.my_instance.arn
   db_user             = "someUser"
   db_password         = "somePass"
 }

--- a/website/docs/r/opsworks_stack.html.markdown
+++ b/website/docs/r/opsworks_stack.html.markdown
@@ -16,8 +16,8 @@ Provides an OpsWorks stack resource.
 resource "aws_opsworks_stack" "main" {
   name                         = "awesome-stack"
   region                       = "us-west-1"
-  service_role_arn             = "${aws_iam_role.opsworks.arn}"
-  default_instance_profile_arn = "${aws_iam_instance_profile.opsworks.arn}"
+  service_role_arn             = aws_iam_role.opsworks.arn
+  default_instance_profile_arn = aws_iam_instance_profile.opsworks.arn
 
   tags = {
     Name = "foobar-terraform-stack"

--- a/website/docs/r/opsworks_static_web_layer.html.markdown
+++ b/website/docs/r/opsworks_static_web_layer.html.markdown
@@ -14,7 +14,7 @@ Provides an OpsWorks static web server layer resource.
 
 ```hcl
 resource "aws_opsworks_static_web_layer" "web" {
-  stack_id = "${aws_opsworks_stack.main.id}"
+  stack_id = aws_opsworks_stack.main.id
 }
 ```
 

--- a/website/docs/r/opsworks_user_profile.html.markdown
+++ b/website/docs/r/opsworks_user_profile.html.markdown
@@ -14,7 +14,7 @@ Provides an OpsWorks User Profile resource.
 
 ```hcl
 resource "aws_opsworks_user_profile" "my_profile" {
-  user_arn     = "${aws_iam_user.user.arn}"
+  user_arn     = aws_iam_user.user.arn
   ssh_username = "my_user"
 }
 ```

--- a/website/docs/r/organizations_organizational_unit.html.markdown
+++ b/website/docs/r/organizations_organizational_unit.html.markdown
@@ -15,7 +15,7 @@ Provides a resource to create an organizational unit.
 ```hcl
 resource "aws_organizations_organizational_unit" "example" {
   name      = "example"
-  parent_id = "${aws_organizations_organization.example.roots.0.id}"
+  parent_id = aws_organizations_organization.example.roots.0.id
 }
 ```
 

--- a/website/docs/r/organizations_policy_attachment.html.markdown
+++ b/website/docs/r/organizations_policy_attachment.html.markdown
@@ -16,7 +16,7 @@ Provides a resource to attach an AWS Organizations policy to an organization acc
 
 ```hcl
 resource "aws_organizations_policy_attachment" "account" {
-  policy_id = "${aws_organizations_policy.example.id}"
+  policy_id = aws_organizations_policy.example.id
   target_id = "123456789012"
 }
 ```
@@ -25,8 +25,8 @@ resource "aws_organizations_policy_attachment" "account" {
 
 ```hcl
 resource "aws_organizations_policy_attachment" "root" {
-  policy_id = "${aws_organizations_policy.example.id}"
-  target_id = "${aws_organizations_organization.example.roots.0.id}"
+  policy_id = aws_organizations_policy.example.id
+  target_id = aws_organizations_organization.example.roots.0.id
 }
 ```
 
@@ -34,8 +34,8 @@ resource "aws_organizations_policy_attachment" "root" {
 
 ```hcl
 resource "aws_organizations_policy_attachment" "unit" {
-  policy_id = "${aws_organizations_policy.example.id}"
-  target_id = "${aws_organizations_organizational_unit.example.id}"
+  policy_id = aws_organizations_policy.example.id
+  target_id = aws_organizations_organizational_unit.example.id
 }
 ```
 

--- a/website/docs/r/pinpoint_adm_channel.markdown
+++ b/website/docs/r/pinpoint_adm_channel.markdown
@@ -20,7 +20,7 @@ Provides a Pinpoint ADM (Amazon Device Messaging) Channel resource.
 resource "aws_pinpoint_app" "app" {}
 
 resource "aws_pinpoint_adm_channel" "channel" {
-  application_id = "${aws_pinpoint_app.app.application_id}"
+  application_id = aws_pinpoint_app.app.application_id
   client_id      = ""
   client_secret  = ""
   enabled        = true

--- a/website/docs/r/pinpoint_apns_channel.markdown
+++ b/website/docs/r/pinpoint_apns_channel.markdown
@@ -17,10 +17,10 @@ Provides a Pinpoint APNs Channel resource.
 
 ```hcl
 resource "aws_pinpoint_apns_channel" "apns" {
-  application_id = "${aws_pinpoint_app.app.application_id}"
+  application_id = aws_pinpoint_app.app.application_id
 
-  certificate = "${file("./certificate.pem")}"
-  private_key = "${file("./private_key.key")}"
+  certificate = file("./certificate.pem")
+  private_key = file("./private_key.key")
 }
 
 resource "aws_pinpoint_app" "app" {}

--- a/website/docs/r/pinpoint_apns_sandbox_channel.markdown
+++ b/website/docs/r/pinpoint_apns_sandbox_channel.markdown
@@ -17,10 +17,10 @@ Provides a Pinpoint APNs Sandbox Channel resource.
 
 ```hcl
 resource "aws_pinpoint_apns_sandbox_channel" "apns_sandbox" {
-  application_id = "${aws_pinpoint_app.app.application_id}"
+  application_id = aws_pinpoint_app.app.application_id
 
-  certificate = "${file("./certificate.pem")}"
-  private_key = "${file("./private_key.key")}"
+  certificate = file("./certificate.pem")
+  private_key = file("./private_key.key")
 }
 
 resource "aws_pinpoint_app" "app" {}

--- a/website/docs/r/pinpoint_apns_voip_channel.markdown
+++ b/website/docs/r/pinpoint_apns_voip_channel.markdown
@@ -17,10 +17,10 @@ Provides a Pinpoint APNs VoIP Channel resource.
 
 ```hcl
 resource "aws_pinpoint_apns_voip_channel" "apns_voip" {
-  application_id = "${aws_pinpoint_app.app.application_id}"
+  application_id = aws_pinpoint_app.app.application_id
 
-  certificate = "${file("./certificate.pem")}"
-  private_key = "${file("./private_key.key")}"
+  certificate = file("./certificate.pem")
+  private_key = file("./private_key.key")
 }
 
 resource "aws_pinpoint_app" "app" {}

--- a/website/docs/r/pinpoint_apns_voip_sandbox_channel.markdown
+++ b/website/docs/r/pinpoint_apns_voip_sandbox_channel.markdown
@@ -17,10 +17,10 @@ Provides a Pinpoint APNs VoIP Sandbox Channel resource.
 
 ```hcl
 resource "aws_pinpoint_apns_voip_sandbox_channel" "apns_voip_sandbox" {
-  application_id = "${aws_pinpoint_app.app.application_id}"
+  application_id = aws_pinpoint_app.app.application_id
 
-  certificate = "${file("./certificate.pem")}"
-  private_key = "${file("./private_key.key")}"
+  certificate = file("./certificate.pem")
+  private_key = file("./private_key.key")
 }
 
 resource "aws_pinpoint_app" "app" {}

--- a/website/docs/r/pinpoint_baidu_channel.markdown
+++ b/website/docs/r/pinpoint_baidu_channel.markdown
@@ -20,7 +20,7 @@ Provides a Pinpoint Baidu Channel resource.
 resource "aws_pinpoint_app" "app" {}
 
 resource "aws_pinpoint_baidu_channel" "channel" {
-  application_id = "${aws_pinpoint_app.app.application_id}"
+  application_id = aws_pinpoint_app.app.application_id
   api_key        = ""
   secret_key     = ""
 }

--- a/website/docs/r/pinpoint_email_channel.markdown
+++ b/website/docs/r/pinpoint_email_channel.markdown
@@ -14,10 +14,10 @@ Provides a Pinpoint SMS Channel resource.
 
 ```hcl
 resource "aws_pinpoint_email_channel" "email" {
-  application_id = "${aws_pinpoint_app.app.application_id}"
+  application_id = aws_pinpoint_app.app.application_id
   from_address   = "user@example.com"
-  identity       = "${aws_ses_domain_identity.identity.arn}"
-  role_arn       = "${aws_iam_role.role.arn}"
+  identity       = aws_ses_domain_identity.identity.arn
+  role_arn       = aws_iam_role.role.arn
 }
 
 resource "aws_pinpoint_app" "app" {}
@@ -46,7 +46,7 @@ EOF
 
 resource "aws_iam_role_policy" "role_policy" {
   name = "role_policy"
-  role = "${aws_iam_role.role.id}"
+  role = aws_iam_role.role.id
 
   policy = <<EOF
 {

--- a/website/docs/r/pinpoint_event_stream.markdown
+++ b/website/docs/r/pinpoint_event_stream.markdown
@@ -14,9 +14,9 @@ Provides a Pinpoint Event Stream resource.
 
 ```hcl
 resource "aws_pinpoint_event_stream" "stream" {
-  application_id         = "${aws_pinpoint_app.app.application_id}"
-  destination_stream_arn = "${aws_kinesis_stream.test_stream.arn}"
-  role_arn               = "${aws_iam_role.test_role.arn}"
+  application_id         = aws_pinpoint_app.app.application_id
+  destination_stream_arn = aws_kinesis_stream.test_stream.arn
+  role_arn               = aws_iam_role.test_role.arn
 }
 
 resource "aws_pinpoint_app" "app" {}
@@ -46,7 +46,7 @@ EOF
 
 resource "aws_iam_role_policy" "test_role_policy" {
   name = "test_policy"
-  role = "${aws_iam_role.test_role.id}"
+  role = aws_iam_role.test_role.id
 
   policy = <<EOF
 {

--- a/website/docs/r/pinpoint_gcm_channel.markdown
+++ b/website/docs/r/pinpoint_gcm_channel.markdown
@@ -17,7 +17,7 @@ Provides a Pinpoint GCM Channel resource.
 
 ```hcl
 resource "aws_pinpoint_gcm_channel" "gcm" {
-  application_id = "${aws_pinpoint_app.app.application_id}"
+  application_id = aws_pinpoint_app.app.application_id
   api_key        = "api_key"
 }
 

--- a/website/docs/r/pinpoint_sms_channel.markdown
+++ b/website/docs/r/pinpoint_sms_channel.markdown
@@ -14,7 +14,7 @@ Provides a Pinpoint SMS Channel resource.
 
 ```hcl
 resource "aws_pinpoint_sms_channel" "sms" {
-  application_id = "${aws_pinpoint_app.app.application_id}"
+  application_id = aws_pinpoint_app.app.application_id
 }
 
 resource "aws_pinpoint_app" "app" {}

--- a/website/docs/r/proxy_protocol_policy.html.markdown
+++ b/website/docs/r/proxy_protocol_policy.html.markdown
@@ -33,7 +33,7 @@ resource "aws_elb" "lb" {
 }
 
 resource "aws_proxy_protocol_policy" "smtp" {
-  load_balancer  = "${aws_elb.lb.name}"
+  load_balancer  = aws_elb.lb.name
   instance_ports = ["25", "587"]
 }
 ```

--- a/website/docs/r/ram_principal_association.markdown
+++ b/website/docs/r/ram_principal_association.markdown
@@ -32,7 +32,7 @@ resource "aws_ram_resource_share" "example" {
 
 resource "aws_ram_principal_association" "example" {
   principal          = "111111111111"
-  resource_share_arn = "${aws_ram_resource_share.example.arn}"
+  resource_share_arn = aws_ram_resource_share.example.arn
 }
 ```
 
@@ -40,8 +40,8 @@ resource "aws_ram_principal_association" "example" {
 
 ```hcl
 resource "aws_ram_principal_association" "example" {
-  principal          = "${aws_organizations_organization.example.arn}"
-  resource_share_arn = "${aws_ram_resource_share.example.arn}"
+  principal          = aws_organizations_organization.example.arn
+  resource_share_arn = aws_ram_resource_share.example.arn
 }
 ```
 

--- a/website/docs/r/ram_resource_association.html.markdown
+++ b/website/docs/r/ram_resource_association.html.markdown
@@ -16,8 +16,8 @@ Manages a Resource Access Manager (RAM) Resource Association.
 
 ```hcl
 resource "aws_ram_resource_association" "example" {
-  resource_arn       = "${aws_subnet.example.arn}"
-  resource_share_arn = "${aws_ram_resource_share.example.arn}"
+  resource_arn       = aws_subnet.example.arn
+  resource_share_arn = aws_ram_resource_share.example.arn
 }
 ```
 

--- a/website/docs/r/ram_resource_share_accepter.markdown
+++ b/website/docs/r/ram_resource_share_accepter.markdown
@@ -40,14 +40,14 @@ resource "aws_ram_resource_share" "sender_share" {
 resource "aws_ram_principal_association" "sender_invite" {
   provider = "aws.alternate"
 
-  principal          = "${data.aws_caller_identity.receiver.account_id}"
-  resource_share_arn = "${aws_ram_resource_share.sender_share.arn}"
+  principal          = data.aws_caller_identity.receiver.account_id
+  resource_share_arn = aws_ram_resource_share.sender_share.arn
 }
 
 data "aws_caller_identity" "receiver" {}
 
 resource "aws_ram_resource_share_accepter" "receiver_accept" {
-  share_arn = "${aws_ram_principal_association.sender_invite.resource_share_arn}"
+  share_arn = aws_ram_principal_association.sender_invite.resource_share_arn
 }
 ```
 

--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -82,7 +82,7 @@ resource "aws_rds_cluster" "postgresql" {
 ```hcl
 resource "aws_rds_cluster" "example" {
   cluster_identifier   = "example"
-  db_subnet_group_name = "${aws_db_subnet_group.example.name}"
+  db_subnet_group_name = aws_db_subnet_group.example.name
   engine_mode          = "multimaster"
   master_password      = "barbarbarbar"
   master_username      = "foo"

--- a/website/docs/r/rds_cluster_endpoint.html.markdown
+++ b/website/docs/r/rds_cluster_endpoint.html.markdown
@@ -27,44 +27,44 @@ resource "aws_rds_cluster" "default" {
 
 resource "aws_rds_cluster_instance" "test1" {
   apply_immediately  = true
-  cluster_identifier = "${aws_rds_cluster.default.id}"
+  cluster_identifier = aws_rds_cluster.default.id
   identifier         = "test1"
   instance_class     = "db.t2.small"
 }
 
 resource "aws_rds_cluster_instance" "test2" {
   apply_immediately  = true
-  cluster_identifier = "${aws_rds_cluster.default.id}"
+  cluster_identifier = aws_rds_cluster.default.id
   identifier         = "test2"
   instance_class     = "db.t2.small"
 }
 
 resource "aws_rds_cluster_instance" "test3" {
   apply_immediately  = true
-  cluster_identifier = "${aws_rds_cluster.default.id}"
+  cluster_identifier = aws_rds_cluster.default.id
   identifier         = "test3"
   instance_class     = "db.t2.small"
 }
 
 resource "aws_rds_cluster_endpoint" "eligible" {
-  cluster_identifier          = "${aws_rds_cluster.default.id}"
+  cluster_identifier          = aws_rds_cluster.default.id
   cluster_endpoint_identifier = "reader"
   custom_endpoint_type        = "READER"
 
   excluded_members = [
-    "${aws_rds_cluster_instance.test1.id}",
-    "${aws_rds_cluster_instance.test2.id}",
+    aws_rds_cluster_instance.test1.id,
+    aws_rds_cluster_instance.test2.id,
   ]
 }
 
 resource "aws_rds_cluster_endpoint" "static" {
-  cluster_identifier          = "${aws_rds_cluster.default.id}"
+  cluster_identifier          = aws_rds_cluster.default.id
   cluster_endpoint_identifier = "static"
   custom_endpoint_type        = "READER"
 
   static_members = [
-    "${aws_rds_cluster_instance.test1.id}",
-    "${aws_rds_cluster_instance.test3.id}",
+    aws_rds_cluster_instance.test1.id,
+    aws_rds_cluster_instance.test3.id,
   ]
 }
 ```

--- a/website/docs/r/rds_cluster_instance.html.markdown
+++ b/website/docs/r/rds_cluster_instance.html.markdown
@@ -29,7 +29,7 @@ For more information on Amazon Aurora, see [Aurora on Amazon RDS][2] in the Amaz
 resource "aws_rds_cluster_instance" "cluster_instances" {
   count              = 2
   identifier         = "aurora-cluster-demo-${count.index}"
-  cluster_identifier = "${aws_rds_cluster.default.id}"
+  cluster_identifier = aws_rds_cluster.default.id
   instance_class     = "db.r4.large"
 }
 

--- a/website/docs/r/rds_global_cluster.html.markdown
+++ b/website/docs/r/rds_global_cluster.html.markdown
@@ -36,14 +36,14 @@ resource "aws_rds_cluster" "primary" {
 
   # ... other configuration ...
   engine_mode               = "global"
-  global_cluster_identifier = "${aws_rds_global_cluster.example.id}"
+  global_cluster_identifier = aws_rds_global_cluster.example.id
 }
 
 resource "aws_rds_cluster_instance" "primary" {
   provider = "aws.primary"
 
   # ... other configuration ...
-  cluster_identifier = "${aws_rds_cluster.primary.id}"
+  cluster_identifier = aws_rds_cluster.primary.id
 }
 
 resource "aws_rds_cluster" "secondary" {
@@ -52,14 +52,14 @@ resource "aws_rds_cluster" "secondary" {
 
   # ... other configuration ...
   engine_mode               = "global"
-  global_cluster_identifier = "${aws_rds_global_cluster.example.id}"
+  global_cluster_identifier = aws_rds_global_cluster.example.id
 }
 
 resource "aws_rds_cluster_instance" "secondary" {
   provider = "aws.secondary"
 
   # ... other configuration ...
-  cluster_identifier = "${aws_rds_cluster.secondary.id}"
+  cluster_identifier = aws_rds_cluster.secondary.id
 }
 ```
 

--- a/website/docs/r/redshift_event_subscription.html.markdown
+++ b/website/docs/r/redshift_event_subscription.html.markdown
@@ -26,10 +26,10 @@ resource "aws_sns_topic" "default" {
 
 resource "aws_redshift_event_subscription" "default" {
   name          = "redshift-event-sub"
-  sns_topic_arn = "${aws_sns_topic.default.arn}"
+  sns_topic_arn = aws_sns_topic.default.arn
 
   source_type = "cluster"
-  source_ids  = ["${aws_redshift_cluster.default.id}"]
+  source_ids  = [aws_redshift_cluster.default.id]
 
   severity = "INFO"
 

--- a/website/docs/r/redshift_snapshot_copy_grant.html.markdown
+++ b/website/docs/r/redshift_snapshot_copy_grant.html.markdown
@@ -23,7 +23,7 @@ resource "aws_redshift_cluster" "test" {
   # ... other configuration ...
   snapshot_copy {
     destination_region = "us-east-2"
-    grant_name         = "${aws_redshift_snapshot_copy_grant.test.snapshot_copy_grant_name}"
+    grant_name         = aws_redshift_snapshot_copy_grant.test.snapshot_copy_grant_name
   }
 }
 ```

--- a/website/docs/r/redshift_snapshot_schedule_association.html.markdown
+++ b/website/docs/r/redshift_snapshot_schedule_association.html.markdown
@@ -28,8 +28,8 @@ resource "aws_redshift_snapshot_schedule" "default" {
 }
 
 resource "aws_redshift_snapshot_schedule_association" "default" {
-  cluster_identifier  = "${aws_redshift_cluster.default.id}"
-  schedule_identifier = "${aws_redshift_snapshot_schedule.default.id}"
+  cluster_identifier  = aws_redshift_cluster.default.id
+  schedule_identifier = aws_redshift_snapshot_schedule.default.id
 }
 ```
 

--- a/website/docs/r/redshift_subnet_group.html.markdown
+++ b/website/docs/r/redshift_subnet_group.html.markdown
@@ -20,7 +20,7 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
   cidr_block        = "10.1.1.0/24"
   availability_zone = "us-west-2a"
-  vpc_id            = "${aws_vpc.foo.id}"
+  vpc_id            = aws_vpc.foo.id
 
   tags = {
     Name = "tf-dbsubnet-test-1"
@@ -30,7 +30,7 @@ resource "aws_subnet" "foo" {
 resource "aws_subnet" "bar" {
   cidr_block        = "10.1.2.0/24"
   availability_zone = "us-west-2b"
-  vpc_id            = "${aws_vpc.foo.id}"
+  vpc_id            = aws_vpc.foo.id
 
   tags = {
     Name = "tf-dbsubnet-test-2"
@@ -39,7 +39,7 @@ resource "aws_subnet" "bar" {
 
 resource "aws_redshift_subnet_group" "foo" {
   name       = "foo"
-  subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
+  subnet_ids = [aws_subnet.foo.id, aws_subnet.bar.id]
 
   tags = {
     environment = "Production"

--- a/website/docs/r/route.html.markdown
+++ b/website/docs/r/route.html.markdown
@@ -36,13 +36,13 @@ resource "aws_vpc" "vpc" {
 }
 
 resource "aws_egress_only_internet_gateway" "egress" {
-  vpc_id = "${aws_vpc.vpc.id}"
+  vpc_id = aws_vpc.vpc.id
 }
 
 resource "aws_route" "r" {
   route_table_id              = "rtb-4fbb3ac4"
   destination_ipv6_cidr_block = "::/0"
-  egress_only_gateway_id      = "${aws_egress_only_internet_gateway.egress.id}"
+  egress_only_gateway_id      = aws_egress_only_internet_gateway.egress.id
 }
 ```
 

--- a/website/docs/r/route53_delegation_set.html.markdown
+++ b/website/docs/r/route53_delegation_set.html.markdown
@@ -19,12 +19,12 @@ resource "aws_route53_delegation_set" "main" {
 
 resource "aws_route53_zone" "primary" {
   name              = "hashicorp.com"
-  delegation_set_id = "${aws_route53_delegation_set.main.id}"
+  delegation_set_id = aws_route53_delegation_set.main.id
 }
 
 resource "aws_route53_zone" "secondary" {
   name              = "terraform.io"
-  delegation_set_id = "${aws_route53_delegation_set.main.id}"
+  delegation_set_id = aws_route53_delegation_set.main.id
 }
 ```
 

--- a/website/docs/r/route53_health_check.html.markdown
+++ b/website/docs/r/route53_health_check.html.markdown
@@ -48,7 +48,7 @@ resource "aws_route53_health_check" "example" {
 resource "aws_route53_health_check" "parent" {
   type                   = "CALCULATED"
   child_health_threshold = 1
-  child_healthchecks     = ["${aws_route53_health_check.child.id}"]
+  child_healthchecks     = [aws_route53_health_check.child.id]
 
   tags = {
     Name = "tf-test-calculated-health-check"
@@ -73,7 +73,7 @@ resource "aws_cloudwatch_metric_alarm" "foobar" {
 
 resource "aws_route53_health_check" "foo" {
   type                            = "CLOUDWATCH_METRIC"
-  cloudwatch_alarm_name           = "${aws_cloudwatch_metric_alarm.foobar.alarm_name}"
+  cloudwatch_alarm_name           = aws_cloudwatch_metric_alarm.foobar.alarm_name
   cloudwatch_alarm_region         = "us-west-2"
   insufficient_data_health_status = "Healthy"
 }

--- a/website/docs/r/route53_query_log.html.markdown
+++ b/website/docs/r/route53_query_log.html.markdown
@@ -55,7 +55,7 @@ data "aws_iam_policy_document" "route53-query-logging-policy" {
 resource "aws_cloudwatch_log_resource_policy" "route53-query-logging-policy" {
   provider = "aws.us-east-1"
 
-  policy_document = "${data.aws_iam_policy_document.route53-query-logging-policy.json}"
+  policy_document = data.aws_iam_policy_document.route53-query-logging-policy.json
   policy_name     = "route53-query-logging-policy"
 }
 
@@ -68,8 +68,8 @@ resource "aws_route53_zone" "example_com" {
 resource "aws_route53_query_log" "example_com" {
   depends_on = ["aws_cloudwatch_log_resource_policy.route53-query-logging-policy"]
 
-  cloudwatch_log_group_arn = "${aws_cloudwatch_log_group.aws_route53_example_com.arn}"
-  zone_id                  = "${aws_route53_zone.example_com.zone_id}"
+  cloudwatch_log_group_arn = aws_cloudwatch_log_group.aws_route53_example_com.arn
+  zone_id                  = aws_route53_zone.example_com.zone_id
 }
 ```
 

--- a/website/docs/r/route53_record.html.markdown
+++ b/website/docs/r/route53_record.html.markdown
@@ -16,11 +16,11 @@ Provides a Route53 record resource.
 
 ```hcl
 resource "aws_route53_record" "www" {
-  zone_id = "${aws_route53_zone.primary.zone_id}"
+  zone_id = aws_route53_zone.primary.zone_id
   name    = "www.example.com"
   type    = "A"
   ttl     = "300"
-  records = ["${aws_eip.lb.public_ip}"]
+  records = [aws_eip.lb.public_ip]
 }
 ```
 
@@ -29,7 +29,7 @@ Other routing policies are configured similarly. See [AWS Route53 Developer Guid
 
 ```hcl
 resource "aws_route53_record" "www-dev" {
-  zone_id = "${aws_route53_zone.primary.zone_id}"
+  zone_id = aws_route53_zone.primary.zone_id
   name    = "www"
   type    = "CNAME"
   ttl     = "5"
@@ -43,7 +43,7 @@ resource "aws_route53_record" "www-dev" {
 }
 
 resource "aws_route53_record" "www-live" {
-  zone_id = "${aws_route53_zone.primary.zone_id}"
+  zone_id = aws_route53_zone.primary.zone_id
   name    = "www"
   type    = "CNAME"
   ttl     = "5"
@@ -78,13 +78,13 @@ resource "aws_elb" "main" {
 }
 
 resource "aws_route53_record" "www" {
-  zone_id = "${aws_route53_zone.primary.zone_id}"
+  zone_id = aws_route53_zone.primary.zone_id
   name    = "example.com"
   type    = "A"
 
   alias {
-    name                   = "${aws_elb.main.dns_name}"
-    zone_id                = "${aws_elb.main.zone_id}"
+    name                   = aws_elb.main.dns_name
+    zone_id                = aws_elb.main.zone_id
     evaluate_target_health = true
   }
 }
@@ -104,13 +104,13 @@ resource "aws_route53_record" "example" {
   name            = "test.example.com"
   ttl             = 30
   type            = "NS"
-  zone_id         = "${aws_route53_zone.example.zone_id}"
+  zone_id         = aws_route53_zone.example.zone_id
 
   records = [
-    "${aws_route53_zone.example.name_servers.0}",
-    "${aws_route53_zone.example.name_servers.1}",
-    "${aws_route53_zone.example.name_servers.2}",
-    "${aws_route53_zone.example.name_servers.3}",
+    aws_route53_zone.example.name_servers.0,
+    aws_route53_zone.example.name_servers.1,
+    aws_route53_zone.example.name_servers.2,
+    aws_route53_zone.example.name_servers.3,
   ]
 }
 ```

--- a/website/docs/r/route53_resolver_endpoint.html.markdown
+++ b/website/docs/r/route53_resolver_endpoint.html.markdown
@@ -18,16 +18,16 @@ resource "aws_route53_resolver_endpoint" "foo" {
   direction = "INBOUND"
 
   security_group_ids = [
-    "${aws_security_group.sg1.id}",
-    "${aws_security_group.sg2.id}",
+    aws_security_group.sg1.id,
+    aws_security_group.sg2.id,
   ]
 
   ip_address {
-    subnet_id = "${aws_subnet.sn1.id}"
+    subnet_id = aws_subnet.sn1.id
   }
 
   ip_address {
-    subnet_id = "${aws_subnet.sn2.id}"
+    subnet_id = aws_subnet.sn2.id
     ip        = "10.0.64.4"
   }
 

--- a/website/docs/r/route53_resolver_rule.html.markdown
+++ b/website/docs/r/route53_resolver_rule.html.markdown
@@ -28,7 +28,7 @@ resource "aws_route53_resolver_rule" "fwd" {
   domain_name          = "example.com"
   name                 = "example"
   rule_type            = "FORWARD"
-  resolver_endpoint_id = "${aws_route53_resolver_endpoint.foo.id}"
+  resolver_endpoint_id = aws_route53_resolver_endpoint.foo.id
 
   target_ip {
     ip = "123.45.67.89"

--- a/website/docs/r/route53_resolver_rule_association.html.markdown
+++ b/website/docs/r/route53_resolver_rule_association.html.markdown
@@ -14,8 +14,8 @@ Provides a Route53 Resolver rule association.
 
 ```hcl
 resource "aws_route53_resolver_rule_association" "example" {
-  resolver_rule_id = "${aws_route53_resolver_rule.sys.id}"
-  vpc_id           = "${aws_vpc.foo.id}"
+  resolver_rule_id = aws_route53_resolver_rule.sys.id
+  vpc_id           = aws_vpc.foo.id
 }
 ```
 

--- a/website/docs/r/route53_zone.html.markdown
+++ b/website/docs/r/route53_zone.html.markdown
@@ -40,16 +40,16 @@ resource "aws_route53_zone" "dev" {
 }
 
 resource "aws_route53_record" "dev-ns" {
-  zone_id = "${aws_route53_zone.main.zone_id}"
+  zone_id = aws_route53_zone.main.zone_id
   name    = "dev.example.com"
   type    = "NS"
   ttl     = "30"
 
   records = [
-    "${aws_route53_zone.dev.name_servers.0}",
-    "${aws_route53_zone.dev.name_servers.1}",
-    "${aws_route53_zone.dev.name_servers.2}",
-    "${aws_route53_zone.dev.name_servers.3}",
+    aws_route53_zone.dev.name_servers.0,
+    aws_route53_zone.dev.name_servers.1,
+    aws_route53_zone.dev.name_servers.2,
+    aws_route53_zone.dev.name_servers.3,
   ]
 }
 ```
@@ -65,7 +65,7 @@ resource "aws_route53_zone" "private" {
   name = "example.com"
 
   vpc {
-    vpc_id = "${aws_vpc.example.id}"
+    vpc_id = aws_vpc.example.id
   }
 }
 ```

--- a/website/docs/r/route53_zone_association.html.markdown
+++ b/website/docs/r/route53_zone_association.html.markdown
@@ -38,7 +38,7 @@ resource "aws_route53_zone" "example" {
   #       resource is for illustrative purposes (e.g. for a separate
   #       cross-account authorization process, which is not shown here).
   vpc {
-    vpc_id = "${aws_vpc.primary.id}"
+    vpc_id = aws_vpc.primary.id
   }
 
   lifecycle {
@@ -47,8 +47,8 @@ resource "aws_route53_zone" "example" {
 }
 
 resource "aws_route53_zone_association" "secondary" {
-  zone_id = "${aws_route53_zone.example.zone_id}"
-  vpc_id  = "${aws_vpc.secondary.id}"
+  zone_id = aws_route53_zone.example.zone_id
+  vpc_id  = aws_vpc.secondary.id
 }
 ```
 

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -33,16 +33,16 @@ the separate resource.
 
 ```hcl
 resource "aws_route_table" "r" {
-  vpc_id = "${aws_vpc.default.id}"
+  vpc_id = aws_vpc.default.id
 
   route {
     cidr_block = "10.0.1.0/24"
-    gateway_id = "${aws_internet_gateway.main.id}"
+    gateway_id = aws_internet_gateway.main.id
   }
 
   route {
     ipv6_cidr_block        = "::/0"
-    egress_only_gateway_id = "${aws_egress_only_internet_gateway.foo.id}"
+    egress_only_gateway_id = aws_egress_only_internet_gateway.foo.id
   }
 
   tags = {

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -32,7 +32,7 @@ resource "aws_s3_bucket" "b" {
 resource "aws_s3_bucket" "b" {
   bucket = "s3-website-test.hashicorp.com"
   acl    = "public-read"
-  policy = "${file("policy.json")}"
+  policy = file("policy.json")
 
   website {
     index_document = "index.html"
@@ -95,7 +95,7 @@ resource "aws_s3_bucket" "b" {
   acl    = "private"
 
   logging {
-    target_bucket = "${aws_s3_bucket.log_bucket.id}"
+    target_bucket = aws_s3_bucket.log_bucket.id
     target_prefix = "log/"
   }
 }
@@ -247,8 +247,8 @@ POLICY
 }
 
 resource "aws_iam_role_policy_attachment" "replication" {
-  role       = "${aws_iam_role.replication.name}"
-  policy_arn = "${aws_iam_policy.replication.arn}"
+  role       = aws_iam_role.replication.name
+  policy_arn = aws_iam_policy.replication.arn
 }
 
 resource "aws_s3_bucket" "destination" {
@@ -271,7 +271,7 @@ resource "aws_s3_bucket" "bucket" {
   }
 
   replication_configuration {
-    role = "${aws_iam_role.replication.arn}"
+    role = aws_iam_role.replication.arn
 
     rules {
       id     = "foobar"
@@ -279,7 +279,7 @@ resource "aws_s3_bucket" "bucket" {
       status = "Enabled"
 
       destination {
-        bucket        = "${aws_s3_bucket.destination.arn}"
+        bucket        = aws_s3_bucket.destination.arn
         storage_class = "STANDARD"
       }
     }
@@ -301,7 +301,7 @@ resource "aws_s3_bucket" "mybucket" {
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
-        kms_master_key_id = "${aws_kms_key.mykey.arn}"
+        kms_master_key_id = aws_kms_key.mykey.arn
         sse_algorithm     = "aws:kms"
       }
     }
@@ -318,7 +318,7 @@ resource "aws_s3_bucket" "bucket" {
   bucket = "mybucket"
 
   grant {
-    id          = "${data.aws_canonical_user_id.current_user.id}"
+    id          = data.aws_canonical_user_id.current_user.id
     type        = "CanonicalUser"
     permissions = ["FULL_CONTROL"]
   }

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -38,16 +38,18 @@ resource "aws_s3_bucket" "b" {
     index_document = "index.html"
     error_document = "error.html"
 
-    routing_rules = <<EOF
-[{
-    "Condition": {
-        "KeyPrefixEquals": "docs/"
-    },
-    "Redirect": {
-        "ReplaceKeyPrefixWith": "documents/"
-    }
-}]
-EOF
+    routing_rules = jsonencode(
+      [
+        {
+          "Condition" = {
+            "KeyPrefixEquals" = "docs/"
+          }
+          "Redirect" = {
+            "ReplaceKeyPrefixWith" = "documents/"
+          }
+        }
+      ]
+    )
   }
 }
 ```
@@ -189,61 +191,57 @@ provider "aws" {
 resource "aws_iam_role" "replication" {
   name = "tf-iam-role-replication-12345"
 
-  assume_role_policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "s3.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-POLICY
+  assume_role_policy = jsonencode({
+    "Version" = "2012-10-17"
+    "Statement" = [
+      {
+        "Action" = "sts:AssumeRole"
+        "Principal" = {
+          "Service" = "s3.amazonaws.com"
+        }
+        "Effect" = "Allow"
+        "Sid"    = ""
+      }
+    ]
+  })
 }
 
 resource "aws_iam_policy" "replication" {
   name = "tf-iam-role-policy-replication-12345"
 
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "s3:GetReplicationConfiguration",
-        "s3:ListBucket"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "${aws_s3_bucket.bucket.arn}"
-      ]
-    },
-    {
-      "Action": [
-        "s3:GetObjectVersion",
-        "s3:GetObjectVersionAcl"
-      ],
-      "Effect": "Allow",
-      "Resource": [
-        "${aws_s3_bucket.bucket.arn}/*"
-      ]
-    },
-    {
-      "Action": [
-        "s3:ReplicateObject",
-        "s3:ReplicateDelete"
-      ],
-      "Effect": "Allow",
-      "Resource": "${aws_s3_bucket.destination.arn}/*"
-    }
-  ]
-}
-POLICY
+  policy = jsonencode({
+    "Version" = "2012-10-17"
+    "Statement" = [
+      {
+        "Action" = [
+          "s3:GetReplicationConfiguration",
+          "s3:ListBucket",
+        ]
+        "Effect" = "Allow"
+        "Resource" = [
+          aws_s3_bucket.bucket.arn
+        ]
+      },
+      {
+        "Action" = [
+          "s3:GetObjectVersion",
+          "s3:GetObjectVersionAcl",
+        ]
+        "Effect" = "Allow"
+        "Resource" = [
+          "${aws_s3_bucket.bucket.arn}/*"
+        ]
+      },
+      {
+        "Action" = [
+          "s3:ReplicateObject",
+          "s3:ReplicateDelete",
+        ]
+        "Effect"   = "Allow"
+        "Resource" = "${aws_s3_bucket.destination.arn}/*"
+      }
+    ]
+  })
 }
 
 resource "aws_iam_role_policy_attachment" "replication" {
@@ -483,7 +481,7 @@ The `apply_server_side_encryption_by_default` object supports the following:
 
 The `grant` object supports the following:
 
-* `id` - (optional) Canonical user id to grant for. Used only when `type` is `CanonicalUser`.  
+* `id` - (optional) Canonical user id to grant for. Used only when `type` is `CanonicalUser`.
 * `type` - (required) - Type of grantee to apply for. Valid values are `CanonicalUser` and `Group`. `AmazonCustomerByEmail` is not supported.
 * `permissions` - (required) List of permissions to apply for grantee. Valid values are `READ`, `WRITE`, `READ_ACP`, `WRITE_ACP`, `FULL_CONTROL`.
 * `uri` - (optional) Uri address to grant for. Used only when `type` is `Group`.

--- a/website/docs/r/s3_bucket_inventory.html.markdown
+++ b/website/docs/r/s3_bucket_inventory.html.markdown
@@ -24,7 +24,7 @@ resource "aws_s3_bucket" "inventory" {
 }
 
 resource "aws_s3_bucket_inventory" "test" {
-  bucket = "${aws_s3_bucket.test.id}"
+  bucket = aws_s3_bucket.test.id
   name   = "EntireBucketDaily"
 
   included_object_versions = "All"
@@ -36,7 +36,7 @@ resource "aws_s3_bucket_inventory" "test" {
   destination {
     bucket {
       format     = "ORC"
-      bucket_arn = "${aws_s3_bucket.inventory.arn}"
+      bucket_arn = aws_s3_bucket.inventory.arn
     }
   }
 }
@@ -54,7 +54,7 @@ resource "aws_s3_bucket" "inventory" {
 }
 
 resource "aws_s3_bucket_inventory" "test-prefix" {
-  bucket = "${aws_s3_bucket.test.id}"
+  bucket = aws_s3_bucket.test.id
   name   = "DocumentsWeekly"
 
   included_object_versions = "All"
@@ -70,7 +70,7 @@ resource "aws_s3_bucket_inventory" "test-prefix" {
   destination {
     bucket {
       format     = "ORC"
-      bucket_arn = "${aws_s3_bucket.inventory.arn}"
+      bucket_arn = aws_s3_bucket.inventory.arn
       prefix     = "inventory"
     }
   }

--- a/website/docs/r/s3_bucket_metric.html.markdown
+++ b/website/docs/r/s3_bucket_metric.html.markdown
@@ -20,7 +20,7 @@ resource "aws_s3_bucket" "example" {
 }
 
 resource "aws_s3_bucket_metric" "example-entire-bucket" {
-  bucket = "${aws_s3_bucket.example.bucket}"
+  bucket = aws_s3_bucket.example.bucket
   name   = "EntireBucket"
 }
 ```
@@ -33,7 +33,7 @@ resource "aws_s3_bucket" "example" {
 }
 
 resource "aws_s3_bucket_metric" "example-filtered" {
-  bucket = "${aws_s3_bucket.example.bucket}"
+  bucket = aws_s3_bucket.example.bucket
   name   = "ImportantBlueDocuments"
 
   filter {

--- a/website/docs/r/s3_bucket_notification.html.markdown
+++ b/website/docs/r/s3_bucket_notification.html.markdown
@@ -20,20 +20,20 @@ Manages a S3 Bucket Notification Configuration. For additional information, see 
 resource "aws_sns_topic" "topic" {
   name = "s3-event-notification-topic"
 
-  policy = <<POLICY
-{
-    "Version":"2012-10-17",
-    "Statement":[{
-        "Effect": "Allow",
-        "Principal": {"AWS":"*"},
-        "Action": "SNS:Publish",
-        "Resource": "arn:aws:sns:*:*:s3-event-notification-topic",
-        "Condition":{
-            "ArnLike":{"aws:SourceArn":"${aws_s3_bucket.bucket.arn}"}
+  policy = jsonencode({
+    "Version" = "2012-10-17"
+    "Statement" = [
+      {
+        "Effect"    = "Allow"
+        "Principal" = { "AWS" = "*" }
+        "Action"    = "SNS:Publish"
+        "Resource"  = "arn:aws:sns:*:*:s3-event-notification-topic"
+        "Condition" = {
+          "ArnLike" = { "aws:SourceArn" : aws_s3_bucket.bucket.arn }
         }
-    }]
-}
-POLICY
+      }
+    ]
+  })
 }
 
 resource "aws_s3_bucket" "bucket" {
@@ -57,22 +57,20 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
 resource "aws_sqs_queue" "queue" {
   name = "s3-event-notification-queue"
 
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "sqs:SendMessage",
-	  "Resource": "arn:aws:sqs:*:*:s3-event-notification-queue",
-      "Condition": {
-        "ArnEquals": { "aws:SourceArn": "${aws_s3_bucket.bucket.arn}" }
+  policy = jsonencode({
+    "Version" = "2012-10-17"
+    "Statement" = [
+      {
+        "Effect"    = "Allow"
+        "Principal" = "*"
+        "Action"    = "sqs:SendMessage"
+        "Resource"  = "arn:aws:sqs:*:*:s3-event-notification-queue"
+        "Condition" = {
+          "ArnEquals" = { "aws:SourceArn" = aws_s3_bucket.bucket.arn }
+        }
       }
-    }
-  ]
-}
-POLICY
+    ]
+  })
 }
 
 resource "aws_s3_bucket" "bucket" {
@@ -96,20 +94,18 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
 resource "aws_iam_role" "iam_for_lambda" {
   name = "iam_for_lambda"
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "lambda.amazonaws.com"
-      },
-      "Effect": "Allow"
-    }
-  ]
-}
-EOF
+  assume_role_policy = jsonencode({
+    "Version" = "2012-10-17"
+    "Statement" = [
+      {
+        "Action" = "sts:AssumeRole"
+        "Principal" = {
+          "Service" = "lambda.amazonaws.com"
+        }
+        "Effect" = "Allow"
+      }
+    ]
+  })
 }
 
 resource "aws_lambda_permission" "allow_bucket" {
@@ -152,20 +148,18 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
 resource "aws_iam_role" "iam_for_lambda" {
   name = "iam_for_lambda"
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "lambda.amazonaws.com"
-      },
-      "Effect": "Allow"
-    }
-  ]
-}
-EOF
+  assume_role_policy = jsonencode({
+    "Version" = "2012-10-17"
+    "Statement" = [
+      {
+        "Action" = "sts:AssumeRole"
+        "Principal" = {
+          "Service" = "lambda.amazonaws.com"
+        }
+        "Effect" = "Allow"
+      }
+    ]
+  })
 }
 
 resource "aws_lambda_permission" "allow_bucket1" {
@@ -222,7 +216,7 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
 
   depends_on = [
     aws_lambda_permission.allow_bucket1,
-    aws_lambda_permission.allow_bucket2
+    aws_lambda_permission.allow_bucket2,
   ]
 }
 ```
@@ -233,22 +227,20 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
 resource "aws_sqs_queue" "queue" {
   name = "s3-event-notification-queue"
 
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "sqs:SendMessage",
-	  "Resource": "arn:aws:sqs:*:*:s3-event-notification-queue",
-      "Condition": {
-        "ArnEquals": { "aws:SourceArn": "${aws_s3_bucket.bucket.arn}" }
+  policy = jsonencode({
+    "Version" = "2012-10-17"
+    "Statement" = [
+      {
+        "Effect"    = "Allow"
+        "Principal" = "*"
+        "Action"    = "sqs:SendMessage"
+        "Resource"  = "arn:aws:sqs:*:*:s3-event-notification-queue"
+        "Condition" = {
+          "ArnEquals" = { "aws:SourceArn" = aws_s3_bucket.bucket.arn }
+        }
       }
-    }
-  ]
-}
-POLICY
+    ]
+  })
 }
 
 resource "aws_s3_bucket" "bucket" {

--- a/website/docs/r/s3_bucket_notification.html.markdown
+++ b/website/docs/r/s3_bucket_notification.html.markdown
@@ -41,10 +41,10 @@ resource "aws_s3_bucket" "bucket" {
 }
 
 resource "aws_s3_bucket_notification" "bucket_notification" {
-  bucket = "${aws_s3_bucket.bucket.id}"
+  bucket = aws_s3_bucket.bucket.id
 
   topic {
-    topic_arn     = "${aws_sns_topic.topic.arn}"
+    topic_arn     = aws_sns_topic.topic.arn
     events        = ["s3:ObjectCreated:*"]
     filter_suffix = ".log"
   }
@@ -80,10 +80,10 @@ resource "aws_s3_bucket" "bucket" {
 }
 
 resource "aws_s3_bucket_notification" "bucket_notification" {
-  bucket = "${aws_s3_bucket.bucket.id}"
+  bucket = aws_s3_bucket.bucket.id
 
   queue {
-    queue_arn     = "${aws_sqs_queue.queue.arn}"
+    queue_arn     = aws_sqs_queue.queue.arn
     events        = ["s3:ObjectCreated:*"]
     filter_suffix = ".log"
   }
@@ -115,15 +115,15 @@ EOF
 resource "aws_lambda_permission" "allow_bucket" {
   statement_id  = "AllowExecutionFromS3Bucket"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.func.arn}"
+  function_name = aws_lambda_function.func.arn
   principal     = "s3.amazonaws.com"
-  source_arn    = "${aws_s3_bucket.bucket.arn}"
+  source_arn    = aws_s3_bucket.bucket.arn
 }
 
 resource "aws_lambda_function" "func" {
   filename      = "your-function.zip"
   function_name = "example_lambda_name"
-  role          = "${aws_iam_role.iam_for_lambda.arn}"
+  role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
   runtime       = "go1.x"
 }
@@ -133,10 +133,10 @@ resource "aws_s3_bucket" "bucket" {
 }
 
 resource "aws_s3_bucket_notification" "bucket_notification" {
-  bucket = "${aws_s3_bucket.bucket.id}"
+  bucket = aws_s3_bucket.bucket.id
 
   lambda_function {
-    lambda_function_arn = "${aws_lambda_function.func.arn}"
+    lambda_function_arn = aws_lambda_function.func.arn
     events              = ["s3:ObjectCreated:*"]
     filter_prefix       = "AWSLogs/"
     filter_suffix       = ".log"
@@ -171,15 +171,15 @@ EOF
 resource "aws_lambda_permission" "allow_bucket1" {
   statement_id  = "AllowExecutionFromS3Bucket1"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.func1.arn}"
+  function_name = aws_lambda_function.func1.arn
   principal     = "s3.amazonaws.com"
-  source_arn    = "${aws_s3_bucket.bucket.arn}"
+  source_arn    = aws_s3_bucket.bucket.arn
 }
 
 resource "aws_lambda_function" "func1" {
   filename      = "your-function1.zip"
   function_name = "example_lambda_name1"
-  role          = "${aws_iam_role.iam_for_lambda.arn}"
+  role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
   runtime       = "go1.x"
 }
@@ -187,15 +187,15 @@ resource "aws_lambda_function" "func1" {
 resource "aws_lambda_permission" "allow_bucket2" {
   statement_id  = "AllowExecutionFromS3Bucket2"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.func2.arn}"
+  function_name = aws_lambda_function.func2.arn
   principal     = "s3.amazonaws.com"
-  source_arn    = "${aws_s3_bucket.bucket.arn}"
+  source_arn    = aws_s3_bucket.bucket.arn
 }
 
 resource "aws_lambda_function" "func2" {
   filename      = "your-function2.zip"
   function_name = "example_lambda_name2"
-  role          = "${aws_iam_role.iam_for_lambda.arn}"
+  role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
 }
 
@@ -204,17 +204,17 @@ resource "aws_s3_bucket" "bucket" {
 }
 
 resource "aws_s3_bucket_notification" "bucket_notification" {
-  bucket = "${aws_s3_bucket.bucket.id}"
+  bucket = aws_s3_bucket.bucket.id
 
   lambda_function {
-    lambda_function_arn = "${aws_lambda_function.func1.arn}"
+    lambda_function_arn = aws_lambda_function.func1.arn
     events              = ["s3:ObjectCreated:*"]
     filter_prefix       = "AWSLogs/"
     filter_suffix       = ".log"
   }
 
   lambda_function {
-    lambda_function_arn = "${aws_lambda_function.func2.arn}"
+    lambda_function_arn = aws_lambda_function.func2.arn
     events              = ["s3:ObjectCreated:*"]
     filter_prefix       = "OtherLogs/"
     filter_suffix       = ".log"
@@ -256,18 +256,18 @@ resource "aws_s3_bucket" "bucket" {
 }
 
 resource "aws_s3_bucket_notification" "bucket_notification" {
-  bucket = "${aws_s3_bucket.bucket.id}"
+  bucket = aws_s3_bucket.bucket.id
 
   queue {
     id            = "image-upload-event"
-    queue_arn     = "${aws_sqs_queue.queue.arn}"
+    queue_arn     = aws_sqs_queue.queue.arn
     events        = ["s3:ObjectCreated:*"]
     filter_prefix = "images/"
   }
 
   queue {
     id            = "video-upload-event"
-    queue_arn     = "${aws_sqs_queue.queue.arn}"
+    queue_arn     = aws_sqs_queue.queue.arn
     events        = ["s3:ObjectCreated:*"]
     filter_prefix = "videos/"
   }

--- a/website/docs/r/s3_bucket_object.html.markdown
+++ b/website/docs/r/s3_bucket_object.html.markdown
@@ -22,8 +22,8 @@ resource "aws_s3_bucket_object" "object" {
 
   # The filemd5() function is available in Terraform 0.11.12 and later
   # For Terraform 0.11.11 and earlier, use the md5() function and the file() function:
-  # etag = "${md5(file("path/to/file"))}"
-  etag = "${filemd5("path/to/file")}"
+  # etag = md5(file("path/to/file"))
+  etag = filemd5("path/to/file")
 }
 ```
 
@@ -42,9 +42,9 @@ resource "aws_s3_bucket" "examplebucket" {
 
 resource "aws_s3_bucket_object" "examplebucket_object" {
   key        = "someobject"
-  bucket     = "${aws_s3_bucket.examplebucket.id}"
+  bucket     = aws_s3_bucket.examplebucket.id
   source     = "index.html"
-  kms_key_id = "${aws_kms_key.examplekms.arn}"
+  kms_key_id = aws_kms_key.examplekms.arn
 }
 ```
 
@@ -58,7 +58,7 @@ resource "aws_s3_bucket" "examplebucket" {
 
 resource "aws_s3_bucket_object" "examplebucket_object" {
   key                    = "someobject"
-  bucket                 = "${aws_s3_bucket.examplebucket.id}"
+  bucket                 = aws_s3_bucket.examplebucket.id
   source                 = "index.html"
   server_side_encryption = "aws:kms"
 }
@@ -74,7 +74,7 @@ resource "aws_s3_bucket" "examplebucket" {
 
 resource "aws_s3_bucket_object" "examplebucket_object" {
   key                    = "someobject"
-  bucket                 = "${aws_s3_bucket.examplebucket.id}"
+  bucket                 = aws_s3_bucket.examplebucket.id
   source                 = "index.html"
   server_side_encryption = "AES256"
 }
@@ -98,7 +98,7 @@ resource "aws_s3_bucket" "examplebucket" {
 
 resource "aws_s3_bucket_object" "examplebucket_object" {
   key    = "someobject"
-  bucket = "${aws_s3_bucket.examplebucket.id}"
+  bucket = aws_s3_bucket.examplebucket.id
   source = "important.txt"
 
   object_lock_legal_hold_status = "ON"
@@ -135,7 +135,7 @@ This attribute is not compatible with KMS encryption, `kms_key_id` or `server_si
 * `kms_key_id` - (Optional) Specifies the AWS KMS Key ARN to use for object encryption.
 This value is a fully qualified **ARN** of the KMS Key. If using `aws_kms_key`,
 use the exported `arn` attribute:
-      `kms_key_id = "${aws_kms_key.foo.arn}"`
+      `kms_key_id = aws_kms_key.foo.arn`
 * `metadata` - (Optional) A mapping of keys/values to provision metadata (will be automatically prefixed by `x-amz-meta-`, note that only lowercase label are currently supported by the AWS Go API).
 * `tags` - (Optional) A mapping of tags to assign to the object.
 * `force_destroy` - (Optional) Allow the object to be deleted by removing any legal hold on any object version.

--- a/website/docs/r/s3_bucket_policy.html.markdown
+++ b/website/docs/r/s3_bucket_policy.html.markdown
@@ -20,7 +20,7 @@ resource "aws_s3_bucket" "b" {
 }
 
 resource "aws_s3_bucket_policy" "b" {
-  bucket = "${aws_s3_bucket.b.id}"
+  bucket = aws_s3_bucket.b.id
 
   policy = <<POLICY
 {

--- a/website/docs/r/s3_bucket_public_access_block.html.markdown
+++ b/website/docs/r/s3_bucket_public_access_block.html.markdown
@@ -18,7 +18,7 @@ resource "aws_s3_bucket" "example" {
 }
 
 resource "aws_s3_bucket_public_access_block" "example" {
-  bucket = "${aws_s3_bucket.example.id}"
+  bucket = aws_s3_bucket.example.id
 
   block_public_acls   = true
   block_public_policy = true

--- a/website/docs/r/sagemaker_endpoint.html.markdown
+++ b/website/docs/r/sagemaker_endpoint.html.markdown
@@ -17,7 +17,7 @@ Basic usage:
 ```hcl
 resource "aws_sagemaker_endpoint" "e" {
   name                 = "my-endpoint"
-  endpoint_config_name = "${aws_sagemaker_endpoint_configuration.ec.name}"
+  endpoint_config_name = aws_sagemaker_endpoint_configuration.ec.name
 
   tags = {
     Name = "foo"

--- a/website/docs/r/sagemaker_endpoint_configuration.html.markdown
+++ b/website/docs/r/sagemaker_endpoint_configuration.html.markdown
@@ -21,7 +21,7 @@ resource "aws_sagemaker_endpoint_configuration" "ec" {
 
   production_variants {
     variant_name           = "variant-1"
-    model_name             = "${aws_sagemaker_model.m.name}"
+    model_name             = aws_sagemaker_model.m.name
     initial_instance_count = 1
     instance_type          = "ml.t2.medium"
   }

--- a/website/docs/r/sagemaker_model.html.markdown
+++ b/website/docs/r/sagemaker_model.html.markdown
@@ -17,7 +17,7 @@ Basic usage:
 ```hcl
 resource "aws_sagemaker_model" "m" {
   name               = "my-model"
-  execution_role_arn = "${aws_iam_role.foo.arn}"
+  execution_role_arn = aws_iam_role.foo.arn
 
   primary_container {
     image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
@@ -25,7 +25,7 @@ resource "aws_sagemaker_model" "m" {
 }
 
 resource "aws_iam_role" "r" {
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 data "aws_iam_policy_document" "assume_role" {

--- a/website/docs/r/sagemaker_notebook_instance.html.markdown
+++ b/website/docs/r/sagemaker_notebook_instance.html.markdown
@@ -17,7 +17,7 @@ Basic usage:
 ```hcl
 resource "aws_sagemaker_notebook_instance" "ni" {
   name          = "my-notebook-instance"
-  role_arn      = "${aws_iam_role.role.arn}"
+  role_arn      = aws_iam_role.role.arn
   instance_type = "ml.t2.medium"
 
   tags = {

--- a/website/docs/r/secretsmanager_secret.html.markdown
+++ b/website/docs/r/secretsmanager_secret.html.markdown
@@ -31,7 +31,7 @@ To enable automatic secret rotation, the Secrets Manager service requires usage 
 ```hcl
 resource "aws_secretsmanager_secret" "rotation-example" {
   name                = "rotation-example"
-  rotation_lambda_arn = "${aws_lambda_function.example.arn}"
+  rotation_lambda_arn = aws_lambda_function.example.arn
 
   rotation_rules {
     automatically_after_days = 7

--- a/website/docs/r/secretsmanager_secret_version.html.markdown
+++ b/website/docs/r/secretsmanager_secret_version.html.markdown
@@ -18,7 +18,7 @@ Provides a resource to manage AWS Secrets Manager secret version including its s
 
 ```hcl
 resource "aws_secretsmanager_secret_version" "example" {
-  secret_id     = "${aws_secretsmanager_secret.example.id}"
+  secret_id     = aws_secretsmanager_secret.example.id
   secret_string = "example-string-to-protect"
 }
 ```
@@ -40,8 +40,8 @@ variable "example" {
 }
 
 resource "aws_secretsmanager_secret_version" "example" {
-  secret_id     = "${aws_secretsmanager_secret.example.id}"
-  secret_string = "${jsonencode(var.example)}"
+  secret_id     = aws_secretsmanager_secret.example.id
+  secret_string = jsonencode(var.example)
 }
 ```
 

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -29,7 +29,7 @@ Basic usage
 resource "aws_security_group" "allow_tls" {
   name        = "allow_tls"
   description = "Allow TLS inbound traffic"
-  vpc_id      = "${aws_vpc.main.id}"
+  vpc_id      = aws_vpc.main.id
 
   ingress {
     description = "TLS from VPC"
@@ -138,7 +138,7 @@ egress {
   from_port       = 0
   to_port         = 0
   protocol        = "-1"
-  prefix_list_ids = ["${aws_vpc_endpoint.my_endpoint.prefix_list_id}"]
+  prefix_list_ids = [aws_vpc_endpoint.my_endpoint.prefix_list_id]
 }
 
 # ...

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -68,7 +68,7 @@ resource "aws_security_group_rule" "allow_all" {
   type              = "egress"
   to_port           = 0
   protocol          = "-1"
-  prefix_list_ids   = ["${aws_vpc_endpoint.my_endpoint.prefix_list_id}"]
+  prefix_list_ids   = [aws_vpc_endpoint.my_endpoint.prefix_list_id]
   from_port         = 0
   security_group_id = "sg-123456"
 }

--- a/website/docs/r/service_discovery_private_dns_namespace.html.markdown
+++ b/website/docs/r/service_discovery_private_dns_namespace.html.markdown
@@ -20,7 +20,7 @@ resource "aws_vpc" "example" {
 resource "aws_service_discovery_private_dns_namespace" "example" {
   name        = "hoge.example.local"
   description = "example"
-  vpc         = "${aws_vpc.example.id}"
+  vpc         = aws_vpc.example.id
 }
 ```
 

--- a/website/docs/r/service_discovery_service.html.markdown
+++ b/website/docs/r/service_discovery_service.html.markdown
@@ -22,14 +22,14 @@ resource "aws_vpc" "example" {
 resource "aws_service_discovery_private_dns_namespace" "example" {
   name        = "example.terraform.local"
   description = "example"
-  vpc         = "${aws_vpc.example.id}"
+  vpc         = aws_vpc.example.id
 }
 
 resource "aws_service_discovery_service" "example" {
   name = "example"
 
   dns_config {
-    namespace_id = "${aws_service_discovery_private_dns_namespace.example.id}"
+    namespace_id = aws_service_discovery_private_dns_namespace.example.id
 
     dns_records {
       ttl  = 10
@@ -55,7 +55,7 @@ resource "aws_service_discovery_service" "example" {
   name = "example"
 
   dns_config {
-    namespace_id = "${aws_service_discovery_public_dns_namespace.example.id}"
+    namespace_id = aws_service_discovery_public_dns_namespace.example.id
 
     dns_records {
       ttl  = 10

--- a/website/docs/r/ses_domain_dkim.html.markdown
+++ b/website/docs/r/ses_domain_dkim.html.markdown
@@ -37,7 +37,7 @@ resource "aws_ses_domain_identity" "example" {
 }
 
 resource "aws_ses_domain_dkim" "example" {
-  domain = "${aws_ses_domain_identity.example.domain}"
+  domain = aws_ses_domain_identity.example.domain
 }
 
 resource "aws_route53_record" "example_amazonses_dkim_record" {

--- a/website/docs/r/ses_domain_identity.html.markdown
+++ b/website/docs/r/ses_domain_identity.html.markdown
@@ -42,7 +42,7 @@ resource "aws_route53_record" "example_amazonses_verification_record" {
   name    = "_amazonses.example.com"
   type    = "TXT"
   ttl     = "600"
-  records = ["${aws_ses_domain_identity.example.verification_token}"]
+  records = [aws_ses_domain_identity.example.verification_token]
 }
 ```
 

--- a/website/docs/r/ses_domain_identity_verification.html.markdown
+++ b/website/docs/r/ses_domain_identity_verification.html.markdown
@@ -24,15 +24,15 @@ resource "aws_ses_domain_identity" "example" {
 }
 
 resource "aws_route53_record" "example_amazonses_verification_record" {
-  zone_id = "${aws_route53_zone.example.zone_id}"
+  zone_id = aws_route53_zone.example.zone_id
   name    = "_amazonses.${aws_ses_domain_identity.example.id}"
   type    = "TXT"
   ttl     = "600"
-  records = ["${aws_ses_domain_identity.example.verification_token}"]
+  records = [aws_ses_domain_identity.example.verification_token]
 }
 
 resource "aws_ses_domain_identity_verification" "example_verification" {
-  domain = "${aws_ses_domain_identity.example.id}"
+  domain = aws_ses_domain_identity.example.id
 
   depends_on = ["aws_route53_record.example_amazonses_verification_record"]
 }

--- a/website/docs/r/ses_domain_mail_from.html.markdown
+++ b/website/docs/r/ses_domain_mail_from.html.markdown
@@ -16,7 +16,7 @@ Provides an SES domain MAIL FROM resource.
 
 ```hcl
 resource "aws_ses_domain_mail_from" "example" {
-  domain           = "${aws_ses_domain_identity.example.domain}"
+  domain           = aws_ses_domain_identity.example.domain
   mail_from_domain = "bounce.${aws_ses_domain_identity.example.domain}"
 }
 
@@ -27,8 +27,8 @@ resource "aws_ses_domain_identity" "example" {
 
 # Example Route53 MX record
 resource "aws_route53_record" "example_ses_domain_mail_from_mx" {
-  zone_id = "${aws_route53_zone.example.id}"
-  name    = "${aws_ses_domain_mail_from.example.mail_from_domain}"
+  zone_id = aws_route53_zone.example.id
+  name    = aws_ses_domain_mail_from.example.mail_from_domain
   type    = "MX"
   ttl     = "600"
   records = ["10 feedback-smtp.us-east-1.amazonses.com"] # Change to the region in which `aws_ses_domain_identity.example` is created
@@ -36,8 +36,8 @@ resource "aws_route53_record" "example_ses_domain_mail_from_mx" {
 
 # Example Route53 TXT record for SPF
 resource "aws_route53_record" "example_ses_domain_mail_from_txt" {
-  zone_id = "${aws_route53_zone.example.id}"
-  name    = "${aws_ses_domain_mail_from.example.mail_from_domain}"
+  zone_id = aws_route53_zone.example.id
+  name    = aws_ses_domain_mail_from.example.mail_from_domain
   type    = "TXT"
   ttl     = "600"
   records = ["v=spf1 include:amazonses.com -all"]

--- a/website/docs/r/ses_event_destination.markdown
+++ b/website/docs/r/ses_event_destination.markdown
@@ -17,7 +17,7 @@ Provides an SES event destination
 ```hcl
 resource "aws_ses_event_destination" "cloudwatch" {
   name                   = "event-destination-cloudwatch"
-  configuration_set_name = "${aws_ses_configuration_set.example.name}"
+  configuration_set_name = aws_ses_configuration_set.example.name
   enabled                = true
   matching_types         = ["bounce", "send"]
 
@@ -34,13 +34,13 @@ resource "aws_ses_event_destination" "cloudwatch" {
 ```hcl
 resource "aws_ses_event_destination" "kinesis" {
   name                   = "event-destination-kinesis"
-  configuration_set_name = "${aws_ses_configuration_set.example.name}"
+  configuration_set_name = aws_ses_configuration_set.example.name
   enabled                = true
   matching_types         = ["bounce", "send"]
 
   kinesis_destination {
-    stream_arn = "${aws_kinesis_firehose_delivery_stream.example.arn}"
-    role_arn   = "${aws_iam_role.example.arn}"
+    stream_arn = aws_kinesis_firehose_delivery_stream.example.arn
+    role_arn   = aws_iam_role.example.arn
   }
 }
 ```
@@ -50,12 +50,12 @@ resource "aws_ses_event_destination" "kinesis" {
 ```hcl
 resource "aws_ses_event_destination" "sns" {
   name                   = "event-destination-sns"
-  configuration_set_name = "${aws_ses_configuration_set.example.name}"
+  configuration_set_name = aws_ses_configuration_set.example.name
   enabled                = true
   matching_types         = ["bounce", "send"]
 
   sns_destination {
-    topic_arn = "${aws_sns_topic.example.arn}"
+    topic_arn = aws_sns_topic.example.arn
   }
 }
 ```

--- a/website/docs/r/ses_identity_notification_topic.markdown
+++ b/website/docs/r/ses_identity_notification_topic.markdown
@@ -14,9 +14,9 @@ Resource for managing SES Identity Notification Topics
 
 ```hcl
 resource "aws_ses_identity_notification_topic" "test" {
-  topic_arn                = "${aws_sns_topic.example.arn}"
+  topic_arn                = aws_sns_topic.example.arn
   notification_type        = "Bounce"
-  identity                 = "${aws_ses_domain_identity.example.domain}"
+  identity                 = aws_ses_domain_identity.example.domain
   include_original_headers = true
 }
 ```

--- a/website/docs/r/ses_identity_policy.html.markdown
+++ b/website/docs/r/ses_identity_policy.html.markdown
@@ -20,7 +20,7 @@ resource "aws_ses_domain_identity" "example" {
 data "aws_iam_policy_document" "example" {
   statement {
     actions   = ["SES:SendEmail", "SES:SendRawEmail"]
-    resources = ["${aws_ses_domain_identity.example.arn}"]
+    resources = [aws_ses_domain_identity.example.arn]
 
     principals {
       identifiers = ["*"]
@@ -30,9 +30,9 @@ data "aws_iam_policy_document" "example" {
 }
 
 resource "aws_ses_identity_policy" "example" {
-  identity = "${aws_ses_domain_identity.example.arn}"
+  identity = aws_ses_domain_identity.example.arn
   name     = "example"
-  policy   = "${data.aws_iam_policy_document.example.json}"
+  policy   = data.aws_iam_policy_document.example.json
 }
 ```
 

--- a/website/docs/r/sfn_state_machine.html.markdown
+++ b/website/docs/r/sfn_state_machine.html.markdown
@@ -17,7 +17,7 @@ Provides a Step Function State Machine resource
 
 resource "aws_sfn_state_machine" "sfn_state_machine" {
   name     = "my-state-machine"
-  role_arn = "${aws_iam_role.iam_for_sfn.arn}"
+  role_arn = aws_iam_role.iam_for_sfn.arn
 
   definition = <<EOF
 {

--- a/website/docs/r/sfn_state_machine.html.markdown
+++ b/website/docs/r/sfn_state_machine.html.markdown
@@ -19,19 +19,17 @@ resource "aws_sfn_state_machine" "sfn_state_machine" {
   name     = "my-state-machine"
   role_arn = aws_iam_role.iam_for_sfn.arn
 
-  definition = <<EOF
-{
-  "Comment": "A Hello World example of the Amazon States Language using an AWS Lambda Function",
-  "StartAt": "HelloWorld",
-  "States": {
-    "HelloWorld": {
-      "Type": "Task",
-      "Resource": "${aws_lambda_function.lambda.arn}",
-      "End": true
+  definition = jsonencode({
+    "Comment" = "A Hello World example of the Amazon States Language using an AWS Lambda Function"
+    "StartAt" = "HelloWorld"
+    "States" = {
+      "HelloWorld" = {
+        "Type"     = "Task"
+        "Resource" = aws_lambda_function.lambda.arn
+        "End"      = true
+      }
     }
-  }
-}
-EOF
+  })
 }
 ```
 

--- a/website/docs/r/shield_protection.html.markdown
+++ b/website/docs/r/shield_protection.html.markdown
@@ -25,7 +25,7 @@ resource "aws_eip" "foo" {
 }
 
 resource "aws_shield_protection" "foo" {
-  name         = "${var.name}"
+  name         = var.name
   resource_arn = "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:eip-allocation/${aws_eip.foo.id}"
 }
 ```

--- a/website/docs/r/snapshot_create_volume_permission.html.markdown
+++ b/website/docs/r/snapshot_create_volume_permission.html.markdown
@@ -14,7 +14,7 @@ Adds permission to create volumes off of a given EBS Snapshot.
 
 ```hcl
 resource "aws_snapshot_create_volume_permission" "example_perm" {
-  snapshot_id = "${aws_ebs_snapshot.example_snapshot.id}"
+  snapshot_id = aws_ebs_snapshot.example_snapshot.id
   account_id  = "12345678"
 }
 
@@ -24,7 +24,7 @@ resource "aws_ebs_volume" "example" {
 }
 
 resource "aws_ebs_snapshot" "example_snapshot" {
-  volume_id = "${aws_ebs_volume.example.id}"
+  volume_id = aws_ebs_volume.example.id
 }
 ```
 

--- a/website/docs/r/sns_topic_policy.html.markdown
+++ b/website/docs/r/sns_topic_policy.html.markdown
@@ -20,9 +20,9 @@ resource "aws_sns_topic" "test" {
 }
 
 resource "aws_sns_topic_policy" "default" {
-  arn = "${aws_sns_topic.test.arn}"
+  arn = aws_sns_topic.test.arn
 
-  policy = "${data.aws_iam_policy_document.sns_topic_policy.json}"
+  policy = data.aws_iam_policy_document.sns_topic_policy.json
 }
 
 data "aws_iam_policy_document" "sns_topic_policy" {
@@ -46,7 +46,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
       variable = "AWS:SourceOwner"
 
       values = [
-        "${var.account-id}",
+        var.account-id,
       ]
     }
 
@@ -58,7 +58,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
     }
 
     resources = [
-      "${aws_sns_topic.test.arn}",
+      aws_sns_topic.test.arn,
     ]
 
     sid = "__default_statement_ID"

--- a/website/docs/r/spot_datafeed_subscription.html.markdown
+++ b/website/docs/r/spot_datafeed_subscription.html.markdown
@@ -21,7 +21,7 @@ resource "aws_s3_bucket" "default" {
 }
 
 resource "aws_spot_datafeed_subscription" "default" {
-  bucket = "${aws_s3_bucket.default.bucket}"
+  bucket = aws_s3_bucket.default.bucket
   prefix = "my_subdirectory"
 }
 ```

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -27,7 +27,7 @@ resource "aws_spot_fleet_request" "cheap_compute" {
     ami                      = "ami-1234"
     spot_price               = "2.793"
     placement_tenancy        = "dedicated"
-    iam_instance_profile_arn = "${aws_iam_instance_profile.example.arn}"
+    iam_instance_profile_arn = aws_iam_instance_profile.example.arn
   }
 
   launch_specification {
@@ -35,7 +35,7 @@ resource "aws_spot_fleet_request" "cheap_compute" {
     ami                      = "ami-5678"
     key_name                 = "my-key"
     spot_price               = "1.117"
-    iam_instance_profile_arn = "${aws_iam_instance_profile.example.arn}"
+    iam_instance_profile_arn = aws_iam_instance_profile.example.arn
     availability_zone        = "us-west-1a"
     subnet_id                = "subnet-1234"
     weighted_capacity        = 35

--- a/website/docs/r/sqs_queue_policy.html.markdown
+++ b/website/docs/r/sqs_queue_policy.html.markdown
@@ -19,7 +19,7 @@ resource "aws_sqs_queue" "q" {
 }
 
 resource "aws_sqs_queue_policy" "test" {
-  queue_url = "${aws_sqs_queue.q.id}"
+  queue_url = aws_sqs_queue.q.id
 
   policy = <<POLICY
 {

--- a/website/docs/r/sqs_queue_policy.html.markdown
+++ b/website/docs/r/sqs_queue_policy.html.markdown
@@ -21,26 +21,24 @@ resource "aws_sqs_queue" "q" {
 resource "aws_sqs_queue_policy" "test" {
   queue_url = aws_sqs_queue.q.id
 
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Id": "sqspolicy",
-  "Statement": [
-    {
-      "Sid": "First",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "sqs:SendMessage",
-      "Resource": "${aws_sqs_queue.q.arn}",
-      "Condition": {
-        "ArnEquals": {
-          "aws:SourceArn": "${aws_sns_topic.example.arn}"
+  policy = jsonencode({
+    "Version" = "2012-10-17"
+    "Id"      = "sqspolicy"
+    "Statement" = [
+      {
+        "Sid"       = "First"
+        "Effect"    = "Allow"
+        "Principal" = "*"
+        "Action"    = "sqs:SendMessage"
+        "Resource"  = aws_sqs_queue.q.arn
+        "Condition" = {
+          "ArnEquals" = {
+            "aws:SourceArn" = aws_sns_topic.example.arn
+          }
         }
       }
-    }
-  ]
-}
-POLICY
+    ]
+  })
 }
 ```
 

--- a/website/docs/r/ssm_activation.html.markdown
+++ b/website/docs/r/ssm_activation.html.markdown
@@ -29,14 +29,14 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "test_attach" {
-  role       = "${aws_iam_role.test_role.name}"
+  role       = aws_iam_role.test_role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
 resource "aws_ssm_activation" "foo" {
   name               = "test_ssm_activation"
   description        = "Test"
-  iam_role           = "${aws_iam_role.test_role.id}"
+  iam_role           = aws_iam_role.test_role.id
   registration_limit = "5"
   depends_on         = ["aws_iam_role_policy_attachment.test_attach"]
 }

--- a/website/docs/r/ssm_association.html.markdown
+++ b/website/docs/r/ssm_association.html.markdown
@@ -14,11 +14,11 @@ Associates an SSM Document to an instance or EC2 tag.
 
 ```hcl
 resource "aws_ssm_association" "example" {
-  name = "${aws_ssm_document.example.name}"
+  name = aws_ssm_document.example.name
 
   targets {
     key    = "InstanceIds"
-    values = ["${aws_instance.example.id}"]
+    values = [aws_instance.example.id]
   }
 }
 ```

--- a/website/docs/r/ssm_maintenance_window_target.html.markdown
+++ b/website/docs/r/ssm_maintenance_window_target.html.markdown
@@ -21,7 +21,7 @@ resource "aws_ssm_maintenance_window" "window" {
 }
 
 resource "aws_ssm_maintenance_window_target" "target1" {
-  window_id     = "${aws_ssm_maintenance_window.window.id}"
+  window_id     = aws_ssm_maintenance_window.window.id
   name          = "maintenance-window-target"
   description   = "This is a maintenance window target"
   resource_type = "INSTANCE"

--- a/website/docs/r/ssm_maintenance_window_task.html.markdown
+++ b/website/docs/r/ssm_maintenance_window_task.html.markdown
@@ -19,14 +19,14 @@ resource "aws_ssm_maintenance_window_task" "example" {
   max_concurrency  = 2
   max_errors       = 1
   priority         = 1
-  service_role_arn = "${aws_iam_role.example.arn}"
+  service_role_arn = aws_iam_role.example.arn
   task_arn         = "AWS-RestartEC2Instance"
   task_type        = "AUTOMATION"
-  window_id        = "${aws_ssm_maintenance_window.example.id}"
+  window_id        = aws_ssm_maintenance_window.example.id
 
   targets {
     key    = "InstanceIds"
-    values = ["${aws_instance.example.id}"]
+    values = [aws_instance.example.id]
   }
 
   task_invocation_parameters {
@@ -35,7 +35,7 @@ resource "aws_ssm_maintenance_window_task" "example" {
 
       parameter {
         name   = "InstanceId"
-        values = ["${aws_instance.example.id}"]
+        values = [aws_instance.example.id]
       }
     }
   }
@@ -49,19 +49,19 @@ resource "aws_ssm_maintenance_window_task" "example" {
   max_concurrency  = 2
   max_errors       = 1
   priority         = 1
-  service_role_arn = "${aws_iam_role.example.arn}"
-  task_arn         = "${aws_lambda_function.example.arn}"
+  service_role_arn = aws_iam_role.example.arn
+  task_arn         = aws_lambda_function.example.arn
   task_type        = "LAMBDA"
-  window_id        = "${aws_ssm_maintenance_window.example.id}"
+  window_id        = aws_ssm_maintenance_window.example.id
 
   targets {
     key    = "InstanceIds"
-    values = ["${aws_instance.example.id}"]
+    values = [aws_instance.example.id]
   }
 
   task_invocation_parameters {
     lambda_parameters {
-      client_context = "${base64encode("{\"key1\":\"value1\"}")}"
+      client_context = base64encode("{\"key1\":\"value1\"}")
       payload        = "{\"key1\":\"value1\"}"
     }
   }
@@ -75,25 +75,25 @@ resource "aws_ssm_maintenance_window_task" "example" {
   max_concurrency  = 2
   max_errors       = 1
   priority         = 1
-  service_role_arn = "${aws_iam_role.example.arn}"
+  service_role_arn = aws_iam_role.example.arn
   task_arn         = "AWS-RunShellScript"
   task_type        = "RUN_COMMAND"
-  window_id        = "${aws_ssm_maintenance_window.example.id}"
+  window_id        = aws_ssm_maintenance_window.example.id
 
   targets {
     key    = "InstanceIds"
-    values = ["${aws_instance.example.id}"]
+    values = [aws_instance.example.id]
   }
 
   task_invocation_parameters {
     run_command_parameters {
-      output_s3_bucket     = "${aws_s3_bucket.example.bucket}"
+      output_s3_bucket     = aws_s3_bucket.example.bucket
       output_s3_key_prefix = "output"
-      service_role_arn     = "${aws_iam_role.example.arn}"
+      service_role_arn     = aws_iam_role.example.arn
       timeout_seconds      = 600
 
       notification_config {
-        notification_arn    = "${aws_sns_topic.example.arn}"
+        notification_arn    = aws_sns_topic.example.arn
         notification_events = ["All"]
         notification_type   = ["Command"]
       }
@@ -114,14 +114,14 @@ resource "aws_ssm_maintenance_window_task" "example" {
   max_concurrency  = 2
   max_errors       = 1
   priority         = 1
-  service_role_arn = "${aws_iam_role.example.arn}"
-  task_arn         = "${aws_sfn_activity.example.id}"
+  service_role_arn = aws_iam_role.example.arn
+  task_arn         = aws_sfn_activity.example.id
   task_type        = "STEP_FUNCTIONS"
-  window_id        = "${aws_ssm_maintenance_window.example.id}"
+  window_id        = aws_ssm_maintenance_window.example.id
 
   targets {
     key    = "InstanceIds"
-    values = ["${aws_instance.example.id}"]
+    values = [aws_instance.example.id]
   }
 
   task_invocation_parameters {

--- a/website/docs/r/ssm_parameter.html.markdown
+++ b/website/docs/r/ssm_parameter.html.markdown
@@ -33,7 +33,7 @@ resource "aws_db_instance" "default" {
   instance_class       = "db.t2.micro"
   name                 = "mydb"
   username             = "foo"
-  password             = "${var.database_master_password}"
+  password             = var.database_master_password
   db_subnet_group_name = "my_database_subnet_group"
   parameter_group_name = "default.mysql5.7"
 }
@@ -42,10 +42,10 @@ resource "aws_ssm_parameter" "secret" {
   name        = "/${var.environment}/database/password/master"
   description = "The parameter description"
   type        = "SecureString"
-  value       = "${var.database_master_password}"
+  value       = var.database_master_password
 
   tags = {
-    environment = "${var.environment}"
+    environment = var.environment
   }
 }
 ```

--- a/website/docs/r/ssm_patch_group.html.markdown
+++ b/website/docs/r/ssm_patch_group.html.markdown
@@ -19,7 +19,7 @@ resource "aws_ssm_patch_baseline" "production" {
 }
 
 resource "aws_ssm_patch_group" "patchgroup" {
-  baseline_id = "${aws_ssm_patch_baseline.production.id}"
+  baseline_id = aws_ssm_patch_baseline.production.id
   patch_group = "patch-group-name"
 }
 ```

--- a/website/docs/r/ssm_resource_data_sync.html.markdown
+++ b/website/docs/r/ssm_resource_data_sync.html.markdown
@@ -19,7 +19,7 @@ resource "aws_s3_bucket" "hoge" {
 }
 
 resource "aws_s3_bucket_policy" "hoge" {
-  bucket = "${aws_s3_bucket.hoge.bucket}"
+  bucket = aws_s3_bucket.hoge.bucket
 
   policy = <<EOF
 {
@@ -57,8 +57,8 @@ resource "aws_ssm_resource_data_sync" "foo" {
   name = "foo"
 
   s3_destination = {
-    bucket_name = "${aws_s3_bucket.hoge.bucket}"
-    region      = "${aws_s3_bucket.hoge.region}"
+    bucket_name = aws_s3_bucket.hoge.bucket
+    region      = aws_s3_bucket.hoge.region
   }
 }
 ```

--- a/website/docs/r/storagegateway_cache.html.markdown
+++ b/website/docs/r/storagegateway_cache.html.markdown
@@ -16,8 +16,8 @@ Manages an AWS Storage Gateway cache.
 
 ```hcl
 resource "aws_storagegateway_cache" "example" {
-  disk_id     = "${data.aws_storagegateway_local_disk.example.id}"
-  gateway_arn = "${aws_storagegateway_gateway.example.arn}"
+  disk_id     = data.aws_storagegateway_local_disk.example.id
+  gateway_arn = aws_storagegateway_gateway.example.arn
 }
 ```
 

--- a/website/docs/r/storagegateway_cached_iscsi_volume.html.markdown
+++ b/website/docs/r/storagegateway_cached_iscsi_volume.html.markdown
@@ -22,8 +22,8 @@ Manages an AWS Storage Gateway cached iSCSI volume.
 
 ```hcl
 resource "aws_storagegateway_cached_iscsi_volume" "example" {
-  gateway_arn          = "${aws_storagegateway_cache.example.gateway_arn}"
-  network_interface_id = "${aws_instance.example.private_ip}"
+  gateway_arn          = aws_storagegateway_cache.example.gateway_arn
+  network_interface_id = aws_instance.example.private_ip
   target_name          = "example"
   volume_size_in_bytes = 5368709120 # 5 GB
 }
@@ -33,11 +33,11 @@ resource "aws_storagegateway_cached_iscsi_volume" "example" {
 
 ```hcl
 resource "aws_storagegateway_cached_iscsi_volume" "example" {
-  gateway_arn          = "${aws_storagegateway_cache.example.gateway_arn}"
-  network_interface_id = "${aws_instance.example.private_ip}"
-  snapshot_id          = "${aws_ebs_snapshot.example.id}"
+  gateway_arn          = aws_storagegateway_cache.example.gateway_arn
+  network_interface_id = aws_instance.example.private_ip
+  snapshot_id          = aws_ebs_snapshot.example.id
   target_name          = "example"
-  volume_size_in_bytes = "${aws_ebs_snapshot.example.volume_size * 1024 * 1024 * 1024}"
+  volume_size_in_bytes = aws_ebs_snapshot.example.volume_size * 1024 * 1024 * 1024
 }
 ```
 
@@ -45,11 +45,11 @@ resource "aws_storagegateway_cached_iscsi_volume" "example" {
 
 ```hcl
 resource "aws_storagegateway_cached_iscsi_volume" "example" {
-  gateway_arn          = "${aws_storagegateway_cache.example.gateway_arn}"
-  network_interface_id = "${aws_instance.example.private_ip}"
-  source_volume_arn    = "${aws_storagegateway_cached_iscsi_volume.existing.arn}"
+  gateway_arn          = aws_storagegateway_cache.example.gateway_arn
+  network_interface_id = aws_instance.example.private_ip
+  source_volume_arn    = aws_storagegateway_cached_iscsi_volume.existing.arn
   target_name          = "example"
-  volume_size_in_bytes = "${aws_storagegateway_cached_iscsi_volume.existing.volume_size_in_bytes}"
+  volume_size_in_bytes = aws_storagegateway_cached_iscsi_volume.existing.volume_size_in_bytes
 }
 ```
 

--- a/website/docs/r/storagegateway_nfs_file_share.html.markdown
+++ b/website/docs/r/storagegateway_nfs_file_share.html.markdown
@@ -15,9 +15,9 @@ Manages an AWS Storage Gateway NFS File Share.
 ```hcl
 resource "aws_storagegateway_nfs_file_share" "example" {
   client_list  = ["0.0.0.0/0"]
-  gateway_arn  = "${aws_storagegateway_gateway.example.arn}"
-  location_arn = "${aws_s3_bucket.example.arn}"
-  role_arn     = "${aws_iam_role.example.arn}"
+  gateway_arn  = aws_storagegateway_gateway.example.arn
+  location_arn = aws_s3_bucket.example.arn
+  role_arn     = aws_iam_role.example.arn
 }
 ```
 

--- a/website/docs/r/storagegateway_smb_file_share.html.markdown
+++ b/website/docs/r/storagegateway_smb_file_share.html.markdown
@@ -19,9 +19,9 @@ Manages an AWS Storage Gateway SMB File Share.
 ```hcl
 resource "aws_storagegateway_smb_file_share" "example" {
   authentication = "ActiveDirectory"
-  gateway_arn    = "${aws_storagegateway_gateway.example.arn}"
-  location_arn   = "${aws_s3_bucket.example.arn}"
-  role_arn       = "${aws_iam_role.example.arn}"
+  gateway_arn    = aws_storagegateway_gateway.example.arn
+  location_arn   = aws_s3_bucket.example.arn
+  role_arn       = aws_iam_role.example.arn
 }
 ```
 
@@ -32,9 +32,9 @@ resource "aws_storagegateway_smb_file_share" "example" {
 ```hcl
 resource "aws_storagegateway_smb_file_share" "example" {
   authentication = "GuestAccess"
-  gateway_arn    = "${aws_storagegateway_gateway.example.arn}"
-  location_arn   = "${aws_s3_bucket.example.arn}"
-  role_arn       = "${aws_iam_role.example.arn}"
+  gateway_arn    = aws_storagegateway_gateway.example.arn
+  location_arn   = aws_s3_bucket.example.arn
+  role_arn       = aws_iam_role.example.arn
 }
 ```
 

--- a/website/docs/r/storagegateway_upload_buffer.html.markdown
+++ b/website/docs/r/storagegateway_upload_buffer.html.markdown
@@ -16,8 +16,8 @@ Manages an AWS Storage Gateway upload buffer.
 
 ```hcl
 resource "aws_storagegateway_upload_buffer" "example" {
-  disk_id     = "${data.aws_storagegateway_local_disk.example.id}"
-  gateway_arn = "${aws_storagegateway_gateway.example.arn}"
+  disk_id     = data.aws_storagegateway_local_disk.example.id
+  gateway_arn = aws_storagegateway_gateway.example.arn
 }
 ```
 

--- a/website/docs/r/storagegateway_working_storage.html.markdown
+++ b/website/docs/r/storagegateway_working_storage.html.markdown
@@ -16,8 +16,8 @@ Manages an AWS Storage Gateway working storage.
 
 ```hcl
 resource "aws_storagegateway_working_storage" "example" {
-  disk_id     = "${data.aws_storagegateway_local_disk.example.id}"
-  gateway_arn = "${aws_storagegateway_gateway.example.arn}"
+  disk_id     = data.aws_storagegateway_local_disk.example.id
+  gateway_arn = aws_storagegateway_gateway.example.arn
 }
 ```
 

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -18,7 +18,7 @@ Provides an VPC subnet resource.
 
 ```hcl
 resource "aws_subnet" "main" {
-  vpc_id     = "${aws_vpc.main.id}"
+  vpc_id     = aws_vpc.main.id
   cidr_block = "10.0.1.0/24"
 
   tags = {
@@ -34,12 +34,12 @@ resource, it is recommended to reference that resource's `vpc_id` attribute to e
 
 ```hcl
 resource "aws_vpc_ipv4_cidr_block_association" "secondary_cidr" {
-  vpc_id     = "${aws_vpc.main.id}"
+  vpc_id     = aws_vpc.main.id
   cidr_block = "172.2.0.0/16"
 }
 
 resource "aws_subnet" "in_secondary_cidr" {
-  vpc_id     = "${aws_vpc_ipv4_cidr_block_association.secondary_cidr.vpc_id}"
+  vpc_id     = aws_vpc_ipv4_cidr_block_association.secondary_cidr.vpc_id
   cidr_block = "172.2.0.0/24"
 }
 ```

--- a/website/docs/r/transfer_server.html.markdown
+++ b/website/docs/r/transfer_server.html.markdown
@@ -33,7 +33,7 @@ EOF
 
 resource "aws_iam_role_policy" "foo" {
   name = "tf-test-transfer-server-iam-policy-%s"
-  role = "${aws_iam_role.foo.id}"
+  role = aws_iam_role.foo.id
 
   policy = <<POLICY
 {
@@ -54,7 +54,7 @@ POLICY
 
 resource "aws_transfer_server" "foo" {
   identity_provider_type = "SERVICE_MANAGED"
-  logging_role           = "${aws_iam_role.foo.arn}"
+  logging_role           = aws_iam_role.foo.arn
 
   tags = {
     NAME = "tf-acc-test-transfer-server"

--- a/website/docs/r/transfer_ssh_key.html.markdown
+++ b/website/docs/r/transfer_ssh_key.html.markdown
@@ -41,7 +41,7 @@ EOF
 
 resource "aws_iam_role_policy" "foo" {
   name = "tf-test-transfer-user-iam-policy-%s"
-  role = "${aws_iam_role.foo.id}"
+  role = aws_iam_role.foo.id
 
   policy = <<POLICY
 {
@@ -61,9 +61,9 @@ POLICY
 }
 
 resource "aws_transfer_user" "foo" {
-  server_id = "${aws_transfer_server.foo.id}"
+  server_id = aws_transfer_server.foo.id
   user_name = "tftestuser"
-  role      = "${aws_iam_role.foo.arn}"
+  role      = aws_iam_role.foo.arn
 
   tags = {
     NAME = "tftestuser"
@@ -71,8 +71,8 @@ resource "aws_transfer_user" "foo" {
 }
 
 resource "aws_transfer_ssh_key" "foo" {
-  server_id = "${aws_transfer_server.foo.id}"
-  user_name = "${aws_transfer_user.foo.user_name}"
+  server_id = aws_transfer_server.foo.id
+  user_name = aws_transfer_user.foo.user_name
   body      = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 example@example.com"
 }
 ```

--- a/website/docs/r/transfer_user.html.markdown
+++ b/website/docs/r/transfer_user.html.markdown
@@ -41,7 +41,7 @@ EOF
 
 resource "aws_iam_role_policy" "foo" {
   name = "tf-test-transfer-user-iam-policy"
-  role = "${aws_iam_role.foo.id}"
+  role = aws_iam_role.foo.id
 
   policy = <<POLICY
 {
@@ -61,9 +61,9 @@ POLICY
 }
 
 resource "aws_transfer_user" "foo" {
-  server_id = "${aws_transfer_server.foo.id}"
+  server_id = aws_transfer_server.foo.id
   user_name = "tftestuser"
-  role      = "${aws_iam_role.foo.arn}"
+  role      = aws_iam_role.foo.arn
 }
 ```
 

--- a/website/docs/r/volume_attachment.html.markdown
+++ b/website/docs/r/volume_attachment.html.markdown
@@ -18,8 +18,8 @@ detach volumes from AWS Instances.
 ```hcl
 resource "aws_volume_attachment" "ebs_att" {
   device_name = "/dev/sdh"
-  volume_id   = "${aws_ebs_volume.example.id}"
-  instance_id = "${aws_instance.web.id}"
+  volume_id   = aws_ebs_volume.example.id
+  instance_id = aws_instance.web.id
 }
 
 resource "aws_instance" "web" {

--- a/website/docs/r/vpc_dhcp_options_association.html.markdown
+++ b/website/docs/r/vpc_dhcp_options_association.html.markdown
@@ -14,8 +14,8 @@ Provides a VPC DHCP Options Association resource.
 
 ```hcl
 resource "aws_vpc_dhcp_options_association" "dns_resolver" {
-  vpc_id          = "${aws_vpc.foo.id}"
-  dhcp_options_id = "${aws_vpc_dhcp_options.foo.id}"
+  vpc_id          = aws_vpc.foo.id
+  dhcp_options_id = aws_vpc_dhcp_options.foo.id
 }
 ```
 

--- a/website/docs/r/vpc_endpoint.html.markdown
+++ b/website/docs/r/vpc_endpoint.html.markdown
@@ -23,7 +23,7 @@ Doing so will cause a conflict of associations and will overwrite the associatio
 
 ```hcl
 resource "aws_vpc_endpoint" "s3" {
-  vpc_id       = "${aws_vpc.main.id}"
+  vpc_id       = aws_vpc.main.id
   service_name = "com.amazonaws.us-west-2.s3"
 }
 ```
@@ -32,7 +32,7 @@ resource "aws_vpc_endpoint" "s3" {
 
 ```hcl
 resource "aws_vpc_endpoint" "s3" {
-  vpc_id       = "${aws_vpc.main.id}"
+  vpc_id       = aws_vpc.main.id
   service_name = "com.amazonaws.us-west-2.s3"
 
   tags = {
@@ -45,12 +45,12 @@ resource "aws_vpc_endpoint" "s3" {
 
 ```hcl
 resource "aws_vpc_endpoint" "ec2" {
-  vpc_id            = "${aws_vpc.main.id}"
+  vpc_id            = aws_vpc.main.id
   service_name      = "com.amazonaws.us-west-2.ec2"
   vpc_endpoint_type = "Interface"
 
   security_group_ids = [
-    "${aws_security_group.sg1.id}",
+    aws_security_group.sg1.id,
   ]
 
   private_dns_enabled = true
@@ -61,30 +61,30 @@ resource "aws_vpc_endpoint" "ec2" {
 
 ```hcl
 resource "aws_vpc_endpoint" "ptfe_service" {
-  vpc_id            = "${var.vpc_id}"
-  service_name      = "${var.ptfe_service}"
+  vpc_id            = var.vpc_id
+  service_name      = var.ptfe_service
   vpc_endpoint_type = "Interface"
 
   security_group_ids = [
-    "${aws_security_group.ptfe_service.id}",
+    aws_security_group.ptfe_service.id,
   ]
 
-  subnet_ids          = ["${local.subnet_ids}"]
+  subnet_ids          = [local.subnet_ids]
   private_dns_enabled = false
 }
 
 data "aws_route53_zone" "internal" {
   name         = "vpc.internal."
   private_zone = true
-  vpc_id       = "${var.vpc_id}"
+  vpc_id       = var.vpc_id
 }
 
 resource "aws_route53_record" "ptfe_service" {
-  zone_id = "${data.aws_route53_zone.internal.zone_id}"
+  zone_id = data.aws_route53_zone.internal.zone_id
   name    = "ptfe.${data.aws_route53_zone.internal.name}"
   type    = "CNAME"
   ttl     = "300"
-  records = ["${lookup(aws_vpc_endpoint.ptfe_service.dns_entry[0], "dns_name")}"]
+  records = [lookup(aws_vpc_endpoint.ptfe_service.dns_entry[0], "dns_name")]
 }
 ```
 

--- a/website/docs/r/vpc_endpoint_connection_notification.html.markdown
+++ b/website/docs/r/vpc_endpoint_connection_notification.html.markdown
@@ -34,12 +34,12 @@ POLICY
 
 resource "aws_vpc_endpoint_service" "foo" {
   acceptance_required        = false
-  network_load_balancer_arns = ["${aws_lb.test.arn}"]
+  network_load_balancer_arns = [aws_lb.test.arn]
 }
 
 resource "aws_vpc_endpoint_connection_notification" "foo" {
-  vpc_endpoint_service_id     = "${aws_vpc_endpoint_service.foo.id}"
-  connection_notification_arn = "${aws_sns_topic.topic.arn}"
+  vpc_endpoint_service_id     = aws_vpc_endpoint_service.foo.id
+  connection_notification_arn = aws_sns_topic.topic.arn
   connection_events           = ["Accept", "Reject"]
 }
 ```

--- a/website/docs/r/vpc_endpoint_route_table_association.html.markdown
+++ b/website/docs/r/vpc_endpoint_route_table_association.html.markdown
@@ -14,8 +14,8 @@ Manages a VPC Endpoint Route Table Association
 
 ```hcl
 resource "aws_vpc_endpoint_route_table_association" "example" {
-  route_table_id  = "${aws_route_table.example.id}"
-  vpc_endpoint_id = "${aws_vpc_endpoint.example.id}"
+  route_table_id  = aws_route_table.example.id
+  vpc_endpoint_id = aws_vpc_endpoint.example.id
 }
 ```
 

--- a/website/docs/r/vpc_endpoint_service.html.markdown
+++ b/website/docs/r/vpc_endpoint_service.html.markdown
@@ -24,7 +24,7 @@ and will overwrite the association.
 ```hcl
 resource "aws_vpc_endpoint_service" "example" {
   acceptance_required        = false
-  network_load_balancer_arns = ["${aws_lb.example.arn}"]
+  network_load_balancer_arns = [aws_lb.example.arn]
 }
 ```
 
@@ -33,7 +33,7 @@ resource "aws_vpc_endpoint_service" "example" {
 ```hcl
 resource "aws_vpc_endpoint_service" "example" {
   acceptance_required        = false
-  network_load_balancer_arns = ["${aws_lb.example.arn}"]
+  network_load_balancer_arns = [aws_lb.example.arn]
 
   tags = {
     Environment = "test"

--- a/website/docs/r/vpc_endpoint_service_allowed_principal.html.markdown
+++ b/website/docs/r/vpc_endpoint_service_allowed_principal.html.markdown
@@ -24,8 +24,8 @@ Basic usage:
 data "aws_caller_identity" "current" {}
 
 resource "aws_vpc_endpoint_service_allowed_principal" "allow_me_to_foo" {
-  vpc_endpoint_service_id = "${aws_vpc_endpoint_service.foo.id}"
-  principal_arn           = "${data.aws_caller_identity.current.arn}"
+  vpc_endpoint_service_id = aws_vpc_endpoint_service.foo.id
+  principal_arn           = data.aws_caller_identity.current.arn
 }
 ```
 

--- a/website/docs/r/vpc_endpoint_subnet_association.html.markdown
+++ b/website/docs/r/vpc_endpoint_subnet_association.html.markdown
@@ -22,8 +22,8 @@ Basic usage:
 
 ```hcl
 resource "aws_vpc_endpoint_subnet_association" "sn_ec2" {
-  vpc_endpoint_id = "${aws_vpc_endpoint.ec2.id}"
-  subnet_id       = "${aws_subnet.sn.id}"
+  vpc_endpoint_id = aws_vpc_endpoint.ec2.id
+  subnet_id       = aws_subnet.sn.id
 }
 ```
 

--- a/website/docs/r/vpc_ipv4_cidr_block_association.html.markdown
+++ b/website/docs/r/vpc_ipv4_cidr_block_association.html.markdown
@@ -21,7 +21,7 @@ resource "aws_vpc" "main" {
 }
 
 resource "aws_vpc_ipv4_cidr_block_association" "secondary_cidr" {
-  vpc_id     = "${aws_vpc.main.id}"
+  vpc_id     = aws_vpc.main.id
   cidr_block = "172.2.0.0/16"
 }
 ```

--- a/website/docs/r/vpc_peering_connection.html.markdown
+++ b/website/docs/r/vpc_peering_connection.html.markdown
@@ -26,9 +26,9 @@ connection and use the `aws_vpc_peering_connection_accepter` resource to manage 
 
 ```hcl
 resource "aws_vpc_peering_connection" "foo" {
-  peer_owner_id = "${var.peer_owner_id}"
-  peer_vpc_id   = "${aws_vpc.bar.id}"
-  vpc_id        = "${aws_vpc.foo.id}"
+  peer_owner_id = var.peer_owner_id
+  peer_vpc_id   = aws_vpc.bar.id
+  vpc_id        = aws_vpc.foo.id
 }
 ```
 
@@ -36,9 +36,9 @@ Basic usage with connection options:
 
 ```hcl
 resource "aws_vpc_peering_connection" "foo" {
-  peer_owner_id = "${var.peer_owner_id}"
-  peer_vpc_id   = "${aws_vpc.bar.id}"
-  vpc_id        = "${aws_vpc.foo.id}"
+  peer_owner_id = var.peer_owner_id
+  peer_vpc_id   = aws_vpc.bar.id
+  vpc_id        = aws_vpc.foo.id
 
   accepter {
     allow_remote_vpc_dns_resolution = true
@@ -54,9 +54,9 @@ Basic usage with tags:
 
 ```hcl
 resource "aws_vpc_peering_connection" "foo" {
-  peer_owner_id = "${var.peer_owner_id}"
-  peer_vpc_id   = "${aws_vpc.bar.id}"
-  vpc_id        = "${aws_vpc.foo.id}"
+  peer_owner_id = var.peer_owner_id
+  peer_vpc_id   = aws_vpc.bar.id
+  vpc_id        = aws_vpc.foo.id
   auto_accept   = true
 
   tags = {
@@ -78,9 +78,9 @@ Basic usage with region:
 
 ```hcl
 resource "aws_vpc_peering_connection" "foo" {
-  peer_owner_id = "${var.peer_owner_id}"
-  peer_vpc_id   = "${aws_vpc.bar.id}"
-  vpc_id        = "${aws_vpc.foo.id}"
+  peer_owner_id = var.peer_owner_id
+  peer_vpc_id   = aws_vpc.bar.id
+  vpc_id        = aws_vpc.foo.id
   peer_region   = "us-east-1"
 }
 

--- a/website/docs/r/vpc_peering_connection_accepter.html.markdown
+++ b/website/docs/r/vpc_peering_connection_accepter.html.markdown
@@ -48,9 +48,9 @@ data "aws_caller_identity" "peer" {
 
 # Requester's side of the connection.
 resource "aws_vpc_peering_connection" "peer" {
-  vpc_id        = "${aws_vpc.main.id}"
-  peer_vpc_id   = "${aws_vpc.peer.id}"
-  peer_owner_id = "${data.aws_caller_identity.peer.account_id}"
+  vpc_id        = aws_vpc.main.id
+  peer_vpc_id   = aws_vpc.peer.id
+  peer_owner_id = data.aws_caller_identity.peer.account_id
   peer_region   = "us-west-2"
   auto_accept   = false
 
@@ -62,7 +62,7 @@ resource "aws_vpc_peering_connection" "peer" {
 # Accepter's side of the connection.
 resource "aws_vpc_peering_connection_accepter" "peer" {
   provider                  = "aws.peer"
-  vpc_peering_connection_id = "${aws_vpc_peering_connection.peer.id}"
+  vpc_peering_connection_id = aws_vpc_peering_connection.peer.id
   auto_accept               = true
 
   tags = {

--- a/website/docs/r/vpc_peering_connection_options.html.markdown
+++ b/website/docs/r/vpc_peering_connection_options.html.markdown
@@ -31,13 +31,13 @@ resource "aws_vpc" "bar" {
 }
 
 resource "aws_vpc_peering_connection" "foo" {
-  vpc_id      = "${aws_vpc.foo.id}"
-  peer_vpc_id = "${aws_vpc.bar.id}"
+  vpc_id      = aws_vpc.foo.id
+  peer_vpc_id = aws_vpc.bar.id
   auto_accept = true
 }
 
 resource "aws_vpc_peering_connection_options" "foo" {
-  vpc_peering_connection_id = "${aws_vpc_peering_connection.foo.id}"
+  vpc_peering_connection_id = aws_vpc_peering_connection.foo.id
 
   accepter {
     allow_remote_vpc_dns_resolution = true
@@ -91,9 +91,9 @@ data "aws_caller_identity" "peer" {
 resource "aws_vpc_peering_connection" "peer" {
   provider = "aws.requester"
 
-  vpc_id        = "${aws_vpc.main.id}"
-  peer_vpc_id   = "${aws_vpc.peer.id}"
-  peer_owner_id = "${data.aws_caller_identity.peer.account_id}"
+  vpc_id        = aws_vpc.main.id
+  peer_vpc_id   = aws_vpc.peer.id
+  peer_owner_id = data.aws_caller_identity.peer.account_id
   auto_accept   = false
 
   tags = {
@@ -105,7 +105,7 @@ resource "aws_vpc_peering_connection" "peer" {
 resource "aws_vpc_peering_connection_accepter" "peer" {
   provider = "aws.accepter"
 
-  vpc_peering_connection_id = "${aws_vpc_peering_connection.peer.id}"
+  vpc_peering_connection_id = aws_vpc_peering_connection.peer.id
   auto_accept               = true
 
   tags = {
@@ -118,7 +118,7 @@ resource "aws_vpc_peering_connection_options" "requester" {
 
   # As options can't be set until the connection has been accepted
   # create an explicit dependency on the accepter.
-  vpc_peering_connection_id = "${aws_vpc_peering_connection_accepter.peer.id}"
+  vpc_peering_connection_id = aws_vpc_peering_connection_accepter.peer.id
 
   requester {
     allow_remote_vpc_dns_resolution = true
@@ -128,7 +128,7 @@ resource "aws_vpc_peering_connection_options" "requester" {
 resource "aws_vpc_peering_connection_options" "accepter" {
   provider = "aws.accepter"
 
-  vpc_peering_connection_id = "${aws_vpc_peering_connection_accepter.peer.id}"
+  vpc_peering_connection_id = aws_vpc_peering_connection_accepter.peer.id
 
   accepter {
     allow_remote_vpc_dns_resolution = true

--- a/website/docs/r/vpn_connection.html.markdown
+++ b/website/docs/r/vpn_connection.html.markdown
@@ -30,9 +30,9 @@ resource "aws_customer_gateway" "example" {
 }
 
 resource "aws_vpn_connection" "example" {
-  customer_gateway_id = "${aws_customer_gateway.example.id}"
-  transit_gateway_id  = "${aws_ec2_transit_gateway.example.id}"
-  type                = "${aws_customer_gateway.example.type}"
+  customer_gateway_id = aws_customer_gateway.example.id
+  transit_gateway_id  = aws_ec2_transit_gateway.example.id
+  type                = aws_customer_gateway.example.type
 }
 ```
 
@@ -44,7 +44,7 @@ resource "aws_vpc" "vpc" {
 }
 
 resource "aws_vpn_gateway" "vpn_gateway" {
-  vpc_id = "${aws_vpc.vpc.id}"
+  vpc_id = aws_vpc.vpc.id
 }
 
 resource "aws_customer_gateway" "customer_gateway" {
@@ -54,8 +54,8 @@ resource "aws_customer_gateway" "customer_gateway" {
 }
 
 resource "aws_vpn_connection" "main" {
-  vpn_gateway_id      = "${aws_vpn_gateway.vpn_gateway.id}"
-  customer_gateway_id = "${aws_customer_gateway.customer_gateway.id}"
+  vpn_gateway_id      = aws_vpn_gateway.vpn_gateway.id
+  customer_gateway_id = aws_customer_gateway.customer_gateway.id
   type                = "ipsec.1"
   static_routes_only  = true
 }

--- a/website/docs/r/vpn_connection_route.html.markdown
+++ b/website/docs/r/vpn_connection_route.html.markdown
@@ -18,7 +18,7 @@ resource "aws_vpc" "vpc" {
 }
 
 resource "aws_vpn_gateway" "vpn_gateway" {
-  vpc_id = "${aws_vpc.vpc.id}"
+  vpc_id = aws_vpc.vpc.id
 }
 
 resource "aws_customer_gateway" "customer_gateway" {
@@ -28,15 +28,15 @@ resource "aws_customer_gateway" "customer_gateway" {
 }
 
 resource "aws_vpn_connection" "main" {
-  vpn_gateway_id      = "${aws_vpn_gateway.vpn_gateway.id}"
-  customer_gateway_id = "${aws_customer_gateway.customer_gateway.id}"
+  vpn_gateway_id      = aws_vpn_gateway.vpn_gateway.id
+  customer_gateway_id = aws_customer_gateway.customer_gateway.id
   type                = "ipsec.1"
   static_routes_only  = true
 }
 
 resource "aws_vpn_connection_route" "office" {
   destination_cidr_block = "192.168.10.0/24"
-  vpn_connection_id      = "${aws_vpn_connection.main.id}"
+  vpn_connection_id      = aws_vpn_connection.main.id
 }
 ```
 

--- a/website/docs/r/vpn_gateway.html.markdown
+++ b/website/docs/r/vpn_gateway.html.markdown
@@ -14,7 +14,7 @@ Provides a resource to create a VPC VPN Gateway.
 
 ```hcl
 resource "aws_vpn_gateway" "vpn_gw" {
-  vpc_id = "${aws_vpc.main.id}"
+  vpc_id = aws_vpc.main.id
 
   tags = {
     Name = "main"

--- a/website/docs/r/vpn_gateway_attachment.html.markdown
+++ b/website/docs/r/vpn_gateway_attachment.html.markdown
@@ -29,8 +29,8 @@ resource "aws_vpn_gateway" "vpn" {
 }
 
 resource "aws_vpn_gateway_attachment" "vpn_attachment" {
-  vpc_id         = "${aws_vpc.network.id}"
-  vpn_gateway_id = "${aws_vpn_gateway.vpn.id}"
+  vpc_id         = aws_vpc.network.id
+  vpn_gateway_id = aws_vpn_gateway.vpn.id
 }
 ```
 

--- a/website/docs/r/vpn_gateway_route_propagation.html.markdown
+++ b/website/docs/r/vpn_gateway_route_propagation.html.markdown
@@ -18,8 +18,8 @@ propagation not explicitly listed in its value will be removed.
 
 ```hcl
 resource "aws_vpn_gateway_route_propagation" "example" {
-  vpn_gateway_id = "${aws_vpn_gateway.example.id}"
-  route_table_id = "${aws_route_table.example.id}"
+  vpn_gateway_id = aws_vpn_gateway.example.id
+  route_table_id = aws_route_table.example.id
 }
 ```
 

--- a/website/docs/r/waf_rate_based_rule.html.markdown
+++ b/website/docs/r/waf_rate_based_rule.html.markdown
@@ -31,7 +31,7 @@ resource "aws_waf_rate_based_rule" "wafrule" {
   rate_limit = 100
 
   predicates {
-    data_id = "${aws_waf_ipset.ipset.id}"
+    data_id = aws_waf_ipset.ipset.id
     negated = false
     type    = "IPMatch"
   }

--- a/website/docs/r/waf_regex_match_set.html.markdown
+++ b/website/docs/r/waf_regex_match_set.html.markdown
@@ -22,7 +22,7 @@ resource "aws_waf_regex_match_set" "example" {
       type = "HEADER"
     }
 
-    regex_pattern_set_id = "${aws_waf_regex_pattern_set.example.id}"
+    regex_pattern_set_id = aws_waf_regex_pattern_set.example.id
     text_transformation  = "NONE"
   }
 }

--- a/website/docs/r/waf_rule.html.markdown
+++ b/website/docs/r/waf_rule.html.markdown
@@ -28,7 +28,7 @@ resource "aws_waf_rule" "wafrule" {
   metric_name = "tfWAFRule"
 
   predicates {
-    data_id = "${aws_waf_ipset.ipset.id}"
+    data_id = aws_waf_ipset.ipset.id
     negated = false
     type    = "IPMatch"
   }

--- a/website/docs/r/waf_rule_group.html.markdown
+++ b/website/docs/r/waf_rule_group.html.markdown
@@ -28,7 +28,7 @@ resource "aws_waf_rule_group" "example" {
     }
 
     priority = 50
-    rule_id  = "${aws_waf_rule.example.id}"
+    rule_id  = aws_waf_rule.example.id
   }
 }
 ```

--- a/website/docs/r/waf_web_acl.html.markdown
+++ b/website/docs/r/waf_web_acl.html.markdown
@@ -28,7 +28,7 @@ resource "aws_waf_rule" "wafrule" {
   metric_name = "tfWAFRule"
 
   predicates {
-    data_id = "${aws_waf_ipset.ipset.id}"
+    data_id = aws_waf_ipset.ipset.id
     negated = false
     type    = "IPMatch"
   }
@@ -49,7 +49,7 @@ resource "aws_waf_web_acl" "waf_acl" {
     }
 
     priority = 1
-    rule_id  = "${aws_waf_rule.wafrule.id}"
+    rule_id  = aws_waf_rule.wafrule.id
     type     = "REGULAR"
   }
 }
@@ -63,7 +63,7 @@ resource "aws_waf_web_acl" "waf_acl" {
 resource "aws_waf_web_acl" "example" {
   # ... other configuration ...
   logging_configuration {
-    log_destination = "${aws_kinesis_firehose_delivery_stream.example.arn}"
+    log_destination = aws_kinesis_firehose_delivery_stream.example.arn
 
     redacted_fields {
       field_to_match {

--- a/website/docs/r/wafregional_rate_based_rule.html.markdown
+++ b/website/docs/r/wafregional_rate_based_rule.html.markdown
@@ -31,7 +31,7 @@ resource "aws_wafregional_rate_based_rule" "wafrule" {
   rate_limit = 100
 
   predicate {
-    data_id = "${aws_wafregional_ipset.ipset.id}"
+    data_id = aws_wafregional_ipset.ipset.id
     negated = false
     type    = "IPMatch"
   }

--- a/website/docs/r/wafregional_regex_match_set.html.markdown
+++ b/website/docs/r/wafregional_regex_match_set.html.markdown
@@ -22,7 +22,7 @@ resource "aws_wafregional_regex_match_set" "example" {
       type = "HEADER"
     }
 
-    regex_pattern_set_id = "${aws_wafregional_regex_pattern_set.example.id}"
+    regex_pattern_set_id = aws_wafregional_regex_pattern_set.example.id
     text_transformation  = "NONE"
   }
 }

--- a/website/docs/r/wafregional_rule.html.markdown
+++ b/website/docs/r/wafregional_rule.html.markdown
@@ -28,7 +28,7 @@ resource "aws_wafregional_rule" "wafrule" {
 
   predicate {
     type    = "IPMatch"
-    data_id = "${aws_wafregional_ipset.ipset.id}"
+    data_id = aws_wafregional_ipset.ipset.id
     negated = false
   }
 }

--- a/website/docs/r/wafregional_rule_group.html.markdown
+++ b/website/docs/r/wafregional_rule_group.html.markdown
@@ -28,7 +28,7 @@ resource "aws_wafregional_rule_group" "example" {
     }
 
     priority = 50
-    rule_id  = "${aws_wafregional_rule.example.id}"
+    rule_id  = aws_wafregional_rule.example.id
   }
 }
 ```

--- a/website/docs/r/wafregional_web_acl.html.markdown
+++ b/website/docs/r/wafregional_web_acl.html.markdown
@@ -29,7 +29,7 @@ resource "aws_wafregional_rule" "wafrule" {
   metric_name = "tfWAFRule"
 
   predicate {
-    data_id = "${aws_wafregional_ipset.ipset.id}"
+    data_id = aws_wafregional_ipset.ipset.id
     negated = false
     type    = "IPMatch"
   }
@@ -49,7 +49,7 @@ resource "aws_wafregional_web_acl" "wafacl" {
     }
 
     priority = 1
-    rule_id  = "${aws_wafregional_rule.wafrule.id}"
+    rule_id  = aws_wafregional_rule.wafrule.id
     type     = "REGULAR"
   }
 }
@@ -68,7 +68,7 @@ resource "aws_wafregional_web_acl" "example" {
 
   rule {
     priority = 1
-    rule_id  = "${aws_wafregional_rule_group.example.id}"
+    rule_id  = aws_wafregional_rule_group.example.id
     type     = "GROUP"
 
     override_action {
@@ -87,7 +87,7 @@ resource "aws_wafregional_web_acl" "example" {
   # ... other configuration ...
 
   logging_configuration {
-    log_destination = "${aws_kinesis_firehose_delivery_stream.example.arn}"
+    log_destination = aws_kinesis_firehose_delivery_stream.example.arn
 
     redacted_fields {
       field_to_match {

--- a/website/docs/r/wafregional_web_acl_association.html.markdown
+++ b/website/docs/r/wafregional_web_acl_association.html.markdown
@@ -29,7 +29,7 @@ resource "aws_wafregional_rule" "foo" {
   metric_name = "tfWAFRule"
 
   predicate {
-    data_id = "${aws_wafregional_ipset.ipset.id}"
+    data_id = aws_wafregional_ipset.ipset.id
     negated = false
     type    = "IPMatch"
   }
@@ -49,7 +49,7 @@ resource "aws_wafregional_web_acl" "foo" {
     }
 
     priority = 1
-    rule_id  = "${aws_wafregional_rule.foo.id}"
+    rule_id  = aws_wafregional_rule.foo.id
   }
 }
 
@@ -60,25 +60,25 @@ resource "aws_vpc" "foo" {
 data "aws_availability_zones" "available" {}
 
 resource "aws_subnet" "foo" {
-  vpc_id            = "${aws_vpc.foo.id}"
+  vpc_id            = aws_vpc.foo.id
   cidr_block        = "10.1.1.0/24"
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  availability_zone = data.aws_availability_zones.available.names[0]
 }
 
 resource "aws_subnet" "bar" {
-  vpc_id            = "${aws_vpc.foo.id}"
+  vpc_id            = aws_vpc.foo.id
   cidr_block        = "10.1.2.0/24"
-  availability_zone = "${data.aws_availability_zones.available.names[1]}"
+  availability_zone = data.aws_availability_zones.available.names[1]
 }
 
 resource "aws_alb" "foo" {
   internal = true
-  subnets  = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
+  subnets  = [aws_subnet.foo.id, aws_subnet.bar.id]
 }
 
 resource "aws_wafregional_web_acl_association" "foo" {
-  resource_arn = "${aws_alb.foo.arn}"
-  web_acl_id   = "${aws_wafregional_web_acl.foo.id}"
+  resource_arn = aws_alb.foo.arn
+  web_acl_id   = aws_wafregional_web_acl.foo.id
 }
 ```
 
@@ -99,7 +99,7 @@ resource "aws_wafregional_rule" "foo" {
   metric_name = "tfWAFRule"
 
   predicate {
-    data_id = "${aws_wafregional_ipset.ipset.id}"
+    data_id = aws_wafregional_ipset.ipset.id
     negated = false
     type    = "IPMatch"
   }
@@ -119,7 +119,7 @@ resource "aws_wafregional_web_acl" "foo" {
     }
 
     priority = 1
-    rule_id  = "${aws_wafregional_rule.foo.id}"
+    rule_id  = aws_wafregional_rule.foo.id
   }
 }
 resource "aws_api_gateway_rest_api" "test" {
@@ -127,57 +127,57 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 resource "aws_api_gateway_resource" "test" {
-  parent_id   = "${aws_api_gateway_rest_api.test.root_resource_id}"
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
   path_part   = "test"
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
 }
 
 resource "aws_api_gateway_method" "test" {
   authorization = "NONE"
   http_method   = "GET"
-  resource_id   = "${aws_api_gateway_resource.test.id}"
-  rest_api_id   = "${aws_api_gateway_rest_api.test.id}"
+  resource_id   = aws_api_gateway_resource.test.id
+  rest_api_id   = aws_api_gateway_rest_api.test.id
 }
 
 resource "aws_api_gateway_method_response" "test" {
-  http_method = "${aws_api_gateway_method.test.http_method}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  http_method = aws_api_gateway_method.test.http_method
+  resource_id = aws_api_gateway_resource.test.id
+  rest_api_id = aws_api_gateway_rest_api.test.id
   status_code = "400"
 }
 
 resource "aws_api_gateway_integration" "test" {
-  http_method             = "${aws_api_gateway_method.test.http_method}"
+  http_method             = aws_api_gateway_method.test.http_method
   integration_http_method = "GET"
-  resource_id             = "${aws_api_gateway_resource.test.id}"
-  rest_api_id             = "${aws_api_gateway_rest_api.test.id}"
+  resource_id             = aws_api_gateway_resource.test.id
+  rest_api_id             = aws_api_gateway_rest_api.test.id
   type                    = "HTTP"
   uri                     = "http://www.example.com"
 }
 
 resource "aws_api_gateway_integration_response" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_integration.test.http_method}"
-  status_code = "${aws_api_gateway_method_response.test.status_code}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_integration.test.http_method
+  status_code = aws_api_gateway_method_response.test.status_code
 }
 
 resource "aws_api_gateway_deployment" "test" {
   depends_on = ["aws_api_gateway_integration_response.test"]
 
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
 }
 
 resource "aws_api_gateway_stage" "test" {
-  deployment_id = "${aws_api_gateway_deployment.test.id}"
-  rest_api_id   = "${aws_api_gateway_rest_api.test.id}"
+  deployment_id = aws_api_gateway_deployment.test.id
+  rest_api_id   = aws_api_gateway_rest_api.test.id
   stage_name    = "test"
 }
 
 
 resource "aws_wafregional_web_acl_association" "association" {
-  resource_arn = "${aws_api_gateway_stage.test.arn}"
-  web_acl_id   = "${aws_wafregional_web_acl.foo.id}"
+  resource_arn = aws_api_gateway_stage.test.arn
+  web_acl_id   = aws_wafregional_web_acl.foo.id
 }
 ```
 

--- a/website/docs/r/worklink_fleet.html.markdown
+++ b/website/docs/r/worklink_fleet.html.markdown
@@ -25,9 +25,9 @@ resource "aws_worklink_fleet" "example" {
   name = "terraform-example"
 
   network {
-    vpc_id             = "${aws_vpc.test.id}"
-    subnet_ids         = ["${aws_subnet.test.*.id}"]
-    security_group_ids = ["${aws_security_group.test.id}"]
+    vpc_id             = aws_vpc.test.id
+    subnet_ids         = [aws_subnet.test.*.id]
+    security_group_ids = [aws_security_group.test.id]
   }
 }
 ```
@@ -40,7 +40,7 @@ resource "aws_worklink_fleet" "test" {
 
   identity_provider {
     type          = "SAML"
-    saml_metadata = "${file("saml-metadata.xml")}"
+    saml_metadata = file("saml-metadata.xml")
   }
 }
 ```

--- a/website/docs/r/worklink_website_certificate_authority_association.html.markdown
+++ b/website/docs/r/worklink_website_certificate_authority_association.html.markdown
@@ -16,8 +16,8 @@ resource "aws_worklink_fleet" "example" {
 }
 
 resource "aws_worklink_website_certificate_authority_association" "test" {
-  fleet_arn   = "${aws_worklink_fleet.test.arn}"
-  certificate = "${file("certificate.pem")}"
+  fleet_arn   = aws_worklink_fleet.test.arn
+  certificate = file("certificate.pem")
 }
 ```
 

--- a/website/docs/r/workspaces_directory.html.markdown
+++ b/website/docs/r/workspaces_directory.html.markdown
@@ -18,13 +18,13 @@ resource "aws_vpc" "main" {
 }
 
 resource "aws_subnet" "private-a" {
-  vpc_id            = "${aws_vpc.main.id}"
+  vpc_id            = aws_vpc.main.id
   availability_zone = "us-east-1a"
   cidr_block        = "10.0.0.0/24"
 }
 
 resource "aws_subnet" "private-b" {
-  vpc_id            = "${aws_vpc.main.id}"
+  vpc_id            = aws_vpc.main.id
   availability_zone = "us-east-1b"
   cidr_block        = "10.0.1.0/24"
 }
@@ -34,13 +34,13 @@ resource "aws_directory_service_directory" "main" {
   password = "#S1ncerely"
   size     = "Small"
   vpc_settings {
-    vpc_id     = "${aws_vpc.main.id}"
-    subnet_ids = ["${aws_subnet.private-a.id}", "${aws_subnet.private-b.id}"]
+    vpc_id     = aws_vpc.main.id
+    subnet_ids = [aws_subnet.private-a.id, aws_subnet.private-b.id]
   }
 }
 
 resource "aws_workspaces_directory" "main" {
-  directory_id = "${aws_directory_service_directory.main.id}"
+  directory_id = aws_directory_service_directory.main.id
 
   self_service_permissions = {
     increase_volume_size = true


### PR DESCRIPTION
This PR includes two commits. 

- The first one updates all of the example code in the AWS provider to remove "interpolation-only expressions". In Terraform 0.12, interpolating a lone value results in a deprecation warning; this update makes our examples 0.12 compliant (and nicer-looking), at the expense of breaking 0.11 compatibility. Is it time to do that yet? Maybe! It's probably worth taking a temperature check of product and support folks before merging this, but it seems like we might finally be at a point where it's worth making 0.11 usage less convenient. 
- The second commit refactors all the examples I could find that were using string interpolation to build complex IAM JSON documents. Those examples now construct native HCL object and tuple literals and pass them to the `jsonencode()` function. This was suggested by a community member over at https://github.com/hashicorp/terraform-website/issues/1047; the reason I did it now was because these examples were causing a bunch of false positives as I was searching for interpolation-only expressions, so when I went back through to un-break them, it seemed worthwhile to make them a little more robust. 

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```