### PR TITLE
r/waf_xss_match_set: read after create + validations

### DIFF
--- a/aws/resource_aws_waf_xss_match_set.go
+++ b/aws/resource_aws_waf_xss_match_set.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 func resourceAwsWafXssMatchSet() *schema.Resource {
@@ -49,6 +49,15 @@ func resourceAwsWafXssMatchSet() *schema.Resource {
 									"type": {
 										Type:     schema.TypeString,
 										Required: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											waf.MatchFieldTypeUri,
+											waf.MatchFieldTypeSingleQueryArg,
+											waf.MatchFieldTypeQueryString,
+											waf.MatchFieldTypeMethod,
+											waf.MatchFieldTypeHeader,
+											waf.MatchFieldTypeBody,
+											waf.MatchFieldTypeAllQueryArgs,
+										}, false),
 									},
 								},
 							},
@@ -56,6 +65,14 @@ func resourceAwsWafXssMatchSet() *schema.Resource {
 						"text_transformation": {
 							Type:     schema.TypeString,
 							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								waf.TextTransformationUrlDecode,
+								waf.TextTransformationNone,
+								waf.TextTransformationHtmlEntityDecode,
+								waf.TextTransformationCompressWhiteSpace,
+								waf.TextTransformationCmdLine,
+								waf.TextTransformationLowercase,
+							}, false),
 						},
 					},
 				},
@@ -79,26 +96,32 @@ func resourceAwsWafXssMatchSetCreate(d *schema.ResourceData, meta interface{}) e
 		return conn.CreateXssMatchSet(params)
 	})
 	if err != nil {
-		return fmt.Errorf("Error creating XssMatchSet: %s", err)
+		return fmt.Errorf("Error creating WAF XSS Match Set: %s", err)
 	}
 	resp := out.(*waf.CreateXssMatchSetOutput)
 
 	d.SetId(*resp.XssMatchSet.XssMatchSetId)
 
-	return resourceAwsWafXssMatchSetUpdate(d, meta)
+	if v, ok := d.GetOk("xss_match_tuples"); ok && v.(*schema.Set).Len() > 0 {
+		err := updateXssMatchSetResource(d.Id(), nil, v.(*schema.Set).List(), conn)
+		if err != nil {
+			return fmt.Errorf("Error setting WAF XSS Match Set tuples: %s", err)
+		}
+	}
+	return resourceAwsWafXssMatchSetRead(d, meta)
 }
 
 func resourceAwsWafXssMatchSetRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).wafconn
-	log.Printf("[INFO] Reading XssMatchSet: %s", d.Get("name").(string))
+	log.Printf("[INFO] Reading WAF XSS Match Set: %s", d.Get("name").(string))
 	params := &waf.GetXssMatchSetInput{
 		XssMatchSetId: aws.String(d.Id()),
 	}
 
 	resp, err := conn.GetXssMatchSet(params)
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == waf.ErrCodeNonexistentItemException {
-			log.Printf("[WARN] WAF IPSet (%s) not found, removing from state", d.Id())
+		if isAWSErr(err, waf.ErrCodeNonexistentItemException, "") {
+			log.Printf("[WARN] WAF XSS Match Set (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
@@ -129,7 +152,7 @@ func resourceAwsWafXssMatchSetUpdate(d *schema.ResourceData, meta interface{}) e
 
 		err := updateXssMatchSetResource(d.Id(), oldT, newT, conn)
 		if err != nil {
-			return fmt.Errorf("Error updating XssMatchSet: %s", err)
+			return fmt.Errorf("Error updating WAF XSS Match Set: %s", err)
 		}
 	}
 
@@ -141,10 +164,9 @@ func resourceAwsWafXssMatchSetDelete(d *schema.ResourceData, meta interface{}) e
 
 	oldTuples := d.Get("xss_match_tuples").(*schema.Set).List()
 	if len(oldTuples) > 0 {
-		noTuples := []interface{}{}
-		err := updateXssMatchSetResource(d.Id(), oldTuples, noTuples, conn)
+		err := updateXssMatchSetResource(d.Id(), oldTuples, nil, conn)
 		if err != nil {
-			return fmt.Errorf("Error updating IPSetDescriptors: %s", err)
+			return fmt.Errorf("Error removing WAF XSS Match Set tuples: %s", err)
 		}
 	}
 
@@ -158,7 +180,7 @@ func resourceAwsWafXssMatchSetDelete(d *schema.ResourceData, meta interface{}) e
 		return conn.DeleteXssMatchSet(req)
 	})
 	if err != nil {
-		return fmt.Errorf("Error deleting XssMatchSet: %s", err)
+		return fmt.Errorf("Error deleting WAF XSS Match Set: %s", err)
 	}
 
 	return nil
@@ -173,11 +195,11 @@ func updateXssMatchSetResource(id string, oldT, newT []interface{}, conn *waf.WA
 			Updates:       diffWafXssMatchSetTuples(oldT, newT),
 		}
 
-		log.Printf("[INFO] Updating XssMatchSet tuples: %s", req)
+		log.Printf("[INFO] Updating WAF XSS Match Set tuples: %s", req)
 		return conn.UpdateXssMatchSet(req)
 	})
 	if err != nil {
-		return fmt.Errorf("Error updating XssMatchSet: %s", err)
+		return fmt.Errorf("Error updating WAF XSS Match Set: %s", err)
 	}
 
 	return nil
@@ -188,7 +210,7 @@ func flattenWafXssMatchTuples(ts []*waf.XssMatchTuple) []interface{} {
 	for i, t := range ts {
 		m := make(map[string]interface{})
 		m["field_to_match"] = flattenFieldToMatch(t.FieldToMatch)
-		m["text_transformation"] = *t.TextTransformation
+		m["text_transformation"] = aws.StringValue(t.TextTransformation)
 		out[i] = m
 	}
 	return out

--- a/aws/resource_aws_waf_xss_match_set.go
+++ b/aws/resource_aws_waf_xss_match_set.go
@@ -37,7 +37,7 @@ func resourceAwsWafXssMatchSet() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"field_to_match": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Required: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
@@ -230,7 +230,7 @@ func diffWafXssMatchSetTuples(oldT, newT []interface{}) []*waf.XssMatchSetUpdate
 		updates = append(updates, &waf.XssMatchSetUpdate{
 			Action: aws.String(waf.ChangeActionDelete),
 			XssMatchTuple: &waf.XssMatchTuple{
-				FieldToMatch:       expandFieldToMatch(tuple["field_to_match"].(*schema.Set).List()[0].(map[string]interface{})),
+				FieldToMatch:       expandFieldToMatch(tuple["field_to_match"].([]interface{})[0].(map[string]interface{})),
 				TextTransformation: aws.String(tuple["text_transformation"].(string)),
 			},
 		})
@@ -242,7 +242,7 @@ func diffWafXssMatchSetTuples(oldT, newT []interface{}) []*waf.XssMatchSetUpdate
 		updates = append(updates, &waf.XssMatchSetUpdate{
 			Action: aws.String(waf.ChangeActionInsert),
 			XssMatchTuple: &waf.XssMatchTuple{
-				FieldToMatch:       expandFieldToMatch(tuple["field_to_match"].(*schema.Set).List()[0].(map[string]interface{})),
+				FieldToMatch:       expandFieldToMatch(tuple["field_to_match"].([]interface{})[0].(map[string]interface{})),
 				TextTransformation: aws.String(tuple["text_transformation"].(string)),
 			},
 		})

--- a/aws/resource_aws_waf_xss_match_set_test.go
+++ b/aws/resource_aws_waf_xss_match_set_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestAccAWSWafXssMatchSet_basic(t *testing.T) {
 	var v waf.XssMatchSet
-	xssMatchSet := fmt.Sprintf("xssMatchSet-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_waf_xss_match_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -23,20 +23,20 @@ func TestAccAWSWafXssMatchSet_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSWafXssMatchSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSWafXssMatchSetConfig(xssMatchSet),
+				Config: testAccAWSWafXssMatchSetConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafXssMatchSetExists(resourceName, &v),
 					testAccMatchResourceAttrGlobalARN(resourceName, "arn", "waf", regexp.MustCompile(`xssmatchset/.+`)),
-					resource.TestCheckResourceAttr(resourceName, "name", xssMatchSet),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.2018581549.field_to_match.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.2018581549.field_to_match.2316364334.data", ""),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.2018581549.field_to_match.2316364334.type", "QUERY_STRING"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.2018581549.text_transformation", "NONE"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.2786024938.field_to_match.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.2786024938.field_to_match.3756326843.data", ""),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.2786024938.field_to_match.3756326843.type", "URI"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.2786024938.text_transformation", "NONE"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.41660541.field_to_match.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.41660541.field_to_match.0.data", ""),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.41660541.field_to_match.0.type", "URI"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.41660541.text_transformation", "NONE"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.599421078.field_to_match.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.599421078.field_to_match.0.data", ""),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.599421078.field_to_match.0.type", "QUERY_STRING"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.599421078.text_transformation", "NONE"),
 				),
 			},
 			{
@@ -50,7 +50,7 @@ func TestAccAWSWafXssMatchSet_basic(t *testing.T) {
 
 func TestAccAWSWafXssMatchSet_changeNameForceNew(t *testing.T) {
 	var before, after waf.XssMatchSet
-	xssMatchSet := fmt.Sprintf("xssMatchSet-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	xssMatchSetNewName := fmt.Sprintf("xssMatchSetNewName-%s", acctest.RandString(5))
 	resourceName := "aws_waf_xss_match_set.test"
 
@@ -60,10 +60,10 @@ func TestAccAWSWafXssMatchSet_changeNameForceNew(t *testing.T) {
 		CheckDestroy: testAccCheckAWSWafXssMatchSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSWafXssMatchSetConfig(xssMatchSet),
+				Config: testAccAWSWafXssMatchSetConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafXssMatchSetExists(resourceName, &before),
-					resource.TestCheckResourceAttr(resourceName, "name", xssMatchSet),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.#", "2"),
 				),
 			},
@@ -86,7 +86,7 @@ func TestAccAWSWafXssMatchSet_changeNameForceNew(t *testing.T) {
 
 func TestAccAWSWafXssMatchSet_disappears(t *testing.T) {
 	var v waf.XssMatchSet
-	xssMatchSet := fmt.Sprintf("xssMatchSet-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_waf_xss_match_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -95,7 +95,7 @@ func TestAccAWSWafXssMatchSet_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAWSWafXssMatchSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSWafXssMatchSetConfig(xssMatchSet),
+				Config: testAccAWSWafXssMatchSetConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafXssMatchSetExists(resourceName, &v),
 					testAccCheckAWSWafXssMatchSetDisappears(&v),
@@ -108,7 +108,7 @@ func TestAccAWSWafXssMatchSet_disappears(t *testing.T) {
 
 func TestAccAWSWafXssMatchSet_changeTuples(t *testing.T) {
 	var before, after waf.XssMatchSet
-	setName := fmt.Sprintf("xssMatchSet-%s", acctest.RandString(5))
+	setName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_waf_xss_match_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -122,14 +122,14 @@ func TestAccAWSWafXssMatchSet_changeTuples(t *testing.T) {
 					testAccCheckAWSWafXssMatchSetExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "name", setName),
 					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.2018581549.field_to_match.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.2018581549.field_to_match.2316364334.data", ""),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.2018581549.field_to_match.2316364334.type", "QUERY_STRING"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.2018581549.text_transformation", "NONE"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.2786024938.field_to_match.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.2786024938.field_to_match.3756326843.data", ""),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.2786024938.field_to_match.3756326843.type", "URI"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.2786024938.text_transformation", "NONE"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.599421078.field_to_match.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.599421078.field_to_match.0.data", ""),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.599421078.field_to_match.0.type", "QUERY_STRING"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.599421078.text_transformation", "NONE"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.41660541.field_to_match.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.41660541.field_to_match.0.data", ""),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.41660541.field_to_match.0.type", "URI"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.41660541.text_transformation", "NONE"),
 				),
 			},
 			{
@@ -138,14 +138,14 @@ func TestAccAWSWafXssMatchSet_changeTuples(t *testing.T) {
 					testAccCheckAWSWafXssMatchSetExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "name", setName),
 					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.2893682529.field_to_match.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.2893682529.field_to_match.4253810390.data", "GET"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.2893682529.field_to_match.4253810390.type", "METHOD"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.2893682529.text_transformation", "HTML_ENTITY_DECODE"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.4270311415.field_to_match.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.4270311415.field_to_match.281401076.data", ""),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.4270311415.field_to_match.281401076.type", "BODY"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.4270311415.text_transformation", "CMD_LINE"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.42378128.field_to_match.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.42378128.field_to_match.0.data", "GET"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.42378128.field_to_match.0.type", "METHOD"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.42378128.text_transformation", "HTML_ENTITY_DECODE"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.3815294338.field_to_match.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.3815294338.field_to_match.0.data", ""),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.3815294338.field_to_match.0.type", "BODY"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.3815294338.text_transformation", "CMD_LINE"),
 				),
 			},
 			{
@@ -159,7 +159,7 @@ func TestAccAWSWafXssMatchSet_changeTuples(t *testing.T) {
 
 func TestAccAWSWafXssMatchSet_noTuples(t *testing.T) {
 	var ipset waf.XssMatchSet
-	setName := fmt.Sprintf("xssMatchSet-%s", acctest.RandString(5))
+	setName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_waf_xss_match_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -219,7 +219,7 @@ func testAccCheckAWSWafXssMatchSetDisappears(v *waf.XssMatchSet) resource.TestCh
 			return conn.DeleteXssMatchSet(opts)
 		})
 		if err != nil {
-			return fmt.Errorf("Error deleting XssMatchSet: %s", err)
+			return fmt.Errorf("Error deleting WAF XSS Match Set: %s", err)
 		}
 		return nil
 	}
@@ -233,7 +233,7 @@ func testAccCheckAWSWafXssMatchSetExists(n string, v *waf.XssMatchSet) resource.
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No WAF XssMatchSet ID is set")
+			return fmt.Errorf("No WAF XSS Match Set ID is set")
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).wafconn

--- a/aws/resource_aws_waf_xss_match_set_test.go
+++ b/aws/resource_aws_waf_xss_match_set_test.go
@@ -274,7 +274,7 @@ func testAccCheckAWSWafXssMatchSetDestroy(s *terraform.State) error {
 
 		// Return nil if the XssMatchSet is already destroyed
 		if isAWSErr(err, waf.ErrCodeNonexistentItemException, "") {
-				return nil
+			return nil
 		}
 
 		return err


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_awaf_xss_match_set: add plan time validations to `xss_match_tuples.text_transformation` and `xss_match_tuples.field_to_match.type`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSWafXssMatchSet_'
--- PASS: TestAccAWSWafXssMatchSet_basic (46.65s)
--- PASS: TestAccAWSWafXssMatchSet_changeNameForceNew (92.59s)
--- PASS: TestAccAWSWafXssMatchSet_disappears (51.95s)
--- PASS: TestAccAWSWafXssMatchSet_noTuples (51.06s)

--- FAIL: TestAccAWSWafXssMatchSet_changeTuples (79.49s) -- unrelated to change
```
