### PR TITLE
fix: failing nil pointer checks

### DIFF
--- a/aws/resource_aws_autoscaling_notification.go
+++ b/aws/resource_aws_autoscaling_notification.go
@@ -66,7 +66,7 @@ func resourceAwsAutoscalingNotificationRead(d *schema.ResourceData, meta interfa
 	}
 
 	topic := d.Get("topic_arn").(string)
-	// Grab all applicable notifcation configurations for this Topic.
+	// Grab all applicable notification configurations for this Topic.
 	// Each NotificationType will have a record, so 1 Group with 3 Types results
 	// in 3 records, all with the same Group name
 	gRaw := make(map[string]bool)
@@ -79,6 +79,7 @@ func resourceAwsAutoscalingNotificationRead(d *schema.ResourceData, meta interfa
 			log.Printf("[DEBUG] Paging DescribeNotificationConfigurations for (%s), page: %d", d.Id(), i)
 		} else {
 			log.Printf("[DEBUG] Paging finished for DescribeNotificationConfigurations (%s)", d.Id())
+			return false
 		}
 
 		for _, n := range resp.NotificationConfigurations {

--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -1425,9 +1425,14 @@ func resourceAwsEMRClusterDelete(d *schema.ResourceData, meta interface{}) error
 }
 
 func countEMRRemainingInstances(resp *emr.ListInstancesOutput, emrClusterId string) int {
+	if resp == nil {
+		log.Printf("[ERROR] response is nil")
+		return 0
+	}
+
 	instanceCount := len(resp.Instances)
 
-	if resp == nil || instanceCount == 0 {
+	if instanceCount == 0 {
 		log.Printf("[DEBUG] No instances found for EMR Cluster (%s)", emrClusterId)
 		return 0
 	}


### PR DESCRIPTION
- fixes missing nil pointer checks
- Fix minor spelling error

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #12413

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:


<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
❯ make testacc TESTARGS='-run=TestAccAWSASGNotification'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSASGNotification -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSASGNotification_basic
=== PAUSE TestAccAWSASGNotification_basic
=== RUN   TestAccAWSASGNotification_update
=== PAUSE TestAccAWSASGNotification_update
=== RUN   TestAccAWSASGNotification_Pagination
=== PAUSE TestAccAWSASGNotification_Pagination
=== CONT  TestAccAWSASGNotification_basic
=== CONT  TestAccAWSASGNotification_Pagination
=== CONT  TestAccAWSASGNotification_update
--- PASS: TestAccAWSASGNotification_Pagination (120.09s)
--- PASS: TestAccAWSASGNotification_basic (197.78s)
--- PASS: TestAccAWSASGNotification_update (254.59s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       254.639s
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap      0.038s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags 0.012s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/naming       0.013s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/service/batch/equivalency    0.065s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks/token    0.098s [no tests to run]
?       github.com/terraform-providers/terraform-provider-aws/awsproviderlint   [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes    0.010s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSAT001   0.017s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSR001    0.032s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/fmtsprintfcallexpr 0.002s [no tests to run]

...
```

Had issues running EMR tests

```
❯ make testacc TESTARGS='-run=TestAccAWSEMRCluster'     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSEMRCluster -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEMRCluster_basic
=== PAUSE TestAccAWSEMRCluster_basic
=== RUN   TestAccAWSEMRCluster_additionalInfo
=== PAUSE TestAccAWSEMRCluster_additionalInfo
=== RUN   TestAccAWSEMRCluster_disappears
=== PAUSE TestAccAWSEMRCluster_disappears
=== RUN   TestAccAWSEMRCluster_configurationsJson
=== PAUSE TestAccAWSEMRCluster_configurationsJson
=== RUN   TestAccAWSEMRCluster_CoreInstanceGroup_AutoscalingPolicy
=== PAUSE TestAccAWSEMRCluster_CoreInstanceGroup_AutoscalingPolicy
=== RUN   TestAccAWSEMRCluster_CoreInstanceGroup_BidPrice
=== PAUSE TestAccAWSEMRCluster_CoreInstanceGroup_BidPrice
=== RUN   TestAccAWSEMRCluster_CoreInstanceGroup_InstanceCount
=== PAUSE TestAccAWSEMRCluster_CoreInstanceGroup_InstanceCount
=== RUN   TestAccAWSEMRCluster_CoreInstanceGroup_InstanceType
=== PAUSE TestAccAWSEMRCluster_CoreInstanceGroup_InstanceType
=== RUN   TestAccAWSEMRCluster_CoreInstanceGroup_Migration_CoreInstanceType
=== PAUSE TestAccAWSEMRCluster_CoreInstanceGroup_Migration_CoreInstanceType
=== RUN   TestAccAWSEMRCluster_CoreInstanceGroup_Migration_InstanceGroup
=== PAUSE TestAccAWSEMRCluster_CoreInstanceGroup_Migration_InstanceGroup
=== RUN   TestAccAWSEMRCluster_CoreInstanceGroup_Name
=== PAUSE TestAccAWSEMRCluster_CoreInstanceGroup_Name
=== RUN   TestAccAWSEMRCluster_instance_group
=== PAUSE TestAccAWSEMRCluster_instance_group
=== RUN   TestAccAWSEMRCluster_instance_group_names
=== PAUSE TestAccAWSEMRCluster_instance_group_names
=== RUN   TestAccAWSEMRCluster_instance_group_update
=== PAUSE TestAccAWSEMRCluster_instance_group_update
=== RUN   TestAccAWSEMRCluster_instance_group_EBSVolumeType_st1
=== PAUSE TestAccAWSEMRCluster_instance_group_EBSVolumeType_st1
=== RUN   TestAccAWSEMRCluster_updateAutoScalingPolicy
=== PAUSE TestAccAWSEMRCluster_updateAutoScalingPolicy
=== RUN   TestAccAWSEMRCluster_Ec2Attributes_DefaultManagedSecurityGroups
=== PAUSE TestAccAWSEMRCluster_Ec2Attributes_DefaultManagedSecurityGroups
=== RUN   TestAccAWSEMRCluster_Kerberos_ClusterDedicatedKdc
=== PAUSE TestAccAWSEMRCluster_Kerberos_ClusterDedicatedKdc
=== RUN   TestAccAWSEMRCluster_MasterInstanceGroup_BidPrice
=== PAUSE TestAccAWSEMRCluster_MasterInstanceGroup_BidPrice
=== RUN   TestAccAWSEMRCluster_MasterInstanceGroup_InstanceCount
=== PAUSE TestAccAWSEMRCluster_MasterInstanceGroup_InstanceCount
=== RUN   TestAccAWSEMRCluster_MasterInstanceGroup_InstanceType
=== PAUSE TestAccAWSEMRCluster_MasterInstanceGroup_InstanceType
=== RUN   TestAccAWSEMRCluster_MasterInstanceGroup_Migration_InstanceGroup
=== PAUSE TestAccAWSEMRCluster_MasterInstanceGroup_Migration_InstanceGroup
=== RUN   TestAccAWSEMRCluster_MasterInstanceGroup_Migration_MasterInstanceType
=== PAUSE TestAccAWSEMRCluster_MasterInstanceGroup_Migration_MasterInstanceType
=== RUN   TestAccAWSEMRCluster_MasterInstanceGroup_Name
=== PAUSE TestAccAWSEMRCluster_MasterInstanceGroup_Name
=== RUN   TestAccAWSEMRCluster_security_config
=== PAUSE TestAccAWSEMRCluster_security_config
=== RUN   TestAccAWSEMRCluster_Step_Basic
=== PAUSE TestAccAWSEMRCluster_Step_Basic
=== RUN   TestAccAWSEMRCluster_Step_ConfigMode
=== PAUSE TestAccAWSEMRCluster_Step_ConfigMode
=== RUN   TestAccAWSEMRCluster_Step_Multiple
=== PAUSE TestAccAWSEMRCluster_Step_Multiple
=== RUN   TestAccAWSEMRCluster_bootstrap_ordering
=== PAUSE TestAccAWSEMRCluster_bootstrap_ordering
=== RUN   TestAccAWSEMRCluster_terminationProtected
=== PAUSE TestAccAWSEMRCluster_terminationProtected
=== RUN   TestAccAWSEMRCluster_keepJob
=== PAUSE TestAccAWSEMRCluster_keepJob
=== RUN   TestAccAWSEMRCluster_visibleToAllUsers
=== PAUSE TestAccAWSEMRCluster_visibleToAllUsers
=== RUN   TestAccAWSEMRCluster_s3Logging
=== PAUSE TestAccAWSEMRCluster_s3Logging
=== RUN   TestAccAWSEMRCluster_tags
=== PAUSE TestAccAWSEMRCluster_tags
=== RUN   TestAccAWSEMRCluster_root_volume_size
=== PAUSE TestAccAWSEMRCluster_root_volume_size
=== RUN   TestAccAWSEMRCluster_step_concurrency_level
=== PAUSE TestAccAWSEMRCluster_step_concurrency_level
=== RUN   TestAccAWSEMRCluster_custom_ami_id
=== PAUSE TestAccAWSEMRCluster_custom_ami_id
=== CONT  TestAccAWSEMRCluster_basic
=== CONT  TestAccAWSEMRCluster_security_config
=== CONT  TestAccAWSEMRCluster_MasterInstanceGroup_Migration_MasterInstanceType
=== CONT  TestAccAWSEMRCluster_visibleToAllUsers
=== CONT  TestAccAWSEMRCluster_Step_ConfigMode
=== CONT  TestAccAWSEMRCluster_custom_ami_id
=== CONT  TestAccAWSEMRCluster_keepJob
=== CONT  TestAccAWSEMRCluster_step_concurrency_level
=== CONT  TestAccAWSEMRCluster_root_volume_size
=== CONT  TestAccAWSEMRCluster_terminationProtected
=== CONT  TestAccAWSEMRCluster_s3Logging
=== CONT  TestAccAWSEMRCluster_tags
=== CONT  TestAccAWSEMRCluster_instance_group_names
=== CONT  TestAccAWSEMRCluster_MasterInstanceGroup_Name
=== CONT  TestAccAWSEMRCluster_Step_Multiple
=== CONT  TestAccAWSEMRCluster_configurationsJson
=== CONT  TestAccAWSEMRCluster_CoreInstanceGroup_InstanceCount
=== CONT  TestAccAWSEMRCluster_CoreInstanceGroup_BidPrice
=== CONT  TestAccAWSEMRCluster_instance_group
=== CONT  TestAccAWSEMRCluster_bootstrap_ordering
TestAccAWSEMRCluster_step_concurrency_level: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: e3512e9d-708b-4864-b257-14f680c75a13

on /tmp/tf-test732757677/main.tf line 35:
(source code not available)


TestAccAWSEMRCluster_MasterInstanceGroup_Migration_MasterInstanceType: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: bbb3a555-9931-4872-80db-af677e4473d3

on /tmp/tf-test787781018/main.tf line 30:
(source code not available)


TestAccAWSEMRCluster_CoreInstanceGroup_InstanceCount: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: 925927d7-4867-4075-8a69-9bc51ccc1d55

on /tmp/tf-test136152625/main.tf line 38:
(source code not available)


TestAccAWSEMRCluster_MasterInstanceGroup_Name: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: 07370a8d-ffa9-4ad5-b8b6-f04a4796eea1

on /tmp/tf-test981835765/main.tf line 34:
(source code not available)


--- FAIL: TestAccAWSEMRCluster_step_concurrency_level (14.23s)
=== CONT  TestAccAWSEMRCluster_CoreInstanceGroup_AutoscalingPolicy
TestAccAWSEMRCluster_Step_ConfigMode: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: 92279800-25a6-47ec-9e6f-d1b880aa3abb

on /tmp/tf-test246127224/main.tf line 52:
(source code not available)


TestAccAWSEMRCluster_s3Logging: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: 2625f552-d498-4ce9-b20a-915160444586

on /tmp/tf-test508618094/main.tf line 43:
(source code not available)


TestAccAWSEMRCluster_security_config: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: c21beae4-3659-4aaf-b005-58778ef08b3d

on /tmp/tf-test296542567/main.tf line 278:
(source code not available)


TestAccAWSEMRCluster_terminationProtected: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: 0a7e3bdc-36e8-4bd4-a6d1-29c4623f6c20

on /tmp/tf-test752248962/main.tf line 233:
(source code not available)


TestAccAWSEMRCluster_tags: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: f3454f16-8f8e-4860-bd55-43c89ec8b5a6

on /tmp/tf-test260003191/main.tf line 236:
(source code not available)


TestAccAWSEMRCluster_bootstrap_ordering: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: 359e9aa5-3487-41b1-bd63-1193a970f412

on /tmp/tf-test816263051/main.tf line 234:
(source code not available)


TestAccAWSEMRCluster_instance_group: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: 13d00669-9f66-47f5-ba48-bc91be2fe619

on /tmp/tf-test968939216/main.tf line 283:
(source code not available)


--- FAIL: TestAccAWSEMRCluster_CoreInstanceGroup_InstanceCount (19.41s)
=== CONT  TestAccAWSEMRCluster_CoreInstanceGroup_Name
--- FAIL: TestAccAWSEMRCluster_MasterInstanceGroup_Name (19.41s)
=== CONT  TestAccAWSEMRCluster_disappears
--- FAIL: TestAccAWSEMRCluster_MasterInstanceGroup_Migration_MasterInstanceType (19.45s)
=== CONT  TestAccAWSEMRCluster_CoreInstanceGroup_Migration_InstanceGroup
TestAccAWSEMRCluster_basic: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: 37ce7892-9d26-4e45-8ab2-2fbb2f5ce562

on /tmp/tf-test965759452/main.tf line 236:
(source code not available)


TestAccAWSEMRCluster_root_volume_size: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: 71af7180-750e-493e-9f31-0f3d3e07fa9b

on /tmp/tf-test083559976/main.tf line 236:
(source code not available)


TestAccAWSEMRCluster_visibleToAllUsers: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: e36aa0cd-d3d0-41b4-8f40-6554691f9aa7

on /tmp/tf-test989925590/main.tf line 236:
(source code not available)


TestAccAWSEMRCluster_CoreInstanceGroup_AutoscalingPolicy: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: ff6d1bd5-7e02-47c6-85e6-c06bee4880d7

on /tmp/tf-test716320062/main.tf line 103:
(source code not available)


--- FAIL: TestAccAWSEMRCluster_terminationProtected (25.63s)
=== CONT  TestAccAWSEMRCluster_Step_Basic
--- FAIL: TestAccAWSEMRCluster_instance_group (25.73s)
=== CONT  TestAccAWSEMRCluster_CoreInstanceGroup_Migration_CoreInstanceType
--- FAIL: TestAccAWSEMRCluster_tags (25.81s)
=== CONT  TestAccAWSEMRCluster_CoreInstanceGroup_InstanceType
TestAccAWSEMRCluster_custom_ami_id: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: b2838199-f471-4abe-8ed9-8b558a310f20

on /tmp/tf-test205941907/main.tf line 263:
(source code not available)


--- FAIL: TestAccAWSEMRCluster_basic (25.90s)
=== CONT  TestAccAWSEMRCluster_additionalInfo
--- FAIL: TestAccAWSEMRCluster_s3Logging (27.82s)
=== CONT  TestAccAWSEMRCluster_Kerberos_ClusterDedicatedKdc
--- FAIL: TestAccAWSEMRCluster_Step_ConfigMode (28.11s)
=== CONT  TestAccAWSEMRCluster_instance_group_EBSVolumeType_st1
TestAccAWSEMRCluster_CoreInstanceGroup_Name: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: 3fe43a12-3a19-41a1-8d2f-05d8b6eae089

on /tmp/tf-test661242759/main.tf line 38:
(source code not available)


TestAccAWSEMRCluster_CoreInstanceGroup_Migration_InstanceGroup: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: fc5eebb6-fa94-46a0-b9e6-17884edfa2ea

on /tmp/tf-test862752570/main.tf line 41:
(source code not available)


--- FAIL: TestAccAWSEMRCluster_bootstrap_ordering (31.03s)
=== CONT  TestAccAWSEMRCluster_MasterInstanceGroup_Migration_InstanceGroup
TestAccAWSEMRCluster_disappears: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: 633f7cab-1617-4918-b7d3-4445dba9c060

on /tmp/tf-test588992849/main.tf line 236:
(source code not available)


--- FAIL: TestAccAWSEMRCluster_visibleToAllUsers (32.54s)
=== CONT  TestAccAWSEMRCluster_Ec2Attributes_DefaultManagedSecurityGroups
--- FAIL: TestAccAWSEMRCluster_CoreInstanceGroup_AutoscalingPolicy (19.72s)
=== CONT  TestAccAWSEMRCluster_MasterInstanceGroup_InstanceType
--- FAIL: TestAccAWSEMRCluster_custom_ami_id (34.56s)
=== CONT  TestAccAWSEMRCluster_MasterInstanceGroup_BidPrice
TestAccAWSEMRCluster_CoreInstanceGroup_InstanceType: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: 00ae5232-7d73-4b86-a544-9b8e1159fc93

on /tmp/tf-test695408917/main.tf line 37:
(source code not available)


TestAccAWSEMRCluster_CoreInstanceGroup_Migration_CoreInstanceType: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: fa04751b-3f4c-467e-a211-02e144fe84c2

on /tmp/tf-test329963888/main.tf line 35:
(source code not available)


--- FAIL: TestAccAWSEMRCluster_root_volume_size (36.30s)
=== CONT  TestAccAWSEMRCluster_MasterInstanceGroup_InstanceCount
TestAccAWSEMRCluster_additionalInfo: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: 4285fdc0-e3b6-4bcf-a2a5-f484efbf5d26

on /tmp/tf-test326699535/main.tf line 245:
(source code not available)


--- FAIL: TestAccAWSEMRCluster_CoreInstanceGroup_Migration_InstanceGroup (17.83s)
=== CONT  TestAccAWSEMRCluster_instance_group_update
--- FAIL: TestAccAWSEMRCluster_CoreInstanceGroup_Name (17.93s)
=== CONT  TestAccAWSEMRCluster_updateAutoScalingPolicy
TestAccAWSEMRCluster_instance_group_names: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: 3c612a7b-fbd8-4a74-8aef-12e979e64cbd

on /tmp/tf-test840305145/main.tf line 264:
(source code not available)


TestAccAWSEMRCluster_Kerberos_ClusterDedicatedKdc: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: 3d8a86ee-9c71-4e30-82ea-3857ec2a50e2

on /tmp/tf-test934082468/main.tf line 54:
(source code not available)


TestAccAWSEMRCluster_instance_group_EBSVolumeType_st1: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: cd2b7bd9-721d-43ac-a39f-48cdfb5bd5a3

on /tmp/tf-test077030067/main.tf line 281:
(source code not available)


--- FAIL: TestAccAWSEMRCluster_disappears (21.28s)
TestAccAWSEMRCluster_MasterInstanceGroup_Migration_InstanceGroup: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: 8c1d0300-ed3a-47e9-bbb9-f23bf553c5c4

on /tmp/tf-test658889565/main.tf line 35:
(source code not available)


TestAccAWSEMRCluster_Ec2Attributes_DefaultManagedSecurityGroups: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: c933c623-bfe7-4acd-970a-691a266de691

on /tmp/tf-test922683672/main.tf line 31:
(source code not available)


TestAccAWSEMRCluster_Step_Basic: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: feb8b0f9-8b30-4235-a4ae-f249a6c8d4af

on /tmp/tf-test938805006/main.tf line 52:
(source code not available)


--- FAIL: TestAccAWSEMRCluster_additionalInfo (17.56s)
--- FAIL: TestAccAWSEMRCluster_CoreInstanceGroup_InstanceType (17.81s)
--- FAIL: TestAccAWSEMRCluster_CoreInstanceGroup_Migration_CoreInstanceType (17.94s)
--- FAIL: TestAccAWSEMRCluster_Kerberos_ClusterDedicatedKdc (16.03s)
TestAccAWSEMRCluster_MasterInstanceGroup_InstanceType: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: 263c7e68-ae68-4fe9-a4c3-7b87c800b7b1

on /tmp/tf-test479365601/main.tf line 33:
(source code not available)


--- FAIL: TestAccAWSEMRCluster_instance_group_names (44.12s)
TestAccAWSEMRCluster_MasterInstanceGroup_BidPrice: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: 4ecd9908-bcc2-46f3-befa-9dbb24124556

on /tmp/tf-test520159692/main.tf line 34:
(source code not available)


--- FAIL: TestAccAWSEMRCluster_instance_group_EBSVolumeType_st1 (17.53s)
TestAccAWSEMRCluster_MasterInstanceGroup_InstanceCount: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: 153ff064-0072-46dd-99e4-3dc4aa1d7a6c

on /tmp/tf-test815614912/main.tf line 42:
(source code not available)


--- FAIL: TestAccAWSEMRCluster_security_config (46.59s)
TestAccAWSEMRCluster_updateAutoScalingPolicy: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: c4706caa-3b40-4be5-9576-3be0f16d8829

on /tmp/tf-test553796521/main.tf line 281:
(source code not available)


TestAccAWSEMRCluster_instance_group_update: testing.go:669: Step 0 error: errors during apply:

Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
status code: 400, request id: 11d988d2-5453-4cf1-9074-6070f0a0dc2d

on /tmp/tf-test901134578/main.tf line 283:
(source code not available)


--- FAIL: TestAccAWSEMRCluster_MasterInstanceGroup_Migration_InstanceGroup (18.05s)
--- FAIL: TestAccAWSEMRCluster_Ec2Attributes_DefaultManagedSecurityGroups (17.49s)
TestAccAWSEMRCluster_CoreInstanceGroup_BidPrice: testing.go:669: Step 0 error: errors during apply:

Error: error running EMR Job Flow: ValidationException: Invalid InstanceProfile: EMR_EC2_DefaultRole.
status code: 400, request id: 89d30d97-c412-4a21-8053-4b0dce01f160

on /tmp/tf-test293423165/main.tf line 2:
(source code not available)


TestAccAWSEMRCluster_Step_Multiple: testing.go:669: Step 0 error: errors during apply:

Error: error running EMR Job Flow: ValidationException: Invalid InstanceProfile: EMR_EC2_DefaultRole.
status code: 400, request id: 28ef5d2b-e213-4a72-8790-437743c04615

on /tmp/tf-test068232454/main.tf line 2:
(source code not available)


--- FAIL: TestAccAWSEMRCluster_MasterInstanceGroup_InstanceType (17.93s)
--- FAIL: TestAccAWSEMRCluster_MasterInstanceGroup_BidPrice (17.72s)
--- FAIL: TestAccAWSEMRCluster_Step_Basic (27.16s)
--- FAIL: TestAccAWSEMRCluster_MasterInstanceGroup_InstanceCount (17.79s)
--- FAIL: TestAccAWSEMRCluster_updateAutoScalingPolicy (17.30s)
--- FAIL: TestAccAWSEMRCluster_instance_group_update (17.42s)
--- FAIL: TestAccAWSEMRCluster_Step_Multiple (72.60s)
--- FAIL: TestAccAWSEMRCluster_CoreInstanceGroup_BidPrice (74.91s)
--- PASS: TestAccAWSEMRCluster_keepJob (443.71s)
--- PASS: TestAccAWSEMRCluster_configurationsJson (485.02s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-aws/aws       485.088s
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap      0.024s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags 0.018s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/naming       0.014s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/service/batch/equivalency    0.040s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks/token    0.046s [no tests to run]
?       github.com/terraform-providers/terraform-provider-aws/awsproviderlint   [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes    0.029s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSAT001   0.015s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSR001    0.019s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/fmtsprintfcallexpr 0.021s [no tests to run]
FAIL
make: *** [GNUmakefile:26: testacc] Error 1
```
