### PR TITLE
resource/aws_appautoscaling_scheduled_action: Include ResourceId in DescribeScheduledActions API call

### DIFF
--- a/aws/resource_aws_appautoscaling_scheduled_action_test.go
+++ b/aws/resource_aws_appautoscaling_scheduled_action_test.go
@@ -63,6 +63,27 @@ func TestAccAWSAppautoscalingScheduledAction_EMR(t *testing.T) {
 	})
 }
 
+func TestAccAWSAppautoscalingScheduledAction_Name_Duplicate(t *testing.T) {
+	resourceName := "aws_appautoscaling_scheduled_action.test"
+	resourceName2 := "aws_appautoscaling_scheduled_action.test2"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsAppautoscalingScheduledActionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppautoscalingScheduledActionConfig_Name_Duplicate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppautoscalingScheduledActionExists(resourceName),
+					testAccCheckAwsAppautoscalingScheduledActionExists(resourceName2),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSAppautoscalingScheduledAction_SpotFleet(t *testing.T) {
 	ts := time.Now().AddDate(0, 0, 1).Format("2006-01-02T15:04:05")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
@@ -91,6 +112,7 @@ func testAccCheckAwsAppautoscalingScheduledActionDestroy(s *terraform.State) err
 		}
 
 		input := &applicationautoscaling.DescribeScheduledActionsInput{
+			ResourceId:           aws.String(rs.Primary.Attributes["resource_id"]),
 			ScheduledActionNames: []*string{aws.String(rs.Primary.Attributes["name"])},
 			ServiceNamespace:     aws.String(rs.Primary.Attributes["service_namespace"]),
 		}
@@ -529,6 +551,76 @@ resource "aws_appautoscaling_scheduled_action" "hoge" {
   }
 }
 `, rName, rName, rName, rName, ts)
+}
+
+func testAccAppautoscalingScheduledActionConfig_Name_Duplicate(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "test2" {
+  name           = "%[1]s-2"
+  read_capacity  = 1
+  write_capacity = 1
+  hash_key       = "UserID"
+
+  attribute {
+    name = "UserID"
+    type = "S"
+  }
+}
+
+resource "aws_appautoscaling_target" "test2" {
+  service_namespace  = "dynamodb"
+  resource_id        = "table/${aws_dynamodb_table.test2.name}"
+  scalable_dimension = "dynamodb:table:ReadCapacityUnits"
+  min_capacity       = 1
+  max_capacity       = 10
+}
+
+resource "aws_appautoscaling_scheduled_action" "test2" {
+  name               = %[1]q
+  service_namespace  = aws_appautoscaling_target.test2.service_namespace
+  resource_id        = aws_appautoscaling_target.test2.resource_id
+  scalable_dimension = aws_appautoscaling_target.test2.scalable_dimension
+  schedule           = "cron(0 17 * * ? *)"
+
+  scalable_target_action {
+    min_capacity = 1
+    max_capacity = 10
+  }
+}
+
+resource "aws_dynamodb_table" "test" {
+  name           = %[1]q
+  read_capacity  = 1
+  write_capacity = 1
+  hash_key       = "UserID"
+
+  attribute {
+    name = "UserID"
+    type = "S"
+  }
+}
+
+resource "aws_appautoscaling_target" "test" {
+  service_namespace  = "dynamodb"
+  resource_id        = "table/${aws_dynamodb_table.test.name}"
+  scalable_dimension = "dynamodb:table:ReadCapacityUnits"
+  min_capacity       = 1
+  max_capacity       = 10
+}
+
+resource "aws_appautoscaling_scheduled_action" "test" {
+  name               = %[1]q
+  service_namespace  = aws_appautoscaling_target.test.service_namespace
+  resource_id        = aws_appautoscaling_target.test.resource_id
+  scalable_dimension = aws_appautoscaling_target.test.scalable_dimension
+  schedule           = "cron(0 17 * * ? *)"
+
+  scalable_target_action {
+    min_capacity = 1
+    max_capacity = 10
+  }
+}
+`, rName)
 }
 
 func testAccAppautoscalingScheduledActionConfig_SpotFleet(rName, ts, validUntil string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12615

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_appautoscaling_scheduled_action: Prevent error on refresh with multiple resources using the same scheduled action name
```

Previously:

```
=== CONT  TestAccAWSAppautoscalingScheduledAction_Name_Duplicate
    TestAccAWSAppautoscalingScheduledAction_Name_Duplicate: testing.go:654: Step 0 error: errors during apply:

        Error: Expected 1 scheduled action under tf-acc-test-7945960136368617828, found 2

          on /var/folders/w8/05f3x02n27x72g0mc2jy6_180000gp/T/tf-test277682481/main.tf line 55:
          (source code not available)

        Error: Expected 1 scheduled action under tf-acc-test-7945960136368617828, found 2

          on /var/folders/w8/05f3x02n27x72g0mc2jy6_180000gp/T/tf-test277682481/main.tf line 22:
          (source code not available)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSAppautoscalingScheduledAction_dynamo (33.49s)
--- PASS: TestAccAWSAppautoscalingScheduledAction_Name_Duplicate (34.71s)
--- PASS: TestAccAWSAppautoscalingScheduledAction_SpotFleet (78.77s)
--- PASS: TestAccAWSAppautoscalingScheduledAction_ECS (81.26s)
--- PASS: TestAccAWSAppautoscalingScheduledAction_EMR (678.71s)
```
