### PR TITLE
Fix for creating an RDS read replica in shared subnets.

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -642,8 +642,11 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 		}
 
 		if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
-			modifyDbInstanceInput.VpcSecurityGroupIds = expandStringSet(attr)
-			requiresModifyDbInstance = true
+			var s []*string
+			for _, v := range attr.List() {
+				s = append(s, aws.String(v.(string)))
+			}
+			opts.VpcSecurityGroupIds = s
 		}
 
 		if attr, ok := d.GetOk("performance_insights_enabled"); ok {

--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -642,11 +642,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 		}
 
 		if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
-			var s []*string
-			for _, v := range attr.List() {
-				s = append(s, aws.String(v.(string)))
-			}
-			opts.VpcSecurityGroupIds = s
+			opts.VpcSecurityGroupIds = expandStringSet(attr)
 		}
 
 		if attr, ok := d.GetOk("performance_insights_enabled"); ok {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Relates to #12447

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_db_instance: Fixes bug when creating a read replica is not possible in a shared subnet
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSDBInstance_Replicate -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_AllocatedStorage
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_AllocatedStorage
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_AllowMajorVersionUpgrade
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_AllowMajorVersionUpgrade
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_AutoMinorVersionUpgrade
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_AutoMinorVersionUpgrade
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_AvailabilityZone
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_AvailabilityZone
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_BackupRetentionPeriod
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_BackupRetentionPeriod
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_BackupWindow
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_BackupWindow
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_DeletionProtection
    TestAccAWSDBInstance_ReplicateSourceDb_DeletionProtection: resource_aws_db_instance_test.go:681: CreateDBInstanceReadReplica API currently ignores DeletionProtection=true with SourceDBInstanceIdentifier set
--- SKIP: TestAccAWSDBInstance_ReplicateSourceDb_DeletionProtection (0.00s)
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_IamDatabaseAuthenticationEnabled
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_IamDatabaseAuthenticationEnabled
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_MaintenanceWindow
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_MaintenanceWindow
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_MaxAllocatedStorage
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_MaxAllocatedStorage
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_Monitoring
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_Monitoring
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_MultiAZ
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_MultiAZ
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_ParameterGroupName
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_ParameterGroupName
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_Port
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_Port
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_VpcSecurityGroupIds
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_VpcSecurityGroupIds
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_CACertificateIdentifier
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_CACertificateIdentifier
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_MaxAllocatedStorage
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_BackupRetentionPeriod
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_AllocatedStorage
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_IamDatabaseAuthenticationEnabled
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_CACertificateIdentifier
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_VpcSecurityGroupIds
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_Port
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_ParameterGroupName
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_MultiAZ
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_AutoMinorVersionUpgrade
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_Monitoring
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_AvailabilityZone
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_AllowMajorVersionUpgrade
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_BackupWindow
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_MaintenanceWindow
    TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled: testing.go:654: Step 0 error: errors during apply:

        Error: Error creating DB Instance: InvalidParameterValue: Invalid DB Instance class: db.m3.medium
        	status code: 400, request id: f7b3e85c-419e-4445-8676-272a435185be, {
          AllocatedStorage: 5,
          AutoMinorVersionUpgrade: true,
          BackupRetentionPeriod: 1,
          CopyTagsToSnapshot: false,
          DBInstanceClass: "db.m3.medium",
          DBInstanceIdentifier: "tf-acc-test-1229761817474322291-source",
          DBName: "",
          DeletionProtection: false,
          Engine: "mysql",
          EngineVersion: "5.6.41",
          MasterUserPassword: "********",
          MasterUsername: "tfacctest",
          PubliclyAccessible: false,
          StorageEncrypted: false,
          Tags: []
        }

          on /var/folders/hv/wjl96v4s2x91w2zgdpnhhlzc0000gp/T/tf-test168956943/main.tf line 24:
          (source code not available)


--- FAIL: TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled (31.12s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AvailabilityZone (1364.73s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AutoMinorVersionUpgrade (1378.69s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_BackupWindow (1379.05s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_VpcSecurityGroupIds (1385.34s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MaxAllocatedStorage (1400.86s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_Port (1419.14s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_IamDatabaseAuthenticationEnabled (1480.54s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AllowMajorVersionUpgrade (1480.71s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_ParameterGroupName (1526.81s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MaintenanceWindow (1583.22s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_Monitoring (1591.07s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_CACertificateIdentifier (1604.92s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb (1831.65s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_BackupRetentionPeriod (1893.22s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AllocatedStorage (1894.13s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MultiAZ (1934.05s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	1935.811s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.406s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.261s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/naming	0.618s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/batch/equivalency	0.578s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks/token	0.400s [no tests to run]
?   	github.com/terraform-providers/terraform-provider-aws/awsproviderlint	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes	0.560s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSAT001	0.839s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSR001	0.201s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/fmtsprintfcallexpr	0.377s [no tests to run]
FAIL
make: *** [testacc] Error 1
➜  terraform-provider-aws git:(rds-read-replica-vpc-sg-ids) AWS_REGION=us-east-2 AWS_PROFILE=nulogy-experiments make testacc TESTARGS='-run=TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled
    TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled: testing.go:654: Step 0 error: errors during apply:

        Error: Error creating DB Instance: InvalidParameterValue: Invalid DB Instance class: db.m3.medium
        	status code: 400, request id: 57bfc747-24eb-4374-86f7-97dc7a5b77ee, {
          AllocatedStorage: 5,
          AutoMinorVersionUpgrade: true,
          BackupRetentionPeriod: 1,
          CopyTagsToSnapshot: false,
          DBInstanceClass: "db.m3.medium",
          DBInstanceIdentifier: "tf-acc-test-5032721235224304652-source",
          DBName: "",
          DeletionProtection: false,
          Engine: "mysql",
          EngineVersion: "5.6.41",
          MasterUserPassword: "********",
          MasterUsername: "tfacctest",
          PubliclyAccessible: false,
          StorageEncrypted: false,
          Tags: []
        }

          on /var/folders/hv/wjl96v4s2x91w2zgdpnhhlzc0000gp/T/tf-test427715136/main.tf line 24:
          (source code not available)


--- FAIL: TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled (30.99s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	32.785s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.346s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.257s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/naming	0.321s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/batch/equivalency	0.431s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks/token	0.463s [no tests to run]
?   	github.com/terraform-providers/terraform-provider-aws/awsproviderlint	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes	0.312s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSAT001	0.437s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSR001	0.248s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/fmtsprintfcallexpr	0.171s [no tests to run]
FAIL
make: *** [testacc] Error 1

------------
I had to rerun this test in us-east-1
-----------

➜  terraform-provider-aws git:(rds-read-replica-vpc-sg-ids) AWS_REGION=us-east-1  make testacc TESTARGS='-run=TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled
=== PAUSE TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled
=== CONT  TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled (1655.57s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1657.313s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.291s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.333s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/naming	0.571s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/batch/equivalency	0.397s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks/token	0.298s [no tests to run]
?   	github.com/terraform-providers/terraform-provider-aws/awsproviderlint	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes	0.381s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSAT001	0.708s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSR001	0.135s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/fmtsprintfcallexpr	0.109s [no tests to run]

...
```
