### PR TITLE
service/acm: Update acceptance tests to use ARN testing check functions 

### DIFF
--- a/aws/data_source_aws_acm_certificate_test.go
+++ b/aws/data_source_aws_acm_certificate_test.go
@@ -41,36 +41,42 @@ func TestAccAWSAcmCertificateDataSource_singleIssued(t *testing.T) {
 			{
 				Config: testAccCheckAwsAcmCertificateDataSourceConfig(domain),
 				Check: resource.ComposeTestCheckFunc(
+					//lintignore:AWSAT001
 					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
 				),
 			},
 			{
 				Config: testAccCheckAwsAcmCertificateDataSourceConfigWithStatus(domain, acm.CertificateStatusIssued),
 				Check: resource.ComposeTestCheckFunc(
+					//lintignore:AWSAT001
 					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
 				),
 			},
 			{
 				Config: testAccCheckAwsAcmCertificateDataSourceConfigWithTypes(domain, acm.CertificateTypeAmazonIssued),
 				Check: resource.ComposeTestCheckFunc(
+					//lintignore:AWSAT001
 					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
 				),
 			},
 			{
 				Config: testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecent(domain, true),
 				Check: resource.ComposeTestCheckFunc(
+					//lintignore:AWSAT001
 					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
 				),
 			},
 			{
 				Config: testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecentAndStatus(domain, acm.CertificateStatusIssued, true),
 				Check: resource.ComposeTestCheckFunc(
+					//lintignore:AWSAT001
 					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
 				),
 			},
 			{
 				Config: testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecentAndTypes(domain, acm.CertificateTypeAmazonIssued, true),
 				Check: resource.ComposeTestCheckFunc(
+					//lintignore:AWSAT001
 					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
 				),
 			},
@@ -119,18 +125,21 @@ func TestAccAWSAcmCertificateDataSource_multipleIssued(t *testing.T) {
 			{
 				Config: testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecent(domain, true),
 				Check: resource.ComposeTestCheckFunc(
+					//lintignore:AWSAT001
 					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
 				),
 			},
 			{
 				Config: testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecentAndStatus(domain, acm.CertificateStatusIssued, true),
 				Check: resource.ComposeTestCheckFunc(
+					//lintignore:AWSAT001
 					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
 				),
 			},
 			{
 				Config: testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecentAndTypes(domain, acm.CertificateTypeAmazonIssued, true),
 				Check: resource.ComposeTestCheckFunc(
+					//lintignore:AWSAT001
 					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
 				),
 			},

--- a/aws/resource_aws_acm_certificate_test.go
+++ b/aws/resource_aws_acm_certificate_test.go
@@ -16,8 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-var certificateArnRegex = regexp.MustCompile(`^arn:aws:acm:[^:]+:[^:]+:certificate/.+$`)
-
 func testAccAwsAcmCertificateDomainFromEnv(t *testing.T) string {
 	rootDomain := os.Getenv("ACM_CERTIFICATE_ROOT_DOMAIN")
 
@@ -64,7 +62,7 @@ func TestAccAWSAcmCertificate_emailValidation(t *testing.T) {
 			{
 				Config: testAccAcmCertificateConfig(domain, acm.ValidationMethodEmail),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(resourceName, "arn", certificateArnRegex),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "acm", regexp.MustCompile("certificate/.+$")),
 					resource.TestCheckResourceAttr(resourceName, "domain_name", domain),
 					resource.TestCheckResourceAttr(resourceName, "domain_validation_options.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "subject_alternative_names.#", "0"),
@@ -95,7 +93,7 @@ func TestAccAWSAcmCertificate_dnsValidation(t *testing.T) {
 			{
 				Config: testAccAcmCertificateConfig(domain, acm.ValidationMethodDns),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(resourceName, "arn", certificateArnRegex),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "acm", regexp.MustCompile("certificate/.+$")),
 					resource.TestCheckResourceAttr(resourceName, "domain_name", domain),
 					resource.TestCheckResourceAttr(resourceName, "domain_validation_options.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "domain_validation_options.0.domain_name", domain),
@@ -128,7 +126,7 @@ func TestAccAWSAcmCertificate_root(t *testing.T) {
 			{
 				Config: testAccAcmCertificateConfig(rootDomain, acm.ValidationMethodDns),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(resourceName, "arn", certificateArnRegex),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "acm", regexp.MustCompile("certificate/.+$")),
 					resource.TestCheckResourceAttr(resourceName, "domain_name", rootDomain),
 					resource.TestCheckResourceAttr(resourceName, "domain_validation_options.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "domain_validation_options.0.domain_name", rootDomain),
@@ -162,7 +160,7 @@ func TestAccAWSAcmCertificate_privateCert(t *testing.T) {
 			{
 				Config: testAccAcmCertificateConfig_privateCert(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(resourceName, "arn", certificateArnRegex),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "acm", regexp.MustCompile("certificate/.+$")),
 					resource.TestCheckResourceAttr(resourceName, "domain_name", fmt.Sprintf("%s.terraformtesting.com", rName)),
 					resource.TestCheckResourceAttr(resourceName, "domain_validation_options.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "subject_alternative_names.#", "0"),
@@ -227,7 +225,7 @@ func TestAccAWSAcmCertificate_rootAndWildcardSan(t *testing.T) {
 			{
 				Config: testAccAcmCertificateConfig_subjectAlternativeNames(rootDomain, strconv.Quote(wildcardDomain), acm.ValidationMethodDns),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(resourceName, "arn", certificateArnRegex),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "acm", regexp.MustCompile("certificate/.+$")),
 					resource.TestCheckResourceAttr(resourceName, "domain_name", rootDomain),
 					resource.TestCheckResourceAttr(resourceName, "domain_validation_options.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "domain_validation_options.0.domain_name", rootDomain),
@@ -267,7 +265,7 @@ func TestAccAWSAcmCertificate_san_single(t *testing.T) {
 			{
 				Config: testAccAcmCertificateConfig_subjectAlternativeNames(domain, strconv.Quote(sanDomain), acm.ValidationMethodDns),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(resourceName, "arn", certificateArnRegex),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "acm", regexp.MustCompile("certificate/.+$")),
 					resource.TestCheckResourceAttr(resourceName, "domain_name", domain),
 					resource.TestCheckResourceAttr(resourceName, "domain_validation_options.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "domain_validation_options.0.domain_name", domain),
@@ -308,7 +306,7 @@ func TestAccAWSAcmCertificate_san_multiple(t *testing.T) {
 			{
 				Config: testAccAcmCertificateConfig_subjectAlternativeNames(domain, fmt.Sprintf("%q, %q", sanDomain1, sanDomain2), acm.ValidationMethodDns),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(resourceName, "arn", certificateArnRegex),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "acm", regexp.MustCompile("certificate/.+$")),
 					resource.TestCheckResourceAttr(resourceName, "domain_name", domain),
 					resource.TestCheckResourceAttr(resourceName, "domain_validation_options.#", "3"),
 					resource.TestCheckResourceAttr(resourceName, "domain_validation_options.0.domain_name", domain),
@@ -392,7 +390,7 @@ func TestAccAWSAcmCertificate_wildcard(t *testing.T) {
 			{
 				Config: testAccAcmCertificateConfig(wildcardDomain, acm.ValidationMethodDns),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(resourceName, "arn", certificateArnRegex),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "acm", regexp.MustCompile("certificate/.+$")),
 					resource.TestCheckResourceAttr(resourceName, "domain_name", wildcardDomain),
 					resource.TestCheckResourceAttr(resourceName, "domain_validation_options.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "domain_validation_options.0.domain_name", wildcardDomain),
@@ -426,7 +424,7 @@ func TestAccAWSAcmCertificate_wildcardAndRootSan(t *testing.T) {
 			{
 				Config: testAccAcmCertificateConfig_subjectAlternativeNames(wildcardDomain, strconv.Quote(rootDomain), acm.ValidationMethodDns),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(resourceName, "arn", certificateArnRegex),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "acm", regexp.MustCompile("certificate/.+$")),
 					resource.TestCheckResourceAttr(resourceName, "domain_name", wildcardDomain),
 					resource.TestCheckResourceAttr(resourceName, "domain_validation_options.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "domain_validation_options.0.domain_name", wildcardDomain),
@@ -464,7 +462,7 @@ func TestAccAWSAcmCertificate_disableCTLogging(t *testing.T) {
 			{
 				Config: testAccAcmCertificateConfig_disableCTLogging(rootDomain, acm.ValidationMethodDns),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(resourceName, "arn", certificateArnRegex),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "acm", regexp.MustCompile("certificate/.+$")),
 					resource.TestCheckResourceAttr(resourceName, "domain_name", rootDomain),
 					resource.TestCheckResourceAttr(resourceName, "domain_validation_options.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "domain_validation_options.0.domain_name", rootDomain),

--- a/aws/resource_aws_acm_certificate_validation_test.go
+++ b/aws/resource_aws_acm_certificate_validation_test.go
@@ -23,7 +23,7 @@ func TestAccAWSAcmCertificateValidation_basic(t *testing.T) {
 			{
 				Config: testAccAcmCertificateValidation_basic(rootDomain, domain),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("aws_acm_certificate_validation.cert", "certificate_arn", certificateArnRegex),
+					testAccMatchResourceAttrRegionalARN("aws_acm_certificate_validation.cert", "certificate_arn", "acm", regexp.MustCompile("certificate/.+$")),
 				),
 			},
 		},
@@ -65,7 +65,7 @@ func TestAccAWSAcmCertificateValidation_validationRecordFqdns(t *testing.T) {
 			{
 				Config: testAccAcmCertificateValidation_validationRecordFqdnsOneRoute53Record(rootDomain, domain),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("aws_acm_certificate_validation.cert", "certificate_arn", certificateArnRegex),
+					testAccMatchResourceAttrRegionalARN("aws_acm_certificate_validation.cert", "certificate_arn", "acm", regexp.MustCompile("certificate/.+$")),
 				),
 			},
 		},
@@ -100,7 +100,7 @@ func TestAccAWSAcmCertificateValidation_validationRecordFqdnsRoot(t *testing.T) 
 			{
 				Config: testAccAcmCertificateValidation_validationRecordFqdnsOneRoute53Record(rootDomain, rootDomain),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("aws_acm_certificate_validation.cert", "certificate_arn", certificateArnRegex),
+					testAccMatchResourceAttrRegionalARN("aws_acm_certificate_validation.cert", "certificate_arn", "acm", regexp.MustCompile("certificate/.+$")),
 				),
 			},
 		},
@@ -119,7 +119,7 @@ func TestAccAWSAcmCertificateValidation_validationRecordFqdnsRootAndWildcard(t *
 			{
 				Config: testAccAcmCertificateValidation_validationRecordFqdnsTwoRoute53Records(rootDomain, rootDomain, strconv.Quote(wildcardDomain)),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("aws_acm_certificate_validation.cert", "certificate_arn", certificateArnRegex),
+					testAccMatchResourceAttrRegionalARN("aws_acm_certificate_validation.cert", "certificate_arn", "acm", regexp.MustCompile("certificate/.+$")),
 				),
 			},
 		},
@@ -139,7 +139,7 @@ func TestAccAWSAcmCertificateValidation_validationRecordFqdnsSan(t *testing.T) {
 			{
 				Config: testAccAcmCertificateValidation_validationRecordFqdnsTwoRoute53Records(rootDomain, domain, strconv.Quote(sanDomain)),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("aws_acm_certificate_validation.cert", "certificate_arn", certificateArnRegex),
+					testAccMatchResourceAttrRegionalARN("aws_acm_certificate_validation.cert", "certificate_arn", "acm", regexp.MustCompile("certificate/.+$")),
 				),
 			},
 		},
@@ -158,7 +158,7 @@ func TestAccAWSAcmCertificateValidation_validationRecordFqdnsWildcard(t *testing
 			{
 				Config: testAccAcmCertificateValidation_validationRecordFqdnsOneRoute53Record(rootDomain, wildcardDomain),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("aws_acm_certificate_validation.cert", "certificate_arn", certificateArnRegex),
+					testAccMatchResourceAttrRegionalARN("aws_acm_certificate_validation.cert", "certificate_arn", "acm", regexp.MustCompile("certificate/.+$")),
 				),
 			},
 		},
@@ -177,7 +177,7 @@ func TestAccAWSAcmCertificateValidation_validationRecordFqdnsWildcardAndRoot(t *
 			{
 				Config: testAccAcmCertificateValidation_validationRecordFqdnsTwoRoute53Records(rootDomain, wildcardDomain, strconv.Quote(rootDomain)),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("aws_acm_certificate_validation.cert", "certificate_arn", certificateArnRegex),
+					testAccMatchResourceAttrRegionalARN("aws_acm_certificate_validation.cert", "certificate_arn", "acm", regexp.MustCompile("certificate/.+$")),
 				),
 			},
 		},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11888

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
aws/data_source_aws_acm_certificate_test.go:44:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/data_source_aws_acm_certificate_test.go:50:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/data_source_aws_acm_certificate_test.go:56:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/data_source_aws_acm_certificate_test.go:62:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/data_source_aws_acm_certificate_test.go:68:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/data_source_aws_acm_certificate_test.go:74:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/data_source_aws_acm_certificate_test.go:122:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/data_source_aws_acm_certificate_test.go:128:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/data_source_aws_acm_certificate_test.go:134:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_acm_certificate_test.go:67:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_acm_certificate_test.go:98:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_acm_certificate_test.go:131:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_acm_certificate_test.go:165:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_acm_certificate_test.go:230:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_acm_certificate_test.go:270:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_acm_certificate_test.go:311:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_acm_certificate_test.go:395:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_acm_certificate_test.go:429:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_acm_certificate_test.go:467:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_acm_certificate_validation_test.go:26:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_acm_certificate_validation_test.go:68:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_acm_certificate_validation_test.go:103:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_acm_certificate_validation_test.go:122:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_acm_certificate_validation_test.go:142:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_acm_certificate_validation_test.go:161:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_acm_certificate_validation_test.go:180:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
```

Output from acceptance testing (test failures are present on `master` branch)

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- FAIL: TestAccAWSAcmCertificateDataSource_multipleIssued (6.47s)
--- FAIL: TestAccAWSAcmCertificateDataSource_singleIssued (6.47s)
--- PASS: TestAccAWSAcmCertificateDataSource_noMatchReturnsError (17.50s)
--- PASS: TestAccAWSAcmCertificateDataSource_KeyTypes (27.91s)

--- FAIL: TestAccAWSAcmCertificate_privateCert (7.81s)
--- PASS: TestAccAWSAcmCertificate_imported_IpAddress (20.17s)
--- FAIL: TestAccAWSAcmCertificate_san_multiple (22.65s)
--- PASS: TestAccAWSAcmCertificate_emailValidation (24.20s)
--- PASS: TestAccAWSAcmCertificate_root (24.43s)
--- PASS: TestAccAWSAcmCertificate_disableCTLogging (24.43s)
--- PASS: TestAccAWSAcmCertificate_wildcardAndRootSan (24.83s)
--- PASS: TestAccAWSAcmCertificate_root_TrailingPeriod (26.01s)
--- PASS: TestAccAWSAcmCertificate_san_TrailingPeriod (26.99s)
--- PASS: TestAccAWSAcmCertificate_dnsValidation (28.13s)
--- PASS: TestAccAWSAcmCertificate_rootAndWildcardSan (28.96s)
--- PASS: TestAccAWSAcmCertificate_san_single (31.28s)
--- PASS: TestAccAWSAcmCertificate_imported_DomainName (33.30s)
--- PASS: TestAccAWSAcmCertificate_wildcard (41.12s)
--- PASS: TestAccAWSAcmCertificate_tags (61.60s)
```
