### PR TITLE
r/aws_ec2_client_vpn_endpoint: add multiple 'authentication_options' …

### DIFF
--- a/aws/resource_aws_ec2_client_vpn_endpoint.go
+++ b/aws/resource_aws_ec2_client_vpn_endpoint.go
@@ -58,7 +58,7 @@ func resourceAwsEc2ClientVpnEndpoint() *schema.Resource {
 			"authentication_options": {
 				Type:     schema.TypeList,
 				Required: true,
-				MaxItems: 1,
+				MaxItems: 2,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": {
@@ -137,26 +137,16 @@ func resourceAwsEc2ClientVpnEndpointCreate(d *schema.ResourceData, meta interfac
 	}
 
 	if v, ok := d.GetOk("authentication_options"); ok {
-		authOptsSet := v.([]interface{})
-		attrs := authOptsSet[0].(map[string]interface{})
+		authOptions := v.([]interface{})
+		authRequests := make([]*ec2.ClientVpnAuthenticationRequest, 0, len(authOptions))
 
-		authOptsReq := &ec2.ClientVpnAuthenticationRequest{
-			Type: aws.String(attrs["type"].(string)),
+		for _, authOpt := range authOptions {
+			auth := authOpt.(map[string]interface{})
+
+			authReq := expandEc2ClientVpnAuthenticationRequest(auth)
+			authRequests = append(authRequests, authReq)
 		}
-
-		if attrs["type"].(string) == "certificate-authentication" {
-			authOptsReq.MutualAuthentication = &ec2.CertificateAuthenticationRequest{
-				ClientRootCertificateChainArn: aws.String(attrs["root_certificate_chain_arn"].(string)),
-			}
-		}
-
-		if attrs["type"].(string) == "directory-service-authentication" {
-			authOptsReq.ActiveDirectory = &ec2.DirectoryServiceAuthenticationRequest{
-				DirectoryId: aws.String(attrs["active_directory_id"].(string)),
-			}
-		}
-
-		req.AuthenticationOptions = []*ec2.ClientVpnAuthenticationRequest{authOptsReq}
+		req.AuthenticationOptions = authRequests
 	}
 
 	if v, ok := d.GetOk("connection_log_options"); ok {
@@ -348,13 +338,38 @@ func flattenConnLoggingConfig(lopts *ec2.ConnectionLogResponseOptions) []map[str
 }
 
 func flattenAuthOptsConfig(aopts []*ec2.ClientVpnAuthentication) []map[string]interface{} {
-	m := make(map[string]interface{})
-	if aopts[0].MutualAuthentication != nil {
-		m["root_certificate_chain_arn"] = *aopts[0].MutualAuthentication.ClientRootCertificateChain
+	result := make([]map[string]interface{}, 0, len(aopts))
+	for _, aopt := range aopts {
+		r := map[string]interface{}{
+			"type": aws.StringValue(aopt.Type),
+		}
+		if aopt.MutualAuthentication != nil {
+			r["root_certificate_chain_arn"] = aws.StringValue(aopt.MutualAuthentication.ClientRootCertificateChain)
+		}
+		if aopt.ActiveDirectory != nil {
+			r["active_directory_id"] = aws.StringValue(aopt.ActiveDirectory.DirectoryId)
+		}
+		result = append([]map[string]interface{}{r}, result...)
 	}
-	if aopts[0].ActiveDirectory != nil {
-		m["active_directory_id"] = *aopts[0].ActiveDirectory.DirectoryId
+	return result
+}
+
+func expandEc2ClientVpnAuthenticationRequest(data map[string]interface{}) *ec2.ClientVpnAuthenticationRequest {
+	req := &ec2.ClientVpnAuthenticationRequest{
+		Type: aws.String(data["type"].(string)),
 	}
-	m["type"] = *aopts[0].Type
-	return []map[string]interface{}{m}
+
+	if data["type"].(string) == ec2.ClientVpnAuthenticationTypeCertificateAuthentication {
+		req.MutualAuthentication = &ec2.CertificateAuthenticationRequest{
+			ClientRootCertificateChainArn: aws.String(data["root_certificate_chain_arn"].(string)),
+		}
+	}
+
+	if data["type"].(string) == ec2.ClientVpnAuthenticationTypeDirectoryServiceAuthentication {
+		req.ActiveDirectory = &ec2.DirectoryServiceAuthenticationRequest{
+			DirectoryId: aws.String(data["active_directory_id"].(string)),
+		}
+	}
+
+	return req
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #8723

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_ec2_client_vpn_endpoint: Allow maximum 2 `authentication_options` to enable both `directory-service-authentication` and `certificate-authentication` in the same EC2 Client VPN Endpoint
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsEc2ClientVpnEndpoint_mutualAuthAndMsAD'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAwsEc2ClientVpnEndpoint_mutualAuthAndMsAD -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAwsEc2ClientVpnEndpoint_mutualAuthAndMsAD
=== PAUSE TestAccAwsEc2ClientVpnEndpoint_mutualAuthAndMsAD
=== CONT  TestAccAwsEc2ClientVpnEndpoint_mutualAuthAndMsAD
--- PASS: TestAccAwsEc2ClientVpnEndpoint_mutualAuthAndMsAD (1796.62s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1798.964s
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.041s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.124s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/naming	0.199s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/batch/equivalency	0.120s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks/token	0.127s [no tests to run]
?   	github.com/terraform-providers/terraform-provider-aws/awsproviderlint	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes	0.191s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSAT001	0.202s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSR001	0.048s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/fmtsprintfcallexpr	0.039s [no tests to run]
```
