### PR TITLE
Add message to highlight ulimit option which can prevent issues with …

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -919,6 +919,8 @@ PASS
 ok  	github.com/terraform-providers/terraform-provider-aws/aws	55.619s
 ```
 
+Please Note: On macOS 10.14 and later, the default user open file limit is 256. This may cause unexpected issues when running the acceptance testing since this can prevent various operations from occurring such as opening network connections to AWS. To view this limit, the `ulimit -n` command can be run. To update this limit, run `ulimit -n 1024`  (or higher).
+
 #### Writing an Acceptance Test
 
 Terraform has a framework for writing acceptance tests which minimises the

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -919,7 +919,7 @@ PASS
 ok  	github.com/terraform-providers/terraform-provider-aws/aws	55.619s
 ```
 
-Please Note: On macOS 10.14 and later, the default user open file limit is 256. This may cause unexpected issues when running the acceptance testing since this can prevent various operations from occurring such as opening network connections to AWS. To view this limit, the `ulimit -n` command can be run. To update this limit, run `ulimit -n 1024`  (or higher). This may also apply on Linux systems, depending on the default set by the distribution.
+Please Note: On macOS 10.14 and later (and some Linux distributions), the default user open file limit is 256. This may cause unexpected issues when running the acceptance testing since this can prevent various operations from occurring such as opening network connections to AWS. To view this limit, the `ulimit -n` command can be run. To update this limit, run `ulimit -n 1024`  (or higher). 
 
 #### Writing an Acceptance Test
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -919,7 +919,7 @@ PASS
 ok  	github.com/terraform-providers/terraform-provider-aws/aws	55.619s
 ```
 
-Please Note: On macOS 10.14 and later, the default user open file limit is 256. This may cause unexpected issues when running the acceptance testing since this can prevent various operations from occurring such as opening network connections to AWS. To view this limit, the `ulimit -n` command can be run. To update this limit, run `ulimit -n 1024`  (or higher).
+Please Note: On macOS 10.14 and later, the default user open file limit is 256. This may cause unexpected issues when running the acceptance testing since this can prevent various operations from occurring such as opening network connections to AWS. To view this limit, the `ulimit -n` command can be run. To update this limit, run `ulimit -n 1024`  (or higher). This may also apply on Linux systems, depending on the default set by the distribution.
 
 #### Writing an Acceptance Test
 

--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -520,6 +520,7 @@ behavior "pull_request_path_labeler" "service_labels" {
   label_map = {
     # label provider related changes
     "provider" = [
+      ".github/*.md",
       "aws/auth_helpers.go",
       "aws/awserr.go",
       "aws/config.go",


### PR DESCRIPTION
Adds a short message to highlight a solution for issues that MacOS uses may experience when running acceptance tests.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
≈
-->

```release-note
NONE
```
