### PR TITLE
New resource r/aws_wafv2_web_acl_association

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -895,6 +895,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_wafv2_regex_pattern_set":                             resourceAwsWafv2RegexPatternSet(),
 			"aws_wafv2_rule_group":                                    resourceAwsWafv2RuleGroup(),
 			"aws_wafv2_web_acl":                                       resourceAwsWafv2WebACL(),
+			"aws_wafv2_web_acl_association":                           resourceAwsWafv2WebACLAssociation(),
 			"aws_worklink_fleet":                                      resourceAwsWorkLinkFleet(),
 			"aws_worklink_website_certificate_authority_association":  resourceAwsWorkLinkWebsiteCertificateAuthorityAssociation(),
 			"aws_workspaces_directory":                                resourceAwsWorkspacesDirectory(),

--- a/aws/resource_aws_wafv2_web_acl_association.go
+++ b/aws/resource_aws_wafv2_web_acl_association.go
@@ -1,0 +1,137 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/wafv2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+const (
+	Wafv2WebACLAssociationCreateTimeout = 2 * time.Minute
+)
+
+func resourceAwsWafv2WebACLAssociation() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsWafv2WebACLAssociationCreate,
+		Read:   resourceAwsWafv2WebACLAssociationRead,
+		Delete: resourceAwsWafv2WebACLAssociationDelete,
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				webAclArn, resourceArn, err := resourceAwsWafv2ACLAssociationDecodeId(d.Id())
+				if err != nil {
+					return nil, fmt.Errorf("Error reading resource ID: %s", err)
+				}
+				d.Set("resource_arn", resourceArn)
+				d.Set("web_acl_arn", webAclArn)
+				return []*schema.ResourceData{d}, nil
+			},
+		},
+
+		Schema: map[string]*schema.Schema{
+			"resource_arn": {
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Required:     true,
+				ValidateFunc: validateArn,
+			},
+			"web_acl_arn": {
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Required:     true,
+				ValidateFunc: validateArn,
+			},
+		},
+	}
+}
+
+func resourceAwsWafv2WebACLAssociationCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafv2conn
+	resourceArn := d.Get("resource_arn").(string)
+	webAclArn := d.Get("web_acl_arn").(string)
+	params := &wafv2.AssociateWebACLInput{
+		ResourceArn: aws.String(resourceArn),
+		WebACLArn:   aws.String(webAclArn),
+	}
+
+	err := resource.Retry(Wafv2WebACLAssociationCreateTimeout, func() *resource.RetryError {
+		var err error
+		_, err = conn.AssociateWebACL(params)
+		if err != nil {
+			if isAWSErr(err, wafv2.ErrCodeWAFUnavailableEntityException, "") {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+
+	if isResourceTimeoutError(err) {
+		_, err = conn.AssociateWebACL(params)
+	}
+
+	if err != nil {
+		return err
+	}
+	d.SetId(fmt.Sprintf("%s,%s", webAclArn, resourceArn))
+
+	return resourceAwsWafv2WebACLAssociationRead(d, meta)
+}
+
+func resourceAwsWafv2WebACLAssociationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafv2conn
+	resourceArn := d.Get("resource_arn").(string)
+	webAclArn := d.Get("web_acl_arn").(string)
+	params := &wafv2.GetWebACLForResourceInput{
+		ResourceArn: aws.String(resourceArn),
+	}
+
+	resp, err := conn.GetWebACLForResource(params)
+	if err != nil {
+		if isAWSErr(err, wafv2.ErrCodeWAFNonexistentItemException, "") {
+			log.Printf("[WARN] WAFv2 Web ACL (%s) not found, removing from state", webAclArn)
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	if resp == nil || resp.WebACL == nil {
+		log.Printf("[WARN] WAFv2 Web ACL associated resource (%s) not found, removing from state", resourceArn)
+		d.SetId("")
+	}
+
+	return nil
+}
+
+func resourceAwsWafv2WebACLAssociationDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafv2conn
+
+	log.Printf("[INFO] Deleting WAFv2 Web ACL Association %s", d.Id())
+
+	params := &wafv2.DisassociateWebACLInput{
+		ResourceArn: aws.String(d.Get("resource_arn").(string)),
+	}
+
+	_, err := conn.DisassociateWebACL(params)
+	if err != nil {
+		return fmt.Errorf("Error disassociating WAFv2 Web ACL: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsWafv2ACLAssociationDecodeId(id string) (string, string, error) {
+	parts := strings.SplitN(id, ",", 2)
+
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("Unexpected format of ID (%s), expected WEB-ACL-ARN,RESOURCE-ARN", id)
+	}
+
+	return parts[0], parts[1], nil
+}

--- a/aws/resource_aws_wafv2_web_acl_association_test.go
+++ b/aws/resource_aws_wafv2_web_acl_association_test.go
@@ -1,0 +1,183 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/wafv2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccAwsWafv2WebACLAssociation_Basic(t *testing.T) {
+	testName := fmt.Sprintf("web-acl-association-%s", acctest.RandString(5))
+	resourceName := "aws_wafv2_web_acl_association.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafv2WebACLAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsWafv2WebACLAssociationConfig(testName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafv2WebACLAssociationExists(resourceName),
+					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "resource_arn", "apigateway", regexp.MustCompile(fmt.Sprintf("/restapis/.*/stages/%s", testName))),
+					testAccMatchResourceAttrRegionalARN(resourceName, "web_acl_arn", "wafv2", regexp.MustCompile(fmt.Sprintf("regional/webacl/%s/.*", testName))),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccAWSWafv2WebACLAssociationImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func TestAccAwsWafv2WebACLAssociation_Disappears(t *testing.T) {
+	testName := fmt.Sprintf("web-acl-association-%s", acctest.RandString(5))
+	resourceName := "aws_wafv2_web_acl_association.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafv2WebACLAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsWafv2WebACLAssociationConfig(testName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafv2WebACLAssociationExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsWafv2WebACLAssociation(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccAwsWafv2WebACLAssociationConfig(testName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafv2WebACLAssociationExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsApiGatewayStage(), "aws_api_gateway_stage.test"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSWafv2WebACLAssociationDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_wafv2_web_acl_association" {
+			continue
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).wafv2conn
+		resp, err := conn.GetWebACLForResource(&wafv2.GetWebACLForResourceInput{
+			ResourceArn: aws.String(rs.Primary.Attributes["resource_arn"]),
+		})
+
+		if err == nil {
+			if resp == nil || resp.WebACL == nil {
+				return fmt.Errorf("Error getting WAFv2 WebACLAssociation")
+			}
+
+			id := fmt.Sprintf("%s,%s", aws.StringValue(resp.WebACL.ARN), rs.Primary.Attributes["resource_arn"])
+			if id == rs.Primary.ID {
+				return fmt.Errorf("WAFv2 WebACLAssociation %s still exists", rs.Primary.ID)
+			}
+			return nil
+		}
+
+		// Return nil if the Web ACL Association is already destroyed
+		if isAWSErr(err, wafv2.ErrCodeWAFNonexistentItemException, "") {
+			return nil
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func testAccCheckAWSWafv2WebACLAssociationExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+		return nil
+	}
+}
+
+func testAccAwsWafv2WebACLAssociationConfig(name string) string {
+	return fmt.Sprintf(`
+resource "aws_api_gateway_stage" "test" {
+  stage_name    = "%s"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  deployment_id = aws_api_gateway_deployment.test.id
+}
+
+resource "aws_api_gateway_rest_api" "test" {
+  name = "%s"
+}
+
+resource "aws_api_gateway_deployment" "test" {
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  depends_on  = [aws_api_gateway_integration.test]
+}
+
+resource "aws_api_gateway_integration" "test" {
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
+  type        = "MOCK"
+}
+
+resource "aws_api_gateway_resource" "test" {
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
+  path_part   = "mytestresource"
+}
+
+resource "aws_api_gateway_method" "test" {
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
+  http_method   = "GET"
+  authorization = "NONE"
+}
+
+resource "aws_wafv2_web_acl" "test" {
+  name  = "%s"
+  scope = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+
+resource "aws_wafv2_web_acl_association" "test" {
+  resource_arn = aws_api_gateway_stage.test.arn
+  web_acl_arn  = aws_wafv2_web_acl.test.arn
+}
+`, name, name, name)
+}
+
+func testAccAWSWafv2WebACLAssociationImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s,%s", rs.Primary.Attributes["web_acl_arn"], rs.Primary.Attributes["resource_arn"]), nil
+	}
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -3595,6 +3595,9 @@
                                 <li>
                                     <a href="/docs/providers/aws/r/wafv2_web_acl.html">aws_wafv2_web_acl</a>
                                 </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/wafv2_web_acl_association.html">aws_wafv2_web_acl_association</a>
+                                </li>
                             </ul>
                         </li>
                     </ul>

--- a/website/docs/r/wafv2_web_acl_association.html.markdown
+++ b/website/docs/r/wafv2_web_acl_association.html.markdown
@@ -1,0 +1,87 @@
+---
+subcategory: "WAFv2"
+layout: "aws"
+page_title: "AWS: aws_wafv2_web_acl_association"
+description: |-
+  Creates a WAFv2 Web ACL Association.
+---
+
+# Resource: aws_wafv2_web_acl_association
+
+Creates a WAFv2 Web ACL Association.
+
+## Example Usage
+
+```hcl
+resource "aws_api_gateway_stage" "example" {
+  stage_name    = "test"
+  rest_api_id   = aws_api_gateway_rest_api.example.id
+  deployment_id = aws_api_gateway_deployment.example.id
+}
+
+resource "aws_api_gateway_rest_api" "example" {
+  name = "web-acl-association-example"
+}
+
+resource "aws_api_gateway_deployment" "example" {
+  rest_api_id = aws_api_gateway_rest_api.example.id
+  depends_on  = [aws_api_gateway_integration.example]
+}
+
+resource "aws_api_gateway_integration" "example" {
+  rest_api_id = aws_api_gateway_rest_api.example.id
+  resource_id = aws_api_gateway_resource.example.id
+  http_method = aws_api_gateway_method.example.http_method
+  type        = "MOCK"
+}
+
+resource "aws_api_gateway_resource" "example" {
+  rest_api_id = aws_api_gateway_rest_api.example.id
+  parent_id   = aws_api_gateway_rest_api.example.root_resource_id
+  path_part   = "mytestresource"
+}
+
+resource "aws_api_gateway_method" "example" {
+  rest_api_id   = aws_api_gateway_rest_api.example.id
+  resource_id   = aws_api_gateway_resource.example.id
+  http_method   = "GET"
+  authorization = "NONE"
+}
+
+resource "aws_wafv2_web_acl" "example" {
+  name  = "web-acl-association-example"
+  scope = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+
+resource "aws_wafv2_web_acl_association" "example" {
+  resource_arn = aws_api_gateway_stage.example.arn
+  web_acl_arn  = aws_wafv2_web_acl.example.arn
+}
+
+```
+
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `resource_arn` - (Required) The Amazon Resource Name (ARN) of the resource to associate with the web ACL. This must be an ARN of an Application Load Balancer or an Amazon API Gateway stage.
+* `web_acl_arn` - (Required) The Amazon Resource Name (ARN) of the Web ACL that you want to associate with the resource.
+
+## Import
+
+WAFv2 Web ACL Association can be imported using `WEB_ACL_ARN,RESOURCE_ARN` e.g.
+
+```
+$ terraform import aws_wafv2_web_acl_association.example arn:aws:wafv2:...7ce849ea,arn:aws:apigateway:...ages/name
+```


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #11177
Relates #11046

This PR can not be merged before  #12688 because of copied dependencies.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
```release-note
* **New Resource**: `aws_wafv2_web_acl_association` (#12698)
```

Output from acceptance testing:

```
make testacc TEST=./aws TESTARGS='-run=TestAccAwsWafv2WebACLAssociation'
...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsWafv2WebACLAssociation -timeout 120m
=== RUN   TestAccAwsWafv2WebACLAssociation_Basic
=== PAUSE TestAccAwsWafv2WebACLAssociation_Basic
=== CONT  TestAccAwsWafv2WebACLAssociation_Basic
--- PASS: TestAccAwsWafv2WebACLAssociation_Basic (83.75s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       84.276s
```
