### PR TITLE
r/volume_attachment - use enums + refactor tests

### DIFF
--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -232,6 +232,7 @@ behavior "regexp_issue_labeler_v2" "service_labels" {
       "aws_spot",
       "aws_route(\"|`|$)",
       "aws_vpn_",
+      "aws_volume_attachment",
     ],
     "service/ecr" = [
       "aws_ecr_",
@@ -805,6 +806,7 @@ behavior "pull_request_path_labeler" "service_labels" {
       "aws/*_aws_subnet*",
       "aws/*_aws_vpc*",
       "aws/*_aws_vpn*",
+      "aws/*_aws_volume_attachment*",
       "website/**/availability_zone*",
       "website/**/customer_gateway*",
       "website/**/default_network_acl*",
@@ -833,7 +835,8 @@ behavior "pull_request_path_labeler" "service_labels" {
       "website/**/spot_*",
       "website/**/subnet*",
       "website/**/vpc*",
-      "website/**/vpn*"
+      "website/**/vpn*",
+      "website/**/volume_attachment*"
     ]
     "service/ecr" = [
       "**/*_ecr_*",

--- a/aws/resource_aws_volume_attachment.go
+++ b/aws/resource_aws_volume_attachment.go
@@ -97,9 +97,9 @@ func resourceAwsVolumeAttachmentCreate(d *schema.ResourceData, meta interface{})
 		// a spot request and whilst the request has been fulfilled the
 		// instance is not running yet
 		stateConf := &resource.StateChangeConf{
-			Pending:    []string{"pending", "stopping"},
-			Target:     []string{"running", "stopped"},
-			Refresh:    InstanceStateRefreshFunc(conn, iID, []string{"terminated"}),
+			Pending:    []string{ec2.InstanceStateNamePending, ec2.InstanceStateNameStopping},
+			Target:     []string{ec2.InstanceStateNameRunning, ec2.InstanceStateNameStopped},
+			Refresh:    InstanceStateRefreshFunc(conn, iID, []string{ec2.InstanceStateNameTerminated}),
 			Timeout:    10 * time.Minute,
 			Delay:      10 * time.Second,
 			MinTimeout: 3 * time.Second,
@@ -126,13 +126,12 @@ func resourceAwsVolumeAttachmentCreate(d *schema.ResourceData, meta interface{})
 				return fmt.Errorf("Error attaching volume (%s) to instance (%s), message: \"%s\", code: \"%s\"",
 					vID, iID, awsErr.Message(), awsErr.Code())
 			}
-			return err
 		}
 	}
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"attaching"},
-		Target:     []string{"attached"},
+		Pending:    []string{ec2.VolumeAttachmentStateAttaching},
+		Target:     []string{ec2.VolumeAttachmentStateAttached},
 		Refresh:    volumeAttachmentStateRefreshFunc(conn, name, vID, iID),
 		Timeout:    5 * time.Minute,
 		Delay:      10 * time.Second,
@@ -183,7 +182,7 @@ func volumeAttachmentStateRefreshFunc(conn *ec2.EC2, name, volumeID, instanceID 
 			}
 		}
 		// assume detached if volume count is 0
-		return 42, "detached", nil
+		return 42, ec2.VolumeAttachmentStateDetached, nil
 	}
 }
 
@@ -206,14 +205,14 @@ func resourceAwsVolumeAttachmentRead(d *schema.ResourceData, meta interface{}) e
 
 	vols, err := conn.DescribeVolumes(request)
 	if err != nil {
-		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidVolume.NotFound" {
+		if isAWSErr(err, "InvalidVolume.NotFound", "") {
 			d.SetId("")
 			return nil
 		}
 		return fmt.Errorf("Error reading EC2 volume %s for instance: %s: %#v", d.Get("volume_id").(string), d.Get("instance_id").(string), err)
 	}
 
-	if len(vols.Volumes) == 0 || *vols.Volumes[0].State == "available" {
+	if len(vols.Volumes) == 0 || *vols.Volumes[0].State == ec2.VolumeStateAvailable {
 		log.Printf("[DEBUG] Volume Attachment (%s) not found, removing from state", d.Id())
 		d.SetId("")
 	}
@@ -250,8 +249,8 @@ func resourceAwsVolumeAttachmentDelete(d *schema.ResourceData, meta interface{})
 			vID, iID, err)
 	}
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"detaching"},
-		Target:     []string{"detached"},
+		Pending:    []string{ec2.VolumeAttachmentStateDetaching},
+		Target:     []string{ec2.VolumeAttachmentStateDetached},
 		Refresh:    volumeAttachmentStateRefreshFunc(conn, name, vID, iID),
 		Timeout:    5 * time.Minute,
 		Delay:      10 * time.Second,

--- a/aws/resource_aws_volume_attachment_test.go
+++ b/aws/resource_aws_volume_attachment_test.go
@@ -15,6 +15,7 @@ import (
 func TestAccAWSVolumeAttachment_basic(t *testing.T) {
 	var i ec2.Instance
 	var v ec2.Volume
+	resourceName := "aws_volume_attachment.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -24,14 +25,10 @@ func TestAccAWSVolumeAttachment_basic(t *testing.T) {
 			{
 				Config: testAccVolumeAttachmentConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"aws_volume_attachment.ebs_att", "device_name", "/dev/sdh"),
-					testAccCheckInstanceExists(
-						"aws_instance.web", &i),
-					testAccCheckVolumeExists(
-						"aws_ebs_volume.example", &v),
-					testAccCheckVolumeAttachmentExists(
-						"aws_volume_attachment.ebs_att", &i, &v),
+					resource.TestCheckResourceAttr(resourceName, "device_name", "/dev/sdh"),
+					testAccCheckInstanceExists("aws_instance.test", &i),
+					testAccCheckVolumeExists("aws_ebs_volume.test", &v),
+					testAccCheckVolumeAttachmentExists(resourceName, &i, &v),
 				),
 			},
 			{
@@ -47,6 +44,7 @@ func TestAccAWSVolumeAttachment_basic(t *testing.T) {
 func TestAccAWSVolumeAttachment_skipDestroy(t *testing.T) {
 	var i ec2.Instance
 	var v ec2.Volume
+	resourceName := "aws_volume_attachment.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -56,14 +54,10 @@ func TestAccAWSVolumeAttachment_skipDestroy(t *testing.T) {
 			{
 				Config: testAccVolumeAttachmentConfigSkipDestroy,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"aws_volume_attachment.ebs_att", "device_name", "/dev/sdh"),
-					testAccCheckInstanceExists(
-						"aws_instance.web", &i),
-					testAccCheckVolumeExists(
-						"aws_ebs_volume.example", &v),
-					testAccCheckVolumeAttachmentExists(
-						"aws_volume_attachment.ebs_att", &i, &v),
+					resource.TestCheckResourceAttr(resourceName, "device_name", "/dev/sdh"),
+					testAccCheckInstanceExists("aws_instance.test", &i),
+					testAccCheckVolumeExists("aws_ebs_volume.test", &v),
+					testAccCheckVolumeAttachmentExists(resourceName, &i, &v),
 				),
 			},
 			{
@@ -82,6 +76,7 @@ func TestAccAWSVolumeAttachment_skipDestroy(t *testing.T) {
 func TestAccAWSVolumeAttachment_attachStopped(t *testing.T) {
 	var i ec2.Instance
 	var v ec2.Volume
+	resourceName := "aws_volume_attachment.test"
 
 	stopInstance := func() {
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
@@ -94,8 +89,8 @@ func TestAccAWSVolumeAttachment_attachStopped(t *testing.T) {
 		}
 
 		stateConf := &resource.StateChangeConf{
-			Pending:    []string{"pending", "running", "stopping"},
-			Target:     []string{"stopped"},
+			Pending:    []string{ec2.InstanceStateNamePending, ec2.InstanceStateNameRunning, ec2.InstanceStateNameStopping},
+			Target:     []string{ec2.InstanceStateNameStopped},
 			Refresh:    InstanceStateRefreshFunc(conn, *i.InstanceId, []string{}),
 			Timeout:    10 * time.Minute,
 			Delay:      10 * time.Second,
@@ -116,22 +111,17 @@ func TestAccAWSVolumeAttachment_attachStopped(t *testing.T) {
 			{
 				Config: testAccVolumeAttachmentConfigInstanceOnly,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExists(
-						"aws_instance.web", &i),
+					testAccCheckInstanceExists("aws_instance.test", &i),
 				),
 			},
 			{
 				PreConfig: stopInstance,
 				Config:    testAccVolumeAttachmentConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"aws_volume_attachment.ebs_att", "device_name", "/dev/sdh"),
-					testAccCheckInstanceExists(
-						"aws_instance.web", &i),
-					testAccCheckVolumeExists(
-						"aws_ebs_volume.example", &v),
-					testAccCheckVolumeAttachmentExists(
-						"aws_volume_attachment.ebs_att", &i, &v),
+					resource.TestCheckResourceAttr(resourceName, "device_name", "/dev/sdh"),
+					testAccCheckInstanceExists("aws_instance.test", &i),
+					testAccCheckVolumeExists("aws_ebs_volume.test", &v),
+					testAccCheckVolumeAttachmentExists(resourceName, &i, &v),
 				),
 			},
 			{
@@ -145,6 +135,8 @@ func TestAccAWSVolumeAttachment_attachStopped(t *testing.T) {
 }
 
 func TestAccAWSVolumeAttachment_update(t *testing.T) {
+	resourceName := "aws_volume_attachment.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -153,10 +145,8 @@ func TestAccAWSVolumeAttachment_update(t *testing.T) {
 			{
 				Config: testAccVolumeAttachmentConfig_update(false),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"aws_volume_attachment.ebs_att", "force_detach", "false"),
-					resource.TestCheckResourceAttr(
-						"aws_volume_attachment.ebs_att", "skip_destroy", "false"),
+					resource.TestCheckResourceAttr(resourceName, "force_detach", "false"),
+					resource.TestCheckResourceAttr(resourceName, "skip_destroy", "false"),
 				),
 			},
 			{
@@ -172,10 +162,8 @@ func TestAccAWSVolumeAttachment_update(t *testing.T) {
 			{
 				Config: testAccVolumeAttachmentConfig_update(true),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"aws_volume_attachment.ebs_att", "force_detach", "true"),
-					resource.TestCheckResourceAttr(
-						"aws_volume_attachment.ebs_att", "skip_destroy", "true"),
+					resource.TestCheckResourceAttr(resourceName, "force_detach", "true"),
+					resource.TestCheckResourceAttr(resourceName, "skip_destroy", "true"),
 				),
 			},
 			{
@@ -187,6 +175,28 @@ func TestAccAWSVolumeAttachment_update(t *testing.T) {
 					"force_detach", // attribute only used on resource deletion
 					"skip_destroy", // attribute only used on resource deletion
 				},
+			},
+		},
+	})
+}
+
+func TestAccAWSVolumeAttachment_disappears(t *testing.T) {
+	var i ec2.Instance
+	var v ec2.Volume
+	resourceName := "aws_volume_attachment.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVolumeAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVolumeAttachmentConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVolumeAttachmentExists(resourceName, &i, &v),
+					testAccCheckVolumeAttachmentDisappears(resourceName, &i, &v),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -205,7 +215,9 @@ func testAccCheckVolumeAttachmentExists(n string, i *ec2.Instance, v *ec2.Volume
 
 		for _, b := range i.BlockDeviceMappings {
 			if rs.Primary.Attributes["device_name"] == *b.DeviceName {
-				if b.Ebs.VolumeId != nil && rs.Primary.Attributes["volume_id"] == *b.Ebs.VolumeId {
+				if b.Ebs.VolumeId != nil &&
+					rs.Primary.Attributes["volume_id"] == *b.Ebs.VolumeId &&
+					rs.Primary.Attributes["volume_id"] == *v.VolumeId {
 					// pass
 					return nil
 				}
@@ -216,107 +228,174 @@ func testAccCheckVolumeAttachmentExists(n string, i *ec2.Instance, v *ec2.Volume
 	}
 }
 
+func testAccCheckVolumeAttachmentDisappears(n string, i *ec2.Instance, v *ec2.Volume) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+		opts := &ec2.DetachVolumeInput{
+			Device:     aws.String(rs.Primary.Attributes["device_name"]),
+			InstanceId: i.InstanceId,
+			VolumeId:   v.VolumeId,
+			Force:      aws.Bool(true),
+		}
+
+		_, err := conn.DetachVolume(opts)
+		if err != nil {
+			return err
+		}
+
+		vId := aws.StringValue(v.VolumeId)
+		iId := aws.StringValue(i.InstanceId)
+
+		stateConf := &resource.StateChangeConf{
+			Pending:    []string{ec2.VolumeAttachmentStateDetaching},
+			Target:     []string{ec2.VolumeAttachmentStateDetached},
+			Refresh:    volumeAttachmentStateRefreshFunc(conn, rs.Primary.Attributes["device_name"], vId, iId),
+			Timeout:    5 * time.Minute,
+			Delay:      10 * time.Second,
+			MinTimeout: 3 * time.Second,
+		}
+
+		log.Printf("[DEBUG] Detaching Volume (%s) from Instance (%s)", vId, iId)
+		_, err = stateConf.WaitForState()
+		if err != nil {
+			return fmt.Errorf(
+				"Error waiting for Volume (%s) to detach from Instance (%s): %s",
+				vId, iId, err)
+		}
+
+		return err
+	}
+}
+
 func testAccCheckVolumeAttachmentDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
 	for _, rs := range s.RootModule().Resources {
-		log.Printf("\n\n----- This is never called")
 		if rs.Type != "aws_volume_attachment" {
 			continue
+		}
+
+		request := &ec2.DescribeVolumesInput{
+			VolumeIds: []*string{aws.String(rs.Primary.Attributes["volume_id"])},
+			Filters: []*ec2.Filter{
+				{
+					Name:   aws.String("attachment.device"),
+					Values: []*string{aws.String(rs.Primary.Attributes["device_name"])},
+				},
+				{
+					Name:   aws.String("attachment.instance-id"),
+					Values: []*string{aws.String(rs.Primary.Attributes["instance_id"])},
+				},
+			},
+		}
+
+		_, err := conn.DescribeVolumes(request)
+		if err != nil {
+			if isAWSErr(err, "InvalidVolume.NotFound", "") {
+				return nil
+			}
+			return fmt.Errorf("error describing volumes (%s): %s", rs.Primary.ID, err)
 		}
 	}
 	return nil
 }
 
 const testAccVolumeAttachmentConfigInstanceOnly = `
-resource "aws_instance" "web" {
-  ami = "ami-21f78e11"
-  availability_zone = "us-west-2a"
-  instance_type = "t1.micro"
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_instance" "test" {
+  ami               = "ami-21f78e11"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  instance_type     = "t1.micro"
+
   tags = {
-    Name = "HelloWorld"
+    Name = "tf-acc-test-volume-attachment"
   }
 }
 `
 
-const testAccVolumeAttachmentConfig = `
-resource "aws_instance" "web" {
-  ami = "ami-21f78e11"
-  availability_zone = "us-west-2a"
-  instance_type = "t1.micro"
+const testAccVolumeAttachmentConfig = testAccVolumeAttachmentConfigInstanceOnly + `
+resource "aws_ebs_volume" "test" {
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  size              = 1
+
   tags = {
-    Name = "HelloWorld"
+    Name = "tf-acc-test-volume-attachment"
   }
 }
 
-resource "aws_ebs_volume" "example" {
-  availability_zone = "us-west-2a"
-  size = 1
-}
-
-resource "aws_volume_attachment" "ebs_att" {
+resource "aws_volume_attachment" "test" {
   device_name = "/dev/sdh"
-  volume_id = "${aws_ebs_volume.example.id}"
-  instance_id = "${aws_instance.web.id}"
+  volume_id   = "${aws_ebs_volume.test.id}"
+  instance_id = "${aws_instance.test.id}"
 }
 `
 
-const testAccVolumeAttachmentConfigSkipDestroy = `
-resource "aws_instance" "web" {
-  ami = "ami-21f78e11"
-  availability_zone = "us-west-2a"
-  instance_type = "t1.micro"
+const testAccVolumeAttachmentConfigSkipDestroy = testAccVolumeAttachmentConfigInstanceOnly + `
+resource "aws_ebs_volume" "test" {
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  size              = 1
+
   tags = {
-    Name = "HelloWorld"
+    Name = "tf-acc-test-volume-attachment"
   }
 }
 
-resource "aws_ebs_volume" "example" {
-  availability_zone = "us-west-2a"
-  size = 1
-  tags = {
-    Name = "TestVolume"
-  }
-}
-
-data "aws_ebs_volume" "ebs_volume" {
+data "aws_ebs_volume" "test" {
   filter {
     name = "size"
-    values = ["${aws_ebs_volume.example.size}"]
+    values = ["${aws_ebs_volume.test.size}"]
   }
   filter {
     name = "availability-zone"
-    values = ["${aws_ebs_volume.example.availability_zone}"]
+    values = ["${aws_ebs_volume.test.availability_zone}"]
   }
   filter {
     name = "tag:Name"
-    values = ["TestVolume"]
+    values = ["tf-acc-test-volume-attachment"]
   }
 }
 
-resource "aws_volume_attachment" "ebs_att" {
-  device_name = "/dev/sdh"
-  volume_id = "${data.aws_ebs_volume.ebs_volume.id}"
-  instance_id = "${aws_instance.web.id}"
+resource "aws_volume_attachment" "test" {
+  device_name  = "/dev/sdh"
+  volume_id    = "${data.aws_ebs_volume.test.id}"
+  instance_id  = "${aws_instance.test.id}"
   skip_destroy = true
 }
 `
 
 func testAccVolumeAttachmentConfig_update(detach bool) string {
-	return fmt.Sprintf(`
-resource "aws_instance" "web" {
-  ami               = "ami-21f78e11"
-  availability_zone = "us-west-2a"
-  instance_type     = "t1.micro"
-}
-
-resource "aws_ebs_volume" "example" {
-  availability_zone = "us-west-2a"
+	return testAccVolumeAttachmentConfigInstanceOnly + fmt.Sprintf(`
+resource "aws_ebs_volume" "test" {
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
   size              = 1
+
+  tags = {
+    Name = "tf-acc-test-volume-attachment"
+  }
 }
 
-resource "aws_volume_attachment" "ebs_att" {
+resource "aws_volume_attachment" "test" {
   device_name  = "/dev/sdh"
-  volume_id    = "${aws_ebs_volume.example.id}"
-  instance_id  = "${aws_instance.web.id}"
+  volume_id    = "${aws_ebs_volume.test.id}"
+  instance_id  = "${aws_instance.test.id}"
   force_detach = %t
   skip_destroy = %t
 }

--- a/aws/resource_aws_volume_attachment_test.go
+++ b/aws/resource_aws_volume_attachment_test.go
@@ -377,7 +377,7 @@ data "aws_ebs_volume" "test" {
   }
   filter {
     name   = "tag:Name"
-    values = ["tf-acc-test-volume-attachment"]
+    values = ["%[1]s"]
   }
 }
 
@@ -387,7 +387,7 @@ resource "aws_volume_attachment" "test" {
   instance_id  = "${aws_instance.test.id}"
   skip_destroy = true
 }
-`)
+`, rName)
 }
 
 func testAccVolumeAttachmentUpdateConfig(rName string, detach bool) string {

--- a/aws/resource_aws_volume_attachment_test.go
+++ b/aws/resource_aws_volume_attachment_test.go
@@ -343,19 +343,9 @@ resource "aws_instance" "test" {
 
 func testAccVolumeAttachmentConfigBase(rName string) string {
 	return testAccVolumeAttachmentInstanceOnlyConfigBase(rName) + fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
-resource "aws_instance" "test" {
-  ami               = "ami-21f78e11"
+resource "aws_ebs_volume" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  instance_type     = "t1.micro"
+  size              = 1
 
   tags = {
     Name = %[1]q

--- a/aws/resource_aws_volume_attachment_test.go
+++ b/aws/resource_aws_volume_attachment_test.go
@@ -319,28 +319,13 @@ func testAccCheckVolumeAttachmentDestroy(s *terraform.State) error {
 }
 
 func testAccVolumeAttachmentInstanceOnlyConfigBase(rName string) string {
-	return fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
 
   filter {
     name   = "opt-in-status"
     values = ["opt-in-not-required"]
-  }
-}
-
-data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
-  most_recent = true
-  owners      = ["amazon"]
-
-  filter {
-    name   = "name"
-    values = ["amzn-ami-minimal-hvm-*"]
-  }
-
-  filter {
-    name   = "root-device-type"
-    values = ["ebs"]
   }
 }
 

--- a/aws/resource_aws_volume_attachment_test.go
+++ b/aws/resource_aws_volume_attachment_test.go
@@ -193,6 +193,8 @@ func TestAccAWSVolumeAttachment_disappears(t *testing.T) {
 			{
 				Config: testAccVolumeAttachmentConfig,
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists("aws_instance.test", &i),
+					testAccCheckVolumeExists("aws_ebs_volume.test", &v),
 					testAccCheckVolumeAttachmentExists(resourceName, &i, &v),
 					testAccCheckVolumeAttachmentDisappears(resourceName, &i, &v),
 				),

--- a/aws/resource_aws_volume_attachment_test.go
+++ b/aws/resource_aws_volume_attachment_test.go
@@ -34,9 +34,9 @@ func TestAccAWSVolumeAttachment_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "aws_volume_attachment.ebs_att",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSVolumeAttachmentImportStateIDFunc("aws_volume_attachment.ebs_att"),
+				ImportStateIdFunc: testAccAWSVolumeAttachmentImportStateIDFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -64,9 +64,9 @@ func TestAccAWSVolumeAttachment_skipDestroy(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "aws_volume_attachment.ebs_att",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSVolumeAttachmentImportStateIDFunc("aws_volume_attachment.ebs_att"),
+				ImportStateIdFunc: testAccAWSVolumeAttachmentImportStateIDFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"skip_destroy", // attribute only used on resource deletion
@@ -129,9 +129,9 @@ func TestAccAWSVolumeAttachment_attachStopped(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "aws_volume_attachment.ebs_att",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSVolumeAttachmentImportStateIDFunc("aws_volume_attachment.ebs_att"),
+				ImportStateIdFunc: testAccAWSVolumeAttachmentImportStateIDFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -155,9 +155,9 @@ func TestAccAWSVolumeAttachment_update(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "aws_volume_attachment.ebs_att",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSVolumeAttachmentImportStateIDFunc("aws_volume_attachment.ebs_att"),
+				ImportStateIdFunc: testAccAWSVolumeAttachmentImportStateIDFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"force_detach", // attribute only used on resource deletion
@@ -172,9 +172,9 @@ func TestAccAWSVolumeAttachment_update(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "aws_volume_attachment.ebs_att",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSVolumeAttachmentImportStateIDFunc("aws_volume_attachment.ebs_att"),
+				ImportStateIdFunc: testAccAWSVolumeAttachmentImportStateIDFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"force_detach", // attribute only used on resource deletion

--- a/aws/resource_aws_volume_attachment_test.go
+++ b/aws/resource_aws_volume_attachment_test.go
@@ -350,11 +350,6 @@ data "aws_ec2_instance_type_offering" "available" {
     values = ["t3.micro", "t2.micro"]
   }
 
-  filter {
-    name   = "location"
-    values = [aws_subnet.test.availability_zone]
-  }
-
   location_type            = "availability-zone"
   preferred_instance_types = ["t3.micro", "t2.micro"]
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSVolumeAttachment_'
--- PASS: TestAccAWSVolumeAttachment_basic (153.52s)
--- PASS: TestAccAWSVolumeAttachment_skipDestroy (144.94s)
--- PASS: TestAccAWSVolumeAttachment_attachStopped (230.09s)
--- PASS: TestAccAWSVolumeAttachment_update (200.17s)
--- PASS: TestAccAWSVolumeAttachment_disappears (163.63s)
```
