### PR TITLE
service/storagegateway: Gateway activation stability and test configuration fixes

### DIFF
--- a/aws/data_source_aws_storagegateway_local_disk_test.go
+++ b/aws/data_source_aws_storagegateway_local_disk_test.go
@@ -15,19 +15,20 @@ func TestAccAWSStorageGatewayLocalDiskDataSource_DiskNode(t *testing.T) {
 	dataSourceName := "data.aws_storagegateway_local_disk.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewayGatewayDestroy,
 		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSStorageGatewayLocalDiskDataSourceConfig_DiskNode_NonExistent(rName),
+				ExpectError: regexp.MustCompile(`no results found`),
+			},
 			{
 				Config: testAccAWSStorageGatewayLocalDiskDataSourceConfig_DiskNode(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccAWSStorageGatewayLocalDiskDataSourceExists(dataSourceName),
 					resource.TestCheckResourceAttrSet(dataSourceName, "disk_id"),
 				),
-			},
-			{
-				Config:      testAccAWSStorageGatewayLocalDiskDataSourceConfig_DiskNode_NonExistent(rName),
-				ExpectError: regexp.MustCompile(`no results found`),
 			},
 		},
 	})
@@ -38,19 +39,20 @@ func TestAccAWSStorageGatewayLocalDiskDataSource_DiskPath(t *testing.T) {
 	dataSourceName := "data.aws_storagegateway_local_disk.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewayGatewayDestroy,
 		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSStorageGatewayLocalDiskDataSourceConfig_DiskPath_NonExistent(rName),
+				ExpectError: regexp.MustCompile(`no results found`),
+			},
 			{
 				Config: testAccAWSStorageGatewayLocalDiskDataSourceConfig_DiskPath(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccAWSStorageGatewayLocalDiskDataSourceExists(dataSourceName),
 					resource.TestCheckResourceAttrSet(dataSourceName, "disk_id"),
 				),
-			},
-			{
-				Config:      testAccAWSStorageGatewayLocalDiskDataSourceConfig_DiskPath_NonExistent(rName),
-				ExpectError: regexp.MustCompile(`no results found`),
 			},
 		},
 	})
@@ -67,106 +69,69 @@ func testAccAWSStorageGatewayLocalDiskDataSourceExists(dataSourceName string) re
 	}
 }
 
-func testAccAWSStorageGatewayLocalDiskDataSourceConfig_DiskNode(rName string) string {
-	return testAccAWSStorageGatewayGatewayConfig_GatewayType_FileS3(rName) + fmt.Sprintf(`
+func testAccAWSStorageGatewayLocalDiskDataSourceConfigBase(rName string) string {
+	return composeConfig(
+		testAccAWSStorageGatewayGatewayConfig_GatewayType_FileS3(rName),
+		fmt.Sprintf(`
 resource "aws_ebs_volume" "test" {
-  availability_zone = "${aws_instance.test.availability_zone}"
+  availability_zone = aws_instance.test.availability_zone
   size              = "10"
   type              = "gp2"
 
   tags = {
-    Name = %q
+    Name = %[1]q
   }
 }
 
 resource "aws_volume_attachment" "test" {
-  device_name  = "/dev/sdb"
+  device_name  = "/dev/xvdb"
   force_detach = true
-  instance_id  = "${aws_instance.test.id}"
-  volume_id    = "${aws_ebs_volume.test.id}"
+  instance_id  = aws_instance.test.id
+  volume_id    = aws_ebs_volume.test.id
+}
+`, rName))
 }
 
+func testAccAWSStorageGatewayLocalDiskDataSourceConfig_DiskNode(rName string) string {
+	return composeConfig(
+		testAccAWSStorageGatewayLocalDiskDataSourceConfigBase(rName),
+		`
 data "aws_storagegateway_local_disk" "test" {
-  disk_node   = "${aws_volume_attachment.test.device_name}"
-  gateway_arn = "${aws_storagegateway_gateway.test.arn}"
+  disk_node   = aws_volume_attachment.test.device_name
+  gateway_arn = aws_storagegateway_gateway.test.arn
 }
-`, rName)
+`)
 }
 
 func testAccAWSStorageGatewayLocalDiskDataSourceConfig_DiskNode_NonExistent(rName string) string {
-	return testAccAWSStorageGatewayGatewayConfig_GatewayType_FileS3(rName) + fmt.Sprintf(`
-resource "aws_ebs_volume" "test" {
-  availability_zone = "${aws_instance.test.availability_zone}"
-  size              = "10"
-  type              = "gp2"
-
-  tags = {
-    Name = %q
-  }
-}
-
-resource "aws_volume_attachment" "test" {
-  device_name  = "/dev/sdb"
-  force_detach = true
-  instance_id  = "${aws_instance.test.id}"
-  volume_id    = "${aws_ebs_volume.test.id}"
-}
-
+	return composeConfig(
+		testAccAWSStorageGatewayLocalDiskDataSourceConfigBase(rName),
+		`
 data "aws_storagegateway_local_disk" "test" {
-  disk_node   = "/dev/sdz"
-  gateway_arn = "${aws_storagegateway_gateway.test.arn}"
+  disk_node   = replace(aws_volume_attachment.test.device_name, "xvdb", "nonexistent")
+  gateway_arn = aws_storagegateway_gateway.test.arn
 }
-`, rName)
+`)
 }
 
 func testAccAWSStorageGatewayLocalDiskDataSourceConfig_DiskPath(rName string) string {
-	return testAccAWSStorageGatewayGatewayConfig_GatewayType_FileS3(rName) + fmt.Sprintf(`
-resource "aws_ebs_volume" "test" {
-  availability_zone = "${aws_instance.test.availability_zone}"
-  size              = "10"
-  type              = "gp2"
-
-  tags = {
-    Name = %q
-  }
-}
-
-resource "aws_volume_attachment" "test" {
-  device_name  = "/dev/xvdb"
-  force_detach = true
-  instance_id  = "${aws_instance.test.id}"
-  volume_id    = "${aws_ebs_volume.test.id}"
-}
-
+	return composeConfig(
+		testAccAWSStorageGatewayLocalDiskDataSourceConfigBase(rName),
+		`
 data "aws_storagegateway_local_disk" "test" {
-  disk_path   = "${aws_volume_attachment.test.device_name}"
-  gateway_arn = "${aws_storagegateway_gateway.test.arn}"
+  disk_path   = split(".", aws_instance.test.instance_type)[0] == "m4" ? aws_volume_attachment.test.device_name : replace(aws_volume_attachment.test.device_name, "xvdb", "nvme1n1")
+  gateway_arn = aws_storagegateway_gateway.test.arn
 }
-`, rName)
+`)
 }
 
 func testAccAWSStorageGatewayLocalDiskDataSourceConfig_DiskPath_NonExistent(rName string) string {
-	return testAccAWSStorageGatewayGatewayConfig_GatewayType_FileS3(rName) + fmt.Sprintf(`
-resource "aws_ebs_volume" "test" {
-  availability_zone = "${aws_instance.test.availability_zone}"
-  size              = "10"
-  type              = "gp2"
-
-  tags = {
-    Name = %q
-  }
-}
-
-resource "aws_volume_attachment" "test" {
-  device_name  = "/dev/xvdb"
-  force_detach = true
-  instance_id  = "${aws_instance.test.id}"
-  volume_id    = "${aws_ebs_volume.test.id}"
-}
-
+	return composeConfig(
+		testAccAWSStorageGatewayLocalDiskDataSourceConfigBase(rName),
+		`
 data "aws_storagegateway_local_disk" "test" {
-  disk_path   = "/dev/xvdz"
-  gateway_arn = "${aws_storagegateway_gateway.test.arn}"
+  disk_path   = replace(aws_volume_attachment.test.device_name, "xvdb", "nonexistent")
+  gateway_arn = aws_storagegateway_gateway.test.arn
 }
-`, rName)
+`)
 }

--- a/aws/resource_aws_storagegateway_cache_test.go
+++ b/aws/resource_aws_storagegateway_cache_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -71,19 +70,21 @@ func TestDecodeStorageGatewayCacheID(t *testing.T) {
 func TestAccAWSStorageGatewayCache_FileGateway(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_storagegateway_cache.test"
+	gatewayResourceName := "aws_storagegateway_gateway.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
-		// Storage Gateway API does not support removing caches
-		CheckDestroy: nil,
+		// Storage Gateway API does not support removing caches,
+		// but we want to ensure other resources are removed.
+		CheckDestroy: testAccCheckAWSStorageGatewayGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSStorageGatewayCacheConfig_FileGateway(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSStorageGatewayCacheExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "disk_id"),
-					resource.TestMatchResourceAttr(resourceName, "gateway_arn", regexp.MustCompile(`^arn:[^:]+:storagegateway:[^:]+:[^:]+:gateway/sgw-.+$`)),
+					resource.TestCheckResourceAttrPair(resourceName, "gateway_arn", gatewayResourceName, "arn"),
 				),
 			},
 			{
@@ -98,19 +99,21 @@ func TestAccAWSStorageGatewayCache_FileGateway(t *testing.T) {
 func TestAccAWSStorageGatewayCache_TapeAndVolumeGateway(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_storagegateway_cache.test"
+	gatewayResourceName := "aws_storagegateway_gateway.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
-		// Storage Gateway API does not support removing caches
-		CheckDestroy: nil,
+		// Storage Gateway API does not support removing caches,
+		// but we want to ensure other resources are removed.
+		CheckDestroy: testAccCheckAWSStorageGatewayGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSStorageGatewayCacheConfig_TapeAndVolumeGateway(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSStorageGatewayCacheExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "disk_id"),
-					resource.TestMatchResourceAttr(resourceName, "gateway_arn", regexp.MustCompile(`^arn:[^:]+:storagegateway:[^:]+:[^:]+:gateway/sgw-.+$`)),
+					resource.TestCheckResourceAttrPair(resourceName, "gateway_arn", gatewayResourceName, "arn"),
 				),
 			},
 			{
@@ -163,7 +166,7 @@ func testAccCheckAWSStorageGatewayCacheExists(resourceName string) resource.Test
 func testAccAWSStorageGatewayCacheConfig_FileGateway(rName string) string {
 	return testAccAWSStorageGatewayGatewayConfig_GatewayType_FileS3(rName) + fmt.Sprintf(`
 resource "aws_ebs_volume" "test" {
-  availability_zone = "${aws_instance.test.availability_zone}"
+  availability_zone = aws_instance.test.availability_zone
   size              = "10"
   type              = "gp2"
 
@@ -175,18 +178,27 @@ resource "aws_ebs_volume" "test" {
 resource "aws_volume_attachment" "test" {
   device_name  = "/dev/xvdb"
   force_detach = true
-  instance_id  = "${aws_instance.test.id}"
-  volume_id    = "${aws_ebs_volume.test.id}"
+  instance_id  = aws_instance.test.id
+  volume_id    = aws_ebs_volume.test.id
 }
 
 data "aws_storagegateway_local_disk" "test" {
-  disk_path   = "${aws_volume_attachment.test.device_name}"
-  gateway_arn = "${aws_storagegateway_gateway.test.arn}"
+  disk_node   = aws_volume_attachment.test.device_name
+  gateway_arn = aws_storagegateway_gateway.test.arn
 }
 
 resource "aws_storagegateway_cache" "test" {
-  disk_id     = "${data.aws_storagegateway_local_disk.test.id}"
-  gateway_arn = "${aws_storagegateway_gateway.test.arn}"
+  # ACCEPTANCE TESTING WORKAROUND:
+  # Data sources are not refreshed before plan after apply in TestStep
+  # Step 0 error: After applying this step, the plan was not empty:
+  #   disk_id:     "877ee674-99d3-4cd4-99f0-aadae7e3942b" => "/dev/nvme1n1" (forces new resource)
+  # We expect this data source value to change due to how Storage Gateway works.
+  lifecycle {
+    ignore_changes = ["disk_id"]
+  }
+
+  disk_id     = data.aws_storagegateway_local_disk.test.id
+  gateway_arn = aws_storagegateway_gateway.test.arn
 }
 `, rName)
 }
@@ -194,7 +206,7 @@ resource "aws_storagegateway_cache" "test" {
 func testAccAWSStorageGatewayCacheConfig_TapeAndVolumeGateway(rName string) string {
 	return testAccAWSStorageGatewayGatewayConfig_GatewayType_Cached(rName) + fmt.Sprintf(`
 resource "aws_ebs_volume" "test" {
-  availability_zone = "${aws_instance.test.availability_zone}"
+  availability_zone = aws_instance.test.availability_zone
   size              = "10"
   type              = "gp2"
 
@@ -206,13 +218,13 @@ resource "aws_ebs_volume" "test" {
 resource "aws_volume_attachment" "test" {
   device_name  = "/dev/xvdc"
   force_detach = true
-  instance_id  = "${aws_instance.test.id}"
-  volume_id    = "${aws_ebs_volume.test.id}"
+  instance_id  = aws_instance.test.id
+  volume_id    = aws_ebs_volume.test.id
 }
 
 data "aws_storagegateway_local_disk" "test" {
-  disk_path   = "${aws_volume_attachment.test.device_name}"
-  gateway_arn = "${aws_storagegateway_gateway.test.arn}"
+  disk_node   = aws_volume_attachment.test.device_name
+  gateway_arn = aws_storagegateway_gateway.test.arn
 }
 
 resource "aws_storagegateway_cache" "test" {
@@ -225,8 +237,8 @@ resource "aws_storagegateway_cache" "test" {
     ignore_changes = ["disk_id"]
   }
 
-  disk_id     = "${data.aws_storagegateway_local_disk.test.id}"
-  gateway_arn = "${aws_storagegateway_gateway.test.arn}"
+  disk_id     = data.aws_storagegateway_local_disk.test.id
+  gateway_arn = aws_storagegateway_gateway.test.arn
 }
 `, rName)
 }

--- a/aws/resource_aws_storagegateway_gateway.go
+++ b/aws/resource_aws_storagegateway_gateway.go
@@ -16,6 +16,10 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
+const (
+	StorageGatewayGatewayConnected = "GatewayConnected"
+)
+
 func resourceAwsStorageGatewayGateway() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsStorageGatewayGatewayCreate,
@@ -222,28 +226,7 @@ func resourceAwsStorageGatewayGatewayCreate(d *schema.ResourceData, meta interfa
 
 	d.SetId(aws.StringValue(output.GatewayARN))
 
-	// Gateway activations can take a few minutes
-	gwInput := &storagegateway.DescribeGatewayInformationInput{
-		GatewayARN: aws.String(d.Id()),
-	}
-	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-		_, err := conn.DescribeGatewayInformation(gwInput)
-		if err != nil {
-			if isAWSErr(err, storagegateway.ErrorCodeGatewayNotConnected, "") {
-				return resource.RetryableError(err)
-			}
-			if isAWSErr(err, storagegateway.ErrCodeInvalidGatewayRequestException, "") {
-				return resource.RetryableError(err)
-			}
-			return resource.NonRetryableError(err)
-		}
-
-		return nil
-	})
-	if isResourceTimeoutError(err) {
-		_, err = conn.DescribeGatewayInformation(gwInput)
-	}
-	if err != nil {
+	if _, err := WaitForStorageGatewayGatewayConnected(conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
 		return fmt.Errorf("error waiting for Storage Gateway Gateway activation: %s", err)
 	}
 
@@ -302,27 +285,7 @@ func resourceAwsStorageGatewayGatewayRead(d *schema.ResourceData, meta interface
 
 	log.Printf("[DEBUG] Reading Storage Gateway Gateway: %s", input)
 
-	// Storage Gateway connectivity can be very flaky for recently created or modified Gateways.
-	// Allow a short retry period to see if the problem resolves itself.
-	var output *storagegateway.DescribeGatewayInformationOutput
-	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-		var err error
-		output, err = conn.DescribeGatewayInformation(input)
-
-		if isAWSErr(err, storagegateway.ErrCodeInvalidGatewayRequestException, "The specified gateway is not connected") {
-			return resource.RetryableError(err)
-		}
-
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
-
-		return nil
-	})
-
-	if isResourceTimeoutError(err) {
-		output, err = conn.DescribeGatewayInformation(input)
-	}
+	output, err := conn.DescribeGatewayInformation(input)
 
 	if err != nil {
 		if isAWSErrStorageGatewayGatewayNotFound(err) {
@@ -503,4 +466,44 @@ func isAWSErrStorageGatewayGatewayNotFound(err error) bool {
 		return true
 	}
 	return false
+}
+
+func StorageGatewayGatewayConnectedStatus(conn *storagegateway.StorageGateway, gatewayARN string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		input := &storagegateway.DescribeGatewayInformationInput{
+			GatewayARN: aws.String(gatewayARN),
+		}
+
+		output, err := conn.DescribeGatewayInformation(input)
+
+		if isAWSErr(err, storagegateway.ErrCodeInvalidGatewayRequestException, "The specified gateway is not connected") {
+			return output, storagegateway.ErrorCodeGatewayNotConnected, nil
+		}
+
+		if err != nil {
+			return output, "", err
+		}
+
+		return output, StorageGatewayGatewayConnected, nil
+	}
+}
+
+func WaitForStorageGatewayGatewayConnected(conn *storagegateway.StorageGateway, gatewayARN string, timeout time.Duration) (*storagegateway.DescribeGatewayInformationOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending:                   []string{storagegateway.ErrorCodeGatewayNotConnected},
+		Target:                    []string{StorageGatewayGatewayConnected},
+		Refresh:                   StorageGatewayGatewayConnectedStatus(conn, gatewayARN),
+		Timeout:                   timeout,
+		MinTimeout:                10 * time.Second,
+		ContinuousTargetOccurence: 6, // Gateway activations can take a few seconds and can trigger a reboot of the Gateway
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	switch output := outputRaw.(type) {
+	case *storagegateway.DescribeGatewayInformationOutput:
+		return output, err
+	default:
+		return nil, err
+	}
 }

--- a/aws/resource_aws_storagegateway_gateway_test.go
+++ b/aws/resource_aws_storagegateway_gateway_test.go
@@ -490,22 +490,10 @@ resource "aws_internet_gateway" "test" {
   }
 }
 
-resource "aws_route_table" "test" {
-  vpc_id = aws_vpc.test.id
-
-  route {
-    cidr_block = "0.0.0.0/0"
-    gateway_id = aws_internet_gateway.test.id
-  }
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_route_table_association" "test" {
-  subnet_id      = aws_subnet.test.id
-  route_table_id = aws_route_table.test.id
+resource "aws_route" "test" {
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.test.id
+  route_table_id         = aws_vpc.test.main_route_table_id
 }
 
 resource "aws_security_group" "test" {
@@ -556,7 +544,7 @@ data "aws_ssm_parameter" "aws_service_storagegateway_ami_FILE_S3_latest" {
 }
 
 resource "aws_instance" "test" {
-  depends_on = ["aws_internet_gateway.test"]
+  depends_on = ["aws_route.test"]
 
   ami                         = data.aws_ssm_parameter.aws_service_storagegateway_ami_FILE_S3_latest.value
   associate_public_ip_address = true
@@ -596,7 +584,7 @@ data "aws_ssm_parameter" "aws_service_storagegateway_ami_CACHED_latest" {
 }
 
 resource "aws_instance" "test" {
-  depends_on = ["aws_internet_gateway.test"]
+  depends_on = ["aws_route.test"]
 
   ami                         = data.aws_ssm_parameter.aws_service_storagegateway_ami_CACHED_latest.value
   associate_public_ip_address = true
@@ -722,24 +710,10 @@ resource "aws_internet_gateway" "test" {
   }
 }
 
-resource "aws_route_table" "test" {
-  vpc_id = aws_vpc.test.id
-
-  route {
-    cidr_block = "0.0.0.0/0"
-    gateway_id = aws_internet_gateway.test.id
-  }
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_route_table_association" "test" {
-  count = 2
-
-  subnet_id      = aws_subnet.test[count.index].id
-  route_table_id = aws_route_table.test.id
+resource "aws_route" "test" {
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.test.id
+  route_table_id         = aws_vpc.test.main_route_table_id
 }
 
 resource "aws_security_group" "test" {
@@ -815,7 +789,7 @@ data "aws_ssm_parameter" "aws_service_storagegateway_ami_FILE_S3_latest" {
 }
 
 resource "aws_instance" "test" {
-  depends_on = [aws_internet_gateway.test, aws_vpc_dhcp_options_association.test]
+  depends_on = [aws_route.test, aws_vpc_dhcp_options_association.test]
 
   ami                         = data.aws_ssm_parameter.aws_service_storagegateway_ami_FILE_S3_latest.value
   associate_public_ip_address = true

--- a/aws/resource_aws_storagegateway_working_storage_test.go
+++ b/aws/resource_aws_storagegateway_working_storage_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -71,19 +70,21 @@ func TestDecodeStorageGatewayWorkingStorageID(t *testing.T) {
 func TestAccAWSStorageGatewayWorkingStorage_Basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_storagegateway_working_storage.test"
+	gatewayResourceName := "aws_storagegateway_gateway.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
-		// Storage Gateway API does not support removing working storages
-		CheckDestroy: nil,
+		// Storage Gateway API does not support removing working storages,
+		// but we want to ensure other resources are removed.
+		CheckDestroy: testAccCheckAWSStorageGatewayGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSStorageGatewayWorkingStorageConfig_Basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSStorageGatewayWorkingStorageExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "disk_id"),
-					resource.TestMatchResourceAttr(resourceName, "gateway_arn", regexp.MustCompile(`^arn:[^:]+:storagegateway:[^:]+:[^:]+:gateway/sgw-.+$`)),
+					resource.TestCheckResourceAttrPair(resourceName, "gateway_arn", gatewayResourceName, "arn"),
 				),
 			},
 			{
@@ -136,30 +137,30 @@ func testAccCheckAWSStorageGatewayWorkingStorageExists(resourceName string) reso
 func testAccAWSStorageGatewayWorkingStorageConfig_Basic(rName string) string {
 	return testAccAWSStorageGatewayGatewayConfig_GatewayType_Stored(rName) + fmt.Sprintf(`
 resource "aws_ebs_volume" "test" {
-  availability_zone = "${aws_instance.test.availability_zone}"
+  availability_zone = aws_instance.test.availability_zone
   size              = "10"
   type              = "gp2"
 
   tags = {
-    Name = %q
+    Name = %[1]q
   }
 }
 
 resource "aws_volume_attachment" "test" {
   device_name  = "/dev/xvdc"
   force_detach = true
-  instance_id  = "${aws_instance.test.id}"
-  volume_id    = "${aws_ebs_volume.test.id}"
+  instance_id  = aws_instance.test.id
+  volume_id    = aws_ebs_volume.test.id
 }
 
 data "aws_storagegateway_local_disk" "test" {
-  disk_path   = "${aws_volume_attachment.test.device_name}"
-  gateway_arn = "${aws_storagegateway_gateway.test.arn}"
+  disk_node   = aws_volume_attachment.test.device_name
+  gateway_arn = aws_storagegateway_gateway.test.arn
 }
 
 resource "aws_storagegateway_working_storage" "test" {
-  disk_id     = "${data.aws_storagegateway_local_disk.test.id}"
-  gateway_arn = "${aws_storagegateway_gateway.test.arn}"
+  disk_id     = data.aws_storagegateway_local_disk.test.id
+  gateway_arn = aws_storagegateway_gateway.test.arn
 }
 `, rName)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_storagegateway_gateway: Perform multiple connectivity checks after activation to wait if the underlying server (e.g. EC2 Instance) is automatically rebooted
```

The majority of the test configuration fixes relate to the difference of disk handling in M4 versus M5 Instance Classes and ensuring the EC2 Route to the EC2 Internet Gateway remains active at all times for the EC2 Instance during destroy. See each commit for additional details about the previous test failures.

Output from acceptance testing:

```
--- PASS: TestAccAWSStorageGatewayCache_FileGateway (323.91s)
--- PASS: TestAccAWSStorageGatewayCache_TapeAndVolumeGateway (394.30s)

--- PASS: TestAccAWSStorageGatewayCachedIscsiVolume_Basic (278.38s)
--- PASS: TestAccAWSStorageGatewayCachedIscsiVolume_SnapshotId (291.18s)
--- PASS: TestAccAWSStorageGatewayCachedIscsiVolume_Tags (336.60s)

--- PASS: TestAccAWSStorageGatewayGateway_CloudWatchLogs (303.20s)
--- PASS: TestAccAWSStorageGatewayGateway_GatewayName (379.28s)
--- PASS: TestAccAWSStorageGatewayGateway_GatewayTimezone (317.40s)
--- PASS: TestAccAWSStorageGatewayGateway_GatewayType_Cached (226.42s)
--- PASS: TestAccAWSStorageGatewayGateway_GatewayType_FileS3 (311.96s)
--- PASS: TestAccAWSStorageGatewayGateway_GatewayType_Stored (228.65s)
--- PASS: TestAccAWSStorageGatewayGateway_GatewayType_Vtl (224.81s)
--- PASS: TestAccAWSStorageGatewayGateway_SmbActiveDirectorySettings (1143.14s)
--- PASS: TestAccAWSStorageGatewayGateway_SmbGuestPassword (312.98s)
--- PASS: TestAccAWSStorageGatewayGateway_tags (321.44s)

--- PASS: TestAccAWSStorageGatewayLocalDiskDataSource_DiskNode (312.00s)
--- PASS: TestAccAWSStorageGatewayLocalDiskDataSource_DiskPath (338.51s)

--- PASS: TestAccAWSStorageGatewayNfsFileShare_basic (329.21s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_ClientList (466.73s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_DefaultStorageClass (428.96s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_GuessMIMETypeEnabled (445.24s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_KMSEncrypted (411.70s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_KMSKeyArn (484.31s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_NFSFileShareDefaults (424.93s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_ObjectACL (422.92s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_ReadOnly (422.45s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_RequesterPays (448.74s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_Squash (427.41s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_tags (475.15s)

--- PASS: TestAccAWSStorageGatewaySmbFileShare_Authentication_ActiveDirectory (858.68s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_Authentication_GuestAccess (305.84s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_DefaultStorageClass (425.75s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_GuessMIMETypeEnabled (433.59s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_InvalidUserList (977.53s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_KMSEncrypted (359.66s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_KMSKeyArn (483.25s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_ObjectACL (455.06s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_ReadOnly (426.51s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_RequesterPays (464.60s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_Tags (481.12s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_ValidUserList (1028.71s)

--- PASS: TestAccAWSStorageGatewayUploadBuffer_Basic (466.40s)

--- PASS: TestAccAWSStorageGatewayWorkingStorage_Basic (436.24s)
```