### PR TITLE
docs: Add Federated Principal information to iam_policy_document

### DIFF
--- a/website/docs/d/iam_policy_document.html.markdown
+++ b/website/docs/d/iam_policy_document.html.markdown
@@ -119,9 +119,11 @@ each accept the following arguments:
 Each policy may have either zero or more `principals` blocks or zero or more
 `not_principals` blocks, both of which each accept the following arguments:
 
-* `type` (Required) The type of principal. For AWS ARNs this is "AWS".  For AWS services (e.g. Lambda), this is "Service".
+* `type` (Required) The type of principal. For AWS ARNs this is "AWS".  For AWS services (e.g. Lambda), this is "Service". For Federated access the type is "Federated".
 * `identifiers` (Required) List of identifiers for principals. When `type`
-  is "AWS", these are IAM user or role ARNs.  When `type` is "Service", these are AWS Service roles e.g. `lambda.amazonaws.com`.
+  is "AWS", these are IAM user or role ARNs.  When `type` is "Service", these are AWS Service roles e.g. `lambda.amazonaws.com`. When `type` is "Federated", these are web identity users or SAML provider ARNs.
+
+For further examples or information about AWS principals then please refer to the [documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html).
 
 Each policy statement may have zero or more `condition` blocks, which each
 accept the following arguments:
@@ -183,6 +185,10 @@ data "aws_iam_policy_document" "event_stream_bucket_role_assume_role_policy" {
     principals {
       type        = "AWS"
       identifiers = ["${var.trusted_role_arn}"]
+    }
+    principals {
+      type        = "Federated"
+      identifiers = ["arn:aws:iam::${var.account_id}:saml-provider/${var.provider_name}", "cognito-identity.amazonaws.com"]
     }
   }
 }

--- a/website/docs/d/iam_policy_document.html.markdown
+++ b/website/docs/d/iam_policy_document.html.markdown
@@ -186,6 +186,7 @@ data "aws_iam_policy_document" "event_stream_bucket_role_assume_role_policy" {
       type        = "AWS"
       identifiers = ["${var.trusted_role_arn}"]
     }
+
     principals {
       type        = "Federated"
       identifiers = ["arn:aws:iam::${var.account_id}:saml-provider/${var.provider_name}", "cognito-identity.amazonaws.com"]


### PR DESCRIPTION
This data source already supports Federated access. It just isn't
documented. This change adds that documentation as well as providing
an example of it being used.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--

-->

```release-note
Documented iam_policy_document support for Principals of type "Federated"
```

