### PR TITLE
Update ValidateFunc for dlm lifecycle policy times

### DIFF
--- a/aws/resource_aws_dlm_lifecycle_policy.go
+++ b/aws/resource_aws_dlm_lifecycle_policy.go
@@ -87,7 +87,7 @@ func resourceAwsDlmLifecyclePolicy() *schema.Resource {
 													MaxItems: 1,
 													Elem: &schema.Schema{
 														Type:         schema.TypeString,
-														ValidateFunc: validation.StringMatch(regexp.MustCompile("^([0-9]|0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$"), "see https://docs.aws.amazon.com/dlm/latest/APIReference/API_CreateRule.html#dlm-Type-CreateRule-Times"),
+														ValidateFunc: validation.StringMatch(regexp.MustCompile("^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$"), "see https://docs.aws.amazon.com/dlm/latest/APIReference/API_CreateRule.html#dlm-Type-CreateRule-Times"),
 													},
 												},
 											},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12799

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Update validation regex for `times` in `resource_aws_dlm_lifecycle_policy`.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
❯ make testacc TESTARGS='-run=TestAccAWSDlmLifecyclePolicy'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSDlmLifecyclePolicy -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSDlmLifecyclePolicy_Basic
=== PAUSE TestAccAWSDlmLifecyclePolicy_Basic
=== RUN   TestAccAWSDlmLifecyclePolicy_Full
=== PAUSE TestAccAWSDlmLifecyclePolicy_Full
=== RUN   TestAccAWSDlmLifecyclePolicy_Tags
=== PAUSE TestAccAWSDlmLifecyclePolicy_Tags
=== CONT  TestAccAWSDlmLifecyclePolicy_Basic
=== CONT  TestAccAWSDlmLifecyclePolicy_Tags
=== CONT  TestAccAWSDlmLifecyclePolicy_Full
--- PASS: TestAccAWSDlmLifecyclePolicy_Basic (20.11s)
--- PASS: TestAccAWSDlmLifecyclePolicy_Full (24.79s)
--- PASS: TestAccAWSDlmLifecyclePolicy_Tags (36.31s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	38.558s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.219s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.456s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/naming	0.424s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/batch/equivalency	0.218s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks/token	0.260s [no tests to run]
?   	github.com/terraform-providers/terraform-provider-aws/awsproviderlint	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes	0.478s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSAT001	0.465s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSR001	0.192s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/fmtsprintfcallexpr	0.131s [no tests to run]
```
This fixes a small bug in validation for DLM Lifecycle Policies. 

The validation that the provider does on `tests` differs slightly from the validation done by the DLM API. The API requires a leading `0` on hours less than `10`.

For example, if you modify https://www.terraform.io/docs/providers/aws/r/dlm_lifecycle_policy.html to use `7:00`:
```
      create_rule {
        interval      = 24
        interval_unit = "HOURS"
        times         = ["7:00"]
      }
```

TF Plan will succeed, but on `apply` you get:
```
* aws_dlm_lifecycle_policy.example: error creating DLM Lifecycle Policy: InvalidRequestException: The following parameter(s) are invalid: Times {7:00} in Schedule {2 weeks of daily snapshots}
        status code: 400, request id: xxxxx-xxxx-xxx
```

I just updated the regex to match the current docs for the API: https://docs.aws.amazon.com/dlm/latest/APIReference/API_CreateRule.html#dlm-Type-CreateRule-Times
