### PR TITLE
service/servicediscovery: Refactor waiter logic into separate package, add test sweepers

### DIFF
--- a/aws/internal/service/servicediscovery/waiter/status.go
+++ b/aws/internal/service/servicediscovery/waiter/status.go
@@ -1,0 +1,35 @@
+package waiter
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/servicediscovery"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// OperationStatus fetches the Operation and its Status
+func OperationStatus(conn *servicediscovery.ServiceDiscovery, operationID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		input := &servicediscovery.GetOperationInput{
+			OperationId: aws.String(operationID),
+		}
+
+		output, err := conn.GetOperation(input)
+
+		if err != nil {
+			return nil, servicediscovery.OperationStatusFail, err
+		}
+
+		// Error messages can also be contained in the response with FAIL status
+		//   "ErrorCode":"CANNOT_CREATE_HOSTED_ZONE",
+		//   "ErrorMessage":"The VPC that you chose, vpc-xxx in region xxx, is already associated with another private hosted zone that has an overlapping name space, xxx.. (Service: AmazonRoute53; Status Code: 400; Error Code: ConflictingDomainExists; Request ID: xxx)"
+		//   "Status":"FAIL",
+
+		if aws.StringValue(output.Operation.Status) == servicediscovery.OperationStatusFail {
+			return output, servicediscovery.OperationStatusFail, fmt.Errorf("%s: %s", aws.StringValue(output.Operation.ErrorCode), aws.StringValue(output.Operation.ErrorMessage))
+		}
+
+		return output, aws.StringValue(output.Operation.Status), nil
+	}
+}

--- a/aws/internal/service/servicediscovery/waiter/waiter.go
+++ b/aws/internal/service/servicediscovery/waiter/waiter.go
@@ -1,0 +1,32 @@
+package waiter
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/servicediscovery"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+const (
+	// Maximum amount of time to wait for an Operation to return Success
+	OperationSuccessTimeout = 5 * time.Minute
+)
+
+// OperationSuccess waits for an Operation to return Success
+func OperationSuccess(conn *servicediscovery.ServiceDiscovery, operationID string) (*servicediscovery.GetOperationOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{servicediscovery.OperationStatusSubmitted, servicediscovery.OperationStatusPending},
+		Target:  []string{servicediscovery.OperationStatusSuccess},
+		Refresh: OperationStatus(conn, operationID),
+		Timeout: OperationSuccessTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	switch output := outputRaw.(type) {
+	case *servicediscovery.GetOperationOutput:
+		return output, err
+	default:
+		return nil, err
+	}
+}

--- a/aws/internal/service/servicediscovery/waiter/waiter.go
+++ b/aws/internal/service/servicediscovery/waiter/waiter.go
@@ -23,10 +23,9 @@ func OperationSuccess(conn *servicediscovery.ServiceDiscovery, operationID strin
 
 	outputRaw, err := stateConf.WaitForState()
 
-	switch output := outputRaw.(type) {
-	case *servicediscovery.GetOperationOutput:
+	if output, ok := outputRaw.(*servicediscovery.GetOperationOutput); ok {
 		return output, err
-	default:
-		return nil, err
 	}
+
+	return nil, err
 }

--- a/aws/resource_aws_service_discovery_http_namespace.go
+++ b/aws/resource_aws_service_discovery_http_namespace.go
@@ -2,12 +2,12 @@ package aws
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/servicediscovery"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicediscovery/waiter"
 )
 
 func resourceAwsServiceDiscoveryHttpNamespace() *schema.Resource {
@@ -54,24 +54,34 @@ func resourceAwsServiceDiscoveryHttpNamespaceCreate(d *schema.ResourceData, meta
 		input.Description = aws.String(v.(string))
 	}
 
-	resp, err := conn.CreateHttpNamespace(input)
+	output, err := conn.CreateHttpNamespace(input)
+
 	if err != nil {
-		return fmt.Errorf("error creating Service Discovery HTTP Namespace (%s): %s", name, err)
+		return fmt.Errorf("error creating Service Discovery HTTP Namespace (%s): %w", name, err)
 	}
 
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{servicediscovery.OperationStatusSubmitted, servicediscovery.OperationStatusPending},
-		Target:  []string{servicediscovery.OperationStatusSuccess},
-		Refresh: servicediscoveryOperationRefreshStatusFunc(conn, *resp.OperationId),
-		Timeout: 5 * time.Minute,
+	if output == nil || output.OperationId == nil {
+		return fmt.Errorf("error creating Service Discovery HTTP Namespace (%s): creation response missing Operation ID", name)
 	}
 
-	opresp, err := stateConf.WaitForState()
+	operationOutput, err := waiter.OperationSuccess(conn, aws.StringValue(output.OperationId))
+
 	if err != nil {
-		return fmt.Errorf("error waiting for Service Discovery HTTP Namespace (%s) creation: %s", name, err)
+		return fmt.Errorf("error waiting for Service Discovery HTTP Namespace (%s) creation: %w", name, err)
 	}
 
-	d.SetId(*opresp.(*servicediscovery.GetOperationOutput).Operation.Targets["NAMESPACE"])
+	if operationOutput == nil || operationOutput.Operation == nil {
+		return fmt.Errorf("error creating Service Discovery HTTP Namespace (%s): operation response missing Operation information", name)
+	}
+
+	namespaceID, ok := operationOutput.Operation.Targets[servicediscovery.OperationTargetTypeNamespace]
+
+	if !ok {
+		return fmt.Errorf("error creating Service Discovery HTTP Namespace (%s): operation response missing Namespace ID", name)
+	}
+
+	d.SetId(aws.StringValue(namespaceID))
+
 	return resourceAwsServiceDiscoveryHttpNamespaceRead(d, meta)
 }
 
@@ -105,25 +115,20 @@ func resourceAwsServiceDiscoveryHttpNamespaceDelete(d *schema.ResourceData, meta
 		Id: aws.String(d.Id()),
 	}
 
-	resp, err := conn.DeleteNamespace(input)
+	output, err := conn.DeleteNamespace(input)
+
+	if isAWSErr(err, servicediscovery.ErrCodeNamespaceNotFound, "") {
+		return nil
+	}
+
 	if err != nil {
-		if isAWSErr(err, servicediscovery.ErrCodeNamespaceNotFound, "") {
-			d.SetId("")
-			return nil
+		return fmt.Errorf("error deleting Service Discovery HTTP Namespace (%s): %w", d.Id(), err)
+	}
+
+	if output != nil && output.OperationId != nil {
+		if _, err := waiter.OperationSuccess(conn, aws.StringValue(output.OperationId)); err != nil {
+			return fmt.Errorf("error waiting for Service Discovery HTTP Namespace (%s) deletion: %w", d.Id(), err)
 		}
-		return fmt.Errorf("error deleting Service Discovery HTTP Namespace (%s): %s", d.Id(), err)
-	}
-
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{servicediscovery.OperationStatusSubmitted, servicediscovery.OperationStatusPending},
-		Target:  []string{servicediscovery.OperationStatusSuccess},
-		Refresh: servicediscoveryOperationRefreshStatusFunc(conn, *resp.OperationId),
-		Timeout: 5 * time.Minute,
-	}
-
-	_, err = stateConf.WaitForState()
-	if err != nil {
-		return fmt.Errorf("error waiting for Service Discovery HTTP Namespace (%s) deletion: %s", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_service_discovery_private_dns_namespace_test.go
+++ b/aws/resource_aws_service_discovery_private_dns_namespace_test.go
@@ -2,15 +2,96 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/servicediscovery"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicediscovery/waiter"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_service_discovery_private_dns_namespace", &resource.Sweeper{
+		Name: "aws_service_discovery_private_dns_namespace",
+		F:    testSweepServiceDiscoveryPrivateDnsNamespaces,
+		Dependencies: []string{
+			"aws_service_discovery_service",
+		},
+	})
+}
+
+func testSweepServiceDiscoveryPrivateDnsNamespaces(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).sdconn
+	var sweeperErrs *multierror.Error
+
+	input := &servicediscovery.ListNamespacesInput{
+		Filters: []*servicediscovery.NamespaceFilter{
+			{
+				Condition: aws.String(servicediscovery.FilterConditionEq),
+				Name:      aws.String(servicediscovery.NamespaceFilterNameType),
+				Values:    aws.StringSlice([]string{servicediscovery.NamespaceTypeDnsPrivate}),
+			},
+		},
+	}
+
+	err = conn.ListNamespacesPages(input, func(page *servicediscovery.ListNamespacesOutput, isLast bool) bool {
+		if page == nil {
+			return !isLast
+		}
+
+		for _, namespace := range page.Namespaces {
+			if namespace == nil {
+				continue
+			}
+
+			id := aws.StringValue(namespace.Id)
+			input := &servicediscovery.DeleteNamespaceInput{
+				Id: namespace.Id,
+			}
+
+			log.Printf("[INFO] Deleting Service Discovery Private DNS Namespace: %s", id)
+			output, err := conn.DeleteNamespace(input)
+
+			if err != nil {
+				sweeperErr := fmt.Errorf("error deleting Service Discovery Private DNS Namespace (%s): %w", id, err)
+				log.Printf("[ERROR] %s", sweeperErr)
+				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+				continue
+			}
+
+			if output != nil && output.OperationId != nil {
+				if _, err := waiter.OperationSuccess(conn, aws.StringValue(output.OperationId)); err != nil {
+					sweeperErr := fmt.Errorf("error waiting for Service Discovery Private DNS Namespace (%s) deletion: %w", id, err)
+					log.Printf("[ERROR] %s", sweeperErr)
+					sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+					continue
+				}
+			}
+		}
+
+		return !isLast
+	})
+
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping Service Discovery Private DNS Namespaces sweep for %s: %s", region, err)
+		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
+	}
+
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving Service Discovery Private DNS Namespaces: %w", err))
+	}
+
+	return sweeperErrs.ErrorOrNil()
+}
 
 func TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic(t *testing.T) {
 	rName := acctest.RandString(5) + ".example.com"
@@ -65,7 +146,7 @@ func TestAccAWSServiceDiscoveryPrivateDnsNamespace_error_Overlap(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccServiceDiscoveryPrivateDnsNamespaceConfigOverlapping(rName),
-				ExpectError: regexp.MustCompile(`overlapping name space`),
+				ExpectError: regexp.MustCompile(`ConflictingDomainExists`),
 			},
 		},
 	})

--- a/aws/resource_aws_service_discovery_public_dns_namespace.go
+++ b/aws/resource_aws_service_discovery_public_dns_namespace.go
@@ -2,12 +2,12 @@ package aws
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/servicediscovery"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicediscovery/waiter"
 )
 
 func resourceAwsServiceDiscoveryPublicDnsNamespace() *schema.Resource {
@@ -64,24 +64,34 @@ func resourceAwsServiceDiscoveryPublicDnsNamespaceCreate(d *schema.ResourceData,
 		input.Description = aws.String(v.(string))
 	}
 
-	resp, err := conn.CreatePublicDnsNamespace(input)
+	output, err := conn.CreatePublicDnsNamespace(input)
+
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating Service Discovery Public DNS Namespace (%s): %w", name, err)
 	}
 
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{servicediscovery.OperationStatusSubmitted, servicediscovery.OperationStatusPending},
-		Target:  []string{servicediscovery.OperationStatusSuccess},
-		Refresh: servicediscoveryOperationRefreshStatusFunc(conn, *resp.OperationId),
-		Timeout: 5 * time.Minute,
+	if output == nil || output.OperationId == nil {
+		return fmt.Errorf("error creating Service Discovery Public DNS Namespace (%s): creation response missing Operation ID", name)
 	}
 
-	opresp, err := stateConf.WaitForState()
+	operationOutput, err := waiter.OperationSuccess(conn, aws.StringValue(output.OperationId))
+
 	if err != nil {
-		return err
+		return fmt.Errorf("error waiting for Service Discovery Public DNS Namespace (%s) creation: %w", name, err)
 	}
 
-	d.SetId(*opresp.(*servicediscovery.GetOperationOutput).Operation.Targets["NAMESPACE"])
+	if operationOutput == nil || operationOutput.Operation == nil {
+		return fmt.Errorf("error creating Service Discovery Public DNS Namespace (%s): operation response missing Operation information", name)
+	}
+
+	namespaceID, ok := operationOutput.Operation.Targets[servicediscovery.OperationTargetTypeNamespace]
+
+	if !ok {
+		return fmt.Errorf("error creating Service Discovery Public DNS Namespace (%s): operation response missing Namespace ID", name)
+	}
+
+	d.SetId(aws.StringValue(namespaceID))
+
 	return resourceAwsServiceDiscoveryPublicDnsNamespaceRead(d, meta)
 }
 
@@ -117,42 +127,17 @@ func resourceAwsServiceDiscoveryPublicDnsNamespaceDelete(d *schema.ResourceData,
 		Id: aws.String(d.Id()),
 	}
 
-	resp, err := conn.DeleteNamespace(input)
+	output, err := conn.DeleteNamespace(input)
+
 	if err != nil {
-		return err
+		return fmt.Errorf("error deleting Service Discovery Public DNS Namespace (%s): %w", d.Id(), err)
 	}
 
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{servicediscovery.OperationStatusSubmitted, servicediscovery.OperationStatusPending},
-		Target:  []string{servicediscovery.OperationStatusSuccess},
-		Refresh: servicediscoveryOperationRefreshStatusFunc(conn, *resp.OperationId),
-		Timeout: 5 * time.Minute,
+	if output != nil && output.OperationId != nil {
+		if _, err := waiter.OperationSuccess(conn, aws.StringValue(output.OperationId)); err != nil {
+			return fmt.Errorf("error waiting for Service Discovery Public DNS Namespace (%s) deletion: %w", d.Id(), err)
+		}
 	}
 
-	_, err = stateConf.WaitForState()
-	return err
-}
-
-func servicediscoveryOperationRefreshStatusFunc(conn *servicediscovery.ServiceDiscovery, oid string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		input := &servicediscovery.GetOperationInput{
-			OperationId: aws.String(oid),
-		}
-		resp, err := conn.GetOperation(input)
-
-		if err != nil {
-			return nil, servicediscovery.OperationStatusFail, err
-		}
-
-		// Error messages can also be contained in the response with FAIL status
-		//   "ErrorCode":"CANNOT_CREATE_HOSTED_ZONE",
-		//   "ErrorMessage":"The VPC that you chose, vpc-xxx in region xxx, is already associated with another private hosted zone that has an overlapping name space, xxx.. (Service: AmazonRoute53; Status Code: 400; Error Code: ConflictingDomainExists; Request ID: xxx)"
-		//   "Status":"FAIL",
-
-		if aws.StringValue(resp.Operation.Status) == servicediscovery.OperationStatusFail {
-			return resp, servicediscovery.OperationStatusFail, fmt.Errorf("%s: %s", aws.StringValue(resp.Operation.ErrorCode), aws.StringValue(resp.Operation.ErrorMessage))
-		}
-
-		return resp, aws.StringValue(resp.Operation.Status), nil
-	}
+	return nil
 }

--- a/aws/resource_aws_service_discovery_public_dns_namespace_test.go
+++ b/aws/resource_aws_service_discovery_public_dns_namespace_test.go
@@ -2,14 +2,95 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/servicediscovery"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicediscovery/waiter"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_service_discovery_public_dns_namespace", &resource.Sweeper{
+		Name: "aws_service_discovery_public_dns_namespace",
+		F:    testSweepServiceDiscoveryPublicDnsNamespaces,
+		Dependencies: []string{
+			"aws_service_discovery_service",
+		},
+	})
+}
+
+func testSweepServiceDiscoveryPublicDnsNamespaces(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).sdconn
+	var sweeperErrs *multierror.Error
+
+	input := &servicediscovery.ListNamespacesInput{
+		Filters: []*servicediscovery.NamespaceFilter{
+			{
+				Condition: aws.String(servicediscovery.FilterConditionEq),
+				Name:      aws.String(servicediscovery.NamespaceFilterNameType),
+				Values:    aws.StringSlice([]string{servicediscovery.NamespaceTypeDnsPublic}),
+			},
+		},
+	}
+
+	err = conn.ListNamespacesPages(input, func(page *servicediscovery.ListNamespacesOutput, isLast bool) bool {
+		if page == nil {
+			return !isLast
+		}
+
+		for _, namespace := range page.Namespaces {
+			if namespace == nil {
+				continue
+			}
+
+			id := aws.StringValue(namespace.Id)
+			input := &servicediscovery.DeleteNamespaceInput{
+				Id: namespace.Id,
+			}
+
+			log.Printf("[INFO] Deleting Service Discovery Public DNS Namespace: %s", id)
+			output, err := conn.DeleteNamespace(input)
+
+			if err != nil {
+				sweeperErr := fmt.Errorf("error deleting Service Discovery Public DNS Namespace (%s): %w", id, err)
+				log.Printf("[ERROR] %s", sweeperErr)
+				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+				continue
+			}
+
+			if output != nil && output.OperationId != nil {
+				if _, err := waiter.OperationSuccess(conn, aws.StringValue(output.OperationId)); err != nil {
+					sweeperErr := fmt.Errorf("error waiting for Service Discovery Public DNS Namespace (%s) deletion: %w", id, err)
+					log.Printf("[ERROR] %s", sweeperErr)
+					sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+					continue
+				}
+			}
+		}
+
+		return !isLast
+	})
+
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping Service Discovery Public DNS Namespaces sweep for %s: %s", region, err)
+		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
+	}
+
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving Service Discovery Public DNS Namespaces: %w", err))
+	}
+
+	return sweeperErrs.ErrorOrNil()
+}
 
 func TestAccAWSServiceDiscoveryPublicDnsNamespace_basic(t *testing.T) {
 	resourceName := "aws_service_discovery_public_dns_namespace.test"

--- a/aws/resource_aws_service_discovery_service.go
+++ b/aws/resource_aws_service_discovery_service.go
@@ -1,14 +1,14 @@
 package aws
 
 import (
+	"fmt"
 	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/servicediscovery"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicediscovery/waiter"
 )
 
 func resourceAwsServiceDiscoveryService() *schema.Resource {
@@ -225,23 +225,16 @@ func resourceAwsServiceDiscoveryServiceUpdate(d *schema.ResourceData, meta inter
 
 	input.Service = sc
 
-	resp, err := conn.UpdateService(input)
+	output, err := conn.UpdateService(input)
+
 	if err != nil {
-		return err
+		return fmt.Errorf("error updating Service Discovery Service (%s): %w", d.Id(), err)
 	}
 
-	stateConf := &resource.StateChangeConf{
-		Pending:    []string{servicediscovery.OperationStatusSubmitted, servicediscovery.OperationStatusPending},
-		Target:     []string{servicediscovery.OperationStatusSuccess},
-		Refresh:    servicediscoveryOperationRefreshStatusFunc(conn, *resp.OperationId),
-		Timeout:    5 * time.Minute,
-		Delay:      10 * time.Second,
-		MinTimeout: 3 * time.Second,
-	}
-
-	_, err = stateConf.WaitForState()
-	if err != nil {
-		return err
+	if output != nil && output.OperationId != nil {
+		if _, err := waiter.OperationSuccess(conn, aws.StringValue(output.OperationId)); err != nil {
+			return fmt.Errorf("error waiting for Service Discovery Service (%s) update: %w", d.Id(), err)
+		}
 	}
 
 	return resourceAwsServiceDiscoveryServiceRead(d, meta)
@@ -255,7 +248,16 @@ func resourceAwsServiceDiscoveryServiceDelete(d *schema.ResourceData, meta inter
 	}
 
 	_, err := conn.DeleteService(input)
-	return err
+
+	if isAWSErr(err, servicediscovery.ErrCodeServiceNotFound, "") {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting Service Discovery Service (%s): %w", d.Id(), err)
+	}
+
+	return nil
 }
 
 func expandServiceDiscoveryDnsConfig(configured map[string]interface{}) *servicediscovery.DnsConfig {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12660

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

As with many resources that have asynchronous deletion processes, the addition of test sweepers needed to reuse that waiter logic to prevent future errors with an upcoming Route 53 Zone sweeper. Rather than copy the waiter logic in yet more places, this consolidates it into a separate package.

This new waiter package setup is a proposal for future refactorings to all services.

This also contains a fix for the failing acceptance test:

```
TestAccAWSServiceDiscoveryPrivateDnsNamespace_error_Overlap: testing.go:662: Step 0, expected error:

        errors during apply: error waiting for Service Discovery Private DNS Namespace (gvrwv.example.com) creation: CANNOT_CREATE_HOSTED_ZONE: The VPC vpc-083c996e0d85ad42e in region us-west-2 has already been associated with the hosted zone Z0432288GS3ZP21ZJMDI with the same domain name. (Service: AmazonRoute53; Status Code: 400; Error Code: ConflictingDomainExists; Request ID: 9b9cbfcb-0c54-4ea7-81ea-b7d47f694dc3)

        To match:

        overlapping name space
```

Output from acceptance testing:

```
--- PASS: TestAccAWSServiceDiscoveryHttpNamespace_basic (88.95s)
--- PASS: TestAccAWSServiceDiscoveryHttpNamespace_Description (89.11s)

--- PASS: TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic (114.07s)
--- PASS: TestAccAWSServiceDiscoveryPrivateDnsNamespace_longname (121.32s)
--- PASS: TestAccAWSServiceDiscoveryPrivateDnsNamespace_error_Overlap (195.29s)

--- PASS: TestAccAWSServiceDiscoveryPublicDnsNamespace_basic (100.89s)
--- PASS: TestAccAWSServiceDiscoveryPublicDnsNamespace_longname (109.14s)

--- PASS: TestAccAWSServiceDiscoveryService_http (92.09s)
--- PASS: TestAccAWSServiceDiscoveryService_public (124.04s)
--- PASS: TestAccAWSServiceDiscoveryService_private (146.52s)
```

Output from sweepers in AWS Commercial:

```console
$ aws servicediscovery list-services | jq '.Services | length'
3

$ aws servicediscovery list-namespaces | jq '.Namespaces | length'
23

$ go test ./aws -v -timeout=10h -sweep-allow-failures -sweep=us-west-2 -sweep-run=aws_service_discovery_http_namespace,aws_service_discovery_public_dns_namespace,aws_service_discovery_private_dns_namespace
2020/04/10 13:07:20 [DEBUG] Running Sweepers for region (us-west-2):
2020/04/10 13:07:20 [DEBUG] Sweeper (aws_service_discovery_private_dns_namespace) has dependency (aws_service_discovery_service), running..
2020/04/10 13:07:20 [DEBUG] Running Sweeper (aws_service_discovery_service) in region (us-west-2)
...
2020/04/10 13:07:24 [INFO] Deleting Service Discovery Service: srv-6u6zvcurfafyydch
2020/04/10 13:07:24 [INFO] Deleting Service Discovery Service: srv-eatg6appbkntd3hg
2020/04/10 13:07:25 [INFO] Deleting Service Discovery Service: srv-vbwvlfj72ljmgugf
...
2020/04/10 13:07:25 [DEBUG] Running Sweeper (aws_service_discovery_private_dns_namespace) in region (us-west-2)
...
2020/04/10 13:07:27 [INFO] Deleting Service Discovery Private DNS Namespace: ns-litixb75ds3f2uf5
2020/04/10 13:07:28 [DEBUG] Waiting for state to become: [SUCCESS]
...
2020/04/10 13:08:14 [INFO] Deleting Service Discovery Private DNS Namespace: ns-r5wjzm375fvgdwh4
...
2020/04/10 13:08:51 [INFO] Deleting Service Discovery Private DNS Namespace: ns-4ytxqn3lisykz7no
...
2020/04/10 13:09:38 [INFO] Deleting Service Discovery Private DNS Namespace: ns-qtpimmlhqxvlpsn6
...
2020/04/10 13:10:25 [INFO] Deleting Service Discovery Private DNS Namespace: ns-g56wgnwsupzygoqe
...
2020/04/10 13:11:12 [INFO] Deleting Service Discovery Private DNS Namespace: ns-7bbfqneobn4rwqpf
...
2020/04/10 13:11:59 [INFO] Deleting Service Discovery Private DNS Namespace: ns-udoy6ezpgshurvoe
...
2020/04/10 13:12:46 [DEBUG] Sweeper (aws_service_discovery_service) already ran in region (us-west-2)
2020/04/10 13:12:46 [DEBUG] Sweeper (aws_service_discovery_public_dns_namespace) has dependency (aws_service_discovery_service), running..
2020/04/10 13:12:46 [DEBUG] Sweeper (aws_service_discovery_service) already ran in region (us-west-2)
2020/04/10 13:12:46 [DEBUG] Running Sweeper (aws_service_discovery_public_dns_namespace) in region (us-west-2)
...
2020/04/10 13:12:49 [INFO] Deleting Service Discovery Public DNS Namespace: ns-nblkmh5ji2m2n5th
...
2020/04/10 13:13:36 [INFO] Deleting Service Discovery Public DNS Namespace: ns-i5byd6xt2r4segki
...
2020/04/10 13:14:23 [INFO] Deleting Service Discovery Public DNS Namespace: ns-wwqgutsv3sjltcvd
...
2020/04/10 13:15:01 [INFO] Deleting Service Discovery Public DNS Namespace: ns-enyejqaeiqmgo3o5
...
2020/04/10 13:15:47 [INFO] Deleting Service Discovery Public DNS Namespace: ns-qq4cew6zzsxalhox
...
2020/04/10 13:16:25 [INFO] Deleting Service Discovery Public DNS Namespace: ns-clbx2ontloe5fkkv
...
2020/04/10 13:17:12 [INFO] Deleting Service Discovery Public DNS Namespace: ns-bsttigkgmqolz74y
...
2020/04/10 13:17:59 [INFO] Deleting Service Discovery Public DNS Namespace: ns-itmaxb5ig6fr4f3f
...
2020/04/10 13:18:45 [INFO] Deleting Service Discovery Public DNS Namespace: ns-6mbdoqjjtpidsqms
...
2020/04/10 13:19:32 [DEBUG] Sweeper (aws_service_discovery_http_namespace) has dependency (aws_service_discovery_service), running..
2020/04/10 13:19:32 [DEBUG] Sweeper (aws_service_discovery_service) already ran in region (us-west-2)
2020/04/10 13:19:32 [DEBUG] Running Sweeper (aws_service_discovery_http_namespace) in region (us-west-2)
...
2020/04/10 13:19:35 [INFO] Deleting Service Discovery HTTP Namespace: ns-ewqs7bukqucp6pdi
...
2020/04/10 13:20:11 [INFO] Deleting Service Discovery HTTP Namespace: ns-akmhftxycyw3mbrv
...
2020/04/10 13:20:48 [INFO] Deleting Service Discovery HTTP Namespace: ns-dqhnlww7lj5soebl
...
2020/04/10 13:21:24 [INFO] Deleting Service Discovery HTTP Namespace: ns-ojutb4eigjvmh4vs
...
2020/04/10 13:22:01 [INFO] Deleting Service Discovery HTTP Namespace: ns-7pngubm2arpkzuas
...
2020/04/10 13:22:37 [INFO] Deleting Service Discovery HTTP Namespace: ns-wf7yw7gdfz4nluk2
...
2020/04/10 13:23:14 [INFO] Deleting Service Discovery HTTP Namespace: ns-m6onhy62jrhepxza
...
2020/04/10 13:23:50 Sweeper Tests ran successfully:
	- aws_service_discovery_private_dns_namespace
	- aws_service_discovery_public_dns_namespace
	- aws_service_discovery_http_namespace
	- aws_service_discovery_service

$ aws servicediscovery list-services | jq '.Services | length'
0

$ aws servicediscovery list-namespaces | jq '.Namespaces | length'
0
```

Output from sweepers in AWS GovCloud (US):

```console
$ go test ./aws -v -timeout=10h -sweep-allow-failures -sweep=us-gov-west-1 -sweep-run=aws_service_discovery_http_namespace,aws_service_discovery_public_dns_namespace,aws_service_discovery_private_dns_namespace
2020/04/10 12:51:43 [DEBUG] Running Sweepers for region (us-gov-west-1):
2020/04/10 12:51:43 [DEBUG] Sweeper (aws_service_discovery_http_namespace) has dependency (aws_service_discovery_service), running..
2020/04/10 12:51:43 [DEBUG] Running Sweeper (aws_service_discovery_service) in region (us-gov-west-1)
...
2020/04/10 12:51:46 [WARN] Skipping Service Discovery Services sweep for us-gov-west-1: RequestError: send request failed
caused by: Post "https://servicediscovery.us-gov-west-1.amazonaws.com/": dial tcp: lookup servicediscovery.us-gov-west-1.amazonaws.com: no such host
2020/04/10 12:51:46 [DEBUG] Running Sweeper (aws_service_discovery_http_namespace) in region (us-gov-west-1)
...
2020/04/10 12:51:49 [WARN] Skipping Service Discovery HTTP Namespaces sweep for us-gov-west-1: RequestError: send request failed
caused by: Post "https://servicediscovery.us-gov-west-1.amazonaws.com/": dial tcp: lookup servicediscovery.us-gov-west-1.amazonaws.com: no such host
2020/04/10 12:51:49 [DEBUG] Sweeper (aws_service_discovery_service) already ran in region (us-gov-west-1)
2020/04/10 12:51:49 [DEBUG] Sweeper (aws_service_discovery_public_dns_namespace) has dependency (aws_service_discovery_service), running..
2020/04/10 12:51:49 [DEBUG] Sweeper (aws_service_discovery_service) already ran in region (us-gov-west-1)
2020/04/10 12:51:49 [DEBUG] Running Sweeper (aws_service_discovery_public_dns_namespace) in region (us-gov-west-1)
...
2020/04/10 12:51:52 [WARN] Skipping Service Discovery Public DNS Namespaces sweep for us-gov-west-1: RequestError: send request failed
caused by: Post "https://servicediscovery.us-gov-west-1.amazonaws.com/": dial tcp: lookup servicediscovery.us-gov-west-1.amazonaws.com: no such host
2020/04/10 12:51:52 [DEBUG] Sweeper (aws_service_discovery_private_dns_namespace) has dependency (aws_service_discovery_service), running..
2020/04/10 12:51:52 [DEBUG] Sweeper (aws_service_discovery_service) already ran in region (us-gov-west-1)
2020/04/10 12:51:52 [DEBUG] Running Sweeper (aws_service_discovery_private_dns_namespace) in region (us-gov-west-1)
...
2020/04/10 12:51:57 [WARN] Skipping Service Discovery Private DNS Namespaces sweep for us-gov-west-1: RequestError: send request failed
caused by: Post "https://servicediscovery.us-gov-west-1.amazonaws.com/": dial tcp: lookup servicediscovery.us-gov-west-1.amazonaws.com: no such host
2020/04/10 12:51:57 Sweeper Tests ran successfully:
	- aws_service_discovery_service
	- aws_service_discovery_http_namespace
	- aws_service_discovery_public_dns_namespace
	- aws_service_discovery_private_dns_namespace
```