### PR TITLE
New data source: aws_wafv2_ip_set

### DIFF
--- a/aws/data_source_aws_wafv2_ip_set.go
+++ b/aws/data_source_aws_wafv2_ip_set.go
@@ -1,0 +1,77 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/wafv2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func dataSourceAwsWafv2IPSet() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsWafv2IPSetRead,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"scope": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					wafv2.ScopeCloudfront,
+					wafv2.ScopeRegional,
+				}, false),
+			},
+		},
+	}
+}
+
+func dataSourceAwsWafv2IPSetRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafv2conn
+	name := d.Get("name").(string)
+
+	var foundIpSet *wafv2.IPSetSummary
+	input := &wafv2.ListIPSetsInput{
+		Scope: aws.String(d.Get("scope").(string)),
+	}
+	for {
+		output, err := conn.ListIPSets(input)
+		if err != nil {
+			return fmt.Errorf("Error reading WAFV2 IPSets: %s", err)
+		}
+
+		for _, ipSet := range output.IPSets {
+			if aws.StringValue(ipSet.Name) == name {
+				foundIpSet = ipSet
+				break
+			}
+		}
+
+		if output.NextMarker == nil || foundIpSet != nil {
+			break
+		}
+		input.NextMarker = output.NextMarker
+	}
+
+	if foundIpSet == nil {
+		return fmt.Errorf("WAFV2 IPSet not found for name: %s", name)
+	}
+
+	d.SetId(aws.StringValue(foundIpSet.Id))
+	d.Set("arn", aws.StringValue(foundIpSet.ARN))
+	d.Set("description", aws.StringValue(foundIpSet.Description))
+
+	return nil
+}

--- a/aws/data_source_aws_wafv2_ip_set_test.go
+++ b/aws/data_source_aws_wafv2_ip_set_test.go
@@ -20,14 +20,16 @@ func TestAccDataSourceAwsWafv2IPSet_Basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataSourceAwsWafv2IPSet_NonExistent(name),
-				ExpectError: regexp.MustCompile(`WAFV2 IPSet not found`),
+				ExpectError: regexp.MustCompile(`WAFv2 IPSet not found`),
 			},
 			{
 				Config: testAccDataSourceAwsWafv2IPSet_Name(name),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "addresses", resourceName, "addresses"),
 					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(datasourceName, "description", resourceName, "description"),
 					resource.TestCheckResourceAttrPair(datasourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "ip_address_version", resourceName, "ip_address_version"),
 					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(datasourceName, "scope", resourceName, "scope"),
 				),

--- a/aws/data_source_aws_wafv2_ip_set_test.go
+++ b/aws/data_source_aws_wafv2_ip_set_test.go
@@ -1,0 +1,67 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceAwsWafv2IPSet_Basic(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_wafv2_ip_set.test"
+	datasourceName := "data.aws_wafv2_ip_set.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSourceAwsWafv2IPSet_NonExistent(name),
+				ExpectError: regexp.MustCompile(`WAFV2 IPSet not found`),
+			},
+			{
+				Config: testAccDataSourceAwsWafv2IPSet_Name(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(datasourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "scope", resourceName, "scope"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsWafv2IPSet_Name(name string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_ip_set" "test" {
+  name               = "%s"
+  scope              = "REGIONAL"
+  ip_address_version = "IPV4"
+}
+
+data "aws_wafv2_ip_set" "test" {
+  name  = aws_wafv2_ip_set.test.name
+  scope = "REGIONAL"
+}
+`, name)
+}
+
+func testAccDataSourceAwsWafv2IPSet_NonExistent(name string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_ip_set" "test" {
+  name               = "%s"
+  scope              = "REGIONAL"
+  ip_address_version = "IPV4"
+}
+
+data "aws_wafv2_ip_set" "test" {
+  name  = "tf-acc-test-does-not-exist"
+  scope = "REGIONAL"
+}
+`, name)
+}

--- a/aws/data_source_aws_wafv2_ip_set_test.go
+++ b/aws/data_source_aws_wafv2_ip_set_test.go
@@ -27,6 +27,7 @@ func TestAccDataSourceAwsWafv2IPSet_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "addresses", resourceName, "addresses"),
 					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					testAccMatchResourceAttrRegionalARN(datasourceName, "arn", "wafv2", regexp.MustCompile(fmt.Sprintf("regional/ipset/%v/.+$", name))),
 					resource.TestCheckResourceAttrPair(datasourceName, "description", resourceName, "description"),
 					resource.TestCheckResourceAttrPair(datasourceName, "id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(datasourceName, "ip_address_version", resourceName, "ip_address_version"),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -333,6 +333,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_wafregional_rule":                          dataSourceAwsWafRegionalRule(),
 			"aws_wafregional_rate_based_rule":               dataSourceAwsWafRegionalRateBasedRule(),
 			"aws_wafregional_web_acl":                       dataSourceAwsWafRegionalWebAcl(),
+			"aws_wafv2_ip_set":                              dataSourceAwsWafv2IPSet(),
 			"aws_workspaces_bundle":                         dataSourceAwsWorkspaceBundle(),
 
 			// Adding the Aliases for the ALB -> LB Rename

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -3562,6 +3562,19 @@
                     </ul>
                 </li>
                 <li>
+                    <a href="#">WAFv2</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/wafv2_ip_set.html">aws_wafv2_ip_set</a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </li>
+                <li>
                     <a href="#">WorkLink</a>
                     <ul class="nav">
                         <li>

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -3552,23 +3552,18 @@
                     <a href="#">WAFv2</a>
                     <ul class="nav">
                         <li>
-                            <a href="#">Resources</a>
-                            <ul class="nav nav-auto-expand">
-                                <li>
-                                    <a href="/docs/providers/aws/r/wafv2_ip_set.html">aws_wafv2_ip_set</a>
-                                </li>
-                            </ul>
-                        </li>
-                    </ul>
-                </li>
-                <li>
-                    <a href="#">WAFv2</a>
-                    <ul class="nav">
-                        <li>
                             <a href="#">Data Sources</a>
                             <ul class="nav nav-auto-expand">
                                 <li>
                                     <a href="/docs/providers/aws/d/wafv2_ip_set.html">aws_wafv2_ip_set</a>
+                                </li>
+                            </ul>
+                        </li>
+                        <li>
+                            <a href="#">Resources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/r/wafv2_ip_set.html">aws_wafv2_ip_set</a>
                                 </li>
                             </ul>
                         </li>

--- a/website/docs/d/wafv2_ip_set.html.markdown
+++ b/website/docs/d/wafv2_ip_set.html.markdown
@@ -24,7 +24,8 @@ data "aws_wafv2_ip_set" "example" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the WAFv2 IP Set.
-* `scope` - (Required) Specifies whether this is for an AWS CloudFront distribution or for a regional application. To work with CloudFront, you must also specify the Region US East (N. Virginia).
+* `scope` - (Required) Specifies whether this is for an AWS CloudFront distribution or for a regional application. Valid values are `CLOUDFRONT` or `REGIONAL`. To work with CloudFront, you must also specify the region `us-east-1` (N. Virginia) on the AWS provider.
+
 
 ## Attributes Reference
 

--- a/website/docs/d/wafv2_ip_set.html.markdown
+++ b/website/docs/d/wafv2_ip_set.html.markdown
@@ -30,6 +30,8 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `addresses` - An array of strings that specify one or more IP addresses or blocks of IP addresses in Classless Inter-Domain Routing (CIDR) notation.
 * `arn` - The Amazon Resource Name (ARN) of the entity.
 * `description` - The description of the set that helps with identification.
 * `id` - The unique identifier for the set.
+* `ip_address_version` - The IP address version of the set.

--- a/website/docs/d/wafv2_ip_set.html.markdown
+++ b/website/docs/d/wafv2_ip_set.html.markdown
@@ -1,0 +1,35 @@
+---
+subcategory: "WAFv2"
+layout: "aws"
+page_title: "AWS: aws_wafv2_ip_set"
+description: |-
+  Retrieves the summary of a WAFv2 IP Set.
+---
+
+# Data Source: aws_wafv2_ip_set
+
+Retrieves the summary of a WAFv2 IP Set.
+
+## Example Usage
+
+```hcl
+data "aws_wafv2_ip_set" "example" {
+  name  = "some-ip-set"
+  scope = "REGIONAL"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the WAFv2 IP Set.
+* `scope` - (Required) Specifies whether this is for an AWS CloudFront distribution or for a regional application. To work with CloudFront, you must also specify the Region US East (N. Virginia).
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The Amazon Resource Name (ARN) of the entity.
+* `description` - The description of the set that helps with identification.
+* `id` - The unique identifier for the set.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #11178
Relates #11046
Depends on #12119 because of duplicated code for tests.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
**New Data Source:** `aws_wafv2_ip_set` (#12788)
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsWafv2IP'
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsWafv2IP -timeout 120m
=== RUN   TestAccDataSourceAwsWafv2IPSet_Basic
=== PAUSE TestAccDataSourceAwsWafv2IPSet_Basic
=== CONT  TestAccDataSourceAwsWafv2IPSet_Basic
--- PASS: TestAccDataSourceAwsWafv2IPSet_Basic (22.06s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       22.417s
```
