### PR TITLE
r/waf_ipset - read after create + refactor tests

### DIFF
--- a/aws/resource_aws_waf_ipset_test.go
+++ b/aws/resource_aws_waf_ipset_test.go
@@ -8,18 +8,17 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func TestAccAWSWafIPSet_basic(t *testing.T) {
 	var v waf.IPSet
-	ipsetName := fmt.Sprintf("ip-set-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_waf_ipset.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWaf(t) },
@@ -27,21 +26,17 @@ func TestAccAWSWafIPSet_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSWafIPSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSWafIPSetConfig(ipsetName),
+				Config: testAccAWSWafIPSetConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafIPSetExists("aws_waf_ipset.ipset", &v),
-					resource.TestCheckResourceAttr(
-						"aws_waf_ipset.ipset", "name", ipsetName),
-					resource.TestCheckResourceAttr(
-						"aws_waf_ipset.ipset", "ip_set_descriptors.4037960608.type", "IPV4"),
-					resource.TestCheckResourceAttr(
-						"aws_waf_ipset.ipset", "ip_set_descriptors.4037960608.value", "192.0.7.0/24"),
-					resource.TestMatchResourceAttr("aws_waf_ipset.ipset", "arn",
-						regexp.MustCompile(`^arn:[\w-]+:waf::\d{12}:ipset/.+$`)),
+					testAccCheckAWSWafIPSetExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptors.4037960608.type", "IPV4"),
+					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptors.4037960608.value", "192.0.7.0/24"),
+					testAccMatchResourceAttrGlobalARN(resourceName, "arn", "waf", regexp.MustCompile(`ipset/.+`)),
 				),
 			},
 			{
-				ResourceName:      "aws_waf_ipset.ipset",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -51,16 +46,18 @@ func TestAccAWSWafIPSet_basic(t *testing.T) {
 
 func TestAccAWSWafIPSet_disappears(t *testing.T) {
 	var v waf.IPSet
-	ipsetName := fmt.Sprintf("ip-set-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_waf_ipset.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWaf(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSWafIPSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSWafIPSetConfig(ipsetName),
+				Config: testAccAWSWafIPSetConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafIPSetExists("aws_waf_ipset.ipset", &v),
+					testAccCheckAWSWafIPSetExists(resourceName, &v),
 					testAccCheckAWSWafIPSetDisappears(&v),
 				),
 				ExpectNonEmptyPlan: true,
@@ -71,8 +68,9 @@ func TestAccAWSWafIPSet_disappears(t *testing.T) {
 
 func TestAccAWSWafIPSet_changeNameForceNew(t *testing.T) {
 	var before, after waf.IPSet
-	ipsetName := fmt.Sprintf("ip-set-%s", acctest.RandString(5))
-	ipsetNewName := fmt.Sprintf("ip-set-new-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	uName := acctest.RandomWithPrefix("tf-acc-test-updated")
+	resourceName := "aws_waf_ipset.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWaf(t) },
@@ -80,27 +78,26 @@ func TestAccAWSWafIPSet_changeNameForceNew(t *testing.T) {
 		CheckDestroy: testAccCheckAWSWafIPSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSWafIPSetConfig(ipsetName),
+				Config: testAccAWSWafIPSetConfig(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafIPSetExists("aws_waf_ipset.ipset", &before),
-					resource.TestCheckResourceAttr(
-						"aws_waf_ipset.ipset", "name", ipsetName),
-					resource.TestCheckResourceAttr(
-						"aws_waf_ipset.ipset", "ip_set_descriptors.4037960608.type", "IPV4"),
-					resource.TestCheckResourceAttr(
-						"aws_waf_ipset.ipset", "ip_set_descriptors.4037960608.value", "192.0.7.0/24"),
+					testAccCheckAWSWafIPSetExists(resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptors.4037960608.type", "IPV4"),
+					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptors.4037960608.value", "192.0.7.0/24"),
 				),
 			},
 			{
-				Config: testAccAWSWafIPSetConfigChangeName(ipsetNewName),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSWafIPSetConfigChangeName(uName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafIPSetExists("aws_waf_ipset.ipset", &after),
-					resource.TestCheckResourceAttr(
-						"aws_waf_ipset.ipset", "name", ipsetNewName),
-					resource.TestCheckResourceAttr(
-						"aws_waf_ipset.ipset", "ip_set_descriptors.4037960608.type", "IPV4"),
-					resource.TestCheckResourceAttr(
-						"aws_waf_ipset.ipset", "ip_set_descriptors.4037960608.value", "192.0.7.0/24"),
+					testAccCheckAWSWafIPSetExists(resourceName, &after),
+					resource.TestCheckResourceAttr(resourceName, "name", uName),
+					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptors.4037960608.type", "IPV4"),
+					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptors.4037960608.value", "192.0.7.0/24"),
 				),
 			},
 		},
@@ -109,7 +106,8 @@ func TestAccAWSWafIPSet_changeNameForceNew(t *testing.T) {
 
 func TestAccAWSWafIPSet_changeDescriptors(t *testing.T) {
 	var before, after waf.IPSet
-	ipsetName := fmt.Sprintf("ip-set-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_waf_ipset.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWaf(t) },
@@ -117,31 +115,28 @@ func TestAccAWSWafIPSet_changeDescriptors(t *testing.T) {
 		CheckDestroy: testAccCheckAWSWafIPSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSWafIPSetConfig(ipsetName),
+				Config: testAccAWSWafIPSetConfig(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafIPSetExists("aws_waf_ipset.ipset", &before),
-					resource.TestCheckResourceAttr(
-						"aws_waf_ipset.ipset", "name", ipsetName),
-					resource.TestCheckResourceAttr(
-						"aws_waf_ipset.ipset", "ip_set_descriptors.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_waf_ipset.ipset", "ip_set_descriptors.4037960608.type", "IPV4"),
-					resource.TestCheckResourceAttr(
-						"aws_waf_ipset.ipset", "ip_set_descriptors.4037960608.value", "192.0.7.0/24"),
+					testAccCheckAWSWafIPSetExists(resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptors.4037960608.type", "IPV4"),
+					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptors.4037960608.value", "192.0.7.0/24"),
 				),
 			},
 			{
-				Config: testAccAWSWafIPSetConfigChangeIPSetDescriptors(ipsetName),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSWafIPSetConfigChangeIPSetDescriptors(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafIPSetExists("aws_waf_ipset.ipset", &after),
-					resource.TestCheckResourceAttr(
-						"aws_waf_ipset.ipset", "name", ipsetName),
-					resource.TestCheckResourceAttr(
-						"aws_waf_ipset.ipset", "ip_set_descriptors.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_waf_ipset.ipset", "ip_set_descriptors.115741513.type", "IPV4"),
-					resource.TestCheckResourceAttr(
-						"aws_waf_ipset.ipset", "ip_set_descriptors.115741513.value", "192.0.8.0/24"),
+					testAccCheckAWSWafIPSetExists(resourceName, &after),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptors.115741513.type", "IPV4"),
+					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptors.115741513.value", "192.0.8.0/24"),
 				),
 			},
 		},
@@ -150,7 +145,8 @@ func TestAccAWSWafIPSet_changeDescriptors(t *testing.T) {
 
 func TestAccAWSWafIPSet_noDescriptors(t *testing.T) {
 	var ipset waf.IPSet
-	ipsetName := fmt.Sprintf("ip-set-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_waf_ipset.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWaf(t) },
@@ -158,14 +154,17 @@ func TestAccAWSWafIPSet_noDescriptors(t *testing.T) {
 		CheckDestroy: testAccCheckAWSWafIPSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSWafIPSetConfig_noDescriptors(ipsetName),
+				Config: testAccAWSWafIPSetConfig_noDescriptors(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafIPSetExists("aws_waf_ipset.ipset", &ipset),
-					resource.TestCheckResourceAttr(
-						"aws_waf_ipset.ipset", "name", ipsetName),
-					resource.TestCheckResourceAttr(
-						"aws_waf_ipset.ipset", "ip_set_descriptors.#", "0"),
+					testAccCheckAWSWafIPSetExists(resourceName, &ipset),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptors.#", "0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -173,8 +172,8 @@ func TestAccAWSWafIPSet_noDescriptors(t *testing.T) {
 
 func TestAccAWSWafIPSet_IpSetDescriptors_1000UpdateLimit(t *testing.T) {
 	var ipset waf.IPSet
-	ipsetName := fmt.Sprintf("ip-set-%s", acctest.RandString(5))
-	resourceName := "aws_waf_ipset.ipset"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_waf_ipset.test"
 
 	incrementIP := func(ip net.IP) {
 		for j := len(ip) - 1; j >= 0; j-- {
@@ -201,11 +200,16 @@ func TestAccAWSWafIPSet_IpSetDescriptors_1000UpdateLimit(t *testing.T) {
 		CheckDestroy: testAccCheckAWSWafIPSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSWafIPSetConfig_IpSetDescriptors(ipsetName, strings.Join(ipSetDescriptors, "\n")),
+				Config: testAccAWSWafIPSetConfig_IpSetDescriptors(rName, strings.Join(ipSetDescriptors, "\n")),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSWafIPSetExists(resourceName, &ipset),
 					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptors.#", "2048"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -290,14 +294,14 @@ func TestDiffWafIpSetDescriptors(t *testing.T) {
 					{
 						Action: aws.String(waf.ChangeActionDelete),
 						IPSetDescriptor: &waf.IPSetDescriptor{
-							Type:  aws.String("IPV4"),
+							Type:  aws.String(waf.IPSetDescriptorTypeIpv4),
 							Value: aws.String("192.0.7.0/24"),
 						},
 					},
 					{
 						Action: aws.String(waf.ChangeActionDelete),
 						IPSetDescriptor: &waf.IPSetDescriptor{
-							Type:  aws.String("IPV4"),
+							Type:  aws.String(waf.IPSetDescriptorTypeIpv4),
 							Value: aws.String("192.0.8.0/24"),
 						},
 					},
@@ -314,6 +318,31 @@ func TestDiffWafIpSetDescriptors(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAccAWSWafIPSet_ipv6(t *testing.T) {
+	var v waf.IPSet
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_waf_ipset.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWaf(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafIPSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSWafIPSetIPV6Config(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafIPSetExists(resourceName, &v),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
 }
 
 func testAccCheckAWSWafIPSetDisappears(v *waf.IPSet) resource.TestCheckFunc {
@@ -377,10 +406,8 @@ func testAccCheckAWSWafIPSetDestroy(s *terraform.State) error {
 		}
 
 		// Return nil if the IPSet is already destroyed
-		if awsErr, ok := err.(awserr.Error); ok {
-			if awsErr.Code() == "WAFNonexistentItemException" {
-				return nil
-			}
+		if isAWSErr(err, waf.ErrCodeNonexistentItemException, "") {
+			return nil
 		}
 
 		return err
@@ -420,8 +447,8 @@ func testAccCheckAWSWafIPSetExists(n string, v *waf.IPSet) resource.TestCheckFun
 
 func testAccAWSWafIPSetConfig(name string) string {
 	return fmt.Sprintf(`
-resource "aws_waf_ipset" "ipset" {
-  name = "%s"
+resource "aws_waf_ipset" "test" {
+  name = %[1]q
 
   ip_set_descriptors {
     type  = "IPV4"
@@ -433,8 +460,8 @@ resource "aws_waf_ipset" "ipset" {
 
 func testAccAWSWafIPSetConfigChangeName(name string) string {
 	return fmt.Sprintf(`
-resource "aws_waf_ipset" "ipset" {
-  name = "%s"
+resource "aws_waf_ipset" "test" {
+  name = %[1]q
 
   ip_set_descriptors {
     type  = "IPV4"
@@ -446,8 +473,8 @@ resource "aws_waf_ipset" "ipset" {
 
 func testAccAWSWafIPSetConfigChangeIPSetDescriptors(name string) string {
 	return fmt.Sprintf(`
-resource "aws_waf_ipset" "ipset" {
-  name = "%s"
+resource "aws_waf_ipset" "test" {
+  name = %[1]q
 
   ip_set_descriptors {
     type  = "IPV4"
@@ -459,8 +486,8 @@ resource "aws_waf_ipset" "ipset" {
 
 func testAccAWSWafIPSetConfig_IpSetDescriptors(name, ipSetDescriptors string) string {
 	return fmt.Sprintf(`
-resource "aws_waf_ipset" "ipset" {
-  name = "%s"
+resource "aws_waf_ipset" "test" {
+  name = %[1]q
 
   %s
 }
@@ -469,8 +496,21 @@ resource "aws_waf_ipset" "ipset" {
 
 func testAccAWSWafIPSetConfig_noDescriptors(name string) string {
 	return fmt.Sprintf(`
-resource "aws_waf_ipset" "ipset" {
-  name = "%s"
+resource "aws_waf_ipset" "test" {
+  name = %[1]q
+}
+`, name)
+}
+
+func testAccAWSWafIPSetIPV6Config(name string) string {
+	return fmt.Sprintf(`
+resource "aws_waf_ipset" "test" {
+  name = %[1]q
+
+  ip_set_descriptors {
+    type  = "IPV6"
+    value = "1234:5678:9abc:6811:0000:0000:0000:0000/64"
+  }
 }
 `, name)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_waf_ipset: add plan time validations for `ip_set_descriptors.type` and `ip_set_descriptors.value`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSWafIPSet_'
--- PASS: TestAccAWSWafIPSet_basic (46.86s)
--- PASS: TestAccAWSWafIPSet_disappears (36.39s)
--- PASS: TestAccAWSWafIPSet_changeNameForceNew (79.04s)
--- PASS: TestAccAWSWafIPSet_changeDescriptors (72.63s)
--- PASS: TestAccAWSWafIPSet_noDescriptors (41.07s)
--- PASS: TestAccAWSWafIPSet_IpSetDescriptors_1000UpdateLimit (127.73s)
--- PASS: TestAccAWSWafIPSet_ipv6 (46.00s)
```
