### PR TITLE
r/ecs_task_definition - fix hash differences for efs volume

### DIFF
--- a/aws/resource_aws_ecs_task_definition.go
+++ b/aws/resource_aws_ecs_task_definition.go
@@ -163,6 +163,7 @@ func resourceAwsEcsTaskDefinition() *schema.Resource {
 										Type:     schema.TypeString,
 										ForceNew: true,
 										Optional: true,
+										Computed: true,
 									},
 									"driver_opts": {
 										Type:     schema.TypeMap,
@@ -196,12 +197,6 @@ func resourceAwsEcsTaskDefinition() *schema.Resource {
 										ForceNew: true,
 										Optional: true,
 										Default:  "/",
-										DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-											if new == "/" && old == "" {
-												return true
-											}
-											return false
-										},
 									},
 								},
 							},
@@ -608,10 +603,6 @@ func resourceAwsEcsTaskDefinitionVolumeHash(v interface{}) int {
 
 		if v, ok := m["autoprovision"]; ok {
 			buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
-		}
-
-		if v, ok := m["scope"]; ok && v.(string) != "" {
-			buf.WriteString(fmt.Sprintf("%s-", v.(string)))
 		}
 
 		if v, ok := m["driver"]; ok && v.(string) != "" {

--- a/aws/resource_aws_ecs_task_definition.go
+++ b/aws/resource_aws_ecs_task_definition.go
@@ -163,7 +163,6 @@ func resourceAwsEcsTaskDefinition() *schema.Resource {
 										Type:     schema.TypeString,
 										ForceNew: true,
 										Optional: true,
-										Computed: true,
 									},
 									"driver_opts": {
 										Type:     schema.TypeMap,
@@ -593,36 +592,6 @@ func resourceAwsEcsTaskDefinitionVolumeHash(v interface{}) int {
 	m := v.(map[string]interface{})
 	buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
 	buf.WriteString(fmt.Sprintf("%s-", m["host_path"].(string)))
-
-	if v, ok := m["docker_volume_configuration"]; ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		m := v.([]interface{})[0].(map[string]interface{})
-
-		if v, ok := m["scope"]; ok && v.(string) != "" {
-			buf.WriteString(fmt.Sprintf("%s-", v.(string)))
-		}
-
-		if v, ok := m["autoprovision"]; ok {
-			buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
-		}
-
-		if v, ok := m["driver"]; ok && v.(string) != "" {
-			buf.WriteString(fmt.Sprintf("%s-", v.(string)))
-		}
-
-		if v, ok := m["driver_opts"].(map[string]interface{}); ok && len(v) > 0 {
-			for k, val := range v {
-				buf.WriteString(fmt.Sprintf("%s-", k))
-				buf.WriteString(fmt.Sprintf("%s-", val.(string)))
-			}
-		}
-
-		if v, ok := m["labels"].(map[string]interface{}); ok && len(v) > 0 {
-			for k, val := range v {
-				buf.WriteString(fmt.Sprintf("%s-", k))
-				buf.WriteString(fmt.Sprintf("%s-", val.(string)))
-			}
-		}
-	}
 
 	if v, ok := m["efs_volume_configuration"]; ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		m := v.([]interface{})[0].(map[string]interface{})

--- a/aws/resource_aws_ecs_task_definition.go
+++ b/aws/resource_aws_ecs_task_definition.go
@@ -195,6 +195,13 @@ func resourceAwsEcsTaskDefinition() *schema.Resource {
 										Type:     schema.TypeString,
 										ForceNew: true,
 										Optional: true,
+										Default:  "/",
+										DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+											if new == "/" && old == "" {
+												return true
+											}
+											return false
+										},
 									},
 								},
 							},
@@ -591,6 +598,53 @@ func resourceAwsEcsTaskDefinitionVolumeHash(v interface{}) int {
 	m := v.(map[string]interface{})
 	buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
 	buf.WriteString(fmt.Sprintf("%s-", m["host_path"].(string)))
+
+	if v, ok := m["docker_volume_configuration"]; ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		m := v.([]interface{})[0].(map[string]interface{})
+
+		if v, ok := m["scope"]; ok && v.(string) != "" {
+			buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+		}
+
+		if v, ok := m["autoprovision"]; ok {
+			buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
+		}
+
+		if v, ok := m["scope"]; ok && v.(string) != "" {
+			buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+		}
+
+		if v, ok := m["driver"]; ok && v.(string) != "" {
+			buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+		}
+
+		if v, ok := m["driver_opts"].(map[string]interface{}); ok && len(v) > 0 {
+			for k, val := range v {
+				buf.WriteString(fmt.Sprintf("%s-", k))
+				buf.WriteString(fmt.Sprintf("%s-", val.(string)))
+			}
+		}
+
+		if v, ok := m["labels"].(map[string]interface{}); ok && len(v) > 0 {
+			for k, val := range v {
+				buf.WriteString(fmt.Sprintf("%s-", k))
+				buf.WriteString(fmt.Sprintf("%s-", val.(string)))
+			}
+		}
+	}
+
+	if v, ok := m["efs_volume_configuration"]; ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		m := v.([]interface{})[0].(map[string]interface{})
+
+		if v, ok := m["file_system_id"]; ok && v.(string) != "" {
+			buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+		}
+
+		if v, ok := m["root_directory"]; ok && v.(string) != "" {
+			buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+		}
+	}
+
 	return hashcode.String(buf.String())
 }
 

--- a/aws/resource_aws_ecs_task_definition_test.go
+++ b/aws/resource_aws_ecs_task_definition_test.go
@@ -187,7 +187,6 @@ func TestAccAWSEcsTaskDefinition_withEFSVolumeMinimalFargate(t *testing.T) {
 	})
 }
 
-
 func TestAccAWSEcsTaskDefinition_withEFSVolume(t *testing.T) {
 	var def ecs.TaskDefinition
 
@@ -1288,7 +1287,7 @@ TASK_DEFINITION
 func testAccAWSEcsTaskDefinitionWithScratchVolume(tdName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
-  family = "%s"
+  family = %[1]q
 
   container_definitions = <<TASK_DEFINITION
 [
@@ -1304,7 +1303,7 @@ resource "aws_ecs_task_definition" "test" {
 TASK_DEFINITION
 
   volume {
-    name = "database_scratch"
+    name = %[1]q
   }
 }
 `, tdName)
@@ -1313,7 +1312,7 @@ TASK_DEFINITION
 func testAccAWSEcsTaskDefinitionWithDockerVolumes(tdName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
-  family = "%s"
+  family = %[1]q
 
   container_definitions = <<TASK_DEFINITION
 [
@@ -1329,7 +1328,7 @@ resource "aws_ecs_task_definition" "test" {
 TASK_DEFINITION
 
   volume {
-    name = "database_scratch"
+    name = %[1]q
 
     docker_volume_configuration {
       driver = "local"
@@ -1355,7 +1354,7 @@ TASK_DEFINITION
 func testAccAWSEcsTaskDefinitionWithDockerVolumesMinimalConfig(tdName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
-  family = "%s"
+  family = %[1]q
 
   container_definitions = <<TASK_DEFINITION
 [
@@ -1371,7 +1370,7 @@ resource "aws_ecs_task_definition" "test" {
 TASK_DEFINITION
 
   volume {
-    name = "database_scratch"
+    name = %[1]q
 
     docker_volume_configuration {
       autoprovision = true
@@ -1384,7 +1383,7 @@ TASK_DEFINITION
 func testAccAWSEcsTaskDefinitionWithTaskScopedDockerVolume(tdName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
-  family = "%s"
+  family = %[1]q
 
   container_definitions = <<TASK_DEFINITION
 [
@@ -1400,7 +1399,7 @@ resource "aws_ecs_task_definition" "test" {
 TASK_DEFINITION
 
   volume {
-    name = "database_scratch"
+    name = %[1]q
 
     docker_volume_configuration {
       scope = "task"
@@ -1433,7 +1432,7 @@ resource "aws_ecs_task_definition" "test" {
 TASK_DEFINITION
 
   volume {
-    name = "database_scratch"
+    name = %[1]q
 
     efs_volume_configuration {
       file_system_id = "${aws_efs_file_system.test.id}"
@@ -1457,11 +1456,15 @@ resource "aws_ecs_service" "test" {
 }
 
 resource "aws_efs_file_system" "test" {
-	creation_token = %[1]q
+  creation_token = %[1]q
 }
 
 resource "aws_ecs_task_definition" "test" {
-  family = %[1]q
+  family                   = %[1]q
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "256"
+  memory                   = "512"
 
   container_definitions = <<TASK_DEFINITION
 [
@@ -1477,7 +1480,7 @@ resource "aws_ecs_task_definition" "test" {
 TASK_DEFINITION
 
   volume {
-    name = "database_scratch"
+    name = %[1]q
 
     efs_volume_configuration {
       file_system_id = "${aws_efs_file_system.test.id}"
@@ -1510,7 +1513,7 @@ resource "aws_ecs_task_definition" "test" {
 TASK_DEFINITION
 
   volume {
-    name = "database_scratch"
+    name = %[1]q
 
     efs_volume_configuration {
       file_system_id = "${aws_efs_file_system.test.id}"
@@ -1524,7 +1527,7 @@ TASK_DEFINITION
 func testAccAWSEcsTaskDefinitionWithTaskRoleArn(roleName, policyName, tdName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
-  name = "%s"
+  name = %[1]q
   path = "/test/"
 
   assume_role_policy = <<EOF
@@ -1545,7 +1548,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "test" {
-  name = "%s"
+  name = %[2]q
   role = "${aws_iam_role.test.id}"
 
   policy = <<EOF
@@ -1566,7 +1569,7 @@ EOF
 }
 
 resource "aws_ecs_task_definition" "test" {
-  family        = "%s"
+  family        = %[3]q
   task_role_arn = "${aws_iam_role.test.arn}"
 
   container_definitions = <<TASK_DEFINITION
@@ -1583,7 +1586,7 @@ resource "aws_ecs_task_definition" "test" {
 TASK_DEFINITION
 
   volume {
-    name = "database_scratch"
+    name = %[3]q
   }
 }
 `, roleName, policyName, tdName)
@@ -1592,7 +1595,7 @@ TASK_DEFINITION
 func testAccAWSEcsTaskDefinitionWithIpcMode(roleName, policyName, tdName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
-  name = "%s"
+  name = %[1]q
   path = "/test/"
 
   assume_role_policy = <<EOF
@@ -1613,7 +1616,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "test" {
-  name = "%s"
+  name = %[2]q
   role = "${aws_iam_role.test.id}"
 
   policy = <<EOF
@@ -1634,7 +1637,7 @@ resource "aws_iam_role_policy" "test" {
 }
 
 resource "aws_ecs_task_definition" "test" {
-  family        = "%s"
+  family        = %[3]q
   task_role_arn = "${aws_iam_role.test.arn}"
   network_mode  = "bridge"
   ipc_mode      = "host"
@@ -1653,7 +1656,7 @@ resource "aws_ecs_task_definition" "test" {
 TASK_DEFINITION
 
   volume {
-    name = "database_scratch"
+    name = %[3]q
   }
 }
 `, roleName, policyName, tdName)
@@ -1662,7 +1665,7 @@ TASK_DEFINITION
 func testAccAWSEcsTaskDefinitionWithPidMode(roleName, policyName, tdName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
-  name = "%s"
+  name = %[1]q
   path = "/test/"
 
   assume_role_policy = <<EOF
@@ -1683,7 +1686,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "test" {
-  name = "%s"
+  name = %[2]q
   role = "${aws_iam_role.test.id}"
 
   policy = <<EOF
@@ -1704,7 +1707,7 @@ resource "aws_iam_role_policy" "test" {
 }
 
 resource "aws_ecs_task_definition" "test" {
-  family        = "%s"
+  family        = %[3]q
   task_role_arn = "${aws_iam_role.test.arn}"
   network_mode  = "bridge"
   pid_mode      = "host"
@@ -1723,7 +1726,7 @@ resource "aws_ecs_task_definition" "test" {
 TASK_DEFINITION
 
   volume {
-    name = "database_scratch"
+    name = %[3]q
   }
 }
 `, roleName, policyName, tdName)
@@ -1732,7 +1735,7 @@ TASK_DEFINITION
 func testAccAWSEcsTaskDefinitionWithNetworkMode(roleName, policyName, tdName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
-  name = "%s"
+  name = %[1]q
   path = "/test/"
 
   assume_role_policy = <<EOF
@@ -1753,7 +1756,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "test" {
-  name = "%s"
+  name = %[2]q
   role = "${aws_iam_role.test.id}"
 
   policy = <<EOF
@@ -1774,7 +1777,7 @@ resource "aws_iam_role_policy" "test" {
 }
 
 resource "aws_ecs_task_definition" "test" {
-  family        = "%s"
+  family        = %[3]q
   task_role_arn = "${aws_iam_role.test.arn}"
   network_mode  = "bridge"
 
@@ -1792,7 +1795,7 @@ resource "aws_ecs_task_definition" "test" {
 TASK_DEFINITION
 
   volume {
-    name = "database_scratch"
+    name = %[3]q
   }
 }
 `, roleName, policyName, tdName)
@@ -1801,18 +1804,18 @@ TASK_DEFINITION
 func testAccAWSEcsTaskDefinitionWithEcsService(clusterName, svcName, tdName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "test" {
-  name = "%s"
+  name = %[1]q
 }
 
 resource "aws_ecs_service" "test" {
-  name            = "%s"
+  name            = %[2]q
   cluster         = "${aws_ecs_cluster.test.id}"
   task_definition = "${aws_ecs_task_definition.test.arn}"
   desired_count   = 1
 }
 
 resource "aws_ecs_task_definition" "test" {
-  family = "%s"
+  family = %[3]q
 
   container_definitions = <<TASK_DEFINITION
 [
@@ -1828,7 +1831,7 @@ resource "aws_ecs_task_definition" "test" {
 TASK_DEFINITION
 
   volume {
-    name = "database_scratch"
+    name = %[3]q
   }
 }
 `, clusterName, svcName, tdName)
@@ -1837,18 +1840,18 @@ TASK_DEFINITION
 func testAccAWSEcsTaskDefinitionWithEcsServiceModified(clusterName, svcName, tdName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "test" {
-  name = "%s"
+  name = %[1]q
 }
 
 resource "aws_ecs_service" "test" {
-  name            = "%s"
+  name            = %[2]q
   cluster         = "${aws_ecs_cluster.test.id}"
   task_definition = "${aws_ecs_task_definition.test.arn}"
   desired_count   = 1
 }
 
 resource "aws_ecs_task_definition" "test" {
-  family = "%s"
+  family = %[3]q
 
   container_definitions = <<TASK_DEFINITION
 [
@@ -1864,7 +1867,7 @@ resource "aws_ecs_task_definition" "test" {
 TASK_DEFINITION
 
   volume {
-    name = "database_scratch"
+    name = %[3]q
   }
 }
 `, clusterName, svcName, tdName)

--- a/aws/resource_aws_ecs_task_definition_test.go
+++ b/aws/resource_aws_ecs_task_definition_test.go
@@ -159,34 +159,6 @@ func TestAccAWSEcsTaskDefinition_withEFSVolumeMinimal(t *testing.T) {
 	})
 }
 
-func TestAccAWSEcsTaskDefinition_withEFSVolumeMinimalFargate(t *testing.T) {
-	var def ecs.TaskDefinition
-
-	tdName := acctest.RandomWithPrefix("tf-acc-td-with-efs-volume-min")
-	resourceName := "aws_ecs_task_definition.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSEcsTaskDefinitionDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSEcsTaskDefinitionWithEFSVolumeMinimalFargate(tdName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &def),
-					resource.TestCheckResourceAttr(resourceName, "volume.#", "1"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccAWSEcsTaskDefinitionImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAWSEcsTaskDefinition_withEFSVolume(t *testing.T) {
 	var def ecs.TaskDefinition
 
@@ -1417,54 +1389,6 @@ resource "aws_efs_file_system" "test" {
 
 resource "aws_ecs_task_definition" "test" {
   family = %[1]q
-
-  container_definitions = <<TASK_DEFINITION
-[
-  {
-    "name": "sleep",
-    "image": "busybox",
-    "cpu": 10,
-    "command": ["sleep","360"],
-    "memory": 10,
-    "essential": true
-  }
-]
-TASK_DEFINITION
-
-  volume {
-    name = %[1]q
-
-    efs_volume_configuration {
-      file_system_id = "${aws_efs_file_system.test.id}"
-    }
-  }
-}
-`, tdName)
-}
-
-func testAccAWSEcsTaskDefinitionWithEFSVolumeMinimalFargate(tdName string) string {
-	return fmt.Sprintf(`
-resource "aws_ecs_cluster" "test" {
-  name = %[1]q
-}
-
-resource "aws_ecs_service" "test" {
-  name            = %[1]q
-  cluster         = "${aws_ecs_cluster.test.id}"
-  task_definition = "${aws_ecs_task_definition.test.arn}"
-  desired_count   = 1
-}
-
-resource "aws_efs_file_system" "test" {
-  creation_token = %[1]q
-}
-
-resource "aws_ecs_task_definition" "test" {
-  family                   = %[1]q
-  network_mode             = "awsvpc"
-  requires_compatibilities = ["FARGATE"]
-  cpu                      = "256"
-  memory                   = "512"
 
   container_definitions = <<TASK_DEFINITION
 [

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -699,7 +699,7 @@ func flattenEcsVolumes(list []*ecs.Volume) []map[string]interface{} {
 			l["docker_volume_configuration"] = flattenDockerVolumeConfiguration(volume.DockerVolumeConfiguration)
 		}
 
-		if volume.DockerVolumeConfiguration != nil {
+		if volume.EfsVolumeConfiguration != nil {
 			l["efs_volume_configuration"] = flattenEFSVolumeConfiguration(volume.EfsVolumeConfiguration)
 		}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12190

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_ecs_task_definition - fix hash differences for `volume` block
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEcsTaskDefinition_'
--- PASS: TestAccAWSEcsTaskDefinition_basic (73.09s)
--- PASS: TestAccAWSEcsTaskDefinition_withScratchVolume (43.74s)
--- PASS: TestAccAWSEcsTaskDefinition_withDockerVolume (42.88s)
--- PASS: TestAccAWSEcsTaskDefinition_withDockerVolumeMinimalConfig (49.40s)
--- PASS: TestAccAWSEcsTaskDefinition_withEFSVolumeMinimal (62.29s)
--- PASS: TestAccAWSEcsTaskDefinition_withEFSVolume (63.41s)
--- PASS: TestAccAWSEcsTaskDefinition_withEcsService (149.76s)
--- PASS: TestAccAWSEcsTaskDefinition_withTaskRoleArn (48.86s)
--- PASS: TestAccAWSEcsTaskDefinition_withNetworkMode (49.80s)
--- PASS: TestAccAWSEcsTaskDefinition_withIPCMode (48.08s)
--- PASS: TestAccAWSEcsTaskDefinition_withPidMode (49.61s)
--- PASS: TestAccAWSEcsTaskDefinition_constraint (42.94s)
--- PASS: TestAccAWSEcsTaskDefinition_changeVolumesForcesNewResource (72.84s)
--- PASS: TestAccAWSEcsTaskDefinition_arrays (43.73s)
--- PASS: TestAccAWSEcsTaskDefinition_Fargate (59.03s)
--- PASS: TestAccAWSEcsTaskDefinition_ExecutionRole (51.76s)
--- PASS: TestAccAWSEcsTaskDefinition_Inactive (68.68s)
--- PASS: TestAccAWSEcsTaskDefinition_Tags (107.83s)
--- PASS: TestAccAWSEcsTaskDefinition_ProxyConfiguration (56.15s)
--- PASS: TestAccAWSEcsTaskDefinition_inferenceAccelerator (41.28s)
```
As a note to maintainers if possible to merge #12571 prior to this one that would be great

