### PR TITLE
New data source: aws_spot_price_history

### DIFF
--- a/aws/data_source_aws_spot_price_history.go
+++ b/aws/data_source_aws_spot_price_history.go
@@ -1,0 +1,137 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"log"
+	"sort"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func dataSourceAwsSpotPriceHistory() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsSpotPriceHistoryRead,
+
+		Schema: map[string]*schema.Schema{
+			"filter": dataSourceFiltersSchema(),
+			"start_time": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsRFC3339Time,
+			},
+			"end_time": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsRFC3339Time,
+			},
+			"latest": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+			"previous": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"timestamp": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"product_description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"spot_price": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"availability_zone": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// dataSourceAwsSpotPriceHistoryRead performs the lookup.
+func dataSourceAwsSpotPriceHistoryRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	params := &ec2.DescribeSpotPriceHistoryInput{}
+
+	if v, ok := d.GetOk("start_time"); ok {
+		t, _ := time.Parse(time.RFC3339, v.(string))
+		params.StartTime = &t
+	}
+
+	if v, ok := d.GetOk("end_time"); ok {
+		t, _ := time.Parse(time.RFC3339, v.(string))
+		params.EndTime = &t
+	}
+
+	if v, ok := d.GetOk("filter"); ok {
+		params.Filters = buildAwsDataSourceFilters(v.(*schema.Set))
+	}
+
+	log.Printf("[DEBUG] Reading Spot Price History: %s", params)
+	var prices []*ec2.SpotPrice
+	err := conn.DescribeSpotPriceHistoryPages(params, func(page *ec2.DescribeSpotPriceHistoryOutput, lastPage bool) bool {
+		prices = append(prices, page.SpotPriceHistory...)
+		return !lastPage
+	})
+	if err != nil {
+		return fmt.Errorf("Error reading Spot Price History: %s", err)
+	}
+	if len(prices) < 1 {
+		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
+	}
+
+	sort.Slice(prices, func(i, j int) bool {
+		itime := prices[i].Timestamp
+		jtime := prices[j].Timestamp
+		return itime.Unix() > jtime.Unix()
+	})
+
+	d.SetId(resource.UniqueId())
+	if err := d.Set("latest", spotPriceHistory(prices[0:1])[0]); err != nil {
+		return err
+	}
+	if len(prices) > 1 {
+		if err := d.Set("previous", spotPriceHistory(prices[1:])); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// convert api output to terraform data attribute
+func spotPriceHistory(prices []*ec2.SpotPrice) []map[string]interface{} {
+	var l []map[string]interface{}
+	for _, v := range prices {
+		price := map[string]interface{}{
+			"timestamp":           v.Timestamp.Format(time.RFC3339),
+			"product_description": aws.StringValue(v.ProductDescription),
+			"instance_type":       aws.StringValue(v.InstanceType),
+			"spot_price":          aws.StringValue(v.SpotPrice),
+			"availability_zone":   aws.StringValue(v.AvailabilityZone),
+		}
+		l = append(l, price)
+	}
+
+	return l
+}

--- a/aws/data_source_aws_spot_price_history_test.go
+++ b/aws/data_source_aws_spot_price_history_test.go
@@ -1,0 +1,205 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestAccAWSSpotPriceHistoryDataSource_product_description_filter_windows(t *testing.T) {
+	resourceName := "data.aws_spot_price_history.product_windows"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSpotPriceHistoryDataSourceProductFilterWindowsConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSpotPriceHistoryFilterResponses("product_description", resourceName),
+				),
+			},
+		},
+	})
+}
+
+/* not working even though documented as valid parameter
+func TestAccAWSSpotPriceHistoryDataSource_product_description_filter_windows_vpc(t *testing.T) {
+	resourceName := "data.aws_spot_price_history.product_windows_vpc"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSpotPriceHistoryDataSourceProductFilterWindowsVPCConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSpotPriceHistoryFilterResponses("product_description", resourceName),
+				),
+			},
+		},
+	})
+}
+*/
+
+func TestAccAWSSpotPriceHistoryDataSource_instance_type_filter(t *testing.T) {
+	resourceName := "data.aws_spot_price_history.instance_type_m1_large"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSpotPriceHistoryDataSourceInstanceTypeFilterConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSpotPriceHistoryFilterResponses("instance_type", resourceName),
+					testAccCheckElementOrder(resourceName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckElementOrder(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find spot price history resource: %s", n)
+		}
+
+		err := testAccCheckLatestPriceIsNewerThanTheFirstPreviousPrice(rs.Primary.Attributes)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckLatestPriceIsNewerThanTheFirstPreviousPrice(attrs map[string]string) error {
+	var previousTime time.Time
+	var latestTime time.Time
+	var err error
+	l, ok := attrs["latest.timestamp"]
+	if !ok {
+		return fmt.Errorf("Spot price history latest is missing, this is probably a bug.")
+	}
+	latestTime, err = time.Parse(time.RFC3339, l)
+	if err != nil {
+		return err
+	}
+
+	c, ok := attrs["previous.#"]
+	if !ok {
+		return fmt.Errorf("Spot price history list is missing, this is probably a bug.")
+	}
+	qty, err := strconv.Atoi(c)
+	if err != nil {
+		return err
+	}
+	if qty < 1 {
+		return fmt.Errorf("No spot price history found, this is probably a bug.")
+	}
+
+	i := make([]string, qty)
+	for n := range i {
+		if t, ok := attrs["previous."+strconv.Itoa(n)+".timestamp"]; ok {
+			previousTime, err = time.Parse(time.RFC3339, t)
+			if err != nil {
+				return err
+			}
+		}
+
+		if latestTime.Sub(previousTime) < 0 {
+			return fmt.Errorf("Spot price history order is not correct. This is definitely bug.")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckSpotPriceHistoryFilterResponses(filter_name, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find spot price history resource: %s", n)
+		}
+
+		err := testAccCheckResponseContainsTheSameValueForFilters(filter_name, rs.Primary.Attributes)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckResponseContainsTheSameValueForFilters(filter_name string, attrs map[string]string) error {
+	c, ok := attrs["latest."+filter_name]
+	if !ok {
+		return fmt.Errorf("Latest spot price is missing, this is probably a bug.")
+	}
+	v, ok := attrs["previous.#"]
+	if !ok {
+		return fmt.Errorf("Spot price history list is missing, this is probably a bug.")
+	}
+	qty, err := strconv.Atoi(v)
+	if err != nil {
+		return err
+	}
+	if qty < 1 {
+		return fmt.Errorf("No spot price history found, this is probably a bug.")
+	}
+	i := make([]string, qty)
+	for n := range i {
+		t, ok := attrs["previous."+strconv.Itoa(n)+"."+filter_name]
+		if ok && c != "" && t != c {
+			return fmt.Errorf("Spot price history list contains different values when filtering for %s. This is definitely bug.", filter_name)
+		}
+		c = t
+	}
+
+	return nil
+}
+
+func testAccAWSSpotPriceHistoryDataSourceProductFilterWindowsConfig() string {
+	now := time.Now()
+	return fmt.Sprintf(`
+data "aws_spot_price_history" "product_windows" {
+	start_time = "%s"
+	end_time = "%s"
+	filter {
+		name = "product-description"
+		values = ["Windows"]
+	}
+}`, now.Add(time.Duration(-1)*time.Hour).Format(time.RFC3339), now.Add(time.Duration(-30)*time.Minute).Format(time.RFC3339))
+}
+
+/*
+func testAccAWSSpotPriceHistoryDataSourceProductFilterWindowsVPCConfig() string {
+	now := time.Now()
+	return fmt.Sprintf(`
+data "aws_spot_price_history" "product_windows_vpc" {
+	start_time = "%s"
+	end_time = "%s"
+	filter {
+		name = "product-description"
+		values = ["Windows (Amazon VPC)"]
+	}
+}`, now.Add(time.Duration(-1)*time.Hour).Format(time.RFC3339), now.Add(time.Duration(-30)*time.Minute).Format(time.RFC3339))
+}
+*/
+
+// specific instance type
+func testAccAWSSpotPriceHistoryDataSourceInstanceTypeFilterConfig() string {
+	now := time.Now()
+	return fmt.Sprintf(`
+data "aws_spot_price_history" "instance_type_m1_large" {
+	start_time = "%s"
+	end_time = "%s"
+	filter {
+    	name = "instance-type"
+    	values = ["m1.large"]
+  	}
+}`, now.Add(time.Duration(-1)*time.Hour).Format(time.RFC3339), now.Add(time.Duration(-30)*time.Minute).Format(time.RFC3339))
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -297,6 +297,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_sfn_activity":                              dataSourceAwsSfnActivity(),
 			"aws_sfn_state_machine":                         dataSourceAwsSfnStateMachine(),
 			"aws_sns_topic":                                 dataSourceAwsSnsTopic(),
+			"aws_spot_price_history":                        dataSourceAwsSpotPriceHistory(),
 			"aws_sqs_queue":                                 dataSourceAwsSqsQueue(),
 			"aws_ssm_document":                              dataSourceAwsSsmDocument(),
 			"aws_ssm_parameter":                             dataSourceAwsSsmParameter(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1098,6 +1098,9 @@
                                 <li>
                                     <a href="/docs/providers/aws/d/launch_template.html">aws_launch_template</a>
                                 </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/spot_price_history.html">aws_spot_price_history</a>
+                                </li>
                             </ul>
                         </li>
                         <li>

--- a/website/docs/d/spot_price_history.html.markdown
+++ b/website/docs/d/spot_price_history.html.markdown
@@ -1,0 +1,64 @@
+---
+subcategory: "EC2"
+layout: "aws"
+page_title: "AWS: aws_spot_price_history"
+description: |-
+  Show price development.
+---
+
+# Resource: aws_spot_price_history
+
+Show the development of spot instance prices. This can be used in conjunction with a launch configuration.
+ 
+See the [AWS Spot Instance
+documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-spot-instances.html)
+for more information.
+
+
+## Example Usage
+
+```hcl
+# Request spot prices
+resource "aws_spot_price_history" "prices" {
+  start_time = "2020-04-13T01:10:30Z"
+  filter {
+    name   = "instance_type"
+    values = ["m4.large"]
+  }
+}
+
+# use the latest price for the launch configuration
+resource "aws_launch_configuration" "default" {
+  name          = "default"
+  image_id      = "${data.aws_ami.ubuntu.id}"
+  instance_type = "m4.large"
+  spot_price    = data.aws_spot_price_history.prices.latest.spot_price * 1.2
+}
+
+```
+
+## Argument Reference
+
+* `start_time` - (Optional) The date and time, up to the past 90 days, from which to start retrieving the price history data, in UTC format (for example, YYYY-MM-DDTHH:MM:SSZ).
+* `end_time` - (Optional) The date and time, up to the current date, from which to stop retrieving the price history data, in UTC format (for example, YYYY-MM-DDTHH:MM:SSZ).
+* `filter` - (Optional) One or more name/value pairs to filter off of. There are several valid keys, 
+for a full reference, check out [describe-spot-price-history in the AWS CLI reference][1].
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - a random ID.
+* `latest` is the latest recorded spot price data. See [Spot Price Data](#spot-price-data)
+* `previous` is a list of older prices. See [Spot Price Data](#spot-price-data) for he format of each element
+
+## Spot Price Data
+
+* `availability_zone` - The zome where this instance type can be started 
+* `instance_type` -  The instance type
+* `product_description` - The product (Linux/UNIX | SUSE Linux | Windows |)
+* `spot_price` - The price
+* `timestamp` - The time from which the price has become available 
+
+
+[1]: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSpotPriceHistory.html


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Motivation

Currently we configure spot prices as terraform variables. In some cases these prices vary frequently, so that somebody has to lookup the prices in AWS and update the code accordingly. 

Please consider the following example, which uses the new resource in conjunction with a launch configuration. If an instance, cannot start due to a higher spot price, just apply the corresponding terraform workspace. 

```hcl
# Request spot prices
resource "aws_spot_price_history" "prices" {
  start_time = "2020-04-13T01:10:30Z"
  filter {
    name = "instance_type"
    values = ["m4.large"]
  } 
}

# use the latest price for the launch configuration
resource "aws_launch_configuration" "default" {
  name          = "default"
  image_id      = "${data.aws_ami.ubuntu.id}"
  instance_type = "m4.large"
  spot_price    = data.aws_spot_price_history.prices.latest.spot_price * 1.2
}

```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSSpotPriceHistoryDataSource_instance_type_filter'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSpotPriceHistoryDataSource_instance_type -timeout 120m
=== RUN   TestAccAWSSpotPriceHistoryDataSource_instance_type_filter
=== PAUSE TestAccAWSSpotPriceHistoryDataSource_instance_type_filter
=== CONT  TestAccAWSSpotPriceHistoryDataSource_instance_type_filter
--- PASS: TestAccAWSSpotPriceHistoryDataSource_instance_type_filter (40.09s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	41.407s
```



