### PR TITLE
tests/service/guardduty: Prevent detector data source concurrency errors, refactor detector resource import testing

### DIFF
--- a/aws/data_source_aws_guardduty_detector_test.go
+++ b/aws/data_source_aws_guardduty_detector_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccAWSGuarddutyDetectorDataSource_basic(t *testing.T) {
+func testAccAWSGuarddutyDetectorDataSource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                  func() { testAccPreCheck(t) },
 		Providers:                 testAccProviders,
@@ -30,7 +30,7 @@ func TestAccAWSGuarddutyDetectorDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSGuarddutyDetectorDataSource_explicit(t *testing.T) {
+func testAccAWSGuarddutyDetectorDataSource_Id(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,

--- a/aws/resource_aws_guardduty_detector_test.go
+++ b/aws/resource_aws_guardduty_detector_test.go
@@ -80,6 +80,11 @@ func testAccAwsGuardDutyDetector_basic(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccGuardDutyDetectorConfig_basic2,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsGuardDutyDetectorExists(resourceName),
@@ -99,27 +104,6 @@ func testAccAwsGuardDutyDetector_basic(t *testing.T) {
 					testAccCheckAwsGuardDutyDetectorExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "finding_publishing_frequency", "FIFTEEN_MINUTES"),
 				),
-			},
-		},
-	})
-}
-
-func testAccAwsGuardDutyDetector_import(t *testing.T) {
-	resourceName := "aws_guardduty_detector.test"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsGuardDutyDetectorDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccGuardDutyDetectorConfig_basic1,
-			},
-
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})

--- a/aws/resource_aws_guardduty_test.go
+++ b/aws/resource_aws_guardduty_test.go
@@ -8,8 +8,9 @@ import (
 func TestAccAWSGuardDuty(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"Detector": {
-			"basic":  testAccAwsGuardDutyDetector_basic,
-			"import": testAccAwsGuardDutyDetector_import,
+			"basic":            testAccAwsGuardDutyDetector_basic,
+			"datasource_basic": testAccAWSGuarddutyDetectorDataSource_basic,
+			"datasource_id":    testAccAWSGuarddutyDetectorDataSource_Id,
 		},
 		"InviteAccepter": {
 			"basic": testAccAwsGuardDutyInviteAccepter_basic,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously (when `TestAccAWSGuarddutyDetectorDataSource_basic` was running at the same time):

```
--- FAIL: TestAccAWSGuarddutyDetectorDataSource_explicit (6.37s)
    testing.go:669: Step 0 error: errors during apply:

        Error: Creating GuardDuty Detector failed: BadRequestException: The request is rejected because a detector already exists for the current account.
```

Output from acceptance testing:

```
--- PASS: TestAccAWSGuardDuty (86.15s)
    --- PASS: TestAccAWSGuardDuty/Detector (86.15s)
        --- PASS: TestAccAWSGuardDuty/Detector/datasource_id (16.18s)
        --- PASS: TestAccAWSGuardDuty/Detector/basic (44.70s)
        --- PASS: TestAccAWSGuardDuty/Detector/datasource_basic (25.27s)
```
