### PR TITLE
New data source: aws_wafv2_regex_pattern_set

### DIFF
--- a/aws/data_source_aws_wafv2_regex_pattern_set.go
+++ b/aws/data_source_aws_wafv2_regex_pattern_set.go
@@ -1,0 +1,77 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/wafv2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func dataSourceAwsWafv2RegexPatternSet() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsWafv2RegexPatternSetRead,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"scope": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					wafv2.ScopeCloudfront,
+					wafv2.ScopeRegional,
+				}, false),
+			},
+		},
+	}
+}
+
+func dataSourceAwsWafv2RegexPatternSetRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafv2conn
+	name := d.Get("name").(string)
+
+	var foundRegexPatternSet *wafv2.RegexPatternSetSummary
+	input := &wafv2.ListRegexPatternSetsInput{
+		Scope: aws.String(d.Get("scope").(string)),
+	}
+	for {
+		output, err := conn.ListRegexPatternSets(input)
+		if err != nil {
+			return fmt.Errorf("Error reading WAFV2 RegexPatternSets: %s", err)
+		}
+
+		for _, regexPatternSet := range output.RegexPatternSets {
+			if aws.StringValue(regexPatternSet.Name) == name {
+				foundRegexPatternSet = regexPatternSet
+				break
+			}
+		}
+
+		if output.NextMarker == nil || foundRegexPatternSet != nil {
+			break
+		}
+		input.NextMarker = output.NextMarker
+	}
+
+	if foundRegexPatternSet == nil {
+		return fmt.Errorf("WAFV2 RegexPatternSet not found for name: %s", name)
+	}
+
+	d.SetId(aws.StringValue(foundRegexPatternSet.Id))
+	d.Set("arn", foundRegexPatternSet.ARN)
+	d.Set("description", aws.StringValue(foundRegexPatternSet.Description))
+
+	return nil
+}

--- a/aws/data_source_aws_wafv2_regex_pattern_set_test.go
+++ b/aws/data_source_aws_wafv2_regex_pattern_set_test.go
@@ -1,0 +1,73 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceAwsWafv2RegexPatternSet_Basic(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_wafv2_regex_pattern_set.test"
+	datasourceName := "data.aws_wafv2_regex_pattern_set.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSourceAwsWafv2RegexPatternSet_NonExistent(name),
+				ExpectError: regexp.MustCompile(`WAFV2 RegexPatternSet not found`),
+			},
+			{
+				Config: testAccDataSourceAwsWafv2RegexPatternSet_Name(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(datasourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "scope", resourceName, "scope"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsWafv2RegexPatternSet_Name(name string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_regex_pattern_set" "test" {
+  name  = "%s"
+  scope = "REGIONAL"
+
+  regular_expression_list {
+    regex_string = "one"
+  }
+}
+
+data "aws_wafv2_regex_pattern_set" "test" {
+  name  = aws_wafv2_regex_pattern_set.test.name
+  scope = "REGIONAL"
+}
+`, name)
+}
+
+func testAccDataSourceAwsWafv2RegexPatternSet_NonExistent(name string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_regex_pattern_set" "test" {
+  name  = "%s"
+  scope = "REGIONAL"
+
+  regular_expression_list {
+    regex_string = "one"
+  }
+}
+
+data "aws_wafv2_regex_pattern_set" "test" {
+  name  = "tf-acc-test-does-not-exist"
+  scope = "REGIONAL"
+}
+`, name)
+}

--- a/aws/data_source_aws_wafv2_regex_pattern_set_test.go
+++ b/aws/data_source_aws_wafv2_regex_pattern_set_test.go
@@ -20,15 +20,17 @@ func TestAccDataSourceAwsWafv2RegexPatternSet_Basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataSourceAwsWafv2RegexPatternSet_NonExistent(name),
-				ExpectError: regexp.MustCompile(`WAFV2 RegexPatternSet not found`),
+				ExpectError: regexp.MustCompile(`WAFv2 RegexPatternSet not found`),
 			},
 			{
 				Config: testAccDataSourceAwsWafv2RegexPatternSet_Name(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					testAccMatchResourceAttrRegionalARN(datasourceName, "arn", "wafv2", regexp.MustCompile(fmt.Sprintf("regional/regexpatternset/%v/.+$", name))),
 					resource.TestCheckResourceAttrPair(datasourceName, "description", resourceName, "description"),
 					resource.TestCheckResourceAttrPair(datasourceName, "id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "regular_expression_list", resourceName, "regular_expression_list"),
 					resource.TestCheckResourceAttrPair(datasourceName, "scope", resourceName, "scope"),
 				),
 			},
@@ -42,7 +44,7 @@ resource "aws_wafv2_regex_pattern_set" "test" {
   name  = "%s"
   scope = "REGIONAL"
 
-  regular_expression_list {
+  regular_expression {
     regex_string = "one"
   }
 }
@@ -60,7 +62,7 @@ resource "aws_wafv2_regex_pattern_set" "test" {
   name  = "%s"
   scope = "REGIONAL"
 
-  regular_expression_list {
+  regular_expression {
     regex_string = "one"
   }
 }

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -335,6 +335,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_wafregional_rate_based_rule":               dataSourceAwsWafRegionalRateBasedRule(),
 			"aws_wafregional_web_acl":                       dataSourceAwsWafRegionalWebAcl(),
 			"aws_wafv2_ip_set":                              dataSourceAwsWafv2IPSet(),
+			"aws_wafv2_regex_pattern_set":                   dataSourceAwsWafv2RegexPatternSet(),
 			"aws_workspaces_bundle":                         dataSourceAwsWorkspaceBundle(),
 
 			// Adding the Aliases for the ALB -> LB Rename

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -3579,6 +3579,19 @@
                     </ul>
                 </li>
                 <li>
+                    <a href="#">WAFv2</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/wafv2_regex_pattern_set.html">aws_wafv2_regex_pattern_set</a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </li>
+                <li>
                     <a href="#">WorkLink</a>
                     <ul class="nav">
                         <li>

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -3563,6 +3563,9 @@
                                 <li>
                                     <a href="/docs/providers/aws/d/wafv2_ip_set.html">aws_wafv2_ip_set</a>
                                 </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/wafv2_regex_pattern_set.html">aws_wafv2_regex_pattern_set</a>
+                                </li>
                             </ul>
                         </li>
                         <li>
@@ -3573,19 +3576,6 @@
                                 </li>
                                 <li>
                                     <a href="/docs/providers/aws/r/wafv2_regex_pattern_set.html">aws_wafv2_regex_pattern_set</a>
-                                </li>
-                            </ul>
-                        </li>
-                    </ul>
-                </li>
-                <li>
-                    <a href="#">WAFv2</a>
-                    <ul class="nav">
-                        <li>
-                            <a href="#">Data Sources</a>
-                            <ul class="nav nav-auto-expand">
-                                <li>
-                                    <a href="/docs/providers/aws/d/wafv2_regex_pattern_set.html">aws_wafv2_regex_pattern_set</a>
                                 </li>
                             </ul>
                         </li>

--- a/website/docs/d/wafv2_regex_pattern_set.html.markdown
+++ b/website/docs/d/wafv2_regex_pattern_set.html.markdown
@@ -33,10 +33,10 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - The Amazon Resource Name (ARN) of the entity.
 * `description` - The description of the set that helps with identification.
 * `id` - The unique identifier for the set.
-* `regular_expression_list` - One or more blocks of regular expression patterns that AWS WAF is searching for. See [Regular Expression](#regular-expression) below for details.
+* `regular_expression` - One or more blocks of regular expression patterns that AWS WAF is searching for. See [Regular Expression](#regular-expression) below for details.
 
 ### Regular Expression
 
-Each `regular_expression_list` supports the following argument:
+Each `regular_expression` supports the following argument:
 
 * `regex_string` - (Required) The string representing the regular expression, see the AWS WAF [documentation](https://docs.aws.amazon.com/waf/latest/developerguide/waf-regex-pattern-set-creating.html) for more information.

--- a/website/docs/d/wafv2_regex_pattern_set.html.markdown
+++ b/website/docs/d/wafv2_regex_pattern_set.html.markdown
@@ -33,3 +33,10 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - The Amazon Resource Name (ARN) of the entity.
 * `description` - The description of the set that helps with identification.
 * `id` - The unique identifier for the set.
+* `regular_expression_list` - One or more blocks of regular expression patterns that AWS WAF is searching for. See [Regular Expression](#regular-expression) below for details.
+
+### Regular Expression
+
+Each `regular_expression_list` supports the following argument:
+
+* `regex_string` - (Required) The string representing the regular expression, see the AWS WAF [documentation](https://docs.aws.amazon.com/waf/latest/developerguide/waf-regex-pattern-set-creating.html) for more information.

--- a/website/docs/d/wafv2_regex_pattern_set.html.markdown
+++ b/website/docs/d/wafv2_regex_pattern_set.html.markdown
@@ -1,0 +1,35 @@
+---
+subcategory: "WAFv2"
+layout: "aws"
+page_title: "AWS: aws_wafv2_regex_pattern_set"
+description: |-
+  Retrieves the summary of a WAFv2 Regex Pattern Set.
+---
+
+# Data Source: aws_wafv2_regex_pattern_set
+
+Retrieves the summary of a WAFv2 Regex Pattern Set.
+
+## Example Usage
+
+```hcl
+data "aws_wafv2_regex_pattern_set" "example" {
+  name  = "some-regex-pattern-set"
+  scope = "REGIONAL"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the WAFv2 Regex Pattern Set.
+* `scope` - (Required) Specifies whether this is for an AWS CloudFront distribution or for a regional application. To work with CloudFront, you must also specify the Region US East (N. Virginia).
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The Amazon Resource Name (ARN) of the entity.
+* `description` - The description of the set that helps with identification.
+* `id` - The unique identifier for the set.

--- a/website/docs/d/wafv2_regex_pattern_set.html.markdown
+++ b/website/docs/d/wafv2_regex_pattern_set.html.markdown
@@ -24,7 +24,7 @@ data "aws_wafv2_regex_pattern_set" "example" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the WAFv2 Regex Pattern Set.
-* `scope` - (Required) Specifies whether this is for an AWS CloudFront distribution or for a regional application. To work with CloudFront, you must also specify the region `us-east-1` (N. Virginia) on the AWS provider.
+* `scope` - (Required) Specifies whether this is for an AWS CloudFront distribution or for a regional application. Valid values are `CLOUDFRONT` or `REGIONAL`. To work with CloudFront, you must also specify the region `us-east-1` (N. Virginia) on the AWS provider.
 
 ## Attributes Reference
 

--- a/website/docs/d/wafv2_regex_pattern_set.html.markdown
+++ b/website/docs/d/wafv2_regex_pattern_set.html.markdown
@@ -24,7 +24,7 @@ data "aws_wafv2_regex_pattern_set" "example" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the WAFv2 Regex Pattern Set.
-* `scope` - (Required) Specifies whether this is for an AWS CloudFront distribution or for a regional application. To work with CloudFront, you must also specify the Region US East (N. Virginia).
+* `scope` - (Required) Specifies whether this is for an AWS CloudFront distribution or for a regional application. To work with CloudFront, you must also specify the region `us-east-1` (N. Virginia) on the AWS provider.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #11179
Relates #11046
Depends on #12284 because of duplicated code for tests.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
**New Data Source:** `aws_wafv2_regex_pattern_set` (#12789)
```

Output from acceptance testing:

```
make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsWafv2Regex'
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsWafv2Regex -timeout 120m
=== RUN   TestAccDataSourceAwsWafv2RegexPatternSet_Basic
=== PAUSE TestAccDataSourceAwsWafv2RegexPatternSet_Basic
=== CONT  TestAccDataSourceAwsWafv2RegexPatternSet_Basic
--- PASS: TestAccDataSourceAwsWafv2RegexPatternSet_Basic (21.41s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       21.777s
```