### PR TITLE
r/aws_iot_topic_rule: Add support for 'operation' in DynamoDB action

### DIFF
--- a/aws/resource_aws_iot_topic_rule.go
+++ b/aws/resource_aws_iot_topic_rule.go
@@ -144,6 +144,11 @@ func resourceAwsIotTopicRule() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
+						"operation": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validateIoTRuleDynamoDBOperation,
+						},
 					},
 				},
 			},
@@ -401,6 +406,9 @@ func createTopicRulePayload(d *schema.ResourceData) *iot.TopicRulePayload {
 		}
 		if v, ok := raw["payload_field"].(string); ok && v != "" {
 			act.DynamoDB.PayloadField = aws.String(v)
+		}
+		if v, ok := raw["operation"].(string); ok && v != "" {
+			act.DynamoDB.Operation = aws.String(v)
 		}
 		actions[i] = act
 		i++

--- a/aws/resource_aws_iot_topic_rule_test.go
+++ b/aws/resource_aws_iot_topic_rule_test.go
@@ -481,7 +481,7 @@ resource "aws_iot_topic_rule" "rule" {
     hash_key_value = "hash_key_value"
     payload_field = "payload_field"
     role_arn = "${aws_iam_role.iot_role.arn}"
-    table_name = "table_name"
+	table_name = "table_name"
   }
 }
 `, rName)
@@ -504,7 +504,8 @@ resource "aws_iot_topic_rule" "rule" {
     range_key_value = "range_key_value"
     range_key_type  = "STRING"
     role_arn = "${aws_iam_role.iot_role.arn}"
-    table_name = "table_name"
+	table_name = "table_name"
+	operation = "INSERT"
   }
 }
 `, rName)

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -2809,6 +2809,10 @@ func flattenIoTRuleDynamoDbActions(actions []*iot.Action) []map[string]interface
 				m["range_key_value"] = aws.StringValue(v.RangeKeyValue)
 			}
 
+			if v.Operation != nil {
+				m["operation"] = aws.StringValue(v.Operation)
+			}
+
 			items = append(items, m)
 		}
 	}

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -754,6 +754,18 @@ func validateHTTPMethod() schema.SchemaValidateFunc {
 	}, false)
 }
 
+func validateIoTRuleDynamoDBOperation(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	pattern := `^INSERT|UPDATE|DELETE$`
+	if !regexp.MustCompile(pattern).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q isn't a valid operation. Use INSERT, UPDATE, or DELETE",
+			k))
+	}
+
+	return
+}
+
 func validateLogMetricFilterName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 

--- a/website/docs/r/iot_topic_rule.html.markdown
+++ b/website/docs/r/iot_topic_rule.html.markdown
@@ -102,6 +102,7 @@ The `dynamodb` object takes the following arguments:
 * `range_key_field` - (Optional) The range key name.
 * `range_key_type` - (Optional) The range key type. Valid values are "STRING" or "NUMBER".
 * `range_key_value` - (Optional) The range key value.
+* `operation` - (Optional) The operation. Valid values are "INSERT", "UPDATE", or "DELETE".
 * `role_arn` - (Required) The ARN of the IAM role that grants access to the DynamoDB table.
 * `table_name` - (Required) The name of the DynamoDB table.
 


### PR DESCRIPTION
This provider did not support the _operation_ parameter when using a DynamoDB action on an IoT rule. This PR adds that support.   It was already supported by the AWS SDK, so adding support for this was straightforward.  Verified that tests pass with and without the optional _operation_ parameter.  Added a test to make sure the _operation_ parameter is one of INSERT, UPDATE, or DELETE.



<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Adds "operation" support for the IoT Rule DyanmoDB action (INSERT, UPDATE, or DELETE).
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSIoTTopicRule_dynamodb'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSIoTTopicRule_dynamodb -timeout 120m
=== RUN   TestAccAWSIoTTopicRule_dynamodb
=== PAUSE TestAccAWSIoTTopicRule_dynamodb
=== CONT  TestAccAWSIoTTopicRule_dynamodb
--- PASS: TestAccAWSIoTTopicRule_dynamodb (35.80s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	37.164s
...
```
