### PR TITLE
service/ecr: Update acceptance tests to use ARN testing check functions

### DIFF
--- a/aws/data_source_aws_ecr_repository_test.go
+++ b/aws/data_source_aws_ecr_repository_test.go
@@ -20,9 +20,9 @@ func TestAccAWSEcrDataSource_ecrRepository(t *testing.T) {
 			{
 				Config: testAccCheckAwsEcrRepositoryDataSourceConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(`^arn:aws:ecr:[a-zA-Z]+-[a-zA-Z]+-\d+:\d+:repository/tf-acc-test-\d+$`)),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ecr", regexp.MustCompile(fmt.Sprintf("repository/%s$", rName))),
 					resource.TestCheckResourceAttrSet(resourceName, "registry_id"),
-					resource.TestMatchResourceAttr(resourceName, "repository_url", regexp.MustCompile(`^\d+\.dkr\.ecr\.[a-zA-Z]+-[a-zA-Z]+-\d+\.amazonaws\.com/tf-acc-test-\d+$`)),
+					resource.TestMatchResourceAttr(resourceName, "repository_url", regexp.MustCompile(fmt.Sprintf(`^\d+\.dkr\.ecr\.%s\.amazonaws\.com/%s$`, testAccGetRegion(), rName))),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Usage", "original"),
 				),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11888

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
aws/data_source_aws_ecr_repository_test.go:23:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSEcrDataSource_ecrRepository (21.03s)
```
