### PR TITLE
r/aws_ecs_task_definition: Add sweeper

### DIFF
--- a/aws/resource_aws_ecs_task_definition_test.go
+++ b/aws/resource_aws_ecs_task_definition_test.go
@@ -18,6 +18,9 @@ func init() {
 	resource.AddTestSweepers("aws_ecs_task_definition", &resource.Sweeper{
 		Name: "aws_ecs_task_definition",
 		F:    testSweepEcsTaskDefinitions,
+		Dependencies: []string{
+			"aws_ecs_service",
+		},
 	})
 }
 

--- a/aws/resource_aws_ecs_task_definition_test.go
+++ b/aws/resource_aws_ecs_task_definition_test.go
@@ -2,15 +2,65 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_ecs_task_definition", &resource.Sweeper{
+		Name: "aws_ecs_task_definition",
+		F:    testSweepEcsTaskDefinitions,
+	})
+}
+
+func testSweepEcsTaskDefinitions(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).ecsconn
+	var sweeperErrs *multierror.Error
+
+	err = conn.ListTaskDefinitionsPages(&ecs.ListTaskDefinitionsInput{}, func(page *ecs.ListTaskDefinitionsOutput, isLast bool) bool {
+		if page == nil {
+			return !isLast
+		}
+
+		for _, taskDefinitionArn := range page.TaskDefinitionArns {
+			arn := aws.StringValue(taskDefinitionArn)
+
+			log.Printf("[INFO] Deleting ECS Task Definition: %s", arn)
+			_, err := conn.DeregisterTaskDefinition(&ecs.DeregisterTaskDefinitionInput{
+				TaskDefinition: aws.String(arn),
+			})
+			if err != nil {
+				sweeperErr := fmt.Errorf("error deleting ECS Task Definition (%s): %w", arn, err)
+				log.Printf("[ERROR] %s", sweeperErr)
+				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+				continue
+			}
+		}
+
+		return !isLast
+	})
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping ECS Task Definitions sweep for %s: %s", region, err)
+		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
+	}
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving ECS Task Definitions: %w", err))
+	}
+
+	return sweeperErrs.ErrorOrNil()
+}
 
 func TestAccAWSEcsTaskDefinition_basic(t *testing.T) {
 	var def ecs.TaskDefinition


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/12657.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ TEST=./aws SWEEP=us-west-2,us-east-1 SWEEPARGS=-sweep-run=aws_ecs_task_definition make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=us-west-2,us-east-1 -sweep-run=aws_ecs_task_definition -timeout 60m
2020/04/10 09:00:12 [DEBUG] Running Sweepers for region (us-west-2):
2020/04/10 09:00:12 [DEBUG] Running Sweeper (aws_ecs_task_definition) in region (us-west-2)
2020/04/10 09:00:12 [INFO] Building AWS auth structure
2020/04/10 09:00:12 [INFO] Setting AWS metadata API timeout to 100ms
2020/04/10 09:00:14 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2020/04/10 09:00:14 [INFO] AWS Auth provider used: "EnvProvider"
2020/04/10 09:00:14 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/04/10 09:00:14 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/04/10 09:00:15 [INFO] Deleting ECS Task Definition: arn:aws:ecs:us-west-2:123456789012:task-definition/tf-acc-td-with-efs-volume-7089869197192278305:1
2020/04/10 09:00:15 [INFO] Deleting ECS Task Definition: arn:aws:ecs:us-west-2:123456789012:task-definition/tf-acc-td-with-efs-volume-min-5442515052622591934:1
2020/04/10 09:00:16 [INFO] Deleting ECS Task Definition: arn:aws:ecs:us-west-2:123456789012:task-definition/tf-acc-test-8317709032973582015:1
2020/04/10 09:00:16 [INFO] Deleting ECS Task Definition: arn:aws:ecs:us-west-2:123456789012:task-definition/tf-acc-test-8693476852412539773:1
2020/04/10 09:00:17 Sweeper Tests ran successfully:
	- aws_ecs_task_definition
2020/04/10 09:00:17 [DEBUG] Running Sweepers for region (us-east-1):
2020/04/10 09:00:17 [DEBUG] Running Sweeper (aws_ecs_task_definition) in region (us-east-1)
2020/04/10 09:00:17 [INFO] Building AWS auth structure
2020/04/10 09:00:17 [INFO] Setting AWS metadata API timeout to 100ms
2020/04/10 09:00:18 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2020/04/10 09:00:18 [INFO] AWS Auth provider used: "EnvProvider"
2020/04/10 09:00:18 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/04/10 09:00:18 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/04/10 09:00:18 [INFO] Deleting ECS Task Definition: arn:aws:ecs:us-east-1:123456789012:task-definition/vk-podspec_vk-fargate-e2e-test_default_test_1526477439853648:1
2020/04/10 09:00:19 [INFO] Deleting ECS Task Definition: arn:aws:ecs:us-east-1:123456789012:task-definition/vk-podspec_vk-fargate-e2e-test_default_test_1526478298692069:1
2020/04/10 09:00:19 Sweeper Tests ran successfully:
	- aws_ecs_task_definition
ok  	github.com/terraform-providers/terraform-provider-aws/aws	6.759s
```
