### PR TITLE
r/wafregional_web_acl - add plan time validation

### DIFF
--- a/aws/resource_aws_wafregional_web_acl.go
+++ b/aws/resource_aws_wafregional_web_acl.go
@@ -42,6 +42,11 @@ func resourceAwsWafRegionalWebAcl() *schema.Resource {
 						"type": {
 							Type:     schema.TypeString,
 							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								waf.WafActionTypeAllow,
+								waf.WafActionTypeBlock,
+								waf.WafActionTypeCount,
+							}, false),
 						},
 					},
 				},
@@ -53,8 +58,9 @@ func resourceAwsWafRegionalWebAcl() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"log_destination": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateArn,
 						},
 						"redacted_fields": {
 							Type:     schema.TypeList,
@@ -74,6 +80,15 @@ func resourceAwsWafRegionalWebAcl() *schema.Resource {
 												"type": {
 													Type:     schema.TypeString,
 													Required: true,
+													ValidateFunc: validation.StringInSlice([]string{
+														waf.MatchFieldTypeAllQueryArgs,
+														waf.MatchFieldTypeBody,
+														waf.MatchFieldTypeHeader,
+														waf.MatchFieldTypeMethod,
+														waf.MatchFieldTypeQueryString,
+														waf.MatchFieldTypeSingleQueryArg,
+														waf.MatchFieldTypeUri,
+													}, false),
 												},
 											},
 										},
@@ -103,6 +118,11 @@ func resourceAwsWafRegionalWebAcl() *schema.Resource {
 									"type": {
 										Type:     schema.TypeString,
 										Required: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											waf.WafActionTypeAllow,
+											waf.WafActionTypeBlock,
+											waf.WafActionTypeCount,
+										}, false),
 									},
 								},
 							},
@@ -116,6 +136,10 @@ func resourceAwsWafRegionalWebAcl() *schema.Resource {
 									"type": {
 										Type:     schema.TypeString,
 										Required: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											waf.WafOverrideActionTypeCount,
+											waf.WafOverrideActionTypeNone,
+										}, false),
 									},
 								},
 							},

--- a/aws/resource_aws_wafregional_web_acl_test.go
+++ b/aws/resource_aws_wafregional_web_acl_test.go
@@ -119,7 +119,7 @@ func testSweepWafRegionalWebAcls(region string) error {
 func TestAccAWSWafRegionalWebAcl_basic(t *testing.T) {
 	var v waf.WebACL
 	wafAclName := fmt.Sprintf("wafacl%s", acctest.RandString(5))
-	resourceName := "aws_wafregional_web_acl.waf_acl"
+	resourceName := "aws_wafregional_web_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -151,7 +151,7 @@ func TestAccAWSWafRegionalWebAcl_basic(t *testing.T) {
 func TestAccAWSWafRegionalWebAcl_tags(t *testing.T) {
 	var v waf.WebACL
 	wafAclName := fmt.Sprintf("wafacl%s", acctest.RandString(5))
-	resourceName := "aws_wafregional_web_acl.waf_acl"
+	resourceName := "aws_wafregional_web_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -195,7 +195,7 @@ func TestAccAWSWafRegionalWebAcl_tags(t *testing.T) {
 func TestAccAWSWafRegionalWebAcl_createRateBased(t *testing.T) {
 	var v waf.WebACL
 	wafAclName := fmt.Sprintf("wafacl%s", acctest.RandString(5))
-	resourceName := "aws_wafregional_web_acl.waf_acl"
+	resourceName := "aws_wafregional_web_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -213,6 +213,11 @@ func TestAccAWSWafRegionalWebAcl_createRateBased(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "metric_name", wafAclName),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -220,7 +225,7 @@ func TestAccAWSWafRegionalWebAcl_createRateBased(t *testing.T) {
 func TestAccAWSWafRegionalWebAcl_createGroup(t *testing.T) {
 	var v waf.WebACL
 	wafAclName := fmt.Sprintf("wafacl%s", acctest.RandString(5))
-	resourceName := "aws_wafregional_web_acl.waf_acl"
+	resourceName := "aws_wafregional_web_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -251,7 +256,7 @@ func TestAccAWSWafRegionalWebAcl_changeNameForceNew(t *testing.T) {
 	var before, after waf.WebACL
 	wafAclName := fmt.Sprintf("wafacl%s", acctest.RandString(5))
 	wafAclNewName := fmt.Sprintf("wafacl%s", acctest.RandString(5))
-	resourceName := "aws_wafregional_web_acl.waf_acl"
+	resourceName := "aws_wafregional_web_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -293,7 +298,7 @@ func TestAccAWSWafRegionalWebAcl_changeDefaultAction(t *testing.T) {
 	var before, after waf.WebACL
 	wafAclName := fmt.Sprintf("wafacl%s", acctest.RandString(5))
 	wafAclNewName := fmt.Sprintf("wafacl%s", acctest.RandString(5))
-	resourceName := "aws_wafregional_web_acl.waf_acl"
+	resourceName := "aws_wafregional_web_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -334,7 +339,7 @@ func TestAccAWSWafRegionalWebAcl_changeDefaultAction(t *testing.T) {
 func TestAccAWSWafRegionalWebAcl_disappears(t *testing.T) {
 	var v waf.WebACL
 	wafAclName := fmt.Sprintf("wafacl%s", acctest.RandString(5))
-	resourceName := "aws_wafregional_web_acl.waf_acl"
+	resourceName := "aws_wafregional_web_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -356,7 +361,7 @@ func TestAccAWSWafRegionalWebAcl_disappears(t *testing.T) {
 func TestAccAWSWafRegionalWebAcl_noRules(t *testing.T) {
 	var v waf.WebACL
 	wafAclName := fmt.Sprintf("wafacl%s", acctest.RandString(5))
-	resourceName := "aws_wafregional_web_acl.waf_acl"
+	resourceName := "aws_wafregional_web_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -387,7 +392,7 @@ func TestAccAWSWafRegionalWebAcl_changeRules(t *testing.T) {
 	var r waf.Rule
 	var idx int
 	wafAclName := fmt.Sprintf("wafacl%s", acctest.RandString(5))
-	resourceName := "aws_wafregional_web_acl.waf_acl"
+	resourceName := "aws_wafregional_web_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -397,7 +402,7 @@ func TestAccAWSWafRegionalWebAcl_changeRules(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalWebAclConfig(wafAclName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalRuleExists("aws_wafregional_rule.wafrule", &r),
+					testAccCheckAWSWafRegionalRuleExists("aws_wafregional_rule.test", &r),
 					testAccCheckAWSWafRegionalWebAclExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "ALLOW"),
@@ -429,7 +434,7 @@ func TestAccAWSWafRegionalWebAcl_changeRules(t *testing.T) {
 func TestAccAWSWafRegionalWebAcl_LoggingConfiguration(t *testing.T) {
 	var webACL1, webACL2, webACL3 waf.WebACL
 	rName := fmt.Sprintf("wafacl%s", acctest.RandString(5))
-	resourceName := "aws_wafregional_web_acl.waf_acl"
+	resourceName := "aws_wafregional_web_acl.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -507,7 +512,7 @@ func testAccCheckAWSWafRegionalWebAclDisappears(v *waf.WebACL) resource.TestChec
 
 			for _, activatedRule := range v.Rules {
 				webACLUpdate := &waf.WebACLUpdate{
-					Action: aws.String("DELETE"),
+					Action: aws.String(waf.ChangeActionDelete),
 					ActivatedRule: &waf.ActivatedRule{
 						Priority: activatedRule.Priority,
 						RuleId:   activatedRule.RuleId,
@@ -597,12 +602,12 @@ func testAccCheckAWSWafRegionalWebAclExists(n string, v *waf.WebACL) resource.Te
 
 func testAccAWSWafRegionalWebAclConfig(name string) string {
 	return fmt.Sprintf(`
-resource "aws_wafregional_rule" "wafrule" {
+resource "aws_wafregional_rule" "test" {
   name        = %[1]q
   metric_name = %[1]q
 }
 
-resource "aws_wafregional_web_acl" "waf_acl" {
+resource "aws_wafregional_web_acl" "test" {
   name        = %[1]q
   metric_name = %[1]q
 
@@ -616,7 +621,7 @@ resource "aws_wafregional_web_acl" "waf_acl" {
     }
 
     priority = 1
-    rule_id  = "${aws_wafregional_rule.wafrule.id}"
+    rule_id  = "${aws_wafregional_rule.test.id}"
   }
 }
 `, name)
@@ -624,12 +629,12 @@ resource "aws_wafregional_web_acl" "waf_acl" {
 
 func testAccAWSWafRegionalWebAclConfigTags1(name, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
-resource "aws_wafregional_rule" "wafrule" {
+resource "aws_wafregional_rule" "test" {
   name        = %[1]q
   metric_name = %[1]q
 }
 
-resource "aws_wafregional_web_acl" "waf_acl" {
+resource "aws_wafregional_web_acl" "test" {
   name        = %[1]q
   metric_name = %[1]q
 
@@ -643,7 +648,7 @@ resource "aws_wafregional_web_acl" "waf_acl" {
     }
 
     priority = 1
-    rule_id  = "${aws_wafregional_rule.wafrule.id}"
+    rule_id  = "${aws_wafregional_rule.test.id}"
   }
 
   tags = {
@@ -655,12 +660,12 @@ resource "aws_wafregional_web_acl" "waf_acl" {
 
 func testAccAWSWafRegionalWebAclConfigTags2(name, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
-resource "aws_wafregional_rule" "wafrule" {
+resource "aws_wafregional_rule" "test" {
   name        = %[1]q
   metric_name = %[1]q
 }
 
-resource "aws_wafregional_web_acl" "waf_acl" {
+resource "aws_wafregional_web_acl" "test" {
   name        = %[1]q
   metric_name = %[1]q
 
@@ -674,7 +679,7 @@ resource "aws_wafregional_web_acl" "waf_acl" {
     }
 
     priority = 1
-    rule_id  = "${aws_wafregional_rule.wafrule.id}"
+    rule_id  = "${aws_wafregional_rule.test.id}"
   }
 
   tags = {
@@ -687,7 +692,7 @@ resource "aws_wafregional_web_acl" "waf_acl" {
 
 func testAccAWSWafRegionalWebAclConfigRateBased(name string) string {
 	return fmt.Sprintf(`
-resource "aws_wafregional_rate_based_rule" "wafrule" {
+resource "aws_wafregional_rate_based_rule" "test" {
   name        = %[1]q
   metric_name = %[1]q
 
@@ -695,7 +700,7 @@ resource "aws_wafregional_rate_based_rule" "wafrule" {
   rate_limit = 2000
 }
 
-resource "aws_wafregional_web_acl" "waf_acl" {
+resource "aws_wafregional_web_acl" "test" {
   name        = %[1]q
   metric_name = %[1]q
 
@@ -710,7 +715,7 @@ resource "aws_wafregional_web_acl" "waf_acl" {
 
     priority = 1
     type     = "RATE_BASED"
-    rule_id  = "${aws_wafregional_rate_based_rule.wafrule.id}"
+    rule_id  = "${aws_wafregional_rate_based_rule.test.id}"
   }
 }
 `, name)
@@ -718,12 +723,12 @@ resource "aws_wafregional_web_acl" "waf_acl" {
 
 func testAccAWSWafRegionalWebAclConfigGroup(name string) string {
 	return fmt.Sprintf(`
-resource "aws_wafregional_rule_group" "wafrulegroup" {
+resource "aws_wafregional_rule_group" "test" {
   name        = %[1]q
   metric_name = %[1]q
 }
 
-resource "aws_wafregional_web_acl" "waf_acl" {
+resource "aws_wafregional_web_acl" "test" {
   name        = %[1]q
   metric_name = %[1]q
 
@@ -738,7 +743,7 @@ resource "aws_wafregional_web_acl" "waf_acl" {
 
     priority = 1
     type     = "GROUP"
-    rule_id  = "${aws_wafregional_rule_group.wafrulegroup.id}" # todo
+    rule_id  = "${aws_wafregional_rule_group.test.id}"
   }
 }
 `, name)
@@ -746,12 +751,12 @@ resource "aws_wafregional_web_acl" "waf_acl" {
 
 func testAccAWSWafRegionalWebAclConfig_changeName(name string) string {
 	return fmt.Sprintf(`
-resource "aws_wafregional_rule" "wafrule" {
+resource "aws_wafregional_rule" "test" {
   name        = %[1]q
   metric_name = %[1]q
 }
 
-resource "aws_wafregional_web_acl" "waf_acl" {
+resource "aws_wafregional_web_acl" "test" {
   name        = %[1]q
   metric_name = %[1]q
 
@@ -765,7 +770,7 @@ resource "aws_wafregional_web_acl" "waf_acl" {
     }
 
     priority = 1
-    rule_id  = "${aws_wafregional_rule.wafrule.id}"
+    rule_id  = "${aws_wafregional_rule.test.id}"
   }
 }
 `, name)
@@ -773,12 +778,12 @@ resource "aws_wafregional_web_acl" "waf_acl" {
 
 func testAccAWSWafRegionalWebAclConfig_changeDefaultAction(name string) string {
 	return fmt.Sprintf(`
-resource "aws_wafregional_rule" "wafrule" {
+resource "aws_wafregional_rule" "test" {
   name        = %[1]q
   metric_name = %[1]q
 }
 
-resource "aws_wafregional_web_acl" "waf_acl" {
+resource "aws_wafregional_web_acl" "test" {
   name        = %[1]q
   metric_name = %[1]q
 
@@ -792,7 +797,7 @@ resource "aws_wafregional_web_acl" "waf_acl" {
     }
 
     priority = 1
-    rule_id  = "${aws_wafregional_rule.wafrule.id}"
+    rule_id  = "${aws_wafregional_rule.test.id}"
   }
 }
 `, name)
@@ -800,7 +805,7 @@ resource "aws_wafregional_web_acl" "waf_acl" {
 
 func testAccAWSWafRegionalWebAclConfig_noRules(name string) string {
 	return fmt.Sprintf(`
-resource "aws_wafregional_web_acl" "waf_acl" {
+resource "aws_wafregional_web_acl" "test" {
   name        = %[1]q
   metric_name = %[1]q
 
@@ -813,12 +818,12 @@ resource "aws_wafregional_web_acl" "waf_acl" {
 
 func testAccAWSWafRegionalWebAclConfig_changeRules(name string) string {
 	return fmt.Sprintf(`
-resource "aws_wafregional_rule" "wafrule" {
+resource "aws_wafregional_rule" "test" {
   name        = %[1]q
   metric_name = %[1]q
 }
 
-resource "aws_wafregional_web_acl" "waf_acl" {
+resource "aws_wafregional_web_acl" "test" {
   name        = %[1]q
   metric_name = %[1]q
 
@@ -832,7 +837,7 @@ resource "aws_wafregional_web_acl" "waf_acl" {
     }
 
     priority = 3
-    rule_id  = "${aws_wafregional_rule.wafrule.id}"
+    rule_id  = "${aws_wafregional_rule.test.id}"
   }
 
   rule {
@@ -841,7 +846,7 @@ resource "aws_wafregional_web_acl" "waf_acl" {
     }
 
     priority = 99
-    rule_id  = "${aws_wafregional_rule.wafrule.id}"
+    rule_id  = "${aws_wafregional_rule.test.id}"
   }
 }
 `, name)
@@ -849,7 +854,7 @@ resource "aws_wafregional_web_acl" "waf_acl" {
 
 func testAccAWSWafRegionalWebAclConfigLoggingConfiguration(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_wafregional_web_acl" "waf_acl" {
+resource "aws_wafregional_web_acl" "test" {
   name        = %[1]q
   metric_name = %[1]q
 
@@ -913,7 +918,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
 func testAccAWSWafRegionalWebAclConfigLoggingConfigurationUpdate(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_wafregional_web_acl" "waf_acl" {
+resource "aws_wafregional_web_acl" "test" {
   name        = %[1]q
   metric_name = %[1]q
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_wafregional_web_acl: add plan time validation to `default_action.type`, `logging_configuration.log_destination`, `redacted_fields.field_to_match.type`, `rule.action.type`, `rule.override_action.type`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=wafregional_web_acl'
--- PASS: TestAccAWSWafRegionalWebAcl_basic (74.36s)
--- PASS: TestAccAWSWafRegionalWebAcl_tags (152.40s)
--- PASS: TestAccAWSWafRegionalWebAcl_createRateBased (73.36s)
--- PASS: TestAccAWSWafRegionalWebAcl_createGroup (75.88s)
--- PASS: TestAccAWSWafRegionalWebAcl_changeNameForceNew (130.95s)
--- PASS: TestAccAWSWafRegionalWebAcl_changeDefaultAction (130.82s)
--- PASS: TestAccAWSWafRegionalWebAcl_disappears (58.25s)
--- PASS: TestAccAWSWafRegionalWebAcl_noRules (54.92s)
--- PASS: TestAccAWSWafRegionalWebAcl_changeRules (115.26s)
--- PASS: TestAccAWSWafRegionalWebAcl_LoggingConfiguration (271.09s)
```
