### PR TITLE
New resource aws_db_proxy_default_target_group

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -508,6 +508,7 @@ func Provider() *schema.Provider {
 			"aws_db_option_group":                                     resourceAwsDbOptionGroup(),
 			"aws_db_parameter_group":                                  resourceAwsDbParameterGroup(),
 			"aws_db_proxy":                                            resourceAwsDbProxy(),
+			"aws_db_proxy_default_target_group":                       resourceAwsDbProxyDefaultTargetGroup(),
 			"aws_db_security_group":                                   resourceAwsDbSecurityGroup(),
 			"aws_db_snapshot":                                         resourceAwsDbSnapshot(),
 			"aws_db_subnet_group":                                     resourceAwsDbSubnetGroup(),

--- a/aws/resource_aws_db_proxy_default_target_group.go
+++ b/aws/resource_aws_db_proxy_default_target_group.go
@@ -1,0 +1,211 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	// "github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func resourceAwsDbProxyDefaultTargetGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsDbProxyDefaultTargetGroupUpdate,
+		Read:   resourceAwsDbProxyDefaultTargetGroupRead,
+		Update: resourceAwsDbProxyDefaultTargetGroupUpdate,
+		Delete: resourceAwsDbProxyDefaultTargetGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"db_proxy_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateRdsIdentifier,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateRdsIdentifier,
+			},
+			"connection_pool_config": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				ForceNew: false,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"connection_borrow_timeout": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"init_query": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"max_connections_percent": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"max_idle_connections_percent": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"session_pinning_filters": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsDbProxyDefaultTargetGroupRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).rdsconn
+
+	tg, err := resourceAwsDbProxyDefaultTargetGroupGet(conn, d.Id())
+
+	if err != nil {
+		if isAWSErr(err, rds.ErrCodeDBProxyNotFoundFault, "") {
+			log.Printf("[WARN] DB Proxy (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	if tg == nil {
+		log.Printf("[WARN] DB Proxy default target group (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("arn", tg.TargetGroupArn)
+	d.Set("db_proxy_name", tg.DBProxyName)
+	d.Set("name", tg.TargetGroupName)
+
+	cpc := tg.ConnectionPoolConfig
+
+	d.Set("connection_borrow_timeout", cpc.ConnectionBorrowTimeout)
+	d.Set("init_query", cpc.InitQuery)
+	d.Set("max_connections_percent", cpc.MaxConnectionsPercent)
+	d.Set("max_idle_connections_percent", cpc.MaxIdleConnectionsPercent)
+	d.Set("session_pinning_filters", flattenStringSet(cpc.SessionPinningFilters))
+
+	return nil
+}
+
+func resourceAwsDbProxyDefaultTargetGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).rdsconn
+
+	oName, nName := d.GetChange("name")
+
+	params := rds.ModifyDBProxyTargetGroupInput{
+		DBProxyName:     aws.String(d.Get("db_proxy_name").(string)),
+		TargetGroupName: aws.String(oName.(string)),
+		NewName:         aws.String(nName.(string)),
+	}
+
+	if v, ok := d.GetOk("connection_pool_config"); ok {
+		params.ConnectionPoolConfig = expandDbProxyConnectionPoolConfig(v.([]interface{}))
+	}
+
+	log.Printf("[DEBUG] Update DB Proxy default target group: %#v", params)
+	_, err := conn.ModifyDBProxyTargetGroup(&params)
+	if err != nil {
+		return fmt.Errorf("Error updating DB Proxy default target group: %s", err)
+	}
+
+	stateChangeConf := &resource.StateChangeConf{
+		Pending: []string{rds.DBProxyStatusModifying},
+		Target:  []string{rds.DBProxyStatusAvailable},
+		Refresh: resourceAwsDbProxyDefaultTargetGroupRefreshFunc(conn, d.Id()),
+		Timeout: d.Timeout(schema.TimeoutCreate),
+	}
+
+	_, err = stateChangeConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for DB Proxy default target group update: %s", err)
+	}
+
+	return resourceAwsDbProxyDefaultTargetGroupRead(d, meta)
+}
+
+func expandDbProxyConnectionPoolConfig(configs []interface{}) *rds.ConnectionPoolConfiguration {
+	if len(configs) < 1 {
+		return nil
+	}
+
+	config := configs[0].(map[string]interface{})
+
+	result := &rds.ConnectionPoolConfiguration{
+		ConnectionBorrowTimeout:   aws.Int64(int64(config["connection_borrow_timeout"].(int))),
+		InitQuery:                 aws.String(config["init_query"].(string)),
+		MaxConnectionsPercent:     aws.Int64(int64(config["max_connections_percent"].(int))),
+		MaxIdleConnectionsPercent: aws.Int64(int64(config["max_idle_connections_percent"].(int))),
+		SessionPinningFilters:     expandStringSet(config["session_pinning_filters"].(*schema.Set)),
+	}
+
+	return result
+}
+
+func resourceAwsDbProxyDefaultTargetGroupGet(conn *rds.RDS, proxyName string) (*rds.DBProxyTargetGroup, error) {
+	params := &rds.DescribeDBProxyTargetGroupsInput{
+		DBProxyName: aws.String(proxyName),
+	}
+
+	resp, err := conn.DescribeDBProxyTargetGroups(params)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Return default target group
+	for _, tg := range resp.TargetGroups {
+		if *tg.IsDefault {
+			return tg, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func resourceAwsDbProxyDefaultTargetGroupRefreshFunc(conn *rds.RDS, proxyName string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		tg, err := resourceAwsDbProxyDefaultTargetGroupGet(conn, proxyName)
+
+		if err != nil {
+			if isAWSErr(err, rds.ErrCodeDBProxyNotFoundFault, "") {
+				return 42, "", nil
+			}
+			return 42, "", err
+		}
+
+		return tg, *tg.Status, nil
+	}
+}
+
+func resourceAwsDbProxyDefaultTargetGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[WARN] Cannot destroy DB Proxy default target group. Terraform will remove this resource from the state file, however resources may remain.")
+	return nil
+}

--- a/aws/resource_aws_db_proxy_default_target_group.go
+++ b/aws/resource_aws_db_proxy_default_target_group.go
@@ -17,7 +17,7 @@ func resourceAwsDbProxyDefaultTargetGroup() *schema.Resource {
 		Create: resourceAwsDbProxyDefaultTargetGroupUpdate,
 		Read:   resourceAwsDbProxyDefaultTargetGroupRead,
 		Update: resourceAwsDbProxyDefaultTargetGroupUpdate,
-		Delete: resourceAwsDbProxyDefaultTargetGroupDelete,
+		Delete: schema.Noop,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -25,7 +25,6 @@ func resourceAwsDbProxyDefaultTargetGroup() *schema.Resource {
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
 			Update: schema.DefaultTimeout(30 * time.Minute),
-			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -47,7 +46,6 @@ func resourceAwsDbProxyDefaultTargetGroup() *schema.Resource {
 				Type:     schema.TypeList,
 				Required: true,
 				MaxItems: 1,
-				ForceNew: false,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"connection_borrow_timeout": {
@@ -59,7 +57,6 @@ func resourceAwsDbProxyDefaultTargetGroup() *schema.Resource {
 						"init_query": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  "",
 						},
 						"max_connections_percent": {
 							Type:         schema.TypeInt,
@@ -103,7 +100,7 @@ func resourceAwsDbProxyDefaultTargetGroupRead(d *schema.ResourceData, meta inter
 			d.SetId("")
 			return nil
 		}
-		return err
+		return fmt.Errorf("error reading RDS DB Proxy (%s) Default Target Group: %w", d.Id(), err)
 	}
 
 	if tg == nil {
@@ -139,7 +136,7 @@ func resourceAwsDbProxyDefaultTargetGroupUpdate(d *schema.ResourceData, meta int
 	log.Printf("[DEBUG] Update DB Proxy default target group: %#v", params)
 	_, err := conn.ModifyDBProxyTargetGroup(&params)
 	if err != nil {
-		return fmt.Errorf("Error updating DB Proxy default target group: %s", err)
+		return fmt.Errorf("error updating RDS DB Proxy (%s) default target group: %w", d.Id(), err)
 	}
 
 	stateChangeConf := &resource.StateChangeConf{

--- a/aws/resource_aws_db_proxy_default_target_group_test.go
+++ b/aws/resource_aws_db_proxy_default_target_group_test.go
@@ -31,7 +31,7 @@ func TestAccAWSDBProxyDefaultTargetGroup_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "connection_pool_config.#", "1"),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "connection_pool_config.*", map[string]string{
 						"connection_borrow_timeout":    "120",
-						"init_query":                   "SET x=1, y=2",
+						"init_query":                   "",
 						"max_connections_percent":      "100",
 						"max_idle_connections_percent": "50",
 					}),
@@ -51,7 +51,6 @@ func TestAccAWSDBProxyDefaultTargetGroup_ConnectionBorrowTimeout(t *testing.T) {
 	var dbProxyTargetGroup rds.DBProxyTargetGroup
 	resourceName := "aws_db_proxy_default_target_group.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	connectionBorrowTimeout := 90
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -59,7 +58,7 @@ func TestAccAWSDBProxyDefaultTargetGroup_ConnectionBorrowTimeout(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBProxyTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDBProxyDefaultTargetGroupConfig_Basic(rName),
+				Config: testAccAWSDBProxyDefaultTargetGroupConfig_ConnectionBorrowTimeout(rName, 120),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBProxyTargetGroupExists(resourceName, &dbProxyTargetGroup),
 					resource.TestCheckResourceAttr(resourceName, "connection_pool_config.0.connection_borrow_timeout", "120"),
@@ -71,7 +70,7 @@ func TestAccAWSDBProxyDefaultTargetGroup_ConnectionBorrowTimeout(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSDBProxyDefaultTargetGroupConfig_ConnectionBorrowTimeout(rName, connectionBorrowTimeout),
+				Config: testAccAWSDBProxyDefaultTargetGroupConfig_ConnectionBorrowTimeout(rName, 90),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBProxyTargetGroupExists(resourceName, &dbProxyTargetGroup),
 					resource.TestCheckResourceAttr(resourceName, "connection_pool_config.0.connection_borrow_timeout", "90"),
@@ -85,7 +84,6 @@ func TestAccAWSDBProxyDefaultTargetGroup_InitQuery(t *testing.T) {
 	var dbProxyTargetGroup rds.DBProxyTargetGroup
 	resourceName := "aws_db_proxy_default_target_group.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	initQuery := "SET a=2, b=1"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -93,7 +91,7 @@ func TestAccAWSDBProxyDefaultTargetGroup_InitQuery(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBProxyTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDBProxyDefaultTargetGroupConfig_Basic(rName),
+				Config: testAccAWSDBProxyDefaultTargetGroupConfig_InitQuery(rName, "SET x=1, y=2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBProxyTargetGroupExists(resourceName, &dbProxyTargetGroup),
 					resource.TestCheckResourceAttr(resourceName, "connection_pool_config.0.init_query", "SET x=1, y=2"),
@@ -105,10 +103,10 @@ func TestAccAWSDBProxyDefaultTargetGroup_InitQuery(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSDBProxyDefaultTargetGroupConfig_InitQuery(rName, initQuery),
+				Config: testAccAWSDBProxyDefaultTargetGroupConfig_InitQuery(rName, "SET a=2, b=1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBProxyTargetGroupExists(resourceName, &dbProxyTargetGroup),
-					resource.TestCheckResourceAttr(resourceName, "connection_pool_config.0.init_query", initQuery),
+					resource.TestCheckResourceAttr(resourceName, "connection_pool_config.0.init_query", "SET a=2, b=1"),
 				),
 			},
 		},
@@ -119,7 +117,6 @@ func TestAccAWSDBProxyDefaultTargetGroup_MaxConnectionsPercent(t *testing.T) {
 	var dbProxyTargetGroup rds.DBProxyTargetGroup
 	resourceName := "aws_db_proxy_default_target_group.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	maxConnectionsPercent := 75
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -127,7 +124,7 @@ func TestAccAWSDBProxyDefaultTargetGroup_MaxConnectionsPercent(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBProxyTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDBProxyDefaultTargetGroupConfig_Basic(rName),
+				Config: testAccAWSDBProxyDefaultTargetGroupConfig_MaxConnectionsPercent(rName, 100),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBProxyTargetGroupExists(resourceName, &dbProxyTargetGroup),
 					resource.TestCheckResourceAttr(resourceName, "connection_pool_config.0.max_connections_percent", "100"),
@@ -139,7 +136,7 @@ func TestAccAWSDBProxyDefaultTargetGroup_MaxConnectionsPercent(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSDBProxyDefaultTargetGroupConfig_MaxConnectionsPercent(rName, maxConnectionsPercent),
+				Config: testAccAWSDBProxyDefaultTargetGroupConfig_MaxConnectionsPercent(rName, 75),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBProxyTargetGroupExists(resourceName, &dbProxyTargetGroup),
 					resource.TestCheckResourceAttr(resourceName, "connection_pool_config.0.max_connections_percent", "75"),
@@ -153,7 +150,6 @@ func TestAccAWSDBProxyDefaultTargetGroup_MaxIdleConnectionsPercent(t *testing.T)
 	var dbProxyTargetGroup rds.DBProxyTargetGroup
 	resourceName := "aws_db_proxy_default_target_group.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	maxIdleConnectionsPercent := 33
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -161,7 +157,7 @@ func TestAccAWSDBProxyDefaultTargetGroup_MaxIdleConnectionsPercent(t *testing.T)
 		CheckDestroy: testAccCheckAWSDBProxyTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDBProxyDefaultTargetGroupConfig_Basic(rName),
+				Config: testAccAWSDBProxyDefaultTargetGroupConfig_MaxIdleConnectionsPercent(rName, 50),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBProxyTargetGroupExists(resourceName, &dbProxyTargetGroup),
 					resource.TestCheckResourceAttr(resourceName, "connection_pool_config.0.max_idle_connections_percent", "50"),
@@ -173,7 +169,7 @@ func TestAccAWSDBProxyDefaultTargetGroup_MaxIdleConnectionsPercent(t *testing.T)
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSDBProxyDefaultTargetGroupConfig_MaxIdleConnectionsPercent(rName, maxIdleConnectionsPercent),
+				Config: testAccAWSDBProxyDefaultTargetGroupConfig_MaxIdleConnectionsPercent(rName, 33),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBProxyTargetGroupExists(resourceName, &dbProxyTargetGroup),
 					resource.TestCheckResourceAttr(resourceName, "connection_pool_config.0.max_idle_connections_percent", "33"),
@@ -426,11 +422,6 @@ resource "aws_db_proxy_default_target_group" "test" {
   db_proxy_name = aws_db_proxy.test.name
 
   connection_pool_config {
-    connection_borrow_timeout    = 120
-    init_query                   = "SET x=1, y=2"
-    max_connections_percent      = 100
-    max_idle_connections_percent = 50
-    session_pinning_filters      = []
   }
 }
 `
@@ -442,11 +433,7 @@ resource "aws_db_proxy_default_target_group" "test" {
   db_proxy_name = aws_db_proxy.test.name
 
   connection_pool_config {
-    connection_borrow_timeout    = %[2]d
-    init_query                   = "SET x=1, y=2"
-    max_connections_percent      = 100
-    max_idle_connections_percent = 50
-    session_pinning_filters      = []
+    connection_borrow_timeout = %[2]d
   }
 }
 `, rName, connectionBorrowTimeout)
@@ -458,11 +445,7 @@ resource "aws_db_proxy_default_target_group" "test" {
   db_proxy_name = aws_db_proxy.test.name
 
   connection_pool_config {
-    connection_borrow_timeout    = 120
-    init_query                   = "%[2]s"
-    max_connections_percent      = 100
-    max_idle_connections_percent = 50
-    session_pinning_filters      = []
+    init_query = "%[2]s"
   }
 }
 `, rName, initQuery)
@@ -474,11 +457,7 @@ resource "aws_db_proxy_default_target_group" "test" {
   db_proxy_name = aws_db_proxy.test.name
 
   connection_pool_config {
-    connection_borrow_timeout    = 120
-    init_query                   = "SET x=1, y=2"
-    max_connections_percent      = %[2]d
-    max_idle_connections_percent = 50
-    session_pinning_filters      = []
+    max_connections_percent = %[2]d
   }
 }
 `, rName, maxConnectionsPercent)
@@ -490,11 +469,7 @@ resource "aws_db_proxy_default_target_group" "test" {
   db_proxy_name = aws_db_proxy.test.name
 
   connection_pool_config {
-    connection_borrow_timeout    = 120
-    init_query                   = "SET x=1, y=2"
-    max_connections_percent      = 100
     max_idle_connections_percent = %[2]d
-    session_pinning_filters      = []
   }
 }
 `, rName, maxIdleConnectionsPercent)
@@ -506,11 +481,7 @@ resource "aws_db_proxy_default_target_group" "test" {
   db_proxy_name = aws_db_proxy.test.name
 
   connection_pool_config {
-    connection_borrow_timeout    = 120
-    init_query                   = "SET x=1, y=2"
-    max_connections_percent      = 100
-    max_idle_connections_percent = 50
-    session_pinning_filters      = ["%[2]s"]
+    session_pinning_filters = ["%[2]s"]
   }
 }
 `, rName, sessionPinningFilters)

--- a/aws/resource_aws_db_proxy_default_target_group_test.go
+++ b/aws/resource_aws_db_proxy_default_target_group_test.go
@@ -250,7 +250,8 @@ func testAccCheckAWSDBProxyTargetGroupDestroy(s *terraform.State) error {
 		// Try to find the Group
 		resp, err := conn.DescribeDBProxyTargetGroups(
 			&rds.DescribeDBProxyTargetGroupsInput{
-				DBProxyName: aws.String(rs.Primary.ID),
+				DBProxyName:     aws.String(rs.Primary.ID),
+				TargetGroupName: aws.String("default"),
 			})
 
 		if err == nil {
@@ -282,7 +283,8 @@ func testAccCheckAWSDBProxyTargetGroupExists(n string, v *rds.DBProxyTargetGroup
 		conn := testAccProvider.Meta().(*AWSClient).rdsconn
 
 		opts := rds.DescribeDBProxyTargetGroupsInput{
-			DBProxyName: aws.String(rs.Primary.ID),
+			DBProxyName:     aws.String(rs.Primary.ID),
+			TargetGroupName: aws.String("default"),
 		}
 
 		resp, err := conn.DescribeDBProxyTargetGroups(&opts)

--- a/aws/resource_aws_db_proxy_default_target_group_test.go
+++ b/aws/resource_aws_db_proxy_default_target_group_test.go
@@ -1,0 +1,515 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
+)
+
+func TestAccAWSDBProxyDefaultTargetGroup_Basic(t *testing.T) {
+	var dbProxyTargetGroup rds.DBProxyTargetGroup
+	resourceName := "aws_db_proxy_default_target_group.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBProxyTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBProxyDefaultTargetGroupConfig_Basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBProxyTargetGroupExists(resourceName, &dbProxyTargetGroup),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "rds", regexp.MustCompile(`target-group:.+`)),
+					resource.TestCheckResourceAttr(resourceName, "connection_pool_config.#", "1"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "connection_pool_config.*", map[string]string{
+						"connection_borrow_timeout":    "120",
+						"init_query":                   "SET x=1, y=2",
+						"max_connections_percent":      "100",
+						"max_idle_connections_percent": "50",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "connection_pool_config.0.session_pinning_filters.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSDBProxyDefaultTargetGroup_ConnectionBorrowTimeout(t *testing.T) {
+	var dbProxyTargetGroup rds.DBProxyTargetGroup
+	resourceName := "aws_db_proxy_default_target_group.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	connectionBorrowTimeout := 90
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBProxyTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBProxyDefaultTargetGroupConfig_Basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBProxyTargetGroupExists(resourceName, &dbProxyTargetGroup),
+					resource.TestCheckResourceAttr(resourceName, "connection_pool_config.0.connection_borrow_timeout", "120"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSDBProxyDefaultTargetGroupConfig_ConnectionBorrowTimeout(rName, connectionBorrowTimeout),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBProxyTargetGroupExists(resourceName, &dbProxyTargetGroup),
+					resource.TestCheckResourceAttr(resourceName, "connection_pool_config.0.connection_borrow_timeout", "90"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDBProxyDefaultTargetGroup_InitQuery(t *testing.T) {
+	var dbProxyTargetGroup rds.DBProxyTargetGroup
+	resourceName := "aws_db_proxy_default_target_group.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	initQuery := "SET a=2, b=1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBProxyTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBProxyDefaultTargetGroupConfig_Basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBProxyTargetGroupExists(resourceName, &dbProxyTargetGroup),
+					resource.TestCheckResourceAttr(resourceName, "connection_pool_config.0.init_query", "SET x=1, y=2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSDBProxyDefaultTargetGroupConfig_InitQuery(rName, initQuery),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBProxyTargetGroupExists(resourceName, &dbProxyTargetGroup),
+					resource.TestCheckResourceAttr(resourceName, "connection_pool_config.0.init_query", initQuery),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDBProxyDefaultTargetGroup_MaxConnectionsPercent(t *testing.T) {
+	var dbProxyTargetGroup rds.DBProxyTargetGroup
+	resourceName := "aws_db_proxy_default_target_group.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	maxConnectionsPercent := 75
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBProxyTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBProxyDefaultTargetGroupConfig_Basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBProxyTargetGroupExists(resourceName, &dbProxyTargetGroup),
+					resource.TestCheckResourceAttr(resourceName, "connection_pool_config.0.max_connections_percent", "100"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSDBProxyDefaultTargetGroupConfig_MaxConnectionsPercent(rName, maxConnectionsPercent),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBProxyTargetGroupExists(resourceName, &dbProxyTargetGroup),
+					resource.TestCheckResourceAttr(resourceName, "connection_pool_config.0.max_connections_percent", "75"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDBProxyDefaultTargetGroup_MaxIdleConnectionsPercent(t *testing.T) {
+	var dbProxyTargetGroup rds.DBProxyTargetGroup
+	resourceName := "aws_db_proxy_default_target_group.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	maxIdleConnectionsPercent := 33
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBProxyTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBProxyDefaultTargetGroupConfig_Basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBProxyTargetGroupExists(resourceName, &dbProxyTargetGroup),
+					resource.TestCheckResourceAttr(resourceName, "connection_pool_config.0.max_idle_connections_percent", "50"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSDBProxyDefaultTargetGroupConfig_MaxIdleConnectionsPercent(rName, maxIdleConnectionsPercent),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBProxyTargetGroupExists(resourceName, &dbProxyTargetGroup),
+					resource.TestCheckResourceAttr(resourceName, "connection_pool_config.0.max_idle_connections_percent", "33"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDBProxyDefaultTargetGroup_SessionPinningFilters(t *testing.T) {
+	var dbProxyTargetGroup rds.DBProxyTargetGroup
+	resourceName := "aws_db_proxy_default_target_group.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	sessionPinningFilters := "EXCLUDE_VARIABLE_SETS"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBProxyTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBProxyDefaultTargetGroupConfig_Basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBProxyTargetGroupExists(resourceName, &dbProxyTargetGroup),
+					resource.TestCheckResourceAttr(resourceName, "connection_pool_config.0.session_pinning_filters.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSDBProxyDefaultTargetGroupConfig_SessionPinningFilters(rName, sessionPinningFilters),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBProxyTargetGroupExists(resourceName, &dbProxyTargetGroup),
+					resource.TestCheckResourceAttr(resourceName, "connection_pool_config.0.session_pinning_filters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "connection_pool_config.0.session_pinning_filters.0", sessionPinningFilters),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDBProxyDefaultTargetGroup_disappears(t *testing.T) {
+	var v rds.DBProxy
+	resourceName := "aws_db_proxy_default_target_group.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBProxyTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBProxyDefaultTargetGroupConfig_Basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBProxyExists(resourceName, &v),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsDbProxyDefaultTargetGroup(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSDBProxyTargetGroupDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).rdsconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_db_proxy_default_target_group" {
+			continue
+		}
+
+		// Try to find the Group
+		resp, err := conn.DescribeDBProxyTargetGroups(
+			&rds.DescribeDBProxyTargetGroupsInput{
+				DBProxyName: aws.String(rs.Primary.ID),
+			})
+
+		if err == nil {
+			if len(resp.TargetGroups) != 0 &&
+				*resp.TargetGroups[0].DBProxyName == rs.Primary.ID {
+				return fmt.Errorf("DB Proxy Target Group still exists")
+			}
+		}
+
+		if !isAWSErr(err, rds.ErrCodeDBProxyNotFoundFault, "") {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAWSDBProxyTargetGroupExists(n string, v *rds.DBProxyTargetGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No DB Proxy ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).rdsconn
+
+		opts := rds.DescribeDBProxyTargetGroupsInput{
+			DBProxyName: aws.String(rs.Primary.ID),
+		}
+
+		resp, err := conn.DescribeDBProxyTargetGroups(&opts)
+
+		if err != nil {
+			return err
+		}
+
+		if len(resp.TargetGroups) != 1 ||
+			*resp.TargetGroups[0].DBProxyName != rs.Primary.ID {
+			return fmt.Errorf("DB Proxy Target Group not found")
+		}
+
+		*v = *resp.TargetGroups[0]
+
+		return nil
+	}
+}
+
+func testAccAWSDBProxyDefaultTargetGroupConfigBase(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_db_proxy" "test" {
+  depends_on = [
+    aws_secretsmanager_secret_version.test,
+    aws_iam_role_policy.test
+  ]
+
+  name                   = "%[1]s"
+  debug_logging          = false
+  engine_family          = "MYSQL"
+  idle_client_timeout    = 1800
+  require_tls            = true
+  role_arn               = aws_iam_role.test.arn
+  vpc_security_group_ids = [aws_security_group.test.id]
+  vpc_subnet_ids         = aws_subnet.test.*.id
+
+  auth {
+    auth_scheme = "SECRETS"
+    description = "test"
+    iam_auth    = "DISABLED"
+    secret_arn  = aws_secretsmanager_secret.test.arn
+  }
+
+  tags = {
+    Name = "%[1]s"
+  }
+}
+
+# Secrets Manager setup
+
+resource "aws_secretsmanager_secret" "test" {
+  name                    = "%[1]s"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "test" {
+  secret_id     = aws_secretsmanager_secret.test.id
+  secret_string = "{\"username\":\"db_user\",\"password\":\"db_user_password\"}"
+}
+
+# IAM setup
+
+resource "aws_iam_role" "test" {
+  name               = "%[1]s"
+  assume_role_policy = data.aws_iam_policy_document.assume.json
+}
+
+data "aws_iam_policy_document" "assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["rds.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "test" {
+  role   = aws_iam_role.test.id
+  policy = data.aws_iam_policy_document.test.json
+}
+
+data "aws_iam_policy_document" "test" {
+  statement {
+    actions = [
+      "secretsmanager:GetRandomPassword",
+      "secretsmanager:CreateSecret",
+      "secretsmanager:ListSecrets",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    actions   = ["secretsmanager:*"]
+    resources = [aws_secretsmanager_secret.test.arn]
+  }
+}
+
+# VPC setup
+
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "%[1]s"
+  }
+}
+
+resource "aws_security_group" "test" {
+	name   = "%[1]s"
+	vpc_id = aws_vpc.test.id
+}
+
+resource "aws_subnet" "test" {
+  count             = 2
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  vpc_id            = aws_vpc.test.id
+
+  tags = {
+    Name = "%[1]s-${count.index}"
+  }
+}
+`, rName)
+}
+
+func testAccAWSDBProxyDefaultTargetGroupConfig_Basic(rName string) string {
+	return testAccAWSDBProxyDefaultTargetGroupConfigBase(rName) + `
+resource "aws_db_proxy_default_target_group" "test" {
+  db_proxy_name = aws_db_proxy.test.name
+
+  connection_pool_config {
+    connection_borrow_timeout    = 120
+    init_query                   = "SET x=1, y=2"
+    max_connections_percent      = 100
+    max_idle_connections_percent = 50
+    session_pinning_filters      = []
+  }
+}
+`
+}
+
+func testAccAWSDBProxyDefaultTargetGroupConfig_ConnectionBorrowTimeout(rName string, connectionBorrowTimeout int) string {
+	return testAccAWSDBProxyDefaultTargetGroupConfigBase(rName) + fmt.Sprintf(`
+resource "aws_db_proxy_default_target_group" "test" {
+  db_proxy_name = aws_db_proxy.test.name
+
+  connection_pool_config {
+    connection_borrow_timeout    = %[2]d
+    init_query                   = "SET x=1, y=2"
+    max_connections_percent      = 100
+    max_idle_connections_percent = 50
+    session_pinning_filters      = []
+  }
+}
+`, rName, connectionBorrowTimeout)
+}
+
+func testAccAWSDBProxyDefaultTargetGroupConfig_InitQuery(rName, initQuery string) string {
+	return testAccAWSDBProxyDefaultTargetGroupConfigBase(rName) + fmt.Sprintf(`
+resource "aws_db_proxy_default_target_group" "test" {
+  db_proxy_name = aws_db_proxy.test.name
+
+  connection_pool_config {
+    connection_borrow_timeout    = 120
+    init_query                   = "%[2]s"
+    max_connections_percent      = 100
+    max_idle_connections_percent = 50
+    session_pinning_filters      = []
+  }
+}
+`, rName, initQuery)
+}
+
+func testAccAWSDBProxyDefaultTargetGroupConfig_MaxConnectionsPercent(rName string, maxConnectionsPercent int) string {
+	return testAccAWSDBProxyDefaultTargetGroupConfigBase(rName) + fmt.Sprintf(`
+resource "aws_db_proxy_default_target_group" "test" {
+  db_proxy_name = aws_db_proxy.test.name
+
+  connection_pool_config {
+    connection_borrow_timeout    = 120
+    init_query                   = "SET x=1, y=2"
+    max_connections_percent      = %[2]d
+    max_idle_connections_percent = 50
+    session_pinning_filters      = []
+  }
+}
+`, rName, maxConnectionsPercent)
+}
+
+func testAccAWSDBProxyDefaultTargetGroupConfig_MaxIdleConnectionsPercent(rName string, maxIdleConnectionsPercent int) string {
+	return testAccAWSDBProxyDefaultTargetGroupConfigBase(rName) + fmt.Sprintf(`
+resource "aws_db_proxy_default_target_group" "test" {
+  db_proxy_name = aws_db_proxy.test.name
+
+  connection_pool_config {
+    connection_borrow_timeout    = 120
+    init_query                   = "SET x=1, y=2"
+    max_connections_percent      = 100
+    max_idle_connections_percent = %[2]d
+    session_pinning_filters      = []
+  }
+}
+`, rName, maxIdleConnectionsPercent)
+}
+
+func testAccAWSDBProxyDefaultTargetGroupConfig_SessionPinningFilters(rName, sessionPinningFilters string) string {
+	return testAccAWSDBProxyDefaultTargetGroupConfigBase(rName) + fmt.Sprintf(`
+resource "aws_db_proxy_default_target_group" "test" {
+  db_proxy_name = aws_db_proxy.test.name
+
+  connection_pool_config {
+    connection_borrow_timeout    = 120
+    init_query                   = "SET x=1, y=2"
+    max_connections_percent      = 100
+    max_idle_connections_percent = 50
+    session_pinning_filters      = ["%[2]s"]
+  }
+}
+`, rName, sessionPinningFilters)
+}

--- a/website/docs/r/db_proxy_default_target_group.html.markdown
+++ b/website/docs/r/db_proxy_default_target_group.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides a resource to manage an RDS DB proxy default target group resource.
 
-The `aws_db_proxy_default_target_group` behaves differently from normal resources, in that Terraform does not _create_ this resource, but instead "adopts" it into management.
+The `aws_db_proxy_default_target_group` behaves differently from normal resources, in that Terraform does not _create_ or _destroy_ this resource, since it implicitly exists as part of an RDS DB Proxy. On Terraform resource creation it is automatically imported and on resource destruction, Terraform performs no actions in RDS.
 
 ## Example Usage
 
@@ -21,15 +21,15 @@ resource "aws_db_proxy" "example" {
   engine_family          = "MYSQL"
   idle_client_timeout    = 1800
   require_tls            = true
-  role_arn               = "arn:aws:iam:us-east-1:123456789012:role/example"
-  vpc_security_group_ids = ["sg-12345678901234567"]
-  vpc_subnet_ids         = ["subnet-12345678901234567"]
+  role_arn               = aws_iam_role.example.arn
+  vpc_security_group_ids = [aws_security_group.example.id]
+  vpc_subnet_ids         = [aws_subnet.example.id]
 
   auth {
     auth_scheme = "SECRETS"
     description = "example"
     iam_auth    = "DISABLED"
-    secret_arn  = "arn:aws:secretsmanager:us-east-1:123456789012:secret:example"
+    secret_arn  = aws_secretsmanager_secret.example.arn
   }
 
   tags = {
@@ -55,7 +55,7 @@ resource "aws_db_proxy_default_target_group" "example" {
 
 The following arguments are supported:
 
-* `db_proxy_name` - (Required) The name of the new proxy to which to assign the target group.
+* `db_proxy_name` - (Required) Name of the RDS DB Proxy.
 * `connection_pool_config` - (Optional) The settings that determine the size and behavior of the connection pool for the target group.
 
 `connection_pool_config` blocks support the following:
@@ -70,7 +70,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The Amazon Resource Name (ARN) for the proxy.
+* `id` - Name of the RDS DB Proxy.
 * `arn` - The Amazon Resource Name (ARN) representing the target group.
 * `name` - The name of the default target group.
 
@@ -78,7 +78,8 @@ In addition to all arguments above, the following attributes are exported:
 
 `aws_db_proxy_default_target_group` provides the following [Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
 
-- `update` - (Default `30 minutes`) Used for modifying DB proxy target groups.
+- `create` - (Default `30 minutes`) Timeout for modifying DB proxy target group on creation.
+- `update` - (Default `30 minutes`) Timeout for modifying DB proxy target group on update.
 
 ## Import
 

--- a/website/docs/r/db_proxy_default_target_group.html.markdown
+++ b/website/docs/r/db_proxy_default_target_group.html.markdown
@@ -56,7 +56,6 @@ resource "aws_db_proxy_default_target_group" "example" {
 The following arguments are supported:
 
 * `db_proxy_name` - (Required) The name of the new proxy to which to assign the target group.
-* `name` - (Optional) The name of the new target group to assign to the proxy.
 * `connection_pool_config` - (Optional) The settings that determine the size and behavior of the connection pool for the target group.
 
 `connection_pool_config` blocks support the following:
@@ -73,6 +72,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The Amazon Resource Name (ARN) for the proxy.
 * `arn` - The Amazon Resource Name (ARN) representing the target group.
+* `name` - The name of the default target group.
 
 ### Timeouts
 

--- a/website/docs/r/db_proxy_default_target_group.html.markdown
+++ b/website/docs/r/db_proxy_default_target_group.html.markdown
@@ -1,0 +1,89 @@
+---
+subcategory: "RDS"
+layout: "aws"
+page_title: "AWS: aws_db_proxy_default_target_group"
+description: |-
+  Manage an RDS DB proxy default target group resource.
+---
+
+# Resource: aws_db_proxy_default_target_group
+
+Provides a resource to manage an RDS DB proxy default target group resource.
+
+The `aws_db_proxy_default_target_group` behaves differently from normal resources, in that Terraform does not _create_ this resource, but instead "adopts" it into management.
+
+## Example Usage
+
+```hcl
+resource "aws_db_proxy" "example" {
+  name                   = "example"
+  debug_logging          = false
+  engine_family          = "MYSQL"
+  idle_client_timeout    = 1800
+  require_tls            = true
+  role_arn               = "arn:aws:iam:us-east-1:123456789012:role/example"
+  vpc_security_group_ids = ["sg-12345678901234567"]
+  vpc_subnet_ids         = ["subnet-12345678901234567"]
+
+  auth {
+    auth_scheme = "SECRETS"
+    description = "example"
+    iam_auth    = "DISABLED"
+    secret_arn  = "arn:aws:secretsmanager:us-east-1:123456789012:secret:example"
+  }
+
+  tags = {
+    Name = "example"
+    Key  = "value"
+  }
+}
+
+resource "aws_db_proxy_default_target_group" "example" {
+  db_proxy_name = aws_db_proxy.example.name
+
+  connection_pool_config {
+    connection_borrow_timeout    = 120
+    init_query                   = "SET x=1, y=2"
+    max_connections_percent      = 100
+    max_idle_connections_percent = 50
+    session_pinning_filters      = ["EXCLUDE_VARIABLE_SETS"]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `db_proxy_name` - (Required) The name of the new proxy to which to assign the target group.
+* `name` - (Optional) The name of the new target group to assign to the proxy.
+* `connection_pool_config` - (Optional) The settings that determine the size and behavior of the connection pool for the target group.
+
+`connection_pool_config` blocks support the following:
+
+* `connection_borrow_timeout` - (Optional) The number of seconds for a proxy to wait for a connection to become available in the connection pool. Only applies when the proxy has opened its maximum number of connections and all connections are busy with client sessions.
+* `init_query` - (Optional) One or more SQL statements for the proxy to run when opening each new database connection. Typically used with `SET` statements to make sure that each connection has identical settings such as time zone and character set. This setting is empty by default. For multiple statements, use semicolons as the separator. You can also include multiple variables in a single `SET` statement, such as `SET x=1, y=2`.
+* `max_connections_percent` - (Optional) The maximum size of the connection pool for each target in a target group. For Aurora MySQL, it is expressed as a percentage of the max_connections setting for the RDS DB instance or Aurora DB cluster used by the target group.
+* `max_idle_connections_percent` - (Optional) Controls how actively the proxy closes idle database connections in the connection pool. A high value enables the proxy to leave a high percentage of idle connections open. A low value causes the proxy to close idle client connections and return the underlying database connections to the connection pool. For Aurora MySQL, it is expressed as a percentage of the max_connections setting for the RDS DB instance or Aurora DB cluster used by the target group.
+* `session_pinning_filters` - (Optional) Each item in the list represents a class of SQL operations that normally cause all later statements in a session using a proxy to be pinned to the same underlying database connection. Including an item in the list exempts that class of SQL operations from the pinning behavior. Currently, the only allowed value is `EXCLUDE_VARIABLE_SETS`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The Amazon Resource Name (ARN) for the proxy.
+* `arn` - The Amazon Resource Name (ARN) representing the target group.
+
+### Timeouts
+
+`aws_db_proxy_default_target_group` provides the following [Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `update` - (Default `30 minutes`) Used for modifying DB proxy target groups.
+
+## Import
+
+DB proxy default target groups can be imported using the `db_proxy_name`, e.g.
+
+```
+$ terraform import aws_db_proxy_default_target_group.example example
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12690

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
**New Resource:** `aws_db_proxy_default_target_group` (#12743)
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$testacc TESTARGS='-run=TestAccAWSDBProxyDefaultTargetGroup_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDBProxyDefaultTargetGroup_ -timeout 120m
=== RUN   TestAccAWSDBProxyDefaultTargetGroup_Basic
=== PAUSE TestAccAWSDBProxyDefaultTargetGroup_Basic
=== RUN   TestAccAWSDBProxyDefaultTargetGroup_ConnectionBorrowTimeout
=== PAUSE TestAccAWSDBProxyDefaultTargetGroup_ConnectionBorrowTimeout
=== RUN   TestAccAWSDBProxyDefaultTargetGroup_InitQuery
=== PAUSE TestAccAWSDBProxyDefaultTargetGroup_InitQuery
=== RUN   TestAccAWSDBProxyDefaultTargetGroup_MaxConnectionsPercent
=== PAUSE TestAccAWSDBProxyDefaultTargetGroup_MaxConnectionsPercent
=== RUN   TestAccAWSDBProxyDefaultTargetGroup_MaxIdleConnectionsPercent
=== PAUSE TestAccAWSDBProxyDefaultTargetGroup_MaxIdleConnectionsPercent
=== RUN   TestAccAWSDBProxyDefaultTargetGroup_SessionPinningFilters
=== PAUSE TestAccAWSDBProxyDefaultTargetGroup_SessionPinningFilters
=== RUN   TestAccAWSDBProxyDefaultTargetGroup_disappears
=== PAUSE TestAccAWSDBProxyDefaultTargetGroup_disappears
=== CONT  TestAccAWSDBProxyDefaultTargetGroup_Basic
=== CONT  TestAccAWSDBProxyDefaultTargetGroup_MaxIdleConnectionsPercent
=== CONT  TestAccAWSDBProxyDefaultTargetGroup_disappears
=== CONT  TestAccAWSDBProxyDefaultTargetGroup_SessionPinningFilters
=== CONT  TestAccAWSDBProxyDefaultTargetGroup_InitQuery
=== CONT  TestAccAWSDBProxyDefaultTargetGroup_MaxConnectionsPercent
=== CONT  TestAccAWSDBProxyDefaultTargetGroup_ConnectionBorrowTimeout
--- PASS: TestAccAWSDBProxyDefaultTargetGroup_InitQuery (628.75s)
--- PASS: TestAccAWSDBProxyDefaultTargetGroup_SessionPinningFilters (692.52s)
--- PASS: TestAccAWSDBProxyDefaultTargetGroup_Basic (722.49s)
--- PASS: TestAccAWSDBProxyDefaultTargetGroup_ConnectionBorrowTimeout (756.94s)
--- PASS: TestAccAWSDBProxyDefaultTargetGroup_MaxIdleConnectionsPercent (778.10s)
--- PASS: TestAccAWSDBProxyDefaultTargetGroup_MaxConnectionsPercent (788.87s)
--- PASS: TestAccAWSDBProxyDefaultTargetGroup_disappears (848.20s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	851.610s
```
