### PR TITLE
New data source: aws_wafv2_rule_group

### DIFF
--- a/aws/data_source_aws_wafv2_rule_group.go
+++ b/aws/data_source_aws_wafv2_rule_group.go
@@ -1,0 +1,83 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/wafv2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func dataSourceAwsWafv2RuleGroup() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsWafv2RuleGroupRead,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"scope": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					wafv2.ScopeCloudfront,
+					wafv2.ScopeRegional,
+				}, false),
+			},
+		},
+	}
+}
+
+func dataSourceAwsWafv2RuleGroupRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafv2conn
+	name := d.Get("name").(string)
+
+	var foundRuleGroup *wafv2.RuleGroupSummary
+	input := &wafv2.ListRuleGroupsInput{
+		Scope: aws.String(d.Get("scope").(string)),
+		Limit: aws.Int64(100),
+	}
+
+	for {
+		resp, err := conn.ListRuleGroups(input)
+		if err != nil {
+			return fmt.Errorf("Error reading WAFv2 RuleGroups: %s", err)
+		}
+
+		if resp == nil || resp.RuleGroups == nil {
+			return fmt.Errorf("Error reading WAFv2 RuleGroups")
+		}
+
+		for _, ruleGroup := range resp.RuleGroups {
+			if aws.StringValue(ruleGroup.Name) == name {
+				foundRuleGroup = ruleGroup
+				break
+			}
+		}
+
+		if resp.NextMarker == nil || foundRuleGroup != nil {
+			break
+		}
+		input.NextMarker = resp.NextMarker
+	}
+
+	if foundRuleGroup == nil {
+		return fmt.Errorf("WAFv2 RuleGroup not found for name: %s", name)
+	}
+
+	d.SetId(aws.StringValue(foundRuleGroup.Id))
+	d.Set("arn", aws.StringValue(foundRuleGroup.ARN))
+	d.Set("description", aws.StringValue(foundRuleGroup.Description))
+
+	return nil
+}

--- a/aws/data_source_aws_wafv2_rule_group_test.go
+++ b/aws/data_source_aws_wafv2_rule_group_test.go
@@ -1,0 +1,80 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceAwsWafv2RuleGroup_Basic(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_wafv2_rule_group.test"
+	datasourceName := "data.aws_wafv2_rule_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSourceAwsWafv2RuleGroup_NonExistent(name),
+				ExpectError: regexp.MustCompile(`WAFv2 RuleGroup not found`),
+			},
+			{
+				Config: testAccDataSourceAwsWafv2RuleGroup_Name(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					testAccMatchResourceAttrRegionalARN(datasourceName, "arn", "wafv2", regexp.MustCompile(fmt.Sprintf("regional/rulegroup/%v/.+$", name))),
+					resource.TestCheckResourceAttrPair(datasourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(datasourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "scope", resourceName, "scope"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsWafv2RuleGroup_Name(name string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_rule_group" "test" {
+  name     = "%s"
+  scope    = "REGIONAL"
+  capacity = 10
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-rule-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+
+data "aws_wafv2_rule_group" "test" {
+  name  = aws_wafv2_rule_group.test.name
+  scope = "REGIONAL"
+}
+`, name)
+}
+
+func testAccDataSourceAwsWafv2RuleGroup_NonExistent(name string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_rule_group" "test" {
+  name     = "%s"
+  scope    = "REGIONAL"
+  capacity = 10
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-rule-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+
+data "aws_wafv2_rule_group" "test" {
+  name  = "tf-acc-test-does-not-exist"
+  scope = "REGIONAL"
+}
+`, name)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -336,6 +336,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_wafregional_web_acl":                       dataSourceAwsWafRegionalWebAcl(),
 			"aws_wafv2_ip_set":                              dataSourceAwsWafv2IPSet(),
 			"aws_wafv2_regex_pattern_set":                   dataSourceAwsWafv2RegexPatternSet(),
+			"aws_wafv2_rule_group":                          dataSourceAwsWafv2RuleGroup(),
 			"aws_workspaces_bundle":                         dataSourceAwsWorkspaceBundle(),
 
 			// Adding the Aliases for the ALB -> LB Rename

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -3569,6 +3569,9 @@
                                 <li>
                                     <a href="/docs/providers/aws/d/wafv2_regex_pattern_set.html">aws_wafv2_regex_pattern_set</a>
                                 </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/wafv2_rule_group.html">aws_wafv2_rule_group</a>
+                                </li>
                             </ul>
                         </li>
                         <li>

--- a/website/docs/d/wafv2_rule_group.html.markdown
+++ b/website/docs/d/wafv2_rule_group.html.markdown
@@ -1,0 +1,35 @@
+---
+subcategory: "WAFv2"
+layout: "aws"
+page_title: "AWS: aws_wafv2_rule_group"
+description: |-
+  Retrieves the summary of a WAFv2 Rule Group.
+---
+
+# Data Source: aws_wafv2_rule_group
+
+Retrieves the summary of a WAFv2 Rule Group.
+
+## Example Usage
+
+```hcl
+data "aws_wafv2_rule_group" "example" {
+  name  = "some-rule-group"
+  scope = "REGIONAL"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the WAFv2 Rule Group.
+* `scope` - (Required) Specifies whether this is for an AWS CloudFront distribution or for a regional application. Valid values are `CLOUDFRONT` or `REGIONAL`. To work with CloudFront, you must also specify the region `us-east-1` (N. Virginia) on the AWS provider.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The Amazon Resource Name (ARN) of the entity.
+* `description` - The description of the rule group that helps with identification.
+* `id` - The unique identifier of the rule group.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #11180
Relates #11046
Depends on #12677 because of duplicated code for tests.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
**New Data Source:** `aws_wafv2_rule_group` (#12790)
```

Output from acceptance testing:

```
make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsWafv2RuleGroup'
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsWafv2RuleGroup -timeout 120m
=== RUN   TestAccDataSourceAwsWafv2RuleGroup_Basic
=== PAUSE TestAccDataSourceAwsWafv2RuleGroup_Basic
=== CONT  TestAccDataSourceAwsWafv2RuleGroup_Basic
--- PASS: TestAccDataSourceAwsWafv2RuleGroup_Basic (45.25s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       45.694s
```