### PR TITLE
Spot Fleet Launch Template Support

### DIFF
--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -362,34 +362,29 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 										Type:     schema.TypeString,
 										Optional: true,
 										ForceNew: true,
-										//ValidateFunc:  validateLaunchTemplateId,
 									},
 									"instance_type": {
 										Type:     schema.TypeString,
 										Optional: true,
 										ForceNew: true,
-										//ValidateFunc:  validateLaunchTemplateName,
 									},
 									"spot_price": {
 										Type:     schema.TypeString,
 										Optional: true,
 										Computed: true,
 										ForceNew: true,
-										//ValidateFunc: validation.StringLenBetween(1, 255),
 									},
 									"subnet_id": {
 										Type:     schema.TypeString,
 										Optional: true,
 										Computed: true,
 										ForceNew: true,
-										//ValidateFunc: validation.StringLenBetween(1, 255),
 									},
 									"weighted_capacity": {
 										Type:     schema.TypeFloat,
 										Optional: true,
 										Computed: true,
 										ForceNew: true,
-										//ValidateFunc: validation.StringLenBetween(1, 255),
 									},
 								},
 							},
@@ -398,7 +393,8 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 					},
 				},
 			},
-			// Everything on a spot fleet is ForceNew except target_capacity
+			// Everything on a spot fleet is ForceNew except target_capacity and excess_capacity_termination_policy,
+			// see https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#ModifySpotFleetRequestInput
 			"target_capacity": {
 				Type:     schema.TypeInt,
 				Required: true,
@@ -408,7 +404,7 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 				Type:          schema.TypeInt,
 				ConflictsWith: []string{"launch_specification"},
 				Optional:      true,
-				ForceNew:      false,
+				ForceNew:      true,
 			},
 			"allocation_strategy": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -954,7 +954,7 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 		resp, err = conn.RequestSpotFleet(spotFleetOpts)
 
 		if isAWSErr(err, "InvalidSpotFleetRequestConfig", "Duplicate: Parameter combination") {
-			return resource.RetryableError(fmt.Errorf("Error creating Spot fleet request: %s", err))
+			return resource.NonRetryableError(fmt.Errorf("Error creating Spot fleet request: %s", err))
 		}
 		if isAWSErr(err, "InvalidSpotFleetRequestConfig", "") {
 			return resource.RetryableError(fmt.Errorf("Error creating Spot fleet request, retrying: %s", err))

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -53,10 +53,9 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 			// http://docs.aws.amazon.com/sdk-for-go/api/service/ec2.html#type-SpotFleetLaunchSpecification
 			// http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_SpotFleetLaunchSpecification.html
 			"launch_specification": {
-				Type:          schema.TypeSet,
-				Optional:      true,
-				ConflictsWith: []string{"launch_template_config"},
-				ForceNew:      true,
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"vpc_security_group_ids": {
@@ -311,14 +310,13 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 					},
 				},
 				Set:          hashLaunchSpecification,
-				AtLeastOneOf: []string{"launch_specification", "launch_template_config"},
+				ExactlyOneOf: []string{"launch_specification", "launch_template_config"},
 			},
 			"launch_template_config": {
-				Type:          schema.TypeSet,
-				Optional:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"launch_specification"},
-				AtLeastOneOf:  []string{"launch_specification", "launch_template_config"},
+				Type:         schema.TypeSet,
+				Optional:     true,
+				ForceNew:     true,
+				ExactlyOneOf: []string{"launch_specification", "launch_template_config"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"launch_template_specification": {

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -1538,10 +1538,10 @@ func deleteSpotFleetRequest(spotFleetRequestID string, terminateInstances bool, 
 		})
 
 		if err != nil || resp == nil {
-			return 0, nil,fmt.Errorf("error reading Spot Fleet Instances (%s): %s", spotFleetRequestID, err)
+			return 0, nil, fmt.Errorf("error reading Spot Fleet Instances (%s): %s", spotFleetRequestID, err)
 		}
 
-		return len(resp.ActiveInstances),resp.ActiveInstances, nil
+		return len(resp.ActiveInstances), resp.ActiveInstances, nil
 	}
 
 	err = resource.Retry(timeout, func() *resource.RetryError {

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -310,13 +310,15 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 						},
 					},
 				},
-				Set: hashLaunchSpecification,
+				Set:          hashLaunchSpecification,
+				AtLeastOneOf: []string{"launch_specification", "launch_template_config"},
 			},
 			"launch_template_config": {
 				Type:          schema.TypeSet,
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"launch_specification"},
+				AtLeastOneOf:  []string{"launch_specification", "launch_template_config"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"launch_template_specification": {

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -505,17 +505,6 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 			},
 			"tags": tagsSchema(),
 		},
-		// A launch template can be created with an id or a name, but once created will have both even though we specify only one.
-		// If either changes, this makes sure the other (which was specified) will register as changed in order to correctly determine diffs.
-		// This was taken from the original implementation of launch templates in resource_aws_autoscaling_group.go
-		CustomizeDiff: customdiff.Sequence(
-			customdiff.ComputedIf("launch_template_configs.0.launch_template_specification.0.id", func(diff *schema.ResourceDiff, meta interface{}) bool {
-				return diff.HasChange("launch_template_configs.0.launch_template_specification.0.name")
-			}),
-			customdiff.ComputedIf("launch_template_configs.0.launch_template_specification.0.name", func(diff *schema.ResourceDiff, meta interface{}) bool {
-				return diff.HasChange("launch_template_configs.0.launch_template_specification.0.id")
-			}),
-		),
 	}
 }
 

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -744,12 +744,12 @@ func readSpotFleetBlockDeviceMappingsFromConfig(
 func buildAwsSpotFleetLaunchSpecifications(
 	d *schema.ResourceData, meta interface{}) ([]*ec2.SpotFleetLaunchSpecification, error) {
 
-	user_specs := d.Get("launch_specification").(*schema.Set).List()
-	specs := make([]*ec2.SpotFleetLaunchSpecification, len(user_specs))
-	for i, user_spec := range user_specs {
-		user_spec_map := user_spec.(map[string]interface{})
+	userSpecs := d.Get("launch_specification").(*schema.Set).List()
+	specs := make([]*ec2.SpotFleetLaunchSpecification, len(userSpecs))
+	for i, userSpec := range userSpecs {
+		userSpecMap := userSpec.(map[string]interface{})
 		// panic: interface conversion: interface {} is map[string]interface {}, not *schema.ResourceData
-		opts, err := buildSpotFleetLaunchSpecification(user_spec_map, meta)
+		opts, err := buildSpotFleetLaunchSpecification(userSpecMap, meta)
 		if err != nil {
 			return nil, err
 		}
@@ -898,11 +898,11 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	if v, ok := d.GetOk("valid_until"); ok {
-		valid_until, err := time.Parse(time.RFC3339, v.(string))
+		validUntil, err := time.Parse(time.RFC3339, v.(string))
 		if err != nil {
 			return err
 		}
-		spotFleetConfig.ValidUntil = aws.Time(valid_until)
+		spotFleetConfig.ValidUntil = aws.Time(validUntil)
 	} else {
 		validUntil := time.Now().Add(24 * time.Hour)
 		spotFleetConfig.ValidUntil = aws.Time(validUntil)

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -1248,7 +1248,7 @@ func flattenSpotFleetRequestLaunchTemplateOverrides(override *ec2.LaunchTemplate
 	}
 
 	if override.WeightedCapacity != nil {
-		m["weighted_capacity"] = aws.Float64Value(override.WeightedCapacity) //strconv.FormatFloat(*override.WeightedCapacity, 'f', 0, 64)
+		m["weighted_capacity"] = aws.Float64Value(override.WeightedCapacity)
 	}
 
 	return m

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -331,7 +331,6 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 										Optional:      true,
 										Computed:      true,
 										ForceNew:      true,
-										ConflictsWith: []string{"launch_template_configs.0.launch_template_specification.0.name"},
 										ValidateFunc:  validateLaunchTemplateId,
 									},
 									"name": {

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"log"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -330,21 +330,18 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 									"id": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										Computed:     true,
 										ForceNew:     true,
 										ValidateFunc: validateLaunchTemplateId,
 									},
 									"name": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										Computed:     true,
 										ForceNew:     true,
 										ValidateFunc: validateLaunchTemplateName,
 									},
 									"version": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										Computed:     true,
 										ForceNew:     true,
 										ValidateFunc: validation.StringLenBetween(1, 255),
 									},
@@ -847,10 +844,6 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 
 	_, launchSpecificationOk := d.GetOk("launch_specification")
 	_, launchTemplateConfigsOk := d.GetOk("launch_template_config")
-
-	if !launchSpecificationOk && !launchTemplateConfigsOk {
-		return fmt.Errorf("One of `launch_specification` or `launch_template` must be set for a fleet request")
-	}
 
 	// http://docs.aws.amazon.com/sdk-for-go/api/service/ec2.html#type-SpotFleetRequestConfigData
 	spotFleetConfig := &ec2.SpotFleetRequestConfigData{

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -338,7 +338,6 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 										Optional:      true,
 										Computed:      true,
 										ForceNew:      true,
-										ConflictsWith: []string{"launch_template_configs.0.launch_template_specification.0.id"},
 										ValidateFunc:  validateLaunchTemplateName,
 									},
 									"version": {

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -857,8 +857,6 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 		TagSpecifications:                ec2TagSpecificationsFromMap(d.Get("tags").(map[string]interface{}), ec2.ResourceTypeSpotFleetRequest),
 	}
 
-	var err error
-
 	if launchSpecificationOk {
 		launchSpecs, err := buildAwsSpotFleetLaunchSpecifications(d, meta)
 		if err != nil {
@@ -953,8 +951,8 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 	// Since IAM is eventually consistent, we retry creation as a newly created role may not
 	// take effect immediately, resulting in an InvalidSpotFleetRequestConfig error
 	var resp *ec2.RequestSpotFleetOutput
-	err = resource.Retry(10*time.Minute, func() *resource.RetryError {
-		resp, err = conn.RequestSpotFleet(spotFleetOpts)
+	err := resource.Retry(10*time.Minute, func() *resource.RetryError {
+		_, err := conn.RequestSpotFleet(spotFleetOpts)
 
 		if isAWSErr(err, "InvalidSpotFleetRequestConfig", "") {
 			return resource.RetryableError(fmt.Errorf("Error creating Spot fleet request, retrying: %s", err))

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -1198,7 +1198,7 @@ func resourceAwsSpotFleetRequestRead(d *schema.ResourceData, meta interface{}) e
 
 	if len(config.LaunchTemplateConfigs) > 0 {
 		if err := d.Set("launch_template_config", flattenFleetLaunchTemplateConfig(config.LaunchTemplateConfigs)); err != nil {
-			return fmt.Errorf("error setting tags: %s", err)
+			return fmt.Errorf("error setting launch_template_config: %s", err)
 		}
 	}
 

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -1224,12 +1224,12 @@ func resourceAwsSpotFleetRequestRead(d *schema.ResourceData, meta interface{}) e
 func setLaunchTemplateOverrides(overrides []*ec2.LaunchTemplateOverrides) *schema.Set {
 	overrideSet := &schema.Set{F: hashLaunchTemplateOverrides}
 	for _, override := range overrides {
-		overrideSet.Add(overrideToMap(override))
+		overrideSet.Add(flattenSpotFleetRequestLaunchTemplateOverrides(override))
 	}
 	return overrideSet
 }
 
-func overrideToMap(override *ec2.LaunchTemplateOverrides) map[string]interface{} {
+func flattenSpotFleetRequestLaunchTemplateOverrides(override *ec2.LaunchTemplateOverrides) map[string]interface{} {
 	m := make(map[string]interface{})
 
 	if override.AvailabilityZone != nil {

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -953,6 +953,9 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 		var err error
 		resp, err = conn.RequestSpotFleet(spotFleetOpts)
 
+		if isAWSErr(err, "InvalidSpotFleetRequestConfig", "Duplicate: Parameter combination") {
+			return resource.RetryableError(fmt.Errorf("Error creating Spot fleet request: %s", err))
+		}
 		if isAWSErr(err, "InvalidSpotFleetRequestConfig", "") {
 			return resource.RetryableError(fmt.Errorf("Error creating Spot fleet request, retrying: %s", err))
 		}

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -1220,7 +1220,7 @@ func resourceAwsSpotFleetRequestRead(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 
-	if config.LaunchTemplateConfigs[0] != nil {
+	if len(config.LaunchTemplateConfigs) > 0 {
 		d.Set("launch_template_configs.0.launch_template_specification.0", flattenFleetLaunchTemplateSpecification(config.LaunchTemplateConfigs[0].LaunchTemplateSpecification))
 		d.Set("launch_template_configs.0.overrides", setLaunchTemplateOverrides(config.LaunchTemplateConfigs[0].Overrides))
 	} else {
@@ -1579,7 +1579,7 @@ func deleteSpotFleetRequest(spotFleetRequestID string, terminateInstances bool, 
 			log.Printf("[DEBUG] Active instance count is %d for Spot Fleet Request (%s), but instances have terminated, removing", n, spotFleetRequestID)
 			return nil
 		} else {
-			log.Printf("[DEBUG] Active instance count is %d for Spot Fleet Request (%s), and %d instances are still running", n, spotFleetRequestID, len(iresp.Reservations))
+			log.Printf("[DEBUG] Active instance count is %d for Spot Fleet Request (%s), and at least 1 instance is still running", n, spotFleetRequestID)
 		}
 
 		log.Printf("[DEBUG] Active instance count is 0 for Spot Fleet Request (%s), removing", spotFleetRequestID)

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -978,6 +978,12 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 		if isAWSErr(err, "InvalidSpotFleetRequestConfig", "") {
 			return resource.RetryableError(fmt.Errorf("Error creating Spot fleet request, retrying: %s", err))
 		}
+		if isAWSErr(err, "InvalidSpotFleetRequestConfig", "LaunchTemplateSpecification") {
+			return resource.NonRetryableError(err)
+		}
+		if isAWSErr(err, "InvalidSpotFleetRequestConfig", "IamFleetRole") {
+			return resource.RetryableError(fmt.Errorf("Error creating Spot fleet request, retrying: %s", err))
+		}
 		if err != nil {
 			return resource.NonRetryableError(err)
 		}

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -835,7 +835,7 @@ func buildLaunchTemplateConfigs(d *schema.ResourceData, meta interface{}) ([]*ec
 				}
 
 				if v, ok := ors["weighted_capacity"].(float64); ok && v > 0 {
-					lto.WeightedCapacity = aws.Float64(float64(v))
+					lto.WeightedCapacity = aws.Float64(v)
 				}
 
 				overrides = append(overrides, lto)

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -1193,8 +1193,10 @@ func resourceAwsSpotFleetRequestRead(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 
-	if err := d.Set("launch_template_config", flattenFleetLaunchTemplateConfig(config.LaunchTemplateConfigs)); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+	if len(config.LaunchTemplateConfigs) > 0 {
+		if err := d.Set("launch_template_config", flattenFleetLaunchTemplateConfig(config.LaunchTemplateConfigs)); err != nil {
+			return fmt.Errorf("error setting tags: %s", err)
+		}
 	}
 
 	return nil
@@ -1619,7 +1621,6 @@ func hashEbsBlockDevice(v interface{}) int {
 }
 
 func flattenFleetLaunchTemplateConfig(ltcs []*ec2.LaunchTemplateConfig) []map[string]interface{} {
-	attrs := map[string]interface{}{}
 	result := make([]map[string]interface{}, 0)
 
 	for _, ltc := range ltcs {
@@ -1632,9 +1633,9 @@ func flattenFleetLaunchTemplateConfig(ltcs []*ec2.LaunchTemplateConfig) []map[st
 		if ltc.Overrides != nil {
 			ltcRes["overrides"] = flattenLaunchTemplateOverrides(ltc.Overrides)
 		}
-	}
 
-	result = append(result, attrs)
+		result = append(result, ltcRes)
+	}
 
 	return result
 }

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -770,7 +770,7 @@ func buildAwsSpotFleetLaunchSpecifications(
 	return specs, nil
 }
 
-func buildLaunchTemplateConfigs(d *schema.ResourceData, meta interface{}) ([]*ec2.LaunchTemplateConfig, error) {
+func buildLaunchTemplateConfigs(d *schema.ResourceData) ([]*ec2.LaunchTemplateConfig, error) {
 	launch_template_cfgs := d.Get("launch_template_configs").(*schema.Set).List()
 	cfgs := make([]*ec2.LaunchTemplateConfig, len(launch_template_cfgs))
 
@@ -877,7 +877,7 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	if launchTemplateConfigsOk {
-		launch_templates, err := buildLaunchTemplateConfigs(d, meta)
+		launch_templates, err := buildLaunchTemplateConfigs(d)
 		if err != nil {
 			return err
 		}

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -950,7 +950,8 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 	// take effect immediately, resulting in an InvalidSpotFleetRequestConfig error
 	var resp *ec2.RequestSpotFleetOutput
 	err := resource.Retry(10*time.Minute, func() *resource.RetryError {
-		_, err := conn.RequestSpotFleet(spotFleetOpts)
+		var err error
+		resp, err = conn.RequestSpotFleet(spotFleetOpts)
 
 		if isAWSErr(err, "InvalidSpotFleetRequestConfig", "") {
 			return resource.RetryableError(fmt.Errorf("Error creating Spot fleet request, retrying: %s", err))

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -778,7 +778,6 @@ func buildAwsSpotFleetLaunchSpecifications(
 
 func buildLaunchTemplateConfigs(d *schema.ResourceData) ([]*ec2.LaunchTemplateConfig, error) {
 	launchTemplateConfigs := d.Get("launch_template_configs").(*schema.Set)
-	log.Printf("haha %#v", launchTemplateConfigs)
 	configs := make([]*ec2.LaunchTemplateConfig, 0)
 
 	for _, launchTemplateConfig := range launchTemplateConfigs.List() {
@@ -1256,6 +1255,10 @@ func flattenSpotFleetRequestLaunchTemplateOverrides(override *ec2.LaunchTemplate
 		m["weighted_capacity"] = aws.Float64Value(override.WeightedCapacity)
 	}
 
+	if override.Priority != nil {
+		m["priority"] = aws.Float64Value(override.Priority)
+	}
+
 	return m
 }
 
@@ -1629,6 +1632,10 @@ func hashLaunchTemplateOverrides(v interface{}) int {
 	if m["weighted_capacity"] != nil {
 		buf.WriteString(fmt.Sprintf("%f-", m["weighted_capacity"].(float64)))
 	}
+	if m["priority"] != nil {
+		buf.WriteString(fmt.Sprintf("%f-", m["priority"].(float64)))
+	}
+
 	return hashcode.String(buf.String())
 }
 

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -838,7 +838,7 @@ func buildLaunchTemplateConfigs(d *schema.ResourceData) ([]*ec2.LaunchTemplateCo
 					lto.WeightedCapacity = aws.Float64(v)
 				}
 
-				if v, ok := ors["priority"].(float64); ok && v > 0 {
+				if v, ok := ors["priority"].(float64); ok {
 					lto.Priority = aws.Float64(v)
 				}
 

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -400,12 +400,6 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 				Required: true,
 				ForceNew: false,
 			},
-			"on_demand_target_capacity": {
-				Type:          schema.TypeInt,
-				ConflictsWith: []string{"launch_specification"},
-				Optional:      true,
-				ForceNew:      true,
-			},
 			"allocation_strategy": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -888,10 +882,6 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 			return err
 		}
 		spotFleetConfig.LaunchTemplateConfigs = launch_templates
-	}
-
-	if v, ok := d.GetOk("on_demand_target_capacity"); ok {
-		spotFleetConfig.OnDemandTargetCapacity = aws.Int64(int64(v.(int)))
 	}
 
 	if v, ok := d.GetOk("excess_capacity_termination_policy"); ok {

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -857,7 +857,7 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 	_, launchTemplateConfigsOk := d.GetOk("launch_template_configs")
 
 	if !launchSpecificationOk && !launchTemplateConfigsOk {
-		return fmt.Errorf("One of `launch_specification` or `launch_template` must be set for an a fleet request")
+		return fmt.Errorf("One of `launch_specification` or `launch_template` must be set for a fleet request")
 	}
 
 	// http://docs.aws.amazon.com/sdk-for-go/api/service/ec2.html#type-SpotFleetRequestConfigData
@@ -882,16 +882,12 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 		spotFleetConfig.LaunchSpecifications = launch_specs
 	}
 
-	// Need to suppport multiples
 	if launchTemplateConfigsOk {
-		// launch_template_cfg, err := buildLaunchTemplateConfig(d, meta)
-		// if err != nil {
-		// 	return err
-		// }
-		spotFleetConfig.LaunchTemplateConfigs, err = buildLaunchTemplateConfigs(d, meta)
+		launch_templates, err := buildLaunchTemplateConfigs(d, meta)
 		if err != nil {
 			return err
 		}
+		spotFleetConfig.LaunchTemplateConfigs = launch_templates
 	}
 
 	if v, ok := d.GetOk("on_demand_target_capacity"); ok {

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -507,6 +507,9 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 			},
 			"tags": tagsSchema(),
 		},
+		// A launch template can be created with an id or a name, but once created will have both even though we specify only one.
+		// If either changes, this makes sure the other (which was specified) will register as changed in order to correctly determine diffs.
+		// This was taken from the original implementation of launch templates in resource_aws_autoscaling_group.go
 		CustomizeDiff: customdiff.Sequence(
 			customdiff.ComputedIf("launch_template_configs.0.launch_template_specification.0.id", func(diff *schema.ResourceDiff, meta interface{}) bool {
 				return diff.HasChange("launch_template_configs.0.launch_template_specification.0.name")

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -56,7 +55,7 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 			"launch_specification": {
 				Type:          schema.TypeSet,
 				Optional:      true,
-				ConflictsWith: []string{"launch_template_configs"},
+				ConflictsWith: []string{"launch_template_config"},
 				ForceNew:      true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -313,7 +312,7 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 				},
 				Set: hashLaunchSpecification,
 			},
-			"launch_template_configs": {
+			"launch_template_config": {
 				Type:          schema.TypeSet,
 				Optional:      true,
 				ForceNew:      true,
@@ -327,18 +326,18 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"id": {
-										Type:          schema.TypeString,
-										Optional:      true,
-										Computed:      true,
-										ForceNew:      true,
-										ValidateFunc:  validateLaunchTemplateId,
+										Type:         schema.TypeString,
+										Optional:     true,
+										Computed:     true,
+										ForceNew:     true,
+										ValidateFunc: validateLaunchTemplateId,
 									},
 									"name": {
-										Type:          schema.TypeString,
-										Optional:      true,
-										Computed:      true,
-										ForceNew:      true,
-										ValidateFunc:  validateLaunchTemplateName,
+										Type:         schema.TypeString,
+										Optional:     true,
+										Computed:     true,
+										ForceNew:     true,
+										ValidateFunc: validateLaunchTemplateName,
 									},
 									"version": {
 										Type:         schema.TypeString,
@@ -764,7 +763,7 @@ func buildAwsSpotFleetLaunchSpecifications(
 }
 
 func buildLaunchTemplateConfigs(d *schema.ResourceData) ([]*ec2.LaunchTemplateConfig, error) {
-	launchTemplateConfigs := d.Get("launch_template_configs").(*schema.Set)
+	launchTemplateConfigs := d.Get("launch_template_config").(*schema.Set)
 	configs := make([]*ec2.LaunchTemplateConfig, 0)
 
 	for _, launchTemplateConfig := range launchTemplateConfigs.List() {
@@ -845,7 +844,7 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 	conn := meta.(*AWSClient).ec2conn
 
 	_, launchSpecificationOk := d.GetOk("launch_specification")
-	_, launchTemplateConfigsOk := d.GetOk("launch_template_configs")
+	_, launchTemplateConfigsOk := d.GetOk("launch_template_config")
 
 	if !launchSpecificationOk && !launchTemplateConfigsOk {
 		return fmt.Errorf("One of `launch_specification` or `launch_template` must be set for a fleet request")
@@ -1203,10 +1202,10 @@ func resourceAwsSpotFleetRequestRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if len(config.LaunchTemplateConfigs) > 0 {
-		d.Set("launch_template_configs.0.launch_template_specification.0", flattenFleetLaunchTemplateSpecification(config.LaunchTemplateConfigs[0].LaunchTemplateSpecification))
-		d.Set("launch_template_configs.0.overrides", setLaunchTemplateOverrides(config.LaunchTemplateConfigs[0].Overrides))
+		d.Set("launch_template_config.0.launch_template_specification.0", flattenFleetLaunchTemplateSpecification(config.LaunchTemplateConfigs[0].LaunchTemplateSpecification))
+		d.Set("launch_template_config.0.overrides", setLaunchTemplateOverrides(config.LaunchTemplateConfigs[0].Overrides))
 	} else {
-		d.Set("launch_template_configs.0.launch_template_specification.0", nil)
+		d.Set("launch_template_config.0.launch_template_specification.0", nil)
 	}
 
 	return nil

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -1555,9 +1555,9 @@ func deleteSpotFleetRequest(spotFleetRequestID string, terminateInstances bool, 
 			return resource.RetryableError(fmt.Errorf("fleet still has (%d) running instances", n))
 		}
 
-		instances := []*string{}
+		var instances []*string
 		for _, instMap := range activeInsts {
-			instances = append(instances, aws.String(*instMap.InstanceId))
+			instances = append(instances, instMap.InstanceId)
 		}
 		iresp, err := conn.DescribeInstances(&ec2.DescribeInstancesInput{
 			InstanceIds: instances,

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -214,7 +214,7 @@ func TestAccAWSSpotFleetRequest_launchTemplateConflictLaunchSpecification(t *tes
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAWSSpotFleetRequestLaunchTemplateConflictLaunchSpecification(rName),
-				ExpectError: regexp.MustCompile(`"launch_template_configs": conflicts with launch_specification`),
+				ExpectError: regexp.MustCompile(`"launch_specification": conflicts with launch_template_configs`),
 			},
 		},
 	})
@@ -1458,8 +1458,8 @@ resource "aws_spot_fleet_request" "test" {
 
     launch_template_configs {
       launch_template_specification {
-        name = "${aws_launch_template.foo.name}"
-        version = "${aws_launch_template.foo.latest_version}"
+        name = "${aws_launch_template.test.name}"
+        version = "${aws_launch_template.test.latest_version}"
       }
     }
 
@@ -1470,7 +1470,7 @@ resource "aws_spot_fleet_request" "test" {
 
 func testAccAWSSpotFleetRequestLaunchTemplateConfigWithOverrides(rName string, rInt int, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
-resource "aws_launch_template" "foo" {
+resource "aws_launch_template" "test" {
   name = "test-launch-template-%[1]s"
   image_id = "ami-516b9131"
   instance_type = "m1.small"

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -167,8 +167,8 @@ func TestAccAWSSpotFleetRequest_launchTemplate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
 					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.4018047529.launch_template_specification.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.4018047529.overrides.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.795271135.launch_template_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.795271135.overrides.#", "0"),
 				),
 			},
 		},
@@ -242,8 +242,8 @@ func TestAccAWSSpotFleetRequest_launchTemplateToLaunchSpec(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
 					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.4018047529.launch_template_specification.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.4018047529.overrides.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.795271135.launch_template_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.795271135.overrides.#", "0"),
 				),
 			},
 			{
@@ -288,8 +288,8 @@ func TestAccAWSSpotFleetRequest_launchSpecToLaunchTemplate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
 					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.4018047529.launch_template_specification.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.4018047529.overrides.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.795271135.launch_template_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.795271135.overrides.#", "0"),
 					testAccCheckAWSSpotFleetRequestConfigRecreated(t, &before, &after),
 				),
 			},
@@ -1324,31 +1324,31 @@ resource "aws_spot_fleet_request" "test" {
 func testAccAWSSpotFleetRequestLaunchTemplateConfig(rName string, rInt int, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
 resource "aws_launch_template" "test" {
-  name = "test-launch-template-%[1]s"
-  image_id = "ami-516b9131"
+  name          = "tf-acc-test-launch-template"
+  image_id      = "ami-516b9131"
   instance_type = "m1.small"
-  key_name = "${aws_key_pair.debugging.key_name}"
+  key_name      = "${aws_key_pair.debugging.key_name}"
 }
 
 resource "aws_spot_fleet_request" "test" {
-    iam_fleet_role = "${aws_iam_role.test-role.arn}"
-    spot_price = "0.005"
-    target_capacity = 2
-    valid_until = %[2]q
-    terminate_instances_with_expiration = true
-    instance_interruption_behaviour = "stop"
-    wait_for_fulfillment = true
+  iam_fleet_role                      = "${aws_iam_role.test-role.arn}"
+  spot_price                          = "0.005"
+  target_capacity                     = 2
+  valid_until                         = %[1]q
+  terminate_instances_with_expiration = true
+  instance_interruption_behaviour     = "stop"
+  wait_for_fulfillment                = true
 
-    launch_template_configs {
-      launch_template_specification {
-        name = "${aws_launch_template.test.name}"
-        version = "${aws_launch_template.test.latest_version}"
-      }
+  launch_template_configs {
+    launch_template_specification {
+      name    = "${aws_launch_template.test.name}"
+      version = "${aws_launch_template.test.latest_version}"
     }
+  }
 
-    depends_on = ["aws_iam_policy_attachment.test-attach"]
+  depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
-`, rName, validUntil)
+`, validUntil)
 }
 
 func testAccAWSSpotFleetRequestLaunchTemplateConflictLaunchSpecification(rName string) string {
@@ -1412,40 +1412,42 @@ resource "aws_spot_fleet_request" "test" {
 func testAccAWSSpotFleetRequestLaunchTemplateConfigWithOverrides(rName string, rInt int, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
 resource "aws_launch_template" "test" {
-  name = "test-launch-template-%[1]s"
-  image_id = "ami-516b9131"
+  name          = "tf-acc-test-launch-template"
+  image_id      = "ami-516b9131"
   instance_type = "m1.small"
-  key_name = "${aws_key_pair.debugging.key_name}"
+  key_name      = "${aws_key_pair.debugging.key_name}"
 }
 
 resource "aws_spot_fleet_request" "test" {
-    iam_fleet_role = "${aws_iam_role.test-role.arn}"
-    spot_price = "0.005"
-    target_capacity = 2
-    valid_until = %[2]q
-    terminate_instances_with_expiration = true
-    instance_interruption_behaviour = "stop"
-    wait_for_fulfillment = true
+  iam_fleet_role                      = "${aws_iam_role.test-role.arn}"
+  spot_price                          = "0.005"
+  target_capacity                     = 2
+  valid_until                         = %[1]q
+  terminate_instances_with_expiration = true
+  instance_interruption_behaviour     = "stop"
+  wait_for_fulfillment                = true
 
-    launch_template_configs {
-      launch_template_specification {
-        name = "${aws_launch_template.test.name}"
-        version = "${aws_launch_template.test.latest_version}"
-      }
-      overrides {
-        instance_type = "t1.micro"
-        weighted_capacity = "2"
-      }
-      overrides {
-        instance_type = "m3.medium"
-        spot_price = "0.26"
-      }
-
+  launch_template_configs {
+    launch_template_specification {
+      name    = "${aws_launch_template.test.name}"
+      version = "${aws_launch_template.test.latest_version}"
     }
 
-    depends_on = ["aws_iam_policy_attachment.test-attach"]
+    overrides {
+      instance_type     = "t1.micro"
+      weighted_capacity = "2"
+    }
+
+    overrides {
+      instance_type = "m3.medium"
+      spot_price    = "0.26"
+    }
+
+  }
+
+  depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
-`, rName, validUntil)
+`, validUntil)
 }
 
 func testAccAWSSpotFleetRequestConfigExcessCapacityTermination(rName string, rInt int, validUntil string) string {

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -337,10 +337,8 @@ func TestAccAWSSpotFleetRequest_fleetType(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestConfigFleetType(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						resourceName, &sfr),
-					resource.TestCheckResourceAttr(
-						resourceName, "spot_request_state", "active"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
 					resource.TestCheckResourceAttr(resourceName, "fleet_type", "request"),
 				),
 			},

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -194,8 +194,12 @@ func TestAccAWSSpotFleetRequest_launchTemplate_multiple(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
 					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "launch_template_config.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_config.795271135.launch_template_specification.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_config.795271135.overrides.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_config.1500071693.launch_template_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_config.1500071693.launch_template_specification.0.name", fmt.Sprintf("%s-1", rName)),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_config.1500071693.overrides.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_config.4234226785.launch_template_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_config.4234226785.launch_template_specification.0.name", fmt.Sprintf("%s-2", rName)),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_config.4234226785.overrides.#", "0"),
 				),
 			},
 		},
@@ -1356,14 +1360,14 @@ resource "aws_spot_fleet_request" "test" {
 func testAccAWSSpotFleetRequestLaunchTemplateMultipleConfig(rName string, rInt int, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
 resource "aws_launch_template" "test1" {
-  name          = "%[2]s-1"
+  name          = "tf-acc-test-1"
   image_id      = "ami-516b9131"
   instance_type = "m1.small"
   key_name      = "${aws_key_pair.debugging.key_name}"
 }
 
 resource "aws_launch_template" "test2" {
-  name          = "%[2]s-2"
+  name          = "tf-acc-test-2"
   image_id      = "ami-516b9131"
   instance_type = "t3.small"
   key_name      = "${aws_key_pair.debugging.key_name}"

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -193,7 +193,7 @@ func TestAccAWSSpotFleetRequest_launchTemplate_multiple(t *testing.T) {
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
 					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_config.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "launch_template_config.2826857687.launch_template_specification.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "launch_template_config.2826857687.launch_template_specification.0.name", "tf-acc-test-1"),
 					resource.TestCheckResourceAttr(resourceName, "launch_template_config.2826857687.overrides.#", "0"),

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -138,63 +138,10 @@ func TestAccAWSSpotFleetRequest_associatePublicIpAddress(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestConfigAssociatePublicIpAddress(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						resourceName, &sfr),
-					resource.TestCheckResourceAttr(
-						resourceName, "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						resourceName, "launch_specification.#", "1"),
-					resource.TestCheckResourceAttr(
-						resourceName, "launch_specification.24370212.associate_public_ip_address", "true"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSSpotFleetRequest_fleetType(t *testing.T) {
-	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotFleetRequestConfigFleetType(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "fleet_type", "request"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSSpotFleetRequest_iamInstanceProfileArn(t *testing.T) {
-	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotFleetRequestConfigIamInstanceProfileArn(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					testAccCheckAWSSpotFleetRequest_IamInstanceProfileArn(&sfr),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.24370212.associate_public_ip_address", "true"),
 				),
 			},
 		},
@@ -205,6 +152,8 @@ func TestAccAWSSpotFleetRequest_launchTemplate(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
 	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
+	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	resourceName := "aws_spot_fleet_request.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -212,20 +161,14 @@ func TestAccAWSSpotFleetRequest_launchTemplate(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestLaunchTemplateConfig(rName, rInt),
+				Config: testAccAWSSpotFleetRequestLaunchTemplateConfig(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.#", "0"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.4018047529.launch_template_specification.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.4018047529.overrides.#", "0"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.4018047529.launch_template_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.4018047529.overrides.#", "0"),
 				),
 			},
 		},
@@ -237,6 +180,8 @@ func TestAccAWSSpotFleetRequest_launchTemplateWithOnDemandCapacity(t *testing.T)
 	var sfr ec2.SpotFleetRequestConfig
 	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
+	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	resourceName := "aws_spot_fleet_request.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -244,22 +189,15 @@ func TestAccAWSSpotFleetRequest_launchTemplateWithOnDemandCapacity(t *testing.T)
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestLaunchTemplateConfigWithOnDemandCapacity(rName, rInt),
+				Config: testAccAWSSpotFleetRequestLaunchTemplateConfigWithOnDemandCapacity(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.#", "0"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.4018047529.launch_template_specification.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.4018047529.overrides.#", "0"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "on_demand_target_capacity", "2"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.4018047529.launch_template_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.4018047529.overrides.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_target_capacity", "2"),
 				),
 			},
 		},
@@ -282,44 +220,12 @@ func TestAccAWSSpotFleetRequest_launchTemplateConflictLaunchSpecification(t *tes
 	})
 }
 
-//On-Demand capacity requires launch template defined spot fleet, so can't test without it.
-func TestAccAWSSpotFleetRequest_launchTemplateWithOnDemandCapacity(t *testing.T) {
-	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotFleetRequestLaunchTemplateConfigWithOnDemandCapacity(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.#", "0"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.4018047529.launch_template_specification.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.4018047529.overrides.#", "0"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "on_demand_target_capacity", "2"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAWSSpotFleetRequest_launchTemplateWithOverrides(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
 	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
+	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	resourceName := "aws_spot_fleet_request.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -327,30 +233,19 @@ func TestAccAWSSpotFleetRequest_launchTemplateWithOverrides(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestLaunchTemplateConfigWithOverrides(rName, rInt),
+				Config: testAccAWSSpotFleetRequestLaunchTemplateConfigWithOverrides(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.#", "0"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.3492852471.launch_template_specification.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.3492852471.overrides.#", "2"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.3492852471.overrides.#", "2"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.3492852471.overrides.3113255372.instance_type", "t1.micro"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.3492852471.overrides.3113255372.weighted_capacity", "2"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.3492852471.overrides.1994766569.instance_type", "m3.medium"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.3492852471.overrides.1994766569.spot_price", "0.26"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.3492852471.launch_template_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.3492852471.overrides.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.3492852471.overrides.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.3492852471.overrides.3113255372.instance_type", "t1.micro"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.3492852471.overrides.3113255372.weighted_capacity", "2"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.3492852471.overrides.1994766569.instance_type", "m3.medium"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.3492852471.overrides.1994766569.spot_price", "0.26"),
 				),
 			},
 		},
@@ -361,6 +256,8 @@ func TestAccAWSSpotFleetRequest_launchTemplateToLaunchSpec(t *testing.T) {
 	var before, after ec2.SpotFleetRequestConfig
 	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
+	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	resourceName := "aws_spot_fleet_request.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -368,33 +265,23 @@ func TestAccAWSSpotFleetRequest_launchTemplateToLaunchSpec(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestLaunchTemplateConfig(rName, rInt),
+				Config: testAccAWSSpotFleetRequestLaunchTemplateConfig(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &before),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.#", "0"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.4018047529.launch_template_specification.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.4018047529.overrides.#", "0"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.4018047529.launch_template_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.4018047529.overrides.#", "0"),
 				),
 			},
 			{
-				Config: testAccAWSSpotFleetRequestConfig(rName, rInt),
+				Config: testAccAWSSpotFleetRequestConfig(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &after),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_price", "0.005"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.#", "1"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &after),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "spot_price", "0.005"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "1"),
 					testAccCheckAWSSpotFleetRequestConfigRecreated(t, &before, &after),
 				),
 			},
@@ -406,6 +293,8 @@ func TestAccAWSSpotFleetRequest_launchSpecToLaunchTemplate(t *testing.T) {
 	var before, after ec2.SpotFleetRequestConfig
 	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
+	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	resourceName := "aws_spot_fleet_request.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -413,33 +302,23 @@ func TestAccAWSSpotFleetRequest_launchSpecToLaunchTemplate(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestConfig(rName, rInt),
+				Config: testAccAWSSpotFleetRequestConfig(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &before),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_price", "0.005"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.#", "1"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "spot_price", "0.005"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "1"),
 				),
 			},
 			{
-				Config: testAccAWSSpotFleetRequestLaunchTemplateConfig(rName, rInt),
+				Config: testAccAWSSpotFleetRequestLaunchTemplateConfig(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &after),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.#", "0"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.4018047529.launch_template_specification.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.4018047529.overrides.#", "0"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &after),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.4018047529.launch_template_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.4018047529.overrides.#", "0"),
 					testAccCheckAWSSpotFleetRequestConfigRecreated(t, &before, &after),
 				),
 			},
@@ -499,7 +378,7 @@ func TestAccAWSSpotFleetRequest_fleetType(t *testing.T) {
 
 func TestAccAWSSpotFleetRequest_iamInstanceProfileArn(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
-						rName := acctest.RandString(10)
+	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
@@ -1004,7 +883,7 @@ func TestAccAWSSpotFleetRequest_withEBSDisk(t *testing.T) {
 func TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDevice_KmsKeyId(t *testing.T) {
 	var config ec2.SpotFleetRequestConfig
 	rName := acctest.RandString(10)
-						rInt := acctest.RandInt()
+	rInt := acctest.RandInt()
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -1017,7 +896,7 @@ func TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDevice_KmsKeyId(t *t
 				Config: testAccAWSSpotFleetRequestLaunchSpecificationEbsBlockDeviceKmsKeyId(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &config),
-					),
+				),
 			},
 		},
 	})
@@ -1033,12 +912,12 @@ func TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDevice_KmsKeyId(t *
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
 		Providers:    testAccProviders,
-						CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSpotFleetRequestLaunchSpecificationRootBlockDeviceKmsKeyId(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(resourceName,&config),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &config),
 				),
 			},
 		},
@@ -1123,7 +1002,7 @@ func TestAccAWSSpotFleetRequest_WithTargetGroups(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
 	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
-validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
@@ -1266,17 +1145,16 @@ func testAccCheckAWSSpotFleetRequest_PlacementAttributes(
 		if placement == nil {
 			return fmt.Errorf("Expected placement to be set, got nil")
 		}
-		if *placement.Tenancy != "dedicated" {
+		if *placement.Tenancy != ec2.TenancyDedicated {
 			return fmt.Errorf("Expected placement tenancy to be %q, got %q", "dedicated", *placement.Tenancy)
 		}
 
-
 		if aws.StringValue(placement.GroupName) != fmt.Sprintf("test-pg-%s", rName) {
 			return fmt.Errorf("Expected placement group to be %q, got %q", fmt.Sprintf("test-pg-%s", rName), aws.StringValue(placement.GroupName))
-	}
+		}
 
-	return nil
-}
+		return nil
+	}
 
 }
 
@@ -1287,8 +1165,8 @@ func testAccPreCheckAWSEc2SpotFleetRequest(t *testing.T) {
 
 	_, err := conn.DescribeSpotFleetRequests(input)
 
-				if testAccPreCheckSkipError(err) {
-				t.Skipf("skipping acceptance testing: %s", err)
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
 	}
 
 	if err != nil {
@@ -1472,96 +1350,40 @@ resource "aws_spot_fleet_request" "test" {
 `, validUntil)
 }
 
-func testAccAWSSpotFleetRequestLaunchTemplateConfig(rName string, rInt int) string {
-	return fmt.Sprintf(`
-resource "aws_key_pair" "debugging" {
-    key_name = "tmp-key-%s"
-    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
-}
-
-resource "aws_iam_policy" "test-policy" {
-  name = "test-policy-%d"
-  path = "/"
-  description = "Spot Fleet Request ACCTest Policy"
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [{
-    "Effect": "Allow",
-    "Action": [
-       "ec2:DescribeImages",
-       "ec2:DescribeSubnets",
-       "ec2:RequestSpotInstances",
-       "ec2:TerminateInstances",
-       "ec2:DescribeInstanceStatus",
-       "iam:PassRole"
-        ],
-    "Resource": ["*"]
-  }]
-}
-EOF
-}
-
-resource "aws_iam_policy_attachment" "test-attach" {
-    name = "test-attachment-%d"
-    roles = ["${aws_iam_role.test-role.name}"]
-    policy_arn = "${aws_iam_policy.test-policy.arn}"
-}
-
-resource "aws_iam_role" "test-role" {
-    name = "test-role-%s"
-    assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": [
-          "spotfleet.amazonaws.com",
-          "ec2.amazonaws.com"
-        ]
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_launch_template" "foo" {
-  name = "test-launch-template"
+func testAccAWSSpotFleetRequestLaunchTemplateConfig(rName string, rInt int, validUntil string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+resource "aws_launch_template" "test" {
+  name = "test-launch-template-%[1]s"
   image_id = "ami-516b9131"
   instance_type = "m1.small"
   key_name = "${aws_key_pair.debugging.key_name}"
 }
 
-resource "aws_spot_fleet_request" "foo" {
+resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
     spot_price = "0.005"
     target_capacity = 2
-    valid_until = "2019-11-04T20:44:20Z"
+    valid_until = %[2]q
     terminate_instances_with_expiration = true
     instance_interruption_behaviour = "stop"
     wait_for_fulfillment = true
 
     launch_template_configs {
       launch_template_specification {
-        name = "${aws_launch_template.foo.name}"
-        version = "${aws_launch_template.foo.latest_version}"
+        name = "${aws_launch_template.test.name}"
+        version = "${aws_launch_template.test.latest_version}"
       }
     }
 
     depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
-`, rName, rInt, rInt, rName)
+`, rName, validUntil)
 }
 
 func testAccAWSSpotFleetRequestLaunchTemplateConflictLaunchSpecification(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test-role" {
-    name = "test-role-%s"
+    name = "test-role-%[1]s"
     assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -1582,21 +1404,21 @@ resource "aws_iam_role" "test-role" {
 EOF
 }
 
-resource "aws_launch_template" "foo" {
-  name = "test-launch-template-%s"
+resource "aws_launch_template" "test" {
+  name = "test-launch-template-%[1]s"
   image_id = "ami-516b9131"
   instance_type = "m1.small"
 }
 
-resource "aws_spot_fleet_request" "foo" {
+resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
     spot_price = "0.005"
     target_capacity = 2
 
     launch_template_configs {
       launch_template_specification {
-        name = "${aws_launch_template.foo.name}"
-        version = "${aws_launch_template.foo.latest_version}"
+        name = "${aws_launch_template.test.name}"
+        version = "${aws_launch_template.test.latest_version}"
       }
       overrides {
         instance_type = "t1.micro"
@@ -1613,79 +1435,23 @@ resource "aws_spot_fleet_request" "foo" {
         ami = "ami-516b9131"
     }
 }
-`, rName, rName)
+`, rName)
 }
 
-func testAccAWSSpotFleetRequestLaunchTemplateConfigWithOnDemandCapacity(rName string, rInt int) string {
-	return fmt.Sprintf(`
-resource "aws_key_pair" "debugging" {
-    key_name = "tmp-key-%s"
-    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
-}
-
-resource "aws_iam_policy" "test-policy" {
-  name = "test-policy-%d"
-  path = "/"
-  description = "Spot Fleet Request ACCTest Policy"
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [{
-    "Effect": "Allow",
-    "Action": [
-       "ec2:DescribeImages",
-       "ec2:DescribeSubnets",
-       "ec2:RequestSpotInstances",
-       "ec2:TerminateInstances",
-       "ec2:DescribeInstanceStatus",
-       "iam:PassRole"
-        ],
-    "Resource": ["*"]
-  }]
-}
-EOF
-}
-
-resource "aws_iam_policy_attachment" "test-attach" {
-    name = "test-attachment-%d"
-    roles = ["${aws_iam_role.test-role.name}"]
-    policy_arn = "${aws_iam_policy.test-policy.arn}"
-}
-
-resource "aws_iam_role" "test-role" {
-    name = "test-role-%s"
-    assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": [
-          "spotfleet.amazonaws.com",
-          "ec2.amazonaws.com"
-        ]
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_launch_template" "foo" {
-  name = "test-launch-template"
+func testAccAWSSpotFleetRequestLaunchTemplateConfigWithOnDemandCapacity(rName string, rInt int, validUntil string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+resource "aws_launch_template" "test" {
+  name = "test-launch-template-%[1]s"
   image_id = "ami-516b9131"
   instance_type = "m1.small"
   key_name = "${aws_key_pair.debugging.key_name}"
 }
 
-resource "aws_spot_fleet_request" "foo" {
+resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
     spot_price = "0.005"
     target_capacity = 2
-    valid_until = "2019-11-04T20:44:20Z"
+    valid_until = %[2]q
     terminate_instances_with_expiration = true
     wait_for_fulfillment = true
     on_demand_target_capacity = 2
@@ -1699,87 +1465,31 @@ resource "aws_spot_fleet_request" "foo" {
 
     depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
-`, rName, rInt, rInt, rName)
+`, rName, validUntil)
 }
 
-func testAccAWSSpotFleetRequestLaunchTemplateConfigWithOverrides(rName string, rInt int) string {
-	return fmt.Sprintf(`
-resource "aws_key_pair" "debugging" {
-    key_name = "tmp-key-%s"
-    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
-}
-
-resource "aws_iam_policy" "test-policy" {
-  name = "test-policy-%d"
-  path = "/"
-  description = "Spot Fleet Request ACCTest Policy"
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [{
-    "Effect": "Allow",
-    "Action": [
-       "ec2:DescribeImages",
-       "ec2:DescribeSubnets",
-       "ec2:RequestSpotInstances",
-       "ec2:TerminateInstances",
-       "ec2:DescribeInstanceStatus",
-       "iam:PassRole"
-        ],
-    "Resource": ["*"]
-  }]
-}
-EOF
-}
-
-resource "aws_iam_policy_attachment" "test-attach" {
-    name = "test-attachment-%d"
-    roles = ["${aws_iam_role.test-role.name}"]
-    policy_arn = "${aws_iam_policy.test-policy.arn}"
-}
-
-resource "aws_iam_role" "test-role" {
-    name = "test-role-%s"
-    assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": [
-          "spotfleet.amazonaws.com",
-          "ec2.amazonaws.com"
-        ]
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
-}
-
+func testAccAWSSpotFleetRequestLaunchTemplateConfigWithOverrides(rName string, rInt int, validUntil string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
 resource "aws_launch_template" "foo" {
-  name = "test-launch-template"
+  name = "test-launch-template-%[1]s"
   image_id = "ami-516b9131"
   instance_type = "m1.small"
   key_name = "${aws_key_pair.debugging.key_name}"
 }
 
-resource "aws_spot_fleet_request" "foo" {
+resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
     spot_price = "0.005"
     target_capacity = 2
-    valid_until = "2019-11-04T20:44:20Z"
+    valid_until = %[2]q
     terminate_instances_with_expiration = true
     instance_interruption_behaviour = "stop"
     wait_for_fulfillment = true
 
     launch_template_configs {
       launch_template_specification {
-        name = "${aws_launch_template.foo.name}"
-        version = "${aws_launch_template.foo.latest_version}"
+        name = "${aws_launch_template.test.name}"
+        version = "${aws_launch_template.test.latest_version}"
       }
       overrides {
         instance_type = "t1.micro"
@@ -1794,7 +1504,7 @@ resource "aws_spot_fleet_request" "foo" {
 
     depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
-`, rName, rInt, rInt, rName)
+`, rName, validUntil)
 }
 
 func testAccAWSSpotFleetRequestConfigExcessCapacityTermination(rName string, rInt int, validUntil string) string {

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -768,7 +768,7 @@ func testAccCheckAWSSpotFleetRequest_IamInstanceProfileArn(
 			return fmt.Errorf("Expected IamInstanceProfile to be set, got nil")
 		}
 		//Validate the string whether it is ARN
-		re := regexp.MustCompile("arn:aws:iam::\\d{12}:instance-profile/?[a-zA-Z0-9+=,.@-_].*")
+		re := regexp.MustCompile(`arn:aws:iam::\d{12}:instance-profile/?[a-zA-Z0-9+=,.@-_].*`)
 		if !re.MatchString(*profile.Arn) {
 			return fmt.Errorf("Expected IamInstanceProfile input as ARN, got %s", *profile.Arn)
 		}

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -2055,23 +2055,12 @@ resource "aws_spot_fleet_request" "test" {
 
 func testAccAWSSpotFleetRequestLaunchSpecificationEbsBlockDeviceKmsKeyId(rName string, rInt int, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
-data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
-  most_recent = true
-  owners      = ["amazon"]
-
-  filter {
-    name   = "name"
-    values = ["amzn-ami-minimal-hvm-*"]
-  }
-
-  filter {
-    name   = "root-device-type"
-    values = ["ebs"]
-  }
-}
-
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+
+  tags = {
+   Name = %[2]q
+  }
 }
 
 resource "aws_spot_fleet_request" "test" {
@@ -2103,28 +2092,17 @@ resource "aws_spot_fleet_request" "test" {
 
   depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
-`, validUntil)
+`, validUntil, rName)
 }
 
 func testAccAWSSpotFleetRequestLaunchSpecificationRootBlockDeviceKmsKeyId(rName string, rInt int, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
-data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
-  most_recent = true
-  owners      = ["amazon"]
-
-  filter {
-    name   = "name"
-    values = ["amzn-ami-minimal-hvm-*"]
-  }
-
-  filter {
-    name   = "root-device-type"
-    values = ["ebs"]
-  }
-}
-
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+
+  tags = {
+   Name = %[2]q
+  }
 }
 
 resource "aws_spot_fleet_request" "test" {
@@ -2149,7 +2127,7 @@ resource "aws_spot_fleet_request" "test" {
 
   depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
-`, validUntil)
+`, validUntil, rName)
 }
 
 func testAccAWSSpotFleetRequestLaunchSpecificationWithInstanceStoreAmi(rName string, rInt int, validUntil string) string {

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -198,22 +198,6 @@ func TestAccAWSSpotFleetRequest_launchTemplate_multiple(t *testing.T) {
 	})
 }
 
-func TestAccAWSSpotFleetRequest_launchTemplateConflictLaunchSpecification(t *testing.T) {
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccAWSSpotFleetRequestLaunchTemplateConflictLaunchSpecification(rName, rInt),
-				ExpectError: regexp.MustCompile(`"launch_specification": only one of .+`),
-			},
-		},
-	})
-}
 
 func TestAccAWSSpotFleetRequest_launchTemplateWithOverrides(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
@@ -1410,41 +1394,6 @@ resource "aws_spot_fleet_request" "test" {
 `, validUntil, rName)
 }
 
-func testAccAWSSpotFleetRequestLaunchTemplateConflictLaunchSpecification(rName string, rInt int) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
-resource "aws_launch_template" "test" {
-  name          = %[1]q
-  image_id      = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
-  instance_type = "${data.aws_ec2_instance_type_offering.available.instance_type}"
-}
-
-resource "aws_spot_fleet_request" "test" {
-  iam_fleet_role = "${aws_iam_role.test-role.arn}"
-  spot_price = "0.005"
-  target_capacity = 2
-
-  launch_template_config {
-    launch_template_specification {
-      name = "${aws_launch_template.test.name}"
-      version = "${aws_launch_template.test.latest_version}"
-    }
-    overrides {
-      instance_type = "t1.micro"
-      weighted_capacity = "2"
-    }
-    overrides {
-      instance_type = "m3.medium"
-      spot_price = "0.26"
-    }
-  }
-
-  launch_specification {
-    ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
-    instance_type = "${data.aws_ec2_instance_type_offering.available.instance_type}"
-  }
-}
-`, rName)
-}
 
 func testAccAWSSpotFleetRequestLaunchTemplateConfigWithOverrides(rName string, rInt int, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) +

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -210,13 +210,14 @@ func TestAccAWSSpotFleetRequest_launchTemplateWithOverrides(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
 					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.3492852471.launch_template_specification.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.3492852471.overrides.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.3492852471.overrides.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.3492852471.overrides.3113255372.instance_type", "t1.micro"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.3492852471.overrides.3113255372.weighted_capacity", "2"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.3492852471.overrides.1994766569.instance_type", "m3.medium"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.3492852471.overrides.1994766569.spot_price", "0.26"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.2247196053.launch_template_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.2247196053.overrides.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.2247196053.overrides.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.2247196053.overrides.1951041615.instance_type", "t1.micro"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.2247196053.overrides.1951041615.weighted_capacity", "2"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.2247196053.overrides.1866154075.instance_type", "m3.medium"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.2247196053.overrides.1866154075.priority", "1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.2247196053.overrides.1866154075.spot_price", "0.26"),
 				),
 			},
 		},
@@ -1440,9 +1441,9 @@ resource "aws_spot_fleet_request" "test" {
 
     overrides {
       instance_type = "m3.medium"
+      priority      = 1
       spot_price    = "0.26"
     }
-
   }
 
   depends_on = ["aws_iam_policy_attachment.test-attach"]

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -1390,7 +1390,7 @@ resource "aws_launch_template" "test1" {
 resource "aws_launch_template" "test2" {
   name          = "%[2]s-2"
   image_id      = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
-  instance_type = "${data.aws_ec2_instance_type_offering.available.test}"
+  instance_type = "${data.aws_ec2_instance_type_offering.test.instance_type}"
   key_name      = "${aws_key_pair.debugging.key_name}"
 }
 

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -1454,11 +1454,11 @@ resource "aws_spot_fleet_request" "test" {
       version = "${aws_launch_template.test.latest_version}"
     }
     overrides {
-      instance_type = "${data.aws_ec2_instance_type_offering.available.instance_type}"
+      instance_type = "t1.micro"
       weighted_capacity = "2"
     }
     overrides {
-      instance_type = "${data.aws_ec2_instance_type_offering.available.instance_type}"
+      instance_type = "m3.medium"
       spot_price = "0.26"
     }
   }
@@ -1498,12 +1498,12 @@ resource "aws_spot_fleet_request" "test" {
     }
 
     overrides {
-      instance_type     = "${data.aws_ec2_instance_type_offering.available.instance_type}"
+      instance_type     = "t1.micro"
       weighted_capacity = "2"
     }
 
     overrides {
-      instance_type = "${data.aws_ec2_instance_type_offering.available.instance_type}"
+      instance_type = "m3.medium"
       priority      = 1
       spot_price    = "0.26"
     }

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -198,7 +198,6 @@ func TestAccAWSSpotFleetRequest_launchTemplate_multiple(t *testing.T) {
 	})
 }
 
-
 func TestAccAWSSpotFleetRequest_launchTemplateWithOverrides(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
 	rName := acctest.RandString(10)
@@ -1393,7 +1392,6 @@ resource "aws_spot_fleet_request" "test" {
 }
 `, validUntil, rName)
 }
-
 
 func testAccAWSSpotFleetRequestLaunchTemplateConfigWithOverrides(rName string, rInt int, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) +

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -1454,11 +1454,11 @@ resource "aws_spot_fleet_request" "test" {
       version = "${aws_launch_template.test.latest_version}"
     }
     overrides {
-      instance_type = "t1.micro"
+      instance_type = "${data.aws_ec2_instance_type_offering.available.instance_type}"
       weighted_capacity = "2"
     }
     overrides {
-      instance_type = "m3.medium"
+      instance_type = "${data.aws_ec2_instance_type_offering.available.instance_type}"
       spot_price = "0.26"
     }
   }
@@ -1498,12 +1498,12 @@ resource "aws_spot_fleet_request" "test" {
     }
 
     overrides {
-      instance_type     = "t1.micro"
+      instance_type     = "${data.aws_ec2_instance_type_offering.available.instance_type}"
       weighted_capacity = "2"
     }
 
     overrides {
-      instance_type = "m3.medium"
+      instance_type = "${data.aws_ec2_instance_type_offering.available.instance_type}"
       priority      = 1
       spot_price    = "0.26"
     }

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -148,6 +148,55 @@ func TestAccAWSSpotFleetRequest_associatePublicIpAddress(t *testing.T) {
 	})
 }
 
+func TestAccAWSSpotFleetRequest_fleetType(t *testing.T) {
+	var sfr ec2.SpotFleetRequestConfig
+	rName := acctest.RandString(10)
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSpotFleetRequestConfigFleetType(rName, rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSSpotFleetRequestExists(
+						"aws_spot_fleet_request.foo", &sfr),
+					resource.TestCheckResourceAttr(
+						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(
+						"aws_spot_fleet_request.foo", "fleet_type", "request"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSpotFleetRequest_iamInstanceProfileArn(t *testing.T) {
+	var sfr ec2.SpotFleetRequestConfig
+	rName := acctest.RandString(10)
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSpotFleetRequestConfigIamInstanceProfileArn(rName, rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSSpotFleetRequestExists(
+						"aws_spot_fleet_request.foo", &sfr),
+					resource.TestCheckResourceAttr(
+						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
+					testAccCheckAWSSpotFleetRequest_IamInstanceProfileArn(&sfr),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSSpotFleetRequest_launchTemplate(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
 	rName := acctest.RandString(10)
@@ -227,6 +276,40 @@ func TestAccAWSSpotFleetRequest_launchTemplateConflictLaunchSpecification(t *tes
             },
         },
     })
+}
+
+//On-Demand capacity requires launch template defined spot fleet, so can't test without it.
+func TestAccAWSSpotFleetRequest_launchTemplateWithOnDemandCapacity(t *testing.T) {
+	var sfr ec2.SpotFleetRequestConfig
+	rName := acctest.RandString(10)
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSpotFleetRequestLaunchTemplateConfigWithOnDemandCapacity(rName, rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSSpotFleetRequestExists(
+						"aws_spot_fleet_request.foo", &sfr),
+					resource.TestCheckResourceAttr(
+						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(
+						"aws_spot_fleet_request.foo", "launch_specification.#", "0"),
+					resource.TestCheckResourceAttr(
+						"aws_spot_fleet_request.foo", "launch_template_configs.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_spot_fleet_request.foo", "launch_template_configs.4018047529.launch_template_specification.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_spot_fleet_request.foo", "launch_template_configs.4018047529.overrides.#", "0"),
+					resource.TestCheckResourceAttr(
+						"aws_spot_fleet_request.foo", "on_demand_target_capacity", "2"),
+				),
+			},
+		},
+	})
 }
 
 func TestAccAWSSpotFleetRequest_launchTemplateWithOverrides(t *testing.T) {
@@ -1465,6 +1548,92 @@ resource "aws_spot_fleet_request" "foo" {
     }
 }
 `, rName, rName)
+}
+
+func testAccAWSSpotFleetRequestLaunchTemplateConfigWithOnDemandCapacity(rName string, rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_key_pair" "debugging" {
+    key_name = "tmp-key-%s"
+    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+}
+
+resource "aws_iam_policy" "test-policy" {
+  name = "test-policy-%d"
+  path = "/"
+  description = "Spot Fleet Request ACCTest Policy"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+       "ec2:DescribeImages",
+       "ec2:DescribeSubnets",
+       "ec2:RequestSpotInstances",
+       "ec2:TerminateInstances",
+       "ec2:DescribeInstanceStatus",
+       "iam:PassRole"
+        ],
+    "Resource": ["*"]
+  }]
+}
+EOF
+}
+
+resource "aws_iam_policy_attachment" "test-attach" {
+    name = "test-attachment-%d"
+    roles = ["${aws_iam_role.test-role.name}"]
+    policy_arn = "${aws_iam_policy.test-policy.arn}"
+}
+
+resource "aws_iam_role" "test-role" {
+    name = "test-role-%s"
+    assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "spotfleet.amazonaws.com",
+          "ec2.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_launch_template" "foo" {
+  name = "test-launch-template"
+  image_id = "ami-516b9131"
+  instance_type = "m1.small"
+  key_name = "${aws_key_pair.debugging.key_name}"
+}
+
+resource "aws_spot_fleet_request" "foo" {
+    iam_fleet_role = "${aws_iam_role.test-role.arn}"
+    spot_price = "0.005"
+    target_capacity = 2
+    valid_until = "2019-11-04T20:44:20Z"
+    terminate_instances_with_expiration = true
+    wait_for_fulfillment = true
+    on_demand_target_capacity = 2
+
+    launch_template_configs {
+      launch_template_specification {
+        name = "${aws_launch_template.foo.name}"
+        version = "${aws_launch_template.foo.latest_version}"
+      }
+    }
+
+    depends_on = ["aws_iam_policy_attachment.test-attach"]
+}
+`, rName, rInt, rInt, rName)
 }
 
 func testAccAWSSpotFleetRequestLaunchTemplateConfigWithOverrides(rName string, rInt int) string {

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -292,13 +292,11 @@ func TestAccAWSSpotFleetRequest_launchTemplateToLaunchSpec(t *testing.T) {
 						"aws_spot_fleet_request.foo", "spot_price", "0.005"),
 					resource.TestCheckResourceAttr(
 						"aws_spot_fleet_request.foo", "launch_specification.#", "1"),
-					// resource.TestCheckResourceAttr(
-					//  "aws_spot_fleet_request.foo", "launch_template_configs.#", "0"),
 					testAccCheckAWSSpotFleetRequestConfigRecreated(t, &before, &after),
-				),
-			},
-		},
-	})
+                ),
+            },
+        },
+    })
 }
 
 func TestAccAWSSpotFleetRequest_launchSpecToLaunchTemplate(t *testing.T) {
@@ -306,46 +304,44 @@ func TestAccAWSSpotFleetRequest_launchSpecToLaunchTemplate(t *testing.T) {
 	rName := acctest.RandString(10)
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotFleetRequestConfig(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &before),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_price", "0.005"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.#", "1"),
-					// resource.TestCheckResourceAttr(
-					//  "aws_spot_fleet_request.foo", "launch_template_configs.#", "0"),
-				),
-			},
-			{
-				Config: testAccAWSSpotFleetRequestLaunchTemplateConfig(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &after),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.#", "0"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.4018047529.launch_template_specification.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.4018047529.overrides.#", "0"),
-					testAccCheckAWSSpotFleetRequestConfigRecreated(t, &before, &after),
-				),
-			},
-		},
-	})
+    resource.Test(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAWSSpotFleetRequestConfig(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &before),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_price", "0.005"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.#", "1"),
+                ),
+            },
+            {
+                Config: testAccAWSSpotFleetRequestLaunchTemplateConfig(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &after),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.#", "0"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_template_configs.#", "1"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_template_configs.4018047529.launch_template_specification.#", "1"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_template_configs.4018047529.overrides.#", "0"),
+                    testAccCheckAWSSpotFleetRequestConfigRecreated(t, &before, &after),
+                ),
+            },
+        },
+    })
 }
 
 func TestAccAWSSpotFleetRequest_instanceInterruptionBehavior(t *testing.T) {

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -1393,6 +1393,7 @@ resource "aws_spot_fleet_request" "foo" {
 `, rName, rInt, rInt, rName)
 }
 
+<<<<<<< HEAD
 func testAccAWSSpotFleetRequestLaunchTemplateConfigWithOnDemandCapacity(rName string, rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_key_pair" "debugging" {
@@ -1479,6 +1480,8 @@ resource "aws_spot_fleet_request" "foo" {
 `, rName, rInt, rInt, rName)
 }
 
+=======
+>>>>>>> removed on-demand spot instance feature due to moving to a different PR
 func testAccAWSSpotFleetRequestLaunchTemplateConfigWithOverrides(rName string, rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_key_pair" "debugging" {

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -194,12 +194,12 @@ func TestAccAWSSpotFleetRequest_launchTemplate_multiple(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
 					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "launch_template_config.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_config.1500071693.launch_template_specification.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_config.1500071693.launch_template_specification.0.name", fmt.Sprintf("%s-1", rName)),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_config.1500071693.overrides.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_config.4234226785.launch_template_specification.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_config.4234226785.launch_template_specification.0.name", fmt.Sprintf("%s-2", rName)),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_config.4234226785.overrides.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_config.2826857687.launch_template_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_config.2826857687.launch_template_specification.0.name", "tf-acc-test-1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_config.2826857687.overrides.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_config.225839035.launch_template_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_config.225839035.launch_template_specification.0.name", "tf-acc-test-2"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_config.225839035.overrides.#", "0"),
 				),
 			},
 		},
@@ -1398,7 +1398,7 @@ resource "aws_spot_fleet_request" "test" {
 
   depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
-`, validUntil, rName)
+`, validUntil)
 }
 
 func testAccAWSSpotFleetRequestLaunchTemplateConflictLaunchSpecification(rName string) string {

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -1143,7 +1143,7 @@ data "aws_availability_zones" "available" {
   }
 }
 resource "aws_key_pair" "test" {
-  key_name   = "tmp-key-%[1]s"
+  key_name   = %[1]q
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 
   tags = {
@@ -1152,7 +1152,7 @@ resource "aws_key_pair" "test" {
 }
 
 resource "aws_iam_role" "test-role" {
-  name = "test-role-%[1]s"
+  name = %[1]q
 
   assume_role_policy = <<EOF
 {

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -385,27 +385,19 @@ func TestAccAWSSpotFleetRequest_changePriceForcesNewRequest(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestConfig(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						resourceName, &before),
-					resource.TestCheckResourceAttr(
-						resourceName, "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						resourceName, "spot_price", "0.005"),
-					resource.TestCheckResourceAttr(
-						resourceName, "launch_specification.#", "1"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "spot_price", "0.005"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "1"),
 				),
 			},
 			{
 				Config: testAccAWSSpotFleetRequestConfigChangeSpotBidPrice(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						resourceName, &after),
-					resource.TestCheckResourceAttr(
-						resourceName, "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						resourceName, "launch_specification.#", "1"),
-					resource.TestCheckResourceAttr(
-						resourceName, "spot_price", "0.01"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &after),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spot_price", "0.01"),
 					testAccCheckAWSSpotFleetRequestConfigRecreated(t, &before, &after),
 				),
 			},
@@ -498,12 +490,9 @@ func TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestConfig(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						resourceName, &sfr),
-					resource.TestCheckResourceAttr(
-						resourceName, "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						resourceName, "launch_specification.#", "1"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "1"),
 				),
 			},
 		},
@@ -525,16 +514,11 @@ func TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestConfigWithAzs(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						resourceName, &sfr),
-					resource.TestCheckResourceAttr(
-						resourceName, "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						resourceName, "launch_specification.#", "2"),
-					resource.TestCheckResourceAttr(
-						resourceName, "launch_specification.1991689378.availability_zone", "us-west-2a"),
-					resource.TestCheckResourceAttr(
-						resourceName, "launch_specification.19404370.availability_zone", "us-west-2b"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.1991689378.availability_zone", "us-west-2a"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.19404370.availability_zone", "us-west-2b"),
 				),
 			},
 		},
@@ -556,12 +540,9 @@ func TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestConfigWithSubnet(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						resourceName, &sfr),
-					resource.TestCheckResourceAttr(
-						resourceName, "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						resourceName, "launch_specification.#", "2"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "2"),
 				),
 			},
 		},
@@ -583,20 +564,13 @@ func TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestConfigMultipleInstanceTypesinSameAz(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						resourceName, &sfr),
-					resource.TestCheckResourceAttr(
-						resourceName, "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						resourceName, "launch_specification.#", "2"),
-					resource.TestCheckResourceAttr(
-						resourceName, "launch_specification.1991689378.instance_type", "m1.small"),
-					resource.TestCheckResourceAttr(
-						resourceName, "launch_specification.1991689378.availability_zone", "us-west-2a"),
-					resource.TestCheckResourceAttr(
-						resourceName, "launch_specification.590403189.instance_type", "m3.large"),
-					resource.TestCheckResourceAttr(
-						resourceName, "launch_specification.590403189.availability_zone", "us-west-2a"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.1991689378.instance_type", "m1.small"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.1991689378.availability_zone", "us-west-2a"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.590403189.instance_type", "m3.large"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.590403189.availability_zone", "us-west-2a"),
 				),
 			},
 		},
@@ -641,12 +615,9 @@ func TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet(t *testing.T) 
 			{
 				Config: testAccAWSSpotFleetRequestConfigMultipleInstanceTypesinSameSubnet(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						resourceName, &sfr),
-					resource.TestCheckResourceAttr(
-						resourceName, "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						resourceName, "launch_specification.#", "2"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "2"),
 				),
 			},
 		},
@@ -668,22 +639,14 @@ func TestAccAWSSpotFleetRequest_overriddingSpotPrice(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestConfigOverridingSpotPrice(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						resourceName, &sfr),
-					resource.TestCheckResourceAttr(
-						resourceName, "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						resourceName, "spot_price", "0.035"),
-					resource.TestCheckResourceAttr(
-						resourceName, "launch_specification.#", "2"),
-					resource.TestCheckResourceAttr(
-						resourceName, "launch_specification.4143232216.spot_price", "0.01"),
-					resource.TestCheckResourceAttr(
-						resourceName, "launch_specification.4143232216.instance_type", "m3.large"),
-					resource.TestCheckResourceAttr(
-						resourceName, "launch_specification.1991689378.spot_price", ""), //there will not be a value here since it's not overriding
-					resource.TestCheckResourceAttr(
-						resourceName, "launch_specification.1991689378.instance_type", "m1.small"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "spot_price", "0.035"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.4143232216.spot_price", "0.01"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.4143232216.instance_type", "m3.large"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.1991689378.spot_price", ""), //there will not be a value here since it's not overriding
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.1991689378.instance_type", "m1.small"),
 				),
 			},
 		},
@@ -705,12 +668,9 @@ func TestAccAWSSpotFleetRequest_withoutSpotPrice(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestConfigWithoutSpotPrice(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						resourceName, &sfr),
-					resource.TestCheckResourceAttr(
-						resourceName, "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						resourceName, "launch_specification.#", "2"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "2"),
 				),
 			},
 		},
@@ -732,14 +692,10 @@ func TestAccAWSSpotFleetRequest_diversifiedAllocation(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestConfigDiversifiedAllocation(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						resourceName, &sfr),
-					resource.TestCheckResourceAttr(
-						resourceName, "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						resourceName, "launch_specification.#", "3"),
-					resource.TestCheckResourceAttr(
-						resourceName, "allocation_strategy", "diversified"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "allocation_strategy", "diversified"),
 				),
 			},
 		},
@@ -761,16 +717,11 @@ func TestAccAWSSpotFleetRequest_multipleInstancePools(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestConfigMultipleInstancePools(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						resourceName, &sfr),
-					resource.TestCheckResourceAttr(
-						resourceName, "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						resourceName, "launch_specification.#", "3"),
-					resource.TestCheckResourceAttr(
-						resourceName, "allocation_strategy", "lowestPrice"),
-					resource.TestCheckResourceAttr(
-						resourceName, "instance_pools_to_use_count", "2"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "allocation_strategy", "lowestPrice"),
+					resource.TestCheckResourceAttr(resourceName, "instance_pools_to_use_count", "2"),
 				),
 			},
 		},
@@ -807,20 +758,13 @@ func TestAccAWSSpotFleetRequest_withWeightedCapacity(t *testing.T) {
 				Config: testAccAWSSpotFleetRequestConfigWithWeightedCapacity(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					fulfillSleep(),
-					testAccCheckAWSSpotFleetRequestExists(
-						resourceName, &sfr),
-					resource.TestCheckResourceAttr(
-						resourceName, "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						resourceName, "launch_specification.#", "2"),
-					resource.TestCheckResourceAttr(
-						resourceName, "launch_specification.4120185872.weighted_capacity", "3"),
-					resource.TestCheckResourceAttr(
-						resourceName, "launch_specification.4120185872.instance_type", "r3.large"),
-					resource.TestCheckResourceAttr(
-						resourceName, "launch_specification.590403189.weighted_capacity", "6"),
-					resource.TestCheckResourceAttr(
-						resourceName, "launch_specification.590403189.instance_type", "m3.large"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.4120185872.weighted_capacity", "3"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.4120185872.instance_type", "r3.large"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.590403189.weighted_capacity", "6"),
+					resource.TestCheckResourceAttr(resourceName, "launch_specification.590403189.instance_type", "m3.large"),
 				),
 			},
 		},
@@ -982,10 +926,8 @@ func TestAccAWSSpotFleetRequest_WithTargetGroups(t *testing.T) {
 			{
 				Config: testAccAWSSpotFleetRequestConfigWithTargetGroups(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						resourceName, &sfr),
-					resource.TestCheckResourceAttr(
-						resourceName, "spot_request_state", "active"),
+					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
+					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
 					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "target_group_arns.#", "1"),
 				),

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -166,9 +166,9 @@ func TestAccAWSSpotFleetRequest_launchTemplate(t *testing.T) {
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
 					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.795271135.launch_template_specification.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.795271135.overrides.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_config.795271135.launch_template_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_config.795271135.overrides.#", "0"),
 				),
 			},
 		},
@@ -185,7 +185,7 @@ func TestAccAWSSpotFleetRequest_launchTemplateConflictLaunchSpecification(t *tes
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAWSSpotFleetRequestLaunchTemplateConflictLaunchSpecification(rName),
-				ExpectError: regexp.MustCompile(`"launch_specification": conflicts with launch_template_configs`),
+				ExpectError: regexp.MustCompile(`"launch_specification": conflicts with launch_template_config`),
 			},
 		},
 	})
@@ -209,15 +209,15 @@ func TestAccAWSSpotFleetRequest_launchTemplateWithOverrides(t *testing.T) {
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
 					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.2247196053.launch_template_specification.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.2247196053.overrides.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.2247196053.overrides.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.2247196053.overrides.1951041615.instance_type", "t1.micro"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.2247196053.overrides.1951041615.weighted_capacity", "2"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.2247196053.overrides.1866154075.instance_type", "m3.medium"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.2247196053.overrides.1866154075.priority", "1"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.2247196053.overrides.1866154075.spot_price", "0.26"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_config.2247196053.launch_template_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_config.2247196053.overrides.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_config.2247196053.overrides.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_config.2247196053.overrides.1951041615.instance_type", "t1.micro"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_config.2247196053.overrides.1951041615.weighted_capacity", "2"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_config.2247196053.overrides.1866154075.instance_type", "m3.medium"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_config.2247196053.overrides.1866154075.priority", "1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_config.2247196053.overrides.1866154075.spot_price", "0.26"),
 				),
 			},
 		},
@@ -242,9 +242,9 @@ func TestAccAWSSpotFleetRequest_launchTemplateToLaunchSpec(t *testing.T) {
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
 					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.795271135.launch_template_specification.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.795271135.overrides.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_config.795271135.launch_template_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_config.795271135.overrides.#", "0"),
 				),
 			},
 			{
@@ -288,9 +288,9 @@ func TestAccAWSSpotFleetRequest_launchSpecToLaunchTemplate(t *testing.T) {
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
 					resource.TestCheckResourceAttr(resourceName, "launch_specification.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.795271135.launch_template_specification.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "launch_template_configs.795271135.overrides.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_config.795271135.launch_template_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "launch_template_config.795271135.overrides.#", "0"),
 					testAccCheckAWSSpotFleetRequestConfigRecreated(t, &before, &after),
 				),
 			},
@@ -1374,7 +1374,7 @@ resource "aws_spot_fleet_request" "test" {
   instance_interruption_behaviour     = "stop"
   wait_for_fulfillment                = true
 
-  launch_template_configs {
+  launch_template_config {
     launch_template_specification {
       name    = "${aws_launch_template.test.name}"
       version = "${aws_launch_template.test.latest_version}"
@@ -1421,7 +1421,7 @@ resource "aws_spot_fleet_request" "test" {
     spot_price = "0.005"
     target_capacity = 2
 
-    launch_template_configs {
+    launch_template_config {
       launch_template_specification {
         name = "${aws_launch_template.test.name}"
         version = "${aws_launch_template.test.latest_version}"
@@ -1462,7 +1462,7 @@ resource "aws_spot_fleet_request" "test" {
   instance_interruption_behaviour     = "stop"
   wait_for_fulfillment                = true
 
-  launch_template_configs {
+  launch_template_config {
     launch_template_specification {
       name    = "${aws_launch_template.test.name}"
       version = "${aws_launch_template.test.latest_version}"

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -1179,7 +1179,7 @@ EOF
 }
 
 resource "aws_iam_policy" "test-policy" {
-  name        = "test-policy-%[2]d"
+  name        = %[1]q
   path        = "/"
   description = "Spot Fleet Request ACCTest Policy"
 
@@ -1203,7 +1203,7 @@ EOF
 }
 
 resource "aws_iam_policy_attachment" "test-attach" {
-  name       = "test-attachment-%[2]d"
+  name       = %[1]q
   roles      = ["${aws_iam_role.test-role.name}"]
   policy_arn = "${aws_iam_policy.test-policy.arn}"
 }

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -149,52 +149,52 @@ func TestAccAWSSpotFleetRequest_associatePublicIpAddress(t *testing.T) {
 }
 
 func TestAccAWSSpotFleetRequest_fleetType(t *testing.T) {
-	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+    var sfr ec2.SpotFleetRequestConfig
+    rName := acctest.RandString(10)
+    rInt := acctest.RandInt()
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotFleetRequestConfigFleetType(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "fleet_type", "request"),
-				),
-			},
-		},
-	})
+    resource.ParallelTest(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAWSSpotFleetRequestConfigFleetType(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &sfr),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "fleet_type", "request"),
+                ),
+            },
+        },
+    })
 }
 
 func TestAccAWSSpotFleetRequest_iamInstanceProfileArn(t *testing.T) {
-	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+    var sfr ec2.SpotFleetRequestConfig
+    rName := acctest.RandString(10)
+    rInt := acctest.RandInt()
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotFleetRequestConfigIamInstanceProfileArn(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					testAccCheckAWSSpotFleetRequest_IamInstanceProfileArn(&sfr),
-				),
-			},
-		},
-	})
+    resource.ParallelTest(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAWSSpotFleetRequestConfigIamInstanceProfileArn(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &sfr),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    testAccCheckAWSSpotFleetRequest_IamInstanceProfileArn(&sfr),
+                ),
+            },
+        },
+    })
 }
 
 func TestAccAWSSpotFleetRequest_launchTemplate(t *testing.T) {
@@ -280,36 +280,36 @@ func TestAccAWSSpotFleetRequest_launchTemplateConflictLaunchSpecification(t *tes
 
 //On-Demand capacity requires launch template defined spot fleet, so can't test without it.
 func TestAccAWSSpotFleetRequest_launchTemplateWithOnDemandCapacity(t *testing.T) {
-	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+    var sfr ec2.SpotFleetRequestConfig
+    rName := acctest.RandString(10)
+    rInt := acctest.RandInt()
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotFleetRequestLaunchTemplateConfigWithOnDemandCapacity(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.#", "0"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.4018047529.launch_template_specification.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.4018047529.overrides.#", "0"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "on_demand_target_capacity", "2"),
-				),
-			},
-		},
-	})
+    resource.ParallelTest(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAWSSpotFleetRequestLaunchTemplateConfigWithOnDemandCapacity(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &sfr),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.#", "0"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_template_configs.#", "1"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_template_configs.4018047529.launch_template_specification.#", "1"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_template_configs.4018047529.overrides.#", "0"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "on_demand_target_capacity", "2"),
+                ),
+            },
+        },
+    })
 }
 
 func TestAccAWSSpotFleetRequest_launchTemplateWithOverrides(t *testing.T) {
@@ -720,6 +720,29 @@ func TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccCheckAWSSpotFleetRequest_IamInstanceProfileArn(
+    sfr *ec2.SpotFleetRequestConfig) resource.TestCheckFunc {
+    return func(s *terraform.State) error {
+        if len(sfr.SpotFleetRequestConfig.LaunchSpecifications) == 0 {
+            return errors.New("Missing launch specification")
+        }
+
+        spec := *sfr.SpotFleetRequestConfig.LaunchSpecifications[0]
+
+        profile := spec.IamInstanceProfile
+        if profile == nil {
+            return fmt.Errorf("Expected IamInstanceProfile to be set, got nil")
+        }
+        //Validate the string whether it is ARN
+        re := regexp.MustCompile("arn:aws:iam::\\d{12}:instance-profile/?[a-zA-Z0-9+=,.@-_].*")
+        if !re.MatchString(*profile.Arn) {
+            return fmt.Errorf("Expected IamInstanceProfile input as ARN, got %s", *profile.Arn)
+        }
+
+        return nil
+    }
 }
 
 func TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet(t *testing.T) {
@@ -1551,7 +1574,7 @@ resource "aws_spot_fleet_request" "foo" {
 }
 
 func testAccAWSSpotFleetRequestLaunchTemplateConfigWithOnDemandCapacity(rName string, rInt int) string {
-	return fmt.Sprintf(`
+    return fmt.Sprintf(`
 resource "aws_key_pair" "debugging" {
     key_name = "tmp-key-%s"
     public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -213,6 +213,22 @@ func TestAccAWSSpotFleetRequest_launchTemplateWithOnDemandCapacity(t *testing.T)
 	})
 }
 
+func TestAccAWSSpotFleetRequest_launchTemplateConflictLaunchSpecification(t *testing.T) {
+    rName := acctest.RandString(10)
+
+    resource.ParallelTest(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config:      testAccAWSSpotFleetRequestLaunchTemplateConflictLaunchSpecification(rName),
+                ExpectError: regexp.MustCompile(`"launch_template_configs": conflicts with launch_specification`),
+            },
+        },
+    })
+}
+
 func TestAccAWSSpotFleetRequest_launchTemplateWithOverrides(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
 	rName := acctest.RandString(10)
@@ -1393,43 +1409,8 @@ resource "aws_spot_fleet_request" "foo" {
 `, rName, rInt, rInt, rName)
 }
 
-<<<<<<< HEAD
-func testAccAWSSpotFleetRequestLaunchTemplateConfigWithOnDemandCapacity(rName string, rInt int) string {
+func testAccAWSSpotFleetRequestLaunchTemplateConflictLaunchSpecification(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_key_pair" "debugging" {
-    key_name = "tmp-key-%s"
-    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
-}
-
-resource "aws_iam_policy" "test-policy" {
-  name = "test-policy-%d"
-  path = "/"
-  description = "Spot Fleet Request ACCTest Policy"
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [{
-    "Effect": "Allow",
-    "Action": [
-       "ec2:DescribeImages",
-       "ec2:DescribeSubnets",
-       "ec2:RequestSpotInstances",
-       "ec2:TerminateInstances",
-       "ec2:DescribeInstanceStatus",
-       "iam:PassRole"
-        ],
-    "Resource": ["*"]
-  }]
-}
-EOF
-}
-
-resource "aws_iam_policy_attachment" "test-attach" {
-    name = "test-attachment-%d"
-    roles = ["${aws_iam_role.test-role.name}"]
-    policy_arn = "${aws_iam_policy.test-policy.arn}"
-}
-
 resource "aws_iam_role" "test-role" {
     name = "test-role-%s"
     assume_role_policy = <<EOF
@@ -1453,35 +1434,39 @@ EOF
 }
 
 resource "aws_launch_template" "foo" {
-  name = "test-launch-template"
+  name = "test-launch-template-%s"
   image_id = "ami-516b9131"
   instance_type = "m1.small"
-  key_name = "${aws_key_pair.debugging.key_name}"
 }
 
 resource "aws_spot_fleet_request" "foo" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
     spot_price = "0.005"
     target_capacity = 2
-    valid_until = "2019-11-04T20:44:20Z"
-    terminate_instances_with_expiration = true
-    wait_for_fulfillment = true
-    on_demand_target_capacity = 2
 
     launch_template_configs {
       launch_template_specification {
         name = "${aws_launch_template.foo.name}"
         version = "${aws_launch_template.foo.latest_version}"
       }
+      overrides {
+        instance_type = "t1.micro"
+        weighted_capacity = "2"
+      }
+      overrides {
+        instance_type = "m3.medium"
+        spot_price = "0.26"
+      }
     }
 
-    depends_on = ["aws_iam_policy_attachment.test-attach"]
+    launch_specification {
+        instance_type = "m1.small"
+        ami = "ami-516b9131"
+    }
 }
-`, rName, rInt, rInt, rName)
+`, rName, rName)
 }
 
-=======
->>>>>>> removed on-demand spot instance feature due to moving to a different PR
 func testAccAWSSpotFleetRequestLaunchTemplateConfigWithOverrides(rName string, rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_key_pair" "debugging" {

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -1280,29 +1280,6 @@ func testAccCheckAWSSpotFleetRequest_PlacementAttributes(
 
 }
 
-func testAccCheckAWSSpotFleetRequest_IamInstanceProfileArn(
-	sfr *ec2.SpotFleetRequestConfig) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if len(sfr.SpotFleetRequestConfig.LaunchSpecifications) == 0 {
-			return errors.New("Missing launch specification")
-		}
-
-		spec := *sfr.SpotFleetRequestConfig.LaunchSpecifications[0]
-
-		profile := spec.IamInstanceProfile
-		if profile == nil {
-			return fmt.Errorf("Expected IamInstanceProfile to be set, got nil")
-		}
-		//Validate the string whether it is ARN
-		re := regexp.MustCompile(`arn:aws:iam::\d{12}:instance-profile/?[a-zA-Z0-9+=,.@-_].*`)
-		if !re.MatchString(*profile.Arn) {
-			return fmt.Errorf("Expected IamInstanceProfile input as ARN, got %s", *profile.Arn)
-		}
-
-		return nil
-	}
-}
-
 func testAccPreCheckAWSEc2SpotFleetRequest(t *testing.T) {
 	conn := testAccProvider.Meta().(*AWSClient).ec2conn
 

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -208,7 +208,7 @@ func TestAccAWSSpotFleetRequest_launchTemplateConflictLaunchSpecification(t *tes
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAWSSpotFleetRequestLaunchTemplateConflictLaunchSpecification(rName),
-				ExpectError: regexp.MustCompile(`"launch_specification": conflicts with launch_template_config`),
+				ExpectError: regexp.MustCompile(`"launch_specification": only one of .+`),
 			},
 		},
 	})
@@ -1371,6 +1371,15 @@ func testAccAWSSpotFleetRequestLaunchTemplateMultipleConfig(rName string, rInt i
 	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) +
 		testAccAWSSpotFleetRequestLaunchTemplateConfigBase() +
 		fmt.Sprintf(`
+data "aws_ec2_instance_type_offering" "test" {
+  filter {
+    name   = "instance-type"
+    values = ["t1.micro"]
+  }
+
+  preferred_instance_types = ["t1.micro"]
+}
+
 resource "aws_launch_template" "test1" {
   name          = "%[2]s-1"
   image_id      = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
@@ -1381,7 +1390,7 @@ resource "aws_launch_template" "test1" {
 resource "aws_launch_template" "test2" {
   name          = "%[2]s-2"
   image_id      = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
-  instance_type = "${data.aws_ec2_instance_type_offering.available.instance_type}"
+  instance_type = "${data.aws_ec2_instance_type_offering.available.test}"
   key_name      = "${aws_key_pair.debugging.key_name}"
 }
 

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -4684,31 +4684,6 @@ func flattenLaunchTemplateSpecification(lt *autoscaling.LaunchTemplateSpecificat
 	return result
 }
 
-func flattenFleetLaunchTemplateSpecification(flt *ec2.FleetLaunchTemplateSpecification) []map[string]interface{} {
-	attrs := map[string]interface{}{}
-	result := make([]map[string]interface{}, 0)
-
-	// unlike autoscaling.LaunchTemplateConfiguration, FleetLaunchTemplateSpecs only return what was set
-	if flt.LaunchTemplateId != nil {
-		attrs["id"] = aws.StringValue(flt.LaunchTemplateId)
-	}
-
-	if flt.LaunchTemplateName != nil {
-		attrs["name"] = aws.StringValue(flt.LaunchTemplateName)
-	}
-
-	// version is returned only if it was previously set
-	if flt.Version != nil {
-		attrs["version"] = aws.StringValue(flt.Version)
-	} else {
-		attrs["version"] = nil
-	}
-
-	result = append(result, attrs)
-
-	return result
-}
-
 func flattenVpcPeeringConnectionOptions(options *ec2.VpcPeeringConnectionOptionsDescription) []interface{} {
 	// When the VPC Peering Connection is pending acceptance,
 	// the details about accepter and/or requester peering

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -4690,16 +4690,16 @@ func flattenFleetLaunchTemplateSpecification(flt *ec2.FleetLaunchTemplateSpecifi
 
 	// unlike autoscaling.LaunchTemplateConfiguration, FleetLaunchTemplateSpecs only return what was set
 	if flt.LaunchTemplateId != nil {
-		attrs["id"] = *flt.LaunchTemplateId
+		attrs["id"] = aws.StringValue(flt.LaunchTemplateId)
 	}
 
 	if flt.LaunchTemplateName != nil {
-		attrs["name"] = *flt.LaunchTemplateName
+		attrs["name"] = aws.StringValue(flt.LaunchTemplateName)
 	}
 
 	// version is returned only if it was previously set
 	if flt.Version != nil {
-		attrs["version"] = *flt.Version
+		attrs["version"] = aws.StringValue(flt.Version)
 	} else {
 		attrs["version"] = nil
 	}

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -13,7 +13,7 @@ instances to be requested on the Spot market.
 
 ## Example Usage
 
-### Using launch specifications:
+### Using launch specifications
 
 ```hcl
 # Request a Spot fleet
@@ -54,7 +54,7 @@ resource "aws_spot_fleet_request" "cheap_compute" {
 }
 ```
 
-### Using launch templates:
+### Using launch templates
 
 ```
 resource "aws_launch_template" "foo" {

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -54,7 +54,7 @@ resource "aws_spot_fleet_request" "cheap_compute" {
 }
 ```
 
-Using launch templates:
+### Using launch templates:
 
 ```
 resource "aws_launch_template" "foo" {

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -13,7 +13,7 @@ instances to be requested on the Spot market.
 
 ## Example Usage
 
-Using launch specifications:
+### Using launch specifications:
 
 ```hcl
 # Request a Spot fleet

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -13,6 +13,8 @@ instances to be requested on the Spot market.
 
 ## Example Usage
 
+Using launch specifications:
+
 ```hcl
 # Request a Spot fleet
 resource "aws_spot_fleet_request" "cheap_compute" {
@@ -52,10 +54,41 @@ resource "aws_spot_fleet_request" "cheap_compute" {
 }
 ```
 
+Using launch templates:
+
+```
+resource "aws_launch_template" "foo" {
+  name = "test-launch-template"
+  image_id = "${var.ami}"
+  instance_type = "${var.instance_type}"
+  key_name = "${var.key_name}"
+  spot_price = "0.05"
+}
+
+resource "aws_spot_fleet_request" "foo" {
+  iam_fleet_role  = "arn:aws:iam::12345678:role/spot-fleet"
+  spot_price      = "0.005"
+  target_capacity = 2
+  valid_until     = "2019-11-04T20:44:20Z"
+
+  launch_template_configs {
+      launch_template_specification {
+        id = "${aws_launch_template.foo.id}"
+        version = "${aws_launch_template.foo.latest_version}"
+      }
+  }
+
+  depends_on = ["aws_iam_policy_attachment.test-attach"]
+}
+```
+
 ~> **NOTE:** Terraform does not support the functionality where multiple `subnet_id` or `availability_zone` parameters can be specified in the same
-launch configuration block. If you want to specify multiple values, then separate launch configuration blocks should be used:
+launch configuration block. If you want to specify multiple values, then separate launch configuration blocks should be used or launch template overrides should be configured, one per subnet:
 
 ```hcl
+#
+# Launch Specification Method
+#
 resource "aws_spot_fleet_request" "foo" {
   iam_fleet_role  = "arn:aws:iam::12345678:role/spot-fleet"
   spot_price      = "0.005"
@@ -76,6 +109,47 @@ resource "aws_spot_fleet_request" "foo" {
     availability_zone = "us-west-2a"
   }
 }
+
+#
+# Launch Template Method
+#
+
+data "aws_subnet_ids" "example" {
+  vpc_id = "${var.vpc_id}"
+}
+
+resource "aws_launch_template" "foo" {
+  name = "test-launch-template"
+  image_id = "${var.ami}"
+  instance_type = "${var.instance_type}"
+  key_name = "${var.key_name}"
+  spot_price = "0.05"
+}
+
+resource "aws_spot_fleet_request" "foo" {
+  iam_fleet_role  = "arn:aws:iam::12345678:role/spot-fleet"
+  spot_price      = "0.005"
+  target_capacity = 2
+  valid_until     = "2019-11-04T20:44:20Z"
+
+  launch_template_configs {
+      launch_template_specification {
+        id = "${aws_launch_template.foo.id}"
+        version = "${aws_launch_template.foo.latest_version}"
+      }
+      overrides {
+        subnet_id = "${data.aws_subnets.example.ids[0]}"
+      }
+      overrides {
+        subnet_id = "${data.aws_subnets.example.ids[1]}"
+      }
+      overrides {
+        subnet_id = "${data.aws_subnets.example.ids[2]}"
+      }
+    }
+
+  depends_on = ["aws_iam_policy_attachment.test-attach"]
+}
 ```
 
 ## Argument Reference
@@ -88,9 +162,9 @@ Most of these arguments directly correspond to the
 CancelSpotFleetRequests or when the Spot fleet request expires, if you set
 terminateInstancesWithExpiration.
 * `replace_unhealthy_instances` - (Optional) Indicates whether Spot fleet should replace unhealthy instances. Default `false`.
-* `launch_specification` - Used to define the launch configuration of the
+* `launch_specification` - (Optional) Used to define the launch configuration of the
   spot-fleet request. Can be specified multiple times to define different bids
-across different markets and instance types.
+across different markets and instance types. Conflicts with `launch_template_configs`. At least one of `launch_specification` or `launch_template_configs` is required.
 
     **Note:** This takes in similar but not
     identical inputs as [`aws_instance`](instance.html).  There are limitations on
@@ -98,6 +172,7 @@ across different markets and instance types.
     [reference documentation](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_SpotFleetLaunchSpecification.html). Any normal [`aws_instance`](instance.html) parameter that corresponds to those inputs may be used and it have
     a additional parameter `iam_instance_profile_arn` takes `aws_iam_instance_profile` attribute `arn` as input.
 
+* `launch_template_configs` - (Optional) Launch template configuration block. See [Launch Template Configs](#launch-template-configs) below for more details. Conflicts with `launch_specification`. At least one of `launch_specification` or `launch_template_configs` is required.
 * `spot_price` - (Optional; Default: On-demand price) The maximum bid price per unit hour.
 * `wait_for_fulfillment` - (Optional; Default: false) If set, Terraform will
   wait for the Spot Request to be fulfilled, and will throw an error if the
@@ -105,6 +180,7 @@ across different markets and instance types.
 * `target_capacity` - The number of units to request. You can choose to set the
   target capacity in terms of instances or a performance characteristic that is
   important to your application workload, such as vCPUs, memory, or I/O.
+* `on_demand_target_capacity` - (Optional) Allows specification of a minimum value of the `target_capacity` to be filled by full price on-demand instance to ensure a minimum capacity of the fleet no matter spot instance availability. Not supported by `launch_specification`, must be used with `launch_template_configs`.
 * `allocation_strategy` - Indicates how to allocate the target capacity across
   the Spot pools specified by the Spot fleet request. The default is
   `lowestPrice`.
@@ -128,6 +204,33 @@ across different markets and instance types.
 * `load_balancers` (Optional) A list of elastic load balancer names to add to the Spot fleet.
 * `target_group_arns` (Optional) A list of `aws_alb_target_group` ARNs, for use with Application Load Balancing.
 * `tags` - (Optional) A map of tags to assign to the resource.
+
+### Launch Template Configs
+
+The `launch_template_configs` block supports the following:
+
+* `launch_template_specification` - (Required) Launch template specification. See [Launch Template Specification](#launch-template-specification) below for more details.
+* `overrides` - (Optional) One or more overide configurations. See [Overrides](#overrides) below for more details. 
+
+### Launch Template Specification
+
+* `id` - The ID of the launch template. Conflicts with `name`.
+* `name` - The name of the launch template. Conflicts with `id`.
+* `version` - (Optional) Template version. Unlike the autoscaling equivalent, does not support `$Latest` or `$Default`, so use the launch_template resource's attribute, e.g. `"${aws_launch_template.foo.latest_version}"`. Wil use default version if omitted.
+
+    **Note:** The specified launch template can specify only a subset of the 
+    inputs of [`aws_launch_template`](launch_template.html).  There are limitations on
+    what you can specify as spot fleet does not support all the attributes that are supported by autoscaling groups. [AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-launch-templates.html#launch-templates-spot-fleet) is currently sparse, but at least `instance_initiated_shutdown_behavior` is confirmed unsupported.
+
+### Overrides
+
+* `instance_type` - (Optional) The type of instance to request.
+* `availability_zone` - (Optional) The availability zone in which to place the request.
+* `spot_price` - (Optional) The maximum spot bid for this override request.
+* `weighted_capacity` - (Optional) The capacity added to the fleet by a fulfilled request.
+* `subnet_id` - (Optional) The subnet in which to launch the requested instance.
+
+  **Note:** Instead of statically defining these override blocks they can be passed in as a list of maps containing the above keys and their values. This allows dynamic, programmatic generation of overrides based on variable or environment data.
 
 ### Timeouts
 

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -223,11 +223,12 @@ The `launch_template_configs` block supports the following:
 
 ### Overrides
 
-* `instance_type` - (Optional) The type of instance to request.
 * `availability_zone` - (Optional) The availability zone in which to place the request.
+* `instance_type` - (Optional) The type of instance to request.
+* `priority` - (Optional) The priority for the launch template override. The lower the number, the higher the priority. If no number is set, the launch template override has the lowest priority.
 * `spot_price` - (Optional) The maximum spot bid for this override request.
-* `weighted_capacity` - (Optional) The capacity added to the fleet by a fulfilled request.
 * `subnet_id` - (Optional) The subnet in which to launch the requested instance.
+* `weighted_capacity` - (Optional) The capacity added to the fleet by a fulfilled request.
 
   **Note:** Instead of statically defining these override blocks they can be passed in as a list of maps containing the above keys and their values. This allows dynamic, programmatic generation of overrides based on variable or environment data.
 

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -71,7 +71,7 @@ resource "aws_spot_fleet_request" "foo" {
   target_capacity = 2
   valid_until     = "2019-11-04T20:44:20Z"
 
-  launch_template_configs {
+  launch_template_config {
     launch_template_specification {
       id      = "${aws_launch_template.foo.id}"
       version = "${aws_launch_template.foo.latest_version}"
@@ -132,7 +132,7 @@ resource "aws_spot_fleet_request" "foo" {
   target_capacity = 2
   valid_until     = "2019-11-04T20:44:20Z"
 
-  launch_template_configs {
+  launch_template_config {
     launch_template_specification {
       id      = "${aws_launch_template.foo.id}"
       version = "${aws_launch_template.foo.latest_version}"
@@ -164,7 +164,7 @@ terminateInstancesWithExpiration.
 * `replace_unhealthy_instances` - (Optional) Indicates whether Spot fleet should replace unhealthy instances. Default `false`.
 * `launch_specification` - (Optional) Used to define the launch configuration of the
   spot-fleet request. Can be specified multiple times to define different bids
-across different markets and instance types. Conflicts with `launch_template_configs`. At least one of `launch_specification` or `launch_template_configs` is required.
+across different markets and instance types. Conflicts with `launch_template_config`. At least one of `launch_specification` or `launch_template_config` is required.
 
     **Note:** This takes in similar but not
     identical inputs as [`aws_instance`](instance.html).  There are limitations on
@@ -172,7 +172,7 @@ across different markets and instance types. Conflicts with `launch_template_con
     [reference documentation](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_SpotFleetLaunchSpecification.html). Any normal [`aws_instance`](instance.html) parameter that corresponds to those inputs may be used and it have
     a additional parameter `iam_instance_profile_arn` takes `aws_iam_instance_profile` attribute `arn` as input.
 
-* `launch_template_configs` - (Optional) Launch template configuration block. See [Launch Template Configs](#launch-template-configs) below for more details. Conflicts with `launch_specification`. At least one of `launch_specification` or `launch_template_configs` is required.
+* `launch_template_config` - (Optional) Launch template configuration block. See [Launch Template Configs](#launch-template-configs) below for more details. Conflicts with `launch_specification`. At least one of `launch_specification` or `launch_template_config` is required.
 * `spot_price` - (Optional; Default: On-demand price) The maximum bid price per unit hour.
 * `wait_for_fulfillment` - (Optional; Default: false) If set, Terraform will
   wait for the Spot Request to be fulfilled, and will throw an error if the
@@ -206,7 +206,7 @@ across different markets and instance types. Conflicts with `launch_template_con
 
 ### Launch Template Configs
 
-The `launch_template_configs` block supports the following:
+The `launch_template_config` block supports the following:
 
 * `launch_template_specification` - (Required) Launch template specification. See [Launch Template Specification](#launch-template-specification) below for more details.
 * `overrides` - (Optional) One or more overide configurations. See [Overrides](#overrides) below for more details. 

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -230,8 +230,6 @@ The `launch_template_config` block supports the following:
 * `subnet_id` - (Optional) The subnet in which to launch the requested instance.
 * `weighted_capacity` - (Optional) The capacity added to the fleet by a fulfilled request.
 
-  **Note:** Instead of statically defining these override blocks they can be passed in as a list of maps containing the above keys and their values. This allows dynamic, programmatic generation of overrides based on variable or environment data.
-
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -58,10 +58,10 @@ resource "aws_spot_fleet_request" "cheap_compute" {
 
 ```hcl
 resource "aws_launch_template" "foo" {
-  name          = "test-launch-template"
-  image_id      = "${var.ami}"
-  instance_type = "${var.instance_type}"
-  key_name      = "${var.key_name}"
+  name          = "launch-template"
+  image_id      = "ami-516b9131"
+  instance_type = "m1.small"
+  key_name      = "some-key"
   spot_price    = "0.05"
 }
 
@@ -119,10 +119,10 @@ data "aws_subnet_ids" "example" {
 }
 
 resource "aws_launch_template" "foo" {
-  name          = "test-launch-template"
-  image_id      = "${var.ami}"
-  instance_type = "${var.instance_type}"
-  key_name      = "${var.key_name}"
+  name          = "launch-template"
+  image_id      = "ami-516b9131"
+  instance_type = "m1.small"
+  key_name      = "some-key"
   spot_price    = "0.05"
 }
 

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -180,7 +180,7 @@ across different markets and instance types. Conflicts with `launch_template_con
 * `target_capacity` - The number of units to request. You can choose to set the
   target capacity in terms of instances or a performance characteristic that is
   important to your application workload, such as vCPUs, memory, or I/O.
-* `on_demand_target_capacity` - (Optional) Allows specification of a minimum value of the `target_capacity` to be filled by full price on-demand instance to ensure a minimum capacity of the fleet no matter spot instance availability. Not supported by `launch_specification`, must be used with `launch_template_configs`.
+* `on_demand_target_capacity` - (Optional) The number of full-price On-Demand units to request in addition to the spot instance capacity. Use this to guarantee a minimum capacity of the fleet even in the event that the spot requests cannot be filled. Capacity is defined in the same units as configured in target_capacity such as vCPUs, memory, or I/O. Not supported by launch_specification, must be used with launch_template_configs.
 * `allocation_strategy` - Indicates how to allocate the target capacity across
   the Spot pools specified by the Spot fleet request. The default is
   `lowestPrice`.
@@ -216,7 +216,7 @@ The `launch_template_configs` block supports the following:
 
 * `id` - The ID of the launch template. Conflicts with `name`.
 * `name` - The name of the launch template. Conflicts with `id`.
-* `version` - (Optional) Template version. Unlike the autoscaling equivalent, does not support `$Latest` or `$Default`, so use the launch_template resource's attribute, e.g. `"${aws_launch_template.foo.latest_version}"`. Wil use default version if omitted.
+* `version` - (Optional) Template version. Unlike the autoscaling equivalent, does not support `$Latest` or `$Default`, so use the launch_template resource's attribute, e.g. `"${aws_launch_template.foo.latest_version}"`. Will use default version if omitted.
 
     **Note:** The specified launch template can specify only a subset of the 
     inputs of [`aws_launch_template`](launch_template.html).  There are limitations on

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -215,7 +215,7 @@ The `launch_template_configs` block supports the following:
 
 * `id` - The ID of the launch template. Conflicts with `name`.
 * `name` - The name of the launch template. Conflicts with `id`.
-* `version` - (Optional) Template version. Unlike the autoscaling equivalent, does not support `$Latest` or `$Default`, so use the launch_template resource's attribute, e.g. `"${aws_launch_template.foo.latest_version}"`. Will use default version if omitted.
+* `version` - (Optional) Template version. Unlike the autoscaling equivalent, does not support `$Latest` or `$Default`, so use the launch_template resource's attribute, e.g. `"${aws_launch_template.foo.latest_version}"`. It will use the default version if omitted.
 
     **Note:** The specified launch template can specify only a subset of the 
     inputs of [`aws_launch_template`](launch_template.html).  There are limitations on

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -209,7 +209,7 @@ across different markets and instance types. Conflicts with `launch_template_con
 The `launch_template_config` block supports the following:
 
 * `launch_template_specification` - (Required) Launch template specification. See [Launch Template Specification](#launch-template-specification) below for more details.
-* `overrides` - (Optional) One or more overide configurations. See [Overrides](#overrides) below for more details. 
+* `overrides` - (Optional) One or more override configurations. See [Overrides](#overrides) below for more details. 
 
 ### Launch Template Specification
 

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -56,13 +56,13 @@ resource "aws_spot_fleet_request" "cheap_compute" {
 
 ### Using launch templates
 
-```
+```hcl
 resource "aws_launch_template" "foo" {
-  name = "test-launch-template"
-  image_id = "${var.ami}"
+  name          = "test-launch-template"
+  image_id      = "${var.ami}"
   instance_type = "${var.instance_type}"
-  key_name = "${var.key_name}"
-  spot_price = "0.05"
+  key_name      = "${var.key_name}"
+  spot_price    = "0.05"
 }
 
 resource "aws_spot_fleet_request" "foo" {
@@ -72,10 +72,10 @@ resource "aws_spot_fleet_request" "foo" {
   valid_until     = "2019-11-04T20:44:20Z"
 
   launch_template_configs {
-      launch_template_specification {
-        id = "${aws_launch_template.foo.id}"
-        version = "${aws_launch_template.foo.latest_version}"
-      }
+    launch_template_specification {
+      id      = "${aws_launch_template.foo.id}"
+      version = "${aws_launch_template.foo.latest_version}"
+    }
   }
 
   depends_on = ["aws_iam_policy_attachment.test-attach"]
@@ -85,10 +85,9 @@ resource "aws_spot_fleet_request" "foo" {
 ~> **NOTE:** Terraform does not support the functionality where multiple `subnet_id` or `availability_zone` parameters can be specified in the same
 launch configuration block. If you want to specify multiple values, then separate launch configuration blocks should be used or launch template overrides should be configured, one per subnet:
 
+### Using multiple launch specifications
+
 ```hcl
-#
-# Launch Specification Method
-#
 resource "aws_spot_fleet_request" "foo" {
   iam_fleet_role  = "arn:aws:iam::12345678:role/spot-fleet"
   spot_price      = "0.005"
@@ -109,21 +108,22 @@ resource "aws_spot_fleet_request" "foo" {
     availability_zone = "us-west-2a"
   }
 }
+```
 
-#
-# Launch Template Method
-#
 
+### Using multiple launch configurations
+
+```hcl
 data "aws_subnet_ids" "example" {
   vpc_id = "${var.vpc_id}"
 }
 
 resource "aws_launch_template" "foo" {
-  name = "test-launch-template"
-  image_id = "${var.ami}"
+  name          = "test-launch-template"
+  image_id      = "${var.ami}"
   instance_type = "${var.instance_type}"
-  key_name = "${var.key_name}"
-  spot_price = "0.05"
+  key_name      = "${var.key_name}"
+  spot_price    = "0.05"
 }
 
 resource "aws_spot_fleet_request" "foo" {
@@ -133,20 +133,20 @@ resource "aws_spot_fleet_request" "foo" {
   valid_until     = "2019-11-04T20:44:20Z"
 
   launch_template_configs {
-      launch_template_specification {
-        id = "${aws_launch_template.foo.id}"
-        version = "${aws_launch_template.foo.latest_version}"
-      }
-      overrides {
-        subnet_id = "${data.aws_subnets.example.ids[0]}"
-      }
-      overrides {
-        subnet_id = "${data.aws_subnets.example.ids[1]}"
-      }
-      overrides {
-        subnet_id = "${data.aws_subnets.example.ids[2]}"
-      }
+    launch_template_specification {
+      id      = "${aws_launch_template.foo.id}"
+      version = "${aws_launch_template.foo.latest_version}"
     }
+    overrides {
+      subnet_id = "${data.aws_subnets.example.ids[0]}"
+    }
+    overrides {
+      subnet_id = "${data.aws_subnets.example.ids[1]}"
+    }
+    overrides {
+      subnet_id = "${data.aws_subnets.example.ids[2]}"
+    }
+  }
 
   depends_on = ["aws_iam_policy_attachment.test-attach"]
 }

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -180,7 +180,6 @@ across different markets and instance types. Conflicts with `launch_template_con
 * `target_capacity` - The number of units to request. You can choose to set the
   target capacity in terms of instances or a performance characteristic that is
   important to your application workload, such as vCPUs, memory, or I/O.
-* `on_demand_target_capacity` - (Optional) The number of full-price On-Demand units to request in addition to the spot instance capacity. Use this to guarantee a minimum capacity of the fleet even in the event that the spot requests cannot be filled. Capacity is defined in the same units as configured in target_capacity such as vCPUs, memory, or I/O. Not supported by launch_specification, must be used with launch_template_configs.
 * `allocation_strategy` - Indicates how to allocate the target capacity across
   the Spot pools specified by the Spot fleet request. The default is
   `lowestPrice`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Replaces #4866
Closes #4267

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_spot_fleet_request: add `launch_template_config` support
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSpotFleetRequest_'
--- PASS: TestAccAWSSpotFleetRequest_basic (281.16s)
--- PASS: TestAccAWSSpotFleetRequest_tags (417.55s)
--- PASS: TestAccAWSSpotFleetRequest_associatePublicIpAddress (263.50s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplate (278.78s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplateConflictLaunchSpecification (3.86s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplateWithOverrides (271.12s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplateToLaunchSpec (544.95s)
--- PASS: TestAccAWSSpotFleetRequest_launchSpecToLaunchTemplate (811.98s)
--- PASS: TestAccAWSSpotFleetRequest_fleetType (333.26s)
--- PASS: TestAccAWSSpotFleetRequest_iamInstanceProfileArn (309.88s)
--- PASS: TestAccAWSSpotFleetRequest_changePriceForcesNewRequest (483.73s)
--- PASS: TestAccAWSSpotFleetRequest_updateTargetCapacity (893.50s)
--- PASS: TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy (602.37s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion (326.32s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList (351.75s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList (340.60s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz (351.36s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet (352.60s)
--- PASS: TestAccAWSSpotFleetRequest_overriddingSpotPrice (431.92s)
--- PASS: TestAccAWSSpotFleetRequest_withoutSpotPrice (290.77s)
--- PASS: TestAccAWSSpotFleetRequest_diversifiedAllocation (362.86s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstancePools (352.32s)
--- PASS: TestAccAWSSpotFleetRequest_withWeightedCapacity (371.93s)
--- PASS: TestAccAWSSpotFleetRequest_withEBSDisk (307.90s)
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDevice_KmsKeyId (177.76s)
--- PASS: TestAccAWSSpotFleetRequest_withTags (267.05s)
--- PASS: TestAccAWSSpotFleetRequest_placementTenancyAndGroup (103.40s)
--- PASS: TestAccAWSSpotFleetRequest_WithELBs (354.51s)
--- PASS: TestAccAWSSpotFleetRequest_WithTargetGroups (423.99s)
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDevice_KmsKeyId (193.76s)
--- PASS: TestAccAWSSpotFleetRequest_disappears (327.77s)
```
