### PR TITLE
r/spot_fleet_request - zero capacity update

### DIFF
--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -1478,9 +1478,11 @@ func resourceAwsSpotFleetRequestUpdate(d *schema.ResourceData, meta interface{})
 
 	updateFlag := false
 
-	if val, ok := d.GetOkExists("target_capacity"); ok {
-		req.TargetCapacity = aws.Int64(int64(val.(int)))
-		updateFlag = true
+	if d.HasChange("target_capacity") {
+		if val, ok := d.GetOkExists("target_capacity"); ok {
+			req.TargetCapacity = aws.Int64(int64(val.(int)))
+			updateFlag = true
+		}
 	}
 
 	if d.HasChange("excess_capacity_termination_policy") {

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -883,7 +883,7 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 	if v, ok := d.GetOk("allocation_strategy"); ok {
 		spotFleetConfig.AllocationStrategy = aws.String(v.(string))
 	} else {
-		spotFleetConfig.AllocationStrategy = aws.String("lowestPrice")
+		spotFleetConfig.AllocationStrategy = aws.String(ec2.AllocationStrategyLowestPrice)
 	}
 
 	if v, ok := d.GetOk("instance_pools_to_use_count"); ok && v.(int) != 1 {
@@ -1478,11 +1478,8 @@ func resourceAwsSpotFleetRequestUpdate(d *schema.ResourceData, meta interface{})
 
 	updateFlag := false
 
-	if d.HasChange("target_capacity") {
-		if val, ok := d.GetOk("target_capacity"); ok {
-			req.TargetCapacity = aws.Int64(int64(val.(int)))
-		}
-
+	if val, ok := d.GetOkExists("target_capacity"); ok {
+		req.TargetCapacity = aws.Int64(int64(val.(int)))
 		updateFlag = true
 	}
 
@@ -1495,8 +1492,24 @@ func resourceAwsSpotFleetRequestUpdate(d *schema.ResourceData, meta interface{})
 	}
 
 	if updateFlag {
+		log.Printf("[DEBUG] Modifying Spot Fleet Request: %#v", req)
 		if _, err := conn.ModifySpotFleetRequest(req); err != nil {
 			return fmt.Errorf("error updating spot request (%s): %s", d.Id(), err)
+		}
+
+		log.Println("[INFO] Waiting for Spot Fleet Request to be modified")
+		stateConf := &resource.StateChangeConf{
+			Pending:    []string{ec2.BatchStateModifying},
+			Target:     []string{ec2.BatchStateActive},
+			Refresh:    resourceAwsSpotFleetRequestStateRefreshFunc(d, meta),
+			Timeout:    10 * time.Minute,
+			MinTimeout: 10 * time.Second,
+			Delay:      30 * time.Second,
+		}
+
+		_, err := stateConf.WaitForState()
+		if err != nil {
+			return err
 		}
 	}
 

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -2354,7 +2354,7 @@ resource "aws_spot_fleet_request" "test" {
 func testAccAWSSpotFleetRequestZeroCapacityConfig(rName string, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
-    iam_fleet_role = "${aws_iam_role.test-role.arn}"
+    iam_fleet_role = "${aws_iam_role.test.arn}"
     spot_price = "0.005"
     target_capacity = 0
     valid_until = %[1]q

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -1074,8 +1074,7 @@ func TestAccAWSSpotFleetRequest_WithTargetGroups(t *testing.T) {
 
 func TestAccAWSSpotFleetRequest_zero_capacity(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -1085,7 +1084,7 @@ func TestAccAWSSpotFleetRequest_zero_capacity(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestZeroCapacityConfig(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestZeroCapacityConfig(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "target_capacity", "0"),
@@ -1098,14 +1097,14 @@ func TestAccAWSSpotFleetRequest_zero_capacity(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"wait_for_fulfillment"},
 			},
 			{
-				Config: testAccAWSSpotFleetRequestConfig(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestConfig(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "target_capacity", "2"),
 				),
 			},
 			{
-				Config: testAccAWSSpotFleetRequestZeroCapacityConfig(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestZeroCapacityConfig(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "target_capacity", "0"),
@@ -2352,8 +2351,8 @@ resource "aws_spot_fleet_request" "test" {
 `, rName, validUntil)
 }
 
-func testAccAWSSpotFleetRequestZeroCapacityConfig(rName string, rInt int, validUntil string) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+func testAccAWSSpotFleetRequestZeroCapacityConfig(rName string, validUntil string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
     spot_price = "0.005"

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -2355,7 +2355,7 @@ func testAccAWSSpotFleetRequestZeroCapacityConfig(rName string, validUntil strin
 	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test.arn}"
-    spot_price = "0.005"
+    spot_price = "0.05"
     target_capacity = 0
     valid_until = %[1]q
     terminate_instances_with_expiration = true

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -2363,9 +2363,9 @@ resource "aws_spot_fleet_request" "test" {
     instance_interruption_behaviour = "stop"
     wait_for_fulfillment = true
     launch_specification {
-        instance_type = "m1.small"
-        ami = "ami-516b9131"
-        key_name = "${aws_key_pair.test.key_name}"
+        instance_type = "${data.aws_ec2_instance_type_offering.available.instance_type}"
+        ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+        key_name      = "${aws_key_pair.test.key_name}"
     }
     depends_on = ["aws_iam_policy_attachment.test-attach"]
 }

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -1092,6 +1092,12 @@ func TestAccAWSSpotFleetRequest_zero_capacity(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"wait_for_fulfillment"},
+			},
+			{
 				Config: testAccAWSSpotFleetRequestConfig(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
@@ -2359,7 +2365,7 @@ resource "aws_spot_fleet_request" "test" {
     launch_specification {
         instance_type = "m1.small"
         ami = "ami-516b9131"
-        key_name = "${aws_key_pair.debugging.key_name}"
+        key_name = "${aws_key_pair.test.key_name}"
     }
     depends_on = ["aws_iam_policy_attachment.test-attach"]
 }

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -2366,7 +2366,7 @@ resource "aws_spot_fleet_request" "test" {
         ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
         key_name      = "${aws_key_pair.test.key_name}"
     }
-    depends_on = ["aws_iam_policy_attachment.test-attach"]
+    depends_on = ["aws_iam_policy_attachment.test"]
 }
 `, validUntil)
 }

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -1109,7 +1109,6 @@ func TestAccAWSSpotFleetRequest_zero_capacity(t *testing.T) {
 	})
 }
 
-
 func TestAccAWSSpotFleetRequest_WithInstanceStoreAmi(t *testing.T) {
 	t.Skip("Test fails due to test harness constraints")
 	rName := acctest.RandomWithPrefix("tf-acc-test")


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12757
Closes #9322  (possibly, as now there is a wait for modification to complete i have encountered a similar issue when working on this) 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_spot_fleet_request: allow updating capacity to zero
resource_aws_spot_fleet_request: wait for modification to complete
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSpotFleetRequest_zero_capacity'
--- PASS: TestAccAWSSpotFleetRequest_zero_capacity (452.08s)
```
